### PR TITLE
PartitionedConfig testing helpers

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
@@ -216,7 +216,12 @@ If you want to test that your <PyObject object="PartitionedConfig" /> creates th
 def my_offset_partitioned_config(start: datetime, _end: datetime):
     return {
         "ops": {
-            "process_data_for_date": {"config": {"start": start.strftime("%Y-%m-%d-%H:%M"), "end": _end.strftime("%Y-%m-%d-%H-%M")}}
+            "process_data": {
+                "config": {
+                    "start": start.strftime("%Y-%m-%d-%H:%M"),
+                    "end": _end.strftime("%Y-%m-%d-%H:%M"),
+                }
+            }
         }
     }
 
@@ -246,7 +251,9 @@ def test_my_offset_partitioned_config():
     # test that the contents of run_config are what you expect
     assert run_config == {
         "ops": {
-            "process_data_for_date": {"config": {"start": "2020-01-01-00:15", "end": "2020-01-02-00:15"}}
+            "process_data": {
+                "config": {"start": "2020-01-01-00:15", "end": "2020-01-02-00:15"}
+            }
         }
     }
 ```

--- a/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
@@ -209,6 +209,48 @@ def test_my_partitioned_config():
     assert validate_run_config(do_stuff_partitioned, run_config)
 ```
 
+If you want to test that your <PyObject object="PartitionedConfig" /> creates the partitions you expect, you can use the `get_partitions` or `get_partition_keys` or `get_run_config_for_partition_key` functions.
+
+```python file=/concepts/partitions_schedules_sensors/partitioned_config_test.py startafter=start_partition_keys endbefore=end_partition_keys
+@daily_partitioned_config(start_date=datetime(2020, 1, 1), minute_offset=15)
+def my_offset_partitioned_config(start: datetime, _end: datetime):
+    return {
+        "ops": {
+            "process_data_for_date": {"config": {"start": start.strftime("%Y-%m-%d-%H:%M"), "end": _end.strftime("%Y-%m-%d-%H-%M")}}
+        }
+    }
+
+
+@op(config_schema={"start": str, "end": str})
+def process_data(context):
+    s = context.op_config["start"]
+    e = context.op_config["end"]
+    context.log.info(f"processing data for {s} - {e}")
+
+
+@job(config=my_offset_partitioned_config)
+def do_more_stuff_partitioned():
+    process_data()
+
+
+def test_my_offset_partitioned_config():
+    # test that the partition keys are what you expect
+    keys = my_offset_partitioned_config.get_partition_keys()
+    assert keys[0] == "2020-01-01"
+    assert keys[1] == "2020-01-02"
+
+    # test that the run_config for a partition is valid for do_stuff_partitioned
+    run_config = my_offset_partitioned_config.get_run_config_for_partition_key(keys[0])
+    assert validate_run_config(do_more_stuff_partitioned, run_config)
+
+    # test that the contents of run_config are what you expect
+    assert run_config == {
+        "ops": {
+            "process_data_for_date": {"config": {"start": "2020-01-01-00:15", "end": "2020-01-02-00:15"}}
+        }
+    }
+```
+
 ### Testing Partitioned Jobs
 
 To run a partitioned job in-process on a particular partition, you can supply a value for the `partition_key` argument of <PyObject object="JobDefinition" method="execute_in_process" />

--- a/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
@@ -209,7 +209,7 @@ def test_my_partitioned_config():
     assert validate_run_config(do_stuff_partitioned, run_config)
 ```
 
-If you want to test that your <PyObject object="PartitionedConfig" /> creates the partitions you expect, you can use the `get_partitions` or `get_partition_keys` or `get_run_config_for_partition_key` functions.
+If you want to test that your <PyObject object="PartitionedConfig" /> creates the partitions you expect, you can use the `get_partition_keys` or `get_run_config_for_partition_key` functions.
 
 ```python file=/concepts/partitions_schedules_sensors/partitioned_config_test.py startafter=start_partition_keys endbefore=end_partition_keys
 @daily_partitioned_config(start_date=datetime(2020, 1, 1), minute_offset=15)

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_config_test.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_config_test.py
@@ -4,6 +4,7 @@
 from docs_snippets.concepts.partitions_schedules_sensors.partitioned_job import (
     do_stuff_partitioned,
 )
+from dagster import job, op
 
 
 # start_partition_config
@@ -33,3 +34,54 @@ def test_my_partitioned_config():
 
 
 # end_partition_config
+
+# start_partition_keys
+
+
+@daily_partitioned_config(start_date=datetime(2020, 1, 1), minute_offset=15)
+def my_offset_partitioned_config(start: datetime, _end: datetime):
+    return {
+        "ops": {
+            "process_data_for_date": {
+                "config": {
+                    "start": start.strftime("%Y-%m-%d-%H:%M"),
+                    "end": _end.strftime("%Y-%m-%d-%H-%M"),
+                }
+            }
+        }
+    }
+
+
+@op(config_schema={"start": str, "end": str})
+def process_data(context):
+    s = context.op_config["start"]
+    e = context.op_config["end"]
+    context.log.info(f"processing data for {s} - {e}")
+
+
+@job(config=my_offset_partitioned_config)
+def do_more_stuff_partitioned():
+    process_data()
+
+
+def test_my_offset_partitioned_config():
+    # test that the partition keys are what you expect
+    keys = my_offset_partitioned_config.get_partition_keys()
+    assert keys[0] == "2020-01-01"
+    assert keys[1] == "2020-01-02"
+
+    # test that the run_config for a partition is valid for do_stuff_partitioned
+    run_config = my_offset_partitioned_config.get_run_config_for_partition_key(keys[0])
+    assert validate_run_config(do_more_stuff_partitioned, run_config)
+
+    # test that the contents of run_config are what you expect
+    assert run_config == {
+        "ops": {
+            "process_data_for_date": {
+                "config": {"start": "2020-01-01-00:15", "end": "2020-01-02-00:15"}
+            }
+        }
+    }
+
+
+# end_partition_keys

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_config_test.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_config_test.py
@@ -42,10 +42,10 @@ def test_my_partitioned_config():
 def my_offset_partitioned_config(start: datetime, _end: datetime):
     return {
         "ops": {
-            "process_data_for_date": {
+            "process_data": {
                 "config": {
                     "start": start.strftime("%Y-%m-%d-%H:%M"),
-                    "end": _end.strftime("%Y-%m-%d-%H-%M"),
+                    "end": _end.strftime("%Y-%m-%d-%H:%M"),
                 }
             }
         }
@@ -77,7 +77,7 @@ def test_my_offset_partitioned_config():
     # test that the contents of run_config are what you expect
     assert run_config == {
         "ops": {
-            "process_data_for_date": {
+            "process_data": {
                 "config": {"start": "2020-01-01-00:15", "end": "2020-01-02-00:15"}
             }
         }

--- a/python_modules/dagster/dagster/core/definitions/partition.py
+++ b/python_modules/dagster/dagster/core/definitions/partition.py
@@ -770,6 +770,13 @@ class PartitionedConfig(Generic[T]):
     def get_partition_keys(self, current_time: Optional[datetime] = None) -> List[str]:
         return [partition.name for partition in self.partitions_def.get_partitions(current_time)]
 
+    def get_run_config_for_partition_key(self, key: str) -> Dict[str, Any]:
+        partitions = self.partitions_def.get_partitions()
+        partition = [p for p in partitions if p.name == key]
+        if len(partition) == 0:
+            raise DagsterInvalidInvocationError(f"No partition for partition key {key}.")
+        return self.run_config_for_partition_fn(partition[0])
+
     def __call__(self, *args, **kwargs):
         if self._decorated_fn is None:
             raise DagsterInvalidInvocationError(

--- a/python_modules/dagster/dagster/core/definitions/partition.py
+++ b/python_modules/dagster/dagster/core/definitions/partition.py
@@ -770,11 +770,16 @@ class PartitionedConfig(Generic[T]):
     def get_partition_keys(self, current_time: Optional[datetime] = None) -> List[str]:
         return [partition.name for partition in self.partitions_def.get_partitions(current_time)]
 
-    def get_run_config_for_partition_key(self, key: str) -> Dict[str, Any]:
+    def get_run_config_for_partition_key(self, partition_key: str) -> Dict[str, Any]:
+        """Generates the run config corresponding to a partition key.
+
+        Args:
+            partition_key (str): the key for a partition that should be used to generate a run config.
+        """
         partitions = self.partitions_def.get_partitions()
-        partition = [p for p in partitions if p.name == key]
+        partition = [p for p in partitions if p.name == partition_key]
         if len(partition) == 0:
-            raise DagsterInvalidInvocationError(f"No partition for partition key {key}.")
+            raise DagsterInvalidInvocationError(f"No partition for partition key {partition_key}.")
         return self.run_config_for_partition_fn(partition[0])
 
     def __call__(self, *args, **kwargs):

--- a/python_modules/dagster/dagster/core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/core/definitions/time_window_partitions.py
@@ -140,8 +140,8 @@ class TimeWindowPartitionsDefinition(
             ),
             execution_timezone=self.timezone,
         )
-        next(iterator)
-        return TimeWindow(start, next(iterator))
+
+        return TimeWindow(next(iterator), next(iterator))
 
     def start_time_for_partition_key(self, partition_key: str) -> datetime:
         return pendulum.instance(datetime.strptime(partition_key, self.fmt), tz=self.timezone)

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_time_window_partitions.py
@@ -7,9 +7,11 @@ from dagster import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
     MonthlyPartitionsDefinition,
+    WeeklyPartitionsDefinition,
     daily_partitioned_config,
     hourly_partitioned_config,
     monthly_partitioned_config,
+    weekly_partitioned_config,
 )
 from dagster.core.definitions.time_window_partitions import TimeWindow
 from dagster.utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
@@ -78,6 +80,29 @@ def test_daily_partitions_with_negative_end_offset():
     ]
 
 
+def test_daily_partitions_with_time_offset():
+    @daily_partitioned_config(start_date="2021-05-05", minute_offset=15)
+    def my_partitioned_config(_start, _end):
+        return {}
+
+    partitions_def = my_partitioned_config.partitions_def
+    assert partitions_def == DailyPartitionsDefinition(start_date="2021-05-05", minute_offset=15)
+
+    partitions = partitions_def.get_partitions(datetime.strptime("2021-05-07", DATE_FORMAT))
+
+    assert [partition.value for partition in partitions] == [
+        time_window("2021-05-05T00:15:00", "2021-05-06T00:15:00"),
+    ]
+
+    assert [partition.name for partition in partitions] == [
+        "2021-05-05",
+    ]
+
+    assert partitions_def.time_window_for_partition_key("2021-05-08") == time_window(
+        "2021-05-08T00:15:00", "2021-05-09T00:15:00"
+    )
+
+
 def test_monthly_partitions():
     @monthly_partitioned_config(start_date="2021-05-01")
     def my_partitioned_config(_start, _end):
@@ -117,6 +142,35 @@ def test_monthly_partitions_with_end_offset():
     ]
 
 
+def test_monthly_partitions_with_time_offset():
+    @monthly_partitioned_config(
+        start_date="2021-05-01", minute_offset=15, hour_offset=3, day_offset=12
+    )
+    def my_partitioned_config(_start, _end):
+        return {}
+
+    partitions_def = my_partitioned_config.partitions_def
+    assert partitions_def == MonthlyPartitionsDefinition(
+        start_date="2021-05-01", minute_offset=15, hour_offset=3, day_offset=12
+    )
+
+    partitions = partitions_def.get_partitions(datetime.strptime("2021-07-13", DATE_FORMAT))
+
+    assert [partition.value for partition in partitions] == [
+        time_window("2021-05-12T03:15:00", "2021-06-12T03:15:00"),
+        time_window("2021-06-12T03:15:00", "2021-07-12T03:15:00"),
+    ]
+
+    assert [partition.name for partition in partitions] == [
+        "2021-05-12",
+        "2021-06-12",
+    ]
+
+    assert partitions_def.time_window_for_partition_key("2021-05-01") == time_window(
+        "2021-05-12T03:15:00", "2021-06-12T03:15:00"
+    )
+
+
 def test_hourly_partitions():
     @hourly_partitioned_config(start_date="2021-05-05-01:00")
     def my_partitioned_config(_start, _end):
@@ -141,4 +195,83 @@ def test_hourly_partitions():
 
     assert partitions_def.time_window_for_partition_key("2021-05-05-01:00") == time_window(
         "2021-05-05T01:00:00", "2021-05-05T02:00:00"
+    )
+
+
+def test_hourly_partitions_with_time_offset():
+    @hourly_partitioned_config(start_date="2021-05-05-01:00", minute_offset=15)
+    def my_partitioned_config(_start, _end):
+        return {}
+
+    partitions_def = my_partitioned_config.partitions_def
+    assert partitions_def == HourlyPartitionsDefinition(
+        start_date="2021-05-05-01:00", minute_offset=15
+    )
+
+    partitions = partitions_def.get_partitions(
+        datetime.strptime("2021-05-05-03:30", DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE)
+    )
+
+    assert [partition.value for partition in partitions] == [
+        time_window("2021-05-05T01:15:00", "2021-05-05T02:15:00"),
+        time_window("2021-05-05T02:15:00", "2021-05-05T03:15:00"),
+    ]
+
+    assert [partition.name for partition in partitions] == [
+        "2021-05-05-01:15",
+        "2021-05-05-02:15",
+    ]
+
+    assert partitions_def.time_window_for_partition_key("2021-05-05-01:00") == time_window(
+        "2021-05-05T01:15:00", "2021-05-05T02:15:00"
+    )
+
+
+def test_weekly_partitions():
+    @weekly_partitioned_config(start_date="2021-05-01")
+    def my_partitioned_config(_start, _end):
+        return {}
+
+    partitions_def = my_partitioned_config.partitions_def
+    assert partitions_def == WeeklyPartitionsDefinition(start_date="2021-05-01")
+
+    assert [
+        partition.value
+        for partition in partitions_def.get_partitions(datetime.strptime("2021-05-18", DATE_FORMAT))
+    ] == [
+        time_window("2021-05-02", "2021-05-09"),
+        time_window("2021-05-09", "2021-05-16"),
+    ]
+
+    assert partitions_def.time_window_for_partition_key("2021-05-01") == time_window(
+        "2021-05-02", "2021-05-09"
+    )
+
+
+def test_weekly_partitions_with_time_offset():
+    @weekly_partitioned_config(
+        start_date="2021-05-01", minute_offset=15, hour_offset=4, day_offset=3
+    )
+    def my_partitioned_config(_start, _end):
+        return {}
+
+    partitions_def = my_partitioned_config.partitions_def
+    assert partitions_def == WeeklyPartitionsDefinition(
+        start_date="2021-05-01", minute_offset=15, hour_offset=4, day_offset=3
+    )
+
+    partitions = partitions_def.get_partitions(datetime.strptime("2021-05-20", DATE_FORMAT))
+
+    assert [partition.value for partition in partitions] == [
+        time_window("2021-05-05T04:15:00", "2021-05-12T04:15:00"),
+        time_window("2021-05-12T04:15:00", "2021-05-19T04:15:00"),
+    ]
+
+    assert [partition.name for partition in partitions] == [
+        "2021-05-05",
+        "2021-05-12",
+    ]
+
+    assert partitions_def.time_window_for_partition_key("2021-05-01") == time_window(
+        "2021-05-05T04:15:00", "2021-05-12T04:15:00"
     )


### PR DESCRIPTION
Adds `run_config_from_partition_key` function to PartitionedConfig so users can validate the config produced by partitions. https://github.com/dagster-io/dagster/issues/6679

Additionally, I found another test file I missed in my previous PR. updated that file to include tests for minute, hour, day offset. In the process of that I found a bug in `get_time_window_for_partition_key` and wrote a potential solution - see comment on that function