### PR TITLE
fix: prevent runs filter from accepting an empty list of run ids

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -56,7 +56,7 @@ class GrapheneRunsFilter(graphene.InputObjectType):
         created_before = pendulum.from_timestamp(self.createdBefore) if self.createdBefore else None
 
         return RunsFilter(
-            run_ids=self.runIds,
+            run_ids=self.runIds if self.runIds else None,
             pipeline_name=self.pipelineName,
             tags=tags,
             statuses=statuses,

--- a/python_modules/dagster/dagster/core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/core/storage/pipeline_run.py
@@ -505,6 +505,9 @@ class RunsFilter(
         pipeline_name: Optional[str] = None,  # for backcompat purposes
     ):
         job_name = job_name or pipeline_name
+
+        check.invariant(run_ids != [], "When filtering on run ids, a non-empty list must be used.")
+
         return super(RunsFilter, cls).__new__(
             cls,
             run_ids=check.opt_list_param(run_ids, "run_ids", of_type=str),

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_pipeline_run.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_pipeline_run.py
@@ -3,6 +3,7 @@ import sys
 import pytest
 
 from dagster import check
+from dagster.check import CheckError
 from dagster.core.code_pointer import ModuleCodePointer
 from dagster.core.definitions.reconstruct import ReconstructableRepository
 from dagster.core.host_representation.origin import (
@@ -20,6 +21,7 @@ from dagster.core.storage.pipeline_run import (
     NON_IN_PROGRESS_RUN_STATUSES,
     PipelineRun,
     PipelineRunStatus,
+    RunsFilter,
 )
 
 
@@ -68,3 +70,11 @@ def test_in_progress_statuses():
     assert len(IN_PROGRESS_RUN_STATUSES) + len(NON_IN_PROGRESS_RUN_STATUSES) == len(
         PipelineRunStatus
     )
+
+
+def test_runs_filter_supports_nonempty_run_ids():
+    assert RunsFilter()
+    assert RunsFilter(run_ids=["1234"])
+
+    with pytest.raises(CheckError):
+        RunsFilter(run_ids=[])


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Currently, applying a run filter with `run_ids` as `None` or `[]` has the same result of fetching all the runs. This is because both values are falsey.

We could change the logic to treat `[]` as a short-circuit and skip fetching any runs, but then the API consumer would need to be wary that passing in `[]` has this particular behavior.

Instead, if `[]` is passed in, throw an error. The API consumer should explicitly guard for this case in their business logic, rather than relying on the underlying API to skip the fetching of any runs.


## Test Plan
pytest

run dagit locally, fill out `id:` field with random values

https://user-images.githubusercontent.com/16431325/160492995-11d5aaff-48f9-4594-8302-07a309d2cbea.mov


