### PR TITLE
Add container_context to Helm chart so that config is automatically passed through from gRPC to launched runs

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/configmap-env-shared.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/configmap-env-shared.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "dagster.fullname" $ -}}-user-deployments-shared-env
+  labels:
+    app: {{ template "dagster.name" $ }}
+    chart: {{ template "dagster.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+data:
+  {{ include "dagsterUserDeployments.sharedEnv" $ | nindent 2 }}
+
+---

--- a/helm/dagster/charts/dagster-user-deployments/templates/configmap-env-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/configmap-env-user.yaml
@@ -9,8 +9,6 @@ metadata:
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
 data:
-  {{ include "dagsterUserDeployments.sharedEnv" $ | nindent 2 }}
-
   {{- range $name, $value := $deployment.env }}
   {{ $name }}: {{ $value | quote }}
   {{- end }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -51,7 +51,15 @@ spec:
                 secretKeyRef:
                   name: {{ include "dagsterUserDeployments.postgresql.secretName" $ }}
                   key: postgresql-password
+            {{- if $deployment.includeConfigInLaunchedRuns.enabled }}
+            # uses the auto_envvar_prefix of the dagster cli to set the --container-context arg
+            # on 'dagster api grpc'
+            - name: DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT
+              value: {{ include "dagsterUserDeployments.k8sContainerContext" (list $ $deployment) | fromYaml | toJson | quote }}
+            {{- end }}
           envFrom:
+            - configMapRef:
+                name: {{ include "dagster.fullname" $ }}-user-deployments-shared-env
             - configMapRef:
                 name: {{ include "dagster.fullname" $ }}-{{ $deployment.name }}-user-env
             {{- range $envConfigMap := $deployment.envConfigMaps }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -91,3 +91,36 @@ DAGSTER_K8S_INSTANCE_CONFIG_MAP: "{{ template "dagster.fullname" .}}-instance"
 DAGSTER_K8S_PIPELINE_RUN_NAMESPACE: "{{ .Release.Namespace }}"
 DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP: "{{ template "dagster.fullname" . }}-pipeline-env"
 {{- end -}}
+
+
+{{- define "dagsterUserDeployments.k8sContainerContext" -}}
+  {{- $ := index . 0 }}
+  {{- with index . 1 }}
+  k8s:
+    image_pull_policy: {{ .image.pullPolicy }}
+    env_config_maps:
+    - {{ include "dagster.fullname" $ }}-{{ .name }}-user-env
+    {{- range $envConfigMap := .envConfigMaps }}
+    {{- if hasKey $envConfigMap "name" }}
+    - {{ $envConfigMap.name }}
+    {{- end }}
+    {{- end }}
+    {{- if .envSecrets }}
+    env_secrets:
+    {{- range $envSecret := .envSecrets }}
+    {{- if hasKey $envSecret "name" }}
+    - {{ $envSecret.name }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- if .volumeMounts }}
+    volume_mounts: {{- .volumeMounts | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if .volumes }}
+    volumes: {{- .volumes | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if .labels }}
+    labels: {{- .labels | toYaml | nindent 6 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -84,6 +84,19 @@
                 "pullPolicy"
             ]
         },
+        "UserDeploymentIncludeConfigInLaunchedRuns": {
+            "title": "UserDeploymentIncludeConfigInLaunchedRuns",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "enabled"
+            ]
+        },
         "ConfigMapEnvSource": {
             "title": "ConfigMapEnvSource",
             "type": "object",
@@ -194,6 +207,9 @@
                         "type": "string"
                     }
                 },
+                "includeConfigInLaunchedRuns": {
+                    "$ref": "#/definitions/UserDeploymentIncludeConfigInLaunchedRuns"
+                },
                 "port": {
                     "title": "Port",
                     "type": "integer"
@@ -275,6 +291,7 @@
                 "name",
                 "image",
                 "dagsterApiGrpcArgs",
+                "includeConfigInLaunchedRuns",
                 "port"
             ]
         },

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -43,6 +43,12 @@ deployments:
       - "-f"
       - "/example_project/example_repo/repo.py"
     port: 3030
+
+    # Whether or not to include configuration specified for this user code deployment in the pods
+    # launched for runs from that deployment
+    includeConfigInLaunchedRuns:
+      enabled: false
+
     # Additional volumes that should be included in the Deployment's Pod. See:
     # https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core
     #

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
@@ -5,10 +5,15 @@ from pydantic import BaseModel  # pylint: disable=no-name-in-module
 from ...utils import kubernetes
 
 
+class UserDeploymentIncludeConfigInLaunchedRuns(BaseModel):
+    enabled: bool
+
+
 class UserDeployment(BaseModel):
     name: str
     image: kubernetes.Image
     dagsterApiGrpcArgs: List[str]
+    includeConfigInLaunchedRuns: UserDeploymentIncludeConfigInLaunchedRuns
     port: int
     env: Optional[Dict[str, str]]
     envConfigMaps: Optional[List[kubernetes.ConfigMapEnvSource]]

--- a/helm/dagster/schema/schema_tests/utils.py
+++ b/helm/dagster/schema/schema_tests/utils.py
@@ -1,17 +1,27 @@
-from schema.charts.dagster_user_deployments.subschema.user_deployments import UserDeployment
+from schema.charts.dagster_user_deployments.subschema.user_deployments import (
+    UserDeployment,
+    UserDeploymentIncludeConfigInLaunchedRuns,
+)
 from schema.charts.utils import kubernetes
 
 
-def create_simple_user_deployment(name: str) -> UserDeployment:
+def create_simple_user_deployment(
+    name: str, include_config_in_launched_runs: bool = False
+) -> UserDeployment:
     return UserDeployment(
         name=name,
         image=kubernetes.Image(repository=f"repo/{name}", tag="tag1", pullPolicy="Always"),
         dagsterApiGrpcArgs=["-m", name],
         port=3030,
+        includeConfigInLaunchedRuns=UserDeploymentIncludeConfigInLaunchedRuns(
+            enabled=include_config_in_launched_runs
+        ),
     )
 
 
-def create_complex_user_deployment(name: str) -> UserDeployment:
+def create_complex_user_deployment(
+    name: str, include_config_in_launched_runs: bool = False
+) -> UserDeployment:
     return UserDeployment(
         name=name,
         image=kubernetes.Image(repository=f"repo/{name}", tag="tag1", pullPolicy="Always"),
@@ -61,4 +71,7 @@ def create_complex_user_deployment(name: str) -> UserDeployment:
             "label_one": "one",
             "label_two": "two",
         },
+        includeConfigInLaunchedRuns=UserDeploymentIncludeConfigInLaunchedRuns(
+            enabled=include_config_in_launched_runs
+        ),
     )

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -405,6 +405,19 @@
             ],
             "additionalProperties": false
         },
+        "UserDeploymentIncludeConfigInLaunchedRuns": {
+            "title": "UserDeploymentIncludeConfigInLaunchedRuns",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "enabled"
+            ]
+        },
         "VolumeMount": {
             "title": "VolumeMount",
             "type": "object",
@@ -434,6 +447,9 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "includeConfigInLaunchedRuns": {
+                    "$ref": "#/definitions/UserDeploymentIncludeConfigInLaunchedRuns"
                 },
                 "port": {
                     "title": "Port",
@@ -516,6 +532,7 @@
                 "name",
                 "image",
                 "dagsterApiGrpcArgs",
+                "includeConfigInLaunchedRuns",
                 "port"
             ]
         },

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -247,6 +247,11 @@ dagster-user-deployments:
         - "/example_project/example_repo/repo.py"
       port: 3030
 
+      # Whether or not to include configuration specified for this user code deployment in the pods
+      # launched for runs from that deployment
+      includeConfigInLaunchedRuns:
+        enabled: false
+
       # Additional environment variables to set.
       # A Kubernetes ConfigMap will be created with these environment variables. See:
       # https://kubernetes.io/docs/concepts/configuration/configmap/

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -24,6 +24,9 @@ TEST_OTHER_CONFIGMAP_NAME = "test-other-env-configmap"
 TEST_SECRET_NAME = "test-env-secret"
 TEST_OTHER_SECRET_NAME = "test-other-env-secret"
 
+# Secret that is set on the deployment only
+TEST_DEPLOYMENT_SECRET_NAME = "test-deployment-env-secret"
+
 TEST_VOLUME_CONFIGMAP_NAME = "test-volume-configmap"
 
 TEST_IMAGE_PULL_SECRET_NAME = "test-image-pull-secret"
@@ -207,6 +210,15 @@ def secrets(namespace, should_cleanup):
     )
     kube_api.create_namespaced_secret(namespace=namespace, body=secret)
 
+    int_val = base64.b64encode(b"2").decode("utf-8")
+    deployment_secret = kubernetes.client.V1Secret(
+        api_version="v1",
+        kind="Secret",
+        data={"WORD_FACTOR": int_val},
+        metadata=kubernetes.client.V1ObjectMeta(name=TEST_DEPLOYMENT_SECRET_NAME),
+    )
+    kube_api.create_namespaced_secret(namespace=namespace, body=deployment_secret)
+
     kube_api.create_namespaced_secret(
         namespace=namespace,
         body=kubernetes.client.V1Secret(
@@ -241,6 +253,7 @@ def secrets(namespace, should_cleanup):
     if should_cleanup:
         kube_api.delete_namespaced_secret(name=TEST_SECRET_NAME, namespace=namespace)
         kube_api.delete_namespaced_secret(name=TEST_OTHER_SECRET_NAME, namespace=namespace)
+        kube_api.delete_namespaced_secret(name=TEST_DEPLOYMENT_SECRET_NAME, namespace=namespace)
         kube_api.delete_namespaced_secret(name=TEST_IMAGE_PULL_SECRET_NAME, namespace=namespace)
         kube_api.delete_namespaced_secret(
             name=TEST_OTHER_IMAGE_PULL_SECRET_NAME, namespace=namespace
@@ -652,6 +665,9 @@ def helm_chart_for_user_deployments_subchart_disabled(namespace, docker_image, s
                             "define_demo_execution_repo",
                         ],
                         "port": 3030,
+                        "includeConfigInLaunchedRuns": {
+                            "enabled": False,
+                        },
                         "env": (
                             {"BUILDKITE": os.getenv("BUILDKITE")} if os.getenv("BUILDKITE") else {}
                         ),
@@ -707,6 +723,9 @@ def helm_chart_for_user_deployments_subchart(namespace, docker_image, should_cle
                     "define_demo_execution_repo",
                 ],
                 "port": 3030,
+                "includeConfigInLaunchedRuns": {
+                    "enabled": False,
+                },
             }
         ],
     }
@@ -739,12 +758,16 @@ def _base_helm_config(docker_image):
                         "define_demo_execution_repo",
                     ],
                     "port": 3030,
+                    "includeConfigInLaunchedRuns": {
+                        "enabled": True,
+                    },
                     "env": (
                         {"BUILDKITE": os.getenv("BUILDKITE")} if os.getenv("BUILDKITE") else {}
                     ),
                     "envConfigMaps": (
                         [{"name": TEST_AWS_CONFIGMAP_NAME}] if not IS_BUILDKITE else []
                     ),
+                    "envSecrets": [{"name": TEST_DEPLOYMENT_SECRET_NAME}],
                     "annotations": {"dagster-integration-tests": "ucd-1-pod-annotation"},
                     "service": {
                         "annotations": {"dagster-integration-tests": "ucd-1-svc-annotation"}

--- a/python_modules/dagster-test/dagster_test/test_project/environments/env_config_from_secrets.yaml
+++ b/python_modules/dagster-test/dagster_test/test_project/environments/env_config_from_secrets.yaml
@@ -1,0 +1,13 @@
+loggers:
+  console:
+    config:
+      log_level: DEBUG
+
+solids:
+  multiply_the_word:
+    inputs:
+      word: bar
+    config:
+      factor:
+        env:
+          WORD_FACTOR

--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
@@ -18,6 +18,7 @@ from dagster import (
     In,
     InputDefinition,
     Int,
+    IntSource,
     List,
     ModeDefinition,
     Output,
@@ -100,13 +101,14 @@ def docker_mode_defs():
     ]
 
 
-@solid(input_defs=[InputDefinition("word", String)], config_schema={"factor": Int})
+@solid(input_defs=[InputDefinition("word", String)], config_schema={"factor": IntSource})
 def multiply_the_word(context, word):
     return word * context.solid_config["factor"]
 
 
 @solid(
-    input_defs=[InputDefinition("word", String)], config_schema={"factor": Int, "sleep_time": Int}
+    input_defs=[InputDefinition("word", String)],
+    config_schema={"factor": IntSource, "sleep_time": IntSource},
 )
 def multiply_the_word_slow(context, word):
     time.sleep(context.solid_config["sleep_time"])
@@ -130,7 +132,7 @@ def always_fail(context, word):
 
 @op(
     ins={"word": In(String)},
-    config_schema={"factor": Int},
+    config_schema={"factor": IntSource},
 )
 def multiply_the_word_op(context, word):
     return word * context.solid_config["factor"]

--- a/python_modules/dagster/dagster/cli/api.py
+++ b/python_modules/dagster/dagster/cli/api.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import sys
@@ -488,6 +489,13 @@ def _execute_step_command_body(
     default="INFO",
     help="Level at which to log output from the gRPC server process",
 )
+@click.option(
+    "--container-context",
+    type=click.STRING,
+    required=False,
+    help="Serialized JSON with configuration for any containers created to run the "
+    "code from this server.",
+)
 def grpc_command(
     port=None,
     socket=None,
@@ -501,6 +509,7 @@ def grpc_command(
     override_system_timezone=None,
     log_level="INFO",
     use_python_environment_entry_point=False,
+    container_context=None,
     **kwargs,
 ):
     if seven.IS_WINDOWS and port is None:
@@ -559,6 +568,7 @@ def grpc_command(
                 if use_python_environment_entry_point
                 else DEFAULT_DAGSTER_ENTRY_POINT
             ),
+            container_context=json.loads(container_context) if container_context != None else None,
         )
 
         code_desc = " "

--- a/python_modules/dagster/dagster/core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/core/host_representation/origin.py
@@ -151,6 +151,7 @@ class InProcessRepositoryLocationOrigin(
             ("loadable_target_origin", LoadableTargetOrigin),
             ("container_image", Optional[str]),
             ("entry_point", List[str]),
+            ("container_context", Optional[Dict[str, Any]]),
         ],
     ),
     RepositoryLocationOrigin,
@@ -165,6 +166,7 @@ class InProcessRepositoryLocationOrigin(
         loadable_target_origin: LoadableTargetOrigin,
         container_image: Optional[str] = None,
         entry_point: Optional[List[str]] = None,
+        container_context=None,
     ):
         return super(InProcessRepositoryLocationOrigin, cls).__new__(
             cls,
@@ -177,6 +179,7 @@ class InProcessRepositoryLocationOrigin(
                 if entry_point
                 else DEFAULT_DAGSTER_ENTRY_POINT
             ),
+            container_context=check.opt_dict_param(container_context, "container_context"),
         )
 
     @property

--- a/python_modules/dagster/dagster/core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/core/host_representation/repository_location.py
@@ -308,6 +308,10 @@ class InProcessRepositoryLocation(RepositoryLocation):
         return self._origin.container_image
 
     @property
+    def container_context(self) -> Optional[Dict[str, Any]]:
+        return self._origin.container_context
+
+    @property
     def entry_point(self) -> Optional[List[str]]:
         return self._origin.entry_point
 
@@ -522,6 +526,7 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
 
         self._executable_path = None
         self._container_image = None
+        self._container_context = None
         self._repository_code_pointer_dict = None
         self._entry_point = None
 
@@ -559,7 +564,12 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
             )
             self._entry_point = list_repositories_response.entry_point
 
-            self._container_image = self._reload_current_image()
+            self._container_image = (
+                list_repositories_response.container_image
+                or self._reload_current_image()  # Back-compat for older gRPC servers that did not include container_image in ListRepositoriesResponse
+            )
+
+            self._container_context = list_repositories_response.container_context
 
             self._external_repositories_data = sync_get_streaming_external_repositories_data_grpc(
                 self.client,
@@ -587,6 +597,10 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
     @property
     def container_image(self) -> str:
         return cast(str, self._container_image)
+
+    @property
+    def container_context(self) -> Optional[Dict[str, Any]]:
+        return self._container_context
 
     @property
     def repository_code_pointer_dict(self) -> Dict[str, CodePointer]:

--- a/python_modules/dagster/dagster/grpc/server.py
+++ b/python_modules/dagster/dagster/grpc/server.py
@@ -165,6 +165,7 @@ class DagsterApiServer(DagsterApiServicer):
         lazy_load_user_code=False,
         fixed_server_id=None,
         entry_point=None,
+        container_context=None,
     ):
         super(DagsterApiServer, self).__init__()
 
@@ -204,6 +205,8 @@ class DagsterApiServer(DagsterApiServicer):
             if entry_point != None
             else DEFAULT_DAGSTER_ENTRY_POINT
         )
+
+        self._container_context = check.opt_dict_param(container_context, "container_context")
 
         try:
             self._loaded_repositories = LoadedRepositories(
@@ -354,6 +357,8 @@ class DagsterApiServer(DagsterApiServicer):
             else None,
             repository_code_pointer_dict=self._loaded_repositories.code_pointers_by_repo_name,
             entry_point=self._entry_point,
+            container_image=_get_current_image(),
+            container_context=self._container_context,
         )
 
         return api_pb2.ListRepositoriesReply(
@@ -777,6 +782,7 @@ class DagsterGrpcServer:
         ipc_output_file=None,
         fixed_server_id=None,
         entry_point=None,
+        container_context=None,
     ):
         check.opt_str_param(host, "host")
         check.opt_int_param(port, "port")
@@ -826,6 +832,7 @@ class DagsterGrpcServer:
                 lazy_load_user_code=lazy_load_user_code,
                 fixed_server_id=fixed_server_id,
                 entry_point=entry_point,
+                container_context=container_context,
             )
         except Exception:
             if self._ipc_output_file:

--- a/python_modules/dagster/dagster/grpc/types.py
+++ b/python_modules/dagster/dagster/grpc/types.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, NamedTuple, Optional
+from typing import Any, Dict, List, NamedTuple, Optional
 
 from dagster import check
 from dagster.core.code_pointer import CodePointer
@@ -256,6 +256,8 @@ class ListRepositoriesResponse(
             ("executable_path", Optional[str]),
             ("repository_code_pointer_dict", Dict[str, CodePointer]),
             ("entry_point", Optional[List[str]]),
+            ("container_image", Optional[str]),
+            ("container_context", Optional[Dict[str, Any]]),
         ],
     )
 ):
@@ -265,6 +267,8 @@ class ListRepositoriesResponse(
         executable_path=None,
         repository_code_pointer_dict=None,
         entry_point=None,
+        container_image=None,
+        container_context=None,
     ):
         return super(ListRepositoriesResponse, cls).__new__(
             cls,
@@ -281,6 +285,12 @@ class ListRepositoriesResponse(
             entry_point=(
                 frozenlist(check.list_param(entry_point, "entry_point", of_type=str))
                 if entry_point != None
+                else None
+            ),
+            container_image=check.opt_str_param(container_image, "container_image"),
+            container_context=(
+                check.dict_param(container_context, "container_context")
+                if container_context != None
                 else None
             ),
         )


### PR DESCRIPTION
Uses the new container_context field in the Helm chart, to resolve https://github.com/dagster-io/dagster/issues/3102.

We may want to make this opt-in for now though (and eventually opt-out in 0.15.0?) There are probably some cases where you don't actually want the configmaps to always be passed through, for example if your runs are happening in a different namespace that might not have access to all the configmaps.