### PR TITLE
fix typecheck for In.dagster_type

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/input.py
+++ b/python_modules/dagster/dagster/core/definitions/input.py
@@ -396,7 +396,9 @@ class In(
     ):
         return super(In, cls).__new__(
             cls,
-            dagster_type=check.opt_inst_param(dagster_type, "dagster_type", (type, DagsterType)),
+            dagster_type=check.inst_param(
+                resolve_dagster_type(dagster_type), "dagster_type", (type, DagsterType)
+            ),
             description=check.opt_str_param(description, "description"),
             default_value=default_value,
             root_manager_key=check.opt_str_param(root_manager_key, "root_manager_key"),


### PR DESCRIPTION
This addresses a regression introduced in one of my previous PRs around Dagster type-checking, which caused issues for some users here: https://dagster.slack.com/archives/C01U954MEER/p1648490266424609

Basically the problem was that I added runtime type-checking to `In/Out`, but `typing.List` and friends weren't passing this check. My solution was to run the passed argument through `resolve_dagster_type` _before_ the check, which is the same strategy pursued a layer down by `InputDefinition`/`OutputDefinition`.

## Test Plan

Existing tests.
