### PR TITLE
small improvements for code loading readability

### DIFF
--- a/python_modules/dagster/dagster/core/code_pointer.py
+++ b/python_modules/dagster/dagster/core/code_pointer.py
@@ -164,6 +164,13 @@ class FileCodePointer(
     ),
     CodePointer,
 ):
+    """
+    'attribute' would be a more accurate name for the 'fn_name' property, because it typically
+    refers to a repository definition, job definition, etc. - not a function.
+
+    It's too much of a pain to change because it crosses process boundaries.
+    """
+
     def __new__(cls, python_file: str, fn_name: str, working_directory: Optional[str] = None):
         return super(FileCodePointer, cls).__new__(
             cls,
@@ -200,6 +207,13 @@ class ModuleCodePointer(
     ),
     CodePointer,
 ):
+    """
+    'attribute' would be a more accurate name for the 'fn_name' property, because it typically
+    refers to a repository definition, job definition, etc. - not a function.
+
+    It's too much of a pain to change because it crosses process boundaries.
+    """
+
     def __new__(cls, module: str, fn_name: str, working_directory: Optional[str] = None):
         return super(ModuleCodePointer, cls).__new__(
             cls,


### PR DESCRIPTION
As I was trying to grok this code, I found a couple small things confusing. Changes are:
* In `_get_code_pointer_dict_from_kwargs`, factor out logic that's the same across code pointer types.
* Use the name `attribute` instead of `fn_name` in code pointer. While many attributes are constructed using decorated functions, that's not a requirement.

These don't change behavior aside from making some errors a little bit clearer.