### PR TITLE
interpret None type annotations as Nothing dagster type

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/input.py
+++ b/python_modules/dagster/dagster/core/definitions/input.py
@@ -12,7 +12,7 @@ from dagster.core.types.dagster_type import (
 )
 from dagster.utils.backcompat import experimental_arg_warning
 
-from .inference import InferredInputProps
+from .inference import InferredInputProps, type_annotation_to_dagster_type
 from .utils import NoValueSentinel, check_valid_name
 
 if TYPE_CHECKING:
@@ -276,7 +276,7 @@ class InputDefinition:
 
 def _checked_inferred_type(inferred: InferredInputProps, decorator_name: str) -> DagsterType:
     try:
-        resolved_type = resolve_dagster_type(inferred.annotation)
+        resolved_type = type_annotation_to_dagster_type(inferred.annotation)
     except DagsterError as e:
         raise DagsterInvalidDefinitionError(
             f"Problem using type '{inferred.annotation}' from type annotation for argument "
@@ -284,7 +284,7 @@ def _checked_inferred_type(inferred: InferredInputProps, decorator_name: str) ->
             "your InputDefinition."
         ) from e
 
-    if resolved_type.is_nothing:
+    if isinstance(inferred.annotation, DagsterType) and inferred.annotation.is_nothing:
         raise DagsterInvalidDefinitionError(
             f"Input parameter {inferred.name} is annotated with {resolved_type.display_name} "
             "which is a type that represents passing no data. This type must be used "

--- a/python_modules/dagster/dagster/core/definitions/output.py
+++ b/python_modules/dagster/dagster/core/definitions/output.py
@@ -2,7 +2,6 @@ import warnings
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
-    Any,
     Callable,
     List,
     NamedTuple,
@@ -20,7 +19,7 @@ from dagster.core.errors import DagsterError, DagsterInvalidDefinitionError
 from dagster.core.types.dagster_type import DagsterType, resolve_dagster_type
 from dagster.utils.backcompat import experimental_arg_warning
 
-from .inference import InferredOutputProps
+from .inference import InferredOutputProps, type_annotation_to_dagster_type
 from .input import NoValueSentinel
 from .utils import DEFAULT_OUTPUT, check_valid_name
 
@@ -258,9 +257,9 @@ class OutputDefinition:
         )
 
 
-def _checked_inferred_type(inferred: Any) -> DagsterType:
+def _checked_inferred_type(inferred: object) -> DagsterType:
     try:
-        return resolve_dagster_type(inferred)
+        return type_annotation_to_dagster_type(inferred)
     except DagsterError as e:
         raise DagsterInvalidDefinitionError(
             f"Problem using type '{inferred}' from return type annotation, correct the issue "

--- a/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
+++ b/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
@@ -575,3 +575,30 @@ def test_composites_user_defined_type():
         return subtract(a, emit_one())
 
     assert add_one.input_mappings
+
+
+def test_none_return_annotation_to_nothing():
+    @op
+    def my_op() -> None:
+        ...
+
+    assert my_op.output_defs[0].dagster_type.is_nothing
+
+
+def test_none_param_annotation_to_nothing():
+    @op
+    def my_op(_in1: None, _in2: None, _in3: str):
+        ...
+
+    assert my_op.input_defs[0].dagster_type.is_nothing
+    assert my_op.input_defs[1].dagster_type.is_nothing
+    assert not my_op.input_defs[2].dagster_type.is_nothing
+
+
+def test_empty_annotations_to_not_nothing():
+    @op
+    def my_op(_in1):
+        ...
+
+    assert not my_op.output_defs[0].dagster_type.is_nothing
+    assert not my_op.input_defs[0].dagster_type.is_nothing


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

If a parameter or return value's value will always be None, there's no point saving / loading it with an IO manager.

Not sure whether we should do this on the input side, at least for now - I think it will require a few more changes to input loading.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.