### PR TITLE
Remove redundant k8s launcher event

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -278,13 +278,6 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         self._instance.report_engine_event(
             "Kubernetes run worker job created",
             run,
-            EngineEventData(
-                [
-                    MetadataEntry("Kubernetes Job name", value=job_name),
-                    MetadataEntry("Kubernetes Namespace", value=self.job_namespace),
-                    MetadataEntry("Run ID", value=run.run_id),
-                ]
-            ),
             cls=self.__class__,
         )
 


### PR DESCRIPTION
We added the two logs here for debugging when the k8s api call fails. We might want to use that again, but we can at least remove the duplicate spew of metadata.

![Screen Shot 2022-03-31 at 11 03 09 AM](https://user-images.githubusercontent.com/22018973/161087203-a506d43e-245b-4af6-99c4-5fe74f170c8d.png)
