### PR TITLE
Add /runs method to DbtCloudResourceV2

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -188,7 +188,7 @@ class DbtCloudResourceV2:
         order_by: Optional[str] = "-id",
         offset: int = 0,
         limit: int = 100,
-    ):
+    ) -> List[Dict[str, any]]:
         """
         Returns a list of runs from dbt cloud. This can be optionally filtered to a specific job using the job_definition_id.
         It supports pagination using offset and limit as well and can be configured to load a variety of related information

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -190,26 +190,29 @@ class DbtCloudResourceV2:
         limit: int = 100,
     ) -> List[Dict[str, any]]:
         """
-        Returns a list of runs from dbt cloud. This can be optionally filtered to a specific job using the job_definition_id.
-        It supports pagination using offset and limit as well and can be configured to load a variety of related information
-        about the runs.
+        Returns a list of runs from dbt cloud. This can be optionally filtered to a specific job
+        using the job_definition_id. It supports pagination using offset and limit as well and
+        can be configured to load a variety of related information about the runs.
 
         Args:
-            include_related (Optional[List[str]]): A list of resources to include in the response from DBT Cloud.
-                This is technically a required field according to the API, but it can be passed with an empty list
-                where it will only load the default run information. Valid values are "trigger", "job", "repository",
-                and "environment".
-            job_definition_id (Optional[int]): This method can be optionally filtered to only load runs for a
-                specific job id if it is included here. If omitted it will pull runs for every job.
-            order_by (Optional[str]): An identifier designated by DBT Cloud in which to sort the results before
-                returning them. Useful when combined with offset and limit to load runs for a job. Defaults to
-                "-id" where "-" designates reverse order and "id" is the key to filter on.
-            offset (int): An offset to apply when listing runs. Can be used to paginate results when combined with
-                order_by and limit. Defaults to 0.
+            include_related (Optional[List[str]]): A list of resources to include in the response
+                from DBT Cloud. This is technically a required field according to the API, but it
+                can be passed with an empty list where it will only load the default run
+                information. Valid values are "trigger", "job", "repository", and "environment".
+            job_definition_id (Optional[int]): This method can be optionally filtered to only
+                load runs for a specific job id if it is included here. If omitted it will pull
+                runs for every job.
+            order_by (Optional[str]): An identifier designated by DBT Cloud in which to sort the
+                results before returning them. Useful when combined with offset and limit to load
+                runs for a job. Defaults to "-id" where "-" designates reverse order and "id" is
+                the key to filter on.
+            offset (int): An offset to apply when listing runs. Can be used to paginate results
+                when combined with order_by and limit. Defaults to 0.
             limit (int): Limits the amount of rows returned by the API. Defaults to 100.
 
         Returns:
-            List[Dict[str, Any]]: A list of dictionaries containing the runs and any included related information.
+            List[Dict[str, Any]]: A list of dictionaries containing the runs and any included
+                related information.
         """
         query_params = f"?include_related={','.join(include_related)}"
         query_params += f"&job_definition_id={job_definition_id}" if job_definition_id else ""

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -181,6 +181,41 @@ class DbtCloudResourceV2:
         )
         return resp
 
+    def get_runs(
+        self,
+        include_related: Optional[List[str]] = [],
+        job_definition_id: Optional[int] = None,
+        order_by: Optional[str] = "-id",
+        offset: int = 0,
+        limit: int = 100,
+    ):
+        """
+        Returns a list of runs from dbt cloud. This can be optionally filtered to a specific job using the job_definition_id.
+        It supports pagination using offset and limit as well and can be configured to load a variety of related information
+        about the runs.
+
+        Args:
+            include_related (Optional[List[str]]): A list of resources to include in the response from DBT Cloud.
+                This is technically a required field according to the API, but it can be passed with an empty list
+                where it will only load the default run information. Valid values are "trigger", "job", "repository",
+                and "environment".
+            job_definition_id (Optional[int]): This method can be optionally filtered to only load runs for a
+                specific job id if it is included here. If omitted it will pull runs for every job.
+            order_by (Optional[str]): An identifier designated by DBT Cloud in which to sort the results before
+                returning them. Useful when combined with offset and limit to load runs for a job. Defaults to
+                "-id" where "-" designates reverse order and "id" is the key to filter on.
+            offset (int): An offset to apply when listing runs. Can be used to paginate results when combined with
+                order_by and limit. Defaults to 0.
+            limit (int): Limits the amount of rows returned by the API. Defaults to 100.
+
+        Returns:
+            List[Dict[str, Any]]: A list of dictionaries containing the runs and any included related information.
+        """
+        query_params = f"?include_related={','.join(include_related)}"
+        query_params += f"&job_definition_id={job_definition_id}" if job_definition_id else ""
+        query_params += f"&order_by={order_by}&offset={offset}&limit={limit}"
+        return self.make_request("GET", f"{self._account_id}/runs/{query_params}")
+
     def get_run(self, run_id: int, include_related: Optional[List[str]] = None) -> Dict[str, Any]:
         """
         Gets details about a specific job run.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_resources.py
@@ -14,6 +14,7 @@ from .utils import (
     sample_list_artifacts,
     sample_run_details,
     sample_run_results,
+    sample_runs_details,
 )
 
 
@@ -37,6 +38,19 @@ def test_get_job():
             json=sample_job_details(),
         )
         assert dc_resource.get_job(SAMPLE_JOB_ID) == sample_job_details()["data"]
+
+
+def test_get_runs():
+
+    dc_resource = get_dbt_cloud_resource()
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            rsps.GET,
+            f"{SAMPLE_API_PREFIX}/runs/",
+            json=sample_runs_details(),
+        )
+        assert dc_resource.get_runs() == sample_runs_details()["data"]
 
 
 def test_get_run():

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_resources.py
@@ -40,17 +40,35 @@ def test_get_job():
         assert dc_resource.get_job(SAMPLE_JOB_ID) == sample_job_details()["data"]
 
 
-def test_get_runs():
-
+@pytest.mark.parametrize(
+    "job_id,include_related,query_string",
+    [
+        (
+            345,
+            ["environment"],
+            "?include_related=%5B%27environment%27%5D&order_by=-id&offset=0&limit=100&job_definition_id=345",
+        ),
+        (
+            None,
+            ["environment", "repository"],
+            "?include_related=%5B%27environment%27%2C+%27repository%27%5D&order_by=-id&offset=0&limit=100",
+        ),
+        (None, None, "?include_related=%5B%5D&order_by=-id&offset=0&limit=100"),
+    ],
+)
+def test_get_runs(job_id, include_related, query_string):
     dc_resource = get_dbt_cloud_resource()
 
     with responses.RequestsMock() as rsps:
         rsps.add(
             rsps.GET,
-            f"{SAMPLE_API_PREFIX}/runs/",
+            f"{SAMPLE_API_PREFIX}/runs/{query_string}",
             json=sample_runs_details(),
         )
-        assert dc_resource.get_runs() == sample_runs_details()["data"]
+        assert (
+            dc_resource.get_runs(include_related=include_related, job_id=job_id)
+            == sample_runs_details()["data"]
+        )
 
 
 def test_get_run():

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/utils.py
@@ -53,6 +53,38 @@ def sample_job_details():
     }
 
 
+def sample_runs_details(include_related=None, **kwargs):
+    runs = [sample_run_details(include_related, **kwargs) for i in range(100)]
+    if include_related and "environment" in include_related:
+        for run in runs:
+            run["environment"] = {
+                "dbt_project_subdirectory": None,
+                "project_id": 50000,
+                "id": 47000,
+                "account_id": SAMPLE_ACCOUNT_ID,
+                "connection_id": 56000,
+                "repository_id": 58000,
+                "credentials_id": 52000,
+                "created_by_id": None,
+                "name": "dbt-environment",
+                "use_custom_branch": False,
+                "custom_branch": None,
+                "dbt_version": "0.21.0",
+                "supports_docs": False,
+                "state": 10,
+            }
+            run = deep_merge_dicts(run, kwargs)
+    return {
+        "status": {
+            "code": 200,
+            "is_success": True,
+            "user_message": "Success!",
+            "developer_message": "",
+        },
+        "data": runs,
+    }
+
+
 def sample_run_details(include_related=None, **kwargs):
     base_data = {
         "id": SAMPLE_RUN_ID,


### PR DESCRIPTION
## Summary
I've added a new method, `get_runs`, to the `DbtCloudResourceV2` class that enables it access to `/runs` from the DBT Cloud API. At Lull we use this method to do quick run validation and give status updates different business units to make sure they are aware of data freshness.

We had recently built out our own DBT Cloud package but after finding a managed version, are attempting to migrate over to this. This method is the last thing we use daily that's preventing us from fully transitioning. This is a purely additive change, and I think this could be valuable for other users as well if they have implemented any sort of monitoring on DBT Cloud infrastructure.

## Test Plan
I've added a test that follows a similar format to the other tests included. It's a bit different since it works with a list of runs instead of a singular item. I leveraged the pre-existing `sample_run_details` to generate a default (100) runs. In the `DBTCloudResourceV2` method I designate that `include_related` can also return `repository` information. But we don't currently utilize that so I've omitted it from the test. I used an API template to build out the one for `environment` and was going to copy the format from the Swagger docs, but I noticed that what it claims for `GET environment` doesn't match the result of `include_related['environment']`. Curious to hear someone's thoughts on what to do for that.

Additionally, there wasn't an immediately obvious way to verify that `order_by`, `offset`, and `limit` work as intended from these runs, so they too have been omitted. They exist as server-side filters anyway.

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.