### PR TITLE
Read instigator state / ticks off of selector_id instead of origin id 5/5

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2195,13 +2195,6 @@ type ScheduleTickFailureData {
   error: PythonError!
 }
 
-type ScheduleTickStatsSnapshot {
-  ticksStarted: Int!
-  ticksSucceeded: Int!
-  ticksSkipped: Int!
-  ticksFailed: Int!
-}
-
 type StartScheduleMutation {
   Output: ScheduleMutationResult!
 }

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
@@ -51,13 +51,15 @@ def get_instigator_state_or_error(graphene_info, selector):
     if repository.has_external_sensor(selector.name):
         external_sensor = repository.get_external_sensor(selector.name)
         stored_state = graphene_info.context.instance.get_instigator_state(
-            external_sensor.get_external_origin_id()
+            external_sensor.get_external_origin_id(),
+            external_sensor.selector_id,
         )
         current_state = external_sensor.get_current_instigator_state(stored_state)
     elif repository.has_external_schedule(selector.name):
         external_schedule = repository.get_external_schedule(selector.name)
         stored_state = graphene_info.context.instance.get_instigator_state(
-            external_schedule.get_external_origin_id()
+            external_schedule.get_external_origin_id(),
+            external_schedule.selector_id,
         )
         current_state = external_schedule.get_current_instigator_state(stored_state)
     else:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -104,7 +104,8 @@ def get_schedules_for_pipeline(graphene_info, pipeline_selector):
             continue
 
         schedule_state = graphene_info.context.instance.get_instigator_state(
-            external_schedule.get_external_origin_id()
+            external_schedule.get_external_origin_id(),
+            external_schedule.selector_id,
         )
         results.append(GrapheneSchedule(external_schedule, schedule_state))
 
@@ -128,7 +129,8 @@ def get_schedule_or_error(graphene_info, schedule_selector):
         )
 
     schedule_state = graphene_info.context.instance.get_instigator_state(
-        external_schedule.get_external_origin_id()
+        external_schedule.get_external_origin_id(),
+        external_schedule.selector_id
     )
     return GrapheneSchedule(external_schedule, schedule_state)
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -72,7 +72,7 @@ def get_schedules_or_error(graphene_info, repository_selector):
         state.name: state
         for state in graphene_info.context.instance.all_instigator_state(
             repository_origin_id=repository.get_external_origin_id(),
-            repository_name=repository.name,
+            repository_selector_id=repository_selector.selector_id,
             instigator_type=InstigatorType.SCHEDULE,
         )
     }

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -72,6 +72,7 @@ def get_schedules_or_error(graphene_info, repository_selector):
         state.name: state
         for state in graphene_info.context.instance.all_instigator_state(
             repository_origin_id=repository.get_external_origin_id(),
+            repository_name=repository.name,
             instigator_type=InstigatorType.SCHEDULE,
         )
     }

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -129,8 +129,7 @@ def get_schedule_or_error(graphene_info, schedule_selector):
         )
 
     schedule_state = graphene_info.context.instance.get_instigator_state(
-        external_schedule.get_external_origin_id(),
-        external_schedule.selector_id
+        external_schedule.get_external_origin_id(), external_schedule.selector_id
     )
     return GrapheneSchedule(external_schedule, schedule_state)
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -23,7 +23,7 @@ def get_sensors_or_error(graphene_info, repository_selector):
         state.name: state
         for state in graphene_info.context.instance.all_instigator_state(
             repository_origin_id=repository.get_external_origin_id(),
-            repository_name=repository.name,
+            repository_selector_id=repository_selector.selector_id,
             instigator_type=InstigatorType.SENSOR,
         )
     }

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -52,7 +52,8 @@ def get_sensor_or_error(graphene_info, selector):
         raise UserFacingGraphQLError(GrapheneSensorNotFoundError(selector.sensor_name))
     external_sensor = repository.get_external_sensor(selector.sensor_name)
     sensor_state = graphene_info.context.instance.get_instigator_state(
-        external_sensor.get_external_origin_id()
+        external_sensor.get_external_origin_id(),
+        external_sensor.selector_id,
     )
 
     return GrapheneSensor(external_sensor, sensor_state)
@@ -73,7 +74,8 @@ def start_sensor(graphene_info, sensor_selector):
     external_sensor = repository.get_external_sensor(sensor_selector.sensor_name)
     graphene_info.context.instance.start_sensor(external_sensor)
     sensor_state = graphene_info.context.instance.get_instigator_state(
-        external_sensor.get_external_origin_id()
+        external_sensor.get_external_origin_id(),
+        external_sensor.selector_id,
     )
     return GrapheneSensor(external_sensor, sensor_state)
 
@@ -93,7 +95,10 @@ def stop_sensor(graphene_info, instigator_origin_id):
         for sensor in repository.get_external_sensors()
     }
     instance.stop_sensor(instigator_origin_id, external_sensors.get(instigator_origin_id))
-    state = graphene_info.context.instance.get_instigator_state(instigator_origin_id)
+    state = graphene_info.context.instance.get_instigator_state(
+        instigator_origin_id,
+        external_sensors.get(instigator_origin_id).selector_id,
+    )
     return GrapheneStopSensorMutationResult(state)
 
 
@@ -147,7 +152,8 @@ def get_sensors_for_pipeline(graphene_info, pipeline_selector):
             continue
 
         sensor_state = graphene_info.context.instance.get_instigator_state(
-            external_sensor.get_external_origin_id()
+            external_sensor.get_external_origin_id(),
+            external_sensor.selector_id,
         )
         results.append(GrapheneSensor(external_sensor, sensor_state))
 
@@ -209,7 +215,10 @@ def set_sensor_cursor(graphene_info, selector, cursor):
         raise UserFacingGraphQLError(GrapheneSensorNotFoundError(selector.sensor_name))
     instance = graphene_info.context.instance
     external_sensor = repository.get_external_sensor(selector.sensor_name)
-    stored_state = instance.get_instigator_state(external_sensor.get_external_origin_id())
+    stored_state = instance.get_instigator_state(
+        external_sensor.get_external_origin_id(),
+        external_sensor.selector_id,
+    )
     sensor_state = external_sensor.get_current_instigator_state(stored_state)
     updated_state = sensor_state.with_data(
         SensorInstigatorData(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -23,6 +23,7 @@ def get_sensors_or_error(graphene_info, repository_selector):
         state.name: state
         for state in graphene_info.context.instance.all_instigator_state(
             repository_origin_id=repository.get_external_origin_id(),
+            repository_name=repository.name,
             instigator_type=InstigatorType.SENSOR,
         )
     }

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -189,7 +189,7 @@ def get_sensor_next_tick(graphene_info, sensor_state):
         return None
 
     ticks = graphene_info.context.instance.get_ticks(
-        sensor_state.instigator_origin_id, sensor_state.get_selector_id(), limit=1
+        sensor_state.instigator_origin_id, sensor_state.selector_id, limit=1
     )
     if not ticks:
         return None

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -188,7 +188,9 @@ def get_sensor_next_tick(graphene_info, sensor_state):
     if not sensor_state.is_running:
         return None
 
-    ticks = graphene_info.context.instance.get_ticks(sensor_state.instigator_origin_id, limit=1)
+    ticks = graphene_info.context.instance.get_ticks(
+        sensor_state.instigator_origin_id, sensor_state.get_selector_id(), limit=1
+    )
     if not ticks:
         return None
     latest_tick = ticks[0]

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -157,6 +157,7 @@ class RepositoryScopedBatchLoader:
                     )
             else:
                 for schedule in self._repository.get_external_schedules():
+                    origin_id = schedule.get_external_origin_id()
                     fetched[origin_id] = self._instance.get_ticks(
                         origin_id, schedule.selector_id, limit=limit
                     )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -129,6 +129,7 @@ class RepositoryScopedBatchLoader:
         elif data_type == RepositoryDataType.SCHEDULE_STATES:
             schedule_states = self._instance.all_instigator_state(
                 repository_origin_id=self._repository.get_external_origin_id(),
+                repository_name=self._repository.name,
                 instigator_type=InstigatorType.SCHEDULE,
             )
             for state in schedule_states:
@@ -137,6 +138,7 @@ class RepositoryScopedBatchLoader:
         elif data_type == RepositoryDataType.SENSOR_STATES:
             sensor_states = self._instance.all_instigator_state(
                 repository_origin_id=self._repository.get_external_origin_id(),
+                repository_name=self._repository.name,
                 instigator_type=InstigatorType.SENSOR,
             )
             for state in sensor_states:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -129,7 +129,7 @@ class RepositoryScopedBatchLoader:
         elif data_type == RepositoryDataType.SCHEDULE_STATES:
             schedule_states = self._instance.all_instigator_state(
                 repository_origin_id=self._repository.get_external_origin_id(),
-                repository_name=self._repository.name,
+                repository_selector_id=self._repository.selector_id,
                 instigator_type=InstigatorType.SCHEDULE,
             )
             for state in schedule_states:
@@ -138,7 +138,7 @@ class RepositoryScopedBatchLoader:
         elif data_type == RepositoryDataType.SENSOR_STATES:
             sensor_states = self._instance.all_instigator_state(
                 repository_origin_id=self._repository.get_external_origin_id(),
-                repository_name=self._repository.name,
+                repository_selector_id=self._repository.selector_id,
                 instigator_type=InstigatorType.SENSOR,
             )
             for state in sensor_states:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -145,26 +145,39 @@ class RepositoryScopedBatchLoader:
                 fetched[state.name].append(state)
 
         elif data_type == RepositoryDataType.SCHEDULE_TICKS:
-            origin_ids = [
-                schedule.get_external_origin_id()
-                for schedule in self._repository.get_external_schedules()
-            ]
             if self._instance.supports_batch_tick_queries:
-                fetched = self._instance.get_batch_ticks(origin_ids, limit=limit)
+                selector_ids = [
+                    schedule.selector_id
+                    for schedule in self._repository.get_external_schedules()
+                ]
+                ticks_by_selector = self._instance.get_batch_ticks(selector_ids, limit=limit)
+                for schedule in self._repository.get_external_schedules():
+                    fetched[schedule.get_external_origin_id()] = ticks_by_selector.get(
+                        schedule.selector_id, []
+                    )
             else:
-                for origin_id in origin_ids:
-                    fetched[origin_id] = self._instance.get_ticks(origin_id, limit=limit)
+                for schedule in self._repository.get_external_schedules():
+                    fetched[origin_id] = self._instance.get_ticks(
+                        origin_id, schedule.selector_id, limit=limit
+                    )
 
         elif data_type == RepositoryDataType.SENSOR_TICKS:
-            origin_ids = [
-                sensor.get_external_origin_id()
-                for sensor in self._repository.get_external_sensors()
-            ]
             if self._instance.supports_batch_tick_queries:
-                fetched = self._instance.get_batch_ticks(origin_ids, limit=limit)
+                selector_ids = [
+                    schedule.selector_id
+                    for schedule in self._repository.get_external_sensors()
+                ]
+                ticks_by_selector = self._instance.get_batch_ticks(selector_ids, limit=limit)
+                for sensor in self._repository.get_external_sensors():
+                    fetched[sensor.get_external_origin_id()] = ticks_by_selector.get(
+                        sensor.selector_id, []
+                    )
             else:
-                for origin_id in origin_ids:
-                    fetched[origin_id] = self._instance.get_ticks(origin_id, limit=limit)
+                for sensor in self._repository.get_external_sensors():
+                    origin_id = sensor.get_external_origin_id()
+                    fetched[origin_id] = self._instance.get_ticks(
+                        origin_id, sensor.selector_id, limit=limit
+                    )
 
         else:
             check.failed(f"Unknown data type for {self.__class__.__name__}: {data_type}")

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -147,8 +147,7 @@ class RepositoryScopedBatchLoader:
         elif data_type == RepositoryDataType.SCHEDULE_TICKS:
             if self._instance.supports_batch_tick_queries:
                 selector_ids = [
-                    schedule.selector_id
-                    for schedule in self._repository.get_external_schedules()
+                    schedule.selector_id for schedule in self._repository.get_external_schedules()
                 ]
                 ticks_by_selector = self._instance.get_batch_ticks(selector_ids, limit=limit)
                 for schedule in self._repository.get_external_schedules():
@@ -165,8 +164,7 @@ class RepositoryScopedBatchLoader:
         elif data_type == RepositoryDataType.SENSOR_TICKS:
             if self._instance.supports_batch_tick_queries:
                 selector_ids = [
-                    schedule.selector_id
-                    for schedule in self._repository.get_external_sensors()
+                    schedule.selector_id for schedule in self._repository.get_external_sensors()
                 ]
                 ticks_by_selector = self._instance.get_batch_ticks(selector_ids, limit=limit)
                 for sensor in self._repository.get_external_sensors():

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -362,7 +362,7 @@ class GrapheneInstigationState(graphene.ObjectType):
     def resolve_tick(self, graphene_info, timestamp):
         matches = graphene_info.context.instance.get_ticks(
             self._instigator_state.instigator_origin_id,
-            self._instigator_state.get_selector_id(),
+            self._instigator_state.selector_id,
             before=timestamp + 1,
             after=timestamp - 1,
             limit=1,
@@ -407,7 +407,7 @@ class GrapheneInstigationState(graphene.ObjectType):
             GrapheneInstigationTick(graphene_info, tick)
             for tick in graphene_info.context.instance.get_ticks(
                 self._instigator_state.instigator_origin_id,
-                self._instigator_state.get_selector_id(),
+                self._instigator_state.selector_id,
                 before=before,
                 after=after,
                 limit=limit,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -362,6 +362,7 @@ class GrapheneInstigationState(graphene.ObjectType):
     def resolve_tick(self, graphene_info, timestamp):
         matches = graphene_info.context.instance.get_ticks(
             self._instigator_state.instigator_origin_id,
+            self._instigator_state.get_selector_id(),
             before=timestamp + 1,
             after=timestamp - 1,
             limit=1,
@@ -406,6 +407,7 @@ class GrapheneInstigationState(graphene.ObjectType):
             GrapheneInstigationTick(graphene_info, tick)
             for tick in graphene_info.context.instance.get_ticks(
                 self._instigator_state.instigator_origin_id,
+                self._instigator_state.get_selector_id(),
                 before=before,
                 after=after,
                 limit=limit,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/__init__.py
@@ -3,7 +3,6 @@ import graphene
 from dagster import check
 from dagster.core.host_representation import ExternalSchedule, ScheduleSelector
 from dagster.core.host_representation.selector import RepositorySelector
-from dagster.core.scheduler.instigation import TickStatsSnapshot
 from dagster.core.workspace.permissions import Permissions
 
 from ...implementation.fetch_schedules import start_schedule, stop_schedule
@@ -46,25 +45,6 @@ class GrapheneSchedulerOrError(graphene.Union):
     class Meta:
         types = (GrapheneScheduler, GrapheneSchedulerNotDefinedError, GraphenePythonError)
         name = "SchedulerOrError"
-
-
-class GrapheneScheduleTickStatsSnapshot(graphene.ObjectType):
-    ticks_started = graphene.NonNull(graphene.Int)
-    ticks_succeeded = graphene.NonNull(graphene.Int)
-    ticks_skipped = graphene.NonNull(graphene.Int)
-    ticks_failed = graphene.NonNull(graphene.Int)
-
-    class Meta:
-        name = "ScheduleTickStatsSnapshot"
-
-    def __init__(self, stats):
-        super().__init__(
-            ticks_started=stats.ticks_started,
-            ticks_succeeded=stats.ticks_succeeded,
-            ticks_skipped=stats.ticks_skipped,
-            ticks_failed=stats.ticks_failed,
-        )
-        self._stats = check.inst_param(stats, "stats", TickStatsSnapshot)
 
 
 class GrapheneScheduleStateResult(graphene.ObjectType):
@@ -133,7 +113,6 @@ def types():
         GrapheneScheduleTick,
         GrapheneScheduleTickFailureData,
         GrapheneScheduleTickSpecificData,
-        GrapheneScheduleTickStatsSnapshot,
         GrapheneScheduleTickSuccessData,
         GrapheneStartScheduleMutation,
         GrapheneStopRunningScheduleMutation,

--- a/python_modules/dagster/dagster/cli/schedule.py
+++ b/python_modules/dagster/dagster/cli/schedule.py
@@ -30,7 +30,9 @@ def print_changes(external_repository, instance, print_fn=print, preview=False):
     errors = debug_info.errors
     external_schedules = external_repository.get_external_schedules()
     schedule_states = instance.all_instigator_state(
-        external_repository.get_external_origin_id(), InstigatorType.SCHEDULE
+        external_repository.get_external_origin_id(),
+        external_repository.name,
+        InstigatorType.SCHEDULE,
     )
     external_schedules_dict = {s.get_external_origin_id(): s for s in external_schedules}
     schedule_states_dict = {s.instigator_origin_id: s for s in schedule_states}
@@ -187,7 +189,9 @@ def execute_list_command(running_filter, stopped_filter, name_filter, cli_args, 
             stored_schedules_by_origin_id = {
                 stored_schedule_state.instigator_origin_id: stored_schedule_state
                 for stored_schedule_state in instance.all_instigator_state(
-                    external_repo.get_external_origin_id(), instigator_type=InstigatorType.SCHEDULE
+                    external_repo.get_external_origin_id(),
+                    external_repo.name,
+                    instigator_type=InstigatorType.SCHEDULE,
                 )
             }
 
@@ -394,7 +398,9 @@ def execute_restart_command(schedule_name, all_running_flag, cli_args, print_fn)
 
             if all_running_flag:
                 for schedule_state in instance.all_instigator_state(
-                    external_repo.get_external_origin_id(), InstigatorType.SCHEDULE
+                    external_repo.get_external_origin_id(),
+                    external_repo.name,
+                    InstigatorType.SCHEDULE,
                 ):
                     if schedule_state.status == InstigatorStatus.RUNNING:
                         try:

--- a/python_modules/dagster/dagster/cli/schedule.py
+++ b/python_modules/dagster/dagster/cli/schedule.py
@@ -31,7 +31,7 @@ def print_changes(external_repository, instance, print_fn=print, preview=False):
     external_schedules = external_repository.get_external_schedules()
     schedule_states = instance.all_instigator_state(
         external_repository.get_external_origin_id(),
-        external_repository.name,
+        external_repository.selector_id,
         InstigatorType.SCHEDULE,
     )
     external_schedules_dict = {s.get_external_origin_id(): s for s in external_schedules}
@@ -190,7 +190,7 @@ def execute_list_command(running_filter, stopped_filter, name_filter, cli_args, 
                 stored_schedule_state.instigator_origin_id: stored_schedule_state
                 for stored_schedule_state in instance.all_instigator_state(
                     external_repo.get_external_origin_id(),
-                    external_repo.name,
+                    external_repo.selector_id,
                     instigator_type=InstigatorType.SCHEDULE,
                 )
             }
@@ -399,7 +399,7 @@ def execute_restart_command(schedule_name, all_running_flag, cli_args, print_fn)
             if all_running_flag:
                 for schedule_state in instance.all_instigator_state(
                     external_repo.get_external_origin_id(),
-                    external_repo.name,
+                    external_repo.selector_id,
                     InstigatorType.SCHEDULE,
                 ):
                     if schedule_state.status == InstigatorStatus.RUNNING:

--- a/python_modules/dagster/dagster/cli/schedule.py
+++ b/python_modules/dagster/dagster/cli/schedule.py
@@ -423,7 +423,8 @@ def execute_restart_command(schedule_name, all_running_flag, cli_args, print_fn)
             else:
                 external_schedule = external_repo.get_external_schedule(schedule_name)
                 schedule_state = instance.get_instigator_state(
-                    external_schedule.get_external_origin_id()
+                    external_schedule.get_external_origin_id(),
+                    external_schedule.selector_id,
                 )
                 if schedule_state != None and schedule_state.status != InstigatorStatus.RUNNING:
                     click.UsageError(

--- a/python_modules/dagster/dagster/cli/sensor.py
+++ b/python_modules/dagster/dagster/cli/sensor.py
@@ -361,7 +361,9 @@ def execute_cursor_command(sensor_name, cli_args, print_fn):
             )
             check_repo_and_scheduler(external_repo, instance)
             external_sensor = external_repo.get_external_sensor(sensor_name)
-            job_state = instance.get_instigator_state(external_sensor.get_external_origin_id(), external_sensor.selector_id)
+            job_state = instance.get_instigator_state(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             if not job_state:
                 instance.add_instigator_state(
                     InstigatorState(

--- a/python_modules/dagster/dagster/cli/sensor.py
+++ b/python_modules/dagster/dagster/cli/sensor.py
@@ -33,7 +33,7 @@ def sensor_cli():
 
 def print_changes(external_repository, instance, print_fn=print, preview=False):
     sensor_states = instance.all_instigator_state(
-        external_repository.get_origin_id(), InstigatorType.SENSOR
+        external_repository.get_origin_id(), external_repository.name, InstigatorType.SENSOR
     )
     external_sensors = external_repository.get_external_sensors()
     external_sensors_dict = {s.get_external_origin_id(): s for s in external_sensors}
@@ -147,7 +147,9 @@ def execute_list_command(running_filter, stopped_filter, name_filter, cli_args, 
             stored_sensors_by_origin_id = {
                 stored_sensor_state.instigator_origin_id: stored_sensor_state
                 for stored_sensor_state in instance.all_instigator_state(
-                    external_repo.get_external_origin_id(), instigator_type=InstigatorType.SENSOR
+                    external_repo.get_external_origin_id(),
+                    external_repo.name,
+                    instigator_type=InstigatorType.SENSOR,
                 )
             }
 

--- a/python_modules/dagster/dagster/cli/sensor.py
+++ b/python_modules/dagster/dagster/cli/sensor.py
@@ -361,7 +361,7 @@ def execute_cursor_command(sensor_name, cli_args, print_fn):
             )
             check_repo_and_scheduler(external_repo, instance)
             external_sensor = external_repo.get_external_sensor(sensor_name)
-            job_state = instance.get_instigator_state(external_sensor.get_external_origin_id())
+            job_state = instance.get_instigator_state(external_sensor.get_external_origin_id(), external_sensor.selector_id)
             if not job_state:
                 instance.add_instigator_state(
                     InstigatorState(

--- a/python_modules/dagster/dagster/cli/sensor.py
+++ b/python_modules/dagster/dagster/cli/sensor.py
@@ -33,7 +33,7 @@ def sensor_cli():
 
 def print_changes(external_repository, instance, print_fn=print, preview=False):
     sensor_states = instance.all_instigator_state(
-        external_repository.get_origin_id(), external_repository.name, InstigatorType.SENSOR
+        external_repository.get_origin_id(), external_repository.selector_id, InstigatorType.SENSOR
     )
     external_sensors = external_repository.get_external_sensors()
     external_sensors_dict = {s.get_external_origin_id(): s for s in external_sensors}
@@ -148,7 +148,7 @@ def execute_list_command(running_filter, stopped_filter, name_filter, cli_args, 
                 stored_sensor_state.instigator_origin_id: stored_sensor_state
                 for stored_sensor_state in instance.all_instigator_state(
                     external_repo.get_external_origin_id(),
-                    external_repo.name,
+                    external_repo.selector_id,
                     instigator_type=InstigatorType.SENSOR,
                 )
             }

--- a/python_modules/dagster/dagster/core/host_representation/external.py
+++ b/python_modules/dagster/dagster/core/host_representation/external.py
@@ -28,7 +28,7 @@ from .external_data import (
 from .handle import InstigatorHandle, PartitionSetHandle, PipelineHandle, RepositoryHandle
 from .pipeline_index import PipelineIndex
 from .represented import RepresentedPipeline
-from .selector import InstigatorSelector
+from .selector import InstigatorSelector, RepositorySelector
 
 if TYPE_CHECKING:
     from dagster.core.scheduler.instigation import InstigatorState
@@ -176,6 +176,12 @@ class ExternalRepository:
     @property
     def handle(self):
         return self._handle
+
+    @property
+    def selector_id(self):
+        return create_snapshot_id(
+            RepositorySelector(self._handle.location_name, self._handle.repository_name)
+        )
 
     def get_external_origin(self):
         return self.handle.get_external_origin()

--- a/python_modules/dagster/dagster/core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/core/host_representation/origin.py
@@ -29,6 +29,8 @@ from dagster.serdes import (
 )
 from dagster.serdes.serdes import WhitelistMap, unpack_inner_value
 
+from .selector import RepositorySelector
+
 if TYPE_CHECKING:
     from dagster.core.host_representation.repository_location import (
         GrpcServerRepositoryLocation,
@@ -353,6 +355,11 @@ class ExternalRepositoryOrigin(
 
     def get_id(self) -> str:
         return create_snapshot_id(self)
+
+    def get_selector_id(self) -> str:
+        return create_snapshot_id(
+            RepositorySelector(self.repository_location_origin.location_name, self.repository_name)
+        )
 
     def get_pipeline_origin(self, pipeline_name: str) -> "ExternalPipelineOrigin":
         return ExternalPipelineOrigin(self, pipeline_name)

--- a/python_modules/dagster/dagster/core/host_representation/selector.py
+++ b/python_modules/dagster/dagster/core/host_representation/selector.py
@@ -1,7 +1,7 @@
 from typing import List, NamedTuple, Optional
 
 from dagster import check
-from dagster.serdes import whitelist_for_serdes
+from dagster.serdes import create_snapshot_id, whitelist_for_serdes
 
 
 class PipelineSelector(
@@ -70,6 +70,10 @@ class RepositorySelector(
             "repositoryLocationName": self.location_name,
             "repositoryName": self.repository_name,
         }
+
+    @property
+    def selector_id(self):
+        return create_snapshot_id(self)
 
     @staticmethod
     def from_graphql_input(graphql_data):

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1719,7 +1719,7 @@ records = instance.get_event_records(
             SensorInstigatorData,
         )
 
-        state = self.get_instigator_state(external_sensor.get_external_origin_id())
+        state = self.get_instigator_state(external_sensor.get_external_origin_id(), external_sensor.selector_id)
 
         if external_sensor.get_current_instigator_state(state).is_running:
             raise Exception(
@@ -1748,7 +1748,7 @@ records = instance.get_event_records(
             SensorInstigatorData,
         )
 
-        state = self.get_instigator_state(instigator_origin_id)
+        state = self.get_instigator_state(instigator_origin_id, external_sensor.selector_id)
 
         if not state:
             return self.add_instigator_state(
@@ -1771,8 +1771,8 @@ records = instance.get_event_records(
         )
 
     @traced
-    def get_instigator_state(self, origin_id):
-        return self._schedule_storage.get_instigator_state(origin_id)
+    def get_instigator_state(self, origin_id, selector_id):
+        return self._schedule_storage.get_instigator_state(origin_id, selector_id)
 
     def add_instigator_state(self, state):
         return self._schedule_storage.add_instigator_state(state)

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1766,10 +1766,10 @@ records = instance.get_event_records(
 
     @traced
     def all_instigator_state(
-        self, repository_origin_id=None, repository_name=None, instigator_type=None
+        self, repository_origin_id=None, repository_selector_id=None, instigator_type=None
     ):
         return self._schedule_storage.all_instigator_state(
-            repository_origin_id, repository_name, instigator_type
+            repository_origin_id, repository_selector_id, instigator_type
         )
 
     @traced

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1813,10 +1813,6 @@ records = instance.get_event_records(
     def update_tick(self, tick):
         return self._schedule_storage.update_tick(tick)
 
-    @traced
-    def get_tick_stats(self, origin_id):
-        return self._schedule_storage.get_tick_stats(origin_id)
-
     def purge_ticks(self, origin_id, tick_status, before):
         self._schedule_storage.purge_ticks(origin_id, tick_status, before)
 

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1763,8 +1763,12 @@ records = instance.get_event_records(
             return self.update_instigator_state(state.with_status(InstigatorStatus.STOPPED))
 
     @traced
-    def all_instigator_state(self, repository_origin_id=None, instigator_type=None):
-        return self._schedule_storage.all_instigator_state(repository_origin_id, instigator_type)
+    def all_instigator_state(
+        self, repository_origin_id=None, repository_name=None, instigator_type=None
+    ):
+        return self._schedule_storage.all_instigator_state(
+            repository_origin_id, repository_name, instigator_type
+        )
 
     @traced
     def get_instigator_state(self, origin_id):

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1719,7 +1719,9 @@ records = instance.get_event_records(
             SensorInstigatorData,
         )
 
-        state = self.get_instigator_state(external_sensor.get_external_origin_id(), external_sensor.selector_id)
+        state = self.get_instigator_state(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
 
         if external_sensor.get_current_instigator_state(state).is_running:
             raise Exception(
@@ -1790,25 +1792,25 @@ records = instance.get_event_records(
     @traced
     def get_batch_ticks(
         self,
-        origin_ids: Sequence[str],
+        selector_ids: Sequence[str],
         limit: Optional[int] = None,
         statuses: Optional[Sequence["TickStatus"]] = None,
     ) -> Mapping[str, Iterable["InstigatorTick"]]:
         if not self._schedule_storage:
             return {}
-        return self._schedule_storage.get_batch_ticks(origin_ids, limit, statuses)
+        return self._schedule_storage.get_batch_ticks(selector_ids, limit, statuses)
 
     @traced
-    def get_tick(self, origin_id, timestamp):
+    def get_tick(self, origin_id, selector_id, timestamp):
         matches = self._schedule_storage.get_ticks(
-            origin_id, before=timestamp + 1, after=timestamp - 1, limit=1
+            origin_id, selector_id, before=timestamp + 1, after=timestamp - 1, limit=1
         )
         return matches[0] if len(matches) else None
 
     @traced
-    def get_ticks(self, origin_id, before=None, after=None, limit=None, statuses=None):
+    def get_ticks(self, origin_id, selector_id, before=None, after=None, limit=None, statuses=None):
         return self._schedule_storage.get_ticks(
-            origin_id, before=before, after=after, limit=limit, statuses=statuses
+            origin_id, selector_id, before=before, after=after, limit=limit, statuses=statuses
         )
 
     def create_tick(self, tick_data):

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1817,8 +1817,8 @@ records = instance.get_event_records(
     def update_tick(self, tick):
         return self._schedule_storage.update_tick(tick)
 
-    def purge_ticks(self, origin_id, tick_status, before):
-        self._schedule_storage.purge_ticks(origin_id, tick_status, before)
+    def purge_ticks(self, origin_id, selector_id, tick_status, before):
+        self._schedule_storage.purge_ticks(origin_id, selector_id, tick_status, before)
 
     def wipe_all_schedules(self):
         if self._scheduler:

--- a/python_modules/dagster/dagster/core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/core/scheduler/instigation.py
@@ -592,30 +592,3 @@ def _validate_tick_args(instigator_type, status, run_ids=None, error=None, skip_
             status == TickStatus.SKIPPED,
             "Tick status was not SKIPPED but skip_reason was provided",
         )
-
-
-class TickStatsSnapshot(
-    NamedTuple(
-        "TickStatsSnapshot",
-        [
-            ("ticks_started", int),
-            ("ticks_succeeded", int),
-            ("ticks_skipped", int),
-            ("ticks_failed", int),
-        ],
-    )
-):
-    def __new__(
-        cls, ticks_started: int, ticks_succeeded: int, ticks_skipped: int, ticks_failed: int
-    ):
-        return super(TickStatsSnapshot, cls).__new__(
-            cls,
-            ticks_started=check.int_param(ticks_started, "ticks_started"),
-            ticks_succeeded=check.int_param(ticks_succeeded, "ticks_succeeded"),
-            ticks_skipped=check.int_param(ticks_skipped, "ticks_skipped"),
-            ticks_failed=check.int_param(ticks_failed, "ticks_failed"),
-        )
-
-
-# for internal backcompat
-JobTickStatsSnapshot = TickStatsSnapshot

--- a/python_modules/dagster/dagster/core/scheduler/job.py
+++ b/python_modules/dagster/dagster/core/scheduler/job.py
@@ -1,3 +1,0 @@
-# pylint: disable=unused-import
-
-from .instigation import JobState, JobTick, JobTickData, JobTickStatsSnapshot, JobTickStatus

--- a/python_modules/dagster/dagster/core/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/core/scheduler/scheduler.py
@@ -74,7 +74,9 @@ class Scheduler(abc.ABC):
         check.inst_param(instance, "instance", DagsterInstance)
         check.inst_param(external_schedule, "external_schedule", ExternalSchedule)
 
-        schedule_state = instance.get_instigator_state(external_schedule.get_external_origin_id(), external_schedule.selector_id)
+        schedule_state = instance.get_instigator_state(
+            external_schedule.get_external_origin_id(), external_schedule.selector_id
+        )
         if external_schedule.get_current_instigator_state(schedule_state).is_running:
             raise DagsterSchedulerError(
                 "You have attempted to start schedule {name}, but it is already running".format(
@@ -115,7 +117,9 @@ class Scheduler(abc.ABC):
         check.str_param(schedule_origin_id, "schedule_origin_id")
         check.opt_inst_param(external_schedule, "external_schedule", ExternalSchedule)
 
-        schedule_state = instance.get_instigator_state(schedule_origin_id, external_schedule.selector_id)
+        schedule_state = instance.get_instigator_state(
+            schedule_origin_id, external_schedule.selector_id
+        )
         if (
             external_schedule
             and not external_schedule.get_current_instigator_state(schedule_state).is_running

--- a/python_modules/dagster/dagster/core/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/core/scheduler/scheduler.py
@@ -74,7 +74,7 @@ class Scheduler(abc.ABC):
         check.inst_param(instance, "instance", DagsterInstance)
         check.inst_param(external_schedule, "external_schedule", ExternalSchedule)
 
-        schedule_state = instance.get_instigator_state(external_schedule.get_external_origin_id())
+        schedule_state = instance.get_instigator_state(external_schedule.get_external_origin_id(), external_schedule.selector_id)
         if external_schedule.get_current_instigator_state(schedule_state).is_running:
             raise DagsterSchedulerError(
                 "You have attempted to start schedule {name}, but it is already running".format(
@@ -115,7 +115,7 @@ class Scheduler(abc.ABC):
         check.str_param(schedule_origin_id, "schedule_origin_id")
         check.opt_inst_param(external_schedule, "external_schedule", ExternalSchedule)
 
-        schedule_state = instance.get_instigator_state(schedule_origin_id)
+        schedule_state = instance.get_instigator_state(schedule_origin_id, external_schedule.selector_id)
         if (
             external_schedule
             and not external_schedule.get_current_instigator_state(schedule_state).is_running

--- a/python_modules/dagster/dagster/core/storage/migration/utils.py
+++ b/python_modules/dagster/dagster/core/storage/migration/utils.py
@@ -285,3 +285,18 @@ def create_instigators_table():
 
     if not has_column("job_ticks", "selector_id"):
         op.add_column("job_ticks", db.Column("selector_id", db.String(255)))
+
+
+def create_tick_selector_index():
+    if not has_table("job_ticks"):
+        # not a schedule storage db
+        return
+
+    indexes = [x.get("name") for x in get_inspector().get_indexes("job_ticks")]
+    if "idx_tick_selector_timestamp" in indexes:
+        # already migrated
+        return
+
+    op.create_index(
+        "idx_tick_selector_timestamp", "job_ticks", ["selector_id", "timestamp"], unique=False
+    )

--- a/python_modules/dagster/dagster/core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/base.py
@@ -24,15 +24,17 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
 
         Args:
             repository_origin_id (Optional[str]): The ExternalRepository target id to scope results to
+            repository_name (Optional[str]): The repository name to scope results to
             instigator_type (Optional[InstigatorType]): The InstigatorType to scope results to
         """
 
     @abc.abstractmethod
-    def get_instigator_state(self, origin_id: str) -> InstigatorState:
+    def get_instigator_state(self, origin_id: str, selector_id: str) -> InstigatorState:
         """Return the instigator state for the given id
 
         Args:
             origin_id (str): The unique instigator identifier
+            selector_id (str): The logical instigator identifier
         """
 
     @abc.abstractmethod
@@ -57,6 +59,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
 
         Args:
             origin_id (str): The id of the instigator target to delete
+            selector_id (str): The logical instigator identifier
         """
 
     @property
@@ -65,7 +68,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
 
     def get_batch_ticks(
         self,
-        origin_ids: Sequence[str],
+        selector_ids: Sequence[str],
         limit: Optional[int] = None,
         statuses: Optional[Sequence[TickStatus]] = None,
     ) -> Mapping[str, Iterable[InstigatorTick]]:
@@ -75,6 +78,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
     def get_ticks(
         self,
         origin_id: str,
+        selector_id: str,
         before: Optional[float] = None,
         after: Optional[float] = None,
         limit: Optional[int] = None,
@@ -84,6 +88,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
 
         Args:
             origin_id (str): The id of the instigator target
+            selector_id (str): The logical instigator identifier
         """
 
     @abc.abstractmethod
@@ -103,11 +108,12 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
         """
 
     @abc.abstractmethod
-    def purge_ticks(self, origin_id: str, tick_status: TickStatus, before: float):
+    def purge_ticks(self, origin_id: str, selector_id: str, tick_status: TickStatus, before: float):
         """Wipe ticks for an instigator for a certain status and timestamp.
 
         Args:
             origin_id (str): The id of the instigator target to delete
+            selector_id (str): The logical instigator identifier
             tick_status (TickStatus): The tick status to wipe
             before (datetime): All ticks before this datetime will get purged
         """

--- a/python_modules/dagster/dagster/core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/base.py
@@ -17,14 +17,14 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
     def all_instigator_state(
         self,
         repository_origin_id: Optional[str] = None,
-        repository_name: Optional[str] = None,
+        repository_selector_id: Optional[str] = None,
         instigator_type: Optional[InstigatorType] = None,
     ) -> Iterable[InstigatorState]:
         """Return all InstigationStates present in storage
 
         Args:
             repository_origin_id (Optional[str]): The ExternalRepository target id to scope results to
-            repository_name (Optional[str]): The repository name to scope results to
+            repository_selector_id (Optional[str]): The repository selector id to scope results to
             instigator_type (Optional[InstigatorType]): The InstigatorType to scope results to
         """
 

--- a/python_modules/dagster/dagster/core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/base.py
@@ -112,14 +112,6 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
         """
 
     @abc.abstractmethod
-    def get_tick_stats(self, origin_id: str):
-        """Get tick stats for a given instigator.
-
-        Args:
-            origin_id (str): The id of the instigator target
-        """
-
-    @abc.abstractmethod
     def upgrade(self):
         """Perform any needed migrations"""
 

--- a/python_modules/dagster/dagster/core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/base.py
@@ -17,6 +17,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
     def all_instigator_state(
         self,
         repository_origin_id: Optional[str] = None,
+        repository_name: Optional[str] = None,
         instigator_type: Optional[InstigatorType] = None,
     ) -> Iterable[InstigatorState]:
         """Return all InstigationStates present in storage

--- a/python_modules/dagster/dagster/core/storage/schedules/schema.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/schema.py
@@ -63,3 +63,4 @@ db.Index(
     mysql_length=32,
 )
 db.Index("idx_job_tick_timestamp", JobTickTable.c.job_origin_id, JobTickTable.c.timestamp)
+db.Index("idx_tick_selector_timestamp", JobTickTable.c.selector_id, JobTickTable.c.timestamp)

--- a/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
@@ -41,13 +41,15 @@ class SqlScheduleStorage(ScheduleStorage):
     def _deserialize_rows(self, rows):
         return list(map(lambda r: deserialize_json_to_dagster_namedtuple(r[0]), rows))
 
-    def all_instigator_state(self, repository_origin_id=None, repository_name=None, instigator_type=None):
+    def all_instigator_state(
+        self, repository_origin_id=None, repository_name=None, instigator_type=None
+    ):
         check.opt_inst_param(instigator_type, "instigator_type", InstigatorType)
 
         if self.has_instigators_table():
-            query = db.select([InstigatorTable.c.instigator_body, InstigatorTable.c.selector_id]).select_from(
-                InstigatorTable
-            )
+            query = db.select(
+                [InstigatorTable.c.instigator_body, InstigatorTable.c.selector_id]
+            ).select_from(InstigatorTable)
             if repository_name:
                 query = query.where(InstigatorTable.c.repository_name == repository_name)
             if instigator_type:
@@ -303,7 +305,7 @@ class SqlScheduleStorage(ScheduleStorage):
                     db.and_(
                         JobTickTable.c.selector_id == None,
                         JobTickTable.c.job_origin_id == origin_id,
-                    )
+                    ),
                 )
             )
         else:
@@ -385,7 +387,7 @@ class SqlScheduleStorage(ScheduleStorage):
                     db.and_(
                         JobTickTable.c.selector_id == None,
                         JobTickTable.c.job_origin_id == origin_id,
-                    )
+                    ),
                 )
             )
         else:
@@ -393,7 +395,6 @@ class SqlScheduleStorage(ScheduleStorage):
 
         with self.connect() as conn:
             conn.execute(query)
-
 
     def wipe(self):
         """Clears the schedule storage."""

--- a/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
@@ -42,14 +42,16 @@ class SqlScheduleStorage(ScheduleStorage):
         return list(map(lambda r: deserialize_json_to_dagster_namedtuple(r[0]), rows))
 
     def all_instigator_state(
-        self, repository_origin_id=None, repository_name=None, instigator_type=None
+        self, repository_origin_id=None, repository_selector_id=None, instigator_type=None
     ):
         check.opt_inst_param(instigator_type, "instigator_type", InstigatorType)
 
         if self.has_instigators_table() and self.has_built_index(SCHEDULE_JOBS_SELECTOR_ID):
             query = db.select([InstigatorsTable.c.instigator_body]).select_from(InstigatorsTable)
-            if repository_name:
-                query = query.where(InstigatorsTable.c.repository_name == repository_name)
+            if repository_selector_id:
+                query = query.where(
+                    InstigatorsTable.c.repository_selector_id == repository_selector_id
+                )
             if instigator_type:
                 query = query.where(InstigatorsTable.c.instigator_type == instigator_type.value)
         else:

--- a/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
@@ -47,11 +47,11 @@ class SqlScheduleStorage(ScheduleStorage):
         check.opt_inst_param(instigator_type, "instigator_type", InstigatorType)
 
         if self.has_instigators_table() and self.has_built_index(SCHEDULE_JOBS_SELECTOR_ID):
-            query = db.select([InstigatorTable.c.instigator_body]).select_from(InstigatorTable)
+            query = db.select([InstigatorsTable.c.instigator_body]).select_from(InstigatorsTable)
             if repository_name:
-                query = query.where(InstigatorTable.c.repository_name == repository_name)
+                query = query.where(InstigatorsTable.c.repository_name == repository_name)
             if instigator_type:
-                query = query.where(InstigatorTable.c.instigator_type == instigator_type.value)
+                query = query.where(InstigatorsTable.c.instigator_type == instigator_type.value)
         else:
             query = db.select([JobTable.c.job_body]).select_from(JobTable)
             if repository_origin_id:
@@ -68,9 +68,9 @@ class SqlScheduleStorage(ScheduleStorage):
 
         if self.has_instigators_table() and self.has_built_index(SCHEDULE_JOBS_SELECTOR_ID):
             query = (
-                db.select([InstigatorTable.c.instigator_body])
-                .select_from(InstigatorTable)
-                .where(InstigatorTable.c.selector_id == selector_id)
+                db.select([InstigatorsTable.c.instigator_body])
+                .select_from(InstigatorsTable)
+                .where(InstigatorsTable.c.selector_id == selector_id)
             )
         else:
             query = (

--- a/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
@@ -47,15 +47,13 @@ class SqlScheduleStorage(ScheduleStorage):
         check.opt_inst_param(instigator_type, "instigator_type", InstigatorType)
 
         if self.has_instigators_table() and self.has_built_index(SCHEDULE_JOBS_SELECTOR_ID):
-            query = db.select(
-                [InstigatorTable.c.instigator_body, InstigatorTable.c.selector_id]
-            ).select_from(InstigatorTable)
+            query = db.select([InstigatorTable.c.instigator_body]).select_from(InstigatorTable)
             if repository_name:
                 query = query.where(InstigatorTable.c.repository_name == repository_name)
             if instigator_type:
                 query = query.where(InstigatorTable.c.instigator_type == instigator_type.value)
         else:
-            query = db.select([JobTable.c.job_body, JobTable.c.selector_id]).select_from(JobTable)
+            query = db.select([JobTable.c.job_body]).select_from(JobTable)
             if repository_origin_id:
                 query = query.where(JobTable.c.repository_origin_id == repository_origin_id)
             if instigator_type:

--- a/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
@@ -9,12 +9,7 @@ import sqlalchemy as db
 from dagster import check
 from dagster.core.definitions.run_request import InstigatorType
 from dagster.core.errors import DagsterInvariantViolationError
-from dagster.core.scheduler.instigation import (
-    InstigatorState,
-    InstigatorTick,
-    TickData,
-    TickStatus,
-)
+from dagster.core.scheduler.instigation import InstigatorState, InstigatorTick, TickData, TickStatus
 from dagster.serdes import deserialize_json_to_dagster_namedtuple, serialize_dagster_namedtuple
 from dagster.utils import utc_datetime_from_timestamp
 
@@ -60,9 +55,7 @@ class SqlScheduleStorage(ScheduleStorage):
             if instigator_type:
                 query = query.where(InstigatorTable.c.instigator_type == instigator_type.value)
         else:
-            query = db.select([JobTable.c.job_body, JobTable.c.selector_id]).select_from(
-                JobTable
-            )
+            query = db.select([JobTable.c.job_body, JobTable.c.selector_id]).select_from(JobTable)
             if repository_origin_id:
                 query = query.where(JobTable.c.repository_origin_id == repository_origin_id)
             if instigator_type:
@@ -77,7 +70,7 @@ class SqlScheduleStorage(ScheduleStorage):
 
         if self.has_instigators_table() and self.has_built_index(SCHEDULE_JOBS_SELECTOR_ID):
             query = (
-                db.select([InstiagorTable.c.instigator_body])
+                db.select([InstigatorTable.c.instigator_body])
                 .select_from(InstigatorTable)
                 .where(InstigatorTable.c.selector_id == selector_id)
             )

--- a/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
@@ -144,7 +144,7 @@ class SqlScheduleStorage(ScheduleStorage):
 
     def update_instigator_state(self, state):
         check.inst_param(state, "state", InstigatorState)
-        if not self.get_instigator_state(state.instigator_origin_id, state.get_selector_id()):
+        if not self.get_instigator_state(state.instigator_origin_id, state.selector_id):
             raise DagsterInvariantViolationError(
                 "InstigatorState {id} is not present in storage".format(
                     id=state.instigator_origin_id

--- a/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
@@ -148,7 +148,7 @@ class SqlScheduleStorage(ScheduleStorage):
 
     def update_instigator_state(self, state):
         check.inst_param(state, "state", InstigatorState)
-        if not self.get_instigator_state(state.instigator_origin_id):
+        if not self.get_instigator_state(state.instigator_origin_id, state.get_selector_id()):
             raise DagsterInvariantViolationError(
                 "InstigatorState {id} is not present in storage".format(
                     id=state.instigator_origin_id
@@ -176,7 +176,7 @@ class SqlScheduleStorage(ScheduleStorage):
         check.str_param(origin_id, "origin_id")
         check.str_param(selector_id, "selector_id")
 
-        if not self.get_instigator_state(origin_id):
+        if not self.get_instigator_state(origin_id, selector_id):
             raise DagsterInvariantViolationError(
                 "InstigatorState {id} is not present in storage".format(id=origin_id)
             )

--- a/python_modules/dagster/dagster/core/storage/schedules/sqlite/alembic/versions/721d858e1dda_add_tick_selector_index.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sqlite/alembic/versions/721d858e1dda_add_tick_selector_index.py
@@ -1,0 +1,22 @@
+"""add tick selector index
+
+Revision ID: 721d858e1dda
+Revises: c892b3fe0a9f
+Create Date: 2022-03-25 10:28:29.065161
+
+"""
+from dagster.core.storage.migration.utils import create_tick_selector_index
+
+# revision identifiers, used by Alembic.
+revision = "721d858e1dda"
+down_revision = "c892b3fe0a9f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    create_tick_selector_index()
+
+
+def downgrade():
+    pass

--- a/python_modules/dagster/dagster/core/storage/schedules/sqlite/sqlite_schedule_storage.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sqlite/sqlite_schedule_storage.py
@@ -82,7 +82,7 @@ class SqliteScheduleStorage(SqlScheduleStorage, ConfigurableClass):
 
     @property
     def supports_batch_queries(self):
-        return get_sqlite_version() > MINIMUM_SQLITE_BATCH_VERSION
+        return get_sqlite_version() > MINIMUM_SQLITE_BATCH_VERSION and super().supports_batch_queries
 
     def upgrade(self):
         alembic_config = get_alembic_config(__file__)

--- a/python_modules/dagster/dagster/core/storage/schedules/sqlite/sqlite_schedule_storage.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sqlite/sqlite_schedule_storage.py
@@ -82,7 +82,9 @@ class SqliteScheduleStorage(SqlScheduleStorage, ConfigurableClass):
 
     @property
     def supports_batch_queries(self):
-        return get_sqlite_version() > MINIMUM_SQLITE_BATCH_VERSION and super().supports_batch_queries
+        return (
+            get_sqlite_version() > MINIMUM_SQLITE_BATCH_VERSION and super().supports_batch_queries
+        )
 
     def upgrade(self):
         alembic_config = get_alembic_config(__file__)

--- a/python_modules/dagster/dagster/daemon/sensor.py
+++ b/python_modules/dagster/dagster/daemon/sensor.py
@@ -142,6 +142,7 @@ class SensorLaunchContext:
 
         self._instance.purge_ticks(
             self._state.instigator_origin_id,
+            selector_id=self._state.get_selector_id(),
             tick_status=TickStatus.SKIPPED,
             before=pendulum.now("UTC").subtract(days=7).timestamp(),  #  keep the last 7 days
         )

--- a/python_modules/dagster/dagster/daemon/sensor.py
+++ b/python_modules/dagster/dagster/daemon/sensor.py
@@ -142,7 +142,7 @@ class SensorLaunchContext:
 
         self._instance.purge_ticks(
             self._state.instigator_origin_id,
-            selector_id=self._state.get_selector_id(),
+            selector_id=self._state.selector_id,
             tick_status=TickStatus.SKIPPED,
             before=pendulum.now("UTC").subtract(days=7).timestamp(),  #  keep the last 7 days
         )

--- a/python_modules/dagster/dagster/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/scheduler/scheduler.py
@@ -260,7 +260,7 @@ def launch_scheduled_runs_for_schedule(
     end_datetime_utc = check.inst_param(end_datetime_utc, "end_datetime_utc", datetime.datetime)
 
     instigator_origin_id = external_schedule.get_external_origin_id()
-    ticks = instance.get_ticks(instigator_origin_id, limit=1)
+    ticks = instance.get_ticks(instigator_origin_id, external_schedule.selector_id, limit=1)
     latest_tick = ticks[0] if ticks else None
 
     instigator_data = cast(ScheduleInstigatorData, schedule_state.instigator_data)

--- a/python_modules/dagster/dagster/utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/utils/test/schedule_storage.py
@@ -124,7 +124,7 @@ class TestScheduleStorage:
 
         state = self.build_schedule("my_schedule", "* * * * *")
         storage.add_instigator_state(state)
-        schedule = storage.get_instigator_state(state.instigator_origin_id)
+        schedule = storage.get_instigator_state(state.instigator_origin_id, state.get_selector_id())
 
         assert schedule.instigator_name == "my_schedule"
         assert schedule.instigator_data.start_timestamp == None
@@ -132,8 +132,9 @@ class TestScheduleStorage:
     def test_get_schedule_state_not_found(self, storage):
         assert storage
 
-        storage.add_instigator_state(self.build_schedule("my_schedule", "* * * * *"))
-        schedule = storage.get_instigator_state("fake_id")
+        state = self.build_schedule("my_schedule", "* * * * *")
+        storage.add_instigator_state(state)
+        schedule = storage.get_instigator_state("fake_id", "fake_selector")
 
         assert schedule is None
 
@@ -355,7 +356,7 @@ class TestScheduleStorage:
 
         state = self.build_sensor("my_sensor")
         storage.add_instigator_state(state)
-        state = storage.get_instigator_state(state.instigator_origin_id)
+        state = storage.get_instigator_state(state.instigator_origin_id, state.get_selector_id())
 
         assert state.instigator_name == "my_sensor"
 
@@ -363,7 +364,7 @@ class TestScheduleStorage:
         assert storage
 
         storage.add_instigator_state(self.build_sensor("my_sensor"))
-        state = storage.get_instigator_state("fake_id")
+        state = storage.get_instigator_state("fake_id", "fake_selector")
         assert state is None
 
     def test_update_state(self, storage):

--- a/python_modules/dagster/dagster/utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/utils/test/schedule_storage.py
@@ -87,6 +87,7 @@ class TestScheduleStorage:
         storage.add_instigator_state(schedule)
         schedules = storage.all_instigator_state(
             self.fake_repo_target().get_id(),
+            self.fake_repo_target().repository_name,
             InstigatorType.SCHEDULE,
         )
         assert len(schedules) == 1
@@ -108,7 +109,9 @@ class TestScheduleStorage:
         storage.add_instigator_state(schedule_3)
 
         schedules = storage.all_instigator_state(
-            self.fake_repo_target().get_id(), InstigatorType.SCHEDULE
+            self.fake_repo_target().get_id(),
+            self.fake_repo_target().repository_name,
+            InstigatorType.SCHEDULE,
         )
         assert len(schedules) == 3
 
@@ -151,7 +154,9 @@ class TestScheduleStorage:
         storage.update_instigator_state(new_schedule)
 
         schedules = storage.all_instigator_state(
-            self.fake_repo_target().get_id(), InstigatorType.SCHEDULE
+            self.fake_repo_target().get_id(),
+            self.fake_repo_target().repository_name,
+            InstigatorType.SCHEDULE,
         )
         assert len(schedules) == 1
 
@@ -166,7 +171,9 @@ class TestScheduleStorage:
         storage.update_instigator_state(stopped_schedule)
 
         schedules = storage.all_instigator_state(
-            self.fake_repo_target().get_id(), InstigatorType.SCHEDULE
+            self.fake_repo_target().get_id(),
+            self.fake_repo_target().repository_name,
+            InstigatorType.SCHEDULE,
         )
         assert len(schedules) == 1
 
@@ -194,7 +201,9 @@ class TestScheduleStorage:
         storage.delete_instigator_state(schedule.instigator_origin_id, schedule.selector_id)
 
         schedules = storage.all_instigator_state(
-            self.fake_repo_target().get_id(), InstigatorType.SCHEDULE
+            self.fake_repo_target().get_id(),
+            self.fake_repo_target().repository_name,
+            InstigatorType.SCHEDULE,
         )
         assert len(schedules) == 0
 
@@ -313,7 +322,9 @@ class TestScheduleStorage:
         assert storage
         sensor_state = self.build_sensor("my_sensor")
         storage.add_instigator_state(sensor_state)
-        states = storage.all_instigator_state(self.fake_repo_target().get_id())
+        states = storage.all_instigator_state(
+            self.fake_repo_target().get_id(), self.fake_repo_target().repository_name
+        )
         assert len(states) == 1
 
         state = states[0]
@@ -330,7 +341,9 @@ class TestScheduleStorage:
         storage.add_instigator_state(state_2)
         storage.add_instigator_state(state_3)
 
-        states = storage.all_instigator_state(self.fake_repo_target().get_id())
+        states = storage.all_instigator_state(
+            self.fake_repo_target().get_id(), self.fake_repo_target().repository_name
+        )
         assert len(states) == 3
 
         assert any(s.instigator_name == "my_sensor" for s in states)
@@ -362,7 +375,9 @@ class TestScheduleStorage:
         new_state = state.with_status(InstigatorStatus.RUNNING)
         storage.update_instigator_state(new_state)
 
-        states = storage.all_instigator_state(self.fake_repo_target().get_id())
+        states = storage.all_instigator_state(
+            self.fake_repo_target().get_id(), self.fake_repo_target().repository_name
+        )
         assert len(states) == 1
 
         state = states[0]
@@ -372,7 +387,9 @@ class TestScheduleStorage:
         stopped_state = state.with_status(InstigatorStatus.STOPPED)
         storage.update_instigator_state(stopped_state)
 
-        states = storage.all_instigator_state(self.fake_repo_target().get_id())
+        states = storage.all_instigator_state(
+            self.fake_repo_target().get_id(), self.fake_repo_target().repository_name
+        )
         assert len(states) == 1
 
         state = states[0]
@@ -397,7 +414,9 @@ class TestScheduleStorage:
         storage.add_instigator_state(state)
         storage.delete_instigator_state(state.instigator_origin_id, state.selector_id)
 
-        states = storage.all_instigator_state(self.fake_repo_target().get_id())
+        states = storage.all_instigator_state(
+            self.fake_repo_target().get_id(), self.fake_repo_target().repository_name
+        )
         assert len(states) == 0
 
     def test_delete_state_not_found(self, storage):

--- a/python_modules/dagster/dagster/utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/utils/test/schedule_storage.py
@@ -309,38 +309,6 @@ class TestScheduleStorage:
         assert tick.run_ids == []
         assert tick.error == SerializableErrorInfo(message="Error", stack=[], cls_name="TestError")
 
-    def test_get_tick_stats(self, storage):
-        assert storage
-
-        current_time = time.time()
-
-        error = SerializableErrorInfo(message="Error", stack=[], cls_name="TestError")
-
-        # Create ticks
-        for x in range(2):
-            storage.create_tick(self.build_schedule_tick(current_time))
-
-        for x in range(3):
-            storage.create_tick(
-                self.build_schedule_tick(current_time, TickStatus.SUCCESS, run_id=str(x)),
-            )
-
-        for x in range(4):
-            storage.create_tick(
-                self.build_schedule_tick(current_time, TickStatus.SKIPPED),
-            )
-
-        for x in range(5):
-            storage.create_tick(
-                self.build_schedule_tick(current_time, TickStatus.FAILURE, error=error),
-            )
-
-        stats = storage.get_tick_stats("my_schedule")
-        assert stats.ticks_started == 2
-        assert stats.ticks_succeeded == 3
-        assert stats.ticks_skipped == 4
-        assert stats.ticks_failed == 5
-
     def test_basic_storage(self, storage):
         assert storage
         sensor_state = self.build_sensor("my_sensor")

--- a/python_modules/dagster/dagster/utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/utils/test/schedule_storage.py
@@ -87,7 +87,7 @@ class TestScheduleStorage:
         storage.add_instigator_state(schedule)
         schedules = storage.all_instigator_state(
             self.fake_repo_target().get_id(),
-            self.fake_repo_target().repository_name,
+            self.fake_repo_target().get_selector_id(),
             InstigatorType.SCHEDULE,
         )
         assert len(schedules) == 1
@@ -110,7 +110,7 @@ class TestScheduleStorage:
 
         schedules = storage.all_instigator_state(
             self.fake_repo_target().get_id(),
-            self.fake_repo_target().repository_name,
+            self.fake_repo_target().get_selector_id(),
             InstigatorType.SCHEDULE,
         )
         assert len(schedules) == 3
@@ -156,7 +156,7 @@ class TestScheduleStorage:
 
         schedules = storage.all_instigator_state(
             self.fake_repo_target().get_id(),
-            self.fake_repo_target().repository_name,
+            self.fake_repo_target().get_selector_id(),
             InstigatorType.SCHEDULE,
         )
         assert len(schedules) == 1
@@ -173,7 +173,7 @@ class TestScheduleStorage:
 
         schedules = storage.all_instigator_state(
             self.fake_repo_target().get_id(),
-            self.fake_repo_target().repository_name,
+            self.fake_repo_target().get_selector_id(),
             InstigatorType.SCHEDULE,
         )
         assert len(schedules) == 1
@@ -203,7 +203,7 @@ class TestScheduleStorage:
 
         schedules = storage.all_instigator_state(
             self.fake_repo_target().get_id(),
-            self.fake_repo_target().repository_name,
+            self.fake_repo_target().get_selector_id(),
             InstigatorType.SCHEDULE,
         )
         assert len(schedules) == 0
@@ -324,7 +324,7 @@ class TestScheduleStorage:
         sensor_state = self.build_sensor("my_sensor")
         storage.add_instigator_state(sensor_state)
         states = storage.all_instigator_state(
-            self.fake_repo_target().get_id(), self.fake_repo_target().repository_name
+            self.fake_repo_target().get_id(), self.fake_repo_target().get_selector_id()
         )
         assert len(states) == 1
 
@@ -343,7 +343,7 @@ class TestScheduleStorage:
         storage.add_instigator_state(state_3)
 
         states = storage.all_instigator_state(
-            self.fake_repo_target().get_id(), self.fake_repo_target().repository_name
+            self.fake_repo_target().get_id(), self.fake_repo_target().get_selector_id()
         )
         assert len(states) == 3
 
@@ -377,7 +377,7 @@ class TestScheduleStorage:
         storage.update_instigator_state(new_state)
 
         states = storage.all_instigator_state(
-            self.fake_repo_target().get_id(), self.fake_repo_target().repository_name
+            self.fake_repo_target().get_id(), self.fake_repo_target().get_selector_id()
         )
         assert len(states) == 1
 
@@ -389,7 +389,7 @@ class TestScheduleStorage:
         storage.update_instigator_state(stopped_state)
 
         states = storage.all_instigator_state(
-            self.fake_repo_target().get_id(), self.fake_repo_target().repository_name
+            self.fake_repo_target().get_id(), self.fake_repo_target().get_selector_id()
         )
         assert len(states) == 1
 
@@ -416,7 +416,7 @@ class TestScheduleStorage:
         storage.delete_instigator_state(state.instigator_origin_id, state.selector_id)
 
         states = storage.all_instigator_state(
-            self.fake_repo_target().get_id(), self.fake_repo_target().repository_name
+            self.fake_repo_target().get_id(), self.fake_repo_target().get_selector_id()
         )
         assert len(states) == 0
 

--- a/python_modules/dagster/dagster/utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/utils/test/schedule_storage.py
@@ -575,7 +575,7 @@ class TestScheduleStorage:
         latest_tick = ticks[0]
         assert latest_tick.tick_id == one_minute_tick.tick_id
 
-        storage.purge_ticks("my_sensor", TickStatus.SKIPPED, now.subtract(minutes=2).timestamp())
+        storage.purge_ticks("my_sensor", "my_sensor", TickStatus.SKIPPED, now.subtract(minutes=2).timestamp())
 
         ticks = storage.get_ticks("my_sensor")
         assert len(ticks) == 2

--- a/python_modules/dagster/dagster/utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/utils/test/schedule_storage.py
@@ -246,7 +246,7 @@ class TestScheduleStorage:
 
         current_time = time.time()
         tick = storage.create_tick(self.build_schedule_tick(current_time))
-        ticks = storage.get_ticks("my_schedule")
+        ticks = storage.get_ticks("my_schedule", "my_schedule")
         assert len(ticks) == 1
         tick = ticks[0]
         assert tick.instigator_name == "my_schedule"
@@ -266,7 +266,7 @@ class TestScheduleStorage:
 
         storage.update_tick(updated_tick)
 
-        ticks = storage.get_ticks("my_schedule")
+        ticks = storage.get_ticks("my_schedule", "my_schedule")
         assert len(ticks) == 1
         tick = ticks[0]
         assert tick.instigator_name == "my_schedule"
@@ -286,7 +286,7 @@ class TestScheduleStorage:
 
         storage.update_tick(updated_tick)
 
-        ticks = storage.get_ticks("my_schedule")
+        ticks = storage.get_ticks("my_schedule", "my_schedule")
         assert len(ticks) == 1
         tick = ticks[0]
         assert tick.instigator_name == "my_schedule"
@@ -309,7 +309,7 @@ class TestScheduleStorage:
 
         storage.update_tick(updated_tick)
 
-        ticks = storage.get_ticks("my_schedule")
+        ticks = storage.get_ticks("my_schedule", "my_schedule")
         assert len(ticks) == 1
         tick = ticks[0]
         assert tick.tick_id > 0
@@ -461,7 +461,7 @@ class TestScheduleStorage:
         tick = storage.create_tick(self.build_sensor_tick(current_time))
         tick_id = tick.tick_id
 
-        ticks = storage.get_ticks("my_sensor")
+        ticks = storage.get_ticks("my_sensor", "my_sensor")
         assert len(ticks) == 1
         tick = ticks[0]
         assert tick.tick_id == tick_id
@@ -481,14 +481,16 @@ class TestScheduleStorage:
         storage.create_tick(self.build_sensor_tick(five_days_ago, TickStatus.SKIPPED))
         storage.create_tick(self.build_sensor_tick(four_days_ago, TickStatus.SKIPPED))
         storage.create_tick(self.build_sensor_tick(one_day_ago, TickStatus.SKIPPED))
-        ticks = storage.get_ticks("my_sensor")
+        ticks = storage.get_ticks("my_sensor", "my_sensor")
         assert len(ticks) == 3
 
-        ticks = storage.get_ticks("my_sensor", after=five_days_ago + 1)
+        ticks = storage.get_ticks("my_sensor", "my_sensor", after=five_days_ago + 1)
         assert len(ticks) == 2
-        ticks = storage.get_ticks("my_sensor", before=one_day_ago - 1)
+        ticks = storage.get_ticks("my_sensor", "my_sensor", before=one_day_ago - 1)
         assert len(ticks) == 2
-        ticks = storage.get_ticks("my_sensor", after=five_days_ago + 1, before=one_day_ago - 1)
+        ticks = storage.get_ticks(
+            "my_sensor", "my_sensor", after=five_days_ago + 1, before=one_day_ago - 1
+        )
         assert len(ticks) == 1
 
     def test_update_sensor_tick_to_success(self, storage):
@@ -502,7 +504,7 @@ class TestScheduleStorage:
 
         storage.update_tick(updated_tick)
 
-        ticks = storage.get_ticks("my_sensor")
+        ticks = storage.get_ticks("my_sensor", "my_sensor")
         assert len(ticks) == 1
         tick = ticks[0]
         assert tick.tick_id > 0
@@ -523,7 +525,7 @@ class TestScheduleStorage:
 
         storage.update_tick(updated_tick)
 
-        ticks = storage.get_ticks("my_sensor")
+        ticks = storage.get_ticks("my_sensor", "my_sensor")
         assert len(ticks) == 1
         tick = ticks[0]
         assert tick.tick_id > 0
@@ -545,7 +547,7 @@ class TestScheduleStorage:
 
         storage.update_tick(updated_tick)
 
-        ticks = storage.get_ticks("my_sensor")
+        ticks = storage.get_ticks("my_sensor", "my_sensor")
         assert len(ticks) == 1
         tick = ticks[0]
         assert tick.tick_id > 0
@@ -569,15 +571,17 @@ class TestScheduleStorage:
         one_minute_tick = storage.create_tick(
             self.build_sensor_tick(one_minute_ago, TickStatus.SKIPPED)
         )
-        ticks = storage.get_ticks("my_sensor")
+        ticks = storage.get_ticks("my_sensor", "my_sensor")
         assert len(ticks) == 3
 
         latest_tick = ticks[0]
         assert latest_tick.tick_id == one_minute_tick.tick_id
 
-        storage.purge_ticks("my_sensor", "my_sensor", TickStatus.SKIPPED, now.subtract(minutes=2).timestamp())
+        storage.purge_ticks(
+            "my_sensor", "my_sensor", TickStatus.SKIPPED, now.subtract(minutes=2).timestamp()
+        )
 
-        ticks = storage.get_ticks("my_sensor")
+        ticks = storage.get_ticks("my_sensor", "my_sensor")
         assert len(ticks) == 2
 
     def test_ticks_filtered(self, storage):
@@ -592,24 +596,26 @@ class TestScheduleStorage:
             )
         )
 
-        ticks = storage.get_ticks("my_sensor")
+        ticks = storage.get_ticks("my_sensor", "my_sensor")
         assert len(ticks) == 4
 
-        started = storage.get_ticks("my_sensor", statuses=[TickStatus.STARTED])
+        started = storage.get_ticks("my_sensor", "my_sensor", statuses=[TickStatus.STARTED])
         assert len(started) == 1
 
-        successes = storage.get_ticks("my_sensor", statuses=[TickStatus.SUCCESS])
+        successes = storage.get_ticks("my_sensor", "my_sensor", statuses=[TickStatus.SUCCESS])
         assert len(successes) == 1
 
-        skips = storage.get_ticks("my_sensor", statuses=[TickStatus.SKIPPED])
+        skips = storage.get_ticks("my_sensor", "my_sensor", statuses=[TickStatus.SKIPPED])
         assert len(skips) == 1
 
-        failures = storage.get_ticks("my_sensor", statuses=[TickStatus.FAILURE])
+        failures = storage.get_ticks("my_sensor", "my_sensor", statuses=[TickStatus.FAILURE])
         assert len(failures) == 1
 
         # everything but skips
         non_skips = storage.get_ticks(
-            "my_sensor", statuses=[TickStatus.STARTED, TickStatus.SUCCESS, TickStatus.FAILURE]
+            "my_sensor",
+            "my_sensor",
+            statuses=[TickStatus.STARTED, TickStatus.SUCCESS, TickStatus.FAILURE],
         )
         assert len(non_skips) == 3
 

--- a/python_modules/dagster/dagster/utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/utils/test/schedule_storage.py
@@ -124,7 +124,7 @@ class TestScheduleStorage:
 
         state = self.build_schedule("my_schedule", "* * * * *")
         storage.add_instigator_state(state)
-        schedule = storage.get_instigator_state(state.instigator_origin_id, state.get_selector_id())
+        schedule = storage.get_instigator_state(state.instigator_origin_id, state.selector_id)
 
         assert schedule.instigator_name == "my_schedule"
         assert schedule.instigator_data.start_timestamp == None
@@ -356,7 +356,7 @@ class TestScheduleStorage:
 
         state = self.build_sensor("my_sensor")
         storage.add_instigator_state(state)
-        state = storage.get_instigator_state(state.instigator_origin_id, state.get_selector_id())
+        state = storage.get_instigator_state(state.instigator_origin_id, state.selector_id)
 
         assert state.instigator_name == "my_sensor"
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
@@ -79,7 +79,9 @@ def test_failure_before_run_created(crash_location, crash_signal, capfd):
             )
             launch_process.start()
             launch_process.join(timeout=60)
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 1
             assert ticks[0].status == TickStatus.SKIPPED
             capfd.readouterr()
@@ -97,7 +99,9 @@ def test_failure_before_run_created(crash_location, crash_signal, capfd):
 
             capfd.readouterr()
 
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 2
             assert ticks[0].status == TickStatus.STARTED
             assert not int(ticks[0].timestamp) % 2  # skip condition for simple_sensor
@@ -124,7 +128,9 @@ def test_failure_before_run_created(crash_location, crash_signal, capfd):
 2019-02-27 18:01:03 -0600 - dagster.daemon.SensorDaemon - INFO - Completed launch of run {run.run_id} for simple_sensor"""
             )
 
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 3
             assert ticks[0].status == TickStatus.SUCCESS
 
@@ -165,7 +171,9 @@ def test_failure_after_run_created_before_run_launched(crash_location, crash_sig
 
             assert launch_process.exitcode != 0
 
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
 
             assert len(ticks) == 1
             assert ticks[0].status == TickStatus.STARTED
@@ -199,7 +207,9 @@ def test_failure_after_run_created_before_run_launched(crash_location, crash_sig
                 in captured.out
             )
 
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 2
             assert ticks[0].status == TickStatus.SUCCESS
 
@@ -248,7 +258,9 @@ def test_failure_after_run_launched(crash_location, crash_signal, capfd):
 
             assert launch_process.exitcode != 0
 
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
 
             assert len(ticks) == 1
             assert ticks[0].status == TickStatus.STARTED
@@ -279,6 +291,8 @@ def test_failure_after_run_launched(crash_location, crash_signal, capfd):
                 in captured.out
             )
 
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 2
             assert ticks[0].status == TickStatus.SKIPPED

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -555,7 +555,7 @@ def test_bad_load_sensor_repository(capfd):
 
             assert instance.get_runs_count() == 0
             ticks = instance.get_ticks(
-                invalid_state.instigator_origin_id, invalid_state.get_selector_id()
+                invalid_state.instigator_origin_id, invalid_state.selector_id
             )
             assert len(ticks) == 0
 
@@ -563,7 +563,7 @@ def test_bad_load_sensor_repository(capfd):
 
             assert instance.get_runs_count() == 0
             ticks = instance.get_ticks(
-                invalid_state.instigator_origin_id, invalid_state.get_selector_id()
+                invalid_state.instigator_origin_id, invalid_state.selector_id
             )
             assert len(ticks) == 0
 
@@ -603,7 +603,7 @@ def test_bad_load_sensor(capfd):
 
             assert instance.get_runs_count() == 0
             ticks = instance.get_ticks(
-                invalid_state.instigator_origin_id, invalid_state.get_selector_id()
+                invalid_state.instigator_origin_id, invalid_state.selector_id
             )
             assert len(ticks) == 0
 
@@ -611,7 +611,7 @@ def test_bad_load_sensor(capfd):
 
             assert instance.get_runs_count() == 0
             ticks = instance.get_ticks(
-                invalid_state.instigator_origin_id, invalid_state.get_selector_id()
+                invalid_state.instigator_origin_id, invalid_state.selector_id
             )
             assert len(ticks) == 0
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -625,7 +625,7 @@ def test_error_sensor(capfd):
                 )
             )
 
-            state = instance.get_instigator_state(external_sensor.get_external_origin_id())
+            state = instance.get_instigator_state(external_sensor.get_external_origin_id(), external_sensor.selector_id)
             assert state.instigator_data is None
 
             assert instance.get_runs_count() == 0
@@ -652,7 +652,7 @@ def test_error_sensor(capfd):
             ) in captured.out
 
             # Tick updated the sensor's last tick time, but not its cursor (due to the failure)
-            state = instance.get_instigator_state(external_sensor.get_external_origin_id())
+            state = instance.get_instigator_state(external_sensor.get_external_origin_id(), external_sensor.selector_id)
             assert state.instigator_data.cursor is None
             assert state.instigator_data.last_tick_timestamp == freeze_datetime.timestamp()
 
@@ -2078,7 +2078,7 @@ def test_status_in_code_sensor():
                 assert instance.get_runs_count() == 0
 
                 assert len(instance.all_instigator_state()) == 1
-                instigator_state = instance.get_instigator_state(always_running_origin.get_id())
+                instigator_state = instance.get_instigator_state(always_running_origin.get_id(), running_sensor.selector_id)
                 assert instigator_state.status == InstigatorStatus.AUTOMATICALLY_RUNNING
 
                 ticks = instance.get_ticks(running_sensor.get_external_origin_id())

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -464,13 +464,17 @@ def test_simple_sensor(capfd):
                 )
             )
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
 
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -493,7 +497,9 @@ def test_simple_sensor(capfd):
             assert instance.get_runs_count() == 1
             run = instance.get_runs()[0]
             validate_run_started(run)
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 2
 
             expected_datetime = create_pendulum_time(
@@ -541,20 +547,24 @@ def test_bad_load_sensor_repository(capfd):
                 valid_origin.instigator_name,
             )
 
-            instance.add_instigator_state(
+            invalid_state = instance.add_instigator_state(
                 InstigatorState(
                     invalid_repo_origin, InstigatorType.SENSOR, InstigatorStatus.RUNNING
                 )
             )
 
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(invalid_repo_origin.get_id())
+            ticks = instance.get_ticks(
+                invalid_state.instigator_origin_id, invalid_state.get_selector_id()
+            )
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
 
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(invalid_repo_origin.get_id())
+            ticks = instance.get_ticks(
+                invalid_state.instigator_origin_id, invalid_state.get_selector_id()
+            )
             assert len(ticks) == 0
 
             captured = capfd.readouterr()
@@ -585,20 +595,24 @@ def test_bad_load_sensor(capfd):
                 "invalid_sensor",
             )
 
-            instance.add_instigator_state(
+            invalid_state = instance.add_instigator_state(
                 InstigatorState(
                     invalid_repo_origin, InstigatorType.SENSOR, InstigatorStatus.RUNNING
                 )
             )
 
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(invalid_repo_origin.get_id())
+            ticks = instance.get_ticks(
+                invalid_state.instigator_origin_id, invalid_state.get_selector_id()
+            )
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
 
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(invalid_repo_origin.get_id())
+            ticks = instance.get_ticks(
+                invalid_state.instigator_origin_id, invalid_state.get_selector_id()
+            )
             assert len(ticks) == 0
 
             captured = capfd.readouterr()
@@ -625,17 +639,23 @@ def test_error_sensor(capfd):
                 )
             )
 
-            state = instance.get_instigator_state(external_sensor.get_external_origin_id(), external_sensor.selector_id)
+            state = instance.get_instigator_state(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert state.instigator_data is None
 
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
 
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -652,7 +672,9 @@ def test_error_sensor(capfd):
             ) in captured.out
 
             # Tick updated the sensor's last tick time, but not its cursor (due to the failure)
-            state = instance.get_instigator_state(external_sensor.get_external_origin_id(), external_sensor.selector_id)
+            state = instance.get_instigator_state(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert state.instigator_data.cursor is None
             assert state.instigator_data.last_tick_timestamp == freeze_datetime.timestamp()
 
@@ -684,12 +706,16 @@ def test_wrong_config_sensor(capfd):
                 )
             )
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 1
 
             validate_tick(
@@ -710,7 +736,9 @@ def test_wrong_config_sensor(capfd):
 
             evaluate_sensors(instance, workspace)
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 2
 
             validate_tick(
@@ -750,14 +778,18 @@ def test_launch_failure(capfd):
                 )
             )
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
 
             assert instance.get_runs_count() == 1
             run = instance.get_runs()[0]
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -804,7 +836,9 @@ def test_launch_once(capfd):
                 )
             )
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
@@ -812,7 +846,9 @@ def test_launch_once(capfd):
 
             assert instance.get_runs_count() == 1
             run = instance.get_runs()[0]
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -827,7 +863,9 @@ def test_launch_once(capfd):
         with pendulum.test(freeze_datetime):
             evaluate_sensors(instance, workspace)
             assert instance.get_runs_count() == 1
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -859,7 +897,9 @@ def test_launch_once(capfd):
         freeze_datetime = freeze_datetime.add(seconds=30)
         with pendulum.test(freeze_datetime):
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
 
             assert len(ticks) == 3
             validate_tick(
@@ -918,7 +958,9 @@ def test_launch_once_unbatched(capfd):
                 )
             )
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
@@ -926,7 +968,9 @@ def test_launch_once_unbatched(capfd):
 
             assert instance.get_runs_count() == 1
             run = instance.get_runs()[0]
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -941,7 +985,9 @@ def test_launch_once_unbatched(capfd):
         with pendulum.test(freeze_datetime):
             evaluate_sensors(instance, workspace)
             assert instance.get_runs_count() == 1
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -969,7 +1015,9 @@ def test_launch_once_unbatched(capfd):
         freeze_datetime = freeze_datetime.add(seconds=30)
         with pendulum.test(freeze_datetime):
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
 
             assert len(ticks) == 3
             validate_tick(
@@ -998,11 +1046,15 @@ def test_custom_interval_sensor():
                     InstigatorStatus.RUNNING,
                 )
             )
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 1
             validate_tick(ticks[0], external_sensor, freeze_datetime, TickStatus.SKIPPED)
 
@@ -1010,7 +1062,9 @@ def test_custom_interval_sensor():
 
         with pendulum.test(freeze_datetime):
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             # no additional tick created after 30 seconds
             assert len(ticks) == 1
 
@@ -1018,7 +1072,9 @@ def test_custom_interval_sensor():
 
         with pendulum.test(freeze_datetime):
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 2
 
             expected_datetime = create_pendulum_time(year=2019, month=2, day=28, hour=0, minute=1)
@@ -1058,13 +1114,17 @@ def test_custom_interval_sensor_with_offset(monkeypatch):
 
             # create a tick
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 1
 
             # calling for another iteration should not generate another tick because time has not
             # advanced
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 1
 
             # call the sensor_iteration_loop, which should loop, and call the monkeypatched sleep
@@ -1079,7 +1139,9 @@ def test_custom_interval_sensor_with_offset(monkeypatch):
             )
 
             assert pendulum.now() == freeze_datetime.add(seconds=65)
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 2
             assert sum(sleeps) == 65
 
@@ -1107,14 +1169,14 @@ def test_sensor_start_stop():
             instance.start_sensor(external_sensor)
 
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(external_origin_id)
+            ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
 
             assert instance.get_runs_count() == 1
             run = instance.get_runs()[0]
-            ticks = instance.get_ticks(external_origin_id)
+            ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1130,7 +1192,7 @@ def test_sensor_start_stop():
             evaluate_sensors(instance, workspace)
             # no new ticks, no new runs, we are below the 30 second min interval
             assert instance.get_runs_count() == 1
-            ticks = instance.get_ticks(external_origin_id)
+            ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
             assert len(ticks) == 1
 
             # stop / start
@@ -1140,7 +1202,7 @@ def test_sensor_start_stop():
             evaluate_sensors(instance, workspace)
             # no new ticks, no new runs, we are below the 30 second min interval
             assert instance.get_runs_count() == 1
-            ticks = instance.get_ticks(external_origin_id)
+            ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
             assert len(ticks) == 1
 
             freeze_datetime = freeze_datetime.add(seconds=16)
@@ -1149,7 +1211,7 @@ def test_sensor_start_stop():
             evaluate_sensors(instance, workspace)
             # should have new tick, new run, we are after the 30 second min interval
             assert instance.get_runs_count() == 2
-            ticks = instance.get_ticks(external_origin_id)
+            ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
             assert len(ticks) == 2
 
 
@@ -1167,7 +1229,9 @@ def test_large_sensor():
             external_sensor = external_repo.get_external_sensor("large_sensor")
             instance.start_sensor(external_sensor)
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                external_sensor.get_external_origin_id(), external_sensor.selector_id
+            )
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1194,7 +1258,9 @@ def test_cursor_sensor():
             instance.start_sensor(run_sensor)
             evaluate_sensors(instance, workspace)
 
-            skip_ticks = instance.get_ticks(skip_sensor.get_external_origin_id())
+            skip_ticks = instance.get_ticks(
+                skip_sensor.get_external_origin_id(), skip_sensor.selector_id
+            )
             assert len(skip_ticks) == 1
             validate_tick(
                 skip_ticks[0],
@@ -1204,7 +1270,9 @@ def test_cursor_sensor():
             )
             assert skip_ticks[0].cursor == "1"
 
-            run_ticks = instance.get_ticks(run_sensor.get_external_origin_id())
+            run_ticks = instance.get_ticks(
+                run_sensor.get_external_origin_id(), run_sensor.selector_id
+            )
             assert len(run_ticks) == 1
             validate_tick(
                 run_ticks[0],
@@ -1218,7 +1286,9 @@ def test_cursor_sensor():
         with pendulum.test(freeze_datetime):
             evaluate_sensors(instance, workspace)
 
-            skip_ticks = instance.get_ticks(skip_sensor.get_external_origin_id())
+            skip_ticks = instance.get_ticks(
+                skip_sensor.get_external_origin_id(), skip_sensor.selector_id
+            )
             assert len(skip_ticks) == 2
             validate_tick(
                 skip_ticks[0],
@@ -1228,7 +1298,9 @@ def test_cursor_sensor():
             )
             assert skip_ticks[0].cursor == "2"
 
-            run_ticks = instance.get_ticks(run_sensor.get_external_origin_id())
+            run_ticks = instance.get_ticks(
+                run_sensor.get_external_origin_id(), run_sensor.selector_id
+            )
             assert len(run_ticks) == 2
             validate_tick(
                 run_ticks[0],
@@ -1255,7 +1327,7 @@ def test_asset_sensor():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(foo_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(foo_sensor.get_external_origin_id(), foo_sensor.selector_id)
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1272,7 +1344,7 @@ def test_asset_sensor():
 
             # should fire the asset sensor
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_ticks(foo_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(foo_sensor.get_external_origin_id(), foo_sensor.selector_id)
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1302,7 +1374,7 @@ def test_asset_job_sensor():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(job_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(job_sensor.get_external_origin_id(), job_sensor.selector_id)
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1319,7 +1391,7 @@ def test_asset_job_sensor():
 
             # should fire the asset sensor
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_ticks(job_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(job_sensor.get_external_origin_id(), job_sensor.selector_id)
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1353,7 +1425,7 @@ def test_asset_sensor_not_triggered_on_observation():
             # observation should not fire the asset sensor
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(foo_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(foo_sensor.get_external_origin_id(), foo_sensor.selector_id)
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1370,7 +1442,7 @@ def test_asset_sensor_not_triggered_on_observation():
 
             # materialization should fire the asset sensor
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_ticks(foo_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(foo_sensor.get_external_origin_id(), foo_sensor.selector_id)
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1397,7 +1469,9 @@ def test_pipeline_failure_sensor():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+            )
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1427,7 +1501,9 @@ def test_pipeline_failure_sensor():
             # should fire the failure sensor
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+            )
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1452,7 +1528,9 @@ def test_run_failure_sensor_that_fails():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+            )
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1482,7 +1560,9 @@ def test_run_failure_sensor_that_fails():
             # should fire the failure sensor and fail
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+            )
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1498,7 +1578,9 @@ def test_run_failure_sensor_that_fails():
             # should fire the failure sensor and fail
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+            )
             assert len(ticks) == 3
             validate_tick(
                 ticks[0],
@@ -1521,7 +1603,9 @@ def test_run_failure_sensor_filtered():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+            )
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1551,7 +1635,9 @@ def test_run_failure_sensor_filtered():
             # should not fire the failure sensor (filtered to failure job)
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+            )
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1582,7 +1668,9 @@ def test_run_failure_sensor_filtered():
             # should not fire the failure sensor (filtered to failure job)
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+            )
             assert len(ticks) == 3
             validate_tick(
                 ticks[0],
@@ -1608,7 +1696,9 @@ def test_run_status_sensor(capfd):
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(success_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                success_sensor.get_external_origin_id(), success_sensor.selector_id
+            )
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1638,7 +1728,9 @@ def test_run_status_sensor(capfd):
             # should not fire the success sensor, should fire the started sensro
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(success_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                success_sensor.get_external_origin_id(), success_sensor.selector_id
+            )
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1647,7 +1739,9 @@ def test_run_status_sensor(capfd):
                 TickStatus.SKIPPED,
             )
 
-            ticks = instance.get_ticks(started_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                started_sensor.get_external_origin_id(), started_sensor.selector_id
+            )
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1676,7 +1770,9 @@ def test_run_status_sensor(capfd):
             # should fire the success sensor and the started sensor
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(success_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                success_sensor.get_external_origin_id(), success_sensor.selector_id
+            )
             assert len(ticks) == 3
             validate_tick(
                 ticks[0],
@@ -1685,7 +1781,9 @@ def test_run_status_sensor(capfd):
                 TickStatus.SUCCESS,
             )
 
-            ticks = instance.get_ticks(started_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(
+                started_sensor.get_external_origin_id(), started_sensor.selector_id
+            )
             assert len(ticks) == 3
             validate_tick(
                 ticks[0],
@@ -1756,7 +1854,9 @@ def test_run_status_sensor_interleave(storage_config_fn):
 
                 evaluate_sensors(instance, workspace)
 
-                ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
+                ticks = instance.get_ticks(
+                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                )
                 assert len(ticks) == 1
                 validate_tick(
                     ticks[0],
@@ -1799,7 +1899,9 @@ def test_run_status_sensor_interleave(storage_config_fn):
                 # should fire for run 2
                 evaluate_sensors(instance, workspace)
 
-                ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
+                ticks = instance.get_ticks(
+                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                )
                 assert len(ticks) == 2
                 validate_tick(
                     ticks[0],
@@ -1823,7 +1925,9 @@ def test_run_status_sensor_interleave(storage_config_fn):
                 # should fire for run 1
                 evaluate_sensors(instance, workspace)
 
-                ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
+                ticks = instance.get_ticks(
+                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                )
                 assert len(ticks) == 3
                 validate_tick(
                     ticks[0],
@@ -1852,7 +1956,9 @@ def test_pipeline_failure_sensor_empty_run_records(storage_config_fn):
 
                 evaluate_sensors(instance, workspace)
 
-                ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
+                ticks = instance.get_ticks(
+                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                )
                 assert len(ticks) == 1
                 validate_tick(
                     ticks[0],
@@ -1891,7 +1997,9 @@ def test_pipeline_failure_sensor_empty_run_records(storage_config_fn):
                 # shouldn't fire the failure sensor due to the mismatch
                 evaluate_sensors(instance, workspace)
 
-                ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
+                ticks = instance.get_ticks(
+                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                )
                 assert len(ticks) == 2
                 validate_tick(
                     ticks[0],
@@ -1917,7 +2025,7 @@ def test_multi_job_sensor():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(job_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(job_sensor.get_external_origin_id(), job_sensor.selector_id)
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1936,7 +2044,7 @@ def test_multi_job_sensor():
 
             # should fire the asset sensor
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_ticks(job_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(job_sensor.get_external_origin_id(), job_sensor.selector_id)
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1967,7 +2075,7 @@ def test_bad_run_request_untargeted():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(job_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(job_sensor.get_external_origin_id(), job_sensor.selector_id)
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1999,7 +2107,7 @@ def test_bad_run_request_mismatch():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(job_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(job_sensor.get_external_origin_id(), job_sensor.selector_id)
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -2030,7 +2138,7 @@ def test_bad_run_request_unspecified():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_ticks(job_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(job_sensor.get_external_origin_id(), job_sensor.selector_id)
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -2068,8 +2176,22 @@ def test_status_in_code_sensor():
                 never_running_origin = not_running_sensor.get_external_origin()
 
                 assert instance.get_runs_count() == 0
-                assert len(instance.get_ticks(always_running_origin.get_id())) == 0
-                assert len(instance.get_ticks(never_running_origin.get_id())) == 0
+                assert (
+                    len(
+                        instance.get_ticks(
+                            always_running_origin.get_id(), running_sensor.selector_id
+                        )
+                    )
+                    == 0
+                )
+                assert (
+                    len(
+                        instance.get_ticks(
+                            never_running_origin.get_id(), not_running_sensor.selector_id
+                        )
+                    )
+                    == 0
+                )
 
                 assert len(instance.all_instigator_state()) == 0
 
@@ -2078,10 +2200,14 @@ def test_status_in_code_sensor():
                 assert instance.get_runs_count() == 0
 
                 assert len(instance.all_instigator_state()) == 1
-                instigator_state = instance.get_instigator_state(always_running_origin.get_id(), running_sensor.selector_id)
+                instigator_state = instance.get_instigator_state(
+                    always_running_origin.get_id(), running_sensor.selector_id
+                )
                 assert instigator_state.status == InstigatorStatus.AUTOMATICALLY_RUNNING
 
-                ticks = instance.get_ticks(running_sensor.get_external_origin_id())
+                ticks = instance.get_ticks(
+                    running_sensor.get_external_origin_id(), running_sensor.selector_id
+                )
                 assert len(ticks) == 1
                 validate_tick(
                     ticks[0],
@@ -2090,7 +2216,14 @@ def test_status_in_code_sensor():
                     TickStatus.SKIPPED,
                 )
 
-                assert len(instance.get_ticks(never_running_origin.get_id())) == 0
+                assert (
+                    len(
+                        instance.get_ticks(
+                            never_running_origin.get_id(), not_running_sensor.selector_id
+                        )
+                    )
+                    == 0
+                )
 
             freeze_datetime = freeze_datetime.add(seconds=30)
             with pendulum.test(freeze_datetime):
@@ -2099,7 +2232,9 @@ def test_status_in_code_sensor():
                 assert instance.get_runs_count() == 1
                 run = instance.get_runs()[0]
                 validate_run_started(run)
-                ticks = instance.get_ticks(running_sensor.get_external_origin_id())
+                ticks = instance.get_ticks(
+                    running_sensor.get_external_origin_id(), running_sensor.selector_id
+                )
                 assert len(ticks) == 2
 
                 expected_datetime = create_pendulum_time(
@@ -2113,4 +2248,11 @@ def test_status_in_code_sensor():
                     [run.run_id],
                 )
 
-                assert len(instance.get_ticks(never_running_origin.get_id())) == 0
+                assert (
+                    len(
+                        instance.get_ticks(
+                            never_running_origin.get_id(), not_running_sensor.selector_id
+                        )
+                    )
+                    == 0
+                )

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -715,7 +715,7 @@ def test_schedule_namedtuple_job_instigator_backcompat():
             for state in states:
                 assert state.instigator_type
                 assert state.instigator_data
-                ticks = instance.get_ticks(state.instigator_origin_id)
+                ticks = instance.get_ticks(state.instigator_origin_id, state.get_selector_id())
                 check.is_list(ticks, of_type=InstigatorTick)
                 for tick in ticks:
                     assert tick.tick_data

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -715,7 +715,7 @@ def test_schedule_namedtuple_job_instigator_backcompat():
             for state in states:
                 assert state.instigator_type
                 assert state.instigator_data
-                ticks = instance.get_ticks(state.instigator_origin_id, state.get_selector_id())
+                ticks = instance.get_ticks(state.instigator_origin_id, state.selector_id)
                 check.is_list(ticks, of_type=InstigatorTick)
                 for tick in ticks:
                     assert tick.tick_data

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
@@ -76,7 +76,9 @@ def test_failure_recovery_before_run_created(instance, external_repo, crash_loca
 
         assert scheduler_process.exitcode != 0
 
-        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(
+            external_schedule.get_external_origin_id(), external_schedule.selector_id
+        )
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.STARTED
 
@@ -100,7 +102,9 @@ def test_failure_recovery_before_run_created(instance, external_repo, crash_loca
             partition_time=create_pendulum_time(2019, 2, 26),
         )
 
-        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(
+            external_schedule.get_external_origin_id(), external_schedule.selector_id
+        )
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -136,7 +140,9 @@ def test_failure_recovery_after_run_created(instance, external_repo, crash_locat
 
         assert scheduler_process.exitcode != 0
 
-        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(
+            external_schedule.get_external_origin_id(), external_schedule.selector_id
+        )
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.STARTED
 
@@ -184,7 +190,9 @@ def test_failure_recovery_after_run_created(instance, external_repo, crash_locat
             instance.get_runs()[0], initial_datetime, create_pendulum_time(2019, 2, 26)
         )
 
-        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(
+            external_schedule.get_external_origin_id(), external_schedule.selector_id
+        )
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -228,7 +236,9 @@ def test_failure_recovery_after_tick_success(instance, external_repo, crash_loca
             instance.get_runs()[0], initial_datetime, create_pendulum_time(2019, 2, 26)
         )
 
-        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(
+            external_schedule.get_external_origin_id(), external_schedule.selector_id
+        )
         assert len(ticks) == 1
 
         if crash_signal == get_terminate_signal():
@@ -260,7 +270,9 @@ def test_failure_recovery_after_tick_success(instance, external_repo, crash_loca
             instance.get_runs()[0], initial_datetime, create_pendulum_time(2019, 2, 26)
         )
 
-        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(
+            external_schedule.get_external_origin_id(), external_schedule.selector_id
+        )
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -298,7 +310,9 @@ def test_failure_recovery_between_multi_runs(instance, external_repo, crash_loca
         assert instance.get_runs_count() == 1
         validate_run_exists(instance.get_runs()[0], initial_datetime)
 
-        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(
+            external_schedule.get_external_origin_id(), external_schedule.selector_id
+        )
         assert len(ticks) == 1
 
     frozen_datetime = frozen_datetime.add(minutes=1)
@@ -312,7 +326,9 @@ def test_failure_recovery_between_multi_runs(instance, external_repo, crash_loca
         assert scheduler_process.exitcode == 0
         assert instance.get_runs_count() == 2
         validate_run_exists(instance.get_runs()[0], initial_datetime)
-        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(
+            external_schedule.get_external_origin_id(), external_schedule.selector_id
+        )
         assert len(ticks) == 1
         validate_tick(
             ticks[0],

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -1869,7 +1869,7 @@ def test_status_in_code_schedule(instance):
 
             assert len(instance.all_instigator_state()) == 1
 
-            instigator_state = instance.get_instigator_state(always_running_origin.get_id())
+            instigator_state = instance.get_instigator_state(always_running_origin.get_id(), running_schedule.selector_id)
 
             assert instigator_state.status == InstigatorStatus.AUTOMATICALLY_RUNNING
             assert (
@@ -2015,7 +2015,7 @@ def test_change_default_status(instance):
             assert len(ticks) == 0
 
             # AUTOMATICALLY_RUNNING row has been removed from the database
-            instigator_state = instance.get_instigator_state(never_running_origin.get_id())
+            instigator_state = instance.get_instigator_state(never_running_origin.get_id(), not_running_schedule.selector_id)
             assert not instigator_state
 
             # schedule can still be manually started

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -1295,7 +1295,7 @@ def test_bad_load_schedule(instance, workspace, external_repo, caplog):
 
         assert instance.get_runs_count() == 0
 
-        ticks = instance.get_ticks(invalid_repo_origin.get_id(), schedule_state.get_selector_id())
+        ticks = instance.get_ticks(invalid_repo_origin.get_id(), schedule_state.selector_id)
 
         assert len(ticks) == 0
 
@@ -1328,7 +1328,7 @@ def test_error_load_repository_location(instance):
 
             assert instance.get_runs_count() == 0
 
-            ticks = instance.get_ticks(fake_origin.get_id(), schedule_state.get_selector_id())
+            ticks = instance.get_ticks(fake_origin.get_id(), schedule_state.selector_id)
 
             assert len(ticks) == 0
 
@@ -1336,7 +1336,7 @@ def test_error_load_repository_location(instance):
         with pendulum.test(initial_datetime):
             list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(fake_origin.get_id(), schedule_state.get_selector_id())
+            ticks = instance.get_ticks(fake_origin.get_id(), schedule_state.selector_id)
             assert len(ticks) == 0
 
 
@@ -1375,7 +1375,7 @@ def test_load_repository_location_not_in_workspace(instance, workspace, external
 
         assert instance.get_runs_count() == 0
 
-        ticks = instance.get_ticks(invalid_repo_origin.get_id(), schedule_state.get_selector_id())
+        ticks = instance.get_ticks(invalid_repo_origin.get_id(), schedule_state.selector_id)
 
         assert len(ticks) == 0
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -529,7 +529,7 @@ def test_simple_schedule(instance, workspace, external_repo):
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
         # launch_scheduled_runs does nothing before the first tick
@@ -542,7 +542,7 @@ def test_simple_schedule(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(seconds=2)
@@ -557,7 +557,7 @@ def test_simple_schedule(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
         expected_datetime = create_pendulum_time(year=2019, month=2, day=28)
@@ -588,7 +588,7 @@ def test_simple_schedule(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 1
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
@@ -604,7 +604,7 @@ def test_simple_schedule(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 1
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
@@ -621,7 +621,7 @@ def test_simple_schedule(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 3
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 3
         assert len([tick for tick in ticks if tick.status == TickStatus.SUCCESS]) == 3
 
@@ -633,7 +633,7 @@ def test_simple_schedule(instance, workspace, external_repo):
         # Check idempotence again
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
         assert instance.get_runs_count() == 3
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 3
 
 
@@ -674,7 +674,7 @@ def test_old_tick_schedule(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 2
 
 
@@ -685,7 +685,7 @@ def test_no_started_schedules(instance, workspace, external_repo):
     list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
     assert instance.get_runs_count() == 0
 
-    ticks = instance.get_ticks(schedule_origin.get_id())
+    ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
     assert len(ticks) == 0
 
 
@@ -712,7 +712,7 @@ def test_schedule_without_timezone(instance):
 
                 assert instance.get_runs_count() == 1
 
-                ticks = instance.get_ticks(schedule_origin.get_id())
+                ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
 
                 assert len(ticks) == 1
 
@@ -737,7 +737,7 @@ def test_schedule_without_timezone(instance):
                 # Verify idempotence
                 list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
                 assert instance.get_runs_count() == 1
-                ticks = instance.get_ticks(schedule_origin.get_id())
+                ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
                 assert len(ticks) == 1
 
 
@@ -751,7 +751,7 @@ def test_bad_env_fn_no_retries(instance, workspace, external_repo):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
         validate_tick(
@@ -768,7 +768,7 @@ def test_bad_env_fn_no_retries(instance, workspace, external_repo):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
         validate_tick(
@@ -786,7 +786,7 @@ def test_bad_env_fn_no_retries(instance, workspace, external_repo):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 2
 
         validate_tick(
@@ -814,7 +814,7 @@ def test_bad_env_fn_with_retries(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
         validate_tick(
@@ -839,7 +839,7 @@ def test_bad_env_fn_with_retries(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
         validate_tick(
@@ -858,7 +858,7 @@ def test_bad_env_fn_with_retries(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
         validate_tick(
@@ -876,7 +876,7 @@ def test_bad_env_fn_with_retries(instance, workspace, external_repo):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 2
 
         validate_tick(
@@ -904,7 +904,7 @@ def test_passes_on_retry(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
         validate_tick(
@@ -924,7 +924,7 @@ def test_passes_on_retry(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
         validate_tick(
@@ -945,7 +945,7 @@ def test_passes_on_retry(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 2
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 2
 
         validate_tick(
@@ -975,7 +975,7 @@ def test_bad_should_execute(instance, workspace, external_repo):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
         validate_tick(
@@ -1002,7 +1002,7 @@ def test_skip(instance, workspace, external_repo):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -1025,7 +1025,7 @@ def test_wrong_config_schedule(instance, workspace, external_repo):
 
         assert instance.get_runs_count() == 0
 
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -1060,7 +1060,7 @@ def test_schedule_run_default_config(instance, workspace, external_repo):
             expected_success=True,
         )
 
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -1127,7 +1127,7 @@ def test_bad_schedules_mixed_with_good_schedule(instance, workspace, external_re
             partition_time=create_pendulum_time(2019, 2, 26),
         )
 
-        good_ticks = instance.get_ticks(good_origin.get_id())
+        good_ticks = instance.get_ticks(good_origin.get_id(), good_schedule.selector_id)
         assert len(good_ticks) == 1
         validate_tick(
             good_ticks[0],
@@ -1137,7 +1137,7 @@ def test_bad_schedules_mixed_with_good_schedule(instance, workspace, external_re
             [run.run_id for run in instance.get_runs()],
         )
 
-        bad_ticks = instance.get_ticks(bad_origin.get_id())
+        bad_ticks = instance.get_ticks(bad_origin.get_id(), bad_schedule.selector_id)
         assert len(bad_ticks) == 1
 
         assert bad_ticks[0].status == TickStatus.FAILURE
@@ -1147,7 +1147,7 @@ def test_bad_schedules_mixed_with_good_schedule(instance, workspace, external_re
             in bad_ticks[0].error.message
         )
 
-        unloadable_ticks = instance.get_ticks(unloadable_origin.get_id())
+        unloadable_ticks = instance.get_ticks(unloadable_origin.get_id(), "fake_selector")
         assert len(unloadable_ticks) == 0
 
     initial_datetime = initial_datetime.add(days=1)
@@ -1167,7 +1167,7 @@ def test_bad_schedules_mixed_with_good_schedule(instance, workspace, external_re
             partition_time=create_pendulum_time(2019, 2, 27),
         )
 
-        good_ticks = instance.get_ticks(good_origin.get_id())
+        good_ticks = instance.get_ticks(good_origin.get_id(), good_schedule.selector_id)
         assert len(good_ticks) == 2
         validate_tick(
             good_ticks[0],
@@ -1186,7 +1186,7 @@ def test_bad_schedules_mixed_with_good_schedule(instance, workspace, external_re
             partition_time=create_pendulum_time(2019, 2, 27),
         )
 
-        bad_ticks = instance.get_ticks(bad_origin.get_id())
+        bad_ticks = instance.get_ticks(bad_origin.get_id(), bad_schedule.selector_id)
         assert len(bad_ticks) == 2
         validate_tick(
             bad_ticks[0],
@@ -1196,7 +1196,7 @@ def test_bad_schedules_mixed_with_good_schedule(instance, workspace, external_re
             [bad_schedule_runs[0].run_id],
         )
 
-        unloadable_ticks = instance.get_ticks(unloadable_origin.get_id())
+        unloadable_ticks = instance.get_ticks(unloadable_origin.get_id(), "fake_selector")
         assert len(unloadable_ticks) == 0
 
 
@@ -1219,7 +1219,7 @@ def test_run_scheduled_on_time_boundary(instance, workspace, external_repo):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
@@ -1256,7 +1256,7 @@ def test_bad_load_repository(instance, workspace, external_repo, caplog):
 
         assert instance.get_runs_count() == 0
 
-        ticks = instance.get_ticks(invalid_repo_origin.get_id())
+        ticks = instance.get_ticks(invalid_repo_origin.get_id(), external_schedule.selector_id)
 
         assert len(ticks) == 0
 
@@ -1295,7 +1295,7 @@ def test_bad_load_schedule(instance, workspace, external_repo, caplog):
 
         assert instance.get_runs_count() == 0
 
-        ticks = instance.get_ticks(invalid_repo_origin.get_id())
+        ticks = instance.get_ticks(invalid_repo_origin.get_id(), schedule_state.get_selector_id())
 
         assert len(ticks) == 0
 
@@ -1328,7 +1328,7 @@ def test_error_load_repository_location(instance):
 
             assert instance.get_runs_count() == 0
 
-            ticks = instance.get_ticks(fake_origin.get_id())
+            ticks = instance.get_ticks(fake_origin.get_id(), schedule_state.get_selector_id())
 
             assert len(ticks) == 0
 
@@ -1336,7 +1336,7 @@ def test_error_load_repository_location(instance):
         with pendulum.test(initial_datetime):
             list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
             assert instance.get_runs_count() == 0
-            ticks = instance.get_ticks(fake_origin.get_id())
+            ticks = instance.get_ticks(fake_origin.get_id(), schedule_state.get_selector_id())
             assert len(ticks) == 0
 
 
@@ -1375,7 +1375,7 @@ def test_load_repository_location_not_in_workspace(instance, workspace, external
 
         assert instance.get_runs_count() == 0
 
-        ticks = instance.get_ticks(invalid_repo_origin.get_id())
+        ticks = instance.get_ticks(invalid_repo_origin.get_id(), schedule_state.get_selector_id())
 
         assert len(ticks) == 0
 
@@ -1408,11 +1408,15 @@ def test_multiple_schedules_on_different_time_ranges(instance, workspace, extern
         )
 
         assert instance.get_runs_count() == 2
-        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(
+            external_schedule.get_external_origin_id(), external_schedule.selector_id
+        )
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
-        hourly_ticks = instance.get_ticks(external_hourly_schedule.get_external_origin_id())
+        hourly_ticks = instance.get_ticks(
+            external_hourly_schedule.get_external_origin_id(), external_hourly_schedule.selector_id
+        )
         assert len(hourly_ticks) == 1
         assert hourly_ticks[0].status == TickStatus.SUCCESS
 
@@ -1422,11 +1426,15 @@ def test_multiple_schedules_on_different_time_ranges(instance, workspace, extern
 
         assert instance.get_runs_count() == 3
 
-        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(
+            external_schedule.get_external_origin_id(), external_schedule.selector_id
+        )
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
-        hourly_ticks = instance.get_ticks(external_hourly_schedule.get_external_origin_id())
+        hourly_ticks = instance.get_ticks(
+            external_hourly_schedule.get_external_origin_id(), external_hourly_schedule.selector_id
+        )
         assert len(hourly_ticks) == 2
         assert len([tick for tick in hourly_ticks if tick.status == TickStatus.SUCCESS]) == 2
 
@@ -1465,7 +1473,7 @@ def test_launch_failure(workspace, external_repo):
                 expected_success=False,
             )
 
-            ticks = instance.get_ticks(schedule_origin.get_id())
+            ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1491,7 +1499,7 @@ def test_partitionless_schedule(instance, workspace, external_repo):
 
         wait_for_all_runs_to_start(instance)
 
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
         validate_tick(
@@ -1534,7 +1542,7 @@ def test_max_catchup_runs(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 2
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 2
 
         first_datetime = create_pendulum_time(year=2019, month=3, day=4)
@@ -1592,20 +1600,20 @@ def test_multi_runs(instance, workspace, external_repo):
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
         # launch_scheduled_runs does nothing before the first tick
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(seconds=2)
     with pendulum.test(freeze_datetime):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
         assert instance.get_runs_count() == 2
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
         expected_datetime = create_pendulum_time(year=2019, month=2, day=28)
@@ -1627,7 +1635,7 @@ def test_multi_runs(instance, workspace, external_repo):
         # Verify idempotence
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
         assert instance.get_runs_count() == 2
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
@@ -1637,7 +1645,7 @@ def test_multi_runs(instance, workspace, external_repo):
         # Traveling one more day in the future before running results in a tick
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
         assert instance.get_runs_count() == 4
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 2
         assert len([tick for tick in ticks if tick.status == TickStatus.SUCCESS]) == 2
         runs = instance.get_runs()
@@ -1656,7 +1664,7 @@ def test_multi_runs_missing_run_key(instance, workspace, external_repo):
 
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
         validate_tick(
@@ -1694,7 +1702,7 @@ def test_large_schedule(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
 
@@ -1720,7 +1728,7 @@ def test_manual_partition_with_solid_selection(instance, workspace, external_rep
         )
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
         run_id = ticks[0].run_ids[0]
 
@@ -1763,7 +1771,7 @@ def test_skip_reason_schedule(instance, workspace, external_repo):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
         expected_datetime = create_pendulum_time(year=2019, month=2, day=28, tz="UTC")
@@ -1805,7 +1813,7 @@ def test_grpc_server_down(instance):
             for _trial in range(3):
                 list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
                 assert instance.get_runs_count() == 0
-                ticks = instance.get_ticks(schedule_origin.get_id())
+                ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
                 assert len(ticks) == 1
 
                 validate_tick(
@@ -1822,7 +1830,7 @@ def test_grpc_server_down(instance):
             with _grpc_server_external_repo(port) as external_repo:
                 list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
                 assert instance.get_runs_count() == 1
-                ticks = instance.get_ticks(schedule_origin.get_id())
+                ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
                 assert len(ticks) == 1
 
                 expected_datetime = create_pendulum_time(year=2019, month=2, day=27)
@@ -1857,8 +1865,20 @@ def test_status_in_code_schedule(instance):
             never_running_origin = not_running_schedule.get_external_origin()
 
             assert instance.get_runs_count() == 0
-            assert len(instance.get_ticks(always_running_origin.get_id())) == 0
-            assert len(instance.get_ticks(never_running_origin.get_id())) == 0
+            assert (
+                len(
+                    instance.get_ticks(always_running_origin.get_id(), running_schedule.selector_id)
+                )
+                == 0
+            )
+            assert (
+                len(
+                    instance.get_ticks(
+                        never_running_origin.get_id(), not_running_schedule.selector_id
+                    )
+                )
+                == 0
+            )
 
             assert len(instance.all_instigator_state()) == 0
 
@@ -1869,17 +1889,26 @@ def test_status_in_code_schedule(instance):
 
             assert len(instance.all_instigator_state()) == 1
 
-            instigator_state = instance.get_instigator_state(always_running_origin.get_id(), running_schedule.selector_id)
+            instigator_state = instance.get_instigator_state(
+                always_running_origin.get_id(), running_schedule.selector_id
+            )
 
             assert instigator_state.status == InstigatorStatus.AUTOMATICALLY_RUNNING
             assert (
                 instigator_state.instigator_data.start_timestamp == pendulum.now("UTC").timestamp()
             )
 
-            ticks = instance.get_ticks(always_running_origin.get_id())
+            ticks = instance.get_ticks(always_running_origin.get_id(), running_schedule.selector_id)
             assert len(ticks) == 0
 
-            assert len(instance.get_ticks(never_running_origin.get_id())) == 0
+            assert (
+                len(
+                    instance.get_ticks(
+                        never_running_origin.get_id(), not_running_schedule.selector_id
+                    )
+                )
+                == 0
+            )
 
         freeze_datetime = freeze_datetime.add(seconds=2)
         with pendulum.test(freeze_datetime):
@@ -1894,9 +1923,16 @@ def test_status_in_code_schedule(instance):
 
             assert instance.get_runs_count() == 1
 
-            assert len(instance.get_ticks(never_running_origin.get_id())) == 0
+            assert (
+                len(
+                    instance.get_ticks(
+                        never_running_origin.get_id(), not_running_schedule.selector_id
+                    )
+                )
+                == 0
+            )
 
-            ticks = instance.get_ticks(always_running_origin.get_id())
+            ticks = instance.get_ticks(always_running_origin.get_id(), running_schedule.selector_id)
 
             assert len(ticks) == 1
 
@@ -1928,7 +1964,7 @@ def test_status_in_code_schedule(instance):
                 )
             )
             assert instance.get_runs_count() == 1
-            ticks = instance.get_ticks(always_running_origin.get_id())
+            ticks = instance.get_ticks(always_running_origin.get_id(), running_schedule.selector_id)
             assert len(ticks) == 1
             assert ticks[0].status == TickStatus.SUCCESS
 
@@ -1944,7 +1980,7 @@ def test_status_in_code_schedule(instance):
                 )
             )
             assert instance.get_runs_count() == 3
-            ticks = instance.get_ticks(always_running_origin.get_id())
+            ticks = instance.get_ticks(always_running_origin.get_id(), running_schedule.selector_id)
             assert len(ticks) == 3
             assert len([tick for tick in ticks if tick.status == TickStatus.SUCCESS]) == 3
 
@@ -1965,7 +2001,7 @@ def test_status_in_code_schedule(instance):
                     pendulum.now("UTC"),
                 )
             )
-            ticks = instance.get_ticks(always_running_origin.get_id())
+            ticks = instance.get_ticks(always_running_origin.get_id(), running_schedule.selector_id)
             assert len(ticks) == 3
             assert len(instance.all_instigator_state()) == 0
 
@@ -2011,11 +2047,15 @@ def test_change_default_status(instance):
                 )
             )
 
-            ticks = instance.get_ticks(never_running_origin.get_id())
+            ticks = instance.get_ticks(
+                never_running_origin.get_id(), not_running_schedule.selector_id
+            )
             assert len(ticks) == 0
 
             # AUTOMATICALLY_RUNNING row has been removed from the database
-            instigator_state = instance.get_instigator_state(never_running_origin.get_id(), not_running_schedule.selector_id)
+            instigator_state = instance.get_instigator_state(
+                never_running_origin.get_id(), not_running_schedule.selector_id
+            )
             assert not instigator_state
 
             # schedule can still be manually started
@@ -2040,7 +2080,9 @@ def test_change_default_status(instance):
                 )
             )
 
-            ticks = instance.get_ticks(never_running_origin.get_id())
+            ticks = instance.get_ticks(
+                never_running_origin.get_id(), not_running_schedule.selector_id
+            )
             assert len(ticks) == 1
             assert len(ticks[0].run_ids) == 1
             assert ticks[0].timestamp == freeze_datetime.timestamp()

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
@@ -27,7 +27,7 @@ def test_non_utc_timezone_run(instance, workspace, external_repo):
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
         list(
@@ -39,7 +39,7 @@ def test_non_utc_timezone_run(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(seconds=2)
@@ -54,7 +54,7 @@ def test_non_utc_timezone_run(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
         expected_datetime = to_timezone(
@@ -87,7 +87,7 @@ def test_non_utc_timezone_run(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 1
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
@@ -110,10 +110,10 @@ def test_differing_timezones(instance, workspace, external_repo):
         instance.start_schedule(external_eastern_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
-        ticks = instance.get_ticks(eastern_origin.get_id())
+        ticks = instance.get_ticks(eastern_origin.get_id(), external_eastern_schedule.selector_id)
         assert len(ticks) == 0
 
         list(
@@ -125,10 +125,10 @@ def test_differing_timezones(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
-        ticks = instance.get_ticks(eastern_origin.get_id())
+        ticks = instance.get_ticks(eastern_origin.get_id(), external_eastern_schedule.selector_id)
         assert len(ticks) == 0
 
     # Past midnight eastern time, the eastern timezone schedule will run, but not the central timezone
@@ -144,7 +144,7 @@ def test_differing_timezones(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_ticks(eastern_origin.get_id())
+        ticks = instance.get_ticks(eastern_origin.get_id(), external_eastern_schedule.selector_id)
         assert len(ticks) == 1
 
         expected_datetime = to_timezone(
@@ -159,7 +159,7 @@ def test_differing_timezones(instance, workspace, external_repo):
             [run.run_id for run in instance.get_runs()],
         )
 
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
         wait_for_all_runs_to_start(instance)
@@ -184,10 +184,10 @@ def test_differing_timezones(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 2
-        ticks = instance.get_ticks(eastern_origin.get_id())
+        ticks = instance.get_ticks(eastern_origin.get_id(), external_eastern_schedule.selector_id)
         assert len(ticks) == 1
 
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
         expected_datetime = to_timezone(
@@ -220,11 +220,11 @@ def test_differing_timezones(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 2
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
-        ticks = instance.get_ticks(eastern_origin.get_id())
+        ticks = instance.get_ticks(eastern_origin.get_id(), external_eastern_schedule.selector_id)
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
@@ -242,7 +242,7 @@ def test_different_days_in_different_timezones(instance, workspace, external_rep
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
         list(
@@ -254,7 +254,7 @@ def test_different_days_in_different_timezones(instance, workspace, external_rep
             )
         )
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(seconds=2)
@@ -269,7 +269,7 @@ def test_different_days_in_different_timezones(instance, workspace, external_rep
         )
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
 
         expected_datetime = to_timezone(
@@ -302,7 +302,7 @@ def test_different_days_in_different_timezones(instance, workspace, external_rep
             )
         )
         assert instance.get_runs_count() == 1
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
@@ -320,7 +320,7 @@ def test_hourly_dst_spring_forward(instance, workspace, external_repo):
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(hours=2)
@@ -340,7 +340,7 @@ def test_hourly_dst_spring_forward(instance, workspace, external_repo):
         wait_for_all_runs_to_start(instance)
 
         assert instance.get_runs_count() == 3
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 3
 
         expected_datetimes_utc = [
@@ -378,7 +378,7 @@ def test_hourly_dst_spring_forward(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 3
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 3
 
 
@@ -395,7 +395,7 @@ def test_hourly_dst_fall_back(instance, workspace, external_repo):
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(hours=4)
@@ -415,7 +415,7 @@ def test_hourly_dst_fall_back(instance, workspace, external_repo):
         wait_for_all_runs_to_start(instance)
 
         assert instance.get_runs_count() == 4
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 4
 
         expected_datetimes_utc = [
@@ -466,7 +466,7 @@ def test_hourly_dst_fall_back(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 4
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 4
 
 
@@ -483,7 +483,7 @@ def test_daily_dst_spring_forward(instance, workspace, external_repo):
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(days=2)
@@ -501,7 +501,7 @@ def test_daily_dst_spring_forward(instance, workspace, external_repo):
         wait_for_all_runs_to_start(instance)
 
         assert instance.get_runs_count() == 3
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 3
 
         # UTC time changed by one hour after the transition, still running daily at the same
@@ -544,7 +544,7 @@ def test_daily_dst_spring_forward(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 3
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 3
 
 
@@ -561,7 +561,7 @@ def test_daily_dst_fall_back(instance, workspace, external_repo):
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(days=2)
@@ -579,7 +579,7 @@ def test_daily_dst_fall_back(instance, workspace, external_repo):
         wait_for_all_runs_to_start(instance)
 
         assert instance.get_runs_count() == 3
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 3
 
         # UTC time changed by one hour after the transition, still running daily at the same
@@ -622,7 +622,7 @@ def test_daily_dst_fall_back(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 3
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 3
 
 
@@ -642,7 +642,7 @@ def test_execute_during_dst_transition_spring_forward(instance, workspace, exter
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(days=3)
@@ -660,7 +660,7 @@ def test_execute_during_dst_transition_spring_forward(instance, workspace, exter
         wait_for_all_runs_to_start(instance)
 
         assert instance.get_runs_count() == 3
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 3
 
         expected_datetimes_utc = [
@@ -710,7 +710,7 @@ def test_execute_during_dst_transition_spring_forward(instance, workspace, exter
             )
         )
         assert instance.get_runs_count() == 3
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 3
 
 
@@ -729,7 +729,7 @@ def test_execute_during_dst_transition_fall_back(instance, workspace, external_r
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(days=3)
@@ -747,7 +747,7 @@ def test_execute_during_dst_transition_fall_back(instance, workspace, external_r
         wait_for_all_runs_to_start(instance)
 
         assert instance.get_runs_count() == 3
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 3
 
         expected_datetimes_utc = [
@@ -788,5 +788,5 @@ def test_execute_during_dst_transition_fall_back(instance, workspace, external_r
             )
         )
         assert instance.get_runs_count() == 3
-        ticks = instance.get_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 3

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/alembic/versions/d32d1d6de793_add_tick_selector_index.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/alembic/versions/d32d1d6de793_add_tick_selector_index.py
@@ -1,0 +1,22 @@
+"""add tick selector index
+
+Revision ID: d32d1d6de793
+Revises: 5b467f7af3f6
+Create Date: 2022-03-25 10:29:10.895341
+
+"""
+from dagster.core.storage.migration.utils import create_tick_selector_index
+
+# revision identifiers, used by Alembic.
+revision = "d32d1d6de793"
+down_revision = "5b467f7af3f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    create_tick_selector_index()
+
+
+def downgrade():
+    pass

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/alembic/versions/b601eb913efa_add_tick_selector_index.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/alembic/versions/b601eb913efa_add_tick_selector_index.py
@@ -1,0 +1,22 @@
+"""add tick selector index
+
+Revision ID: b601eb913efa
+Revises: 16e3115a602a
+Create Date: 2022-03-25 10:28:53.372766
+
+"""
+from dagster.core.storage.migration.utils import create_tick_selector_index
+
+# revision identifiers, used by Alembic.
+revision = "b601eb913efa"
+down_revision = "16e3115a602a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    create_tick_selector_index()
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
## Summary
Can't reopen the incorrectly merged https://github.com/dagster-io/dagster/pull/7205, so reopening

Starts querying the instigators table, and using selector_id instead of origin_id for instances
that have migrated over.


## Test Plan
BK

