### PR TITLE
[@dagster-io/ui] Cleanup for publish

### DIFF
--- a/js_modules/dagit/packages/ui/CHANGES.md
+++ b/js_modules/dagit/packages/ui/CHANGES.md
@@ -1,3 +1,9 @@
+## 1.0.2 (April 4, 2022)
+
+- Publish a JS build with Rollup
+- Generate TypeScript type definitions
+- Add more details to README
+
 ## 1.0.1
 
 - Create README

--- a/js_modules/dagit/packages/ui/package.json
+++ b/js_modules/dagit/packages/ui/package.json
@@ -1,13 +1,18 @@
 {
   "name": "@dagster-io/ui",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Dagster UI Component Library",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
+  "files": [
+    "lib/**/*"
+  ],
   "sideEffects": false,
   "scripts": {
+    "prepack": "yarn build",
+    "prepublish": "yarn lint && yarn ts && yarn jest",
     "build": "rm -rf lib && tsc --declaration --emitDeclarationOnly --noEmit false -p . && yarn rollup -c rollup.config.js",
     "lint": "eslint src/ --ext=.tsx,.ts,.js --fix -c .eslintrc.js",
     "jest": "jest",


### PR DESCRIPTION
## Summary

A handful of items in preparation for publishing `@dagster-io/ui` 1.0.2:

- Add `prepack` and `prepublish` scripts for `yarn publish` workflow.
- Set `files` in `package.json` to limit what gets published

After this merges, I'll publish 1.0.2 and we can make sure that @benpankow's dependency is working!

## Test Plan

`yarn pack`, verify that `prepack` creates a build output and that only `lib` gets tarballed.
