### PR TITLE
fix invariant in batch tick loader

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -219,23 +219,17 @@ class RepositoryScopedBatchLoader:
         states = self._get(RepositoryDataType.SENSOR_STATES, sensor_state, 1)
         return states[0] if states else None
 
-    def get_sensor_ticks(self, origin_id, limit):
+    def get_sensor_ticks(self, origin_id, selector_id, limit):
         check.invariant(
-            origin_id
-            in [
-                sensor.get_external_origin_id()
-                for sensor in self._repository.get_external_sensors()
-            ]
+            selector_id
+            in [sensor.selector_id for sensor in self._repository.get_external_sensors()]
         )
         return self._get(RepositoryDataType.SENSOR_TICKS, origin_id, limit)
 
-    def get_schedule_ticks(self, origin_id, limit):
+    def get_schedule_ticks(self, origin_id, selector_id, limit):
         check.invariant(
-            origin_id
-            in [
-                schedule.get_external_origin_id()
-                for schedule in self._repository.get_external_schedules()
-            ]
+            selector_id
+            in [schedule.selector_id for schedule in self._repository.get_external_schedules()]
         )
         return self._get(RepositoryDataType.SCHEDULE_TICKS, origin_id, limit)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -394,11 +394,15 @@ class GrapheneInstigationState(graphene.ObjectType):
         if self._batch_loader and limit and not cursor and not before and not after:
             ticks = (
                 self._batch_loader.get_sensor_ticks(
-                    self._instigator_state.instigator_origin_id, limit
+                    self._instigator_state.instigator_origin_id,
+                    self._instigator_state.selector_id,
+                    limit,
                 )
                 if self._instigator_state.instigator_type == InstigatorType.SENSOR
                 else self._batch_loader.get_schedule_ticks(
-                    self._instigator_state.instigator_origin_id, limit
+                    self._instigator_state.instigator_origin_id,
+                    self._instigator_state.selector_id,
+                    limit,
                 )
             )
             return [GrapheneInstigationTick(graphene_info, tick) for tick in ticks]


### PR DESCRIPTION
## Summary
Fixes an issue where the batch tick loader was enforcing an overly strict check that all the origin_ids were known.  This is no longer the case after https://github.com/dagster-io/dagster/pull/7268, since we could be reading state where the selector matches but the origin id does not (e.g. user changed their python executable).


## Test Plan
BK, manually ran dagit using two versions of python, ran the data migration, saw no error.

