### PR TITLE
[dagster-airbyte] fix airbyte materializations without streamStats

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
@@ -31,24 +31,28 @@ def _materialization_for_stream(
 
 def generate_materializations(output: AirbyteOutput, asset_key_prefix: List[str]):
     prefix = output.connection_details.get("prefix") or ""
-    stream_info = {
-        prefix + stream["stream"]["name"]: stream
+    # all the streams that are set to be sync'd by this connection
+    all_stream_props = {
+        prefix
+        + stream["stream"]["name"]: stream.get("stream", {})
+        .get("jsonSchema", {})
+        .get("properties", {})
         for stream in output.connection_details.get("syncCatalog", {}).get("streams", [])
         if stream.get("config", {}).get("selected")
     }
 
-    stream_stats = (
-        output.job_details.get("attempts", [{}])[-1].get("attempt", {}).get("streamStats", [])
-    )
-    for stats in stream_stats:
-        name = stats["streamName"]
-
-        stream_schema_props = (
-            stream_info.get(name, {}).get("stream", {}).get("jsonSchema", {}).get("properties", {})
-        )
+    # stats for each stream that had data sync'd
+    all_stream_stats = {
+        s["streamName"]: s.get("stats", {})
+        for s in output.job_details.get("attempts", [{}])[-1]
+        .get("attempt", {})
+        .get("streamStats", [])
+    }
+    for stream_name, stream_props in all_stream_props.items():
         yield _materialization_for_stream(
-            name,
-            stream_schema_props,
-            stats.get("stats", {}),
+            stream_name,
+            stream_props,
+            # if no records are sync'd, no stats will be avaiable for this stream
+            all_stream_stats.get(stream_name, {}),
             asset_key_prefix=asset_key_prefix,
         )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
@@ -73,13 +73,6 @@ def get_sample_job_json(schema_prefix=""):
                             },
                         },
                         {
-                            "streamName": schema_prefix + "bar",
-                            "stats": {
-                                "bytesEmitted": 1234,
-                                "recordsCommitted": 4321,
-                            },
-                        },
-                        {
                             "streamName": schema_prefix + "baz",
                             "stats": {
                                 "bytesEmitted": 1111,


### PR DESCRIPTION
The previous implementation assumed that any stream sync'd by a given Airbyte connection would have a corresponding entry in the streamStats API response (even if there were no records updated for that stream). This is not the case. The updated test failed with the previous implementation and now passes.

Slack: https://dagster.slack.com/archives/C01U954MEER/p1648766665541209

