### PR TITLE
Avoid mentioning pipelines in Dagit empty state

### DIFF
--- a/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
@@ -81,10 +81,10 @@ const FinalRedirectOrLoadingRoot = () => {
     <Box padding={{vertical: 64}}>
       <NonIdealState
         icon="no-results"
-        title={repoWithNoJob ? 'No pipelines or jobs' : 'No repositories'}
+        title={repoWithNoJob ? 'No jobs' : 'No repositories'}
         description={
           repoWithNoJob
-            ? 'Your repository is loaded but no pipelines or jobs were found.'
+            ? 'Your repository is loaded, but no jobs were found.'
             : 'Add a repository to get started.'
         }
         action={


### PR DESCRIPTION
Pipelines are legacy, so we should only talk about them to users who are talking about them to us.