### PR TITLE
Add MenuLink shim for internal compatibility

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/MenuLink.tsx
+++ b/js_modules/dagit/packages/core/src/ui/MenuLink.tsx
@@ -1,0 +1,3 @@
+// todo dish: Move implementation from `ui`
+
+export {MenuLink} from '@dagster-io/ui';


### PR DESCRIPTION
## Summary

Cloud uses a `MenuLink` import that points at `@dagster-io/ui`, but this will be removed in #7285. Add a shim export that can be used by Cloud to eliminate the compatibility failure. This will be followed by a Cloud PR that updates the import, at which point #7285 will be safe to land.

## Test Plan

Buildkite
