### PR TITLE
fix selector injection for k8s-celery test

### DIFF
--- a/python_modules/dagster-test/dagster_test/test_project/__init__.py
+++ b/python_modules/dagster-test/dagster_test/test_project/__init__.py
@@ -16,6 +16,7 @@ from dagster.core.host_representation import (
     ExternalSchedule,
     GrpcServerRepositoryLocationOrigin,
     InProcessRepositoryLocationOrigin,
+    InstigatorSelector,
     RepositoryLocation,
 )
 from dagster.core.host_representation.origin import (
@@ -29,7 +30,7 @@ from dagster.core.origin import (
     RepositoryPythonOrigin,
 )
 from dagster.core.test_utils import in_process_test_workspace
-from dagster.serdes import whitelist_for_serdes
+from dagster.serdes import create_snapshot_id, whitelist_for_serdes
 from dagster.utils import file_relative_path, git_repository_root
 
 IS_BUILDKITE = os.getenv("BUILDKITE") is not None
@@ -245,6 +246,19 @@ class ReOriginatedExternalScheduleForTest(ExternalSchedule):
                 repository_name="demo_execution_repo",
             ),
             instigator_name=self.name,
+        )
+
+    @property
+    def selector_id(self):
+        """
+        Hack! Inject a selector that matches the one that the k8s helm chart will use.
+        """
+        return create_snapshot_id(
+            InstigatorSelector(
+                "user-code-deployment-1",
+                "demo_execution_repo",
+                self.name,
+            )
         )
 
 


### PR DESCRIPTION
## Summary
Celery k8s integration test suite mocks out the origin, so that stored schedule state is consistent.  Since switching out storage reads to use selector id instead of origin id, we need to apply a similar mocking scheme to get the integration tests to pass.

Fixes the integration tests that have been broken since https://github.com/dagster-io/dagster/pull/7268

## Test Plan
BK


