### PR TITLE
[dagster-dbt] fix issue w/ conflicting dbt op names

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -101,8 +101,11 @@ def _dbt_nodes_to_assets(
         out_name_to_node_info[node_name] = node_info
         internal_asset_deps[node_name] = asset_deps
 
+    # unique id to prevent name collisions between multiple dbt multi-assets
+    uid = hash(tuple(outs.keys())) % 10000
+
     @multi_asset(
-        name="dbt_project",
+        name=f"dbt_project_{uid}",
         non_argument_deps=sources,
         outs=outs,
         required_resource_keys={"dbt"},

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -1,7 +1,7 @@
+import hashlib
 import json
 import os
 import textwrap
-import hashlib
 from typing import AbstractSet, Any, Callable, Dict, Mapping, Optional, Sequence, Set, Tuple
 
 from dagster_dbt.cli.types import DbtCliOutput
@@ -107,7 +107,7 @@ def _dbt_nodes_to_assets(
     # prevent op name collisions between multiple dbt multi-assets
     op_name = f"run_dbt_{package_name}"
     if select != "*":
-        op_name += "_" + hashlib.md5(str(sorted(selected_unique_ids)).encode()).hexdigest()[-5:]
+        op_name += "_" + hashlib.md5(select.encode()).hexdigest()[-5:]
 
     @multi_asset(
         name=op_name,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -105,6 +105,8 @@ def test_basic(
 
     dbt_assets = load_assets_from_dbt_project(test_project_dir, dbt_config_dir)
 
+    assert dbt_assets[0].op.name == "run_dbt_dagster_dbt_test_project"
+
     result = build_assets_job(
         "test_job",
         dbt_assets,
@@ -131,6 +133,8 @@ def test_select_from_project(
     dbt_assets = load_assets_from_dbt_project(
         test_project_dir, dbt_config_dir, select="sort_by_calories subdir.least_caloric"
     )
+
+    assert dbt_assets[0].op.name == "run_dbt_dagster_dbt_test_project_b5883"
 
     result = build_assets_job(
         "test_job",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -7,7 +7,7 @@ from dagster_dbt.asset_defs import load_assets_from_dbt_manifest, load_assets_fr
 from dagster_dbt.errors import DagsterDbtCliFatalRuntimeError
 from dagster_dbt.types import DbtOutput
 
-from dagster import AssetKey, MetadataEntry, ResourceDefinition, repository, AssetGroup
+from dagster import AssetGroup, AssetKey, MetadataEntry, ResourceDefinition, repository
 from dagster.core.asset_defs import build_assets_job
 from dagster.core.asset_defs.decorators import ASSET_DEPENDENCY_METADATA_KEY
 from dagster.utils import file_relative_path

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -134,7 +134,7 @@ def test_select_from_project(
         test_project_dir, dbt_config_dir, select="sort_by_calories subdir.least_caloric"
     )
 
-    assert dbt_assets[0].op.name == "run_dbt_dagster_dbt_test_project_b5883"
+    assert dbt_assets[0].op.name == "run_dbt_dagster_dbt_test_project_e4753"
 
     result = build_assets_job(
         "test_job",


### PR DESCRIPTION
Slack: https://dagster.slack.com/archives/C01U954MEER/p1649200935894489

This is a quick little hack to enforce uniqueness between the names of the ops that will be produced for different subsets of a dbt graph.

Test failed before the change, succeeds now