### PR TITLE
[dagit] Fix config refresh when reloading repo

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
@@ -154,7 +154,10 @@ const LaunchpadSessionContainer: React.FC<LaunchpadSessionContainerProps> = (pro
     const partitionSetsForMode = partitionSets.results;
 
     if (presetsForMode.length === 1 && partitionSetsForMode.length === 0) {
-      return {runConfigYaml: presetsForMode[0].runConfigYaml};
+      return {
+        base: {presetName: presetsForMode[0].name, tags: null},
+        runConfigYaml: presetsForMode[0].runConfigYaml,
+      };
     }
 
     if (!presetsForMode.length && partitionSetsForMode.length === 1) {


### PR DESCRIPTION
## Summary

Resolves #6312.

When setting config editor sessions for jobs with preset configs, we aren't currently setting the preset as the "base" of the session. This means that when the repository is reloaded, we don't notice that the session's config may need to be refreshed as well, so we never prompt the user.

To fix this, set the preset in the session `base`.

## Test Plan

Follow repro steps in attached issue. Verify that when I modify the job config and reload the repository in Dagit, I am prompted to refresh the config. Verify that refreshing the config works properly.
