### PR TITLE
Add option to disable max_concurrent_runs

### DIFF
--- a/docs/content/deployment/run-coordinator.mdx
+++ b/docs/content/deployment/run-coordinator.mdx
@@ -38,7 +38,10 @@ You can set the following parameters on the QueuedRunCoordinator by modifying it
 
 You can place limits on the number of runs that can be in progress at a single time. Any runs beyond this limit will be queued, and won’t use any compute.
 
-- An overall limit on the number of runs can be placed using the `max_concurrent_runs` key.
+- An overall limit on the number of runs can be placed using the `max_concurrent_runs` key. Defaults to `10`.
+  - You can disable this limit by setting it to `-1`
+  - You can also prevent any runs from launching by setting to `0`
+  - Any negative numbers other than `-1` are disallowed
 - More specific limits can be configured based on run tags, with `tag_concurrency_limits`. Limits can be specified for all runs with a certain tag key or key-value pair.
 
 If any limit would be exceeded by launching a run, then the run will stay queued.

--- a/python_modules/dagster/dagster/core/run_coordinator/queued_run_coordinator.py
+++ b/python_modules/dagster/dagster/core/run_coordinator/queued_run_coordinator.py
@@ -40,6 +40,10 @@ class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
         self._max_concurrent_runs = check.opt_int_param(
             max_concurrent_runs, "max_concurrent_runs", 10
         )
+        check.invariant(
+            self._max_concurrent_runs >= -1,
+            "Negative values other than -1 (which disables the limit) for max_concurrent_runs are disallowed.",
+        )
         self._tag_concurrency_limits = check.opt_list_param(
             tag_concurrency_limits,
             "tag_concurrency_limits",
@@ -70,7 +74,9 @@ class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
             "max_concurrent_runs": Field(
                 config=IntSource,
                 is_required=False,
-                description="The maximum number of runs that are allowed to be in progress at once",
+                description="The maximum number of runs that are allowed to be in progress at once. "
+                "Defaults to 10. Set to -1 to disable the limit. Set to 0 to stop any runs from launching. "
+                "Any other negative values are disallowed.",
             ),
             "tag_concurrency_limits": Field(
                 config=Noneable(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -142,6 +142,33 @@ def test_get_queued_runs_max_runs(num_in_progress_runs, workspace, daemon):
         assert len(instance.run_launcher.queue()) == max(0, max_runs - num_in_progress_runs)
 
 
+def test_disable_max_concurrent_runs_limit(workspace, daemon):
+    with instance_for_queued_run_coordinator(max_concurrent_runs=-1) as instance:
+        # create ongoing runs
+        in_progress_run_ids = ["in_progress-run-{}".format(i) for i in range(5)]
+        for i, run_id in enumerate(in_progress_run_ids):
+            # get a selection of all in progress statuses
+            status = IN_PROGRESS_RUN_STATUSES[i % len(IN_PROGRESS_RUN_STATUSES)]
+            create_run(
+                instance,
+                run_id=run_id,
+                status=status,
+            )
+
+        # add more queued runs
+        queued_run_ids = ["queued-run-{}".format(i) for i in range(6)]
+        for run_id in queued_run_ids:
+            create_run(
+                instance,
+                run_id=run_id,
+                status=PipelineRunStatus.QUEUED,
+            )
+
+        list(daemon.run_iteration(instance, workspace))
+
+        assert len(instance.run_launcher.queue()) == 6
+
+
 def test_priority(instance, workspace, daemon):
     create_run(instance, run_id="default-pri-run", status=PipelineRunStatus.QUEUED)
     create_run(


### PR DESCRIPTION
User wants to have tag_concurrency_limits without a maximum number of runs

https://dagster.slack.com/archives/C01U954MEER/p1649252665576439

I would prefer some sort of explicit `disable: true` api but that's troublesome with an IntSource, I think this is fine

