### PR TITLE
[dagit] Fix CodeMirror show-hint error

### DIFF
--- a/js_modules/dagit/packages/core/src/configeditor/codemirror-yaml/mode.tsx
+++ b/js_modules/dagit/packages/core/src/configeditor/codemirror-yaml/mode.tsx
@@ -308,11 +308,7 @@ CodeMirror.registerHelper(
     options: {
       schema?: ConfigEditorRunConfigSchemaFragment;
     },
-  ): {list: Array<CodemirrorHint>} => {
-    if (!options.schema) {
-      return {list: []};
-    }
-
+  ): {list: Array<CodemirrorHint>; from: CodemirrorLocation; to: CodemirrorLocation} => {
     const {
       cursor,
       context,
@@ -321,8 +317,16 @@ CodeMirror.registerHelper(
       searchString,
       prevToken,
     } = expandAutocompletionContextAtCursor(editor);
+
+    const from = {line: cursor.line, ch: start};
+    const to = {line: cursor.line, ch: token.end};
+
+    if (!options.schema) {
+      return {list: [], from, to};
+    }
+
     if (!context) {
-      return {list: []};
+      return {list: [], from, to};
     }
 
     // Since writing meaningful tests for this functionality is difficult given a) no jsdom
@@ -433,8 +437,8 @@ CodeMirror.registerHelper(
         }
         el.appendChild(div);
       },
-      from: {line: cursor.line, ch: start},
-      to: {line: cursor.line, ch: token.end},
+      from,
+      to,
     });
 
     // Calculate if this is on a new-line child of a scalar union type, as an indication that we
@@ -458,6 +462,8 @@ CodeMirror.registerHelper(
               field.description,
             ),
           ),
+        from,
+        to,
       };
     }
 
@@ -470,6 +476,8 @@ CodeMirror.registerHelper(
         list: context.type.values
           .filter((val) => val.value.startsWith(searchWithoutQuotes))
           .map((val) => buildSuggestion(val.value, `"${val.value}"`, null)),
+        from,
+        to,
       };
     }
 
@@ -479,6 +487,8 @@ CodeMirror.registerHelper(
         list: ['True', 'False']
           .filter((val) => val.startsWith(searchString))
           .map((val) => buildSuggestion(val, val, null)),
+        from,
+        to,
       };
     }
 
@@ -513,10 +523,10 @@ CodeMirror.registerHelper(
           );
       }
 
-      return {list: [...scalarSuggestions, ...nonScalarSuggestions]};
+      return {list: [...scalarSuggestions, ...nonScalarSuggestions], from, to};
     }
 
-    return {list: []};
+    return {list: [], from, to};
   },
 );
 


### PR DESCRIPTION
## Summary

There is an error within the CodeMirror show-hint addon that fires on an empty Launchpad. This appears to be because we aren't providing `from` and `to` values in the return value for the `hint` helper function, and they are expected to be there. Add them.

## Test Plan

View Launchpad, clear out editor config. Start typing in the empty editor, verify that hint suggestions render properly and that there are no JS errors in the console.
