### PR TITLE
[dagit] Add "Copy config" button to "View tags and config" dialog

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
@@ -10,11 +10,13 @@ import {
   Icon,
   MetadataTable,
   Tooltip,
+  IconName,
 } from '@dagster-io/ui';
 import * as React from 'react';
 import * as yaml from 'yaml';
 
 import {AppContext} from '../app/AppContext';
+import {useCopyToClipboard} from '../app/browser';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {RunStatus} from '../types/globalTypes';
 
@@ -114,8 +116,17 @@ export const RunDetails: React.FC<{
 
 export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({run, isJob}) => {
   const [showDialog, setShowDialog] = React.useState(false);
+  const [copyIcon, setCopyIcon] = React.useState<IconName>('copy_to_clipboard');
   const {rootServerURI} = React.useContext(AppContext);
   const runConfigYaml = yaml.stringify(run.runConfig) || '';
+  const copy = useCopyToClipboard();
+
+  const copyConfig = () => {
+    copy(runConfigYaml);
+    setCopyIcon('copy_to_clipboard_done');
+    setTimeout(() => setCopyIcon('copy_to_clipboard'), 2000);
+  };
+
   return (
     <div>
       <Group direction="row" spacing={8}>
@@ -152,6 +163,9 @@ export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({r
           </Group>
         </DialogBody>
         <DialogFooter>
+          <Button icon={<Icon name={copyIcon} />} onClick={() => copyConfig()} intent="none">
+            Copy config
+          </Button>
           <Button onClick={() => setShowDialog(false)} intent="primary">
             OK
           </Button>


### PR DESCRIPTION
## Summary

Resolves #7298.

Add a "Copy config" button to the dialog on the Run page.

## Test Plan

View a run. Open "View tags and config" dialog, click "Copy config". Verify that the icon changes briefly, and that I can paste the config into a document.
