### PR TITLE
[dagit] Store whitespace state in localStorage

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
@@ -33,6 +33,7 @@ import {
   responseToYamlValidationResult,
 } from '../configeditor/ConfigEditorUtils';
 import {isHelpContextEqual} from '../configeditor/isHelpContextEqual';
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {DagsterTag} from '../runs/RunTag';
 import {RepositorySelector} from '../types/globalTypes';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
@@ -81,7 +82,6 @@ interface ILaunchpadSessionState {
   previewedDocument: any | null;
   configLoading: boolean;
   editorHelpContext: ConfigEditorHelpContext | null;
-  showWhitespace: boolean;
   tagEditorOpen: boolean;
 }
 
@@ -97,8 +97,7 @@ type Action =
     }
   | {type: 'toggle-tag-editor'; payload: boolean}
   | {type: 'toggle-config-loading'; payload: boolean}
-  | {type: 'set-editor-help-context'; payload: ConfigEditorHelpContext | null}
-  | {type: 'toggle-whitepsace'; payload: boolean};
+  | {type: 'set-editor-help-context'; payload: ConfigEditorHelpContext | null};
 
 const reducer = (state: ILaunchpadSessionState, action: Action) => {
   switch (action.type) {
@@ -119,8 +118,6 @@ const reducer = (state: ILaunchpadSessionState, action: Action) => {
       return {...state, configLoading: action.payload};
     case 'set-editor-help-context':
       return {...state, editorHelpContext: action.payload};
-    case 'toggle-whitepsace':
-      return {...state, showWhitespace: action.payload};
     default:
       return state;
   }
@@ -131,7 +128,6 @@ const initialState: ILaunchpadSessionState = {
   previewLoading: false,
   previewedDocument: null,
   configLoading: false,
-  showWhitespace: true,
   editorHelpContext: null,
   tagEditorOpen: false,
 };
@@ -146,6 +142,11 @@ const LaunchpadSessionContainer: React.FC<LaunchpadSessionContainerProps> = (pro
   const editor = React.useRef<ConfigEditor | null>(null);
   const editorSplitPanelContainer = React.useRef<SplitPanelContainer | null>(null);
   const previewCounter = React.useRef(0);
+
+  const [showWhitespace, setShowWhitespace] = useStateWithStorage(
+    'launchpad-whitespace',
+    (json: any) => (typeof json === 'boolean' ? json : true),
+  );
 
   const {isJob, presets} = pipeline;
 
@@ -515,7 +516,6 @@ const LaunchpadSessionContainer: React.FC<LaunchpadSessionContainerProps> = (pro
     previewedDocument,
     configLoading,
     editorHelpContext,
-    showWhitespace,
     tagEditorOpen,
   } = state;
 
@@ -606,7 +606,11 @@ const LaunchpadSessionContainer: React.FC<LaunchpadSessionContainerProps> = (pro
                 title="Toggle whitespace"
                 icon={<Icon name="toggle_whitespace" />}
                 active={showWhitespace}
-                onClick={() => dispatch({type: 'toggle-whitepsace', payload: !showWhitespace})}
+                onClick={() =>
+                  setShowWhitespace((current: boolean | undefined) =>
+                    current === undefined ? true : !current,
+                  )
+                }
               />
               <SessionSettingsSpacer />
               <SecondPanelToggle axis="horizontal" container={editorSplitPanelContainer} />


### PR DESCRIPTION
## Summary

Resolves #7293.

Track the "toggle whitespace" launchpad setting in localStorage.

## Test Plan

View launchpad, turn on whitespace visibility. Reload page, verify persistence. Turn it off, repeat, verify same.
