### PR TITLE
[dagit] Make the “Latest Run” tag on the Job page auto-refresh

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetNodeInstigatorTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeInstigatorTag.tsx
@@ -2,7 +2,7 @@ import {gql} from '@apollo/client';
 import {flatMap} from 'lodash';
 import React from 'react';
 
-import {ScheduleOrSensorTag} from '../nav/JobMetadata';
+import {ScheduleOrSensorTag} from '../nav/ScheduleOrSensorTag';
 import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
 import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
 import {RepoAddress} from '../workspace/types';

--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
-import {ScheduleOrSensorTag} from '../nav/JobMetadata';
+import {ScheduleOrSensorTag} from '../nav/ScheduleOrSensorTag';
 import {LegacyPipelineTag} from '../pipelines/LegacyPipelineTag';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {RunStatusIndicator} from '../runs/RunStatusDots';

--- a/js_modules/dagit/packages/core/src/nav/LatestRunTag.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LatestRunTag.tsx
@@ -1,0 +1,111 @@
+import {useQuery, gql} from '@apollo/client';
+import {Box, Colors, StyledTable, Tag, Tooltip} from '@dagster-io/ui';
+import React from 'react';
+import {Link} from 'react-router-dom';
+
+import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
+import {timingStringForStatus} from '../runs/RunDetails';
+import {RunStatusIndicator} from '../runs/RunStatusDots';
+import {RunTime, RUN_TIME_FRAGMENT} from '../runs/RunUtils';
+import {TimestampDisplay} from '../schedules/TimestampDisplay';
+import {RunStatus} from '../types/globalTypes';
+
+import {LatestRunTagQuery, LatestRunTagQueryVariables} from './types/LatestRunTagQuery';
+
+const TIME_FORMAT = {showSeconds: true, showTimezone: false};
+
+export const LatestRunTag: React.FC<{pipelineName: string}> = ({pipelineName}) => {
+  const lastRunQuery = useQuery<LatestRunTagQuery, LatestRunTagQueryVariables>(
+    LATEST_RUN_TAG_QUERY,
+    {variables: {runsFilter: {pipelineName}}},
+  );
+
+  useQueryRefreshAtInterval(lastRunQuery, FIFTEEN_SECONDS);
+
+  const run = React.useMemo(() => {
+    const runsOrError = lastRunQuery.data?.pipelineRunsOrError;
+    if (runsOrError && runsOrError.__typename === 'Runs') {
+      return runsOrError.results[0] || null;
+    }
+    return null;
+  }, [lastRunQuery]);
+
+  if (!run) {
+    return null;
+  }
+
+  const stats = {start: run.startTime, end: run.endTime, status: run.status};
+  const intent = () => {
+    switch (run.status) {
+      case RunStatus.SUCCESS:
+        return 'success';
+      case RunStatus.CANCELED:
+      case RunStatus.CANCELING:
+      case RunStatus.FAILURE:
+        return 'danger';
+      default:
+        return 'none';
+    }
+  };
+
+  return (
+    <Tag intent={intent()}>
+      <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+        <RunStatusIndicator status={run.status} size={10} />
+        Latest run:
+        {stats ? (
+          <Tooltip
+            placement="bottom"
+            content={
+              <StyledTable>
+                <tbody>
+                  <tr>
+                    <td style={{color: Colors.Gray300}}>
+                      <Box padding={{right: 16}}>Started</Box>
+                    </td>
+                    <td>
+                      {stats.start ? (
+                        <TimestampDisplay timestamp={stats.start} timeFormat={TIME_FORMAT} />
+                      ) : (
+                        timingStringForStatus(stats.status)
+                      )}
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style={{color: Colors.Gray300}}>Ended</td>
+                    <td>
+                      {stats.end ? (
+                        <TimestampDisplay timestamp={stats.end} timeFormat={TIME_FORMAT} />
+                      ) : (
+                        timingStringForStatus(stats.status)
+                      )}
+                    </td>
+                  </tr>
+                </tbody>
+              </StyledTable>
+            }
+          >
+            <Link to={`/instance/runs/${run.id}`}>
+              <RunTime run={run} />
+            </Link>
+          </Tooltip>
+        ) : null}
+      </Box>
+    </Tag>
+  );
+};
+
+const LATEST_RUN_TAG_QUERY = gql`
+  query LatestRunTagQuery($runsFilter: RunsFilter) {
+    pipelineRunsOrError(filter: $runsFilter, limit: 1) {
+      ... on PipelineRuns {
+        results {
+          id
+          status
+          ...RunTimeFragment
+        }
+      }
+    }
+  }
+  ${RUN_TIME_FRAGMENT}
+`;

--- a/js_modules/dagit/packages/core/src/nav/ScheduleOrSensorTag.tsx
+++ b/js_modules/dagit/packages/core/src/nav/ScheduleOrSensorTag.tsx
@@ -1,0 +1,231 @@
+import {
+  Box,
+  Button,
+  ButtonLink,
+  Colors,
+  DialogFooter,
+  Dialog,
+  Table,
+  Tag,
+  Subheading,
+  Tooltip,
+  FontFamily,
+} from '@dagster-io/ui';
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+
+import {ScheduleSwitch} from '../schedules/ScheduleSwitch';
+import {humanCronString} from '../schedules/humanCronString';
+import {ScheduleSwitchFragment} from '../schedules/types/ScheduleSwitchFragment';
+import {SensorSwitch} from '../sensors/SensorSwitch';
+import {SensorSwitchFragment} from '../sensors/types/SensorSwitchFragment';
+import {RepoAddress} from '../workspace/types';
+import {workspacePathFromAddress} from '../workspace/workspacePath';
+
+export const ScheduleOrSensorTag: React.FC<{
+  schedules: ScheduleSwitchFragment[];
+  sensors: SensorSwitchFragment[];
+  repoAddress: RepoAddress;
+  showSwitch?: boolean;
+}> = ({schedules, sensors, repoAddress, showSwitch = true}) => {
+  const [open, setOpen] = React.useState(false);
+
+  const scheduleCount = schedules.length;
+  const sensorCount = sensors.length;
+
+  if (scheduleCount > 1 || sensorCount > 1 || (scheduleCount && sensorCount)) {
+    const buttonText =
+      scheduleCount && sensorCount
+        ? `View ${scheduleCount + sensorCount} schedules/sensors`
+        : scheduleCount
+        ? `View ${scheduleCount} schedules`
+        : `View ${sensorCount} sensors`;
+
+    const dialogTitle =
+      scheduleCount && sensorCount
+        ? 'Schedules and sensors'
+        : scheduleCount
+        ? 'Schedules'
+        : 'Sensors';
+
+    const icon = scheduleCount > 1 ? 'schedule' : 'sensors';
+
+    return (
+      <>
+        <Tag icon={icon}>
+          <ButtonLink onClick={() => setOpen(true)} color={Colors.Link}>
+            {buttonText}
+          </ButtonLink>
+        </Tag>
+        <Dialog
+          title={dialogTitle}
+          canOutsideClickClose
+          canEscapeKeyClose
+          isOpen={open}
+          style={{width: '50vw', minWidth: '600px', maxWidth: '800px'}}
+          onClose={() => setOpen(false)}
+        >
+          <Box padding={{bottom: 12}}>
+            {schedules.length ? (
+              <>
+                {sensors.length ? (
+                  <Box padding={{vertical: 16, horizontal: 24}}>
+                    <Subheading>Schedules ({schedules.length})</Subheading>
+                  </Box>
+                ) : null}
+                <Table>
+                  <thead>
+                    <tr>
+                      {showSwitch ? <th style={{width: '80px'}} /> : null}
+                      <th>Schedule name</th>
+                      <th>Schedule</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {schedules.map((schedule) => (
+                      <tr key={schedule.name}>
+                        {showSwitch ? (
+                          <td>
+                            <ScheduleSwitch repoAddress={repoAddress} schedule={schedule} />
+                          </td>
+                        ) : null}
+                        <td>
+                          <Link
+                            to={workspacePathFromAddress(
+                              repoAddress,
+                              `/schedules/${schedule.name}`,
+                            )}
+                          >
+                            {schedule.name}
+                          </Link>
+                        </td>
+                        <td>{humanCronString(schedule.cronSchedule)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              </>
+            ) : null}
+            {sensors.length ? (
+              <>
+                {schedules.length ? (
+                  <Box padding={{vertical: 16, horizontal: 24}}>
+                    <Subheading>Sensors ({sensors.length})</Subheading>
+                  </Box>
+                ) : null}
+                <Table>
+                  <thead>
+                    <tr>
+                      {showSwitch ? <th style={{width: '80px'}} /> : null}
+                      <th>Sensor name</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sensors.map((sensor) => (
+                      <tr key={sensor.name}>
+                        {showSwitch ? (
+                          <td>
+                            <SensorSwitch repoAddress={repoAddress} sensor={sensor} />
+                          </td>
+                        ) : null}
+                        <td>
+                          <Link
+                            to={workspacePathFromAddress(repoAddress, `/sensors/${sensor.name}`)}
+                          >
+                            {sensor.name}
+                          </Link>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              </>
+            ) : null}
+          </Box>
+          <DialogFooter>
+            <Button intent="primary" onClick={() => setOpen(false)}>
+              OK
+            </Button>
+          </DialogFooter>
+        </Dialog>
+      </>
+    );
+  }
+
+  if (scheduleCount) {
+    return (
+      <MatchingSchedule schedule={schedules[0]} repoAddress={repoAddress} showSwitch={showSwitch} />
+    );
+  }
+
+  if (sensorCount) {
+    return <MatchingSensor sensor={sensors[0]} repoAddress={repoAddress} showSwitch={showSwitch} />;
+  }
+
+  return null;
+};
+
+const MatchingSchedule: React.FC<{
+  schedule: ScheduleSwitchFragment;
+  repoAddress: RepoAddress;
+  showSwitch: boolean;
+}> = ({schedule, repoAddress, showSwitch}) => {
+  const running = schedule.scheduleState.status === 'RUNNING';
+  const tag = (
+    <Tag intent={running ? 'primary' : 'none'} icon="schedule">
+      <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+        Schedule:
+        <Link to={workspacePathFromAddress(repoAddress, `/schedules/${schedule.name}`)}>
+          {humanCronString(schedule.cronSchedule)}
+        </Link>
+        {showSwitch ? (
+          <ScheduleSwitch size="small" repoAddress={repoAddress} schedule={schedule} />
+        ) : null}
+      </Box>
+    </Tag>
+  );
+
+  return schedule.cronSchedule ? (
+    <Tooltip
+      placement="bottom"
+      content={
+        <Box flex={{direction: 'column', gap: 4}}>
+          <div>
+            Name: <strong>{schedule.name}</strong>
+          </div>
+          <div>
+            Cron:{' '}
+            <span style={{fontFamily: FontFamily.monospace, marginLeft: '4px'}}>
+              ({schedule.cronSchedule})
+            </span>
+          </div>
+        </Box>
+      }
+    >
+      {tag}
+    </Tooltip>
+  ) : (
+    tag
+  );
+};
+
+const MatchingSensor: React.FC<{
+  sensor: SensorSwitchFragment;
+  repoAddress: RepoAddress;
+  showSwitch: boolean;
+}> = ({sensor, repoAddress, showSwitch}) => {
+  const running = sensor.sensorState.status === 'RUNNING';
+  return (
+    <Tag intent={running ? 'primary' : 'none'} icon="sensors">
+      <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+        Sensor:
+        <Link to={workspacePathFromAddress(repoAddress, `/sensors/${sensor.name}`)}>
+          {sensor.name}
+        </Link>
+        {showSwitch ? (
+          <SensorSwitch size="small" repoAddress={repoAddress} sensor={sensor} />
+        ) : null}
+      </Box>
+    </Tag>
+  );
+};

--- a/js_modules/dagit/packages/core/src/nav/types/LatestRunTagQuery.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/LatestRunTagQuery.ts
@@ -1,0 +1,39 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { RunsFilter, RunStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: LatestRunTagQuery
+// ====================================================
+
+export interface LatestRunTagQuery_pipelineRunsOrError_InvalidPipelineRunsFilterError {
+  __typename: "InvalidPipelineRunsFilterError" | "PythonError";
+}
+
+export interface LatestRunTagQuery_pipelineRunsOrError_Runs_results {
+  __typename: "Run";
+  id: string;
+  status: RunStatus;
+  runId: string;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
+}
+
+export interface LatestRunTagQuery_pipelineRunsOrError_Runs {
+  __typename: "Runs";
+  results: LatestRunTagQuery_pipelineRunsOrError_Runs_results[];
+}
+
+export type LatestRunTagQuery_pipelineRunsOrError = LatestRunTagQuery_pipelineRunsOrError_InvalidPipelineRunsFilterError | LatestRunTagQuery_pipelineRunsOrError_Runs;
+
+export interface LatestRunTagQuery {
+  pipelineRunsOrError: LatestRunTagQuery_pipelineRunsOrError;
+}
+
+export interface LatestRunTagQueryVariables {
+  runsFilter?: RunsFilter | null;
+}


### PR DESCRIPTION
## Summary
This PR splits out the (very light) query used for the "Latest Run" tag on job pages and attaches a 15-second autorefresh to it.

I think this is important, because recent changes to Dagit allow you to launch runs without leaving the page, so it's super easy to get into a situation where this "Latest Run" tag is out-of-date, and the only way to see it change is to hard-reload the page.

I also split things into a couple files because JobMetadata.tsx was exporting some sub-components that were used elsewhere.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.