### PR TITLE
[dagit] Move data fetching for the asset graph into hooks

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/useAssetGraphData.tsx
@@ -1,0 +1,117 @@
+import {gql, useQuery} from '@apollo/client';
+import React from 'react';
+
+import {filterByQuery, GraphQueryItem} from '../../app/GraphQueryImpl';
+import {tokenForAssetKey} from '../../app/Util';
+import {PipelineSelector} from '../../types/globalTypes';
+
+import {ASSET_NODE_FRAGMENT} from './AssetNode';
+import {buildGraphData} from './Utils';
+import {
+  AssetGraphQuery,
+  AssetGraphQueryVariables,
+  AssetGraphQuery_assetNodes,
+} from './types/AssetGraphQuery';
+
+/** Fetches data for rendering an asset graph:
+ *
+ * @param pipelineSelector: Optionally scope to an asset job, or pass null for the global graph
+ *
+ * @param opsQuery: filter the returned graph using selector syntax string (eg: asset_name++)
+ *
+ * @param filterNodes: filter the returned graph using the provided function. The global graph
+ * uses this option to implement the "3 of 4 repositories" picker.
+ */
+export function useAssetGraphData(
+  pipelineSelector: PipelineSelector | null | undefined,
+  opsQuery: string,
+  filterNodes?: (assetNode: AssetGraphQuery_assetNodes) => boolean,
+) {
+  const fetchResult = useQuery<AssetGraphQuery, AssetGraphQueryVariables>(ASSET_GRAPH_QUERY, {
+    variables: {pipelineSelector},
+    notifyOnNetworkStatusChange: true,
+  });
+
+  const fetchResultFilteredNodes = React.useMemo(() => {
+    const nodes = fetchResult.data?.assetNodes;
+    if (!nodes) {
+      return undefined;
+    }
+    return filterNodes ? nodes.filter(filterNodes) : nodes;
+  }, [fetchResult.data, filterNodes]);
+
+  const {
+    assetGraphData,
+    graphQueryItems,
+    graphAssetKeys,
+    applyingEmptyDefault,
+  } = React.useMemo(() => {
+    if (fetchResultFilteredNodes === undefined) {
+      return {
+        graphAssetKeys: [],
+        graphQueryItems: [],
+        assetGraphData: null,
+        applyingEmptyDefault: false,
+      };
+    }
+    const graphQueryItems = buildGraphQueryItems(fetchResultFilteredNodes);
+    const {all, applyingEmptyDefault} = filterByQuery(graphQueryItems, opsQuery);
+
+    return {
+      graphAssetKeys: all.map((n) => ({path: n.node.assetKey.path})),
+      assetGraphData: buildGraphData(all.map((n) => n.node)),
+      graphQueryItems,
+      applyingEmptyDefault,
+    };
+  }, [fetchResultFilteredNodes, opsQuery]);
+
+  return {
+    fetchResult,
+    assetGraphData,
+    graphQueryItems,
+    graphAssetKeys,
+    applyingEmptyDefault,
+  };
+}
+
+type AssetNode = AssetGraphQuery_assetNodes;
+
+const buildGraphQueryItems = (nodes: AssetNode[]) => {
+  const items: {
+    [name: string]: GraphQueryItem & {
+      node: AssetNode;
+    };
+  } = {};
+
+  for (const node of nodes) {
+    const name = tokenForAssetKey(node.assetKey);
+    items[name] = {
+      node: node,
+      name: name,
+      inputs: node.dependencyKeys.map((key) => ({
+        dependsOn: [{solid: {name: tokenForAssetKey(key)}}],
+      })),
+      outputs: node.dependedByKeys.map((key) => ({
+        dependedBy: [{solid: {name: tokenForAssetKey(key)}}],
+      })),
+    };
+  }
+  return Object.values(items);
+};
+
+const ASSET_GRAPH_QUERY = gql`
+  query AssetGraphQuery($pipelineSelector: PipelineSelector) {
+    assetNodes(pipeline: $pipelineSelector) {
+      id
+      ...AssetNodeFragment
+      jobNames
+      dependencyKeys {
+        path
+      }
+      dependedByKeys {
+        path
+      }
+    }
+  }
+  ${ASSET_NODE_FRAGMENT}
+`;

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/useLiveDataForAssetKeys.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/useLiveDataForAssetKeys.tsx
@@ -1,0 +1,76 @@
+import {gql, useQuery} from '@apollo/client';
+import React from 'react';
+
+import {AssetKeyInput, PipelineSelector} from '../../types/globalTypes';
+
+import {ASSET_NODE_LIVE_FRAGMENT} from './AssetNode';
+import {buildLiveData, GraphData, REPOSITORY_LIVE_FRAGMENT} from './Utils';
+import {AssetGraphLiveQuery, AssetGraphLiveQueryVariables} from './types/AssetGraphLiveQuery';
+
+/** Fetches the last materialization, "upstream changed", and other live state
+ * for the assets in the given pipeline or in the given set of asset keys (or both).
+ *
+ * Note: The "upstream changed" flag cascades, so it may not appear if the upstream
+ * node that has changed is not in scope.
+ */
+export function useLiveDataForAssetKeys(
+  pipelineSelector: PipelineSelector | null | undefined,
+  graphData: GraphData | null,
+  graphAssetKeys: AssetKeyInput[],
+) {
+  const liveResult = useQuery<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>(
+    ASSETS_GRAPH_LIVE_QUERY,
+    {
+      skip: graphAssetKeys.length === 0,
+      variables: {
+        assetKeys: graphAssetKeys,
+        repositorySelector: pipelineSelector
+          ? {
+              repositoryLocationName: pipelineSelector.repositoryLocationName,
+              repositoryName: pipelineSelector.repositoryName,
+            }
+          : undefined,
+      },
+      notifyOnNetworkStatusChange: true,
+    },
+  );
+
+  const liveDataByNode = React.useMemo(() => {
+    if (!liveResult.data || !graphData) {
+      return {};
+    }
+
+    const {repositoriesOrError, assetNodes: liveAssetNodes} = liveResult.data;
+    const repos =
+      repositoriesOrError.__typename === 'RepositoryConnection' ? repositoriesOrError.nodes : [];
+
+    return buildLiveData(graphData, liveAssetNodes, repos);
+  }, [graphData, liveResult]);
+
+  return {
+    liveResult,
+    liveDataByNode,
+    graphAssetKeys,
+  };
+}
+
+const ASSETS_GRAPH_LIVE_QUERY = gql`
+  query AssetGraphLiveQuery($repositorySelector: RepositorySelector, $assetKeys: [AssetKeyInput!]) {
+    repositoriesOrError(repositorySelector: $repositorySelector) {
+      __typename
+      ... on RepositoryConnection {
+        nodes {
+          __typename
+          id
+          ...RepositoryLiveFragment
+        }
+      }
+    }
+    assetNodes(assetKeys: $assetKeys, loadMaterializations: true) {
+      id
+      ...AssetNodeLiveFragment
+    }
+  }
+  ${REPOSITORY_LIVE_FRAGMENT}
+  ${ASSET_NODE_LIVE_FRAGMENT}
+`;


### PR DESCRIPTION
## Summary
This PR doesn't change any logic - just breaking a lot of the data fetching and memoization out of the AssetGraphExplorer into bespoke / one-off hooks so that things are a bit easier to grok. I think that AssetGraphExplorer might continue to get more complex and it was hitting a size where it was tricky to see what was going on.



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.