### PR TITLE
fix dagster-ge library

### DIFF
--- a/python_modules/libraries/dagster-ge/setup.py
+++ b/python_modules/libraries/dagster-ge/setup.py
@@ -35,6 +35,7 @@ if __name__ == "__main__":
         install_requires=[
             f"dagster{pin}",
             f"dagster-pandas{pin}",
+            "dataclasses; python_version < '3.7'",
             "pandas",
             "great_expectations >=0.11.9, !=0.12.8, !=0.13.17, !=0.13.27",
         ],


### PR DESCRIPTION
## Summary
Latest release version of great expectations using `dataclasses` which needs a backport for python 3.6.

## Test Plan
BK; explicitly added py36 support in https://buildkite.com/dagster/dagster/builds/27575
