### PR TITLE
ResourceDefinition.none_resource instead of no_step_launcher in EMR pyspark example

### DIFF
--- a/docs/content/integrations/spark.mdx
+++ b/docs/content/integrations/spark.mdx
@@ -110,8 +110,7 @@ from dagster_pyspark import pyspark_resource
 from pyspark.sql import DataFrame, Row
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
-from dagster import IOManager, graph, io_manager, op, repository
-from dagster.core.definitions.no_step_launcher import no_step_launcher
+from dagster import IOManager, ResourceDefinition, graph, io_manager, op, repository
 
 
 class ParquetIOManager(IOManager):
@@ -162,7 +161,7 @@ emr_resource_defs = {
 }
 
 local_resource_defs = {
-    "pyspark_step_launcher": no_step_launcher,
+    "pyspark_step_launcher": ResourceDefinition.none_resource(),
     "pyspark": pyspark_resource.configured({"spark_conf": {"spark.default.parallelism": 1}}),
     "io_manager": parquet_io_manager.configured({"path_prefix": "."}),
 }

--- a/examples/emr_pyspark/repo.py
+++ b/examples/emr_pyspark/repo.py
@@ -7,8 +7,7 @@ from dagster_pyspark import pyspark_resource
 from pyspark.sql import DataFrame, Row
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
-from dagster import IOManager, graph, io_manager, op, repository
-from dagster.core.definitions.no_step_launcher import no_step_launcher
+from dagster import IOManager, ResourceDefinition, graph, io_manager, op, repository
 
 
 class ParquetIOManager(IOManager):
@@ -59,7 +58,7 @@ emr_resource_defs = {
 }
 
 local_resource_defs = {
-    "pyspark_step_launcher": no_step_launcher,
+    "pyspark_step_launcher": ResourceDefinition.none_resource(),
     "pyspark": pyspark_resource.configured({"spark_conf": {"spark.default.parallelism": 1}}),
     "io_manager": parquet_io_manager.configured({"path_prefix": "."}),
 }


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.