### PR TITLE
Allow jobs to be passed in lazily to repository definitions

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/repository_definition.py
@@ -1,5 +1,6 @@
 import warnings
 from abc import ABC, abstractmethod
+from inspect import isfunction
 from types import FunctionType
 from typing import (
     TYPE_CHECKING,
@@ -594,7 +595,7 @@ class CachingRepositoryData(RepositoryData):
 
             if isinstance(job, GraphDefinition):
                 repository_definitions["jobs"][key] = job.coerce_to_job()
-            elif not isinstance(job, JobDefinition):
+            elif not isinstance(job, JobDefinition) and not isfunction(job):
                 raise DagsterInvalidDefinitionError(
                     f"Object mapped to {key} is not an instance of JobDefinition or GraphDefinition."
                 )


### PR DESCRIPTION
Summary:
This check was crashing when a job was passed in lazily.

It will still crash when a graph is passed in lazily (the assumption that repos consist of jobs not graphs appears to be pretty deep) but this will make it so that users can pass in a lambda that returns a job. The error is a bit odd, but is the same error you would get if you passed in a job function that returned some other random object that wasn't a job.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.