### PR TITLE
Remove lazy load example from repository docblock

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
@@ -114,23 +114,7 @@ def repository(
     Use this form when you have no need to lazy load pipelines or other definitions. This is the
     typical use case.
 
-    2. A dict of the form:
-
-    .. code-block:: python
-
-        {
-            'jobs': Dict[str, Callable[[], JobDefinition]],
-            'pipelines': Dict[str, Callable[[], PipelineDefinition]],
-            'partition_sets': Dict[str, Callable[[], PartitionSetDefinition]],
-            'schedules': Dict[str, Callable[[], ScheduleDefinition]]
-            'sensors': Dict[str, Callable[[], SensorDefinition]]
-        }
-
-    This form is intended to allow definitions to be created lazily when accessed by name,
-    which can be helpful for performance when there are many definitions in a repository, or
-    when constructing the definitions is costly.
-
-    3. A :py:class:`RepositoryData`. Return this object if you need fine-grained
+    2. A :py:class:`RepositoryData`. Return this object if you need fine-grained
     control over the construction and indexing of definitions within the repository, e.g., to
     create definitions dynamically from .yaml files in a directory.
 
@@ -178,34 +162,6 @@ def repository(
         @repository
         def simple_repository():
             return [simple_job, some_sensor, my_schedule]
-
-
-        ######################################################################
-        # A lazy-loaded repository
-        ######################################################################
-
-        def make_expensive_job():
-            @job
-            def expensive_job():
-                for i in range(10000):
-                    return_n.alias(f'return_n_{i}')()
-
-            return expensive_job
-
-        def make_expensive_schedule():
-            @job
-            def other_expensive_job():
-                for i in range(11000):
-                    return_n.alias(f'my_return_n_{i}')()
-
-            return ScheduleDefinition(cron_schedule="0 0 * * *", job=other_expensive_job)
-
-        @repository
-        def lazy_loaded_repository():
-            return {
-                'jobs': {'expensive_job': make_expensive_job},
-                'schedules': {'expensive_schedule: make_expensive_schedule}
-            }
 
 
         ######################################################################


### PR DESCRIPTION
Summary:
This feature isn't really compatible with CRAG - for example, schedules require passing in the job object now, not just the job name, so there isn't any feasible path to using these lazy-loaded objects as soon as you have a schedule or sensor.

We don't need to remove the underlying functionality or anything, but we shouldn't expose it in the docblock if it will stop working as soon as you use a schedule.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.