### PR TITLE
Add grpc server timeout config to instance settings

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/test_memory.py
+++ b/integration_tests/test_suites/daemon-test-suite/test_memory.py
@@ -45,11 +45,11 @@ def example_repo():
 
 
 @contextmanager
-def get_example_repository_location():
+def get_example_repository_location(instance):
     load_target = workspace_load_target()
     origin = load_target.create_origins()[0]
 
-    with origin.create_single_location() as location:
+    with origin.create_single_location(instance) as location:
         yield location
 
 
@@ -63,8 +63,8 @@ def workspace_load_target():
 
 
 @contextmanager
-def get_example_repo():
-    with get_example_repository_location() as location:
+def get_example_repo(instance):
+    with get_example_repository_location(instance) as location:
         yield location.get_repository("example_repo")
 
 
@@ -83,44 +83,48 @@ def test_no_memory_leaks():
                 },
             },
         }
-    ) as instance, get_example_repo() as repo:
+    ) as instance:
+        with get_example_repo(instance) as repo:
 
-        external_schedule = repo.get_external_schedule("always_run_schedule")
-        external_sensor = repo.get_external_sensor("always_on_sensor")
+            external_schedule = repo.get_external_schedule("always_run_schedule")
+            external_sensor = repo.get_external_sensor("always_on_sensor")
 
-        instance.start_schedule(external_schedule)
-        instance.start_sensor(external_sensor)
+            instance.start_schedule(external_schedule)
+            instance.start_sensor(external_sensor)
 
-        with daemon_controller_from_instance(
-            instance, workspace_load_target=workspace_load_target(), wait_for_processes_on_exit=True
-        ) as controller:
-            start_time = time.time()
-
-            growth = objgraph.growth(
-                limit=10,
-                filter=lambda obj: inspect.getmodule(obj)
-                and "dagster" in inspect.getmodule(obj).__name__,
-            )
-            while True:
-                time.sleep(30)
-
-                controller.check_daemon_threads()
-                controller.check_daemon_heartbeats()
+            with daemon_controller_from_instance(
+                instance,
+                workspace_load_target=workspace_load_target(),
+                wait_for_processes_on_exit=True,
+            ) as controller:
+                start_time = time.time()
 
                 growth = objgraph.growth(
                     limit=10,
                     filter=lambda obj: inspect.getmodule(obj)
                     and "dagster" in inspect.getmodule(obj).__name__,
                 )
-                if not growth:
-                    print(  # pylint: disable=print-call
-                        f"Memory stopped growing after {int(time.time() - start_time)} seconds"
-                    )
-                    break
+                while True:
+                    time.sleep(30)
 
-                if (time.time() - start_time) > 300:
-                    raise Exception(
-                        "Memory still growing after 5 minutes. Most recent growth: " + str(growth)
-                    )
+                    controller.check_daemon_threads()
+                    controller.check_daemon_heartbeats()
 
-                print("Growth: " + str(growth))  # pylint: disable=print-call
+                    growth = objgraph.growth(
+                        limit=10,
+                        filter=lambda obj: inspect.getmodule(obj)
+                        and "dagster" in inspect.getmodule(obj).__name__,
+                    )
+                    if not growth:
+                        print(  # pylint: disable=print-call
+                            f"Memory stopped growing after {int(time.time() - start_time)} seconds"
+                        )
+                        break
+
+                    if (time.time() - start_time) > 300:
+                        raise Exception(
+                            "Memory still growing after 5 minutes. Most recent growth: "
+                            + str(growth)
+                        )
+
+                    print("Growth: " + str(growth))  # pylint: disable=print-call

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_dagster_environment.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_dagster_environment.py
@@ -1,17 +1,19 @@
 import sys
 
 from dagster.core.host_representation import ManagedGrpcPythonEnvRepositoryLocationOrigin
+from dagster.core.test_utils import instance_for_test
 from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster.utils import file_relative_path
 
 
 def test_dagster_out_of_process_location():
-    with ManagedGrpcPythonEnvRepositoryLocationOrigin(
-        location_name="test_location",
-        loadable_target_origin=LoadableTargetOrigin(
-            executable_path=sys.executable,
-            python_file=file_relative_path(__file__, "setup.py"),
-            attribute="test_repo",
-        ),
-    ).create_single_location() as env:
-        assert env.get_repository("test_repo")
+    with instance_for_test() as instance:
+        with ManagedGrpcPythonEnvRepositoryLocationOrigin(
+            location_name="test_location",
+            loadable_target_origin=LoadableTargetOrigin(
+                executable_path=sys.executable,
+                python_file=file_relative_path(__file__, "setup.py"),
+                attribute="test_repo",
+            ),
+        ).create_single_location(instance) as env:
+            assert env.get_repository("test_repo")

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
@@ -31,7 +31,8 @@ query JobQuery($instigationSelector: InstigationSelector!) {
 
 def _create_sensor_tick(graphql_context):
     with create_test_daemon_workspace(
-        graphql_context.process_context.workspace_load_target
+        graphql_context.process_context.workspace_load_target,
+        graphql_context.instance,
     ) as workspace:
         list(
             execute_sensor_iteration(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -471,7 +471,8 @@ def test_sensor_next_ticks(graphql_context):
 
 def _create_tick(graphql_context):
     with create_test_daemon_workspace(
-        graphql_context.process_context.workspace_load_target
+        graphql_context.process_context.workspace_load_target,
+        graphql_context.instance,
     ) as workspace:
         list(
             execute_sensor_iteration(

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -61,7 +61,11 @@ from dagster.utils import traced
 from dagster.utils.backcompat import experimental_functionality_warning
 from dagster.utils.error import serializable_error_info_from_exc_info
 
-from .config import DAGSTER_CONFIG_YAML_FILENAME, is_dagster_home_set
+from .config import (
+    DAGSTER_CONFIG_YAML_FILENAME,
+    DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT,
+    is_dagster_home_set,
+)
 from .ref import InstanceRef
 
 # 'airflow_execution_date' and 'is_airflow_ingest_pipeline' are hardcoded tags used in the
@@ -71,7 +75,6 @@ from .ref import InstanceRef
 # https://github.com/dagster-io/dagster/issues/2403
 AIRFLOW_EXECUTION_DATE_STR = "airflow_execution_date"
 IS_AIRFLOW_INGEST_PIPELINE_STR = "is_airflow_ingest_pipeline"
-
 
 if TYPE_CHECKING:
     from dagster.core.debug import DebugRunPayload
@@ -594,6 +597,16 @@ class DagsterInstance:
     @property
     def run_monitoring_start_timeout_seconds(self) -> int:
         return self.run_monitoring_settings.get("start_timeout_seconds", 180)
+
+    @property
+    def code_server_settings(self) -> Dict:
+        return self.get_settings("code_servers")
+
+    @property
+    def code_server_process_startup_timeout(self) -> int:
+        return self.code_server_settings.get(
+            "local_startup_timeout", DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
+        )
 
     @property
     def run_monitoring_max_resume_run_attempts(self) -> int:

--- a/python_modules/dagster/dagster/core/instance/config.py
+++ b/python_modules/dagster/dagster/core/instance/config.py
@@ -97,6 +97,9 @@ def python_logs_config_schema():
     )
 
 
+DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT = 60
+
+
 def dagster_instance_config_schema():
     return {
         "local_artifact_storage": config_field_for_configurable_class(),
@@ -126,5 +129,9 @@ def dagster_instance_config_schema():
                 "poll_interval_seconds": Field(int, is_required=False),
                 "cancellation_thread_poll_interval_seconds": Field(int, is_required=False),
             },
+        ),
+        "code_servers": Field(
+            {"local_startup_timeout": Field(int, is_required=False)},
+            is_required=False,
         ),
     }

--- a/python_modules/dagster/dagster/core/instance/ref.py
+++ b/python_modules/dagster/dagster/core/instance/ref.py
@@ -214,7 +214,7 @@ class InstanceRef(
             defaults["run_launcher"],
         )
 
-        settings_keys = {"telemetry", "python_logs", "run_monitoring"}
+        settings_keys = {"telemetry", "python_logs", "run_monitoring", "code_servers"}
         settings = {key: config_value.get(key) for key in settings_keys if config_value.get(key)}
 
         return InstanceRef(

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -453,10 +453,10 @@ def in_process_test_workspace(instance, loadable_target_origin, container_image=
 
 
 @contextmanager
-def create_test_daemon_workspace(workspace_load_target):
+def create_test_daemon_workspace(workspace_load_target, instance):
     """Creates a DynamicWorkspace suitable for passing into a DagsterDaemon loop when running tests."""
     configure_loggers()
-    with create_daemon_grpc_server_registry() as grpc_server_registry:
+    with create_daemon_grpc_server_registry(instance) as grpc_server_registry:
         with DaemonWorkspace(grpc_server_registry, workspace_load_target) as workspace:
             yield workspace
 

--- a/python_modules/dagster/dagster/core/workspace/context.py
+++ b/python_modules/dagster/dagster/core/workspace/context.py
@@ -50,7 +50,6 @@ if TYPE_CHECKING:
 
 
 DAGIT_GRPC_SERVER_HEARTBEAT_TTL = 45
-DAGIT_GRPC_SERVER_STARTUP_TIMEOUT = 30
 
 
 class BaseWorkspaceRequestContext(IWorkspace):
@@ -436,7 +435,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
                 ProcessGrpcServerRegistry(
                     reload_interval=0,
                     heartbeat_ttl=DAGIT_GRPC_SERVER_HEARTBEAT_TTL,
-                    startup_timeout=DAGIT_GRPC_SERVER_STARTUP_TIMEOUT,
+                    startup_timeout=instance.code_server_process_startup_timeout,
                 )
             )
 

--- a/python_modules/dagster/dagster/daemon/controller.py
+++ b/python_modules/dagster/dagster/daemon/controller.py
@@ -44,7 +44,6 @@ HEARTBEAT_CHECK_INTERVAL = 15
 
 DAEMON_GRPC_SERVER_RELOAD_INTERVAL = 60
 DAEMON_GRPC_SERVER_HEARTBEAT_TTL = 120
-DAEMON_GRPC_SERVER_STARTUP_TIMEOUT = 30
 
 
 def _sorted_quoted(strings):
@@ -58,11 +57,11 @@ def create_daemons_from_instance(instance):
     ]
 
 
-def create_daemon_grpc_server_registry():
+def create_daemon_grpc_server_registry(instance):
     return ProcessGrpcServerRegistry(
         reload_interval=DAEMON_GRPC_SERVER_RELOAD_INTERVAL,
         heartbeat_ttl=DAEMON_GRPC_SERVER_HEARTBEAT_TTL,
-        startup_timeout=DAEMON_GRPC_SERVER_STARTUP_TIMEOUT,
+        startup_timeout=instance.code_server_process_startup_timeout,
     )
 
 
@@ -81,7 +80,7 @@ def daemon_controller_from_instance(
     grpc_server_registry = None
     try:
         with ExitStack() as stack:
-            grpc_server_registry = stack.enter_context(create_daemon_grpc_server_registry())
+            grpc_server_registry = stack.enter_context(create_daemon_grpc_server_registry(instance))
             daemons = [stack.enter_context(daemon) for daemon in gen_daemons(instance)]
 
             # Create this in each daemon to generate a workspace per-daemon

--- a/python_modules/dagster/dagster/grpc/server.py
+++ b/python_modules/dagster/dagster/grpc/server.py
@@ -938,7 +938,7 @@ def wait_for_grpc_server(server_process, client, subprocess_args, timeout=60):
         except DagsterUserCodeUnreachableError:
             last_error = serializable_error_info_from_exc_info(sys.exc_info())
 
-        if time.time() - start_time > timeout:
+        if timeout > 0 and (time.time() - start_time > timeout):
             raise Exception(
                 f"Timed out waiting for gRPC server to start with arguments: \"{' '.join(subprocess_args)}\". Most recent connection error: {str(last_error)}"
             )

--- a/python_modules/dagster/dagster_tests/api_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/api_tests/conftest.py
@@ -1,0 +1,11 @@
+# pylint: disable=redefined-outer-name
+
+import pytest
+
+from dagster.core.test_utils import instance_for_test
+
+
+@pytest.fixture()
+def instance():
+    with instance_for_test() as instance:
+        yield instance

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_launch_run.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_launch_run.py
@@ -20,7 +20,7 @@ def _check_event_log_contains(event_log, expected_type_and_message):
 
 def test_launch_run_with_unloadable_pipeline_grpc():
     with instance_for_test() as instance:
-        with get_bar_repo_repository_location() as repository_location:
+        with get_bar_repo_repository_location(instance) as repository_location:
             pipeline_handle = PipelineHandle(
                 "foo", repository_location.get_repository("bar_repo").handle
             )
@@ -85,7 +85,7 @@ def test_launch_run_with_unloadable_pipeline_grpc():
 
 def test_launch_run_grpc():
     with instance_for_test() as instance:
-        with get_bar_repo_repository_location() as repository_location:
+        with get_bar_repo_repository_location(instance) as repository_location:
             pipeline_handle = PipelineHandle(
                 "foo", repository_location.get_repository("bar_repo").handle
             )
@@ -145,7 +145,7 @@ def test_launch_run_grpc():
 
 def test_launch_unloadable_run_grpc():
     with instance_for_test() as instance:
-        with get_bar_repo_repository_location() as repository_location:
+        with get_bar_repo_repository_location(instance) as repository_location:
             pipeline_handle = PipelineHandle(
                 "foo", repository_location.get_repository("bar_repo").handle
             )

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_notebook_data.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_notebook_data.py
@@ -4,9 +4,9 @@ from dagster.utils import file_relative_path
 from .utils import get_bar_repo_repository_location
 
 
-def test_external_notebook_grpc():
+def test_external_notebook_grpc(instance):
     notebook_path = file_relative_path(__file__, "foo.ipynb")
-    with get_bar_repo_repository_location() as repository_location:
+    with get_bar_repo_repository_location(instance) as repository_location:
         api_client = repository_location.client
 
         content = sync_get_streaming_external_notebook_data_grpc(

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_execution_plan.py
@@ -10,8 +10,8 @@ from dagster.core.snap.execution_plan_snapshot import ExecutionPlanSnapshot
 from .utils import get_bar_repo_repository_location
 
 
-def test_execution_plan_error_grpc():
-    with get_bar_repo_repository_location() as repository_location:
+def test_execution_plan_error_grpc(instance):
+    with get_bar_repo_repository_location(instance) as repository_location:
         pipeline_handle = PipelineHandle(
             "foo", repository_location.get_repository("bar_repo").handle
         )
@@ -30,8 +30,8 @@ def test_execution_plan_error_grpc():
             )
 
 
-def test_execution_plan_snapshot_api_grpc():
-    with get_bar_repo_repository_location() as repository_location:
+def test_execution_plan_snapshot_api_grpc(instance):
+    with get_bar_repo_repository_location(instance) as repository_location:
         pipeline_handle = PipelineHandle(
             "foo", repository_location.get_repository("bar_repo").handle
         )
@@ -53,8 +53,8 @@ def test_execution_plan_snapshot_api_grpc():
         assert len(execution_plan_snapshot.steps) == 2
 
 
-def test_execution_plan_with_step_keys_to_execute_snapshot_api_grpc():
-    with get_bar_repo_repository_location() as repository_location:
+def test_execution_plan_with_step_keys_to_execute_snapshot_api_grpc(instance):
+    with get_bar_repo_repository_location(instance) as repository_location:
         pipeline_handle = PipelineHandle(
             "foo", repository_location.get_repository("bar_repo").handle
         )
@@ -76,8 +76,8 @@ def test_execution_plan_with_step_keys_to_execute_snapshot_api_grpc():
         assert len(execution_plan_snapshot.steps) == 2
 
 
-def test_execution_plan_with_subset_snapshot_api_grpc():
-    with get_bar_repo_repository_location() as repository_location:
+def test_execution_plan_with_subset_snapshot_api_grpc(instance):
+    with get_bar_repo_repository_location(instance) as repository_location:
         pipeline_handle = PipelineHandle(
             "foo", repository_location.get_repository("bar_repo").handle
         )

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
@@ -19,8 +19,8 @@ from dagster.core.host_representation import (
 from .utils import get_bar_repo_repository_location
 
 
-def test_external_partition_names_grpc():
-    with get_bar_repo_repository_location() as repository_location:
+def test_external_partition_names_grpc(instance):
+    with get_bar_repo_repository_location(instance) as repository_location:
         repository_handle = repository_location.get_repository("bar_repo").handle
         data = sync_get_external_partition_names_grpc(
             repository_location.client, repository_handle, "baz_partitions"
@@ -29,8 +29,8 @@ def test_external_partition_names_grpc():
         assert data.partition_names == list(string.ascii_lowercase)
 
 
-def test_external_partition_names_error_grpc():
-    with get_bar_repo_repository_location() as repository_location:
+def test_external_partition_names_error_grpc(instance):
+    with get_bar_repo_repository_location(instance) as repository_location:
         repository_handle = repository_location.get_repository("bar_repo").handle
 
         with pytest.raises(DagsterUserCodeProcessError, match="womp womp"):
@@ -41,8 +41,8 @@ def test_external_partition_names_error_grpc():
             )
 
 
-def test_external_partitions_config_grpc():
-    with get_bar_repo_repository_location() as repository_location:
+def test_external_partitions_config_grpc(instance):
+    with get_bar_repo_repository_location(instance) as repository_location:
         repository_handle = repository_location.get_repository("bar_repo").handle
 
         data = sync_get_external_partition_config_grpc(
@@ -56,8 +56,8 @@ def test_external_partitions_config_grpc():
         assert data.run_config["solids"]["do_input"]["inputs"]["x"]["value"] == "c"
 
 
-def test_external_partitions_config_error_grpc():
-    with get_bar_repo_repository_location() as repository_location:
+def test_external_partitions_config_error_grpc(instance):
+    with get_bar_repo_repository_location(instance) as repository_location:
         repository_handle = repository_location.get_repository("bar_repo").handle
 
         with pytest.raises(DagsterUserCodeProcessError):
@@ -69,8 +69,8 @@ def test_external_partitions_config_error_grpc():
             )
 
 
-def test_external_partitions_tags_grpc():
-    with get_bar_repo_repository_location() as repository_location:
+def test_external_partitions_tags_grpc(instance):
+    with get_bar_repo_repository_location(instance) as repository_location:
         repository_handle = repository_location.get_repository("bar_repo").handle
 
         data = sync_get_external_partition_tags_grpc(
@@ -84,8 +84,8 @@ def test_external_partitions_tags_grpc():
         assert data.tags["foo"] == "bar"
 
 
-def test_external_partitions_tags_error_grpc():
-    with get_bar_repo_repository_location() as repository_location:
+def test_external_partitions_tags_error_grpc(instance):
+    with get_bar_repo_repository_location(instance) as repository_location:
         repository_handle = repository_location.get_repository("bar_repo").handle
 
         with pytest.raises(DagsterUserCodeProcessError):
@@ -97,8 +97,8 @@ def test_external_partitions_tags_error_grpc():
             )
 
 
-def test_external_partition_set_execution_params_grpc():
-    with get_bar_repo_repository_location() as repository_location:
+def test_external_partition_set_execution_params_grpc(instance):
+    with get_bar_repo_repository_location(instance) as repository_location:
         repository_handle = repository_location.get_repository("bar_repo").handle
 
         data = sync_get_external_partition_set_execution_param_data_grpc(

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_pipeline.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_pipeline.py
@@ -18,8 +18,8 @@ def _test_pipeline_subset_grpc(pipeline_handle, api_client, solid_selection=None
     )
 
 
-def test_pipeline_snapshot_api_grpc():
-    with get_bar_repo_repository_location() as repository_location:
+def test_pipeline_snapshot_api_grpc(instance):
+    with get_bar_repo_repository_location(instance) as repository_location:
         pipeline_handle = PipelineHandle(
             "foo", repository_location.get_repository("bar_repo").handle
         )
@@ -31,8 +31,8 @@ def test_pipeline_snapshot_api_grpc():
         assert external_pipeline_subset_result.external_pipeline_data.name == "foo"
 
 
-def test_pipeline_with_valid_subset_snapshot_api_grpc():
-    with get_bar_repo_repository_location() as repository_location:
+def test_pipeline_with_valid_subset_snapshot_api_grpc(instance):
+    with get_bar_repo_repository_location(instance) as repository_location:
         pipeline_handle = PipelineHandle(
             "foo", repository_location.get_repository("bar_repo").handle
         )
@@ -46,8 +46,8 @@ def test_pipeline_with_valid_subset_snapshot_api_grpc():
         assert external_pipeline_subset_result.external_pipeline_data.name == "foo"
 
 
-def test_pipeline_with_invalid_subset_snapshot_api_grpc():
-    with get_bar_repo_repository_location() as repository_location:
+def test_pipeline_with_invalid_subset_snapshot_api_grpc(instance):
+    with get_bar_repo_repository_location(instance) as repository_location:
         pipeline_handle = PipelineHandle(
             "foo", repository_location.get_repository("bar_repo").handle
         )
@@ -60,8 +60,8 @@ def test_pipeline_with_invalid_subset_snapshot_api_grpc():
             _test_pipeline_subset_grpc(pipeline_handle, api_client, ["invalid_solid"])
 
 
-def test_pipeline_with_invalid_definition_snapshot_api_grpc():
-    with get_bar_repo_repository_location() as repository_location:
+def test_pipeline_with_invalid_definition_snapshot_api_grpc(instance):
+    with get_bar_repo_repository_location(instance) as repository_location:
         pipeline_handle = PipelineHandle(
             "bar", repository_location.get_repository("bar_repo").handle
         )

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -9,13 +9,14 @@ from dagster.core.host_representation import (
     ExternalRepositoryData,
     ManagedGrpcPythonEnvRepositoryLocationOrigin,
 )
+from dagster.core.test_utils import instance_for_test
 from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
 
 from .utils import get_bar_repo_repository_location
 
 
-def test_streaming_external_repositories_api_grpc():
-    with get_bar_repo_repository_location() as repository_location:
+def test_streaming_external_repositories_api_grpc(instance):
+    with get_bar_repo_repository_location(instance) as repository_location:
         external_repo_datas = sync_get_streaming_external_repositories_data_grpc(
             repository_location.client, repository_location
         )
@@ -51,7 +52,7 @@ def giant_repo():
 
 
 @contextmanager
-def get_giant_repo_grpc_repository_location():
+def get_giant_repo_grpc_repository_location(instance):
     with ManagedGrpcPythonEnvRepositoryLocationOrigin(
         loadable_target_origin=LoadableTargetOrigin(
             executable_path=sys.executable,
@@ -59,21 +60,22 @@ def get_giant_repo_grpc_repository_location():
             module_name="dagster_tests.api_tests.test_api_snapshot_repository",
         ),
         location_name="giant_repo_location",
-    ).create_single_location() as location:
+    ).create_single_location(instance) as location:
         yield location
 
 
 @pytest.mark.skip("https://github.com/dagster-io/dagster/issues/6940")
 def test_giant_external_repository_streaming_grpc():
-    with get_giant_repo_grpc_repository_location() as repository_location:
-        # Using streaming allows the giant repo to load
-        external_repos_data = sync_get_streaming_external_repositories_data_grpc(
-            repository_location.client, repository_location
-        )
+    with instance_for_test() as instance:
+        with get_giant_repo_grpc_repository_location(instance) as repository_location:
+            # Using streaming allows the giant repo to load
+            external_repos_data = sync_get_streaming_external_repositories_data_grpc(
+                repository_location.client, repository_location
+            )
 
-        assert len(external_repos_data) == 1
+            assert len(external_repos_data) == 1
 
-        external_repository_data = external_repos_data["giant_repo"]
+            external_repository_data = external_repos_data["giant_repo"]
 
-        assert isinstance(external_repository_data, ExternalRepositoryData)
-        assert external_repository_data.name == "giant_repo"
+            assert isinstance(external_repository_data, ExternalRepositoryData)
+            assert external_repository_data.name == "giant_repo"

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_schedule_execution_data.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_schedule_execution_data.py
@@ -8,7 +8,7 @@ from .utils import get_bar_repo_handle
 
 def test_external_schedule_execution_data_api_grpc():
     with instance_for_test() as instance:
-        with get_bar_repo_handle() as repository_handle:
+        with get_bar_repo_handle(instance) as repository_handle:
             execution_data = sync_get_external_schedule_execution_data_ephemeral_grpc(
                 instance,
                 repository_handle,
@@ -24,7 +24,7 @@ def test_external_schedule_execution_data_api_grpc():
 
 def test_external_schedule_execution_data_api_never_execute_grpc():
     with instance_for_test() as instance:
-        with get_bar_repo_handle() as repository_handle:
+        with get_bar_repo_handle(instance) as repository_handle:
             execution_data = sync_get_external_schedule_execution_data_ephemeral_grpc(
                 instance,
                 repository_handle,
@@ -37,7 +37,7 @@ def test_external_schedule_execution_data_api_never_execute_grpc():
 
 def test_include_execution_time_grpc():
     with instance_for_test() as instance:
-        with get_bar_repo_handle() as repository_handle:
+        with get_bar_repo_handle(instance) as repository_handle:
             execution_time = get_current_datetime_in_utc()
             execution_data = sync_get_external_schedule_execution_data_ephemeral_grpc(
                 instance,

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_sensor.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_sensor.py
@@ -3,37 +3,33 @@ import pytest
 from dagster.api.snapshot_sensor import sync_get_external_sensor_execution_data_ephemeral_grpc
 from dagster.core.definitions.sensor_definition import SensorExecutionData
 from dagster.core.errors import DagsterUserCodeProcessError
-from dagster.core.test_utils import instance_for_test
 
 from .utils import get_bar_repo_handle
 
 
-def test_external_sensor_grpc():
-    with get_bar_repo_handle() as repository_handle:
-        with instance_for_test() as instance:
-            result = sync_get_external_sensor_execution_data_ephemeral_grpc(
-                instance, repository_handle, "sensor_foo", None, None, None
+def test_external_sensor_grpc(instance):
+    with get_bar_repo_handle(instance) as repository_handle:
+        result = sync_get_external_sensor_execution_data_ephemeral_grpc(
+            instance, repository_handle, "sensor_foo", None, None, None
+        )
+        assert isinstance(result, SensorExecutionData)
+        assert len(result.run_requests) == 2
+        run_request = result.run_requests[0]
+        assert run_request.run_config == {"foo": "FOO"}
+        assert run_request.tags == {"foo": "foo_tag"}
+
+
+def test_external_sensor_error(instance):
+    with get_bar_repo_handle(instance) as repository_handle:
+        with pytest.raises(DagsterUserCodeProcessError, match="womp womp"):
+            sync_get_external_sensor_execution_data_ephemeral_grpc(
+                instance, repository_handle, "sensor_error", None, None, None
             )
-            assert isinstance(result, SensorExecutionData)
-            assert len(result.run_requests) == 2
-            run_request = result.run_requests[0]
-            assert run_request.run_config == {"foo": "FOO"}
-            assert run_request.tags == {"foo": "foo_tag"}
 
 
-def test_external_sensor_error():
-    with get_bar_repo_handle() as repository_handle:
-        with instance_for_test() as instance:
-            with pytest.raises(DagsterUserCodeProcessError, match="womp womp"):
-                sync_get_external_sensor_execution_data_ephemeral_grpc(
-                    instance, repository_handle, "sensor_error", None, None, None
-                )
-
-
-def test_external_sensor_raises_dagster_error():
-    with get_bar_repo_handle() as repository_handle:
-        with instance_for_test() as instance:
-            with pytest.raises(DagsterUserCodeProcessError, match="Dagster error"):
-                sync_get_external_sensor_execution_data_ephemeral_grpc(
-                    instance, repository_handle, "sensor_raises_dagster_error", None, None, None
-                )
+def test_external_sensor_raises_dagster_error(instance):
+    with get_bar_repo_handle(instance) as repository_handle:
+        with pytest.raises(DagsterUserCodeProcessError, match="Dagster error"):
+            sync_get_external_sensor_execution_data_ephemeral_grpc(
+                instance, repository_handle, "sensor_raises_dagster_error", None, None, None
+            )

--- a/python_modules/dagster/dagster_tests/api_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/api_tests/utils.py
@@ -26,7 +26,7 @@ def get_bar_workspace(instance):
 
 
 @contextmanager
-def get_bar_repo_repository_location():
+def get_bar_repo_repository_location(instance):
     loadable_target_origin = LoadableTargetOrigin(
         executable_path=sys.executable,
         python_file=file_relative_path(__file__, "api_tests_repo.py"),
@@ -36,23 +36,17 @@ def get_bar_repo_repository_location():
 
     origin = ManagedGrpcPythonEnvRepositoryLocationOrigin(loadable_target_origin, location_name)
 
-    with origin.create_single_location() as location:
+    with origin.create_single_location(instance) as location:
         yield location
 
 
 @contextmanager
-def get_bar_repo_handle():
-    with get_bar_repo_repository_location() as location:
+def get_bar_repo_handle(instance):
+    with get_bar_repo_repository_location(instance) as location:
         yield location.get_repository("bar_repo").handle
 
 
 @contextmanager
-def get_foo_pipeline_handle():
-    with get_bar_repo_handle() as repo_handle:
+def get_foo_pipeline_handle(instance):
+    with get_bar_repo_handle(instance) as repo_handle:
         yield PipelineHandle("foo", repo_handle)
-
-
-@contextmanager
-def get_foo_external_pipeline():
-    with get_bar_repo_repository_location() as location:
-        yield location.get_repository("bar_repo").get_full_external_pipeline("foo")

--- a/python_modules/dagster/dagster_tests/cli_tests/test_api_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_api_commands.py
@@ -35,17 +35,17 @@ def runner_execute_run(runner, cli_args):
 
 
 def test_execute_run():
-    with get_foo_pipeline_handle() as pipeline_handle:
-        runner = CliRunner()
-
-        with instance_for_test(
-            overrides={
-                "compute_logs": {
-                    "module": "dagster.core.storage.noop_compute_log_manager",
-                    "class": "NoOpComputeLogManager",
-                }
+    with instance_for_test(
+        overrides={
+            "compute_logs": {
+                "module": "dagster.core.storage.noop_compute_log_manager",
+                "class": "NoOpComputeLogManager",
             }
-        ) as instance:
+        }
+    ) as instance:
+        with get_foo_pipeline_handle(instance) as pipeline_handle:
+            runner = CliRunner()
+
             instance = DagsterInstance.get()
             run = create_run_for_test(instance, pipeline_name="foo", run_id="new_run")
 
@@ -70,18 +70,18 @@ def test_execute_run():
 
 
 def test_execute_run_fail_pipeline():
-    with get_bar_repo_handle() as repo_handle:
-        pipeline_handle = PipelineHandle("fail", repo_handle)
-        runner = CliRunner()
-
-        with instance_for_test(
-            overrides={
-                "compute_logs": {
-                    "module": "dagster.core.storage.noop_compute_log_manager",
-                    "class": "NoOpComputeLogManager",
-                }
+    with instance_for_test(
+        overrides={
+            "compute_logs": {
+                "module": "dagster.core.storage.noop_compute_log_manager",
+                "class": "NoOpComputeLogManager",
             }
-        ) as instance:
+        }
+    ) as instance:
+        with get_bar_repo_handle(instance) as repo_handle:
+            pipeline_handle = PipelineHandle("fail", repo_handle)
+            runner = CliRunner()
+
             instance = DagsterInstance.get()
             run = create_run_for_test(instance, pipeline_name="foo", run_id="new_run")
 
@@ -126,18 +126,16 @@ def test_execute_run_fail_pipeline():
 
 
 def test_execute_run_cannot_load():
-    with get_foo_pipeline_handle() as pipeline_handle:
-        runner = CliRunner()
-
-        with instance_for_test(
-            overrides={
-                "compute_logs": {
-                    "module": "dagster.core.storage.noop_compute_log_manager",
-                    "class": "NoOpComputeLogManager",
-                }
+    with instance_for_test(
+        overrides={
+            "compute_logs": {
+                "module": "dagster.core.storage.noop_compute_log_manager",
+                "class": "NoOpComputeLogManager",
             }
-        ) as instance:
-            instance = DagsterInstance.get()
+        }
+    ) as instance:
+        with get_foo_pipeline_handle(instance) as pipeline_handle:
+            runner = CliRunner()
 
             input_json = serialize_dagster_namedtuple(
                 ExecuteRunArgs(
@@ -181,17 +179,17 @@ def runner_execute_step(runner, cli_args):
 
 
 def test_execute_step():
-    with get_foo_pipeline_handle() as pipeline_handle:
-        runner = CliRunner()
-
-        with instance_for_test(
-            overrides={
-                "compute_logs": {
-                    "module": "dagster.core.storage.noop_compute_log_manager",
-                    "class": "NoOpComputeLogManager",
-                }
+    with instance_for_test(
+        overrides={
+            "compute_logs": {
+                "module": "dagster.core.storage.noop_compute_log_manager",
+                "class": "NoOpComputeLogManager",
             }
-        ) as instance:
+        }
+    ) as instance:
+        with get_foo_pipeline_handle(instance) as pipeline_handle:
+            runner = CliRunner()
+
             run = create_run_for_test(instance, pipeline_name="foo", run_id="new_run")
 
             input_json = serialize_dagster_namedtuple(
@@ -212,17 +210,18 @@ def test_execute_step():
 
 
 def test_execute_step_1():
-    with get_foo_pipeline_handle() as pipeline_handle:
-        runner = CliRunner()
 
-        with instance_for_test(
-            overrides={
-                "compute_logs": {
-                    "module": "dagster.core.storage.noop_compute_log_manager",
-                    "class": "NoOpComputeLogManager",
-                }
+    with instance_for_test(
+        overrides={
+            "compute_logs": {
+                "module": "dagster.core.storage.noop_compute_log_manager",
+                "class": "NoOpComputeLogManager",
             }
-        ) as instance:
+        }
+    ) as instance:
+        with get_foo_pipeline_handle(instance) as pipeline_handle:
+            runner = CliRunner()
+
             run = create_run_for_test(instance, pipeline_name="foo", run_id="new_run")
 
             input_json = serialize_dagster_namedtuple(
@@ -243,17 +242,17 @@ def test_execute_step_1():
 
 
 def test_execute_step_verify_step():
-    with get_foo_pipeline_handle() as pipeline_handle:
-        runner = CliRunner()
-
-        with instance_for_test(
-            overrides={
-                "compute_logs": {
-                    "module": "dagster.core.storage.noop_compute_log_manager",
-                    "class": "NoOpComputeLogManager",
-                }
+    with instance_for_test(
+        overrides={
+            "compute_logs": {
+                "module": "dagster.core.storage.noop_compute_log_manager",
+                "class": "NoOpComputeLogManager",
             }
-        ) as instance:
+        }
+    ) as instance:
+        with get_foo_pipeline_handle(instance) as pipeline_handle:
+            runner = CliRunner()
+
             run = create_run_for_test(
                 instance,
                 pipeline_name="foo",
@@ -304,19 +303,19 @@ def test_execute_step_verify_step():
 
 @mock.patch("dagster.cli.api.verify_step")
 def test_execute_step_verify_step_framework_error(mock_verify_step):
-    with get_foo_pipeline_handle() as pipeline_handle:
-        runner = CliRunner()
-
-        mock_verify_step.side_effect = Exception("Unexpected framework error text")
-
-        with instance_for_test(
-            overrides={
-                "compute_logs": {
-                    "module": "dagster.core.storage.noop_compute_log_manager",
-                    "class": "NoOpComputeLogManager",
-                }
+    with instance_for_test(
+        overrides={
+            "compute_logs": {
+                "module": "dagster.core.storage.noop_compute_log_manager",
+                "class": "NoOpComputeLogManager",
             }
-        ) as instance:
+        }
+    ) as instance:
+        with get_foo_pipeline_handle(instance) as pipeline_handle:
+            runner = CliRunner()
+
+            mock_verify_step.side_effect = Exception("Unexpected framework error text")
+
             run = create_run_for_test(
                 instance,
                 pipeline_name="foo",

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/multi_location/test_multi_location_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/multi_location/test_multi_location_workspace.py
@@ -6,6 +6,7 @@ import yaml
 
 from dagster import DagsterInstance
 from dagster.core.host_representation import GrpcServerRepositoryLocation
+from dagster.core.test_utils import instance_for_test
 from dagster.core.workspace import WorkspaceProcessContext
 from dagster.core.workspace.load import (
     load_workspace_process_context_from_yaml_paths,
@@ -190,8 +191,9 @@ def test_grpc_multi_location_workspace(config_source):
         file_relative_path(__file__, "not_a_real.yaml"),
     )
     with ExitStack() as stack:
+        instance = stack.enter_context(instance_for_test())
         repository_locations = {
-            name: stack.enter_context(origin.create_single_location())
+            name: stack.enter_context(origin.create_single_location(instance))
             for name, origin in origins.items()
         }
 

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -14,6 +14,7 @@ from dagster.core.errors import (
 )
 from dagster.core.execution.api import create_execution_plan
 from dagster.core.instance import DagsterInstance, InstanceRef
+from dagster.core.instance.config import DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
 from dagster.core.launcher import LaunchRunContext, RunLauncher
 from dagster.core.run_coordinator.queued_run_coordinator import QueuedRunCoordinator
 from dagster.core.snap import (
@@ -201,7 +202,20 @@ class TestNonResumeRunLauncher(RunLauncher, ConfigurableClass):
         return True
 
 
-def test_run_monitoring(capsys):
+def test_grpc_default_settings():
+    with instance_for_test() as instance:
+        assert (
+            instance.code_server_process_startup_timeout
+            == DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
+        )
+
+
+def test_grpc_override_settings():
+    with instance_for_test(overrides={"code_servers": {"local_startup_timeout": 60}}) as instance:
+        assert instance.code_server_process_startup_timeout == 60
+
+
+def test_run_monitoring(capsys):  # pylint: disable=unused-argument
     with instance_for_test(
         overrides={
             "run_monitoring": {"enabled": True},

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -172,20 +172,21 @@ def test_diamond_toposort():
 
 
 def test_external_diamond_toposort():
-    with location_origin_from_python_file(
-        python_file=__file__,
-        attribute="create_diamond_pipeline",
-        working_directory=None,
-    ).create_single_location() as repo_location:
-        external_repo = next(iter(repo_location.get_repositories().values()))
-        external_pipeline = next(iter(external_repo.get_all_external_pipelines()))
-        assert external_pipeline.solid_names_in_topological_order == [
-            "A_source",
-            "A",
-            "B",
-            "C",
-            "D",
-        ]
+    with instance_for_test() as instance:
+        with location_origin_from_python_file(
+            python_file=__file__,
+            attribute="create_diamond_pipeline",
+            working_directory=None,
+        ).create_single_location(instance) as repo_location:
+            external_repo = next(iter(repo_location.get_repositories().values()))
+            external_pipeline = next(iter(external_repo.get_all_external_pipelines()))
+            assert external_pipeline.solid_names_in_topological_order == [
+                "A_source",
+                "A",
+                "B",
+                "C",
+                "D",
+            ]
 
 
 def compute_called(name):

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -210,10 +210,10 @@ def the_repo():
 
 
 @contextmanager
-def default_repo():
+def default_repo(instance):
     load_target = workspace_load_target()
     origin = load_target.create_origins()[0]
-    with origin.create_single_location() as location:
+    with origin.create_single_location(instance) as location:
         yield location.get_repository("the_repo")
 
 
@@ -230,9 +230,10 @@ def workspace_load_target():
 def instance_for_context(external_repo_context, overrides=None):
     with instance_for_test(overrides) as instance:
         with create_test_daemon_workspace(
-            workspace_load_target=workspace_load_target()
+            workspace_load_target=workspace_load_target(),
+            instance=instance,
         ) as workspace:
-            with external_repo_context() as external_repo:
+            with external_repo_context(instance) as external_repo:
                 yield (instance, workspace, external_repo)
 
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
@@ -33,7 +33,7 @@ def _test_backfill_in_subprocess(instance_ref, debug_crash_flags):
     with DagsterInstance.from_ref(instance_ref) as instance:
         try:
             with pendulum.test(execution_datetime), create_test_daemon_workspace(
-                workspace_load_target=workspace_load_target()
+                workspace_load_target=workspace_load_target(), instance=instance
             ) as workspace:
                 list(
                     execute_backfill_iteration(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
@@ -87,8 +87,10 @@ def instance():
 
 
 @pytest.fixture
-def workspace():
-    with create_test_daemon_workspace(workspace_load_target=EmptyWorkspaceTarget()) as workspace:
+def workspace(instance):
+    with create_test_daemon_workspace(
+        workspace_load_target=EmptyWorkspaceTarget(), instance=instance
+    ) as workspace:
         yield workspace
 
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -54,13 +54,15 @@ def daemon_fixture():
 
 
 @pytest.fixture(name="workspace")
-def workspace_fixture():
-    with create_test_daemon_workspace(workspace_load_target=EmptyWorkspaceTarget()) as workspace:
+def workspace_fixture(instance):
+    with create_test_daemon_workspace(
+        workspace_load_target=EmptyWorkspaceTarget(), instance=instance
+    ) as workspace:
         yield workspace
 
 
 def create_run(instance, **kwargs):
-    with get_foo_pipeline_handle() as pipeline_handle:
+    with get_foo_pipeline_handle(instance) as pipeline_handle:
         create_run_for_test(
             instance,
             external_pipeline_origin=pipeline_handle.get_external_origin(),

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
@@ -32,7 +32,8 @@ def _test_launch_sensor_runs_in_subprocess(instance_ref, execution_datetime, deb
     with DagsterInstance.from_ref(instance_ref) as instance:
         try:
             with pendulum.test(execution_datetime), create_test_daemon_workspace(
-                workspace_load_target=workspace_load_target()
+                workspace_load_target=workspace_load_target(),
+                instance=instance,
             ) as workspace:
                 list(
                     execute_sensor_iteration(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -349,7 +349,9 @@ def the_status_in_code_repo():
 @contextmanager
 def instance_with_sensors(overrides=None, attribute="the_repo"):
     with instance_for_test(overrides) as instance:
-        with create_test_daemon_workspace(workspace_load_target(attribute)) as workspace:
+        with create_test_daemon_workspace(
+            workspace_load_target(attribute), instance=instance
+        ) as workspace:
             yield (
                 instance,
                 workspace,
@@ -2161,7 +2163,8 @@ def test_status_in_code_sensor():
     )
     with instance_for_test() as instance:
         with create_test_daemon_workspace(
-            workspace_load_target(attribute="the_status_in_code_repo")
+            workspace_load_target(attribute="the_status_in_code_repo"),
+            instance=instance,
         ) as workspace:
             external_repo = next(
                 iter(workspace.get_workspace_snapshot().values())

--- a/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
@@ -36,7 +36,9 @@ def workspace_load_target(attribute="the_repo"):
 
 @pytest.fixture(name="workspace", scope="session")
 def workspace_fixture(instance_session_scoped):  # pylint: disable=unused-argument
-    with create_test_daemon_workspace(workspace_load_target=workspace_load_target()) as workspace:
+    with create_test_daemon_workspace(
+        workspace_load_target=workspace_load_target(), instance=instance_session_scoped
+    ) as workspace:
         yield workspace
 
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
@@ -31,7 +31,7 @@ spawn_ctx = multiprocessing.get_context("spawn")
 def _test_launch_scheduled_runs_in_subprocess(instance_ref, execution_datetime, debug_crash_flags):
     with DagsterInstance.from_ref(instance_ref) as instance:
         try:
-            with create_test_daemon_workspace(workspace_load_target()) as workspace:
+            with create_test_daemon_workspace(workspace_load_target(), instance) as workspace:
                 with pendulum.test(execution_datetime):
                     list(
                         launch_scheduled_runs(

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -692,7 +692,8 @@ def test_no_started_schedules(instance, workspace, external_repo):
 def test_schedule_without_timezone(instance):
     with mock_system_timezone("US/Eastern"):
         with create_test_daemon_workspace(
-            workspace_load_target=workspace_load_target()
+            workspace_load_target=workspace_load_target(),
+            instance=instance,
         ) as workspace:
             external_repo = next(
                 iter(workspace.get_workspace_snapshot().values())
@@ -1303,7 +1304,9 @@ def test_bad_load_schedule(instance, workspace, external_repo, caplog):
 
 
 def test_error_load_repository_location(instance):
-    with create_test_daemon_workspace(_get_unloadable_workspace_load_target()) as workspace:
+    with create_test_daemon_workspace(
+        _get_unloadable_workspace_load_target(), instance
+    ) as workspace:
         fake_origin = _get_unloadable_schedule_origin()
         initial_datetime = create_pendulum_time(
             year=2019,
@@ -1801,7 +1804,8 @@ def test_grpc_server_down(instance):
 
     initial_datetime = create_pendulum_time(year=2019, month=2, day=27, hour=0, minute=0, second=0)
     with create_test_daemon_workspace(
-        GrpcServerTarget(host="localhost", port=port, socket=None, location_name="test_location")
+        GrpcServerTarget(host="localhost", port=port, socket=None, location_name="test_location"),
+        instance,
     ) as workspace:
         with pendulum.test(initial_datetime):
             with _grpc_server_external_repo(port) as external_repo:
@@ -1851,7 +1855,8 @@ def test_status_in_code_schedule(instance):
         "US/Central",
     )
     with create_test_daemon_workspace(
-        workspace_load_target(attribute="the_status_in_code_repo")
+        workspace_load_target(attribute="the_status_in_code_repo"),
+        instance,
     ) as workspace:
         external_repo = next(
             iter(workspace.get_workspace_snapshot().values())
@@ -1991,7 +1996,7 @@ def test_status_in_code_schedule(instance):
 
     # Now try with an empty workspace - ticks are still there, but the job state is deleted
     # once it's no longer present in the workspace
-    with create_test_daemon_workspace(EmptyWorkspaceTarget()) as empty_workspace:
+    with create_test_daemon_workspace(EmptyWorkspaceTarget(), instance) as empty_workspace:
         with pendulum.test(freeze_datetime):
             list(
                 launch_scheduled_runs(
@@ -2013,7 +2018,8 @@ def test_change_default_status(instance):
         "US/Central",
     )
     with create_test_daemon_workspace(
-        workspace_load_target(attribute="the_status_in_code_repo")
+        workspace_load_target(attribute="the_status_in_code_repo"),
+        instance,
     ) as workspace:
         external_repo = next(
             iter(workspace.get_workspace_snapshot().values())


### PR DESCRIPTION
Summary:
Creates an instance setting that you can use to say that your server should be allowed more than 60 seconds to start up when waiting for a gRPC server to start.