### PR TITLE
allow AssetGroups to have assets with different partitions defs

### DIFF
--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/partitioned_assets.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/partitioned_assets.py
@@ -1,5 +1,7 @@
 # pylint: disable=redefined-outer-name
-from dagster import AssetGroup, DailyPartitionsDefinition, asset
+from datetime import datetime
+
+from dagster import AssetGroup, DailyPartitionsDefinition, HourlyPartitionsDefinition, asset
 
 daily_partitions_def = DailyPartitionsDefinition(start_date="2020-01-01")
 
@@ -12,6 +14,16 @@ def upstream_daily_partitioned_asset():
 @asset(partitions_def=daily_partitions_def)
 def downstream_daily_partitioned_asset(upstream_daily_partitioned_asset):
     assert upstream_daily_partitioned_asset is None
+
+
+@asset(partitions_def=HourlyPartitionsDefinition(start_date=datetime(2022, 3, 12, 0, 0)))
+def hourly_partitioned_asset():
+    pass
+
+
+@asset
+def unpartitioned_asset():
+    pass
 
 
 partitioned_asset_group = AssetGroup.from_current_module()

--- a/python_modules/dagster-test/dagster_test_tests/test_graph_job_op_toys.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_graph_job_op_toys.py
@@ -303,8 +303,8 @@ def test_software_defined_assets_job():
 
 
 def test_partitioned_assets():
-    assert (
-        partitioned_asset_group.build_job("all_assets")
-        .execute_in_process(partition_key="2020-02-01")
-        .success
-    )
+    for job_def in partitioned_asset_group.get_base_jobs():
+        partition_key = job_def.mode_definitions[
+            0
+        ].partitioned_config.partitions_def.get_partition_keys()[0]
+        assert job_def.execute_in_process(partition_key=partition_key).success

--- a/python_modules/dagster/dagster/core/definitions/partition.py
+++ b/python_modules/dagster/dagster/core/definitions/partition.py
@@ -202,6 +202,9 @@ class StaticPartitionsDefinition(
     ) -> List[Partition[str]]:
         return self._partitions
 
+    def __hash__(self):
+        return hash(self.__repr__())
+
     def __eq__(self, other) -> bool:
         return (
             isinstance(other, StaticPartitionsDefinition)

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
@@ -6,6 +6,8 @@ import pytest
 from dagster import (
     AssetKey,
     DagsterInvalidDefinitionError,
+    DailyPartitionsDefinition,
+    HourlyPartitionsDefinition,
     IOManager,
     Out,
     fs_asset_io_manager,
@@ -56,7 +58,7 @@ def test_asset_group_from_list():
 
     assert len(the_repo.get_all_jobs()) == 1
     asset_group_underlying_job = the_repo.get_all_jobs()[0]
-    assert asset_group_underlying_job.name == group.all_assets_job_name()
+    assert AssetGroup.is_base_job_name(asset_group_underlying_job.name)
 
     result = asset_group_underlying_job.execute_in_process()
     assert result.success
@@ -91,7 +93,7 @@ def test_asset_group_source_asset():
         return [group]
 
     asset_group_underlying_job = the_repo.get_all_jobs()[0]
-    assert asset_group_underlying_job.name == group.all_assets_job_name()
+    assert AssetGroup.is_base_job_name(asset_group_underlying_job.name)
 
     result = asset_group_underlying_job.execute_in_process()
     assert result.success
@@ -113,7 +115,7 @@ def test_asset_group_with_resources():
         return [group]
 
     asset_group_underlying_job = the_repo.get_all_jobs()[0]
-    assert asset_group_underlying_job.name == group.all_assets_job_name()
+    assert AssetGroup.is_base_job_name(asset_group_underlying_job.name)
 
     result = asset_group_underlying_job.execute_in_process()
     assert result.success
@@ -456,10 +458,10 @@ def test_job_with_reserved_name():
     def the_graph():
         pass
 
-    the_job = the_graph.to_job(name=AssetGroup.all_assets_job_name())
+    the_job = the_graph.to_job(name="__ASSET_GROUP")
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match=f"Attempted to provide job called {AssetGroup.all_assets_job_name()} to repository, which is a reserved name.",
+        match="Attempted to provide job called __ASSET_GROUP to repository, which is a reserved name.",
     ):
 
         @repository
@@ -521,3 +523,50 @@ def test_materialize_with_selection():
     assert result.output_for_node("middle_asset", "o1") == "foo"
     assert result.output_for_node("follows_o2") == "foo"
     assert result.output_for_node("start_asset") == "foo"
+
+
+def test_multiple_partitions_defs():
+    @asset(partitions_def=DailyPartitionsDefinition(start_date="2021-05-05"))
+    def daily_asset():
+        ...
+
+    @asset(partitions_def=DailyPartitionsDefinition(start_date="2021-05-05"))
+    def daily_asset2():
+        ...
+
+    @asset(partitions_def=DailyPartitionsDefinition(start_date="2020-05-05"))
+    def daily_asset_different_start_date():
+        ...
+
+    @asset(partitions_def=HourlyPartitionsDefinition(start_date="2021-05-05-00:00"))
+    def hourly_asset():
+        ...
+
+    @asset
+    def unpartitioned_asset():
+        ...
+
+    group = AssetGroup(
+        [
+            daily_asset,
+            daily_asset2,
+            daily_asset_different_start_date,
+            hourly_asset,
+            unpartitioned_asset,
+        ]
+    )
+
+    jobs = group.get_base_jobs()
+    assert len(jobs) == 3
+    assert {job_def.name for job_def in jobs} == {
+        "__ASSET_GROUP_0",
+        "__ASSET_GROUP_1",
+        "__ASSET_GROUP_2",
+    }
+    assert {
+        frozenset([node_def.name for node_def in job_def.all_node_defs]) for job_def in jobs
+    } == {
+        frozenset(["daily_asset", "daily_asset2", "unpartitioned_asset"]),
+        frozenset(["hourly_asset", "unpartitioned_asset"]),
+        frozenset(["daily_asset_different_start_date", "unpartitioned_asset"]),
+    }

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dagster import AssetGroup, AssetKey, DagsterInvariantViolationError, Out
+from dagster import AssetKey, DagsterInvariantViolationError, Out
 from dagster.check import CheckError
 from dagster.core.asset_defs import AssetIn, SourceAsset, asset, build_assets_job, multi_asset
 from dagster.core.definitions.metadata import MetadataEntry, MetadataValue
@@ -73,59 +73,6 @@ def test_two_asset_job():
             op_name="asset2",
             op_description=None,
             job_names=["assets_job"],
-            output_name="result",
-            output_description=None,
-        ),
-    ]
-
-
-def test_two_asset_job_with_group():
-    @asset
-    def asset1():
-        return 1
-
-    @asset
-    def asset2(asset1):
-        assert asset1 == 1
-
-    asset_group = AssetGroup(assets=[asset1, asset2])
-    asset_group_job = build_assets_job(
-        asset_group.all_assets_job_name(),
-        assets=asset_group.assets,
-        source_assets=asset_group.source_assets,
-        resource_defs=asset_group.resource_defs,
-        executor_def=asset_group.executor_def,
-    )
-    assets_job = asset_group.build_job(name="assets_job")
-
-    external_asset_nodes = external_asset_graph_from_defs(
-        [asset_group_job, assets_job], source_assets_by_key={}
-    )
-
-    assert external_asset_nodes == [
-        ExternalAssetNode(
-            asset_key=AssetKey("asset1"),
-            dependencies=[],
-            depended_by=[
-                ExternalAssetDependedBy(
-                    downstream_asset_key=AssetKey("asset2"), input_name="asset1"
-                )
-            ],
-            op_name="asset1",
-            op_description=None,
-            job_names=[AssetGroup.all_assets_job_name(), "assets_job"],
-            output_name="result",
-            output_description=None,
-        ),
-        ExternalAssetNode(
-            asset_key=AssetKey("asset2"),
-            dependencies=[
-                ExternalAssetDependency(upstream_asset_key=AssetKey("asset1"), input_name="asset1")
-            ],
-            depended_by=[],
-            op_name="asset2",
-            op_description=None,
-            job_names=[AssetGroup.all_assets_job_name(), "assets_job"],
             output_name="result",
             output_description=None,
         ),


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

The constraint here is that all the assets within a job must have the same partitions definition or no partitions definition.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.