### PR TITLE
[dagit] Show /instance when there are any repos with jobs

### DIFF
--- a/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
@@ -70,8 +70,8 @@ const FinalRedirectOrLoadingRoot = () => {
     );
   }
 
-  // If we have more than one job, route to the instance overview
-  if (reposWithAJob.length > 1) {
+  // Otherwise, if we have any repos with jobs, route to the instance overview.
+  if (reposWithAJob.length) {
     return <Redirect to="/instance" />;
   }
 


### PR DESCRIPTION
## Summary

When Dagit is loaded with at least one repository that contains more than one job, we should redirect to `/instance`. This is currently broken, and falls through to the "No jobs" error state.

## Test Plan

Load Cloud with a single repo loaded with many jobs in it. Verify that I am redirected to Instance Overview.
