### PR TITLE
[draft][rfc] Hackernews with resources, deployment info, on repositories

### DIFF
--- a/examples/hacker_news/hacker_news/jobs/dbt_metrics.py
+++ b/examples/hacker_news/hacker_news/jobs/dbt_metrics.py
@@ -1,6 +1,5 @@
 from dagster_dbt import dbt_cli_resource
 from hacker_news.ops.dbt import hn_dbt_run, hn_dbt_test
-from hacker_news.resources import RESOURCES_PROD, RESOURCES_STAGING
 from hacker_news.resources.dbt_asset_resource import SnowflakeQueryDbtAssetResource
 from hacker_news.resources.snowflake_io_manager import SHARED_SNOWFLAKE_CONF
 
@@ -28,33 +27,25 @@ def dbt_metrics():
 
 dbt_prod_job = dbt_metrics.to_job(
     resource_defs={
-        **RESOURCES_PROD,
-        **{
-            "dbt": dbt_prod_resource,
-            # this is an alternative pattern to the configured() api. If you know that you won't want to
-            # further configure this resource per pipeline run, this can be a bit more convenient than
-            # defining an @resource with a config schema.
-            "dbt_assets": ResourceDefinition.hardcoded_resource(
-                SnowflakeQueryDbtAssetResource(
-                    {**{"database": "DEMO_DB"}, **SHARED_SNOWFLAKE_CONF}, "hackernews"
-                )
-            ),
-            "partition_bounds": ResourceDefinition.none_resource(),
-        },
+        "dbt": dbt_prod_resource,
+        # this is an alternative pattern to the configured() api. If you know that you won't want to
+        # further configure this resource per pipeline run, this can be a bit more convenient than
+        # defining an @resource with a config schema.
+        "dbt_assets": ResourceDefinition.hardcoded_resource(
+            SnowflakeQueryDbtAssetResource(
+                {**{"database": "DEMO_DB"}, **SHARED_SNOWFLAKE_CONF}, "hackernews"
+            )
+        ),
     }
 )
 
 dbt_staging_job = dbt_metrics.to_job(
     resource_defs={
-        **RESOURCES_STAGING,
-        **{
-            "dbt": dbt_staging_resource,
-            "dbt_assets": ResourceDefinition.hardcoded_resource(
-                SnowflakeQueryDbtAssetResource(
-                    {**{"database": "DEMO_DB_STAGING"}, **SHARED_SNOWFLAKE_CONF}, "hackernews"
-                )
-            ),
-            "partition_bounds": ResourceDefinition.none_resource(),
-        },
+        "dbt": dbt_staging_resource,
+        "dbt_assets": ResourceDefinition.hardcoded_resource(
+            SnowflakeQueryDbtAssetResource(
+                {**{"database": "DEMO_DB_STAGING"}, **SHARED_SNOWFLAKE_CONF}, "hackernews"
+            )
+        ),
     }
 )

--- a/examples/hacker_news/hacker_news/jobs/hacker_news_api_download.py
+++ b/examples/hacker_news/hacker_news/jobs/hacker_news_api_download.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 from hacker_news.ops.download_items import build_comments, build_stories, download_items
 from hacker_news.ops.id_range_for_time import id_range_for_time
-from hacker_news.resources import RESOURCES_LOCAL, RESOURCES_PROD, RESOURCES_STAGING
 from hacker_news.resources.hn_resource import hn_api_subsample_client, hn_snapshot_client
 from hacker_news.resources.partition_bounds import partition_bounds
 
@@ -51,11 +50,8 @@ def hourly_download_config(start: datetime, end: datetime):
 
 download_prod_job = hacker_news_api_download.to_job(
     resource_defs={
-        **{
-            "partition_bounds": partition_bounds,
-            "hn_client": hn_api_subsample_client.configured({"sample_rate": 10}),
-        },
-        **RESOURCES_PROD,
+        "partition_bounds": partition_bounds,
+        "hn_client": hn_api_subsample_client.configured({"sample_rate": 10}),
     },
     tags=DOWNLOAD_TAGS,
     config=hourly_download_config,
@@ -64,11 +60,8 @@ download_prod_job = hacker_news_api_download.to_job(
 
 download_staging_job = hacker_news_api_download.to_job(
     resource_defs={
-        **{
-            "partition_bounds": partition_bounds,
-            "hn_client": hn_api_subsample_client.configured({"sample_rate": 10}),
-        },
-        **RESOURCES_STAGING,
+        "partition_bounds": partition_bounds,
+        "hn_client": hn_api_subsample_client.configured({"sample_rate": 10}),
     },
     tags=DOWNLOAD_TAGS,
     config=hourly_download_config,
@@ -76,18 +69,13 @@ download_staging_job = hacker_news_api_download.to_job(
 
 download_local_job = hacker_news_api_download.to_job(
     resource_defs={
-        **{"partition_bounds": partition_bounds, "hn_client": hn_snapshot_client},
-        **RESOURCES_LOCAL,
-    },
-    config={
-        "resources": {
-            "partition_bounds": {
-                "config": {
-                    "start": "2020-12-30 00:00:00",
-                    "end": "2020-12-30 01:00:00",
-                }
-            },
-        }
+        "partition_bounds": partition_bounds.configured(
+            {
+                "start": "2020-12-30 00:00:00",
+                "end": "2020-12-30 01:00:00",
+            }
+        ),
+        "hn_client": hn_snapshot_client,
     },
     executor_def=in_process_executor,
 )

--- a/examples/hacker_news/hacker_news/jobs/story_recommender.py
+++ b/examples/hacker_news/hacker_news/jobs/story_recommender.py
@@ -6,7 +6,6 @@ from hacker_news.ops.recommender_model import (
 )
 from hacker_news.ops.user_story_matrix import build_user_story_matrix
 from hacker_news.ops.user_top_recommended_stories import build_user_top_recommended_stories
-from hacker_news.resources import RESOURCES_LOCAL, RESOURCES_PROD, RESOURCES_STAGING
 
 from dagster import ResourceDefinition, graph
 
@@ -23,25 +22,3 @@ def story_recommender():
     model_perf_notebook(recommender_model)
     build_component_top_stories(recommender_model, user_story_matrix)
     build_user_top_recommended_stories(recommender_model, user_story_matrix)
-
-
-story_recommender_prod_job = story_recommender.to_job(
-    resource_defs={
-        **RESOURCES_PROD,
-        **{"partition_bounds": ResourceDefinition.none_resource()},
-    }
-)
-
-story_recommender_staging_job = story_recommender.to_job(
-    resource_defs={
-        **RESOURCES_STAGING,
-        **{"partition_bounds": ResourceDefinition.none_resource()},
-    }
-)
-
-story_recommender_local_job = story_recommender.to_job(
-    resource_defs={
-        **RESOURCES_LOCAL,
-        **{"partition_bounds": ResourceDefinition.none_resource()},
-    }
-)

--- a/examples/hacker_news/hacker_news/repo.py
+++ b/examples/hacker_news/hacker_news/repo.py
@@ -6,39 +6,32 @@ from .jobs.hacker_news_api_download import (
     download_prod_job,
     download_staging_job,
 )
-from .jobs.story_recommender import (
-    story_recommender_local_job,
-    story_recommender_prod_job,
-    story_recommender_staging_job,
-)
+from .jobs.story_recommender import story_recommender
 from .sensors.hn_tables_updated_sensor import make_hn_tables_updated_sensor
 from .sensors.slack_on_failure_sensor import make_slack_on_failure_sensor
+from hacker_news.resources import RESOURCES_LOCAL, RESOURCES_PROD, RESOURCES_STAGING
 
 
 @repository
-def hacker_news_local():
-    return [
-        download_local_job,
-        story_recommender_local_job,
-        dbt_staging_job,
-    ]
+def hacker_news(context):
+    if context.deployment_info.deployment_name == "local":
+        return [download_local_job, story_recommender, dbt_staging_job, RESOURCES_LOCAL]
+    elif context.deployment_info.deployment_name == "staging":
+        return [
+            build_schedule_from_partitioned_job(download_staging_job),
+            make_slack_on_failure_sensor(base_url="my_staging_dagit_url.com"),
+            make_hn_tables_updated_sensor(story_recommender),
+            make_hn_tables_updated_sensor(dbt_staging_job),
+            RESOURCES_STAGING,
+        ]
 
-
-@repository
-def hacker_news_prod():
-    return [
-        build_schedule_from_partitioned_job(download_prod_job),
-        make_slack_on_failure_sensor(base_url="my_prod_dagit_url.com"),
-        make_hn_tables_updated_sensor(story_recommender_prod_job),
-        make_hn_tables_updated_sensor(dbt_prod_job),
-    ]
-
-
-@repository
-def hacker_news_staging():
-    return [
-        build_schedule_from_partitioned_job(download_staging_job),
-        make_slack_on_failure_sensor(base_url="my_staging_dagit_url.com"),
-        make_hn_tables_updated_sensor(story_recommender_staging_job),
-        make_hn_tables_updated_sensor(dbt_staging_job),
-    ]
+    elif context.deployment_nfo.deployment_name == "prod":
+        return [
+            build_schedule_from_partitioned_job(download_prod_job),
+            make_slack_on_failure_sensor(base_url="my_prod_dagit_url.com"),
+            make_hn_tables_updated_sensor(story_recommender),
+            make_hn_tables_updated_sensor(dbt_prod_job),
+            RESOURCES_PROD,
+        ]
+    else:
+        raise Exception(f"Unexpected deployment {context.deployment_info.deployment_name}")


### PR DESCRIPTION
This RFC models how hacker-news might look in a world where you could specify a set of resources on a repository, and decide which code artifacts to return based on deployment information.