### PR TITLE
[dagster-graphql] remove gevent

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql/cli.py
@@ -3,8 +3,6 @@ from urllib.parse import urljoin, urlparse
 import click
 import requests
 from graphql import graphql
-from graphql.execution.executors.gevent import GeventExecutor
-from graphql.execution.executors.sync import SyncExecutor
 
 from dagster import __version__ as dagster_version
 from dagster import check, seven
@@ -27,26 +25,22 @@ def create_dagster_graphql_cli():
     return ui
 
 
-def execute_query(workspace_process_context, query, variables=None, use_sync_executor=False):
+def execute_query(workspace_process_context, query, variables=None):
     check.inst_param(
         workspace_process_context, "workspace_process_context", WorkspaceProcessContext
     )
     check.str_param(query, "query")
     check.opt_dict_param(variables, "variables")
-    check.bool_param(use_sync_executor, "use_sync_executor")
 
     query = query.strip("'\" \n\t")
 
     context = workspace_process_context.create_request_context()
-
-    executor = SyncExecutor() if use_sync_executor else GeventExecutor()
 
     result = graphql(
         request_string=query,
         schema=create_schema(),
         context_value=context,
         variable_values=variables,
-        executor=executor,
     )
 
     result_dict = result.to_dict()

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/pipeline_run_storage.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/pipeline_run_storage.py
@@ -3,8 +3,6 @@ from enum import Enum
 from threading import Event, Thread
 from time import sleep
 
-import gevent
-
 from dagster import check
 
 
@@ -52,19 +50,13 @@ class PipelineRunObservableSubscribe:
     def load_events(self):
         self.state = State.LOADING
 
-        # support for gevent based dagit server
-        if gevent.get_hub().gr_frame:
-            self.stopping = gevent.event.Event()
-            self.stopped = gevent.event.Event()
-            load_thread = gevent.Greenlet(self.background_event_loading, gevent.sleep)
-        else:
-            self.stopping = Event()
-            self.stopped = Event()
-            load_thread = Thread(
-                target=self.background_event_loading,
-                args=(sleep,),
-                name=f"load-events-{self.run_id}",
-            )
+        self.stopping = Event()
+        self.stopped = Event()
+        load_thread = Thread(
+            target=self.background_event_loading,
+            args=(sleep,),
+            name=f"load-events-{self.run_id}",
+        )
 
         load_thread.start()
 

--- a/python_modules/dagster-graphql/setup.py
+++ b/python_modules/dagster-graphql/setup.py
@@ -36,8 +36,6 @@ if __name__ == "__main__":
             f"dagster{pin}",
             "graphene>=2.1.3,<3",  # compatability with graphql-ws in dagit
             "graphql-core>=2.1,<3",  # compatability with graphql-ws in dagit
-            "gevent-websocket>=0.10.1",
-            "gevent",
             "requests",
             "gql<3",
         ],


### PR DESCRIPTION
some clean-up ahead of trying to convert Observables to async gens to drop rx


## Test Plan

bk - we should only be using the threads path now