### PR TITLE
[dagit] Allow colon in run tag value

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/TokenizingField.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TokenizingField.tsx
@@ -66,12 +66,19 @@ export const tokenizedValuesFromString = (str: string, providers: SuggestionProv
 export const tokenizedValuesFromStringArray = (tokens: string[], providers: SuggestionProvider[]) =>
   tokens.map((token) => tokenizedValueFromString(token, providers));
 
+export const tokenizeString = (str: string): [string, string] => {
+  const colonAt = str.indexOf(':');
+  if (colonAt === -1) {
+    return [str, ''];
+  }
+  return [str.slice(0, colonAt), str.slice(colonAt + 1)];
+};
+
 export function tokenizedValueFromString(
   str: string,
   providers: SuggestionProvider[],
 ): TokenizingFieldValue {
-  const [token = '', value = ''] = str.split(':');
-
+  const [token, value] = tokenizeString(str);
   if (findProviderByToken(token, providers)) {
     if (token && value) {
       return {token, value};

--- a/js_modules/dagit/packages/ui/src/components/tokenizeString.test.tsx
+++ b/js_modules/dagit/packages/ui/src/components/tokenizeString.test.tsx
@@ -1,0 +1,15 @@
+import {tokenizeString} from './TokenizingField';
+
+describe('tokenizeString', () => {
+  it('tokenizes when there is only a token', () => {
+    expect(tokenizeString('foo')).toEqual(['foo', '']);
+  });
+
+  it('tokenizes when there is a token and value', () => {
+    expect(tokenizeString('foo:bar')).toEqual(['foo', 'bar']);
+  });
+
+  it('tokenizes when there is only a value with colons in it', () => {
+    expect(tokenizeString('foo:bar:baz')).toEqual(['foo', 'bar:baz']);
+  });
+});


### PR DESCRIPTION
## Summary

When we parse tags for run filtering, we use a `:` split to divide the token and value. This means that the `value` can't support having a `:` character, though there's no reason to disallow this as far as I know.

Modify the split logic so that `:` is supported.

## Test Plan

In Runs view, click on a filter with a colon in the value. Verify that it populates the filter input correctly, and that the filter search finds the correct runs.
