### PR TITLE
avoid framework code triggering metadata_entries warning

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/ops.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/ops.py
@@ -3,7 +3,6 @@ from dagster import (
     Field,
     FileHandle,
     In,
-    MetadataEntry,
     MetadataValue,
     Out,
     Output,
@@ -75,9 +74,7 @@ def file_handle_to_s3(context, file_handle):
 
         yield AssetMaterialization(
             asset_key=s3_file_handle.s3_path,
-            metadata_entries=[
-                MetadataEntry(last_key(key), value=MetadataValue.path(s3_file_handle.s3_path))
-            ],
+            metadata={last_key(key): MetadataValue.path(s3_file_handle.s3_path)},
         )
 
         yield Output(value=s3_file_handle, output_name="s3_file_handle")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/utils.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 from requests import Response
 from requests.exceptions import RequestException
 
-from dagster import Failure, MetadataEntry, RetryRequested
+from dagster import Failure, RetryRequested
 from dagster.core.execution.context.compute import SolidExecutionContext
 
 
@@ -50,35 +50,33 @@ def raise_for_rpc_error(context: SolidExecutionContext, resp: Response) -> None:
         elif error["code"] == DBTErrors.project_compile_failure_error.value:
             raise Failure(
                 description=error["message"],
-                metadata_entries=[
-                    MetadataEntry("RPC Error Code", value=str(error["code"])),
-                    MetadataEntry("RPC Error Cause", value=error["data"]["cause"]["message"]),
-                ],
+                metadata={
+                    "RPC Error Code": str(error["code"]),
+                    "RPC Error Cause": error["data"]["cause"]["message"],
+                },
             )
         elif error["code"] == DBTErrors.rpc_process_killed_error.value:
             raise Failure(
                 description=error["message"],
-                metadata_entries=[
-                    MetadataEntry("RPC Error Code", value=str(error["code"])),
-                    MetadataEntry("RPC Signum", value=str(error["data"]["signum"])),
-                    MetadataEntry("RPC Error Message", value=error["data"]["message"]),
-                ],
+                metadata={
+                    "RPC Error Code": str(error["code"]),
+                    "RPC Signum": str(error["data"]["signum"]),
+                    "RPC Error Message": error["data"]["message"],
+                },
             )
         elif error["code"] == DBTErrors.rpc_timeout_error.value:
             raise Failure(
                 description=error["message"],
-                metadata_entries=[
-                    MetadataEntry("RPC Error Code", value=str(error["code"])),
-                    MetadataEntry("RPC Timeout", value=str(error["data"]["timeout"])),
-                    MetadataEntry("RPC Error Message", value=error["data"]["message"]),
-                ],
+                metadata={
+                    "RPC Error Code": str(error["code"]),
+                    "RPC Timeout": str(error["data"]["timeout"]),
+                    "RPC Error Message": error["data"]["message"],
+                },
             )
         else:
             raise Failure(
                 description=error["message"],
-                metadata_entries=[
-                    MetadataEntry("RPC Error Code", value=str(error["code"])),
-                ],
+                metadata={"RPC Error Code": str(error["code"])},
             )
 
 

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -21,7 +21,7 @@ from dagster import (
     seven,
 )
 from dagster.core.definitions.events import AssetMaterialization, Failure, RetryRequested
-from dagster.core.definitions.metadata import MetadataEntry, MetadataValue
+from dagster.core.definitions.metadata import MetadataValue
 from dagster.core.definitions.reconstruct import ReconstructablePipeline
 from dagster.core.definitions.utils import validate_tags
 from dagster.core.execution.context.compute import SolidExecutionContext
@@ -256,12 +256,9 @@ def _dm_compute(
                     yield AssetMaterialization(
                         asset_key=(asset_key_prefix + [f"{name}_output_notebook"]),
                         description="Location of output notebook in file manager",
-                        metadata_entries=[
-                            MetadataEntry(
-                                "path",
-                                value=MetadataValue.path(executed_notebook_materialization_path),
-                            )
-                        ],
+                        metadata={
+                            "path": MetadataValue.path(executed_notebook_materialization_path),
+                        },
                     )
 
                 except Exception:


### PR DESCRIPTION
The metadata_entries arg to AssetMaterialization is deprecated, but we sometimes use it, which gives users unfixable warnings.