### PR TITLE
handle asset partitions in default IO managers

### DIFF
--- a/python_modules/dagster/dagster/core/execution/context/output.py
+++ b/python_modules/dagster/dagster/core/execution/context/output.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Sequence, Union, cast
 
 from dagster import check
 from dagster.core.definitions.events import (
@@ -383,6 +383,15 @@ class OutputContext:
                 identifier.append(self.mapping_key)
 
         return identifier
+
+    def get_asset_output_identifier(self) -> Sequence[str]:
+        if self.asset_key is not None:
+            if self.has_asset_partitions:
+                return self.asset_key.path + [self.asset_partition_key]
+            else:
+                return self.asset_key.path
+        else:
+            check.failed("Can't get asset output identifier for an output with no asset key")
 
     def log_event(
         self, event: Union[AssetObservation, AssetMaterialization, Materialization]

--- a/python_modules/dagster/dagster/core/storage/fs_asset_io_manager.py
+++ b/python_modules/dagster/dagster/core/storage/fs_asset_io_manager.py
@@ -81,4 +81,4 @@ def fs_asset_io_manager(init_context):
 
 class AssetPickledObjectFilesystemIOManager(PickledObjectFilesystemIOManager):
     def _get_path(self, context):
-        return os.path.join(self.base_dir, *context.asset_key.path)
+        return os.path.join(self.base_dir, *context.get_asset_output_identifier())

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_asset_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_asset_io_manager.py
@@ -2,18 +2,23 @@ import os
 import pickle
 import tempfile
 
+from dagster import DailyPartitionsDefinition
 from dagster.core.asset_defs import AssetIn, asset, build_assets_job
 from dagster.core.storage.fs_asset_io_manager import fs_asset_io_manager
 
 
-def get_assets_job(io_manager_def):
+def get_assets_job(io_manager_def, partitions_def=None):
     asset1_namespace = ["one", "two", "three"]
 
-    @asset(namespace=["one", "two", "three"])
+    @asset(namespace=["one", "two", "three"], partitions_def=partitions_def)
     def asset1():
         return [1, 2, 3]
 
-    @asset(namespace=["four", "five"], ins={"asset1": AssetIn(namespace=asset1_namespace)})
+    @asset(
+        namespace=["four", "five"],
+        ins={"asset1": AssetIn(namespace=asset1_namespace)},
+        partitions_def=partitions_def,
+    )
     def asset2(asset1):
         return asset1 + [4]
 
@@ -45,6 +50,36 @@ def test_fs_asset_io_manager():
         assert loaded_input_events[0].event_specific_data.upstream_step_key.endswith("asset1")
 
         filepath_b = os.path.join(tmpdir_path, "four", "five", "asset2")
+        assert os.path.isfile(filepath_b)
+        with open(filepath_b, "rb") as read_obj:
+            assert pickle.load(read_obj) == [1, 2, 3, 4]
+
+
+def test_fs_asset_io_manager_partitioned():
+    with tempfile.TemporaryDirectory() as tmpdir_path:
+        io_manager_def = fs_asset_io_manager.configured({"base_dir": tmpdir_path})
+        job_def = get_assets_job(
+            io_manager_def, partitions_def=DailyPartitionsDefinition(start_date="2020-02-01")
+        )
+
+        result = job_def.execute_in_process(partition_key="2020-05-03")
+        assert result.success
+
+        handled_output_events = list(
+            filter(lambda evt: evt.is_handled_output, result.all_node_events)
+        )
+        assert len(handled_output_events) == 2
+
+        filepath_a = os.path.join(tmpdir_path, "one", "two", "three", "asset1", "2020-05-03")
+        assert os.path.isfile(filepath_a)
+        with open(filepath_a, "rb") as read_obj:
+            assert pickle.load(read_obj) == [1, 2, 3]
+
+        loaded_input_events = list(filter(lambda evt: evt.is_loaded_input, result.all_node_events))
+        assert len(loaded_input_events) == 1
+        assert loaded_input_events[0].event_specific_data.upstream_step_key.endswith("asset1")
+
+        filepath_b = os.path.join(tmpdir_path, "four", "five", "asset2", "2020-05-03")
         assert os.path.isfile(filepath_b)
         with open(filepath_b, "rb") as read_obj:
             assert pickle.load(read_obj) == [1, 2, 3, 4]

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -109,7 +109,7 @@ def s3_pickle_io_manager(init_context):
 
 class PickledObjectS3AssetIOManager(PickledObjectS3IOManager):
     def _get_path(self, context):
-        return "/".join([self.s3_prefix, *context.asset_key.path])
+        return "/".join([self.s3_prefix, *context.get_asset_output_identifier()])
 
 
 @io_manager(

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -136,7 +136,7 @@ def adls2_pickle_io_manager(init_context):
 
 class PickledObjectADLS2AssetIOManager(PickledObjectADLS2IOManager):
     def _get_path(self, context):
-        return "/".join([self.prefix, *context.asset_key.path])
+        return "/".join([self.prefix, *context.get_asset_output_identifier()])
 
 
 @io_manager(

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/gcs_fake_resource.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/gcs_fake_resource.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Union
+from typing import AbstractSet, Dict, Optional, Union
 
 
 class FakeGCSBlob:
@@ -90,3 +90,10 @@ class FakeGCSClient:
                 yield blob
             elif prefix in blob.name:
                 yield blob
+
+    def get_all_blob_paths(self) -> AbstractSet[str]:
+        return {
+            f"{bucket.name}/{blob.name}"
+            for bucket in self.buckets.values()
+            for blob in bucket.blobs.values()
+        }

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
@@ -109,7 +109,7 @@ def gcs_pickle_io_manager(init_context):
 
 class PickledObjectGCSAssetIOManager(PickledObjectGCSIOManager):
     def _get_path(self, context):
-        return "/".join([self.prefix, *context.asset_key.path])
+        return "/".join([self.prefix, *context.get_asset_output_identifier()])
 
 
 @io_manager(


### PR DESCRIPTION
This allows using asset partitions out-of-the-box, without defining a custom IO manager.