### PR TITLE
[1/n] RFC: Don't rely on OutputDefinition.asset_key for SDAs

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/asset_group.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_group.py
@@ -559,7 +559,7 @@ def _validate_resource_reqs_for_asset_group(
                 f"AssetGroup is missing required resource keys for asset '{asset_def.op.name}'. Missing resource keys: {missing_resource_keys}"
             )
 
-        for asset_key, output_def in asset_def.output_defs_by_asset_key.items():
+        for output_def, asset_key in asset_def.output_def_to_asset_key.items():
             if output_def.io_manager_key and output_def.io_manager_key not in present_resource_keys:
                 raise DagsterInvalidDefinitionError(
                     f"Output '{output_def.name}' with AssetKey '{asset_key}' "

--- a/python_modules/dagster/dagster/core/asset_defs/asset_group.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_group.py
@@ -559,7 +559,7 @@ def _validate_resource_reqs_for_asset_group(
                 f"AssetGroup is missing required resource keys for asset '{asset_def.op.name}'. Missing resource keys: {missing_resource_keys}"
             )
 
-        for output_def, asset_key in asset_def.output_def_to_asset_key.items():
+        for output_def, asset_key in asset_def.asset_key_by_output_def.items():
             if output_def.io_manager_key and output_def.io_manager_key not in present_resource_keys:
                 raise DagsterInvalidDefinitionError(
                     f"Output '{output_def.name}' with AssetKey '{asset_key}' "

--- a/python_modules/dagster/dagster/core/asset_defs/asset_group.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_group.py
@@ -315,13 +315,13 @@ class AssetGroup(
                     "a source asset. Source assets can't be materialized, and "
                     "therefore can't be subsetted into a job. Please choose a "
                     "subset on asset keys that are materializable - that is, "
-                    f"included on assets within the group. Valid assets: {list(asset_keys_to_ops.keys())}"
+                    f"included on assets within the group. Valid assets: {sorted(list(asset_keys_to_ops.keys()))}"
                 )
             if key_str not in asset_keys_to_ops:
                 raise DagsterInvalidDefinitionError(
                     f"When attempting to create job '{job_name}', the clause "
                     f"'{clause}' within the asset key selection did not match "
-                    f"any asset keys. Present asset keys: {list(asset_keys_to_ops.keys())}"
+                    f"any asset keys. Present asset keys: {sorted(list(asset_keys_to_ops.keys()))}"
                 )
 
             seen_asset_keys.add(key_str)
@@ -559,7 +559,7 @@ def _validate_resource_reqs_for_asset_group(
                 f"AssetGroup is missing required resource keys for asset '{asset_def.op.name}'. Missing resource keys: {missing_resource_keys}"
             )
 
-        for output_def, asset_key in asset_def.asset_key_by_output_def.items():
+        for output_def, asset_key in asset_def.asset_keys_by_output_def.items():
             if output_def.io_manager_key and output_def.io_manager_key not in present_resource_keys:
                 raise DagsterInvalidDefinitionError(
                     f"Output '{output_def.name}' with AssetKey '{asset_key}' "

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -11,22 +11,22 @@ from .partition_mapping import PartitionMapping
 class AssetsDefinition:
     def __init__(
         self,
-        input_name_to_asset_key: Mapping[str, AssetKey],
-        output_name_to_asset_key: Mapping[str, AssetKey],
+        asset_key_by_input_name: Mapping[str, AssetKey],
+        asset_key_by_output_name: Mapping[str, AssetKey],
         op: OpDefinition,
         partitions_def: Optional[PartitionsDefinition] = None,
         partition_mappings: Optional[Mapping[AssetKey, PartitionMapping]] = None,
         asset_deps: Optional[Mapping[AssetKey, AbstractSet[AssetKey]]] = None,
     ):
         self._op = op
-        self._input_def_to_asset_key = {
+        self._asset_key_by_input_def = {
             op.input_dict[input_name]: asset_key
-            for input_name, asset_key in input_name_to_asset_key.items()
+            for input_name, asset_key in asset_key_by_input_name.items()
         }
 
-        self._output_def_to_asset_key = {
+        self._asset_key_by_output_def = {
             op.output_dict[output_name]: asset_key
-            for output_name, asset_key in output_name_to_asset_key.items()
+            for output_name, asset_key in asset_key_by_output_name.items()
         }
         self._partitions_def = partitions_def
         self._partition_mappings = partition_mappings or {}
@@ -35,6 +35,9 @@ class AssetsDefinition:
         self._asset_deps = asset_deps or {
             out_asset_key: self.input_asset_keys for out_asset_key in self.asset_keys
         }
+        print("AD")
+        print(asset_deps)
+        print(self._asset_deps)
 
         # ensure that the specified asset_deps make sense
         valid_asset_deps = self.asset_keys | self.input_asset_keys
@@ -64,23 +67,23 @@ class AssetsDefinition:
 
     @property
     def input_asset_keys(self) -> AbstractSet[AssetKey]:
-        return set(self._input_def_to_asset_key.values())
+        return set(self._asset_key_by_input_def.values())
 
     @property
     def asset_keys(self) -> AbstractSet[AssetKey]:
-        return set(self._output_def_to_asset_key.values())
+        return set(self._asset_key_by_output_def.values())
 
     @property
     def asset_deps(self) -> Mapping[AssetKey, AbstractSet[AssetKey]]:
         return self._asset_deps
 
     @property
-    def output_def_to_asset_key(self) -> Mapping[OutputDefinition, AssetKey]:
-        return self._output_def_to_asset_key
+    def asset_key_by_output_def(self) -> Mapping[OutputDefinition, AssetKey]:
+        return self._asset_key_by_output_def
 
     @property
-    def input_def_to_asset_key(self) -> Mapping[InputDefinition, AssetKey]:
-        return self._input_def_to_asset_key
+    def asset_key_by_input_def(self) -> Mapping[InputDefinition, AssetKey]:
+        return self._asset_key_by_input_def
 
     @property
     def partitions_def(self) -> Optional[PartitionsDefinition]:

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -1,7 +1,7 @@
 from typing import AbstractSet, Mapping, Optional, Tuple
 
 from dagster import check
-from dagster.core.definitions import OpDefinition, OutputDefinition, InputDefinition
+from dagster.core.definitions import InputDefinition, OpDefinition, OutputDefinition
 from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.partition import PartitionsDefinition
 
@@ -11,22 +11,22 @@ from .partition_mapping import PartitionMapping
 class AssetsDefinition:
     def __init__(
         self,
-        asset_key_by_input_name: Mapping[str, AssetKey],
-        asset_key_by_output_name: Mapping[str, AssetKey],
+        asset_keys_by_input_name: Mapping[str, AssetKey],
+        asset_keys_by_output_name: Mapping[str, AssetKey],
         op: OpDefinition,
         partitions_def: Optional[PartitionsDefinition] = None,
         partition_mappings: Optional[Mapping[AssetKey, PartitionMapping]] = None,
         asset_deps: Optional[Mapping[AssetKey, AbstractSet[AssetKey]]] = None,
     ):
         self._op = op
-        self._asset_key_by_input_def = {
+        self._asset_keys_by_input_def = {
             op.input_dict[input_name]: asset_key
-            for input_name, asset_key in asset_key_by_input_name.items()
+            for input_name, asset_key in asset_keys_by_input_name.items()
         }
 
-        self._asset_key_by_output_def = {
+        self._asset_keys_by_output_def = {
             op.output_dict[output_name]: asset_key
-            for output_name, asset_key in asset_key_by_output_name.items()
+            for output_name, asset_key in asset_keys_by_output_name.items()
         }
         self._partitions_def = partitions_def
         self._partition_mappings = partition_mappings or {}
@@ -64,23 +64,23 @@ class AssetsDefinition:
 
     @property
     def input_asset_keys(self) -> AbstractSet[AssetKey]:
-        return set(self._asset_key_by_input_def.values())
+        return set(self._asset_keys_by_input_def.values())
 
     @property
     def asset_keys(self) -> AbstractSet[AssetKey]:
-        return set(self._asset_key_by_output_def.values())
+        return set(self._asset_keys_by_output_def.values())
 
     @property
     def asset_deps(self) -> Mapping[AssetKey, AbstractSet[AssetKey]]:
         return self._asset_deps
 
     @property
-    def asset_key_by_output_def(self) -> Mapping[OutputDefinition, AssetKey]:
-        return self._asset_key_by_output_def
+    def asset_keys_by_output_def(self) -> Mapping[OutputDefinition, AssetKey]:
+        return self._asset_keys_by_output_def
 
     @property
-    def asset_key_by_input_def(self) -> Mapping[InputDefinition, AssetKey]:
-        return self._asset_key_by_input_def
+    def asset_keys_by_input_def(self) -> Mapping[InputDefinition, AssetKey]:
+        return self._asset_keys_by_input_def
 
     @property
     def partitions_def(self) -> Optional[PartitionsDefinition]:

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -35,9 +35,6 @@ class AssetsDefinition:
         self._asset_deps = asset_deps or {
             out_asset_key: self.input_asset_keys for out_asset_key in self.asset_keys
         }
-        print("AD")
-        print(asset_deps)
-        print(self._asset_deps)
 
         # ensure that the specified asset_deps make sense
         valid_asset_deps = self.asset_keys | self.input_asset_keys

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -1,7 +1,7 @@
-from typing import AbstractSet, Mapping, Optional
+from typing import AbstractSet, Mapping, Optional, Tuple
 
 from dagster import check
-from dagster.core.definitions import OpDefinition
+from dagster.core.definitions import OpDefinition, OutputDefinition, InputDefinition
 from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.partition import PartitionsDefinition
 
@@ -11,24 +11,49 @@ from .partition_mapping import PartitionMapping
 class AssetsDefinition:
     def __init__(
         self,
-        input_names_by_asset_key: Mapping[AssetKey, str],
-        output_names_by_asset_key: Mapping[AssetKey, str],
+        input_name_to_asset_key: Mapping[str, AssetKey],
+        output_name_to_asset_key: Mapping[str, AssetKey],
         op: OpDefinition,
         partitions_def: Optional[PartitionsDefinition] = None,
         partition_mappings: Optional[Mapping[AssetKey, PartitionMapping]] = None,
+        asset_deps: Optional[Mapping[AssetKey, AbstractSet[AssetKey]]] = None,
     ):
         self._op = op
-        self._input_defs_by_asset_key = {
-            asset_key: op.input_dict[input_name]
-            for asset_key, input_name in input_names_by_asset_key.items()
+        self._input_def_to_asset_key = {
+            op.input_dict[input_name]: asset_key
+            for input_name, asset_key in input_name_to_asset_key.items()
         }
 
-        self._output_defs_by_asset_key = {
-            asset_key: op.output_dict[output_name]
-            for asset_key, output_name in output_names_by_asset_key.items()
+        self._output_def_to_asset_key = {
+            op.output_dict[output_name]: asset_key
+            for output_name, asset_key in output_name_to_asset_key.items()
         }
         self._partitions_def = partitions_def
         self._partition_mappings = partition_mappings or {}
+
+        # if not specified assume all output assets depend on all input assets
+        self._asset_deps = asset_deps or {
+            out_asset_key: self.input_asset_keys for out_asset_key in self.asset_keys
+        }
+
+        # ensure that the specified asset_deps make sense
+        valid_asset_deps = self.asset_keys | self.input_asset_keys
+        for asset_key, dep_asset_keys in self._asset_deps.items():
+            invalid_asset_deps = dep_asset_keys.difference(valid_asset_deps)
+            check.invariant(
+                not invalid_asset_deps,
+                f"Invalid asset dependencies: {invalid_asset_deps} specified in `asset_deps` "
+                f"argument for AssetsDefinition '{self.op.name}' on key '{asset_key}'. "
+                "Each specified asset key must be associated with an input to the asset or "
+                f"produced by this asset. Valid keys: {valid_asset_deps}",
+            )
+        check.invariant(
+            set(self._asset_deps.keys()) == self.asset_keys,
+            "The set of asset keys with dependencies specified in the asset_deps argument must "
+            "equal the set of asset keys produced by this AssetsDefinition. \n"
+            f"asset_deps keys: {set(self._asset_deps.keys())} \n"
+            f"expected keys: {self.asset_keys}",
+        )
 
     def __call__(self, *args, **kwargs):
         return self._op(*args, **kwargs)
@@ -38,16 +63,24 @@ class AssetsDefinition:
         return self._op
 
     @property
+    def input_asset_keys(self) -> AbstractSet[AssetKey]:
+        return set(self._input_def_to_asset_key.values())
+
+    @property
     def asset_keys(self) -> AbstractSet[AssetKey]:
-        return self._output_defs_by_asset_key.keys()
+        return set(self._output_def_to_asset_key.values())
 
     @property
-    def output_defs_by_asset_key(self):
-        return self._output_defs_by_asset_key
+    def asset_deps(self) -> Mapping[AssetKey, AbstractSet[AssetKey]]:
+        return self._asset_deps
 
     @property
-    def input_defs_by_asset_key(self):
-        return self._input_defs_by_asset_key
+    def output_def_to_asset_key(self) -> Mapping[OutputDefinition, AssetKey]:
+        return self._output_def_to_asset_key
+
+    @property
+    def input_def_to_asset_key(self) -> Mapping[InputDefinition, AssetKey]:
+        return self._input_def_to_asset_key
 
     @property
     def partitions_def(self) -> Optional[PartitionsDefinition]:

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -186,7 +186,6 @@ class _Asset:
 
         out_asset_key = AssetKey(list(filter(None, [*(self.namespace or []), asset_name])))
         out = Out(
-            asset_key=out_asset_key,
             metadata=self.metadata or {},
             io_manager_key=self.io_manager_key,
             dagster_type=self.dagster_type if self.dagster_type else NoValueSentinel,
@@ -211,10 +210,10 @@ class _Asset:
             )(fn)
 
         return AssetsDefinition(
-            input_name_to_asset_key={
+            asset_key_by_input_name={
                 input_name: asset_key for asset_key, (input_name, _) in asset_ins.items()
             },
-            output_name_to_asset_key={"result": out_asset_key},
+            asset_key_by_output_name={"result": out_asset_key},
             op=op,
             partitions_def=self.partitions_def,
             partition_mappings={
@@ -289,10 +288,10 @@ def multi_asset(
             )(fn)
 
         return AssetsDefinition(
-            input_name_to_asset_key={
+            asset_key_by_input_name={
                 input_name: asset_key for asset_key, (input_name, _) in asset_ins.items()
             },
-            output_name_to_asset_key={
+            asset_key_by_output_name={
                 output_name: asset_key for asset_key, (output_name, _) in asset_outs.items()
             },
             op=op,

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -8,10 +8,10 @@ from typing import (
     Optional,
     Sequence,
     Set,
+    Tuple,
     Union,
     cast,
     overload,
-    Tuple,
 )
 
 from dagster import check
@@ -210,10 +210,10 @@ class _Asset:
             )(fn)
 
         return AssetsDefinition(
-            asset_key_by_input_name={
+            asset_keys_by_input_name={
                 input_name: asset_key for asset_key, (input_name, _) in asset_ins.items()
             },
-            asset_key_by_output_name={"result": out_asset_key},
+            asset_keys_by_output_name={"result": out_asset_key},
             op=op,
             partitions_def=self.partitions_def,
             partition_mappings={
@@ -288,10 +288,10 @@ def multi_asset(
             )(fn)
 
         return AssetsDefinition(
-            asset_key_by_input_name={
+            asset_keys_by_input_name={
                 input_name: asset_key for asset_key, (input_name, _) in asset_ins.items()
             },
-            asset_key_by_output_name={
+            asset_keys_by_output_name={
                 output_name: asset_key for asset_key, (output_name, _) in asset_outs.items()
             },
             op=op,
@@ -376,6 +376,6 @@ def build_asset_ins(
 
     for asset_key in non_argument_deps:
         in_name = "_".join(asset_key.path)
-        ins[asset_key] = (in_name, In(dagster_type=cast(type, Nothing), asset_key=asset_key))
+        ins[asset_key] = (in_name, In(dagster_type=cast(type, Nothing)))
 
     return ins

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -11,6 +11,7 @@ from typing import (
     Union,
     cast,
     overload,
+    Tuple,
 )
 
 from dagster import check
@@ -197,7 +198,7 @@ class _Asset:
             op = _Op(
                 name="__".join(out_asset_key.path),
                 description=self.description,
-                ins=asset_ins,
+                ins=dict(asset_ins.values()),
                 out=out,
                 required_resource_keys=self.required_resource_keys,
                 tags={"kind": self.compute_kind} if self.compute_kind else None,
@@ -209,20 +210,17 @@ class _Asset:
                 },
             )(fn)
 
-        # NOTE: we can `cast` below because we know the Ins returned by `build_asset_ins` always
-        # have a plain AssetKey asset key. Dynamic asset keys will be deprecated in 0.15.0, when
-        # they are gone we can remove this cast.
         return AssetsDefinition(
-            input_names_by_asset_key={
-                cast(AssetKey, in_def.asset_key): input_name
-                for input_name, in_def in asset_ins.items()
+            input_name_to_asset_key={
+                input_name: asset_key for asset_key, (input_name, _) in asset_ins.items()
             },
-            output_names_by_asset_key={out_asset_key: "result"},
+            output_name_to_asset_key={"result": out_asset_key},
             op=op,
             partitions_def=self.partitions_def,
             partition_mappings={
-                cast(AssetKey, asset_ins[input_name].asset_key): partition_mapping
-                for input_name, partition_mapping in self.partition_mappings.items()
+                asset_key: self.partition_mappings[input_name]
+                for asset_key, (input_name, _) in asset_ins.items()
+                if input_name in self.partition_mappings
             }
             if self.partition_mappings
             else None,
@@ -238,7 +236,7 @@ def multi_asset(
     description: Optional[str] = None,
     required_resource_keys: Optional[Set[str]] = None,
     compute_kind: Optional[str] = None,
-    internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
+    internal_asset_deps: Optional[Mapping[AssetKey, Set[AssetKey]]] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a combined definition of multiple assets that are computed using the same op and same
     upstream assets.
@@ -259,9 +257,9 @@ def multi_asset(
             (default: "io_manager").
         compute_kind (Optional[str]): A string to represent the kind of computation that produces
             the asset, e.g. "dbt" or "spark". It will be displayed in Dagit as a badge on the asset.
-        internal_asset_deps (Optional[Mapping[str, Set[AssetKey]]]): By default, it is assumed
+        internal_asset_deps (Optional[Mapping[AssetKey, Set[AssetKey]]]): By default, it is assumed
             that all assets produced by a multi_asset depend on all assets that are consumed by that
-            multi asset. If this default is not correct, you pass in a map of output names to a
+            multi asset. If this default is not correct, you pass in a map of output keys to a
             corrected set of AssetKeys that they depend on. Any AssetKeys in this list must be either
             used as input to the asset or produced within the op.
     """
@@ -271,37 +269,34 @@ def multi_asset(
         "The asset_key argument for Outs supplied to a multi_asset must be a constant or None, not a function. ",
     )
     internal_asset_deps = check.opt_dict_param(
-        internal_asset_deps, "internal_asset_deps", key_type=str, value_type=set
+        internal_asset_deps, "internal_asset_deps", key_type=AssetKey, value_type=set
     )
 
     def inner(fn: Callable[..., Any]) -> AssetsDefinition:
         op_name = name or fn.__name__
         asset_ins = build_asset_ins(fn, None, ins or {}, non_argument_deps)
-        asset_outs = build_asset_outs(op_name, outs, asset_ins, internal_asset_deps or {})
+        asset_outs = build_asset_outs(op_name, outs, asset_ins)
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=ExperimentalWarning)
             op = _Op(
                 name=op_name,
                 description=description,
-                ins=asset_ins,
-                out=asset_outs,
+                ins=dict(asset_ins.values()),
+                out=dict(asset_outs.values()),
                 required_resource_keys=required_resource_keys,
                 tags={"kind": compute_kind} if compute_kind else None,
             )(fn)
 
-        # NOTE: we can `cast` below because we know the Ins returned by `build_asset_ins` always
-        # have a plain AssetKey asset key. Dynamic asset keys will be deprecated in 0.15.0, when
-        # they are gone we can remove this cast.
         return AssetsDefinition(
-            input_names_by_asset_key={
-                cast(AssetKey, in_def.asset_key): input_name
-                for input_name, in_def in asset_ins.items()
+            input_name_to_asset_key={
+                input_name: asset_key for asset_key, (input_name, _) in asset_ins.items()
             },
-            output_names_by_asset_key={
-                cast(AssetKey, out_def.asset_key): output_name for output_name, out_def in asset_outs.items()  # type: ignore
+            output_name_to_asset_key={
+                output_name: asset_key for asset_key, (output_name, _) in asset_outs.items()
             },
             op=op,
+            asset_deps=internal_asset_deps or None,
         )
 
     return inner
@@ -310,9 +305,9 @@ def multi_asset(
 def build_asset_outs(
     op_name: str,
     outs: Mapping[str, Out],
-    ins: Mapping[str, In],
-    internal_asset_deps: Mapping[str, Set[AssetKey]],
-) -> Dict[str, Out]:
+    asset_ins: Mapping[AssetKey, In],
+    out_name_to_asset_key: Optional[Mapping[str, AssetKey]] = None,
+) -> Dict[AssetKey, Tuple[str, Out]]:
 
     # if an AssetKey is not supplied, create one based off of the out's name
     asset_keys_by_out_name = {
@@ -320,41 +315,14 @@ def build_asset_outs(
         for out_name, out in outs.items()
     }
 
-    # update asset_key if necessary, add metadata indicating inter asset deps
-    outs = {
-        out_name: out._replace(
-            asset_key=asset_keys_by_out_name[out_name],
-            metadata=dict(
-                **(out.metadata or {}),
-                **(
-                    {ASSET_DEPENDENCY_METADATA_KEY: internal_asset_deps[out_name]}
-                    if out_name in internal_asset_deps
-                    else {}
-                ),
-            ),
-        )
-        for out_name, out in outs.items()
+    # if an AssetKeys are not supplied, create them based off of the out's name
+    if not out_name_to_asset_key:
+        out_name_to_asset_key = {out_name: AssetKey([out_name]) for out_name in outs.keys()}
+
+    return {
+        asset_key: (out_name, outs.get(out_name))
+        for out_name, asset_key in out_name_to_asset_key.items()
     }
-
-    # validate that the internal_asset_deps make sense
-    valid_asset_deps = set(in_def.asset_key for in_def in ins.values())
-    valid_asset_deps.update(asset_keys_by_out_name.values())
-    for out_name, asset_keys in internal_asset_deps.items():
-        check.invariant(
-            out_name in outs,
-            f"Invalid out key '{out_name}' supplied to `internal_asset_deps` argument for multi-asset "
-            f"{op_name}. Must be one of the outs for this multi-asset {list(outs.keys())}.",
-        )
-        invalid_asset_deps = asset_keys.difference(valid_asset_deps)
-        check.invariant(
-            not invalid_asset_deps,
-            f"Invalid asset dependencies: {invalid_asset_deps} specified in `internal_asset_deps` "
-            f"argument for multi-asset '{op_name}' on key '{out_name}'. Each specified asset key "
-            "must be associated with an input to the asset or produced by this asset. Valid "
-            f"keys: {valid_asset_deps}",
-        )
-
-    return outs
 
 
 def build_asset_ins(
@@ -362,7 +330,7 @@ def build_asset_ins(
     asset_namespace: Optional[Sequence[str]],
     asset_ins: Mapping[str, AssetIn],
     non_argument_deps: Optional[AbstractSet[AssetKey]],
-) -> Dict[str, In]:
+) -> Dict[AssetKey, Tuple[str, In]]:
 
     non_argument_deps = check.opt_set_param(non_argument_deps, "non_argument_deps", AssetKey)
 
@@ -383,7 +351,7 @@ def build_asset_ins(
                 "of the arguments to the decorated function"
             )
 
-    ins: Dict[str, In] = {}
+    ins: Dict[AssetKey, Tuple[str, In]] = {}
     for input_name in all_input_names:
         asset_key = None
 
@@ -399,16 +367,16 @@ def build_asset_ins(
             list(filter(None, [*(namespace or asset_namespace or []), input_name]))
         )
 
-        ins[input_name] = In(
-            metadata=metadata,
-            root_manager_key="root_manager",
-            asset_key=asset_key,
+        ins[asset_key] = (
+            input_name,
+            In(
+                metadata=metadata,
+                root_manager_key="root_manager",
+            ),
         )
 
     for asset_key in non_argument_deps:
-        stringified_asset_key = "_".join(asset_key.path)
-        if stringified_asset_key:
-            # cast due to mypy bug-- doesn't understand Nothing is a type
-            ins[stringified_asset_key] = In(dagster_type=cast(type, Nothing), asset_key=asset_key)
+        in_name = "_".join(asset_key.path)
+        ins[asset_key] = (in_name, In(dagster_type=cast(type, Nothing), asset_key=asset_key))
 
     return ins

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -7,7 +7,9 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Mapping,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Union,
@@ -22,6 +24,7 @@ from dagster.config.config_type import ConfigType
 from dagster.config.validate import validate_config
 from dagster.core.definitions.config import ConfigMapping
 from dagster.core.definitions.definition_config_schema import IDefinitionConfigSchema
+from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.mode import ModeDefinition
 from dagster.core.definitions.policy import RetryPolicy
 from dagster.core.definitions.resource_definition import ResourceDefinition
@@ -42,6 +45,7 @@ from .dependency import (
     NodeHandle,
     NodeInvocation,
     SolidInputHandle,
+    SolidOutputHandle,
 )
 from .hook_definition import HookDefinition
 from .input import FanInInputPointer, InputDefinition, InputMapping, InputPointer
@@ -461,9 +465,9 @@ class GraphDefinition(NodeDefinition):
         version_strategy: Optional[VersionStrategy] = None,
         op_selection: Optional[List[str]] = None,
         partitions_def: Optional["PartitionsDefinition"] = None,
-        asset_key_by_input_def=None,
-        asset_key_by_output_def=None,
-        asset_deps=None,
+        asset_keys_by_input_handle: Optional[Mapping[SolidInputHandle, AssetKey]] = None,
+        asset_keys_by_output_handle: Optional[Mapping[SolidOutputHandle, AssetKey]] = None,
+        asset_deps: Optional[Mapping[AssetKey, Sequence[AssetKey]]] = None,
     ) -> "JobDefinition":
         """
         Make this graph in to an executable Job by providing remaining components required for execution.
@@ -584,8 +588,8 @@ class GraphDefinition(NodeDefinition):
             hook_defs=hooks,
             version_strategy=version_strategy,
             op_retry_policy=op_retry_policy,
-            asset_key_by_input_def=asset_key_by_input_def,
-            asset_key_by_output_def=asset_key_by_output_def,
+            asset_keys_by_output_handle=asset_keys_by_output_handle,
+            asset_keys_by_input_handle=asset_keys_by_input_handle,
             asset_deps=asset_deps,
         ).get_job_def_for_op_selection(op_selection)
 

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -461,8 +461,8 @@ class GraphDefinition(NodeDefinition):
         version_strategy: Optional[VersionStrategy] = None,
         op_selection: Optional[List[str]] = None,
         partitions_def: Optional["PartitionsDefinition"] = None,
-        input_def_to_asset_key=None,
-        output_def_to_asset_key=None,
+        asset_key_by_input_def=None,
+        asset_key_by_output_def=None,
         asset_deps=None,
     ) -> "JobDefinition":
         """
@@ -568,9 +568,6 @@ class GraphDefinition(NodeDefinition):
                 f"is an object of type {type(config)}"
             )
 
-        print("lmao")
-        print(output_def_to_asset_key)
-
         return JobDefinition(
             name=job_name,
             description=description or self.description,
@@ -587,8 +584,8 @@ class GraphDefinition(NodeDefinition):
             hook_defs=hooks,
             version_strategy=version_strategy,
             op_retry_policy=op_retry_policy,
-            input_def_to_asset_key=input_def_to_asset_key,
-            output_def_to_asset_key=output_def_to_asset_key,
+            asset_key_by_input_def=asset_key_by_input_def,
+            asset_key_by_output_def=asset_key_by_output_def,
             asset_deps=asset_deps,
         ).get_job_def_for_op_selection(op_selection)
 

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -461,6 +461,9 @@ class GraphDefinition(NodeDefinition):
         version_strategy: Optional[VersionStrategy] = None,
         op_selection: Optional[List[str]] = None,
         partitions_def: Optional["PartitionsDefinition"] = None,
+        input_def_to_asset_key=None,
+        output_def_to_asset_key=None,
+        asset_deps=None,
     ) -> "JobDefinition":
         """
         Make this graph in to an executable Job by providing remaining components required for execution.
@@ -565,6 +568,9 @@ class GraphDefinition(NodeDefinition):
                 f"is an object of type {type(config)}"
             )
 
+        print("lmao")
+        print(output_def_to_asset_key)
+
         return JobDefinition(
             name=job_name,
             description=description or self.description,
@@ -581,6 +587,9 @@ class GraphDefinition(NodeDefinition):
             hook_defs=hooks,
             version_strategy=version_strategy,
             op_retry_policy=op_retry_policy,
+            input_def_to_asset_key=input_def_to_asset_key,
+            output_def_to_asset_key=output_def_to_asset_key,
+            asset_deps=asset_deps,
         ).get_job_def_for_op_selection(op_selection)
 
     def coerce_to_job(self):

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -14,6 +14,9 @@ from typing import (
 )
 
 from dagster import check
+from dagster.core.definitions.events import AssetKey
+from dagster.core.definitions.input import InputDefinition
+from dagster.core.definitions.output import OutputDefinition
 from dagster.core.definitions.composition import MappedInputPlaceholder
 from dagster.core.definitions.dependency import (
     DependencyDefinition,
@@ -65,6 +68,9 @@ class JobDefinition(PipelineDefinition):
         hook_defs: Optional[AbstractSet[HookDefinition]] = None,
         op_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
+        output_def_to_asset_key: Optional[Mapping[OutputDefinition, AssetKey]] = None,
+        input_def_to_asset_key: Optional[Mapping[InputDefinition, AssetKey]] = None,
+        asset_deps: Optional[Mapping[AssetKey, AbstractSet[AssetKey]]] = None,
         _op_selection_data: Optional[OpSelectionData] = None,
     ):
 
@@ -72,6 +78,15 @@ class JobDefinition(PipelineDefinition):
         self._op_selection_data = check.opt_inst_param(
             _op_selection_data, "_op_selection_data", OpSelectionData
         )
+
+        # TODO: scrape asset key info off of input def / output def
+        # TODO: scrape asset dep info off of output def + dependency structure
+
+        print("ayy")
+        print(output_def_to_asset_key)
+        self._output_def_to_asset_key = output_def_to_asset_key
+        self._input_def_to_asset_key = input_def_to_asset_key
+        self._asset_deps = asset_deps
 
         super(JobDefinition, self).__init__(
             name=name,
@@ -84,6 +99,20 @@ class JobDefinition(PipelineDefinition):
             graph_def=graph_def,
             version_strategy=version_strategy,
         )
+
+    @property
+    def input_def_to_asset_key(self):
+        return self._input_def_to_asset_key
+
+    @property
+    def output_def_to_asset_key(self):
+        print("hi")
+        print(self._output_def_to_asset_key)
+        return self._output_def_to_asset_key
+
+    @property
+    def asset_deps(self):
+        return self._asset_deps
 
     @property
     def target_type(self) -> str:

--- a/python_modules/dagster/dagster/core/execution/context/input.py
+++ b/python_modules/dagster/dagster/core/execution/context/input.py
@@ -205,16 +205,14 @@ class InputContext:
 
     @property
     def asset_key(self) -> Optional[AssetKey]:
+        from dagster.core.definitions.job_definition import JobDefinition
+
         if not self._name:
             return None
-
-        matching_input_defs = [
-            input_def
-            for input_def in cast(SolidDefinition, self._solid_def).input_defs
-            if input_def.name == self.name
-        ]
-        check.invariant(len(matching_input_defs) == 1)
-        return matching_input_defs[0].get_asset_key(self)
+        if not isinstance(self.step_context.pipeline_def, JobDefinition):
+            return None
+        input_handle = self.step_context.solid.input_handle(self.name)
+        return self.step_context.pipeline_def.asset_keys_by_input_handle.get(input_handle)
 
     @property
     def step_context(self) -> "StepExecutionContext":

--- a/python_modules/dagster/dagster/core/execution/context/output.py
+++ b/python_modules/dagster/dagster/core/execution/context/output.py
@@ -239,13 +239,12 @@ class OutputContext:
 
     @property
     def asset_key(self) -> Optional[AssetKey]:
-        matching_output_defs = [
-            output_def
-            for output_def in cast(SolidDefinition, self._solid_def).output_defs
-            if output_def.name == self.name
-        ]
-        check.invariant(len(matching_output_defs) == 1)
-        return matching_output_defs[0].get_asset_key(self)
+        from dagster.core.definitions.job_definition import JobDefinition
+
+        if not isinstance(self.step_context.pipeline_def, JobDefinition):
+            return None
+        output_handle = self.step_context.solid.output_handle(self.name)
+        return self.step_context.pipeline_def.asset_keys_by_output_handle.get(output_handle)
 
     @property
     def step_context(self) -> "StepExecutionContext":

--- a/python_modules/dagster/dagster/core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_step.py
@@ -422,7 +422,7 @@ def _asset_key_and_partitions_for_output(
 
     if (
         isinstance(pipeline_def, JobDefinition)
-        and output_def in pipeline_def.output_def_to_asset_key
+        and output_def in pipeline_def.asset_key_by_output_def
     ):
         if manager_asset_key is not None:
             solid_def = cast(SolidDefinition, output_context.solid_def)
@@ -433,7 +433,7 @@ def _asset_key_and_partitions_for_output(
                 "specify an AssetKey in its get_output_asset_key() function."
             )
         return (
-            pipeline_def.output_def_to_asset_key[output_def],
+            pipeline_def.asset_key_by_output_def[output_def],
             output_def.get_asset_partitions(output_context) or set(),
         )
     elif manager_asset_key:

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -794,7 +794,6 @@ def external_asset_graph_from_defs(
                 for id in node_def.input_defs
                 if id in job.asset_key_by_input_def
             }
-            print(input_name_by_asset_key)
 
             output_name_by_asset_key = {
                 job.asset_key_by_output_def[id]: id.name
@@ -808,8 +807,6 @@ def external_asset_graph_from_defs(
                 output_asset_key = job.asset_key_by_output_def.get(output_def)
                 if not output_asset_key:
                     continue
-                print(job.asset_deps)
-                print(job.asset_deps[output_asset_key])
                 node_defs_by_asset_key[output_asset_key].append((output_def, node_def, job))
                 for upstream_asset_key in job.asset_deps[output_asset_key]:
                     deps[output_asset_key][upstream_asset_key] = ExternalAssetDependency(

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
@@ -218,7 +218,7 @@ def test_asset_group_build_subset_job():
     def start_asset():
         return "foo"
 
-    @multi_asset(outs={"o1": Out(asset_key=AssetKey("o1")), "o2": Out(asset_key=AssetKey("o2"))})
+    @multi_asset(outs={"o1": Out(), "o2": Out()})
     def middle_asset(start_asset):
         return (start_asset, start_asset)
 
@@ -313,7 +313,7 @@ def test_asset_group_build_subset_job():
         DagsterInvalidDefinitionError,
         match=r"When attempting to create job 'bad_subset', the clause "
         r"'doesnt_exist' within the asset key selection did not match any asset "
-        r"keys. Present asset keys: \['start_asset', 'o1', 'o2', 'follows_o1', 'follows_o2'\]",
+        r"keys. Present asset keys: \['follows_o1', 'follows_o2', 'o1', 'o2', 'start_asset'\]",
     ):
         group.build_job(name="bad_subset", selection="doesnt_exist")
 
@@ -498,7 +498,7 @@ def test_materialize_with_selection():
     def start_asset():
         return "foo"
 
-    @multi_asset(outs={"o1": Out(asset_key=AssetKey("o1")), "o2": Out(asset_key=AssetKey("o2"))})
+    @multi_asset(outs={"o1": Out(), "o2": Out()})
     def middle_asset(start_asset):
         return (start_asset, start_asset)
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -310,7 +310,6 @@ def test_invoking_asset_with_deps():
 
     # check that the asset dependencies are in place
     job = build_assets_job("foo", [upstream, downstream])
-    print("JOB CREATED")
     assert job.execute_in_process().success
 
     out = downstream([3])

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -311,6 +311,7 @@ def test_invoking_asset_with_deps():
 
     # check that the asset dependencies are in place
     job = build_assets_job("foo", [upstream, downstream])
+    print("JOB CREATED")
     assert job.execute_in_process().success
 
     out = downstream([3])

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -68,6 +68,7 @@ def test_multi_asset_with_compute_kind():
     assert my_asset.op.tags == {"kind": "sql"}
 
 
+@pytest.mark.skip(reason="Temporarily disable this behavior")
 def test_multi_asset_out_name_diff_from_asset_key():
     @multi_asset(
         outs={

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -343,8 +343,9 @@ def test_inter_op_dependency():
     @multi_asset(
         outs={"only_in": Out(), "mixed": Out(), "only_out": Out()},
         internal_asset_deps={
-            "mixed": {AssetKey("in1"), AssetKey("only_in")},
-            "only_out": {AssetKey("only_in"), AssetKey("mixed")},
+            AssetKey(["only_in"]): {AssetKey("in1"), AssetKey("in2")},
+            AssetKey(["mixed"]): {AssetKey("in1"), AssetKey("only_in")},
+            AssetKey(["only_out"]): {AssetKey("only_in"), AssetKey("mixed")},
         },
     )
     def assets(in1, in2):  # pylint: disable=unused-argument
@@ -433,13 +434,6 @@ def test_inter_op_dependency():
             op_description=None,
             job_names=["assets_job"],
             output_name="mixed",
-            metadata_entries=[
-                MetadataEntry(
-                    label=".dagster/asset_deps",
-                    description=None,
-                    entry_data=MetadataValue.text("[set] (unserializable)"),
-                )
-            ],
         ),
         ExternalAssetNode(
             asset_key=AssetKey(["only_in"]),
@@ -483,13 +477,7 @@ def test_inter_op_dependency():
             op_description=None,
             job_names=["assets_job"],
             output_name="only_out",
-            metadata_entries=[
-                MetadataEntry(
-                    label=".dagster/asset_deps",
-                    description=None,
-                    entry_data=MetadataValue.text("[set] (unserializable)"),
-                )
-            ],
+            metadata_entries=[],
         ),
     ]
 

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -299,12 +299,7 @@ def test_same_asset_in_multiple_pipelines():
 
 
 def test_basic_multi_asset():
-    @multi_asset(
-        outs={
-            f"out{i}": Out(description=f"foo: {i}", asset_key=AssetKey(f"asset{i}"))
-            for i in range(10)
-        }
-    )
+    @multi_asset(outs={f"out{i}": Out(description=f"foo: {i}") for i in range(10)})
     def assets():
         pass
 
@@ -314,7 +309,7 @@ def test_basic_multi_asset():
 
     assert external_asset_nodes == [
         ExternalAssetNode(
-            asset_key=AssetKey(f"asset{i}"),
+            asset_key=AssetKey(f"out{i}"),
             dependencies=[],
             depended_by=[],
             op_name="assets",


### PR DESCRIPTION
This is the first of a few PRs that will be stacked on top of this. This PR is not currently independently mergeable.

Some consequences:

1. We no longer require that the OutputDefinitions for ops inside of AssetsDefinitions encode their asset keys. Instead, the AssetsDefinition itself is responsible for holding all of the dependency information as well as a mapping from OutputDefinition to AssetKey.
2. When constructing a JobDefinition from AssetsDefinitions, we compile their individual asset dependency mappings + mappings from InputDef/OutputDef->AssetKey into global dictionaries. These global dictionaries are used both at runtime (to determine that we should yield an AssetMaterialization when a given Output is created), as well as at serialization time (so we use this info to construct ExternalAssetNodes).
3. For backwards compatibility, if there are OutputDefinitions/InputDefinitions with asset key information, we build the global dictionaries on the JobDefinition using this information (raising an error if info is specified in multiple places). AssetDependency information is not currently scraped in this way, but should be.
4. multi_asset no longer has a way to specify a specific asset key for an output (it is always created using the output's name). You used to be able to do this by changing the asset key argument on the outs supplied to the decorator, but now that we don't want you using the asset key argument to Out(), this is no longer possible. This will be remedied in the next PR, outlined below

# TBD PRs:

## [2/n] Refactor decorators:

In this PR, I'll introduce a new decorator, @assets_definition. This will basically just be sugar for creating an AssetsDefinition object, and will have nearly identical parameters. The new recommendation for creating what we used to call "multi_assets" will be:

```
@assets_definition
@op(out={"a": Out(), "b": Out()})
def multi_asset_op(x):
    return ...

# or, if you want to opt out of magic asset key guessing:

@assets_definition(asset_key_by_output_name={"a": AssetKey("a_asset"), "b": AssetKey("b_asset")})
@op(out={"a": Out(), "b": Out()})
def multi_asset_op(x):
    return ...
```

@asset would basically just be a combination of these two decorators.

Ideally, this would coincide with the deprecation of @multi_asset, but I can keep it around (as an alias for this sort of thing) if that seems too spicy.

## [3/n] Enable graph computations

In this pr, I'll enable AssetsDefinitions to be backed by graphs as well as ops. The syntax for this will take advantage of the new @assets_definition decorator introduced in [2/n]:

```
@assets_definition
@graph
def multi_asset_graph():
    ...
```

This will probably involve some fairly extensive code changes (lots of things assume we're always working with ops), but I don't think there will be anything all that hard here.

We can consider creating an @graph_asset decorator to combine the two of these to simplify the most common case.