### PR TITLE
make k8s container context volumes and volume mounts use snake case, not camel case

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional
 
+import kubernetes
+
 from dagster import check
 from dagster.config.validate import process_config
 from dagster.core.errors import DagsterInvalidConfigError
@@ -10,6 +12,7 @@ if TYPE_CHECKING:
     from . import K8sRunLauncher
 
 from .job import DagsterK8sJobConfig
+from .models import k8s_snake_case_dict
 
 
 def _dedupe_list(values):
@@ -59,8 +62,14 @@ class K8sContainerContext(
             env_config_maps=check.opt_list_param(env_config_maps, "env_config_maps"),
             env_secrets=check.opt_list_param(env_secrets, "env_secrets"),
             env_vars=check.opt_list_param(env_vars, "env_vars"),
-            volume_mounts=check.opt_list_param(volume_mounts, "volume_mounts"),
-            volumes=check.opt_list_param(volumes, "volumes"),
+            volume_mounts=[
+                k8s_snake_case_dict(kubernetes.client.V1VolumeMount, mount)
+                for mount in check.opt_list_param(volume_mounts, "volume_mounts")
+            ],
+            volumes=[
+                k8s_snake_case_dict(kubernetes.client.V1Volume, volume)
+                for volume in check.opt_list_param(volumes, "volumes")
+            ],
             labels=check.opt_dict_param(labels, "labels"),
             namespace=check.opt_str_param(namespace, "namespace"),
         )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -418,14 +418,16 @@ class DagsterK8sJobConfig(
             ),
             "volume_mounts": Field(
                 Array(
-                    Shape(
+                    # Can supply either snake_case or camelCase, but in typeaheads based on the
+                    # schema we assume snake_case
+                    Permissive(
                         {
                             "name": StringSource,
-                            "mountPath": StringSource,
-                            "mountPropagation": Field(StringSource, is_required=False),
-                            "readOnly": Field(BoolSource, is_required=False),
-                            "subPath": Field(StringSource, is_required=False),
-                            "subPathExpr": Field(StringSource, is_required=False),
+                            "mount_path": Field(StringSource, is_required=False),
+                            "mount_propagation": Field(StringSource, is_required=False),
+                            "read_only": Field(BoolSource, is_required=False),
+                            "sub_path": Field(StringSource, is_required=False),
+                            "sub_path_expr": Field(StringSource, is_required=False),
                         }
                     )
                 ),


### PR DESCRIPTION
Summary:
I realized when writing the docs that this field sticks out like a sore thumb in the typeahead since it's the only thing that expects snake case. We already have logic that is set up to coerce both snake case and camel case to be the right form, but this makes the default config that container_context uses use snake case instead of camel case.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.