### PR TITLE
adding the first PR draft

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -17,6 +17,7 @@ from .client_queries import (
     GET_PIPELINE_RUN_STATUS_QUERY,
     RELOAD_REPOSITORY_LOCATION_MUTATION,
     SHUTDOWN_REPOSITORY_LOCATION_MUTATION,
+    TERMINATE_RUN_JOB_MUTATION,
 )
 from .utils import (
     DagsterGraphQLClientError,
@@ -422,3 +423,32 @@ class DagsterGraphQLClient:
             )
         else:
             raise Exception(f"Unexpected query result type {query_result_type}")
+
+    def terminate_run(self, run_id: str) -> str:
+        """
+        Terminates a pipeline run. This method it is useful when you would like to stop a pipeline run
+        based on a external event.
+
+        Args:
+            run_id (str): The run id of the pipeline run to terminate
+
+        Returns:
+            PipelineRunStatus: The status of the terminated run
+        """
+        check.str_param(run_id, "run_id")
+
+        res_data: Dict[str, Dict[str, Any]] = self._execute(
+            TERMINATE_RUN_JOB_MUTATION, {"runId": run_id}
+        )
+
+        query_result: Dict[str, Any] = res_data["terminateRun"]
+        query_result_type: str = query_result["__typename"]
+        if query_result_type == "TerminateRunSuccess":
+            return query_result["run"]
+
+        elif query_result_type == "RunNotFoundError":
+            raise DagsterGraphQLClientError(
+                "RunNotFoundError", f"Run Id {run_id} not found"
+            )
+        else:
+            raise DagsterGraphQLClientError(query_result_type, query_result["message"])

--- a/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
@@ -123,3 +123,26 @@ mutation ($repositoryLocationName: String!) {
    }
 }
 """
+
+TERMINATE_RUN_JOB_MUTATION = """
+mutation TerminateRun($runId: String!) {
+  terminateRun(runId: $runId){
+    __typename
+    ... on TerminateRunSuccess{
+      run {
+        runId
+      }
+    }
+    ... on TerminateRunFailure {
+      message
+    }
+    ... on RunNotFoundError {
+      runId
+    }
+    ... on PythonError {
+      message
+      stack
+    }
+  }
+}
+"""

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_terminate_run.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_terminate_run.py
@@ -1,0 +1,55 @@
+import time
+from urllib import response
+
+import pytest
+from dagster_graphql import DagsterGraphQLClientError
+from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
+from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_selector
+
+from dagster.core.storage.pipeline_run import PipelineRunStatus
+#from dagster.core.run_coordinator import Run
+
+from ..graphql.graphql_context_test_suite import ExecutingGraphQLContextTestMatrix
+from ..graphql.setup import csv_hello_world_solids_config
+from .conftest import MockClient, python_client_test_suite
+
+RUN_ID = "foo"
+
+@python_client_test_suite
+def test_terminate_run_status_success(mock_client: MockClient):
+    expected_result = "foo"
+    response = {"terminateRun": {"__typename": "TerminateRunSuccess", "run": expected_result}}
+    mock_client.mock_gql_client.execute.return_value = response
+
+    actual_result = mock_client.python_client.terminate_run(RUN_ID)
+    assert actual_result == expected_result
+
+@python_client_test_suite
+def test_terminate_run_not_failure(mock_client: MockClient):
+    expected_result = "Unable to terminate run"
+    response = {"terminateRun": {"__typename": "TerminateRunFailure", "message": expected_result}}
+    mock_client.mock_gql_client.execute.return_value = response
+
+    with pytest.raises(DagsterGraphQLClientError) as e:
+        mock_client.python_client.terminate_run(RUN_ID)
+        assert e.value.message == expected_result
+
+@python_client_test_suite
+def test_terminate_run_not_found(mock_client: MockClient):
+    expected_result = "Run Id foo not found"
+    response = {"terminateRun": {"__typename": "RunNotFoundError", "runId": expected_result}}
+
+    with pytest.raises(DagsterGraphQLClientError) as e:
+        mock_client.mock_gql_client.execute.return_value = response
+        mock_client.python_client.terminate_run(RUN_ID)
+        assert e.value.message == expected_result
+
+@python_client_test_suite
+def test_terminate_run_python_error(mock_client: MockClient):
+    expected_result = "Unable to terminate run"
+    response = {"terminateRun": {"__typename": "PythonError", "message": expected_result}}
+
+    with pytest.raises(DagsterGraphQLClientError) as e:
+        mock_client.mock_gql_client.execute.return_value = response
+        mock_client.python_client.terminate_run(RUN_ID)
+        assert e.value.message == expected_result


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
This PR adds an extra method to the DagsterGraphQL python client to enable the possibility to terminate a run. It follows the documentation guide to terminate a run based on an event Dagster provides https://docs.dagster.io/concepts/dagit/graphql#terminate-an-in-progress-run.


An issue was already open an accepted with this feature. https://github.com/dagster-io/dagster/issues/7356


## Test Plan

The PR contains a suit of unit tests similar to the other methods defined on the client. Moreover I already test the same code in a production environment in my company (we are using Dagster and it is great =) ). Not sure what are the needed steps for integration testing. Let me know if they need to be added.





## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ X ] I have added tests to cover my changes.