### PR TITLE
Unbreak stopping unloadable schedules/sensors

### DIFF
--- a/integration_tests/test_suites/celery-k8s-integration-test-suite/test_daemon_scheduler.py
+++ b/integration_tests/test_suites/celery-k8s-integration-test-suite/test_daemon_scheduler.py
@@ -50,7 +50,9 @@ def test_execute_schedule_on_celery_k8s(  # pylint: disable=redefined-outer-name
 
         finally:
             dagster_instance_for_daemon.stop_schedule(
-                reoriginated_schedule.get_external_origin_id(), reoriginated_schedule
+                reoriginated_schedule.get_external_origin_id(),
+                reoriginated_schedule.selector_id,
+                reoriginated_schedule,
             )
 
         last_run = schedule_runs[0]

--- a/js_modules/dagit/packages/core/src/assets/types/AssetNodeInstigatorsFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNodeInstigatorsFragment.ts
@@ -12,6 +12,7 @@ import { InstigationStatus } from "./../../types/globalTypes";
 export interface AssetNodeInstigatorsFragment_jobs_schedules_scheduleState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   status: InstigationStatus;
 }
 
@@ -26,6 +27,7 @@ export interface AssetNodeInstigatorsFragment_jobs_schedules {
 export interface AssetNodeInstigatorsFragment_jobs_sensors_sensorState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   status: InstigationStatus;
 }
 

--- a/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
@@ -39,6 +39,7 @@ export interface AssetQuery_assetOrError_Asset_definition_repository {
 export interface AssetQuery_assetOrError_Asset_definition_jobs_schedules_scheduleState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   status: InstigationStatus;
 }
 
@@ -53,6 +54,7 @@ export interface AssetQuery_assetOrError_Asset_definition_jobs_schedules {
 export interface AssetQuery_assetOrError_Asset_definition_jobs_sensors_sensorState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   status: InstigationStatus;
 }
 

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1165,6 +1165,7 @@ type Schedule {
 
 type InstigationState {
   id: ID!
+  selectorId: String!
   name: String!
   instigationType: InstigationType!
   status: InstigationStatus!
@@ -1799,10 +1800,13 @@ type DagitMutation {
   launchPipelineReexecution(executionParams: ExecutionParams!): LaunchRunReexecutionResult!
   launchRunReexecution(executionParams: ExecutionParams!): LaunchRunReexecutionResult!
   startSchedule(scheduleSelector: ScheduleSelector!): ScheduleMutationResult!
-  stopRunningSchedule(scheduleOriginId: String!): ScheduleMutationResult!
+  stopRunningSchedule(
+    scheduleOriginId: String!
+    scheduleSelectorId: String!
+  ): ScheduleMutationResult!
   startSensor(sensorSelector: SensorSelector!): SensorOrError!
   setSensorCursor(cursor: String, sensorSelector: SensorSelector!): SensorOrError!
-  stopSensor(jobOriginId: String!): StopSensorMutationResultOrError!
+  stopSensor(jobOriginId: String!, jobSelectorId: String!): StopSensorMutationResultOrError!
   terminatePipelineExecution(
     runId: String!
     terminatePolicy: TerminateRunPolicy

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceOverviewInitialQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceOverviewInitialQuery.ts
@@ -57,6 +57,7 @@ export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locatio
   __typename: "InstigationState";
   id: string;
   status: InstigationStatus;
+  selectorId: string;
 }
 
 export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_futureTicks_results {
@@ -89,6 +90,7 @@ export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locatio
   __typename: "InstigationState";
   id: string;
   status: InstigationStatus;
+  selectorId: string;
 }
 
 export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors {

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceSchedulesQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceSchedulesQuery.ts
@@ -124,6 +124,7 @@ export interface InstanceSchedulesQuery_repositoriesOrError_RepositoryConnection
 export interface InstanceSchedulesQuery_repositoriesOrError_RepositoryConnection_nodes_schedules_scheduleState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   name: string;
   instigationType: InstigationType;
   status: InstigationStatus;
@@ -250,6 +251,7 @@ export interface InstanceSchedulesQuery_unloadableInstigationStatesOrError_Insti
 export interface InstanceSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   name: string;
   instigationType: InstigationType;
   status: InstigationStatus;

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceSensorsQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceSensorsQuery.ts
@@ -123,6 +123,7 @@ export interface InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_n
 export interface InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_nodes_sensors_sensorState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   name: string;
   instigationType: InstigationType;
   status: InstigationStatus;
@@ -254,6 +255,7 @@ export interface InstanceSensorsQuery_unloadableInstigationStatesOrError_Instiga
 export interface InstanceSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   name: string;
   instigationType: InstigationType;
   status: InstigationStatus;

--- a/js_modules/dagit/packages/core/src/instigation/InstigationUtils.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationUtils.tsx
@@ -42,6 +42,7 @@ export const RUN_STATUS_FRAGMENT = gql`
 export const INSTIGATION_STATE_FRAGMENT = gql`
   fragment InstigationStateFragment on InstigationState {
     id
+    selectorId
     name
     instigationType
     status

--- a/js_modules/dagit/packages/core/src/instigation/Unloadable.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/Unloadable.tsx
@@ -133,7 +133,7 @@ const UnloadableScheduleInfo = () => (
 );
 
 const SensorStateRow = ({sensorState}: {sensorState: InstigationStateFragment}) => {
-  const {id, name, status, repositoryOrigin, ticks} = sensorState;
+  const {id, selectorId, name, status, repositoryOrigin, ticks} = sensorState;
 
   const [stopSensor, {loading: toggleOffInFlight}] = useMutation<StopSensor>(STOP_SENSOR_MUTATION, {
     onCompleted: displaySensorMutationErrors,
@@ -150,7 +150,7 @@ const SensorStateRow = ({sensorState}: {sensorState: InstigationStateFragment}) 
           'If you turn it off, you will not be able to turn it back on from ' +
           'the currently loaded workspace.',
       });
-      stopSensor({variables: {jobOriginId: id}});
+      stopSensor({variables: {jobOriginId: id, jobSelectorId: selectorId}});
     }
   };
 
@@ -206,7 +206,7 @@ const ScheduleStateRow: React.FC<{
   );
   const [showRepositoryOrigin, setShowRepositoryOrigin] = React.useState(false);
   const confirm = useConfirmation();
-  const {id, name, ticks, status, repositoryOrigin, typeSpecificData} = scheduleState;
+  const {id, selectorId, name, ticks, status, repositoryOrigin, typeSpecificData} = scheduleState;
   const latestTick = ticks.length > 0 ? ticks[0] : null;
   const cronSchedule =
     typeSpecificData && typeSpecificData.__typename === 'ScheduleData'
@@ -221,7 +221,7 @@ const ScheduleStateRow: React.FC<{
           'If you turn it off, you will not be able to turn it back on from ' +
           'the currently loaded workspace.',
       });
-      stopSchedule({variables: {scheduleOriginId: id}});
+      stopSchedule({variables: {scheduleOriginId: id, scheduleSelectorId: selectorId}});
     }
   };
 

--- a/js_modules/dagit/packages/core/src/instigation/types/InstigationStateFragment.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/InstigationStateFragment.ts
@@ -71,6 +71,7 @@ export interface InstigationStateFragment_ticks {
 export interface InstigationStateFragment {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   name: string;
   instigationType: InstigationType;
   status: InstigationStatus;

--- a/js_modules/dagit/packages/core/src/nav/types/JobMetadataFragment.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/JobMetadataFragment.ts
@@ -12,6 +12,7 @@ import { InstigationStatus } from "./../../types/globalTypes";
 export interface JobMetadataFragment_schedules_scheduleState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   status: InstigationStatus;
 }
 
@@ -33,6 +34,7 @@ export interface JobMetadataFragment_sensors_targets {
 export interface JobMetadataFragment_sensors_sensorState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   status: InstigationStatus;
 }
 

--- a/js_modules/dagit/packages/core/src/nav/types/JobMetadataQuery.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/JobMetadataQuery.ts
@@ -16,6 +16,7 @@ export interface JobMetadataQuery_pipelineOrError_PipelineNotFoundError {
 export interface JobMetadataQuery_pipelineOrError_Pipeline_schedules_scheduleState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   status: InstigationStatus;
 }
 
@@ -37,6 +38,7 @@ export interface JobMetadataQuery_pipelineOrError_Pipeline_sensors_targets {
 export interface JobMetadataQuery_pipelineOrError_Pipeline_sensors_sensorState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   status: InstigationStatus;
 }
 

--- a/js_modules/dagit/packages/core/src/runs/types/SchedulerInfoQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/SchedulerInfoQuery.ts
@@ -118,6 +118,7 @@ export interface SchedulerInfoQuery_repositoriesOrError_RepositoryConnection_nod
 export interface SchedulerInfoQuery_repositoriesOrError_RepositoryConnection_nodes_schedules_scheduleState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   name: string;
   instigationType: InstigationType;
   status: InstigationStatus;

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleMutations.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleMutations.tsx
@@ -27,8 +27,11 @@ export const START_SCHEDULE_MUTATION = gql`
 `;
 
 export const STOP_SCHEDULE_MUTATION = gql`
-  mutation StopSchedule($scheduleOriginId: String!) {
-    stopRunningSchedule(scheduleOriginId: $scheduleOriginId) {
+  mutation StopSchedule($scheduleOriginId: String!, $scheduleSelectorId: String!) {
+    stopRunningSchedule(
+      scheduleOriginId: $scheduleOriginId
+      scheduleSelectorId: $scheduleSelectorId
+    ) {
       __typename
       ... on ScheduleStateResult {
         scheduleState {

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleSwitch.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleSwitch.tsx
@@ -25,7 +25,7 @@ interface Props {
 export const ScheduleSwitch: React.FC<Props> = (props) => {
   const {repoAddress, schedule, size = 'large'} = props;
   const {name, scheduleState} = schedule;
-  const {status, id} = scheduleState;
+  const {status, id, selectorId} = scheduleState;
 
   const {canStartSchedule, canStopRunningSchedule} = usePermissions();
 
@@ -50,7 +50,7 @@ export const ScheduleSwitch: React.FC<Props> = (props) => {
   const onStatusChange = () => {
     if (status === InstigationStatus.RUNNING) {
       stopSchedule({
-        variables: {scheduleOriginId: id},
+        variables: {scheduleOriginId: id, scheduleSelectorId: selectorId},
       });
     } else {
       startSchedule({
@@ -102,6 +102,7 @@ export const SCHEDULE_SWITCH_FRAGMENT = gql`
     cronSchedule
     scheduleState {
       id
+      selectorId
       status
     }
   }

--- a/js_modules/dagit/packages/core/src/schedules/types/RepositorySchedulesFragment.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/RepositorySchedulesFragment.ts
@@ -83,6 +83,7 @@ export interface RepositorySchedulesFragment_schedules_scheduleState_ticks {
 export interface RepositorySchedulesFragment_schedules_scheduleState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   name: string;
   instigationType: InstigationType;
   status: InstigationStatus;

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleFragment.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleFragment.ts
@@ -77,6 +77,7 @@ export interface ScheduleFragment_scheduleState_ticks {
 export interface ScheduleFragment_scheduleState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   name: string;
   instigationType: InstigationType;
   status: InstigationStatus;

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleRootQuery.ts
@@ -77,6 +77,7 @@ export interface ScheduleRootQuery_scheduleOrError_Schedule_scheduleState_ticks 
 export interface ScheduleRootQuery_scheduleOrError_Schedule_scheduleState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   name: string;
   instigationType: InstigationType;
   status: InstigationStatus;

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleSwitchFragment.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleSwitchFragment.ts
@@ -12,6 +12,7 @@ import { InstigationStatus } from "./../../types/globalTypes";
 export interface ScheduleSwitchFragment_scheduleState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   status: InstigationStatus;
 }
 

--- a/js_modules/dagit/packages/core/src/schedules/types/SchedulesRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/SchedulesRootQuery.ts
@@ -87,6 +87,7 @@ export interface SchedulesRootQuery_repositoryOrError_Repository_schedules_sched
 export interface SchedulesRootQuery_repositoryOrError_Repository_schedules_scheduleState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   name: string;
   instigationType: InstigationType;
   status: InstigationStatus;
@@ -214,6 +215,7 @@ export interface SchedulesRootQuery_unloadableInstigationStatesOrError_Instigati
 export interface SchedulesRootQuery_unloadableInstigationStatesOrError_InstigationStates_results {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   name: string;
   instigationType: InstigationType;
   status: InstigationStatus;

--- a/js_modules/dagit/packages/core/src/schedules/types/StopSchedule.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/StopSchedule.ts
@@ -46,4 +46,5 @@ export interface StopSchedule {
 
 export interface StopScheduleVariables {
   scheduleOriginId: string;
+  scheduleSelectorId: string;
 }

--- a/js_modules/dagit/packages/core/src/sensors/SensorMutations.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorMutations.tsx
@@ -26,8 +26,8 @@ export const START_SENSOR_MUTATION = gql`
 `;
 
 export const STOP_SENSOR_MUTATION = gql`
-  mutation StopSensor($jobOriginId: String!) {
-    stopSensor(jobOriginId: $jobOriginId) {
+  mutation StopSensor($jobOriginId: String!, $jobSelectorId: String!) {
+    stopSensor(jobOriginId: $jobOriginId, jobSelectorId: $jobSelectorId) {
       __typename
       ... on StopSensorMutationResult {
         instigationState {

--- a/js_modules/dagit/packages/core/src/sensors/SensorSwitch.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorSwitch.tsx
@@ -27,7 +27,7 @@ export const SensorSwitch: React.FC<Props> = (props) => {
   const {canStartSensor, canStopSensor} = usePermissions();
 
   const {jobOriginId, name, sensorState} = sensor;
-  const {status} = sensorState;
+  const {status, selectorId} = sensorState;
   const sensorSelector = {
     ...repoAddressToSelector(repoAddress),
     sensorName: name,
@@ -43,7 +43,7 @@ export const SensorSwitch: React.FC<Props> = (props) => {
 
   const onChangeSwitch = () => {
     if (status === InstigationStatus.RUNNING) {
-      stopSensor({variables: {jobOriginId}});
+      stopSensor({variables: {jobOriginId, jobSelectorId: selectorId}});
     } else {
       startSensor({variables: {sensorSelector}});
     }
@@ -92,6 +92,7 @@ export const SENSOR_SWITCH_FRAGMENT = gql`
     name
     sensorState {
       id
+      selectorId
       status
     }
   }

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.ts
@@ -76,6 +76,7 @@ export interface SensorFragment_sensorState_ticks {
 export interface SensorFragment_sensorState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   name: string;
   instigationType: InstigationType;
   status: InstigationStatus;

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorRootQuery.ts
@@ -80,6 +80,7 @@ export interface SensorRootQuery_sensorOrError_Sensor_sensorState_ticks {
 export interface SensorRootQuery_sensorOrError_Sensor_sensorState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   name: string;
   instigationType: InstigationType;
   status: InstigationStatus;

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorSwitchFragment.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorSwitchFragment.ts
@@ -12,6 +12,7 @@ import { InstigationStatus } from "./../../types/globalTypes";
 export interface SensorSwitchFragment_sensorState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   status: InstigationStatus;
 }
 

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorsRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorsRootQuery.ts
@@ -93,6 +93,7 @@ export interface SensorsRootQuery_sensorsOrError_Sensors_results_sensorState_tic
 export interface SensorsRootQuery_sensorsOrError_Sensors_results_sensorState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   name: string;
   instigationType: InstigationType;
   status: InstigationStatus;
@@ -202,6 +203,7 @@ export interface SensorsRootQuery_unloadableInstigationStatesOrError_Instigation
 export interface SensorsRootQuery_unloadableInstigationStatesOrError_InstigationStates_results {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   name: string;
   instigationType: InstigationType;
   status: InstigationStatus;

--- a/js_modules/dagit/packages/core/src/sensors/types/StopSensor.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/StopSensor.ts
@@ -45,4 +45,5 @@ export interface StopSensor {
 
 export interface StopSensorVariables {
   jobOriginId: string;
+  jobSelectorId: string;
 }

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -25,7 +25,7 @@ def start_schedule(graphene_info, schedule_selector):
 
 
 @capture_error
-def stop_schedule(graphene_info, schedule_origin_id):
+def stop_schedule(graphene_info, schedule_origin_id, schedule_selector_id):
     from ..schema.instigation import GrapheneInstigationState
     from ..schema.schedules import GrapheneScheduleStateResult
 
@@ -40,7 +40,7 @@ def stop_schedule(graphene_info, schedule_origin_id):
     }
 
     schedule_state = instance.stop_schedule(
-        schedule_origin_id, external_schedules.get(schedule_origin_id)
+        schedule_origin_id, schedule_selector_id, external_schedules.get(schedule_origin_id)
     )
     return GrapheneScheduleStateResult(GrapheneInstigationState(schedule_state))
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -81,7 +81,7 @@ def start_sensor(graphene_info, sensor_selector):
 
 
 @capture_error
-def stop_sensor(graphene_info, instigator_origin_id):
+def stop_sensor(graphene_info, instigator_origin_id, instigator_selector_id):
     from ..schema.sensors import GrapheneStopSensorMutationResult
 
     check.inst_param(graphene_info, "graphene_info", ResolveInfo)
@@ -94,10 +94,12 @@ def stop_sensor(graphene_info, instigator_origin_id):
         for repository in repository_location.get_repositories().values()
         for sensor in repository.get_external_sensors()
     }
-    instance.stop_sensor(instigator_origin_id, external_sensors.get(instigator_origin_id))
+    instance.stop_sensor(
+        instigator_origin_id, instigator_selector_id, external_sensors.get(instigator_origin_id)
+    )
     state = graphene_info.context.instance.get_instigator_state(
         instigator_origin_id,
-        external_sensors.get(instigator_origin_id).selector_id,
+        instigator_selector_id,
     )
     return GrapheneStopSensorMutationResult(state)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -260,6 +260,7 @@ class GrapheneFutureInstigationTicks(graphene.ObjectType):
 
 class GrapheneInstigationState(graphene.ObjectType):
     id = graphene.NonNull(graphene.ID)
+    selectorId = graphene.NonNull(graphene.String)
     name = graphene.NonNull(graphene.String)
     instigationType = graphene.NonNull(GrapheneInstigationType)
     status = graphene.NonNull(GrapheneInstigationStatus)
@@ -301,6 +302,7 @@ class GrapheneInstigationState(graphene.ObjectType):
         )
         super().__init__(
             id=instigator_state.instigator_origin_id,
+            selectorId=instigator_state.selector_id,
             name=instigator_state.name,
             instigationType=instigator_state.instigator_type,
             status=(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/__init__.py
@@ -80,14 +80,15 @@ class GrapheneStopRunningScheduleMutation(graphene.Mutation):
 
     class Arguments:
         schedule_origin_id = graphene.NonNull(graphene.String)
+        schedule_selector_id = graphene.NonNull(graphene.String)
 
     class Meta:
         name = "StopRunningScheduleMutation"
 
     @capture_error
     @check_permission(Permissions.STOP_RUNNING_SCHEDULE)
-    def mutate(self, graphene_info, schedule_origin_id):
-        return stop_schedule(graphene_info, schedule_origin_id)
+    def mutate(self, graphene_info, schedule_origin_id, schedule_selector_id):
+        return stop_schedule(graphene_info, schedule_origin_id, schedule_selector_id)
 
 
 def types():

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -149,9 +149,6 @@ class GrapheneStopSensorMutationResult(graphene.ObjectType):
         )
 
     def resolve_instigationState(self, _graphene_info):
-        if not self._instigator_state:
-            return None
-
         return GrapheneInstigationState(instigator_state=self._instigator_state)
 
 
@@ -166,14 +163,15 @@ class GrapheneStopSensorMutation(graphene.Mutation):
 
     class Arguments:
         job_origin_id = graphene.NonNull(graphene.String)
+        job_selector_id = graphene.NonNull(graphene.String)
 
     class Meta:
         name = "StopSensorMutation"
 
     @capture_error
     @check_permission(Permissions.EDIT_SENSOR)
-    def mutate(self, graphene_info, job_origin_id):
-        return stop_sensor(graphene_info, job_origin_id)
+    def mutate(self, graphene_info, job_origin_id, job_selector_id):
+        return stop_sensor(graphene_info, job_origin_id, job_selector_id)
 
 
 class GrapheneSetSensorCursorMutation(graphene.Mutation):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 import pendulum
 import pytest
 from dagster_graphql.test.utils import (
@@ -9,13 +12,19 @@ from dagster_graphql.test.utils import (
 )
 
 from dagster.core.definitions.run_request import InstigatorType
+from dagster.core.host_representation import (
+    ExternalRepositoryOrigin,
+    InProcessRepositoryLocationOrigin,
+)
 from dagster.core.scheduler.instigation import (
     InstigatorState,
     InstigatorStatus,
+    SensorInstigatorData,
     TickData,
     TickStatus,
 )
 from dagster.core.test_utils import create_test_daemon_workspace
+from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster.daemon import get_default_daemon_logger
 from dagster.daemon.sensor import execute_sensor_iteration
 from dagster.utils import Counter, traced_counter
@@ -119,12 +128,30 @@ query SensorStateQuery($sensorSelector: SensorSelector!) {
       sensorState {
         id
         status
+        selectorId
       }
     }
   }
 }
 """
 
+GET_UNLOADABLE_QUERY = """
+query getUnloadableSensors {
+  unloadableInstigationStatesOrError(instigationType: SENSOR) {
+    ... on InstigationStates {
+      results {
+        id
+        name
+        status
+      }
+    }
+    ... on PythonError {
+      message
+      stack
+    }
+  }
+}
+"""
 
 GET_SENSOR_TICK_RANGE_QUERY = """
 query SensorQuery($sensorSelector: SensorSelector!, $dayRange: Int, $dayOffset: Int) {
@@ -160,6 +187,7 @@ mutation($sensorSelector: SensorSelector!) {
       id
       jobOriginId
       sensorState {
+        selectorId
         status
       }
     }
@@ -168,8 +196,8 @@ mutation($sensorSelector: SensorSelector!) {
 """
 
 STOP_SENSORS_QUERY = """
-mutation($jobOriginId: String!) {
-  stopSensor(jobOriginId: $jobOriginId) {
+mutation($jobOriginId: String!, $jobSelectorId: String!) {
+  stopSensor(jobOriginId: $jobOriginId, jobSelectorId: $jobSelectorId) {
     ... on PythonError {
       message
       className
@@ -333,10 +361,11 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
         )
 
         job_origin_id = start_result.data["startSensor"]["jobOriginId"]
+        job_selector_id = start_result.data["startSensor"]["sensorState"]["selectorId"]
         result = execute_dagster_graphql(
             graphql_context,
             STOP_SENSORS_QUERY,
-            variables={"jobOriginId": job_origin_id},
+            variables={"jobOriginId": job_origin_id, "jobSelectorId": job_selector_id},
         )
         assert result.data
         assert (
@@ -392,6 +421,7 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
 
         assert result.data["sensorOrError"]["sensorState"]["status"] == "RUNNING"
         sensor_origin_id = result.data["sensorOrError"]["sensorState"]["id"]
+        sensor_selector_id = result.data["sensorOrError"]["sensorState"]["selectorId"]
 
         start_result = execute_dagster_graphql(
             graphql_context,
@@ -407,7 +437,7 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
         stop_result = execute_dagster_graphql(
             graphql_context,
             STOP_SENSORS_QUERY,
-            variables={"jobOriginId": sensor_origin_id},
+            variables={"jobOriginId": sensor_origin_id, "jobSelectorId": sensor_selector_id},
         )
 
         assert stop_result.data["stopSensor"]["instigationState"]["status"] == "STOPPED"
@@ -670,3 +700,61 @@ def test_sensor_ticks_filtered(graphql_context):
     )
     assert len(result.data["sensorOrError"]["sensorState"]["ticks"]) == 1
     assert result.data["sensorOrError"]["sensorState"]["ticks"][0]["status"] == "SKIPPED"
+
+
+def _get_unloadable_sensor_origin(name):
+    working_directory = os.path.dirname(__file__)
+    loadable_target_origin = LoadableTargetOrigin(
+        executable_path=sys.executable,
+        python_file=__file__,
+        working_directory=working_directory,
+    )
+    return ExternalRepositoryOrigin(
+        InProcessRepositoryLocationOrigin(loadable_target_origin), "fake_repository"
+    ).get_instigator_origin(name)
+
+
+def test_unloadable_sensor(graphql_context):
+    instance = graphql_context.instance
+
+    running_origin = _get_unloadable_sensor_origin("unloadable_running")
+    running_instigator_state = InstigatorState(
+        running_origin,
+        InstigatorType.SENSOR,
+        InstigatorStatus.RUNNING,
+        SensorInstigatorData(min_interval=30, cursor=None),
+    )
+
+    stopped_origin = _get_unloadable_sensor_origin("unloadable_stopped")
+
+    instance.add_instigator_state(running_instigator_state)
+
+    instance.add_instigator_state(
+        InstigatorState(
+            stopped_origin,
+            InstigatorType.SENSOR,
+            InstigatorStatus.STOPPED,
+            SensorInstigatorData(min_interval=30, cursor=None),
+        )
+    )
+
+    result = execute_dagster_graphql(graphql_context, GET_UNLOADABLE_QUERY)
+    assert len(result.data["unloadableInstigationStatesOrError"]["results"]) == 1
+    assert (
+        result.data["unloadableInstigationStatesOrError"]["results"][0]["name"]
+        == "unloadable_running"
+    )
+
+    # Verify that we can stop the unloadable sensor
+    stop_result = execute_dagster_graphql(
+        graphql_context,
+        STOP_SENSORS_QUERY,
+        variables={
+            "jobOriginId": running_instigator_state.instigator_origin_id,
+            "jobSelectorId": running_instigator_state.selector_id,
+        },
+    )
+    assert (
+        stop_result.data["stopSensor"]["instigationState"]["status"]
+        == InstigatorStatus.STOPPED.value
+    )

--- a/python_modules/dagster/dagster/cli/schedule.py
+++ b/python_modules/dagster/dagster/cli/schedule.py
@@ -299,7 +299,9 @@ def execute_stop_command(schedule_name, cli_args, print_fn, instance=None):
             try:
                 external_schedule = external_repo.get_external_schedule(schedule_name)
                 instance.stop_schedule(
-                    external_schedule.get_external_origin_id(), external_schedule
+                    external_schedule.get_external_origin_id(),
+                    external_schedule.selector_id,
+                    external_schedule,
                 )
             except DagsterInvariantViolationError as ex:
                 raise click.UsageError(ex)
@@ -409,6 +411,7 @@ def execute_restart_command(schedule_name, all_running_flag, cli_args, print_fn)
                             )
                             instance.stop_schedule(
                                 schedule_state.instigator_origin_id,
+                                external_schedule.selector_id,
                                 external_schedule,
                             )
                             instance.start_schedule(external_schedule)
@@ -434,7 +437,11 @@ def execute_restart_command(schedule_name, all_running_flag, cli_args, print_fn)
                     )
 
                 try:
-                    instance.stop_schedule(schedule_state.instigator_origin_id, external_schedule)
+                    instance.stop_schedule(
+                        schedule_state.instigator_origin_id,
+                        external_schedule.selector_id,
+                        external_schedule,
+                    )
                     instance.start_schedule(external_schedule)
                 except DagsterInvariantViolationError as ex:
                     raise click.UsageError(ex)

--- a/python_modules/dagster/dagster/cli/sensor.py
+++ b/python_modules/dagster/dagster/cli/sensor.py
@@ -234,7 +234,11 @@ def execute_stop_command(sensor_name, cli_args, print_fn):
             check_repo_and_scheduler(external_repo, instance)
             try:
                 external_sensor = external_repo.get_external_sensor(sensor_name)
-                instance.stop_sensor(external_sensor.get_external_origin_id(), external_sensor)
+                instance.stop_sensor(
+                    external_sensor.get_external_origin_id(),
+                    external_sensor.selector_id,
+                    external_sensor,
+                )
             except DagsterInvariantViolationError as ex:
                 raise click.UsageError(ex)
 

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1773,8 +1773,10 @@ records = instance.get_event_records(
     def start_schedule(self, external_schedule):
         return self._scheduler.start_schedule(self, external_schedule)
 
-    def stop_schedule(self, schedule_origin_id, external_schedule):
-        return self._scheduler.stop_schedule(self, schedule_origin_id, external_schedule)
+    def stop_schedule(self, schedule_origin_id, schedule_selector_id, external_schedule):
+        return self._scheduler.stop_schedule(
+            self, schedule_origin_id, schedule_selector_id, external_schedule
+        )
 
     def scheduler_debug_info(self):
         from dagster.core.definitions.run_request import InstigatorType
@@ -1835,7 +1837,7 @@ records = instance.get_event_records(
         else:
             return self.update_instigator_state(state.with_status(InstigatorStatus.RUNNING))
 
-    def stop_sensor(self, instigator_origin_id, external_sensor):
+    def stop_sensor(self, instigator_origin_id, selector_id, external_sensor):
         from dagster.core.definitions.run_request import InstigatorType
         from dagster.core.scheduler.instigation import (
             InstigatorState,
@@ -1843,9 +1845,10 @@ records = instance.get_event_records(
             SensorInstigatorData,
         )
 
-        state = self.get_instigator_state(instigator_origin_id, external_sensor.selector_id)
+        state = self.get_instigator_state(instigator_origin_id, selector_id)
 
         if not state:
+            assert external_sensor
             return self.add_instigator_state(
                 InstigatorState(
                     external_sensor.get_external_origin(),

--- a/python_modules/dagster/dagster/core/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/core/scheduler/scheduler.py
@@ -104,7 +104,7 @@ class Scheduler(abc.ABC):
             instance.update_instigator_state(started_schedule)
         return started_schedule
 
-    def stop_schedule(self, instance, schedule_origin_id, external_schedule):
+    def stop_schedule(self, instance, schedule_origin_id, schedule_selector_id, external_schedule):
         """
         Updates the status of the given schedule to `InstigatorStatus.STOPPED` in schedule storage,
 
@@ -117,9 +117,7 @@ class Scheduler(abc.ABC):
         check.str_param(schedule_origin_id, "schedule_origin_id")
         check.opt_inst_param(external_schedule, "external_schedule", ExternalSchedule)
 
-        schedule_state = instance.get_instigator_state(
-            schedule_origin_id, external_schedule.selector_id
-        )
+        schedule_state = instance.get_instigator_state(schedule_origin_id, schedule_selector_id)
         if (
             external_schedule
             and not external_schedule.get_current_instigator_state(schedule_state).is_running
@@ -131,6 +129,7 @@ class Scheduler(abc.ABC):
             )
 
         if not schedule_state:
+            assert external_schedule
             stopped_schedule = InstigatorState(
                 external_schedule.get_external_origin(),
                 InstigatorType.SCHEDULE,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -1198,7 +1198,7 @@ def test_sensor_start_stop():
             assert len(ticks) == 1
 
             # stop / start
-            instance.stop_sensor(external_origin_id, external_sensor)
+            instance.stop_sensor(external_origin_id, external_sensor.selector_id, external_sensor)
             instance.start_sensor(external_sensor)
 
             evaluate_sensors(instance, workspace)


### PR DESCRIPTION
Summary:
The new stop mutations assume that the ExternalSensor can be loaded, which is not the case for unloadable schedules and sensors. Getting this right requires threading the selector ID all the way through into the mutation path (at least in the unloadable path, but might as well do it everywhere for consistency)

Will add a test at the graphql python level as well.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.