### PR TITLE
bump black to 22.3.0

### DIFF
--- a/examples/docs_snippets/pyproject.toml
+++ b/examples/docs_snippets/pyproject.toml
@@ -6,7 +6,7 @@
 
 [tool.black]
 line-length = 88
-required-version = "22.1.0"
+required-version = "22.3.0"
 target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 line-length = 100
 
 # Black will refuse to run if it's not this version.
-required-version = "22.1.0"
+required-version = "22.3.0"
 
 # Ensure black's output will be compatible with all listed versions.
 target-version = ['py36', 'py37', 'py38', 'py39', 'py310']

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -118,7 +118,7 @@ if __name__ == "__main__":
                 "pylint==2.6.0",
             ],
             "black": [
-                "black[jupyter]==22.1.0",
+                "black[jupyter]==22.3.0",
             ],
             "isort": [
                 "isort==5.10.1",


### PR DESCRIPTION
This black version bump is necessary to maintain compatibility with newer versions of `click`. I don't fully understand the details but many people experienced this problem and the new black version was released to address it. There are no relevant formatter changes:

https://github.com/psf/black/issues/2964
