### PR TITLE
[dagit] Add bulk re-execution dialog to Runs page

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/ReexecutionDialog.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ReexecutionDialog.test.tsx
@@ -1,0 +1,156 @@
+import {gql, useQuery} from '@apollo/client';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+
+import {TestProvider} from '../testing/TestProvider';
+
+import {ReexecutionDialog} from './ReexecutionDialog';
+import {RUN_TABLE_RUN_FRAGMENT} from './RunTable';
+import {ReexecutionDialogTestQuery} from './types/ReexecutionDialogTestQuery';
+
+describe('ReexecutionDialog', () => {
+  const defaultMocks = {
+    RepositoryOrigin: () => ({
+      repositoryName: () => 'foo',
+      repositoryLocationName: () => 'bar',
+    }),
+    Workspace: () => ({
+      locationEntries: () => [...new Array(1)],
+    }),
+    Repository: () => ({
+      id: () => 'foo',
+      name: () => 'foo',
+      pipelines: () => [{id: 'my_pipeline', name: 'my_pipeline'}],
+    }),
+    RepositoryLocation: () => ({
+      id: () => 'bar',
+      name: () => 'bar',
+      repositories: () => [...new Array(1)],
+    }),
+    Run: () => ({
+      pipelineName: () => 'my_pipeline',
+    }),
+    Runs: () => ({
+      results: () => [...new Array(3)],
+    }),
+  };
+
+  const Test = () => {
+    const {data} = useQuery<ReexecutionDialogTestQuery>(REEXECUTION_DIALOG_TEST_QUERY);
+    const runs = data?.pipelineRunsOrError;
+
+    if (!runs || runs.__typename !== 'Runs' || !runs.results?.length) {
+      return null;
+    }
+
+    const selectedMap = runs.results.reduce((accum, run) => ({...accum, [run.id]: run}), {});
+
+    return (
+      <ReexecutionDialog
+        isOpen
+        onClose={jest.fn()}
+        onComplete={jest.fn()}
+        selectedRuns={selectedMap}
+      />
+    );
+  };
+
+  it('prompts the user with the number of runs to re-execute', async () => {
+    render(
+      <TestProvider apolloProps={{mocks: [defaultMocks]}}>
+        <Test />
+      </TestProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/3 runs will be re\-executed from failure\. do you wish to continue\?/i),
+      ).toBeVisible();
+    });
+  });
+
+  it('moves into loading state upon re-execution', async () => {
+    render(
+      <TestProvider apolloProps={{mocks: [defaultMocks]}}>
+        <Test />
+      </TestProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/3 runs will be re\-executed\ from failure. do you wish to continue\?/i),
+      ).toBeVisible();
+    });
+
+    const button = screen.getByText(/re\-execute 3 runs/i);
+    userEvent.click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Please do not close the window or navigate away during re-execution./i),
+      ).toBeVisible();
+      expect(screen.getByRole('button', {name: /Re-executing 3 runs.../i})).toBeVisible();
+    });
+  });
+
+  it('displays success message if mutations are successful', async () => {
+    const mocks = {
+      LaunchRunReexecutionResult: () => ({
+        __typename: 'LaunchRunSuccess',
+      }),
+    };
+
+    render(
+      <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
+        <Test />
+      </TestProvider>,
+    );
+
+    await waitFor(() => {
+      const button = screen.getByText(/re\-execute 3 runs/i);
+      userEvent.click(button);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Successfully requested re-execution for 3 runs./i)).toBeVisible();
+    });
+  });
+
+  it('displays python errors', async () => {
+    const mocks = {
+      LaunchRunReexecutionResult: () => ({
+        __typename: 'PythonError',
+      }),
+    };
+
+    render(
+      <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
+        <Test />
+      </TestProvider>,
+    );
+
+    await waitFor(() => {
+      const button = screen.getByText(/re\-execute 3 runs/i);
+      userEvent.click(button);
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/A wild python error appeared!/i)).toHaveLength(3);
+    });
+  });
+});
+
+const REEXECUTION_DIALOG_TEST_QUERY = gql`
+  query ReexecutionDialogTestQuery {
+    pipelineRunsOrError(limit: 3) {
+      ... on Runs {
+        results {
+          id
+          ...RunTableRunFragment
+        }
+      }
+    }
+  }
+  ${RUN_TABLE_RUN_FRAGMENT}
+`;

--- a/js_modules/dagit/packages/core/src/runs/ReexecutionDialog.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ReexecutionDialog.tsx
@@ -1,0 +1,329 @@
+import {useMutation} from '@apollo/client';
+// eslint-disable-next-line no-restricted-imports
+import {ProgressBar} from '@blueprintjs/core';
+import {Button, Colors, DialogBody, DialogFooter, Dialog, Group, Icon, Mono} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {ReexecutionPolicy} from '../types/globalTypes';
+
+import {NavigationBlock} from './NavitationBlock';
+import {LAUNCH_PIPELINE_REEXECUTION_MUTATION} from './RunUtils';
+import {
+  LaunchPipelineReexecution,
+  LaunchPipelineReexecutionVariables,
+  LaunchPipelineReexecution_launchPipelineReexecution_InvalidStepError,
+  LaunchPipelineReexecution_launchPipelineReexecution_PipelineNotFoundError,
+  LaunchPipelineReexecution_launchPipelineReexecution_PythonError,
+  LaunchPipelineReexecution_launchPipelineReexecution_RunConfigValidationInvalid,
+} from './types/LaunchPipelineReexecution';
+import {RunTableRunFragment} from './types/RunTableRunFragment';
+
+export interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  onComplete: (reexecutionState: ReexecutionState) => void;
+  selectedRuns: {[id: string]: RunTableRunFragment};
+}
+
+type Error =
+  | LaunchPipelineReexecution_launchPipelineReexecution_InvalidStepError
+  | LaunchPipelineReexecution_launchPipelineReexecution_PipelineNotFoundError
+  | LaunchPipelineReexecution_launchPipelineReexecution_RunConfigValidationInvalid
+  | LaunchPipelineReexecution_launchPipelineReexecution_PythonError
+  | undefined;
+
+const errorText = (error: Error) => {
+  if (!error) {
+    return 'Unknown error';
+  }
+  switch (error.__typename) {
+    case 'ConflictingExecutionParamsError':
+      return 'Conflicting execution parameters';
+    case 'InvalidOutputError':
+      return 'Invalid output';
+    case 'InvalidStepError':
+      return 'Invalid step';
+    case 'NoModeProvidedError':
+      return 'No mode provided';
+    case 'PipelineNotFoundError':
+      return 'Job not found in workspace';
+    case 'PresetNotFoundError':
+      return 'Preset not found';
+    case 'PythonError':
+      return error.message;
+    case 'RunConfigValidationInvalid':
+      return 'Run config invalid';
+    case 'RunConflict':
+      return 'Run conflict';
+    case 'UnauthorizedError':
+      return 'Re-execution not authorized';
+    default:
+      return 'Unknown error';
+  }
+};
+
+export type ReexecutionState = {completed: number; errors: {[id: string]: Error}};
+
+type ReexecutionDialogState = {
+  frozenRuns: SelectedRuns;
+  step: 'initial' | 'reexecuting' | 'completed';
+  reexecution: ReexecutionState;
+};
+
+type SelectedRuns = {[id: string]: RunTableRunFragment};
+
+const initializeState = (selectedRuns: SelectedRuns): ReexecutionDialogState => {
+  return {
+    frozenRuns: selectedRuns,
+    step: 'initial',
+    reexecution: {completed: 0, errors: {}},
+  };
+};
+
+type ReexecutionDialogAction =
+  | {type: 'reset'; frozenRuns: SelectedRuns}
+  | {type: 'start'}
+  | {type: 'reexecution-success'}
+  | {type: 'reexecution-error'; id: string; error: Error}
+  | {type: 'complete'};
+
+const reexecutionDialogReducer = (
+  prevState: ReexecutionDialogState,
+  action: ReexecutionDialogAction,
+): ReexecutionDialogState => {
+  switch (action.type) {
+    case 'reset':
+      return initializeState(action.frozenRuns);
+    case 'start':
+      return {...prevState, step: 'reexecuting'};
+    case 'reexecution-success': {
+      const {reexecution} = prevState;
+      return {
+        ...prevState,
+        step: 'reexecuting',
+        reexecution: {...reexecution, completed: reexecution.completed + 1},
+      };
+    }
+    case 'reexecution-error': {
+      const {reexecution} = prevState;
+      return {
+        ...prevState,
+        step: 'reexecuting',
+        reexecution: {
+          ...reexecution,
+          completed: reexecution.completed + 1,
+          errors: {...reexecution.errors, [action.id]: action.error},
+        },
+      };
+    }
+    case 'complete':
+      return {...prevState, step: 'completed'};
+  }
+};
+
+export const ReexecutionDialog = (props: Props) => {
+  const {isOpen, onClose, onComplete, selectedRuns} = props;
+
+  // Freeze the selected IDs, since the list may change as runs continue processing and
+  // re-executing. We want to preserve the list we're given.
+  const frozenRuns = React.useRef<SelectedRuns>(selectedRuns);
+
+  const [state, dispatch] = React.useReducer(
+    reexecutionDialogReducer,
+    frozenRuns.current,
+    initializeState,
+  );
+
+  const count = Object.keys(state.frozenRuns).length;
+
+  // If the dialog is newly open, update state to match the frozen list.
+  React.useEffect(() => {
+    if (isOpen) {
+      dispatch({type: 'reset', frozenRuns: frozenRuns.current});
+    }
+  }, [isOpen]);
+
+  // If the dialog is not open, update the ref so that the frozen list will be entered
+  // into state the next time the dialog opens.
+  React.useEffect(() => {
+    if (!isOpen) {
+      frozenRuns.current = selectedRuns;
+    }
+  }, [isOpen, selectedRuns]);
+
+  const [reexecute] = useMutation<LaunchPipelineReexecution, LaunchPipelineReexecutionVariables>(
+    LAUNCH_PIPELINE_REEXECUTION_MUTATION,
+  );
+
+  const mutate = async () => {
+    dispatch({type: 'start'});
+
+    const runList = Object.keys(state.frozenRuns);
+    for (let ii = 0; ii < runList.length; ii++) {
+      const runId = runList[ii];
+      const {data} = await reexecute({
+        variables: {
+          reexecutionParams: {
+            parentRunId: runId,
+            // Temporary! Add a prop to support this and `ALL_OPS`, based on the
+            // user's choice.
+            policy: ReexecutionPolicy.FROM_FAILURE,
+          },
+        },
+      });
+
+      if (data?.launchPipelineReexecution.__typename === 'LaunchRunSuccess') {
+        dispatch({type: 'reexecution-success'});
+      } else {
+        dispatch({type: 'reexecution-error', id: runId, error: data?.launchPipelineReexecution});
+      }
+    }
+
+    dispatch({type: 'complete'});
+    onComplete(state.reexecution);
+  };
+
+  const progressContent = () => {
+    switch (state.step) {
+      case 'initial':
+        if (!count) {
+          return (
+            <Group direction="column" spacing={16}>
+              <div>No runs selected for re-execution.</div>
+              <div>The runs you selected may already have finished executing.</div>
+            </Group>
+          );
+        }
+
+        return (
+          <Group direction="column" spacing={16}>
+            <div>
+              {`${count} ${
+                count === 1 ? 'run' : 'runs'
+              } will be re-executed from failure. Do you wish to continue?`}
+            </div>
+          </Group>
+        );
+      case 'reexecuting':
+      case 'completed':
+        const value = count > 0 ? state.reexecution.completed / count : 1;
+        return (
+          <Group direction="column" spacing={8}>
+            <ProgressBar intent="primary" value={Math.max(0.1, value)} animate={value < 1} />
+            {state.step === 'reexecuting' ? (
+              <NavigationBlock message="Re-execution in progress, please do not navigate away yet." />
+            ) : null}
+          </Group>
+        );
+      default:
+        return null;
+    }
+  };
+
+  const buttons = () => {
+    switch (state.step) {
+      case 'initial':
+        if (!count) {
+          return (
+            <Button intent="none" onClick={onClose}>
+              OK
+            </Button>
+          );
+        }
+
+        return (
+          <>
+            <Button intent="none" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button intent="primary" onClick={mutate}>
+              {`Re-execute ${`${count} ${count === 1 ? 'run' : 'runs'}`}`}
+            </Button>
+          </>
+        );
+      case 'reexecuting':
+        return (
+          <Button intent="primary" disabled>
+            {`Re-executing ${`${count} ${count === 1 ? 'run' : 'runs'}...`}`}
+          </Button>
+        );
+      case 'completed':
+        return (
+          <Button intent="primary" onClick={onClose}>
+            Done
+          </Button>
+        );
+    }
+  };
+
+  const completionContent = () => {
+    if (state.step === 'initial') {
+      return null;
+    }
+
+    if (state.step === 'reexecuting') {
+      return <div>Please do not close the window or navigate away during re-execution.</div>;
+    }
+
+    const errors = state.reexecution.errors;
+    const errorCount = Object.keys(errors).length;
+    const successCount = state.reexecution.completed - errorCount;
+
+    return (
+      <Group direction="column" spacing={8}>
+        {successCount ? (
+          <Group direction="row" spacing={8} alignItems="flex-start">
+            <Icon name="check_circle" color={Colors.Green500} />
+            <div>
+              {`Successfully requested re-execution for ${successCount} ${
+                successCount === 1 ? 'run' : `runs`
+              }.`}
+            </div>
+          </Group>
+        ) : null}
+        {errorCount ? (
+          <Group direction="column" spacing={8}>
+            <Group direction="row" spacing={8} alignItems="flex-start">
+              <Icon name="warning" color={Colors.Yellow500} />
+              <div>
+                {`Could not request re-execution for ${errorCount} ${
+                  errorCount === 1 ? 'run' : 'runs'
+                }:`}
+              </div>
+            </Group>
+            <ul>
+              {Object.keys(errors).map((runId) => (
+                <li key={runId}>
+                  <Group direction="row" spacing={8} alignItems="baseline">
+                    <Mono>{runId.slice(0, 8)}</Mono>
+                    {errors[runId] ? <div>{errorText(errors[runId])}</div> : null}
+                  </Group>
+                </li>
+              ))}
+            </ul>
+          </Group>
+        ) : null}
+      </Group>
+    );
+  };
+
+  const canQuicklyClose = state.step !== 'reexecuting';
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      title="Re-execute runs"
+      canEscapeKeyClose={canQuicklyClose}
+      canOutsideClickClose={canQuicklyClose}
+      onClose={onClose}
+    >
+      <DialogBody>
+        <Group direction="column" spacing={24}>
+          {progressContent()}
+          {completionContent()}
+        </Group>
+      </DialogBody>
+      <DialogFooter>{buttons()}</DialogFooter>
+    </Dialog>
+  );
+};

--- a/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
@@ -255,8 +255,14 @@ export const TERMINATE_MUTATION = gql`
 `;
 
 export const LAUNCH_PIPELINE_REEXECUTION_MUTATION = gql`
-  mutation LaunchPipelineReexecution($executionParams: ExecutionParams!) {
-    launchPipelineReexecution(executionParams: $executionParams) {
+  mutation LaunchPipelineReexecution(
+    $executionParams: ExecutionParams
+    $reexecutionParams: ReexecutionParams
+  ) {
+    launchPipelineReexecution(
+      executionParams: $executionParams
+      reexecutionParams: $reexecutionParams
+    ) {
       __typename
       ... on LaunchRunSuccess {
         run {

--- a/js_modules/dagit/packages/core/src/runs/types/LaunchPipelineReexecution.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/LaunchPipelineReexecution.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { ExecutionParams } from "./../../types/globalTypes";
+import { ExecutionParams, ReexecutionParams } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: LaunchPipelineReexecution
@@ -62,5 +62,6 @@ export interface LaunchPipelineReexecution {
 }
 
 export interface LaunchPipelineReexecutionVariables {
-  executionParams: ExecutionParams;
+  executionParams?: ExecutionParams | null;
+  reexecutionParams?: ReexecutionParams | null;
 }

--- a/js_modules/dagit/packages/core/src/runs/types/ReexecutionDialogTestQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/ReexecutionDialogTestQuery.ts
@@ -1,0 +1,58 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { RunStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: ReexecutionDialogTestQuery
+// ====================================================
+
+export interface ReexecutionDialogTestQuery_pipelineRunsOrError_InvalidPipelineRunsFilterError {
+  __typename: "InvalidPipelineRunsFilterError" | "PythonError";
+}
+
+export interface ReexecutionDialogTestQuery_pipelineRunsOrError_Runs_results_repositoryOrigin {
+  __typename: "RepositoryOrigin";
+  id: string;
+  repositoryName: string;
+  repositoryLocationName: string;
+}
+
+export interface ReexecutionDialogTestQuery_pipelineRunsOrError_Runs_results_tags {
+  __typename: "PipelineTag";
+  key: string;
+  value: string;
+}
+
+export interface ReexecutionDialogTestQuery_pipelineRunsOrError_Runs_results {
+  __typename: "Run";
+  id: string;
+  runId: string;
+  status: RunStatus;
+  stepKeysToExecute: string[] | null;
+  canTerminate: boolean;
+  mode: string;
+  rootRunId: string | null;
+  parentRunId: string | null;
+  pipelineSnapshotId: string | null;
+  pipelineName: string;
+  repositoryOrigin: ReexecutionDialogTestQuery_pipelineRunsOrError_Runs_results_repositoryOrigin | null;
+  solidSelection: string[] | null;
+  tags: ReexecutionDialogTestQuery_pipelineRunsOrError_Runs_results_tags[];
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
+}
+
+export interface ReexecutionDialogTestQuery_pipelineRunsOrError_Runs {
+  __typename: "Runs";
+  results: ReexecutionDialogTestQuery_pipelineRunsOrError_Runs_results[];
+}
+
+export type ReexecutionDialogTestQuery_pipelineRunsOrError = ReexecutionDialogTestQuery_pipelineRunsOrError_InvalidPipelineRunsFilterError | ReexecutionDialogTestQuery_pipelineRunsOrError_Runs;
+
+export interface ReexecutionDialogTestQuery {
+  pipelineRunsOrError: ReexecutionDialogTestQuery_pipelineRunsOrError;
+}

--- a/js_modules/dagit/packages/core/src/types/globalTypes.ts
+++ b/js_modules/dagit/packages/core/src/types/globalTypes.ts
@@ -117,6 +117,11 @@ export enum ObjectStoreOperationType {
   SET_OBJECT = "SET_OBJECT",
 }
 
+export enum ReexecutionPolicy {
+  ALL_OPS = "ALL_OPS",
+  FROM_FAILURE = "FROM_FAILURE",
+}
+
 export enum RepositoryLocationLoadStatus {
   LOADED = "LOADED",
   LOADING = "LOADING",
@@ -217,6 +222,11 @@ export interface PipelineSelector {
   repositoryName: string;
   repositoryLocationName: string;
   solidSelection?: string[] | null;
+}
+
+export interface ReexecutionParams {
+  parentRunId: string;
+  policy: ReexecutionPolicy;
 }
 
 export interface RepositorySelector {


### PR DESCRIPTION
## Summary

Resolves #6158, or at least proposes to. It's probably worth talking through whether this is the change we want.

Introduce another bulk operation option on the Runs page: re-execute all. This uses a very similar UI to terminate-all and delete-all bulk operations on this page.

- The user is presented with a dialog asking to confirm the re-execution.
- If confirmed, re-execution is performed using the run config from the original run. There is no customization or step selection, because I'm not sure how we could even do that here without making the UI super complex.
- Upon confirmation, send a series of mutations to perform re-executions. Show a progress bar as the runs are requested.
- Upon completion, show errors in a list, and show the number of confirmed re-execution requests.

Screenshots below.

## Test Plan

Jest test. Run Dagit, re-execute runs in bulk, or at least attempt to do so. Verify that some runs re-execute correctly, and tha some have workspace mismatch errors because the relevant jobs are not loaded in my current workspace.
