### PR TITLE
[graph] use the correct input definition for type checks

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/node_definition.py
@@ -107,19 +107,19 @@ class NodeDefinition(NamedConfigurableDefinition):
     def output_dict(self) -> Mapping[str, "OutputDefinition"]:
         return self._output_dict
 
-    def has_input(self, name):
+    def has_input(self, name) -> bool:
         check.str_param(name, "name")
         return name in self._input_dict
 
-    def input_def_named(self, name):
+    def input_def_named(self, name) -> "InputDefinition":
         check.str_param(name, "name")
         return self._input_dict[name]
 
-    def has_output(self, name):
+    def has_output(self, name) -> bool:
         check.str_param(name, "name")
         return name in self._output_dict
 
-    def output_def_named(self, name):
+    def output_def_named(self, name) -> "OutputDefinition":
         check.str_param(name, "name")
         return self._output_dict[name]
 

--- a/python_modules/dagster/dagster/core/events/__init__.py
+++ b/python_modules/dagster/dagster/core/events/__init__.py
@@ -707,8 +707,7 @@ class DagsterEvent(
     def step_input_event(
         step_context: StepExecutionContext, step_input_data: "StepInputData"
     ) -> "DagsterEvent":
-        step_input = step_context.step.step_input_named(step_input_data.input_name)
-        input_def = step_input.source.get_input_def(step_context.pipeline_def)
+        input_def = step_context.solid_def.input_def_named(step_input_data.input_name)
 
         return DagsterEvent.from_step(
             event_type=DagsterEventType.STEP_INPUT,

--- a/python_modules/dagster/dagster/core/execution/context/input.py
+++ b/python_modules/dagster/dagster/core/execution/context/input.py
@@ -292,8 +292,9 @@ class InputContext:
 
         partition_key_range = self.asset_partition_key_range
         return TimeWindow(
-            partitions_def.time_window_for_partition_key(partition_key_range.start).start,
-            partitions_def.time_window_for_partition_key(partition_key_range.end).end,
+            # mypy thinks partitions_def is <nothing> here because ????
+            partitions_def.time_window_for_partition_key(partition_key_range.start).start,  # type: ignore
+            partitions_def.time_window_for_partition_key(partition_key_range.end).end,  # type: ignore
         )
 
     def consume_events(self) -> Iterator["DagsterEvent"]:

--- a/python_modules/dagster/dagster/core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/core/execution/resources_init.py
@@ -368,7 +368,7 @@ def get_required_resource_keys_for_step(pipeline_def, execution_step, execution_
 
     # add input type, input loader, and input io manager resource keys
     for step_input in execution_step.step_inputs:
-        input_def = step_input.source.get_input_def(pipeline_def)
+        input_def = solid_def.input_def_named(step_input.name)
 
         resource_keys = resource_keys.union(input_def.dagster_type.required_resource_keys)
 

--- a/python_modules/dagster/dagster/core/types/config_schema.py
+++ b/python_modules/dagster/dagster/core/types/config_schema.py
@@ -1,11 +1,11 @@
 import hashlib
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Generator, Optional
+from typing import TYPE_CHECKING, AbstractSet, Callable, Iterator, Optional, Union
 
 from dagster import check
 from dagster.config.config_type import ConfigType
 from dagster.core.decorator_utils import get_function_params, validate_expected_params
-from dagster.core.definitions.events import AssetMaterialization
+from dagster.core.definitions.events import AssetMaterialization, Materialization
 from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.utils import ensure_gen
 from dagster.utils.backcompat import experimental_arg_warning
@@ -64,7 +64,7 @@ class DagsterTypeMaterializer(ABC):
     @abstractmethod
     def materialize_runtime_values(
         self, _context: "StepExecutionContext", _config_value: object, _runtime_value: object
-    ) -> object:
+    ) -> Iterator[Union[AssetMaterialization, Materialization]]:
         """
         How to materialize a runtime value given configuration.
         """
@@ -215,7 +215,7 @@ class DagsterTypeMaterializerForDecorator(DagsterTypeMaterializer):
 
     def materialize_runtime_values(
         self, context: "StepExecutionContext", config_value: object, runtime_value: object
-    ) -> Generator[AssetMaterialization, Any, Any]:
+    ) -> Iterator[Union[Materialization, AssetMaterialization]]:
         return ensure_gen(self._func(context, config_value, runtime_value))
 
     def required_resource_keys(self) -> AbstractSet[str]:

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_execution_plan.py
@@ -68,10 +68,10 @@ snapshots['test_create_execution_plan_with_dep 1'] = '''{
           "source": {
             "__class__": "FromStepOutput",
             "fan_in": false,
-            "input_name": "num",
+            "input_name": "",
             "solid_handle": {
               "__class__": "SolidHandle",
-              "name": "solid_two",
+              "name": "",
               "parent": null
             },
             "step_output_handle": {
@@ -278,10 +278,10 @@ snapshots['test_create_with_composite 1'] = '''{
           "source": {
             "__class__": "FromStepOutput",
             "fan_in": false,
-            "input_name": "num_one",
+            "input_name": "",
             "solid_handle": {
               "__class__": "SolidHandle",
-              "name": "add",
+              "name": "",
               "parent": null
             },
             "step_output_handle": {
@@ -307,10 +307,10 @@ snapshots['test_create_with_composite 1'] = '''{
           "source": {
             "__class__": "FromStepOutput",
             "fan_in": false,
-            "input_name": "num_two",
+            "input_name": "",
             "solid_handle": {
               "__class__": "SolidHandle",
-              "name": "add",
+              "name": "",
               "parent": null
             },
             "step_output_handle": {
@@ -377,15 +377,11 @@ snapshots['test_create_with_composite 1'] = '''{
           "source": {
             "__class__": "FromStepOutput",
             "fan_in": false,
-            "input_name": "num",
+            "input_name": "",
             "solid_handle": {
               "__class__": "SolidHandle",
-              "name": "add_one",
-              "parent": {
-                "__class__": "SolidHandle",
-                "name": "comp_1",
-                "parent": null
-              }
+              "name": "",
+              "parent": null
             },
             "step_output_handle": {
               "__class__": "StepOutputHandle",
@@ -507,15 +503,11 @@ snapshots['test_create_with_composite 1'] = '''{
           "source": {
             "__class__": "FromStepOutput",
             "fan_in": false,
-            "input_name": "num",
+            "input_name": "",
             "solid_handle": {
               "__class__": "SolidHandle",
-              "name": "add_one",
-              "parent": {
-                "__class__": "SolidHandle",
-                "name": "comp_2",
-                "parent": null
-              }
+              "name": "",
+              "parent": null
             },
             "step_output_handle": {
               "__class__": "StepOutputHandle",

--- a/python_modules/libraries/dagstermill/dagstermill/manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill/manager.py
@@ -358,7 +358,10 @@ class Manager:
         # load input from source
         step_context = self.context._step_context  # pylint: disable=protected-access
         step_input = step_context.step.step_input_named(input_name)
-        for event_or_input_value in ensure_gen(step_input.source.load_input_object(step_context)):
+        input_def = step_context.solid_def.input_def_named(input_name)
+        for event_or_input_value in ensure_gen(
+            step_input.source.load_input_object(step_context, input_def)
+        ):
             if isinstance(event_or_input_value, DagsterEvent):
                 continue
             else:


### PR DESCRIPTION
https://dagster.phacility.com/D6155 added things to the input source types to allow for removing all user code from the execution plan structure. 

`input_name` and `solid_handle` values were added to the source objects. The way these values are populated is that they correspond to where along the mapping chain the dependency was resolved. This is important for the `FromConfig` since the config may be supplied at different places in the config structure which map to different input mapping layers.
Unfortunately, for other sources such as `FromStepOutput` this information is more confusing than useful. 

This subtle confusion was fine with `@composite_solid` since it enforced that all types were equal along a mapping chain.

`@graph` dropped this requirement, which exposes this subtle "bug" and caused type checks to source the `dagster_type` from the mapping input def, which in the `@graph` case is likely `Any` instead of the `@op` input def. 


This diff fixes the underlying issue by passing `input_def` directly and deprecating the confusing properties from the input sources they are not needed on.


resolves #7452

## Test Plan

test added

still need to ensure that the serdes changes are safe and do not require more extensive back-compat / forward-compat protections .