### PR TITLE
RFC: Asset definition decorator

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -4,6 +4,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    List,
     Mapping,
     Optional,
     Sequence,
@@ -11,16 +12,15 @@ from typing import (
     Union,
     cast,
     overload,
-    Tuple,
-    List,
 )
 
 from dagster import check
 from dagster.builtins import Nothing
 from dagster.config import Field
 from dagster.core.decorator_utils import get_function_params, get_valid_name_permutations
-from dagster.core.definitions.decorators.op_decorator import _Op
 from dagster.core.definitions import OpDefinition
+from dagster.core.definitions.decorators.op_decorator import _Op
+from dagster.core.definitions.decorators.solid_decorator import DecoratedSolidFunction
 from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.input import In
 from dagster.core.definitions.output import Out
@@ -28,6 +28,7 @@ from dagster.core.definitions.partition import PartitionsDefinition
 from dagster.core.definitions.utils import NoValueSentinel
 from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.types.dagster_type import DagsterType
+from dagster.seven import funcsigs
 from dagster.utils.backcompat import ExperimentalWarning, experimental_decorator
 
 from .asset_in import AssetIn
@@ -318,7 +319,7 @@ def assets_definition(
     asset_keys_by_input_name: Optional[Mapping[str, AssetKey]] = None,
     asset_keys_by_output_name: Optional[Mapping[str, AssetKey]] = None,
     internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
-) -> Callable[[Callable[..., Any]], AssetsDefinition]:
+) -> Callable[[OpDefinition], AssetsDefinition]:
     """Create a definition of multiple assets which share the same computation and same upstream assets.
 
     Each argument to the decorated function references an upstream asset that these assets depends on.
@@ -359,10 +360,10 @@ def assets_definition(
         return AssetsDefinition(
             input_names_by_asset_key=_infer_input_names_by_asset_key(
                 op_def,
-                asset_keys_by_input_name,
+                asset_keys_by_input_name or {},
             ),
             output_names_by_asset_key=_infer_output_names_by_asset_key(
-                op_def, asset_keys_by_output_name
+                op_def, asset_keys_by_output_name or {}
             ),
             op=op_def,
         )
@@ -373,23 +374,24 @@ def assets_definition(
             "assets_definition decorator can only be applied to an OpDefinition",
         )
         output_names_by_asset_key = _infer_output_names_by_asset_key(
-            op_def, asset_keys_by_output_name
+            op_def, asset_keys_by_output_name or {}
         )
         asset_key_by_output_name = {
             output_name: asset_key for asset_key, output_name in output_names_by_asset_key.items()
         }
         transformed_internal_asset_deps = {}
-        for output_name, asset_keys in internal_asset_deps:
-            check.invariant(
-                output_name in asset_key_by_output_name,
-                f"output_name {output_name} specified in internal_asset_deps does not exist in the decorated function",
-            )
-            transformed_internal_asset_deps[asset_key_by_output_name[output_name]] = asset_keys
+        if internal_asset_deps:
+            for output_name, asset_keys in internal_asset_deps.items():
+                check.invariant(
+                    output_name in asset_key_by_output_name,
+                    f"output_name {output_name} specified in internal_asset_deps does not exist in the decorated function",
+                )
+                transformed_internal_asset_deps[asset_key_by_output_name[output_name]] = asset_keys
 
         return AssetsDefinition(
             input_names_by_asset_key=_infer_input_names_by_asset_key(
                 op_def,
-                asset_keys_by_input_name,
+                asset_keys_by_input_name or {},
             ),
             output_names_by_asset_key=output_names_by_asset_key,
             op=op_def,
@@ -399,7 +401,7 @@ def assets_definition(
     return inner
 
 
-def _get_input_param_names(fn_params: List[str]) -> List[str]:
+def _get_input_param_names(fn_params: List[funcsigs.Parameter]) -> List[str]:
     is_context_provided = len(fn_params) > 0 and fn_params[0].name in get_valid_name_permutations(
         "context"
     )
@@ -409,12 +411,14 @@ def _get_input_param_names(fn_params: List[str]) -> List[str]:
 
 
 def _infer_input_names_by_asset_key(
-    op_def: OpDefinition, asset_keys_by_input_name: Dict[str, AssetKey]
-) -> Dict[AssetKey, str]:
+    op_def: OpDefinition, asset_keys_by_input_name: Mapping[str, AssetKey]
+) -> Mapping[AssetKey, str]:
     # Infer non-argument deps for inputs with type In(nothing) with AssetKey(input_name)
 
-    params = get_function_params(op_def.compute_fn.decorated_fn)
-    input_param_names = _get_input_param_names(params)
+    input_param_names = []
+    if isinstance(op_def.compute_fn, DecoratedSolidFunction):
+        params = get_function_params(op_def.compute_fn.decorated_fn)
+        input_param_names = _get_input_param_names(params)
 
     for in_key in asset_keys_by_input_name.keys():
         if in_key not in input_param_names:
@@ -436,14 +440,14 @@ def _infer_input_names_by_asset_key(
 
 
 def _infer_output_names_by_asset_key(
-    op_def: OpDefinition, asset_keys_by_output_name: Dict[str, AssetKey]
-) -> Dict[AssetKey, str]:
+    op_def: OpDefinition, asset_keys_by_output_name: Mapping[str, AssetKey]
+) -> Mapping[AssetKey, str]:
     inferred_output_name_by_asset_key: Dict[AssetKey, str] = {
         asset_key: output_name for output_name, asset_key in asset_keys_by_output_name.items()
     }
     op_outs = op_def.outs
 
-    for output_name, asset_key in asset_keys_by_output_name.items():
+    for output_name in asset_keys_by_output_name.keys():
         if output_name not in op_outs:
             raise DagsterInvalidDefinitionError(
                 f"Key {output_name} in provided asset_keys_by_output_name does not correspond "

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -3,9 +3,10 @@ import warnings
 import pytest
 
 from dagster import (
-    Nothing,
     AssetKey,
     DagsterInvalidDefinitionError,
+    In,
+    Nothing,
     OpExecutionContext,
     Out,
     Output,
@@ -14,7 +15,6 @@ from dagster import (
     build_op_context,
     check,
     op,
-    In,
     resource,
 )
 from dagster.core.asset_defs import AssetIn, AssetsDefinition, asset, build_assets_job, multi_asset

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -342,6 +342,7 @@ def test_partitions_def():
 
     assert my_asset.partitions_def == partitions_def
 
+
 def test_asset_definition_decorator():
     @assets_definition(
         asset_keys_by_input_name={"x": AssetKey("x_asset"), "y": AssetKey("y_asset")},
@@ -436,3 +437,13 @@ def test_assets_definition_errors_when_not_op_decorated():
         @resource
         def my_op():
             return 5, 6
+
+
+def test_internal_asset_deps():
+    with pytest.raises(Exception):
+
+        @assets_definition(internal_asset_deps={"non_exist_output_name": AssetKey("b")})
+        @op(out={"a": Out(), "b": Out()})
+        def multi_asset_op(context):
+            yield Output(1, "a")
+            yield Output(2, "b")

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -342,10 +342,6 @@ def test_partitions_def():
 
     assert my_asset.partitions_def == partitions_def
 
-def _invert_dict(input_dict):
-    return {v: k for k, v in input_dict.items()}
-
-
 def test_asset_definition_decorator():
     @assets_definition(
         asset_keys_by_input_name={"x": AssetKey("x_asset"), "y": AssetKey("y_asset")},
@@ -356,8 +352,8 @@ def test_asset_definition_decorator():
         yield Output(1, "a")
         yield Output(2, "b")
 
-    output_def_by_asset_key = _invert_dict(multi_asset_op.asset_key_by_output_def)
-    input_def_by_asset_key = _invert_dict(multi_asset_op.asset_key_by_input_def)
+    output_def_by_asset_key = multi_asset_op.output_defs_by_asset_key
+    input_def_by_asset_key = multi_asset_op.input_defs_by_asset_key
 
     assert output_def_by_asset_key[AssetKey("a_asset")].name == "a"
     assert output_def_by_asset_key[AssetKey("b_asset")].name == "b"
@@ -372,8 +368,8 @@ def test_asset_definition_no_names_specified():
         yield Output(1, "a")
         yield Output(2, "b")
 
-    output_def_by_asset_key = _invert_dict(multi_asset_op.asset_key_by_output_def)
-    input_def_by_asset_key = _invert_dict(multi_asset_op.asset_key_by_input_def)
+    output_def_by_asset_key = multi_asset_op.output_defs_by_asset_key
+    input_def_by_asset_key = multi_asset_op.input_defs_by_asset_key
 
     assert output_def_by_asset_key[AssetKey("a")].name == "a"
     assert output_def_by_asset_key[AssetKey("b")].name == "b"
@@ -389,7 +385,7 @@ def test_assets_no_ins_outs():
         yield Output(1, "a")
         yield Output(2, "b")
 
-    input_def_by_asset_key = _invert_dict(multi_asset_op.asset_key_by_input_def)
+    input_def_by_asset_key = multi_asset_op.input_defs_by_asset_key
     assert input_def_by_asset_key[AssetKey("x_asset")].name == "x"
     assert input_def_by_asset_key[AssetKey("y")].name == "y"
 
@@ -404,8 +400,8 @@ def test_partial_asset_keys_provided():
         yield Output(1, "a")
         yield Output(2, "b")
 
-    output_def_by_asset_key = _invert_dict(multi_asset_op.asset_key_by_output_def)
-    input_def_by_asset_key = _invert_dict(multi_asset_op.asset_key_by_input_def)
+    output_def_by_asset_key = multi_asset_op.output_defs_by_asset_key
+    input_def_by_asset_key = multi_asset_op.input_defs_by_asset_key
 
     assert output_def_by_asset_key[AssetKey("a_asset")].name == "a"
     assert output_def_by_asset_key[AssetKey("b")].name == "b"
@@ -419,8 +415,8 @@ def test_default_assets_and_op_definition():
     def my_op():
         return 5, 6
 
-    output_def_by_asset_key = _invert_dict(my_op.asset_key_by_output_def)
-    input_def_by_asset_key = _invert_dict(my_op.asset_key_by_input_def)
+    output_def_by_asset_key = my_op.output_defs_by_asset_key
+    input_def_by_asset_key = my_op.input_defs_by_asset_key
 
     assert input_def_by_asset_key == {}
     assert output_def_by_asset_key[AssetKey("result_asset")].name == "result"


### PR DESCRIPTION
This PR introduces an `@assets_definition` decorator that decorates an op to create an `AssetsDefinition`:

Code snippet from https://github.com/dagster-io/dagster/pull/7432:
```
@assets_definition
@op(out={"a": Out(), "b": Out()})
def multi_asset_op(x):
    return ...

# or, if you want to opt out of magic asset key guessing:

@assets_definition(asset_key_by_output_name={"a": AssetKey("a_asset"), "b": AssetKey("b_asset")})
@op(out={"a": Out(), "b": Out()})
def multi_asset_op(x):
    return ...
```
Specifying no arguments on `assets_definition` and `op` will automatically infer the input and output asset keys from the decorated function. For the below function:
- input asset keys would be `AssetKey("a")` and `AssetKey("b")`
- output asset key would be `AssetKey("result")` since by default the output of an op is named "result"
```
@assets_definition
@op
def multi_asset_op(a, b):
    return y
```

Some distinctions:
- `non_argument_deps` is no longer an argument to `assets_definition`. Because `assets_definition` decorates an op, any input with type `Nothing` will have asset key `AssetKey(input_def.name)`.
- `resource_defs` will not be an argument as all operational domain arguments will exist on the op definition layer
- Will probably need to add a description field on this decorator in the future, but punting on this for now