### PR TITLE
[Asset/Op Interop 3/n] Graphs inside AssetsDefinition

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -214,7 +214,7 @@ class _Asset:
                 input_name: asset_key for asset_key, (input_name, _) in asset_ins.items()
             },
             asset_keys_by_output_name={"result": out_asset_key},
-            op=op,
+            node_def=op,
             partitions_def=self.partitions_def,
             partition_mappings={
                 asset_key: self.partition_mappings[input_name]
@@ -294,7 +294,7 @@ def multi_asset(
             asset_keys_by_output_name={
                 output_name: asset_key for asset_key, (output_name, _) in asset_outs.items()
             },
-            op=op,
+            node_def=op,
             asset_deps=internal_asset_deps or None,
         )
 

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -465,8 +465,12 @@ class GraphDefinition(NodeDefinition):
         version_strategy: Optional[VersionStrategy] = None,
         op_selection: Optional[List[str]] = None,
         partitions_def: Optional["PartitionsDefinition"] = None,
-        asset_keys_by_input_handle: Optional[Mapping[SolidInputHandle, AssetKey]] = None,
-        asset_keys_by_output_handle: Optional[Mapping[SolidOutputHandle, AssetKey]] = None,
+        asset_keys_by_input_handle: Optional[
+            Mapping[Tuple[NodeHandle, InputDefinition], AssetKey]
+        ] = None,
+        asset_keys_by_output_handle: Optional[
+            Mapping[Tuple[NodeHandle, OutputDefinition], AssetKey]
+        ] = None,
         asset_deps: Optional[Mapping[AssetKey, Sequence[AssetKey]]] = None,
     ) -> "JobDefinition":
         """

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -69,8 +69,12 @@ class JobDefinition(PipelineDefinition):
         hook_defs: Optional[AbstractSet[HookDefinition]] = None,
         op_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
-        asset_keys_by_output_handle: Optional[Mapping[SolidOutputHandle, AssetKey]] = None,
-        asset_keys_by_input_handle: Optional[Mapping[SolidInputHandle, AssetKey]] = None,
+        asset_keys_by_input_handle: Optional[
+            Mapping[Tuple[NodeHandle, InputDefinition], AssetKey]
+        ] = None,
+        asset_keys_by_output_handle: Optional[
+            Mapping[Tuple[NodeHandle, OutputDefinition], AssetKey]
+        ] = None,
         asset_deps: Optional[Mapping[AssetKey, AbstractSet[AssetKey]]] = None,
         _op_selection_data: Optional[OpSelectionData] = None,
     ):
@@ -80,18 +84,16 @@ class JobDefinition(PipelineDefinition):
             _op_selection_data, "_op_selection_data", OpSelectionData
         )
 
-        # TODO: scrape asset dep info off of output def + dependency structure
-
         self._asset_keys_by_output_handle = check.opt_dict_param(
             asset_keys_by_output_handle,
             "asset_keys_by_output_handle",
-            key_type=SolidOutputHandle,
+            key_type=tuple,
             value_type=AssetKey,
         )
         self._asset_keys_by_input_handle = check.opt_dict_param(
             asset_keys_by_input_handle,
             "asset_keys_by_input_handle",
-            key_type=SolidInputHandle,
+            key_type=tuple,
             value_type=AssetKey,
         )
         self._asset_deps = check.opt_dict_param(

--- a/python_modules/dagster/dagster/core/execution/context/input.py
+++ b/python_modules/dagster/dagster/core/execution/context/input.py
@@ -211,8 +211,15 @@ class InputContext:
             return None
         if not isinstance(self.step_context.pipeline_def, JobDefinition):
             return None
-        input_handle = self.step_context.solid.input_handle(self.name)
-        return self.step_context.pipeline_def.asset_keys_by_input_handle.get(input_handle)
+
+        matching_input_defs = [
+            input_def
+            for input_def in cast(SolidDefinition, self._solid_def).input_defs
+            if input_def.name == self.name
+        ]
+        check.invariant(len(matching_input_defs) == 1)
+        input_key = (self.step_context.solid_handle, matching_input_defs[0])
+        return self.step_context.pipeline_def.asset_keys_by_input_handle.get(input_key)
 
     @property
     def step_context(self) -> "StepExecutionContext":

--- a/python_modules/dagster/dagster/core/execution/context/output.py
+++ b/python_modules/dagster/dagster/core/execution/context/output.py
@@ -243,8 +243,15 @@ class OutputContext:
 
         if not isinstance(self.step_context.pipeline_def, JobDefinition):
             return None
-        output_handle = self.step_context.solid.output_handle(self.name)
-        return self.step_context.pipeline_def.asset_keys_by_output_handle.get(output_handle)
+
+        matching_output_defs = [
+            output_def
+            for output_def in cast(SolidDefinition, self._solid_def).output_defs
+            if output_def.name == self.name
+        ]
+        check.invariant(len(matching_output_defs) == 1)
+        output_key = (self.step_context.solid_handle, matching_output_defs[0])
+        return self.step_context.pipeline_def.asset_keys_by_output_handle.get(output_key)
 
     @property
     def step_context(self) -> "StepExecutionContext":

--- a/python_modules/dagster/dagster/core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_step.py
@@ -413,7 +413,6 @@ def _type_check_and_store_output(
 
 
 def _asset_key_and_partitions_for_output(
-    pipeline_def: PipelineDefinition,
     output_context: OutputContext,
     output_def: OutputDefinition,
     output_manager: IOManager,
@@ -421,12 +420,11 @@ def _asset_key_and_partitions_for_output(
 
     manager_asset_key = output_manager.get_output_asset_key(output_context)
 
-    output_handle = SolidOutputHandle(
-        solid=output_context.step_context.solid, output_def=output_def
-    )
+    pipeline_def = output_context.step_context.pipeline_def
+    output_key = (output_context.step_context.solid_handle, output_def)
     if (
         isinstance(pipeline_def, JobDefinition)
-        and output_handle in pipeline_def.asset_keys_by_output_handle
+        and output_key in pipeline_def.asset_keys_by_output_handle
     ):
         if manager_asset_key is not None:
             solid_def = cast(SolidDefinition, output_context.solid_def)
@@ -437,7 +435,7 @@ def _asset_key_and_partitions_for_output(
                 "specify an AssetKey in its get_output_asset_key() function."
             )
         return (
-            pipeline_def.asset_keys_by_output_handle[output_handle],
+            pipeline_def.asset_keys_by_output_handle[output_key],
             output_def.get_asset_partitions(output_context) or set(),
         )
     elif manager_asset_key:
@@ -596,7 +594,7 @@ def _store_output(
         yield DagsterEvent.asset_materialization(step_context, materialization, input_lineage)
 
     asset_key, partitions = _asset_key_and_partitions_for_output(
-        step_context.pipeline_def, output_context, output_def, output_manager
+        output_context, output_def, output_manager
     )
     if asset_key:
         for materialization in _get_output_asset_materializations(

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
@@ -5,6 +5,7 @@ import pytest
 
 from dagster import (
     AssetKey,
+    AssetsDefinition,
     DagsterInvalidDefinitionError,
     IOManager,
     Out,

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -7,8 +7,11 @@ from dagster import (
     AssetsDefinition,
     DagsterInvalidDefinitionError,
     DependencyDefinition,
+    GraphOut,
     IOManager,
     NodeInvocation,
+    Out,
+    graph,
     io_manager,
     op,
 )
@@ -324,12 +327,12 @@ def test_same_op_different_assets():
     foo_plus_one = AssetsDefinition(
         asset_keys_by_input_name={"in_asset": AssetKey("foo")},
         asset_keys_by_output_name={"result": AssetKey("foo_plus_one")},
-        op=add_one,
+        node_def=add_one,
     )
     foo_plus_two = AssetsDefinition(
         asset_keys_by_input_name={"in_asset": AssetKey("foo_plus_one")},
         asset_keys_by_output_name={"result": AssetKey("foo_plus_two")},
-        op=add_one,
+        node_def=add_one,
     )
 
     job = build_assets_job("foos", [foo, foo_plus_one, foo_plus_two])
@@ -342,3 +345,242 @@ def test_same_op_different_assets():
     }
     result = job.execute_in_process()
     assert result.output_for_node("add_one_2") == 3
+
+
+def test_basic_graph_asset():
+    @op
+    def return_one():
+        return 1
+
+    @op
+    def add_one(in1):
+        pass
+
+    @graph
+    def create_cool_thing():
+        return add_one(add_one(return_one()))
+
+    cool_thing_asset = AssetsDefinition(
+        asset_keys_by_input_name={},
+        asset_keys_by_output_name={"result": AssetKey("cool_thing")},
+        node_def=create_cool_thing,
+    )
+    job = build_assets_job("graph_asset_job", [cool_thing_asset])
+
+    result = job.execute_in_process()
+    assert len(result.asset_materializations_for_node("create_cool_thing.add_one_2")) == 1
+
+
+def test_input_mapped_graph_asset():
+    @asset
+    def a():
+        return "a"
+
+    @asset
+    def b():
+        return "b"
+
+    @op
+    def double_string(s):
+        return s * 2
+
+    @op
+    def combine_strings(s1, s2):
+        return s1 + s2
+
+    @graph
+    def create_cool_thing(a, b):
+        da = double_string(double_string(a))
+        db = double_string(b)
+        return combine_strings(da, db)
+
+    cool_thing_asset = AssetsDefinition(
+        asset_keys_by_input_name={"a": AssetKey("a"), "b": AssetKey("b")},
+        asset_keys_by_output_name={"result": AssetKey("cool_thing")},
+        node_def=create_cool_thing,
+    )
+
+    job = build_assets_job("graph_asset_job", [a, b, cool_thing_asset])
+
+    result = job.execute_in_process()
+    assert result.success
+    assert result.output_for_node("create_cool_thing.combine_strings") == "aaaabb"
+    assert len(result.asset_materializations_for_node("create_cool_thing")) == 1
+    assert len(result.asset_materializations_for_node("create_cool_thing.combine_strings")) == 1
+
+
+def test_output_mapped_same_op_graph_asset():
+    @asset
+    def a():
+        return "a"
+
+    @asset
+    def b():
+        return "b"
+
+    @op
+    def double_string(s):
+        return s * 2
+
+    @op(out={"ns1": Out(), "ns2": Out()})
+    def combine_strings_and_split(s1, s2):
+        return (s1 + s2, s2 + s1)
+
+    @graph(out={"o1": GraphOut(), "o2": GraphOut()})
+    def create_cool_things(a, b):
+        da = double_string(double_string(a))
+        db = double_string(b)
+        o1, o2 = combine_strings_and_split(da, db)
+        return o1, o2
+
+    @asset
+    def out_asset1_plus_one(out_asset1):
+        return out_asset1 + "one"
+
+    @asset
+    def out_asset2_plus_one(out_asset2):
+        return out_asset2 + "one"
+
+    complex_asset = AssetsDefinition(
+        asset_keys_by_input_name={"a": AssetKey("a"), "b": AssetKey("b")},
+        asset_keys_by_output_name={"o1": AssetKey("out_asset1"), "o2": AssetKey("out_asset2")},
+        node_def=create_cool_things,
+    )
+
+    job = build_assets_job(
+        "graph_asset_job", [a, b, complex_asset, out_asset1_plus_one, out_asset2_plus_one]
+    )
+
+    result = job.execute_in_process()
+    assert result.success
+    assert result.output_for_node("out_asset1_plus_one") == "aaaabbone"
+    assert result.output_for_node("out_asset2_plus_one") == "bbaaaaone"
+
+    assert len(result.asset_materializations_for_node("create_cool_things")) == 2
+    assert (
+        len(result.asset_materializations_for_node("create_cool_things.combine_strings_and_split"))
+        == 2
+    )
+
+
+def test_output_mapped_different_op_graph_asset():
+    @asset
+    def a():
+        return "a"
+
+    @asset
+    def b():
+        return "b"
+
+    @op
+    def double_string(s):
+        return s * 2
+
+    @op(out={"ns1": Out(), "ns2": Out()})
+    def combine_strings_and_split(s1, s2):
+        return (s1 + s2, s2 + s1)
+
+    @graph(out={"o1": GraphOut(), "o2": GraphOut()})
+    def create_cool_things(a, b):
+        ab, ba = combine_strings_and_split(a, b)
+        dab = double_string(ab)
+        dba = double_string(ba)
+        return dab, dba
+
+    @asset
+    def out_asset1_plus_one(out_asset1):
+        return out_asset1 + "one"
+
+    @asset
+    def out_asset2_plus_one(out_asset2):
+        return out_asset2 + "one"
+
+    complex_asset = AssetsDefinition(
+        asset_keys_by_input_name={"a": AssetKey("a"), "b": AssetKey("b")},
+        asset_keys_by_output_name={"o1": AssetKey("out_asset1"), "o2": AssetKey("out_asset2")},
+        node_def=create_cool_things,
+    )
+
+    job = build_assets_job(
+        "graph_asset_job", [a, b, complex_asset, out_asset1_plus_one, out_asset2_plus_one]
+    )
+
+    result = job.execute_in_process()
+    assert result.success
+    assert result.output_for_node("out_asset1_plus_one") == "ababone"
+    assert result.output_for_node("out_asset2_plus_one") == "babaone"
+
+    assert len(result.asset_materializations_for_node("create_cool_things")) == 2
+    assert len(result.asset_materializations_for_node("create_cool_things.double_string")) == 1
+    assert len(result.asset_materializations_for_node("create_cool_things.double_string_2")) == 1
+
+
+def test_nasty_nested_graph_assets():
+    @op
+    def add_one(i):
+        return i + 1
+
+    @graph
+    def add_three(i):
+        return add_one(add_one(add_one(i)))
+
+    @graph
+    def add_five(i):
+        return add_one(add_three(add_one(i)))
+
+    @op
+    def get_sum(a, b):
+        return a + b
+
+    @graph
+    def sum_plus_one(a, b):
+        return add_one(get_sum(a, b))
+
+    @asset
+    def zero():
+        return 0
+
+    @graph(out={"eight": GraphOut(), "five": GraphOut()})
+    def create_eight_and_five(zero):
+        return add_five(add_three(zero)), add_five(zero)
+
+    @graph(out={"thirteen": GraphOut(), "six": GraphOut()})
+    def create_thirteen_and_six(eight, five, zero):
+        return add_five(eight), sum_plus_one(five, zero)
+
+    @graph
+    def create_twenty(thirteen, six):
+        return sum_plus_one(thirteen, six)
+
+    eight_and_five = AssetsDefinition(
+        asset_keys_by_input_name={"zero": AssetKey("zero")},
+        asset_keys_by_output_name={"eight": AssetKey("eight"), "five": AssetKey("five")},
+        node_def=create_eight_and_five,
+    )
+
+    thirteen_and_six = AssetsDefinition(
+        asset_keys_by_input_name={
+            "eight": AssetKey("eight"),
+            "five": AssetKey("five"),
+            "zero": AssetKey("zero"),
+        },
+        asset_keys_by_output_name={"thirteen": AssetKey("thirteen"), "six": AssetKey("six")},
+        node_def=create_thirteen_and_six,
+    )
+
+    twenty = AssetsDefinition(
+        asset_keys_by_input_name={"thirteen": AssetKey("thirteen"), "six": AssetKey("six")},
+        asset_keys_by_output_name={"result": AssetKey("twenty")},
+        node_def=create_twenty,
+    )
+
+    job = build_assets_job("graph_asset_job", [zero, eight_and_five, thirteen_and_six, twenty])
+
+    result = job.execute_in_process()
+    assert result.success
+    assert result.output_for_node("create_thirteen_and_six", "six") == 6
+    assert result.output_for_node("create_twenty") == 20
+
+    assert len(result.asset_materializations_for_node("create_eight_and_five")) == 2
+    assert len(result.asset_materializations_for_node("create_thirteen_and_six")) == 2
+    assert len(result.asset_materializations_for_node("create_twenty")) == 1

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -1,6 +1,15 @@
 import pytest
 
-from dagster import AssetGroup, AssetKey, DagsterInvariantViolationError, Out
+from dagster import (
+    AssetGroup,
+    AssetKey,
+    AssetsDefinition,
+    DagsterInvariantViolationError,
+    GraphOut,
+    Out,
+    graph,
+    op,
+)
 from dagster.check import CheckError
 from dagster.core.asset_defs import AssetIn, SourceAsset, asset, build_assets_job, multi_asset
 from dagster.core.definitions.metadata import MetadataEntry, MetadataValue
@@ -53,11 +62,7 @@ def test_two_asset_job():
         ExternalAssetNode(
             asset_key=AssetKey("asset1"),
             dependencies=[],
-            depended_by=[
-                ExternalAssetDependedBy(
-                    downstream_asset_key=AssetKey("asset2"), input_name="asset1"
-                )
-            ],
+            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey("asset2"))],
             op_name="asset1",
             op_description=None,
             job_names=["assets_job"],
@@ -66,9 +71,7 @@ def test_two_asset_job():
         ),
         ExternalAssetNode(
             asset_key=AssetKey("asset2"),
-            dependencies=[
-                ExternalAssetDependency(upstream_asset_key=AssetKey("asset1"), input_name="asset1")
-            ],
+            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey("asset1"))],
             depended_by=[],
             op_name="asset2",
             op_description=None,
@@ -106,11 +109,7 @@ def test_two_asset_job_with_group():
         ExternalAssetNode(
             asset_key=AssetKey("asset1"),
             dependencies=[],
-            depended_by=[
-                ExternalAssetDependedBy(
-                    downstream_asset_key=AssetKey("asset2"), input_name="asset1"
-                )
-            ],
+            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey("asset2"))],
             op_name="asset1",
             op_description=None,
             job_names=[AssetGroup.all_assets_job_name(), "assets_job"],
@@ -119,9 +118,7 @@ def test_two_asset_job_with_group():
         ),
         ExternalAssetNode(
             asset_key=AssetKey("asset2"),
-            dependencies=[
-                ExternalAssetDependency(upstream_asset_key=AssetKey("asset1"), input_name="asset1")
-            ],
+            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey("asset1"))],
             depended_by=[],
             op_name="asset2",
             op_description=None,
@@ -146,20 +143,12 @@ def test_input_name_matches_output_name():
         ExternalAssetNode(
             asset_key=AssetKey("not_result"),
             dependencies=[],
-            depended_by=[
-                ExternalAssetDependedBy(
-                    downstream_asset_key=AssetKey("something"), input_name="result"
-                )
-            ],
+            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey("something"))],
             job_names=[],
         ),
         ExternalAssetNode(
             asset_key=AssetKey("something"),
-            dependencies=[
-                ExternalAssetDependency(
-                    upstream_asset_key=AssetKey("not_result"), input_name="result"
-                )
-            ],
+            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey("not_result"))],
             depended_by=[],
             op_name="something",
             output_name="result",
@@ -189,12 +178,8 @@ def test_two_downstream_assets_job():
             asset_key=AssetKey("asset1"),
             dependencies=[],
             depended_by=[
-                ExternalAssetDependedBy(
-                    downstream_asset_key=AssetKey("asset2_a"), input_name="asset1"
-                ),
-                ExternalAssetDependedBy(
-                    downstream_asset_key=AssetKey("asset2_b"), input_name="asset1"
-                ),
+                ExternalAssetDependedBy(downstream_asset_key=AssetKey("asset2_a")),
+                ExternalAssetDependedBy(downstream_asset_key=AssetKey("asset2_b")),
             ],
             op_name="asset1",
             op_description=None,
@@ -204,9 +189,7 @@ def test_two_downstream_assets_job():
         ),
         ExternalAssetNode(
             asset_key=AssetKey("asset2_a"),
-            dependencies=[
-                ExternalAssetDependency(upstream_asset_key=AssetKey("asset1"), input_name="asset1")
-            ],
+            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey("asset1"))],
             depended_by=[],
             op_name="asset2_a",
             op_description=None,
@@ -216,9 +199,7 @@ def test_two_downstream_assets_job():
         ),
         ExternalAssetNode(
             asset_key=AssetKey("asset2_b"),
-            dependencies=[
-                ExternalAssetDependency(upstream_asset_key=AssetKey("asset1"), input_name="asset1")
-            ],
+            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey("asset1"))],
             depended_by=[],
             op_name="asset2_b",
             op_description=None,
@@ -248,11 +229,7 @@ def test_cross_job_asset_dependency():
         ExternalAssetNode(
             asset_key=AssetKey("asset1"),
             dependencies=[],
-            depended_by=[
-                ExternalAssetDependedBy(
-                    downstream_asset_key=AssetKey("asset2"), input_name="asset1"
-                )
-            ],
+            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey("asset2"))],
             op_name="asset1",
             op_description=None,
             job_names=["assets_job1"],
@@ -261,9 +238,7 @@ def test_cross_job_asset_dependency():
         ),
         ExternalAssetNode(
             asset_key=AssetKey("asset2"),
-            dependencies=[
-                ExternalAssetDependency(upstream_asset_key=AssetKey("asset1"), input_name="asset1")
-            ],
+            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey("asset1"))],
             depended_by=[],
             op_name="asset2",
             op_description=None,
@@ -322,6 +297,126 @@ def test_basic_multi_asset():
     ]
 
 
+def test_nasty_nested_graph_asset():
+    @op
+    def add_one(i):
+        return i + 1
+
+    @graph
+    def add_three(i):
+        return add_one(add_one(add_one(i)))
+
+    @graph
+    def add_five(i):
+        return add_one(add_three(add_one(i)))
+
+    @op
+    def get_sum(a, b):
+        return a + b
+
+    @graph
+    def sum_plus_one(a, b):
+        return add_one(get_sum(a, b))
+
+    @asset
+    def zero():
+        return 0
+
+    @graph(out={"eight": GraphOut(), "five": GraphOut()})
+    def create_eight_and_five(zero):
+        return add_five(add_three(zero)), add_five(zero)
+
+    @graph(out={"thirteen": GraphOut(), "six": GraphOut()})
+    def create_thirteen_and_six(eight, five, zero):
+        return add_five(eight), sum_plus_one(five, zero)
+
+    @graph
+    def create_twenty(thirteen, six):
+        return sum_plus_one(thirteen, six)
+
+    eight_and_five = AssetsDefinition(
+        asset_keys_by_input_name={"zero": AssetKey("zero")},
+        asset_keys_by_output_name={"eight": AssetKey("eight"), "five": AssetKey("five")},
+        node_def=create_eight_and_five,
+    )
+
+    thirteen_and_six = AssetsDefinition(
+        asset_keys_by_input_name={
+            "eight": AssetKey("eight"),
+            "five": AssetKey("five"),
+            "zero": AssetKey("zero"),
+        },
+        asset_keys_by_output_name={"thirteen": AssetKey("thirteen"), "six": AssetKey("six")},
+        node_def=create_thirteen_and_six,
+    )
+
+    twenty = AssetsDefinition(
+        asset_keys_by_input_name={"thirteen": AssetKey("thirteen"), "six": AssetKey("six")},
+        asset_keys_by_output_name={"result": AssetKey("twenty")},
+        node_def=create_twenty,
+    )
+
+    assets_job = build_assets_job("assets_job", [zero, eight_and_five, thirteen_and_six, twenty])
+
+    external_asset_nodes = external_asset_graph_from_defs([assets_job], source_assets_by_key={})
+    # sort so that test is deterministic
+    sorted_nodes = sorted(
+        [
+            node._replace(
+                dependencies=sorted(node.dependencies, key=lambda d: d.upstream_asset_key),
+                depended_by=sorted(node.depended_by, key=lambda d: d.downstream_asset_key),
+            )
+            for node in external_asset_nodes
+        ],
+        key=lambda n: n.asset_key,
+    )
+
+    assert [
+        ExternalAssetNode(
+            asset_key=AssetKey(["thirteen"]),
+            dependencies=[
+                ExternalAssetDependency(AssetKey(["eight"])),
+                ExternalAssetDependency(AssetKey(["five"])),
+                ExternalAssetDependency(AssetKey(["zero"])),
+            ],
+            depended_by=[ExternalAssetDependedBy(AssetKey(["twenty"]))],
+            op_name="add_one",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="result",
+            metadata_entries=[],
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey(["twenty"]),
+            dependencies=[
+                ExternalAssetDependency(AssetKey(["six"])),
+                ExternalAssetDependency(AssetKey(["thirteen"])),
+            ],
+            depended_by=[],
+            op_name="add_one",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="result",
+            metadata_entries=[],
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey(["zero"]),
+            dependencies=[],
+            depended_by=[
+                ExternalAssetDependedBy(AssetKey(["eight"])),
+                ExternalAssetDependedBy(AssetKey(["five"])),
+                ExternalAssetDependedBy(AssetKey(["six"])),
+                ExternalAssetDependedBy(AssetKey(["thirteen"])),
+            ],
+            op_name="zero",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="result",
+            metadata_entries=[],
+        ),
+    ]
+
+
 def test_inter_op_dependency():
     @asset
     def in1():
@@ -365,13 +460,9 @@ def test_inter_op_dependency():
         ExternalAssetNode(
             asset_key=AssetKey(["downstream"]),
             dependencies=[
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["mixed"]), input_name="mixed"),
-                ExternalAssetDependency(
-                    upstream_asset_key=AssetKey(["only_in"]), input_name="only_in"
-                ),
-                ExternalAssetDependency(
-                    upstream_asset_key=AssetKey(["only_out"]), input_name="only_out"
-                ),
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["mixed"])),
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["only_in"])),
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["only_out"])),
             ],
             depended_by=[],
             op_name="downstream",
@@ -384,10 +475,8 @@ def test_inter_op_dependency():
             asset_key=AssetKey(["in1"]),
             dependencies=[],
             depended_by=[
-                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["mixed"]), input_name="in1"),
-                ExternalAssetDependedBy(
-                    downstream_asset_key=AssetKey(["only_in"]), input_name="in1"
-                ),
+                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["mixed"])),
+                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["only_in"])),
             ],
             op_name="in1",
             op_description=None,
@@ -398,11 +487,7 @@ def test_inter_op_dependency():
         ExternalAssetNode(
             asset_key=AssetKey(["in2"]),
             dependencies=[],
-            depended_by=[
-                ExternalAssetDependedBy(
-                    downstream_asset_key=AssetKey(["only_in"]), input_name="in2"
-                )
-            ],
+            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey(["only_in"]))],
             op_name="in2",
             op_description=None,
             job_names=["assets_job"],
@@ -412,18 +497,12 @@ def test_inter_op_dependency():
         ExternalAssetNode(
             asset_key=AssetKey(["mixed"]),
             dependencies=[
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["in1"]), input_name="in1"),
-                ExternalAssetDependency(
-                    upstream_asset_key=AssetKey(["only_in"]), output_name="only_in"
-                ),
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["in1"])),
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["only_in"])),
             ],
             depended_by=[
-                ExternalAssetDependedBy(
-                    downstream_asset_key=AssetKey(["downstream"]), input_name="mixed"
-                ),
-                ExternalAssetDependedBy(
-                    downstream_asset_key=AssetKey(["only_out"]), output_name="mixed"
-                ),
+                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["downstream"])),
+                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["only_out"])),
             ],
             op_name="assets",
             op_description=None,
@@ -433,19 +512,13 @@ def test_inter_op_dependency():
         ExternalAssetNode(
             asset_key=AssetKey(["only_in"]),
             dependencies=[
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["in1"]), input_name="in1"),
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["in2"]), input_name="in2"),
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["in1"])),
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["in2"])),
             ],
             depended_by=[
-                ExternalAssetDependedBy(
-                    downstream_asset_key=AssetKey(["downstream"]), input_name="only_in"
-                ),
-                ExternalAssetDependedBy(
-                    downstream_asset_key=AssetKey(["mixed"]), output_name="only_in"
-                ),
-                ExternalAssetDependedBy(
-                    downstream_asset_key=AssetKey(["only_out"]), output_name="only_in"
-                ),
+                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["downstream"])),
+                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["mixed"])),
+                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["only_out"])),
             ],
             op_name="assets",
             op_description=None,
@@ -456,17 +529,11 @@ def test_inter_op_dependency():
         ExternalAssetNode(
             asset_key=AssetKey(["only_out"]),
             dependencies=[
-                ExternalAssetDependency(
-                    upstream_asset_key=AssetKey(["mixed"]), output_name="mixed"
-                ),
-                ExternalAssetDependency(
-                    upstream_asset_key=AssetKey(["only_in"]), output_name="only_in"
-                ),
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["mixed"])),
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["only_in"])),
             ],
             depended_by=[
-                ExternalAssetDependedBy(
-                    downstream_asset_key=AssetKey(["downstream"]), input_name="only_out"
-                ),
+                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["downstream"])),
             ],
             op_name="assets",
             op_description=None,
@@ -493,14 +560,14 @@ def test_source_asset_with_op():
             asset_key=AssetKey("foo"),
             op_description=None,
             dependencies=[],
-            depended_by=[ExternalAssetDependedBy(AssetKey("bar"), input_name="foo")],
+            depended_by=[ExternalAssetDependedBy(AssetKey("bar"))],
             job_names=[],
         ),
         ExternalAssetNode(
             asset_key=AssetKey("bar"),
             op_name="bar",
             op_description=None,
-            dependencies=[ExternalAssetDependency(AssetKey("foo"), input_name="foo")],
+            dependencies=[ExternalAssetDependency(AssetKey("foo"))],
             depended_by=[],
             job_names=["assets_job"],
             output_name="result",
@@ -550,18 +617,14 @@ def test_used_source_asset():
             asset_key=AssetKey("bar"),
             op_description="def",
             dependencies=[],
-            depended_by=[
-                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["foo"]), input_name="bar")
-            ],
+            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey(["foo"]))],
             job_names=[],
         ),
         ExternalAssetNode(
             asset_key=AssetKey("foo"),
             op_name="foo",
             op_description=None,
-            dependencies=[
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["bar"]), input_name="bar")
-            ],
+            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey(["bar"]))],
             depended_by=[],
             job_names=["job1"],
             output_name="result",
@@ -582,28 +645,6 @@ def test_source_asset_conflicts_with_asset():
     with pytest.raises(DagsterInvariantViolationError):
         external_asset_graph_from_defs(
             [job1], source_assets_by_key={AssetKey("bar"): bar_source_asset}
-        )
-
-
-def test_input_name_or_output_name_dep_by():
-    with pytest.raises(CheckError, match="input `foo` and output `bar`"):
-        ExternalAssetDependedBy(
-            downstream_asset_key=AssetKey("bar"), input_name="foo", output_name="bar"
-        )
-    with pytest.raises(CheckError, match="input `None` and output `None`"):
-        ExternalAssetDependedBy(
-            downstream_asset_key=AssetKey("bar"), input_name=None, output_name=None
-        )
-
-
-def test_input_name_or_output_name_dependency():
-    with pytest.raises(CheckError, match="input `foo` and output `bar`"):
-        ExternalAssetDependency(
-            upstream_asset_key=AssetKey("bar"), input_name="foo", output_name="bar"
-        )
-    with pytest.raises(CheckError, match="input `None` and output `None`"):
-        ExternalAssetDependency(
-            upstream_asset_key=AssetKey("bar"), input_name=None, output_name=None
         )
 
 


### PR DESCRIPTION
Follow up from: https://github.com/dagster-io/dagster/pull/7432

Right now, the only way to create one of these objects is by manually instantiating an AssetsDefinition, but decorators will come in the future.

It turned out that the code changes required here were actually fairly minimal (mostly renaming), but the major diff here is that I realized that a SolidOutputHandle (/SolidInputHandle) is not sufficient to uniquely identify an output in a graph that is nested multiple levels deep.

A SolidOutputHandle only takes in a Node (which is basically a GraphDefinition + OpDefinition) and an OutputDefinition, but you can have multiple copies of the same Node in a Graph when you do something like:

```
@graph
def add_two(i):
    return add_another(add_one(i))

@graph
def add_four(i):
    return add_two(add_two(i))
```

In this case, the add_four graph will have two copies of the node `Node(graph_def=add_two, op_def=add_one)`. Basically, multiple levels of graph nesting are not supported by these objects.

As a workaround, and a way to get a truly unique reference to an output, I switch the strategy to use a tuple of NodeHandle (which is fully unique to a node, storing all levels of graph nesting), and OutputDefinition (which will be unique per-node). This works well, but might be a little less aesthetic.

The other big change is that I've removed input_name/output name from ExternalAssetDependency / ExternalAssetDependedBy. The reason here is that these values are a) hard to calculate in the new world and b) do not seem to provide much value (not really used anywhere). That brings me to the description of a future PR in this stack:

## [5/n] Reorganize serialized objects

Right now, the serialized ExternalAssetNode object has tons of fields that don't make a huge amount of sense in the graph_asset world. For example, lots of the field names are op-focused (op_name, op_description), and in general we should rethink exactly what data we want to store here.