### PR TITLE
Add asset metadata to one of the dagster_test asset groups

### DIFF
--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/partitioned_assets.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/partitioned_assets.py
@@ -1,27 +1,43 @@
 # pylint: disable=redefined-outer-name
 from datetime import datetime
 
-from dagster import AssetGroup, DailyPartitionsDefinition, HourlyPartitionsDefinition, asset
+from dagster import (
+    AssetGroup,
+    DailyPartitionsDefinition,
+    HourlyPartitionsDefinition,
+    MetadataValue,
+    asset,
+)
 
 daily_partitions_def = DailyPartitionsDefinition(start_date="2020-01-01")
 
 
-@asset(partitions_def=daily_partitions_def)
+@asset(metadata={"owner": "alice@example.com"}, partitions_def=daily_partitions_def)
 def upstream_daily_partitioned_asset():
     pass
 
 
-@asset(partitions_def=daily_partitions_def)
+@asset(metadata={"owner": "alice@example.com"}, partitions_def=daily_partitions_def)
 def downstream_daily_partitioned_asset(upstream_daily_partitioned_asset):
     assert upstream_daily_partitioned_asset is None
 
 
-@asset(partitions_def=HourlyPartitionsDefinition(start_date=datetime(2022, 3, 12, 0, 0)))
+@asset(
+    metadata={"owner": "alice@example.com"},
+    partitions_def=HourlyPartitionsDefinition(start_date=datetime(2022, 3, 12, 0, 0)),
+)
 def hourly_partitioned_asset():
     pass
 
 
-@asset
+@asset(
+    metadata={
+        "owner": "bob@example.com",
+        "text_metadata": "Text-based metadata about this asset",
+        "path": MetadataValue.path("/unpartitioned/asset"),
+        "dashboard_url": MetadataValue.url("http://mycoolsite.com/url_for_my_asset"),
+    },
+)
 def unpartitioned_asset():
     pass
 


### PR DESCRIPTION
## Summary
I don't think any of our default dagster_test toys were using asset metadata. Adding a few metadata entries so that we're more likely to see this UI in drive-by testing!


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.