### PR TITLE
unexperimentalize the asset decorator

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -59,7 +59,6 @@ def asset(
     ...
 
 
-@experimental_decorator
 def asset(
     name: Optional[Union[Callable[..., Any], Optional[str]]] = None,
     namespace: Optional[Sequence[str]] = None,


### PR DESCRIPTION
It causes a lot of annoying warnings, and I think we can be pretty confident that it's sticking around at this point.