### PR TITLE
[1/n] Interop Stack: Use AssetJobInfo at runtime instead of OutputDefinition

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -19,6 +19,7 @@ from .node_definition import NodeDefinition
 
 if TYPE_CHECKING:
     from dagster.core.execution.context.output import OutputContext
+
     from .partition import PartitionsDefinition
 
 

--- a/python_modules/dagster/dagster/core/definitions/assets_info.py
+++ b/python_modules/dagster/dagster/core/definitions/assets_info.py
@@ -1,0 +1,184 @@
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Callable,
+    Dict,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+)
+
+from dagster import check
+from dagster.core.definitions.events import AssetKey
+
+from .dependency import NodeHandle, NodeInputHandle, NodeOutputHandle
+from .graph_definition import GraphDefinition
+from .node_definition import NodeDefinition
+from .partition import PartitionsDefinition
+
+if TYPE_CHECKING:
+    from dagster.core.execution.context.output import OutputContext
+
+
+class AssetInfo(
+    NamedTuple(
+        "_AssetInfo",
+        [
+            ("asset_key", AssetKey),
+            ("asset_partitions_fn", Callable[["OutputContext"], Optional[AbstractSet[str]]]),
+            ("asset_partitions_def", Optional[PartitionsDefinition]),
+        ],
+    )
+):
+    """Defines all of the asset-related information for a given input or output.
+
+    Args:
+        asset_key (AssetKey): The AssetKey
+        asset_partitions_fn (OutputContext -> Optional[Set[str]], optional): A function which takes the
+            current OutputContext and generates a set of partition names that will be materialized
+            for this asset.
+        asset_partitions_def (PartitionsDefinition, optional): Defines the set of valid partitions
+            for this asset.
+    """
+
+    def __new__(
+        cls,
+        asset_key: AssetKey,
+        asset_partitions_fn: Optional[
+            Callable[["OutputContext"], Optional[AbstractSet[str]]]
+        ] = None,
+        asset_partitions_def: Optional["PartitionsDefinition"] = None,
+    ):
+        return super().__new__(
+            cls,
+            asset_key=check.inst_param(asset_key, "asset_key", AssetKey),
+            asset_partitions_fn=check.opt_callable_param(
+                asset_partitions_fn, "asset_partitions_fn", lambda _: None
+            ),
+            asset_partitions_def=check.opt_inst_param(
+                asset_partitions_def, "asset_partitions_def", PartitionsDefinition
+            ),
+        )
+
+
+def _assets_job_info_for_node(
+    node_def: NodeDefinition, node_handle: Optional[NodeHandle]
+) -> Tuple[
+    Mapping[NodeInputHandle, AssetInfo],
+    Mapping[NodeOutputHandle, AssetInfo],
+    Mapping[AssetKey, AbstractSet[AssetKey]],
+]:
+    """
+    Recursively iterate through all the sub-nodes of a Node to find any ops with asset info
+    encoded on their inputs/outputs
+    """
+    check.inst_param(node_def, "node_def", NodeDefinition)
+    check.opt_inst_param(node_handle, "node_handle", NodeHandle)
+
+    asset_info_by_input: Dict[NodeInputHandle, AssetInfo] = {}
+    asset_info_by_output: Dict[NodeOutputHandle, AssetInfo] = {}
+    asset_deps: Dict[AssetKey, AbstractSet[AssetKey]] = {}
+    if not isinstance(node_def, GraphDefinition):
+        # must be in an op (or solid)
+        if node_handle is None:
+            check.failed("Must have node_handle for non-graph NodeDefinition")
+        input_asset_keys: Set[AssetKey] = set()
+        for input_def in node_def.input_defs:
+            input_key = input_def.hardcoded_asset_key
+            if input_key:
+                input_asset_keys.add(input_key)
+                input_handle = NodeInputHandle(node_handle, input_def.name)
+                asset_info_by_input[input_handle] = AssetInfo(
+                    asset_key=input_key,
+                    asset_partitions_fn=input_def.get_asset_partitions,
+                )
+        for output_def in node_def.output_defs:
+            output_key = output_def.hardcoded_asset_key
+            if output_key:
+                output_handle = NodeOutputHandle(node_handle, output_def.name)
+                asset_info_by_output[output_handle] = AssetInfo(
+                    asset_key=output_key,
+                    asset_partitions_fn=output_def.get_asset_partitions,
+                    asset_partitions_def=output_def.asset_partitions_def,
+                )
+                # assume output depends on all inputs
+                asset_deps[output_key] = input_asset_keys
+    else:
+        # keep recursing through structure
+        for sub_node_name, sub_node in node_def.node_dict.items():
+            n_asset_info_by_input, n_asset_info_by_output, n_asset_deps = _assets_job_info_for_node(
+                node_def=sub_node.definition,
+                node_handle=NodeHandle(sub_node_name, parent=node_handle),
+            )
+            asset_info_by_input.update(n_asset_info_by_input)
+            asset_info_by_output.update(n_asset_info_by_output)
+            asset_deps.update(n_asset_deps)
+    return asset_info_by_input, asset_info_by_output, asset_deps
+
+
+class AssetsJobInfo:
+    """
+    Stores all of the asset-related information for a Dagster JobDefinition. Maps each
+    input / output in the underlying graph to the asset it represents (if any), and records the
+    dependencies between each asset.
+
+    Args:
+        asset_info_by_node_input_handle (Mapping[NodeInputHandle, AssetInfo], optional): A mapping
+            from a unique input in the underlying graph to the associated AssetInfo.
+        asset_info_by_node_output_handle (Mapping[NodeOutputHandle, AssetInfo], optional): A mapping
+            from a unique output in the underlying graph to the associated AssetInfo.
+        asset_deps (Mapping[AssetKey, AbstractSet[AssetKey]], optional): Records the upstream asset
+            keys for each asset key produced by this job.
+    """
+
+    def __init__(
+        self,
+        asset_info_by_node_input_handle: Optional[Mapping[NodeInputHandle, AssetInfo]] = None,
+        asset_info_by_node_output_handle: Optional[Mapping[NodeOutputHandle, AssetInfo]] = None,
+        asset_deps: Optional[Mapping[AssetKey, AbstractSet[AssetKey]]] = None,
+    ):
+        self._asset_info_by_node_input_handle = check.opt_dict_param(
+            asset_info_by_node_input_handle,
+            "asset_info_by_node_input_handle",
+            key_type=NodeInputHandle,
+            value_type=AssetInfo,
+        )
+        self._asset_info_by_node_output_handle = check.opt_dict_param(
+            asset_info_by_node_output_handle,
+            "asset_info_by_node_output_handle",
+            key_type=NodeOutputHandle,
+            value_type=AssetInfo,
+        )
+        self._asset_deps = check.opt_dict_param(
+            asset_deps, "asset_deps", key_type=AssetKey, value_type=set
+        )
+
+    @staticmethod
+    def from_graph(graph_def: GraphDefinition) -> "AssetsJobInfo":
+        """Scrape asset info off of InputDefinition/OutputDefinition instances"""
+        check.inst_param(graph_def, "graph_def", GraphDefinition)
+        asset_by_input, asset_by_output, asset_deps = _assets_job_info_for_node(graph_def, None)
+        return AssetsJobInfo(
+            asset_info_by_node_input_handle=asset_by_input,
+            asset_info_by_node_output_handle=asset_by_output,
+            asset_deps=asset_deps,
+        )
+
+    def upstream_assets(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
+        check.invariant(
+            asset_key in self._asset_deps,
+            "AssetKey '{asset_key}' is not produced by this JobDefinition.",
+        )
+        return self._asset_deps[asset_key]
+
+    def asset_info_for_input(self, node_handle: NodeHandle, input_name: str) -> Optional[AssetInfo]:
+        return self._asset_info_by_node_input_handle.get(NodeInputHandle(node_handle, input_name))
+
+    def asset_info_for_output(
+        self, node_handle: NodeHandle, output_name: str
+    ) -> Optional[AssetInfo]:
+        return self._asset_info_by_node_output_handle.get(
+            NodeOutputHandle(node_handle, output_name)
+        )

--- a/python_modules/dagster/dagster/core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/core/definitions/dependency.py
@@ -423,30 +423,6 @@ class NodeInputHandle(
     A structured object to uniquely identify inputs in the potentially recursive graph structure.
     """
 
-    def __new__(cls, node_handle: NodeHandle, input_name: str):
-        return super(NodeInputHandle, cls).__new__(
-            cls,
-            check.inst_param(node_handle, "node_handle", NodeHandle),
-            check.inst_param(input_name, "input_name", str),
-        )
-
-    def _inner_str(self) -> str:
-        return struct_to_string(
-            "NodeInputHandle", node_handle=str(self.node_handle), input_name=self.input_name
-        )
-
-    def __str__(self):
-        return self._inner_str()
-
-    def __repr__(self):
-        return self._inner_str()
-
-    def __hash__(self):
-        return hash((self.node_handle, self.input_name))
-
-    def __eq__(self, other):
-        return self.node_handle == other.node_handle and self.input_name == other.input_name
-
 
 class NodeOutputHandle(
     NamedTuple("_NodeOutputHandle", [("node_handle", NodeHandle), ("output_name", str)])
@@ -454,30 +430,6 @@ class NodeOutputHandle(
     """
     A structured object to uniquely identify outputs in the potentially recursive graph structure.
     """
-
-    def __new__(cls, node_handle: NodeHandle, output_name: str):
-        return super(NodeOutputHandle, cls).__new__(
-            cls,
-            check.inst_param(node_handle, "node_handle", NodeHandle),
-            check.inst_param(output_name, "output_name", str),
-        )
-
-    def _inner_str(self) -> str:
-        return struct_to_string(
-            "NodeOutputHandle", node_handle=str(self.node_handle), output_name=self.output_name
-        )
-
-    def __str__(self):
-        return self._inner_str()
-
-    def __repr__(self):
-        return self._inner_str()
-
-    def __hash__(self):
-        return hash((self.node_handle, self.output_name))
-
-    def __eq__(self, other):
-        return self.node_handle == other.node_handle and self.output_name == other.output_name
 
 
 # previous name for NodeHandle was SolidHandle

--- a/python_modules/dagster/dagster/core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/core/definitions/dependency.py
@@ -416,6 +416,70 @@ class NodeHandle(
         return NodeHandle(**{k: dict_repr[k] for k in ["name", "parent"]})
 
 
+class NodeInputHandle(
+    NamedTuple("_NodeInputHandle", [("node_handle", NodeHandle), ("input_name", str)])
+):
+    """
+    A structured object to uniquely identify inputs in the potentially recursive graph structure.
+    """
+
+    def __new__(cls, node_handle: NodeHandle, input_name: str):
+        return super(NodeInputHandle, cls).__new__(
+            cls,
+            check.inst_param(node_handle, "node_handle", NodeHandle),
+            check.inst_param(input_name, "input_name", str),
+        )
+
+    def _inner_str(self) -> str:
+        return struct_to_string(
+            "NodeInputHandle", node_handle=str(self.node_handle), input_name=self.input_name
+        )
+
+    def __str__(self):
+        return self._inner_str()
+
+    def __repr__(self):
+        return self._inner_str()
+
+    def __hash__(self):
+        return hash((self.node_handle, self.input_name))
+
+    def __eq__(self, other):
+        return self.node_handle == other.node_handle and self.input_name == other.input_name
+
+
+class NodeOutputHandle(
+    NamedTuple("_NodeOutputHandle", [("node_handle", NodeHandle), ("output_name", str)])
+):
+    """
+    A structured object to uniquely identify outputs in the potentially recursive graph structure.
+    """
+
+    def __new__(cls, node_handle: NodeHandle, output_name: str):
+        return super(NodeOutputHandle, cls).__new__(
+            cls,
+            check.inst_param(node_handle, "node_handle", NodeHandle),
+            check.inst_param(output_name, "output_name", str),
+        )
+
+    def _inner_str(self) -> str:
+        return struct_to_string(
+            "NodeOutputHandle", node_handle=str(self.node_handle), output_name=self.output_name
+        )
+
+    def __str__(self):
+        return self._inner_str()
+
+    def __repr__(self):
+        return self._inner_str()
+
+    def __hash__(self):
+        return hash((self.node_handle, self.output_name))
+
+    def __eq__(self, other):
+        return self.node_handle == other.node_handle and self.output_name == other.output_name
+
+
 # previous name for NodeHandle was SolidHandle
 register_serdes_tuple_fallbacks({"SolidHandle": NodeHandle})
 

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -36,8 +36,8 @@ from dagster.core.selector.subset_selector import (
 from dagster.core.storage.fs_asset_io_manager import fs_asset_io_manager
 from dagster.core.utils import str_format_set
 
-from .config import ConfigMapping
 from .asset_layer import AssetLayer
+from .config import ConfigMapping
 from .executor_definition import ExecutorDefinition
 from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .hook_definition import HookDefinition

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -37,6 +37,7 @@ from dagster.core.storage.fs_asset_io_manager import fs_asset_io_manager
 from dagster.core.utils import str_format_set
 
 from .config import ConfigMapping
+from .assets_info import AssetsJobInfo
 from .executor_definition import ExecutorDefinition
 from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .hook_definition import HookDefinition
@@ -71,6 +72,7 @@ class JobDefinition(PipelineDefinition):
         hook_defs: Optional[AbstractSet[HookDefinition]] = None,
         op_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
+        assets_info: Optional[AssetsJobInfo] = None,
         _op_selection_data: Optional[OpSelectionData] = None,
     ):
 
@@ -86,6 +88,9 @@ class JobDefinition(PipelineDefinition):
         self._cached_partition_set: Optional["PartitionSetDefinition"] = None
         self._op_selection_data = check.opt_inst_param(
             _op_selection_data, "_op_selection_data", OpSelectionData
+        )
+        self._assets_info = check.opt_inst_param(
+            assets_info, "assets_nfo", AssetsJobInfo, default=AssetsJobInfo.from_graph(graph_def)
         )
 
         super(JobDefinition, self).__init__(
@@ -130,6 +135,10 @@ class JobDefinition(PipelineDefinition):
     @property
     def loggers(self) -> Mapping[str, LoggerDefinition]:
         return self.get_mode_definition().loggers
+
+    @property
+    def assets_info(self) -> AssetsJobInfo:
+        return self._assets_info
 
     def execute_in_process(
         self,
@@ -190,6 +199,7 @@ class JobDefinition(PipelineDefinition):
             tags=self.tags,
             op_retry_policy=self._solid_retry_policy,
             version_strategy=self.version_strategy,
+            assets_info=self.assets_info,
         ).get_job_def_for_op_selection(op_selection)
 
         tags = None
@@ -254,6 +264,8 @@ class JobDefinition(PipelineDefinition):
             op_retry_policy=self._solid_retry_policy,
             graph_def=sub_graph,
             version_strategy=self.version_strategy,
+            # TODO: subset this structure
+            assets_info=self.assets_info,
             _op_selection_data=OpSelectionData(
                 op_selection=op_selection,
                 resolved_op_selection=set(
@@ -313,6 +325,7 @@ class JobDefinition(PipelineDefinition):
             hook_defs=hook_defs | self.hook_defs,
             description=self._description,
             op_retry_policy=self._solid_retry_policy,
+            assets_info=self.assets_info,
             _op_selection_data=self._op_selection_data,
         )
 

--- a/python_modules/dagster/dagster/core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_step.py
@@ -9,11 +9,9 @@ from dagster.core.definitions import (
     AssetMaterialization,
     AssetObservation,
     ExpectationResult,
-    JobDefinition,
     Materialization,
     Output,
     OutputDefinition,
-    SolidDefinition,
     TypeCheck,
 )
 from dagster.core.definitions.decorators.solid_decorator import DecoratedSolidFunction

--- a/python_modules/dagster/dagster/core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_step.py
@@ -9,6 +9,7 @@ from dagster.core.definitions import (
     AssetMaterialization,
     AssetObservation,
     ExpectationResult,
+    JobDefinition,
     Materialization,
     Output,
     OutputDefinition,
@@ -429,7 +430,27 @@ def _asset_key_and_partitions_for_output(
 
     manager_asset_key = output_manager.get_output_asset_key(output_context)
 
-    if output_def.is_asset:
+    pipeline_def = output_context.step_context.pipeline_def
+    if isinstance(pipeline_def, JobDefinition):
+        node_handle = output_context.step_context.solid_handle
+        output_asset_info = pipeline_def.assets_info.asset_info_for_output(
+            node_handle=output_context.step_context.solid_handle, output_name=output_def.name
+        )
+        if output_asset_info:
+            if manager_asset_key is not None:
+                raise DagsterInvariantViolationError(
+                    f'The IOManager of output "{output_def.name}" on node "{node_handle}" associates it '
+                    f'with asset key "{manager_asset_key}", but this output has already been defined to '
+                    f'produce asset "{output_asset_info.asset_key}", either via a Software Defined Asset, '
+                    "or by setting the asset_key parameter on the OutputDefinition. In most cases, this "
+                    "means that you should use an IOManager that does not specify an AssetKey in its "
+                    "get_output_asset_key() function for this output."
+                )
+            return (
+                output_asset_info.asset_key,
+                output_asset_info.asset_partitions_fn(output_context) or set(),
+            )
+    elif output_def.is_asset:
         if manager_asset_key is not None:
             solid_def = cast(SolidDefinition, output_context.solid_def)
             raise DagsterInvariantViolationError(
@@ -442,7 +463,8 @@ def _asset_key_and_partitions_for_output(
             output_def.get_asset_key(output_context),
             output_def.get_asset_partitions(output_context) or set(),
         )
-    elif manager_asset_key:
+
+    if manager_asset_key:
         return manager_asset_key, output_manager.get_output_asset_partitions(output_context)
 
     return None, set()

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -19,6 +19,10 @@ from dagster.core.snap.dep_snapshot import (
 from dagster.utils import safe_tempfile_path
 
 
+def _asset_keys_for_node(result, node_name):
+    return {mat.asset_key for mat in result.asset_materializations_for_node(node_name)}
+
+
 def test_single_asset_pipeline():
     @asset
     def asset1():
@@ -94,7 +98,8 @@ def test_join():
             "asset2": DependencyDefinition("asset2", "result"),
         },
     }
-    assert job.execute_in_process().success
+    result = job.execute_in_process()
+    assert _asset_keys_for_node(result, "asset3") == {AssetKey("asset3")}
 
 
 def test_asset_key_output():
@@ -110,6 +115,7 @@ def test_asset_key_output():
     result = job.execute_in_process()
     assert result.success
     assert result.output_for_node("asset2") == 1
+    assert _asset_keys_for_node(result, "asset2") == {AssetKey("asset2")}
 
 
 def test_asset_key_matches_input_name():
@@ -131,6 +137,7 @@ def test_asset_key_matches_input_name():
     result = job.execute_in_process()
     assert result.success
     assert result.output_for_node("last_asset") == "foo"
+    assert _asset_keys_for_node(result, "last_asset") == {AssetKey("last_asset")}
 
 
 def test_asset_key_and_inferred():
@@ -150,6 +157,7 @@ def test_asset_key_and_inferred():
     result = job.execute_in_process()
     assert result.success
     assert result.output_for_node("asset_baz") == 7
+    assert _asset_keys_for_node(result, "asset_baz") == {AssetKey("asset_baz")}
 
 
 def test_asset_key_for_asset_with_namespace_list():
@@ -177,6 +185,9 @@ def test_asset_key_for_asset_with_namespace_list():
     result = job.execute_in_process()
     assert result.success
     assert result.output_for_node("success_asset") == "foo"
+    assert _asset_keys_for_node(result, "hell__o__asset_foo") == {
+        AssetKey(["hell", "o", "asset_foo"])
+    }
 
 
 def test_asset_key_for_asset_with_namespace_str():
@@ -193,6 +204,7 @@ def test_asset_key_for_asset_with_namespace_str():
     result = job.execute_in_process()
     assert result.success
     assert result.output_for_node("success_asset") == "foo"
+    assert _asset_keys_for_node(result, "hello__asset_foo") == {AssetKey(["hello", "asset_foo"])}
 
 
 def test_source_asset():
@@ -225,7 +237,9 @@ def test_source_asset():
         },
     )
     assert job.graph.node_defs == [asset1.op]
-    assert job.execute_in_process().success
+    result = job.execute_in_process()
+    assert result.success
+    assert _asset_keys_for_node(result, "asset1") == {AssetKey("asset1")}
 
 
 def test_source_op_asset():
@@ -256,7 +270,9 @@ def test_source_op_asset():
         resource_defs={"special_io_manager": my_io_manager},
     )
     assert job.graph.node_defs == [asset1.op]
-    assert job.execute_in_process().success
+    result = job.execute_in_process()
+    assert result.success
+    assert _asset_keys_for_node(result, "asset1") == {AssetKey("asset1")}
 
 
 def test_non_argument_deps():
@@ -273,7 +289,10 @@ def test_non_argument_deps():
             assert os.path.exists(path)
 
         job = build_assets_job("a", [foo, bar])
-        assert job.execute_in_process().success
+        result = job.execute_in_process()
+        assert result.success
+        assert _asset_keys_for_node(result, "foo") == {AssetKey("foo")}
+        assert _asset_keys_for_node(result, "bar") == {AssetKey("bar")}
 
 
 def test_multiple_non_argument_deps():
@@ -313,3 +332,5 @@ def test_multiple_non_argument_deps():
     result = job.execute_in_process()
     assert result.success
     assert result.output_for_node("qux") == 1
+    assert _asset_keys_for_node(result, "namespace__bar") == {AssetKey(["namespace", "bar"])}
+    assert _asset_keys_for_node(result, "qux") == {AssetKey("qux")}

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -5,6 +5,7 @@ import pytest
 from dagster import (
     AssetKey,
     DagsterInvalidDefinitionError,
+    DagsterInvariantViolationError,
     DependencyDefinition,
     IOManager,
     ResourceDefinition,
@@ -334,3 +335,36 @@ def test_multiple_non_argument_deps():
     assert result.output_for_node("qux") == 1
     assert _asset_keys_for_node(result, "namespace__bar") == {AssetKey(["namespace", "bar"])}
     assert _asset_keys_for_node(result, "qux") == {AssetKey("qux")}
+
+
+def test_fail_with_get_output_asset_key():
+    @io_manager
+    def my_io_manager(context):
+        class Mine(IOManager):
+            def get_output_asset_key(self, context):
+                return AssetKey("hey")
+
+            def handle_output(self, context, obj):
+                pass
+
+            def load_input(self, context):
+                return None
+
+        return Mine()
+
+    @asset
+    def foo():
+        return 1
+
+    @asset
+    def bar(foo):
+        return foo + 1
+
+    job = build_assets_job("x", [foo, bar], resource_defs={"io_manager": my_io_manager})
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match='The IOManager of output "result" on node "foo" associates it with asset key '
+        "\"AssetKey\(\['hey'\]\)\", but this output has already been defined to produce asset "
+        "\"AssetKey\(\['foo'\]\)\"",
+    ):
+        job.execute_in_process()

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_asset_events.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_asset_events.py
@@ -39,6 +39,7 @@ def check_materialization(materialization, asset_key, parent_assets=None, metada
     assert event_data.asset_lineage == (parent_assets or [])
 
 
+@pytest.mark.skip(reason="no longer supporting dynamic asset key")
 def test_output_definition_single_partition_materialization():
 
     entry1 = MetadataEntry("nrows", value=123)

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_asset_lineage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_asset_lineage.py
@@ -124,6 +124,7 @@ def test_multiple_definition_fails():
         execute_pipeline(my_pipeline)
 
 
+@pytest.mark.skip(reason="no longer supporting lineage feature")
 def test_input_definition_multiple_partition_lineage():
 
     entry1 = MetadataEntry("nrows", value=123)
@@ -269,6 +270,7 @@ def test_mixed_asset_definition_lineage():
     )
 
 
+@pytest.mark.skip(reason="no longer supporting dynamic output asset keys")
 def test_dynamic_output_definition_single_partition_materialization():
 
     entry1 = MetadataEntry("nrows", value=123)


### PR DESCRIPTION
Reorganizing / restructuring: https://github.com/dagster-io/dagster/pull/7432, and breaking up the work into more bite-size / individually testable pieces.

In this PR:

- create a new AssetsJobInfo structure to hold all job-level asset information
- use this structure instead of OutputDefinitions when we're executing a step to figure out what AssetMaterialization to yield (if any)
- this structure is currently computed solely by iterating through the OutputDefinitions in the underlying graph, so no user-facing changes in this diff

Next PR:

- use this structure to compute ExternalAssetNodes
