### PR TITLE
Fix back-compat for new helm chart param for container context

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -51,11 +51,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "dagsterUserDeployments.postgresql.secretName" $ }}
                   key: postgresql-password
+            {{- if $deployment.includeConfigInLaunchedRuns }}
             {{- if $deployment.includeConfigInLaunchedRuns.enabled }}
             # uses the auto_envvar_prefix of the dagster cli to set the --container-context arg
             # on 'dagster api grpc'
             - name: DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT
               value: {{ include "dagsterUserDeployments.k8sContainerContext" (list $ $deployment) | fromYaml | toJson | quote }}
+            {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -291,7 +291,6 @@
                 "name",
                 "image",
                 "dagsterApiGrpcArgs",
-                "includeConfigInLaunchedRuns",
                 "port"
             ]
         },

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
@@ -13,7 +13,7 @@ class UserDeployment(BaseModel):
     name: str
     image: kubernetes.Image
     dagsterApiGrpcArgs: List[str]
-    includeConfigInLaunchedRuns: UserDeploymentIncludeConfigInLaunchedRuns
+    includeConfigInLaunchedRuns: Optional[UserDeploymentIncludeConfigInLaunchedRuns]
     port: int
     env: Optional[Dict[str, str]]
     envConfigMaps: Optional[List[kubernetes.ConfigMapEnvSource]]

--- a/helm/dagster/schema/schema_tests/utils.py
+++ b/helm/dagster/schema/schema_tests/utils.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from schema.charts.dagster_user_deployments.subschema.user_deployments import (
     UserDeployment,
     UserDeploymentIncludeConfigInLaunchedRuns,
@@ -6,15 +8,17 @@ from schema.charts.utils import kubernetes
 
 
 def create_simple_user_deployment(
-    name: str, include_config_in_launched_runs: bool = False
+    name: str, include_config_in_launched_runs: Optional[bool] = False
 ) -> UserDeployment:
     return UserDeployment(
         name=name,
         image=kubernetes.Image(repository=f"repo/{name}", tag="tag1", pullPolicy="Always"),
         dagsterApiGrpcArgs=["-m", name],
         port=3030,
-        includeConfigInLaunchedRuns=UserDeploymentIncludeConfigInLaunchedRuns(
-            enabled=include_config_in_launched_runs
+        includeConfigInLaunchedRuns=(
+            UserDeploymentIncludeConfigInLaunchedRuns(enabled=include_config_in_launched_runs)
+            if include_config_in_launched_runs != None
+            else None
         ),
     )
 

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -532,7 +532,6 @@
                 "name",
                 "image",
                 "dagsterApiGrpcArgs",
-                "includeConfigInLaunchedRuns",
                 "port"
             ]
         },

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -665,9 +665,6 @@ def helm_chart_for_user_deployments_subchart_disabled(namespace, docker_image, s
                             "define_demo_execution_repo",
                         ],
                         "port": 3030,
-                        "includeConfigInLaunchedRuns": {
-                            "enabled": False,
-                        },
                         "env": (
                             {"BUILDKITE": os.getenv("BUILDKITE")} if os.getenv("BUILDKITE") else {}
                         ),
@@ -723,9 +720,6 @@ def helm_chart_for_user_deployments_subchart(namespace, docker_image, should_cle
                     "define_demo_execution_repo",
                 ],
                 "port": 3030,
-                "includeConfigInLaunchedRuns": {
-                    "enabled": False,
-                },
             }
         ],
     }


### PR DESCRIPTION
Summary:
I incorrectly thought that the default values.yaml of False would be applied for this param, but since it's in a list of deployments, the values in values.yaml do not matter. Fix that and add tests that still use the old format where includeConfigInLaunchedRuns is not set at all.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.