### PR TITLE
[dagit] Repair async graph layout for path-prefix

### DIFF
--- a/js_modules/dagit/packages/app/src/index.tsx
+++ b/js_modules/dagit/packages/app/src/index.tsx
@@ -29,6 +29,7 @@ const config = {
   apolloLinks,
   basePath: pathPrefix,
   origin: process.env.REACT_APP_BACKEND_ORIGIN || document.location.origin,
+  staticPathRoot: `${pathPrefix}/`,
   telemetryEnabled,
 };
 

--- a/js_modules/dagit/packages/core/src/app/AppContext.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppContext.tsx
@@ -1,13 +1,21 @@
 import * as React from 'react';
 
 export type AppContextValue = {
+  // `basePath` is the root used for routing and GraphQL requests. In open source Dagit,
+  // this will also be the same as the root for static assets, `staticPathRoot`.
   basePath: string;
   rootServerURI: string;
+  // `staticPathRoot` is the root where static assets are served from. In open source Dagit,
+  // this value will be essentially the same as `basePath`, e.g. `${basePath}/`. Setting this
+  // value in context allows us to set __webpack_public_path__ for WebWorkers, thereby allowing
+  // WebWorkers to import other files.
+  staticPathRoot?: string;
   telemetryEnabled: boolean;
 };
 
 export const AppContext = React.createContext<AppContextValue>({
   basePath: '',
   rootServerURI: '',
+  staticPathRoot: '/',
   telemetryEnabled: false,
 });

--- a/js_modules/dagit/packages/core/src/app/AppProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppProvider.tsx
@@ -110,15 +110,23 @@ export interface AppProviderProps {
   config: {
     apolloLinks: ApolloLink[];
     basePath?: string;
-    telemetryEnabled?: boolean;
     headers?: {[key: string]: string};
     origin: string;
+    staticPathRoot?: string;
+    telemetryEnabled?: boolean;
   };
 }
 
 export const AppProvider: React.FC<AppProviderProps> = (props) => {
   const {appCache, config} = props;
-  const {apolloLinks, basePath = '', headers = {}, origin, telemetryEnabled = false} = config;
+  const {
+    apolloLinks,
+    basePath = '',
+    headers = {},
+    origin,
+    staticPathRoot = '/',
+    telemetryEnabled = false,
+  } = config;
 
   const graphqlPath = `${basePath}/graphql`;
   const rootServerURI = `${origin}${basePath}`;
@@ -158,9 +166,10 @@ export const AppProvider: React.FC<AppProviderProps> = (props) => {
     () => ({
       basePath,
       rootServerURI,
+      staticPathRoot,
       telemetryEnabled,
     }),
-    [basePath, rootServerURI, telemetryEnabled],
+    [basePath, rootServerURI, staticPathRoot, telemetryEnabled],
   );
 
   return (

--- a/js_modules/dagit/packages/core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagit/packages/core/src/graph/asyncGraphLayout.ts
@@ -1,16 +1,12 @@
 import memoize from 'lodash/memoize';
 import React from 'react';
 
+import {AppContext} from '../app/AppContext';
 import {asyncMemoize} from '../app/Util';
 import {GraphData} from '../asset-graph/Utils';
 import {AssetGraphLayout, layoutAssetGraph} from '../asset-graph/layout';
 
 import {ILayoutOp, layoutOpGraph, OpGraphLayout} from './layout';
-
-// Loads the web worker using the Webpack loader `worker-loader`, specifying the import inline.
-// This allows us to use web workers without ejecting from `create-react-app` (in order to use the
-// config).  We need both worker-loader (wraps the worker code) and babel-loader (transpiles from
-// TypeScript to target ES5) in order to keep worker code in sync with our existing libraries.
 
 const ASYNC_LAYOUT_SOLID_COUNT = 50;
 
@@ -24,16 +20,19 @@ const _opLayoutCacheKey = (ops: ILayoutOp[], parentOp?: ILayoutOp) => {
 
 export const getFullOpLayout = memoize(layoutOpGraph, _opLayoutCacheKey);
 
-export const asyncGetFullOpLayout = asyncMemoize((ops: ILayoutOp[], parentOp?: ILayoutOp) => {
-  return new Promise<OpGraphLayout>((resolve) => {
-    const worker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
-    worker.addEventListener('message', (event) => {
-      resolve(event.data);
-      worker.terminate();
+export const asyncGetFullOpLayout = asyncMemoize(
+  (ops: ILayoutOp[], parentOp?: ILayoutOp, staticPathRoot?: string) => {
+    return new Promise<OpGraphLayout>((resolve) => {
+      const worker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
+      worker.addEventListener('message', (event) => {
+        resolve(event.data);
+        worker.terminate();
+      });
+      worker.postMessage({type: 'layoutOpGraph', ops, parentOp, staticPathRoot});
     });
-    worker.postMessage({type: 'layoutOpGraph', ops, parentOp});
-  });
-}, _opLayoutCacheKey);
+  },
+  _opLayoutCacheKey,
+);
 
 // Asset Graph
 
@@ -43,16 +42,19 @@ const _assetLayoutCacheKey = (graphData: GraphData) => {
 
 export const getFullAssetLayout = memoize(layoutAssetGraph, _assetLayoutCacheKey);
 
-export const asyncGetFullAssetLayout = asyncMemoize((graphData: GraphData) => {
-  return new Promise<OpGraphLayout>((resolve) => {
-    const worker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
-    worker.addEventListener('message', (event) => {
-      resolve(event.data);
-      worker.terminate();
+export const asyncGetFullAssetLayout = asyncMemoize(
+  (graphData: GraphData, staticPathRoot?: string) => {
+    return new Promise<AssetGraphLayout>((resolve) => {
+      const worker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
+      worker.addEventListener('message', (event) => {
+        resolve(event.data);
+        worker.terminate();
+      });
+      worker.postMessage({type: 'layoutAssetGraph', graphData, staticPathRoot});
     });
-    worker.postMessage({type: 'layoutAssetGraph', graphData});
-  });
-}, _assetLayoutCacheKey);
+  },
+  _assetLayoutCacheKey,
+);
 
 // Helper Hooks:
 // - Automatically switch between sync and async loading strategies
@@ -97,60 +99,65 @@ const initialState: State = {
 
 export function useOpLayout(ops: ILayoutOp[], parentOp?: ILayoutOp) {
   const [state, dispatch] = React.useReducer(reducer, initialState);
+  const {staticPathRoot} = React.useContext(AppContext);
 
   const cacheKey = _opLayoutCacheKey(ops, parentOp);
+  const runAsync = ops.length >= ASYNC_LAYOUT_SOLID_COUNT;
 
   React.useEffect(() => {
     async function runAsyncLayout() {
       dispatch({type: 'loading'});
-      const layout = await asyncGetFullOpLayout(ops, parentOp);
+      const layout = await asyncGetFullOpLayout(ops, parentOp, staticPathRoot);
       dispatch({
         type: 'layout',
         payload: {layout, cacheKey},
       });
     }
 
-    if (ops.length < ASYNC_LAYOUT_SOLID_COUNT) {
+    if (!runAsync) {
       const layout = getFullOpLayout(ops, parentOp);
       dispatch({type: 'layout', payload: {layout, cacheKey}});
     } else {
       void runAsyncLayout();
     }
-  }, [cacheKey, ops, parentOp]);
+  }, [cacheKey, ops, parentOp, runAsync, staticPathRoot]);
 
   return {
     loading: state.loading || !state.layout || state.cacheKey !== cacheKey,
-    async: ops.length >= ASYNC_LAYOUT_SOLID_COUNT,
+    async: runAsync,
     layout: state.layout as OpGraphLayout | null,
   };
 }
 
 export function useAssetLayout(graphData: GraphData) {
   const [state, dispatch] = React.useReducer(reducer, initialState);
+  const {staticPathRoot} = React.useContext(AppContext);
 
   const cacheKey = _assetLayoutCacheKey(graphData);
+  const nodeCount = Object.keys(graphData.nodes).length;
+  const runAsync = nodeCount >= ASYNC_LAYOUT_SOLID_COUNT;
 
   React.useEffect(() => {
     async function runAsyncLayout() {
       dispatch({type: 'loading'});
-      const layout = await asyncGetFullAssetLayout(graphData);
+      const layout = await asyncGetFullAssetLayout(graphData, staticPathRoot);
       dispatch({
         type: 'layout',
         payload: {layout, cacheKey},
       });
     }
 
-    if (Object.keys(graphData.nodes).length < ASYNC_LAYOUT_SOLID_COUNT) {
+    if (!runAsync) {
       const layout = getFullAssetLayout(graphData);
       dispatch({type: 'layout', payload: {layout, cacheKey}});
     } else {
       void runAsyncLayout();
     }
-  }, [cacheKey, graphData]);
+  }, [cacheKey, graphData, runAsync, staticPathRoot]);
 
   return {
     loading: state.loading || !state.layout || state.cacheKey !== cacheKey,
-    async: Object.keys(graphData.nodes).length >= ASYNC_LAYOUT_SOLID_COUNT,
+    async: runAsync,
     layout: state.layout as AssetGraphLayout | null,
   };
 }

--- a/js_modules/dagit/packages/core/src/testing/TestProvider.tsx
+++ b/js_modules/dagit/packages/core/src/testing/TestProvider.tsx
@@ -30,6 +30,7 @@ export const PERMISSIONS_ALLOW_ALL: PermissionsFromJSON = {
 const testValue: AppContextValue = {
   basePath: '',
   rootServerURI: '',
+  staticPathRoot: '/',
   telemetryEnabled: false,
 };
 


### PR DESCRIPTION
## Summary

Resolves #6938.

Our DAG layout WebWorker fails when running Dagit with a path-prefix. This is because Webpack, when executing `importScripts` in the scope of the WebWorker, doesn't make use of our `__webpack_path_prefix__` value as set at the beginning of the app. The result is that when the worker script attempts to import its dependencies (the graph layout functions) it cannot do so -- the files don't exist at the path Webpack is looking at, because the prefix is missing.

To resolve this, we can set it at runtime in the WebWorker message handler, and use dynamic imports to pull in our dependencies. This requires tracking the path prefix value in app context and passing it through to the worker. This is notably distinct from the `basePath` value, which is used for routing and GraphQL request paths, but need not be used for static asset paths. (This is what we do in Cloud, but in Cloud we can host static assets at whatever path we want, independent of `basePath`.)

## Test Plan

Set async layouts to occur at 3 nodes. Create a production build.

- Run dagit with `--path-prefix=/foo`. Load an op graph and asset graph. Verify that async rendering via WebWorker works correctly, with no errors related to script imports or anything else.
- Run dagit with no path prefix, verify same.
- Run JS dev Dagit, verify same.
