### PR TITLE
Change head_bucket to list_objects in PickledObjectS3IOManager

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -15,7 +15,7 @@ class PickledObjectS3IOManager(MemoizableIOManager):
         self.bucket = check.str_param(s3_bucket, "s3_bucket")
         self.s3_prefix = check.str_param(s3_prefix, "s3_prefix")
         self.s3 = s3_session
-        self.s3.head_bucket(Bucket=self.bucket)
+        self.s3.list_objects(Bucket=self.bucket, Prefix=self.s3_prefix, MaxKeys=1)
 
     def _get_path(self, context):
         return "/".join([self.s3_prefix, "storage", *context.get_output_identifier()])


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
While testing a Dagster deployment recently in a new environment, we ran into a permissions issues while attempting to leverage the `dagster_aws.s3.s3_pickle_io_manager`, specifically when the IOManager called `s3.head_bucket` at initialization.  In debugging this issue we learned that even if you have full access to read/write to an S3 bucket owned by a different account, the [`head_bucket` request](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.head_bucket) will fail:
> If the bucket is owned by a different account, the request fails with the HTTP status code 403 Forbidden (access denied).

Assuming that this call is in this `IOManager` to fail fast if the bucket is not accessible... we found that we could replace `.head_bucket` with a `.list_objects` call (with a specified prefix) to answer the same "do we have the appropriate permissions to access this bucket?" question in a way that works when using a cross-account bucket.  (Including `MaxKeys=1` just makes sure we don't waste too much effort on this list operation.)


## Test Plan
Not entirely sure!  Open to suggestions, obviously.  I don't think this is explicitly tested in unit tests, or at least I didn't notice anything at a quick glance.



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.