### PR TITLE
[for 0.15.0] default includeConfigInLaunchedRuns in helm chart to true

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -51,13 +51,12 @@ spec:
                 secretKeyRef:
                   name: {{ include "dagsterUserDeployments.postgresql.secretName" $ }}
                   key: postgresql-password
-            {{- if $deployment.includeConfigInLaunchedRuns }}
-            {{- if $deployment.includeConfigInLaunchedRuns.enabled }}
+            {{- $includeConfigInLaunchedRuns := $deployment.includeConfigInLaunchedRuns | default (dict "enabled" true) }}
+            {{- if $includeConfigInLaunchedRuns.enabled }}
             # uses the auto_envvar_prefix of the dagster cli to set the --container-context arg
             # on 'dagster api grpc'
             - name: DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT
               value: {{ include "dagsterUserDeployments.k8sContainerContext" (list $ $deployment) | fromYaml | toJson | quote }}
-            {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -47,7 +47,7 @@ deployments:
     # Whether or not to include configuration specified for this user code deployment in the pods
     # launched for runs from that deployment
     includeConfigInLaunchedRuns:
-      enabled: false
+      enabled: true
 
     # Additional volumes that should be included in the Deployment's Pod. See:
     # https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core

--- a/helm/dagster/schema/schema_tests/utils.py
+++ b/helm/dagster/schema/schema_tests/utils.py
@@ -8,7 +8,7 @@ from schema.charts.utils import kubernetes
 
 
 def create_simple_user_deployment(
-    name: str, include_config_in_launched_runs: Optional[bool] = False
+    name: str, include_config_in_launched_runs: Optional[bool] = None
 ) -> UserDeployment:
     return UserDeployment(
         name=name,

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -268,7 +268,7 @@ dagster-user-deployments:
       # Whether or not to include configuration specified for this user code deployment in the pods
       # launched for runs from that deployment
       includeConfigInLaunchedRuns:
-        enabled: false
+        enabled: true
 
       # Additional environment variables to set.
       # A Kubernetes ConfigMap will be created with these environment variables. See:


### PR DESCRIPTION
Summary:
I'll sit on this until we cut the branch for 0.15.0, but just holding onto it so I don't forget. Since it could be a minor breaking change (especically for people who are launching runs in a different namespace than their gRPC servers), but makes the most sense as the default going forward IMO.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.