### PR TITLE
[dagit] Fix job header “View assets” link, add missing graphQL types

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -23,14 +23,14 @@ import {RepoAddress} from '../workspace/types';
 
 import {LiveDataForNode, displayNameForAssetKey} from './Utils';
 import {SidebarAssetFragment} from './types/SidebarAssetFragment';
-import {SidebarAssetQuery} from './types/SidebarAssetQuery';
+import {SidebarAssetQuery, SidebarAssetQueryVariables} from './types/SidebarAssetQuery';
 
 export const SidebarAssetInfo: React.FC<{
   assetKey: AssetKey;
   liveData: LiveDataForNode;
 }> = ({assetKey, liveData}) => {
   const partitionHealthData = usePartitionHealthData([assetKey]);
-  const {data} = useQuery<SidebarAssetQuery>(SIDEBAR_ASSET_QUERY, {
+  const {data} = useQuery<SidebarAssetQuery, SidebarAssetQueryVariables>(SIDEBAR_ASSET_QUERY, {
     variables: {assetKey: {path: assetKey.path}},
     fetchPolicy: 'cache-and-network',
   });

--- a/js_modules/dagit/packages/core/src/assets/AssetEntryRoot.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEntryRoot.tsx
@@ -8,7 +8,7 @@ import {Loading} from '../ui/Loading';
 import {AssetPageHeader} from './AssetPageHeader';
 import {AssetView} from './AssetView';
 import {AssetsCatalogTable} from './AssetsCatalogTable';
-import {AssetEntryRootQuery} from './types/AssetEntryRootQuery';
+import {AssetEntryRootQuery, AssetEntryRootQueryVariables} from './types/AssetEntryRootQuery';
 
 export const AssetEntryRoot = () => {
   const params = useParams();
@@ -17,9 +17,12 @@ export const AssetEntryRoot = () => {
     .filter((x: string) => x)
     .map(decodeURIComponent);
 
-  const queryResult = useQuery<AssetEntryRootQuery>(ASSET_ENTRY_ROOT_QUERY, {
-    variables: {assetKey: {path: currentPath}},
-  });
+  const queryResult = useQuery<AssetEntryRootQuery, AssetEntryRootQueryVariables>(
+    ASSET_ENTRY_ROOT_QUERY,
+    {
+      variables: {assetKey: {path: currentPath}},
+    },
+  );
 
   return queryResult.loading ? (
     <Page>

--- a/js_modules/dagit/packages/core/src/assets/AssetWipeDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetWipeDialog.tsx
@@ -5,6 +5,8 @@ import * as React from 'react';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
 
+import {AssetWipeMutation, AssetWipeMutationVariables} from './types/AssetWipeMutation';
+
 interface AssetKey {
   path: string[];
 }
@@ -16,10 +18,13 @@ export const AssetWipeDialog: React.FC<{
   onComplete: (assetKeys: AssetKey[]) => void;
   requery?: RefetchQueriesFunction;
 }> = ({assetKeys, isOpen, onClose, onComplete, requery}) => {
-  const [requestWipe] = useMutation(ASSET_WIPE_MUTATION, {
-    variables: {assetKeys: assetKeys.map((key) => ({path: key.path || []}))},
-    refetchQueries: requery,
-  });
+  const [requestWipe] = useMutation<AssetWipeMutation, AssetWipeMutationVariables>(
+    ASSET_WIPE_MUTATION,
+    {
+      variables: {assetKeys: assetKeys.map((key) => ({path: key.path || []}))},
+      refetchQueries: requery,
+    },
+  );
 
   const wipe = async () => {
     if (!assetKeys.length) {

--- a/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
@@ -13,6 +13,7 @@ import {RunStateSummary, RunTime, RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 
 import {
   RunGroupPanelQuery,
+  RunGroupPanelQueryVariables,
   RunGroupPanelQuery_runGroupOrError_RunGroup_runs,
 } from './types/RunGroupPanelQuery';
 
@@ -27,11 +28,14 @@ export const RunGroupPanel: React.FC<{runId: string; runStatusLastChangedAt: num
   runId,
   runStatusLastChangedAt,
 }) => {
-  const {data, refetch} = useQuery<RunGroupPanelQuery>(RUN_GROUP_PANEL_QUERY, {
-    variables: {runId},
-    fetchPolicy: 'cache-and-network',
-    pollInterval: 15000, // 15s
-  });
+  const {data, refetch} = useQuery<RunGroupPanelQuery, RunGroupPanelQueryVariables>(
+    RUN_GROUP_PANEL_QUERY,
+    {
+      variables: {runId},
+      fetchPolicy: 'cache-and-network',
+      pollInterval: 15000, // 15s
+    },
+  );
 
   // Because the RunGroupPanel makes it's own query for the runs and their statuses,
   // the log + gantt chart UI can show that the run is "completed" for up to 15s before

--- a/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
@@ -7,6 +7,7 @@ import {doneStatuses} from '../runs/RunStatuses';
 import {TerminationDialog} from '../runs/TerminationDialog';
 import {BulkActionStatus} from '../types/globalTypes';
 
+import {CancelBackfill, CancelBackfillVariables} from './types/CancelBackfill';
 import {InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results} from './types/InstanceBackfillsQuery';
 
 type Backfill = InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results;
@@ -17,7 +18,9 @@ interface Props {
   onComplete: () => void;
 }
 export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props) => {
-  const [cancelBackfill] = useMutation(CANCEL_BACKFILL_MUTATION);
+  const [cancelBackfill] = useMutation<CancelBackfill, CancelBackfillVariables>(
+    CANCEL_BACKFILL_MUTATION,
+  );
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
   if (!backfill) {

--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -60,6 +60,7 @@ import {
   InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_runs,
 } from './types/InstanceBackfillsQuery';
 import {InstanceHealthForBackfillsQuery} from './types/InstanceHealthForBackfillsQuery';
+import {resumeBackfill, resumeBackfillVariables} from './types/resumeBackfill';
 
 type Backfill = InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results;
 type BackfillRun = InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_runs;
@@ -170,7 +171,9 @@ const INSTANCE_HEALTH_FOR_BACKFILLS_QUERY = gql`
 
 const BackfillTable = ({backfills, refetch}: {backfills: Backfill[]; refetch: () => void}) => {
   const [terminationBackfill, setTerminationBackfill] = React.useState<Backfill>();
-  const [resumeBackfill] = useMutation(RESUME_BACKFILL_MUTATION);
+  const [resumeBackfill] = useMutation<resumeBackfill, resumeBackfillVariables>(
+    RESUME_BACKFILL_MUTATION,
+  );
   const [cancelRunBackfill, setCancelRunBackfill] = React.useState<Backfill>();
   const {canCancelPartitionBackfill} = usePermissions();
 
@@ -199,7 +202,7 @@ const BackfillTable = ({backfills, refetch}: {backfills: Backfill[]; refetch: ()
         icon: 'error',
         intent: 'danger',
       });
-    } else {
+    } else if (data && data.resumePartitionBackfill.__typename === 'PythonError') {
       const error = data.resumePartitionBackfill;
       SharedToaster.show({
         message: <div>An unexpected error occurred. This backfill was not retried.</div>,

--- a/js_modules/dagit/packages/core/src/instance/StepSummaryForRun.tsx
+++ b/js_modules/dagit/packages/core/src/instance/StepSummaryForRun.tsx
@@ -7,7 +7,10 @@ import {Link} from 'react-router-dom';
 import {failedStatuses, inProgressStatuses} from '../runs/RunStatuses';
 import {StepEventStatus} from '../types/globalTypes';
 
-import {StepSummaryForRunQuery} from './types/StepSummaryForRunQuery';
+import {
+  StepSummaryForRunQuery,
+  StepSummaryForRunQueryVariables,
+} from './types/StepSummaryForRunQuery';
 
 interface Props {
   runId: string;
@@ -15,7 +18,10 @@ interface Props {
 
 export const StepSummaryForRun = (props: Props) => {
   const {runId} = props;
-  const {data} = useQuery<StepSummaryForRunQuery>(STEP_SUMMARY_FOR_RUN_QUERY, {variables: {runId}});
+  const {data} = useQuery<StepSummaryForRunQuery, StepSummaryForRunQueryVariables>(
+    STEP_SUMMARY_FOR_RUN_QUERY,
+    {variables: {runId}},
+  );
 
   const run = data?.pipelineRunOrError;
   const status = run?.__typename === 'Run' ? run.status : null;

--- a/js_modules/dagit/packages/core/src/instigation/Unloadable.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/Unloadable.tsx
@@ -8,9 +8,9 @@ import {
   STOP_SCHEDULE_MUTATION,
 } from '../schedules/ScheduleMutations';
 import {humanCronString} from '../schedules/humanCronString';
-import {StopSchedule} from '../schedules/types/StopSchedule';
+import {StopSchedule, StopScheduleVariables} from '../schedules/types/StopSchedule';
 import {displaySensorMutationErrors, STOP_SENSOR_MUTATION} from '../sensors/SensorMutations';
-import {StopSensor} from '../sensors/types/StopSensor';
+import {StopSensor, StopSensorVariables} from '../sensors/types/StopSensor';
 import {InstigationStatus, InstigationType} from '../types/globalTypes';
 import {InstigatorSelectorInformation} from '../workspace/RepositoryInformation';
 
@@ -125,9 +125,12 @@ const UnloadableScheduleInfo = () => (
 const SensorStateRow = ({sensorState}: {sensorState: InstigationStateFragment}) => {
   const {id, selectorId, name, status, ticks} = sensorState;
 
-  const [stopSensor, {loading: toggleOffInFlight}] = useMutation<StopSensor>(STOP_SENSOR_MUTATION, {
-    onCompleted: displaySensorMutationErrors,
-  });
+  const [stopSensor, {loading: toggleOffInFlight}] = useMutation<StopSensor, StopSensorVariables>(
+    STOP_SENSOR_MUTATION,
+    {
+      onCompleted: displaySensorMutationErrors,
+    },
+  );
   const confirm = useConfirmation();
 
   const onChangeSwitch = async () => {
@@ -180,12 +183,12 @@ const SensorStateRow = ({sensorState}: {sensorState: InstigationStateFragment}) 
 const ScheduleStateRow: React.FC<{
   scheduleState: InstigationStateFragment;
 }> = ({scheduleState}) => {
-  const [stopSchedule, {loading: toggleOffInFlight}] = useMutation<StopSchedule>(
-    STOP_SCHEDULE_MUTATION,
-    {
-      onCompleted: displayScheduleMutationErrors,
-    },
-  );
+  const [stopSchedule, {loading: toggleOffInFlight}] = useMutation<
+    StopSchedule,
+    StopScheduleVariables
+  >(STOP_SCHEDULE_MUTATION, {
+    onCompleted: displayScheduleMutationErrors,
+  });
   const confirm = useConfirmation();
   const {id, selectorId, name, ticks, status, typeSpecificData} = scheduleState;
   const latestTick = ticks.length > 0 ? ticks[0] : null;

--- a/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -33,6 +33,7 @@ import {
 } from './types/ConfigEditorGeneratorPipelineFragment';
 import {
   ConfigPartitionsQuery,
+  ConfigPartitionsQueryVariables,
   ConfigPartitionsQuery_partitionSetOrError_PartitionSet_partitionsOrError_Partitions_results,
 } from './types/ConfigPartitionsQuery';
 
@@ -146,10 +147,13 @@ const ConfigEditorPartitionPicker: React.FC<ConfigEditorPartitionPickerProps> = 
   (props) => {
     const {partitionSetName, value, onSelect, repoAddress} = props;
     const repositorySelector = repoAddressToSelector(repoAddress);
-    const {data, loading} = useQuery<ConfigPartitionsQuery>(CONFIG_PARTITIONS_QUERY, {
-      variables: {repositorySelector, partitionSetName},
-      fetchPolicy: 'network-only',
-    });
+    const {data, loading} = useQuery<ConfigPartitionsQuery, ConfigPartitionsQueryVariables>(
+      CONFIG_PARTITIONS_QUERY,
+      {
+        variables: {repositorySelector, partitionSetName},
+        fetchPolicy: 'network-only',
+      },
+    );
 
     const [sortOrder, setSortOrder] = React.useState('asc');
 

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchRootExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchRootExecutionButton.tsx
@@ -25,9 +25,10 @@ interface LaunchRootExecutionButtonProps {
 
 export const LaunchRootExecutionButton: React.FC<LaunchRootExecutionButtonProps> = (props) => {
   const {canLaunchPipelineExecution} = usePermissions();
-  const [launchPipelineExecution] = useMutation<LaunchPipelineExecution>(
-    LAUNCH_PIPELINE_EXECUTION_MUTATION,
-  );
+  const [launchPipelineExecution] = useMutation<
+    LaunchPipelineExecution,
+    LaunchPipelineExecutionVariables
+  >(LAUNCH_PIPELINE_EXECUTION_MUTATION);
   const logTelemetry = useTelemetryAction();
   const history = useHistory();
 

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
@@ -15,7 +15,7 @@ import {
 } from './ConfigEditorConfigPicker';
 import {LaunchpadSessionError} from './LaunchpadSessionError';
 import {LaunchpadSessionLoading} from './LaunchpadSessionLoading';
-import {LaunchpadRootQuery} from './types/LaunchpadRootQuery';
+import {LaunchpadRootQuery, LaunchpadRootQueryVariables} from './types/LaunchpadRootQuery';
 
 const LaunchpadSessionContainer = React.lazy(() => import('./LaunchpadSessionContainer'));
 
@@ -49,11 +49,14 @@ const LaunchpadAllowedRoot: React.FC<Props> = (props) => {
 
   const {name: repositoryName, location: repositoryLocationName} = repoAddress;
 
-  const result = useQuery<LaunchpadRootQuery>(PIPELINE_EXECUTION_ROOT_QUERY, {
-    variables: {repositoryName, repositoryLocationName, pipelineName},
-    fetchPolicy: 'cache-and-network',
-    partialRefetch: true,
-  });
+  const result = useQuery<LaunchpadRootQuery, LaunchpadRootQueryVariables>(
+    PIPELINE_EXECUTION_ROOT_QUERY,
+    {
+      variables: {repositoryName, repositoryLocationName, pipelineName},
+      fetchPolicy: 'cache-and-network',
+      partialRefetch: true,
+    },
+  );
 
   const pipelineOrError = result?.data?.pipelineOrError;
   const partitionSetsOrError = result?.data?.partitionSetsOrError;

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
@@ -60,7 +60,10 @@ import {
 } from './types/ConfigPartitionSelectionQuery';
 import {LaunchpadSessionContainerPartitionSetsFragment} from './types/LaunchpadSessionContainerPartitionSetsFragment';
 import {LaunchpadSessionContainerPipelineFragment} from './types/LaunchpadSessionContainerPipelineFragment';
-import {PipelineExecutionConfigSchemaQuery} from './types/PipelineExecutionConfigSchemaQuery';
+import {
+  PipelineExecutionConfigSchemaQuery,
+  PipelineExecutionConfigSchemaQueryVariables,
+} from './types/PipelineExecutionConfigSchemaQuery';
 import {PreviewConfigQuery, PreviewConfigQueryVariables} from './types/PreviewConfigQuery';
 
 const YAML_SYNTAX_INVALID = `The YAML you provided couldn't be parsed. Please fix the syntax errors and try again.`;
@@ -181,14 +184,14 @@ const LaunchpadSessionContainer: React.FC<LaunchpadSessionContainerProps> = (pro
     solidSelection: currentSession?.solidSelection || undefined,
   };
 
-  const configResult = useQuery<PipelineExecutionConfigSchemaQuery>(
-    PIPELINE_EXECUTION_CONFIG_SCHEMA_QUERY,
-    {
-      variables: {selector: pipelineSelector, mode: currentSession?.mode},
-      fetchPolicy: 'cache-and-network',
-      partialRefetch: true,
-    },
-  );
+  const configResult = useQuery<
+    PipelineExecutionConfigSchemaQuery,
+    PipelineExecutionConfigSchemaQueryVariables
+  >(PIPELINE_EXECUTION_CONFIG_SCHEMA_QUERY, {
+    variables: {selector: pipelineSelector, mode: currentSession?.mode},
+    fetchPolicy: 'cache-and-network',
+    partialRefetch: true,
+  });
 
   const configSchemaOrError = configResult?.data?.runConfigSchemaOrError;
 

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupFromRunRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupFromRunRoot.tsx
@@ -17,7 +17,7 @@ import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 import {LaunchpadSessionError} from './LaunchpadSessionError';
 import {LaunchpadSessionLoading} from './LaunchpadSessionLoading';
-import {ConfigForRunQuery} from './types/ConfigForRunQuery';
+import {ConfigForRunQuery, ConfigForRunQueryVariables} from './types/ConfigForRunQuery';
 
 export const LaunchpadSetupFromRunRoot: React.FC<{repoAddress: RepoAddress}> = (props) => {
   const {repoAddress} = props;
@@ -64,7 +64,10 @@ const LaunchpadSetupFromRunAllowedRoot: React.FC<Props> = (props) => {
 
   const [storageData, onSave] = useExecutionSessionStorage(repoAddress, pipelineName);
 
-  const {data, loading} = useQuery<ConfigForRunQuery>(CONFIG_FOR_RUN_QUERY, {variables: {runId}});
+  const {data, loading} = useQuery<ConfigForRunQuery, ConfigForRunQueryVariables>(
+    CONFIG_FOR_RUN_QUERY,
+    {variables: {runId}},
+  );
   const runOrError = data?.runOrError;
   const run = runOrError?.__typename === 'Run' ? runOrError : null;
 

--- a/js_modules/dagit/packages/core/src/launchpad/OpSelector.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/OpSelector.tsx
@@ -13,7 +13,7 @@ import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
-import {OpSelectorQuery} from './types/OpSelectorQuery';
+import {OpSelectorQuery, OpSelectorQueryVariables} from './types/OpSelectorQuery';
 
 interface IOpSelectorProps {
   pipelineName: string;
@@ -69,10 +69,13 @@ export const OpSelector = (props: IOpSelectorProps) => {
   const selector = {...repoAddressToSelector(repoAddress), pipelineName};
   const repo = useRepository(repoAddress);
   const isJob = isThisThingAJob(repo, pipelineName);
-  const {data, loading} = useQuery<OpSelectorQuery>(SOLID_SELECTOR_QUERY, {
-    variables: {selector, requestScopeHandleID: flattenGraphs ? undefined : ''},
-    fetchPolicy: 'cache-and-network',
-  });
+  const {data, loading} = useQuery<OpSelectorQuery, OpSelectorQueryVariables>(
+    SOLID_SELECTOR_QUERY,
+    {
+      variables: {selector, requestScopeHandleID: flattenGraphs ? undefined : ''},
+      fetchPolicy: 'cache-and-network',
+    },
+  );
 
   const query = props.query || '*';
 

--- a/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
@@ -11,7 +11,7 @@ import {RepoAddress} from '../workspace/types';
 import {LatestRunTag} from './LatestRunTag';
 import {ScheduleOrSensorTag} from './ScheduleOrSensorTag';
 import {JobMetadataFragment as Job} from './types/JobMetadataFragment';
-import {JobMetadataQuery} from './types/JobMetadataQuery';
+import {JobMetadataQuery, JobMetadataQueryVariables} from './types/JobMetadataQuery';
 import {RunMetadataFragment} from './types/RunMetadataFragment';
 
 interface Props {
@@ -22,8 +22,11 @@ interface Props {
 export const JobMetadata: React.FC<Props> = (props) => {
   const {pipelineName, repoAddress} = props;
 
-  const {data} = useQuery<JobMetadataQuery>(JOB_METADATA_QUERY, {
+  const {data} = useQuery<JobMetadataQuery, JobMetadataQueryVariables>(JOB_METADATA_QUERY, {
     variables: {
+      runsFilter: {
+        pipelineName,
+      },
       params: {
         pipelineName,
         repositoryName: repoAddress.name,
@@ -191,7 +194,7 @@ const JOB_METADATA_FRAGMENT = gql`
 `;
 
 const JOB_METADATA_QUERY = gql`
-  query JobMetadataQuery($params: PipelineSelector!, $runsFilter: RunsFilter) {
+  query JobMetadataQuery($params: PipelineSelector!, $runsFilter: RunsFilter!) {
     pipelineOrError(params: $params) {
       ... on Pipeline {
         id

--- a/js_modules/dagit/packages/core/src/nav/types/JobMetadataQuery.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/JobMetadataQuery.ts
@@ -102,5 +102,5 @@ export interface JobMetadataQuery {
 
 export interface JobMetadataQueryVariables {
   params: PipelineSelector;
-  runsFilter?: RunsFilter | null;
+  runsFilter: RunsFilter;
 }

--- a/js_modules/dagit/packages/core/src/ops/OpDetailsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/ops/OpDetailsRoot.tsx
@@ -12,7 +12,7 @@ import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
 import {OpCard, OP_CARD_SOLID_DEFINITION_FRAGMENT} from './OpCard';
-import {UsedSolidDetailsQuery} from './types/UsedSolidDetailsQuery';
+import {UsedSolidDetailsQuery, UsedSolidDetailsQueryVariables} from './types/UsedSolidDetailsQuery';
 
 interface UsedSolidDetailsProps {
   name: string;
@@ -24,12 +24,15 @@ export const UsedSolidDetails: React.FC<UsedSolidDetailsProps> = (props) => {
   const {name, onClickInvocation, repoAddress} = props;
   const repositorySelector = repoAddressToSelector(repoAddress);
 
-  const queryResult = useQuery<UsedSolidDetailsQuery>(USED_SOLID_DETAILS_QUERY, {
-    variables: {
-      name,
-      repositorySelector,
+  const queryResult = useQuery<UsedSolidDetailsQuery, UsedSolidDetailsQueryVariables>(
+    USED_SOLID_DETAILS_QUERY,
+    {
+      variables: {
+        name,
+        repositorySelector,
+      },
     },
-  });
+  );
 
   return (
     <Loading queryResult={queryResult}>

--- a/js_modules/dagit/packages/core/src/ops/OpsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/ops/OpsRoot.tsx
@@ -27,6 +27,7 @@ import {OpDetailScrollContainer, UsedSolidDetails} from './OpDetailsRoot';
 import {OpTypeSignature, OP_TYPE_SIGNATURE_FRAGMENT} from './OpTypeSignature';
 import {
   OpsRootQuery,
+  OpsRootQueryVariables,
   OpsRootQuery_repositoryOrError_Repository_usedSolids,
 } from './types/OpsRootQuery';
 
@@ -122,7 +123,7 @@ export const OpsRoot: React.FC<Props> = (props) => {
   useDocumentTitle('Ops');
   const repositorySelector = repoAddressToSelector(repoAddress);
 
-  const queryResult = useQuery<OpsRootQuery>(OPS_ROOT_QUERY, {
+  const queryResult = useQuery<OpsRootQuery, OpsRootQueryVariables>(OPS_ROOT_QUERY, {
     variables: {repositorySelector},
   });
 

--- a/js_modules/dagit/packages/core/src/partitions/PartitionProgress.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionProgress.tsx
@@ -28,6 +28,7 @@ import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 import {
   PartitionProgressQuery,
+  PartitionProgressQueryVariables,
   PartitionProgressQuery_partitionBackfillOrError_PartitionBackfill,
   PartitionProgressQuery_partitionBackfillOrError_PartitionBackfill_runs,
 } from './types/PartitionProgressQuery';
@@ -44,14 +45,17 @@ export const PartitionProgress = (props: Props) => {
   const [shouldPoll, setShouldPoll] = React.useState(true);
   const [isTerminating, setIsTerminating] = React.useState(false);
 
-  const queryResult = useQuery<PartitionProgressQuery>(PARTITION_PROGRESS_QUERY, {
-    fetchPolicy: 'network-only',
-    notifyOnNetworkStatusChange: true,
-    variables: {
-      backfillId,
-      limit: 100000,
+  const queryResult = useQuery<PartitionProgressQuery, PartitionProgressQueryVariables>(
+    PARTITION_PROGRESS_QUERY,
+    {
+      fetchPolicy: 'network-only',
+      notifyOnNetworkStatusChange: true,
+      variables: {
+        backfillId,
+        limit: 100000,
+      },
     },
-  });
+  );
 
   // Technically we still poll if you disable polling on this page, just very very slowly.
   // The useQueryRefreshAtInterval hook is already complex enough, don't want to add a

--- a/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
@@ -46,9 +46,15 @@ import {
   TopLabel,
   TopLabelTilted,
 } from './RunMatrixUtils';
-import {LaunchPartitionBackfill} from './types/LaunchPartitionBackfill';
-import {PartitionStatusQuery} from './types/PartitionStatusQuery';
-import {PartitionsBackfillSelectorQuery} from './types/PartitionsBackfillSelectorQuery';
+import {
+  LaunchPartitionBackfill,
+  LaunchPartitionBackfillVariables,
+} from './types/LaunchPartitionBackfill';
+import {PartitionStatusQuery, PartitionStatusQueryVariables} from './types/PartitionStatusQuery';
+import {
+  PartitionsBackfillSelectorQuery,
+  PartitionsBackfillSelectorQueryVariables,
+} from './types/PartitionsBackfillSelectorQuery';
 
 const OVERSCROLL = 200;
 const DEFAULT_RUN_LAUNCHER_NAME = 'DefaultRunLauncher';
@@ -106,25 +112,25 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
     };
   }, [onLaunch]);
 
-  const {loading, data} = useQuery<PartitionsBackfillSelectorQuery>(
-    PARTITIONS_BACKFILL_SELECTOR_QUERY,
-    {
-      variables: {
-        repositorySelector,
-        partitionSetName,
-        pipelineSelector: {
-          ...repositorySelector,
-          pipelineName,
-        },
+  const {loading, data} = useQuery<
+    PartitionsBackfillSelectorQuery,
+    PartitionsBackfillSelectorQueryVariables
+  >(PARTITIONS_BACKFILL_SELECTOR_QUERY, {
+    variables: {
+      repositorySelector,
+      partitionSetName,
+      pipelineSelector: {
+        ...repositorySelector,
+        pipelineName,
       },
-      fetchPolicy: 'network-only',
     },
-  );
+    fetchPolicy: 'network-only',
+  });
 
-  const [
-    queryStatuses,
-    {loading: statusesLoading, data: statusesData},
-  ] = useLazyQuery<PartitionStatusQuery>(PARTITION_STATUS_QUERY, {
+  const [queryStatuses, {loading: statusesLoading, data: statusesData}] = useLazyQuery<
+    PartitionStatusQuery,
+    PartitionStatusQueryVariables
+  >(PARTITION_STATUS_QUERY, {
     variables: {
       repositorySelector,
       partitionSetName,
@@ -546,9 +552,10 @@ const LaunchBackfillButton: React.FC<{
 }) => {
   const repositorySelector = repoAddressToSelector(repoAddress);
   const mounted = React.useRef(true);
-  const [launchBackfill, {loading}] = useMutation<LaunchPartitionBackfill>(
-    LAUNCH_PARTITION_BACKFILL_MUTATION,
-  );
+  const [launchBackfill, {loading}] = useMutation<
+    LaunchPartitionBackfill,
+    LaunchPartitionBackfillVariables
+  >(LAUNCH_PARTITION_BACKFILL_MUTATION);
 
   React.useEffect(() => {
     mounted.current = true;

--- a/js_modules/dagit/packages/core/src/runs/DeletionDialog.tsx
+++ b/js_modules/dagit/packages/core/src/runs/DeletionDialog.tsx
@@ -11,6 +11,7 @@ import {
   Delete_deletePipelineRun_RunNotFoundError,
   Delete_deletePipelineRun_PythonError,
   Delete_deletePipelineRun_UnauthorizedError,
+  DeleteVariables,
 } from './types/Delete';
 
 export interface Props {
@@ -113,7 +114,7 @@ export const DeletionDialog = (props: Props) => {
     }
   }, [isOpen, selectedRuns]);
 
-  const [destroy] = useMutation<Delete>(DELETE_MUTATION);
+  const [destroy] = useMutation<Delete, DeleteVariables>(DELETE_MUTATION);
 
   const mutate = async () => {
     dispatch({type: 'start'});

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
@@ -35,8 +35,14 @@ import {
   handleLaunchResult,
 } from './RunUtils';
 import {TerminationDialog} from './TerminationDialog';
-import {LaunchPipelineReexecution} from './types/LaunchPipelineReexecution';
-import {PipelineEnvironmentYamlQuery} from './types/PipelineEnvironmentYamlQuery';
+import {
+  LaunchPipelineReexecution,
+  LaunchPipelineReexecutionVariables,
+} from './types/LaunchPipelineReexecution';
+import {
+  PipelineEnvironmentYamlQuery,
+  PipelineEnvironmentYamlQueryVariables,
+} from './types/PipelineEnvironmentYamlQuery';
 import {RunTableRunFragment} from './types/RunTableRunFragment';
 
 export const RunActionsMenu: React.FC<{
@@ -53,16 +59,19 @@ export const RunActionsMenu: React.FC<{
 
   const copyConfig = useCopyToClipboard();
 
-  const [reexecute] = useMutation<LaunchPipelineReexecution>(LAUNCH_PIPELINE_REEXECUTION_MUTATION, {
-    onCompleted: refetch,
-  });
-
-  const [loadEnv, {called, loading, data}] = useLazyQuery<PipelineEnvironmentYamlQuery>(
-    PIPELINE_ENVIRONMENT_YAML_QUERY,
+  const [reexecute] = useMutation<LaunchPipelineReexecution, LaunchPipelineReexecutionVariables>(
+    LAUNCH_PIPELINE_REEXECUTION_MUTATION,
     {
-      variables: {runId: run.runId},
+      onCompleted: refetch,
     },
   );
+
+  const [loadEnv, {called, loading, data}] = useLazyQuery<
+    PipelineEnvironmentYamlQuery,
+    PipelineEnvironmentYamlQueryVariables
+  >(PIPELINE_ENVIRONMENT_YAML_QUERY, {
+    variables: {runId: run.runId},
+  });
 
   const closeDialogs = () => {
     setVisibleDialog('none');

--- a/js_modules/dagit/packages/core/src/runs/RunRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunRoot.tsx
@@ -16,12 +16,12 @@ import {RunConfigDialog, RunDetails} from './RunDetails';
 import {RunFragments} from './RunFragments';
 import {RunStatusTag} from './RunStatusTag';
 import {RunStepKeysAssetList} from './RunStepKeysAssetList';
-import {RunRootQuery} from './types/RunRootQuery';
+import {RunRootQuery, RunRootQueryVariables} from './types/RunRootQuery';
 
 export const RunRoot = () => {
   const {runId} = useParams<{runId: string}>();
 
-  const {data, loading} = useQuery<RunRootQuery>(RUN_ROOT_QUERY, {
+  const {data, loading} = useQuery<RunRootQuery, RunRootQueryVariables>(RUN_ROOT_QUERY, {
     fetchPolicy: 'cache-and-network',
     partialRefetch: true,
     variables: {runId},

--- a/js_modules/dagit/packages/core/src/runs/TerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/runs/TerminationDialog.tsx
@@ -25,6 +25,7 @@ import {
   Terminate_terminatePipelineExecution_PythonError,
   Terminate_terminatePipelineExecution_UnauthorizedError,
   Terminate_terminatePipelineExecution_TerminateRunFailure,
+  TerminateVariables,
 } from './types/Terminate';
 
 export interface Props {
@@ -137,7 +138,7 @@ export const TerminationDialog = (props: Props) => {
     }
   }, [isOpen, selectedRuns]);
 
-  const [terminate] = useMutation<Terminate>(TERMINATE_MUTATION);
+  const [terminate] = useMutation<Terminate, TerminateVariables>(TERMINATE_MUTATION);
   const policy = state.mustForce
     ? TerminateRunPolicy.MARK_AS_CANCELED_IMMEDIATELY
     : TerminateRunPolicy.SAFE_TERMINATE;

--- a/js_modules/dagit/packages/core/src/runs/useComputeLogs.tsx
+++ b/js_modules/dagit/packages/core/src/runs/useComputeLogs.tsx
@@ -5,7 +5,10 @@ import {ComputeIOType} from '../types/globalTypes';
 
 import {COMPUTE_LOG_CONTENT_FRAGMENT, MAX_STREAMING_LOG_BYTES} from './ComputeLogContent';
 import {ComputeLogContentFileFragment} from './types/ComputeLogContentFileFragment';
-import {ComputeLogsSubscription} from './types/ComputeLogsSubscription';
+import {
+  ComputeLogsSubscription,
+  ComputeLogsSubscriptionVariables,
+} from './types/ComputeLogsSubscription';
 import {ComputeLogsSubscriptionFragment} from './types/ComputeLogsSubscriptionFragment';
 
 const slice = (s: string) =>
@@ -69,27 +72,33 @@ const initialState: State = {
 export const useComputeLogs = (runId: string, stepKey?: string) => {
   const [state, dispatch] = React.useReducer(reducer, initialState);
 
-  useSubscription<ComputeLogsSubscription>(COMPUTE_LOGS_SUBSCRIPTION, {
-    fetchPolicy: 'no-cache',
-    variables: {runId, stepKey, ioType: ComputeIOType.STDOUT, cursor: null},
-    skip: !stepKey,
-    onSubscriptionData: ({subscriptionData}) => {
-      if (stepKey) {
-        dispatch({type: 'stdout', stepKey, log: subscriptionData.data?.computeLogs || null});
-      }
+  useSubscription<ComputeLogsSubscription, ComputeLogsSubscriptionVariables>(
+    COMPUTE_LOGS_SUBSCRIPTION,
+    {
+      fetchPolicy: 'no-cache',
+      variables: {runId, stepKey: stepKey!, ioType: ComputeIOType.STDOUT, cursor: null},
+      skip: !stepKey,
+      onSubscriptionData: ({subscriptionData}) => {
+        if (stepKey) {
+          dispatch({type: 'stdout', stepKey, log: subscriptionData.data?.computeLogs || null});
+        }
+      },
     },
-  });
+  );
 
-  useSubscription<ComputeLogsSubscription>(COMPUTE_LOGS_SUBSCRIPTION, {
-    fetchPolicy: 'no-cache',
-    variables: {runId, stepKey, ioType: ComputeIOType.STDERR, cursor: null},
-    skip: !stepKey,
-    onSubscriptionData: ({subscriptionData}) => {
-      if (stepKey) {
-        dispatch({type: 'stderr', stepKey, log: subscriptionData.data?.computeLogs || null});
-      }
+  useSubscription<ComputeLogsSubscription, ComputeLogsSubscriptionVariables>(
+    COMPUTE_LOGS_SUBSCRIPTION,
+    {
+      fetchPolicy: 'no-cache',
+      variables: {runId, stepKey: stepKey!, ioType: ComputeIOType.STDERR, cursor: null},
+      skip: !stepKey,
+      onSubscriptionData: ({subscriptionData}) => {
+        if (stepKey) {
+          dispatch({type: 'stderr', stepKey, log: subscriptionData.data?.computeLogs || null});
+        }
+      },
     },
-  });
+  );
 
   return state;
 };

--- a/js_modules/dagit/packages/core/src/schedules/SchedulePartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulePartitionStatus.tsx
@@ -16,7 +16,10 @@ import {
   SchedulePartitionStatusFragment,
   SchedulePartitionStatusFragment_partitionSet_partitionStatusesOrError_PartitionStatuses_results as Partition,
 } from './types/SchedulePartitionStatusFragment';
-import {SchedulePartitionStatusQuery} from './types/SchedulePartitionStatusQuery';
+import {
+  SchedulePartitionStatusQuery,
+  SchedulePartitionStatusQueryVariables,
+} from './types/SchedulePartitionStatusQuery';
 
 const RUN_STATUSES = ['Succeeded', 'Failed', 'Missing', 'Pending'];
 
@@ -65,18 +68,18 @@ export const SchedulePartitionStatus: React.FC<{
 
   const partitionURL = workspacePathFromAddress(repoAddress, partitionPath);
 
-  const [retrievePartitionStatus, {data, loading}] = useLazyQuery<SchedulePartitionStatusQuery>(
-    SCHEDULE_PARTITION_STATUS_QUERY,
-    {
-      variables: {
-        scheduleSelector: {
-          scheduleName,
-          repositoryName: repoAddress.name,
-          repositoryLocationName: repoAddress.location,
-        },
+  const [retrievePartitionStatus, {data, loading}] = useLazyQuery<
+    SchedulePartitionStatusQuery,
+    SchedulePartitionStatusQueryVariables
+  >(SCHEDULE_PARTITION_STATUS_QUERY, {
+    variables: {
+      scheduleSelector: {
+        scheduleName,
+        repositoryName: repoAddress.name,
+        repositoryLocationName: repoAddress.location,
       },
     },
-  );
+  });
 
   const onClick = React.useCallback(() => retrievePartitionStatus(), [retrievePartitionStatus]);
 

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleRoot.tsx
@@ -16,9 +16,13 @@ import {RepoAddress} from '../workspace/types';
 import {ScheduleDetails} from './ScheduleDetails';
 import {SCHEDULE_FRAGMENT} from './ScheduleUtils';
 import {SchedulerInfo} from './SchedulerInfo';
-import {PreviousRunsForScheduleQuery} from './types/PreviousRunsForScheduleQuery';
+import {
+  PreviousRunsForScheduleQuery,
+  PreviousRunsForScheduleQueryVariables,
+} from './types/PreviousRunsForScheduleQuery';
 import {
   ScheduleRootQuery,
+  ScheduleRootQueryVariables,
   ScheduleRootQuery_scheduleOrError_Schedule as Schedule,
 } from './types/ScheduleRootQuery';
 
@@ -41,7 +45,7 @@ export const ScheduleRoot: React.FC<Props> = (props) => {
 
   const [selectedTab, setSelectedTab] = React.useState<string>('ticks');
 
-  const queryResult = useQuery<ScheduleRootQuery>(SCHEDULE_ROOT_QUERY, {
+  const queryResult = useQuery<ScheduleRootQuery, ScheduleRootQueryVariables>(SCHEDULE_ROOT_QUERY, {
     variables: {
       scheduleSelector,
     },
@@ -112,18 +116,21 @@ export const SchedulePreviousRuns: React.FC<{
   tabs?: React.ReactElement;
   highlightedIds?: string[];
 }> = ({schedule, highlightedIds, tabs}) => {
-  const {data} = useQuery<PreviousRunsForScheduleQuery>(PREVIOUS_RUNS_FOR_SCHEDULE_QUERY, {
-    fetchPolicy: 'cache-and-network',
-    variables: {
-      limit: 20,
-      filter: {
-        pipelineName: schedule.pipelineName,
-        tags: [{key: DagsterTag.ScheduleName, value: schedule.name}],
+  const {data} = useQuery<PreviousRunsForScheduleQuery, PreviousRunsForScheduleQueryVariables>(
+    PREVIOUS_RUNS_FOR_SCHEDULE_QUERY,
+    {
+      fetchPolicy: 'cache-and-network',
+      variables: {
+        limit: 20,
+        filter: {
+          pipelineName: schedule.pipelineName,
+          tags: [{key: DagsterTag.ScheduleName, value: schedule.name}],
+        },
       },
+      partialRefetch: true,
+      pollInterval: 15 * 1000,
     },
-    partialRefetch: true,
-    pollInterval: 15 * 1000,
-  });
+  );
 
   if (!data) {
     return null;

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleSwitch.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleSwitch.tsx
@@ -13,8 +13,8 @@ import {
   STOP_SCHEDULE_MUTATION,
 } from './ScheduleMutations';
 import {ScheduleSwitchFragment} from './types/ScheduleSwitchFragment';
-import {StartSchedule} from './types/StartSchedule';
-import {StopSchedule} from './types/StopSchedule';
+import {StartSchedule, StartScheduleVariables} from './types/StartSchedule';
+import {StopSchedule, StopScheduleVariables} from './types/StopSchedule';
 
 interface Props {
   repoAddress: RepoAddress;
@@ -29,18 +29,18 @@ export const ScheduleSwitch: React.FC<Props> = (props) => {
 
   const {canStartSchedule, canStopRunningSchedule} = usePermissions();
 
-  const [startSchedule, {loading: toggleOnInFlight}] = useMutation<StartSchedule>(
-    START_SCHEDULE_MUTATION,
-    {
-      onCompleted: displayScheduleMutationErrors,
-    },
-  );
-  const [stopSchedule, {loading: toggleOffInFlight}] = useMutation<StopSchedule>(
-    STOP_SCHEDULE_MUTATION,
-    {
-      onCompleted: displayScheduleMutationErrors,
-    },
-  );
+  const [startSchedule, {loading: toggleOnInFlight}] = useMutation<
+    StartSchedule,
+    StartScheduleVariables
+  >(START_SCHEDULE_MUTATION, {
+    onCompleted: displayScheduleMutationErrors,
+  });
+  const [stopSchedule, {loading: toggleOffInFlight}] = useMutation<
+    StopSchedule,
+    StopScheduleVariables
+  >(STOP_SCHEDULE_MUTATION, {
+    onCompleted: displayScheduleMutationErrors,
+  });
 
   const scheduleSelector = {
     ...repoAddressToSelector(repoAddress),

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
@@ -45,6 +45,7 @@ import {RepositorySchedulesFragment} from './types/RepositorySchedulesFragment';
 import {ScheduleFragment} from './types/ScheduleFragment';
 import {
   ScheduleTickConfigQuery,
+  ScheduleTickConfigQueryVariables,
   ScheduleTickConfigQuery_scheduleOrError_Schedule_futureTick_evaluationResult,
   ScheduleTickConfigQuery_scheduleOrError_Schedule_futureTick_evaluationResult_runRequests,
 } from './types/ScheduleTickConfigQuery';
@@ -169,15 +170,15 @@ const NextTickMenu: React.FC<{
     scheduleName: schedule.name,
   };
   const [isOpen, setOpen] = React.useState<boolean>(false);
-  const [loadTickConfig, {called, loading, data}] = useLazyQuery<ScheduleTickConfigQuery>(
-    SCHEDULE_TICK_CONFIG_QUERY,
-    {
-      variables: {
-        scheduleSelector,
-        tickTimestamp,
-      },
+  const [loadTickConfig, {called, loading, data}] = useLazyQuery<
+    ScheduleTickConfigQuery,
+    ScheduleTickConfigQueryVariables
+  >(SCHEDULE_TICK_CONFIG_QUERY, {
+    variables: {
+      scheduleSelector,
+      tickTimestamp,
     },
-  );
+  });
 
   const infoReady = called ? !loading : false;
   const evaluationResult =

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesRoot.tsx
@@ -14,21 +14,24 @@ import {SCHEDULES_ROOT_QUERY} from './ScheduleUtils';
 import {SchedulerInfo} from './SchedulerInfo';
 import {SchedulesNextTicks} from './SchedulesNextTicks';
 import {SchedulesTable} from './SchedulesTable';
-import {SchedulesRootQuery} from './types/SchedulesRootQuery';
+import {SchedulesRootQuery, SchedulesRootQueryVariables} from './types/SchedulesRootQuery';
 
 export const SchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
   useDocumentTitle('Schedules');
   const repositorySelector = repoAddressToSelector(repoAddress);
 
-  const queryResult = useQuery<SchedulesRootQuery>(SCHEDULES_ROOT_QUERY, {
-    variables: {
-      repositorySelector,
-      instigationType: InstigationType.SCHEDULE,
+  const queryResult = useQuery<SchedulesRootQuery, SchedulesRootQueryVariables>(
+    SCHEDULES_ROOT_QUERY,
+    {
+      variables: {
+        repositorySelector,
+        instigationType: InstigationType.SCHEDULE,
+      },
+      fetchPolicy: 'cache-and-network',
+      pollInterval: 50 * 1000,
+      partialRefetch: true,
     },
-    fetchPolicy: 'cache-and-network',
-    pollInterval: 50 * 1000,
-    partialRefetch: true,
-  });
+  );
 
   return (
     <Loading queryResult={queryResult} allowStaleData={true}>

--- a/js_modules/dagit/packages/core/src/sensors/EditCursorDialog.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/EditCursorDialog.tsx
@@ -11,6 +11,11 @@ import {SharedToaster} from '../app/DomUtils';
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {SensorSelector} from '../types/globalTypes';
 
+import {
+  SetSensorCursorMutation,
+  SetSensorCursorMutationVariables,
+} from './types/SetSensorCursorMutation';
+
 export const EditCursorDialog: React.FC<{
   cursor: string;
   sensorSelector: SensorSelector;
@@ -18,7 +23,9 @@ export const EditCursorDialog: React.FC<{
 }> = ({sensorSelector, cursor, onClose}) => {
   const [cursorValue, setCursorValue] = React.useState(cursor);
   const [isSaving, setIsSaving] = React.useState(false);
-  const [requestSet] = useMutation(SET_CURSOR_MUTATION);
+  const [requestSet] = useMutation<SetSensorCursorMutation, SetSensorCursorMutationVariables>(
+    SET_CURSOR_MUTATION,
+  );
 
   const onSave = async () => {
     setIsSaving(true);
@@ -27,7 +34,7 @@ export const EditCursorDialog: React.FC<{
     });
     if (data?.setSensorCursor.__typename === 'Sensor') {
       SharedToaster.show({message: 'Cursor value updated', intent: 'success'});
-    } else {
+    } else if (data?.setSensorCursor) {
       const error = data.setSensorCursor;
       SharedToaster.show({
         intent: 'danger',
@@ -40,7 +47,12 @@ export const EditCursorDialog: React.FC<{
               onClick={() => {
                 showCustomAlert({
                   title: 'Python Error',
-                  body: <PythonErrorInfo error={error} />,
+                  body:
+                    error.__typename === 'PythonError' ? (
+                      <PythonErrorInfo error={error} />
+                    ) : (
+                      'Sensor not found'
+                    ),
                 });
               }}
             >

--- a/js_modules/dagit/packages/core/src/sensors/SensorPreviousRuns.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorPreviousRuns.tsx
@@ -6,7 +6,10 @@ import {RunTable, RUN_TABLE_RUN_FRAGMENT} from '../runs/RunTable';
 import {DagsterTag} from '../runs/RunTag';
 import {RepoAddress} from '../workspace/types';
 
-import {PreviousRunsForSensorQuery} from './types/PreviousRunsForSensorQuery';
+import {
+  PreviousRunsForSensorQuery,
+  PreviousRunsForSensorQueryVariables,
+} from './types/PreviousRunsForSensorQuery';
 import {SensorFragment} from './types/SensorFragment';
 
 const RUNS_LIMIT = 20;
@@ -17,16 +20,19 @@ export const SensorPreviousRuns: React.FC<{
   tabs?: React.ReactElement;
   highlightedIds?: string[];
 }> = ({sensor, highlightedIds, tabs}) => {
-  const {data} = useQuery<PreviousRunsForSensorQuery>(PREVIOUS_RUNS_FOR_SENSOR_QUERY, {
-    fetchPolicy: 'cache-and-network',
-    variables: {
-      limit: RUNS_LIMIT,
-      filter: {
-        pipelineName: sensor.targets?.length === 1 ? sensor.targets[0].pipelineName : undefined,
-        tags: [{key: DagsterTag.SensorName, value: sensor.name}],
+  const {data} = useQuery<PreviousRunsForSensorQuery, PreviousRunsForSensorQueryVariables>(
+    PREVIOUS_RUNS_FOR_SENSOR_QUERY,
+    {
+      fetchPolicy: 'cache-and-network',
+      variables: {
+        limit: RUNS_LIMIT,
+        filter: {
+          pipelineName: sensor.targets?.length === 1 ? sensor.targets[0].pipelineName : undefined,
+          tags: [{key: DagsterTag.SensorName, value: sensor.name}],
+        },
       },
     },
-  });
+  );
 
   if (!data || data.pipelineRunsOrError.__typename !== 'Runs') {
     return null;

--- a/js_modules/dagit/packages/core/src/sensors/SensorRoot.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorRoot.tsx
@@ -14,7 +14,7 @@ import {SensorDetails} from './SensorDetails';
 import {SENSOR_FRAGMENT} from './SensorFragment';
 import {SensorInfo} from './SensorInfo';
 import {SensorPreviousRuns} from './SensorPreviousRuns';
-import {SensorRootQuery} from './types/SensorRootQuery';
+import {SensorRootQuery, SensorRootQueryVariables} from './types/SensorRootQuery';
 
 const INTERVAL = 15 * 1000;
 
@@ -28,7 +28,7 @@ export const SensorRoot: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) 
   };
 
   const [selectedTab, setSelectedTab] = React.useState<string>('ticks');
-  const queryResult = useQuery<SensorRootQuery>(SENSOR_ROOT_QUERY, {
+  const queryResult = useQuery<SensorRootQuery, SensorRootQueryVariables>(SENSOR_ROOT_QUERY, {
     variables: {
       sensorSelector,
     },

--- a/js_modules/dagit/packages/core/src/sensors/SensorSwitch.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorSwitch.tsx
@@ -13,8 +13,8 @@ import {
   STOP_SENSOR_MUTATION,
 } from './SensorMutations';
 import {SensorSwitchFragment} from './types/SensorSwitchFragment';
-import {StartSensor} from './types/StartSensor';
-import {StopSensor} from './types/StopSensor';
+import {StartSensor, StartSensorVariables} from './types/StartSensor';
+import {StopSensor, StopSensorVariables} from './types/StopSensor';
 
 interface Props {
   repoAddress: RepoAddress;
@@ -33,13 +33,16 @@ export const SensorSwitch: React.FC<Props> = (props) => {
     sensorName: name,
   };
 
-  const [startSensor, {loading: toggleOnInFlight}] = useMutation<StartSensor>(
+  const [startSensor, {loading: toggleOnInFlight}] = useMutation<StartSensor, StartSensorVariables>(
     START_SENSOR_MUTATION,
     {onCompleted: displaySensorMutationErrors},
   );
-  const [stopSensor, {loading: toggleOffInFlight}] = useMutation<StopSensor>(STOP_SENSOR_MUTATION, {
-    onCompleted: displaySensorMutationErrors,
-  });
+  const [stopSensor, {loading: toggleOffInFlight}] = useMutation<StopSensor, StopSensorVariables>(
+    STOP_SENSOR_MUTATION,
+    {
+      onCompleted: displaySensorMutationErrors,
+    },
+  );
 
   const onChangeSwitch = () => {
     if (status === InstigationStatus.RUNNING) {

--- a/js_modules/dagit/packages/core/src/sensors/SensorsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorsRoot.tsx
@@ -15,7 +15,7 @@ import {RepoAddress} from '../workspace/types';
 import {SENSOR_FRAGMENT} from './SensorFragment';
 import {SensorInfo} from './SensorInfo';
 import {SensorsTable} from './SensorsTable';
-import {SensorsRootQuery} from './types/SensorsRootQuery';
+import {SensorsRootQuery, SensorsRootQueryVariables} from './types/SensorsRootQuery';
 
 interface Props {
   repoAddress: RepoAddress;
@@ -26,7 +26,7 @@ export const SensorsRoot = (props: Props) => {
   useDocumentTitle('Sensors');
   const repositorySelector = repoAddressToSelector(repoAddress);
 
-  const queryResult = useQuery<SensorsRootQuery>(SENSORS_ROOT_QUERY, {
+  const queryResult = useQuery<SensorsRootQuery, SensorsRootQueryVariables>(SENSORS_ROOT_QUERY, {
     variables: {
       repositorySelector,
       instigationType: InstigationType.SENSOR,

--- a/js_modules/dagit/packages/core/src/snapshots/SnapshotNav.tsx
+++ b/js_modules/dagit/packages/core/src/snapshots/SnapshotNav.tsx
@@ -8,7 +8,7 @@ import {TabLink} from '../ui/TabLink';
 import {useActivePipelineForName} from '../workspace/WorkspaceContext';
 import {workspacePipelinePathGuessRepo} from '../workspace/workspacePath';
 
-import {SnapshotQuery} from './types/SnapshotQuery';
+import {SnapshotQuery, SnapshotQueryVariables} from './types/SnapshotQuery';
 
 const SNAPSHOT_PARENT_QUERY = gql`
   query SnapshotQuery($snapshotId: String!) {
@@ -28,7 +28,7 @@ interface SnapshotNavProps {
 
 export const SnapshotNav = (props: SnapshotNavProps) => {
   const {activeTab = '', explorerPath} = props;
-  const {pipelineName, snapshotId} = explorerPath;
+  const {pipelineName, snapshotId = ''} = explorerPath;
   const explorerPathString = explorerPathToString({
     ...explorerPath,
     opNames: [],
@@ -38,7 +38,7 @@ export const SnapshotNav = (props: SnapshotNavProps) => {
   const isJob = !!currentPipelineState?.isJob;
   const currentSnapshotID = currentPipelineState?.pipelineSnapshotId;
 
-  const {data, loading} = useQuery<SnapshotQuery>(SNAPSHOT_PARENT_QUERY, {
+  const {data, loading} = useQuery<SnapshotQuery, SnapshotQueryVariables>(SNAPSHOT_PARENT_QUERY, {
     variables: {snapshotId},
   });
 

--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeListContainer.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeListContainer.tsx
@@ -13,7 +13,10 @@ import {findRepoContainingPipeline} from '../workspace/findRepoContainingPipelin
 import {RepoAddress} from '../workspace/types';
 
 import {TypeList, TYPE_LIST_FRAGMENT} from './TypeList';
-import {TypeListContainerQuery} from './types/TypeListContainerQuery';
+import {
+  TypeListContainerQuery,
+  TypeListContainerQueryVariables,
+} from './types/TypeListContainerQuery';
 
 interface ITypeListContainerProps {
   explorerPath: ExplorerPath;
@@ -37,11 +40,14 @@ export const TypeListContainer: React.FC<ITypeListContainerProps> = ({
     return buildPipelineSelector(repoAddress, pipelineName);
   }, [options, pipelineName, repoAddress, snapshotId]);
 
-  const queryResult = useQuery<TypeListContainerQuery>(TYPE_LIST_CONTAINER_QUERY, {
-    fetchPolicy: 'cache-and-network',
-    variables: {pipelineSelector},
-    skip: !pipelineSelector,
-  });
+  const queryResult = useQuery<TypeListContainerQuery, TypeListContainerQueryVariables>(
+    TYPE_LIST_CONTAINER_QUERY,
+    {
+      fetchPolicy: 'cache-and-network',
+      variables: {pipelineSelector: pipelineSelector!},
+      skip: !pipelineSelector,
+    },
+  );
 
   if (!pipelineSelector) {
     return (

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
@@ -10,7 +10,10 @@ import {RepositoryLink} from '../nav/RepositoryLink';
 import {repoAddressAsString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
-import {RepositoryAssetsListQuery} from './types/RepositoryAssetsListQuery';
+import {
+  RepositoryAssetsListQuery,
+  RepositoryAssetsListQueryVariables,
+} from './types/RepositoryAssetsListQuery';
 
 const REPOSITORY_ASSETS_LIST_QUERY = gql`
   query RepositoryAssetsListQuery($repositorySelector: RepositorySelector!) {
@@ -50,7 +53,10 @@ export const RepositoryAssetsList: React.FC<Props> = (props) => {
   const {repoAddress} = props;
   const repositorySelector = repoAddressToSelector(repoAddress);
 
-  const {data, error, loading} = useQuery<RepositoryAssetsListQuery>(REPOSITORY_ASSETS_LIST_QUERY, {
+  const {data, error, loading} = useQuery<
+    RepositoryAssetsListQuery,
+    RepositoryAssetsListQueryVariables
+  >(REPOSITORY_ASSETS_LIST_QUERY, {
     fetchPolicy: 'cache-and-network',
     variables: {repositorySelector},
   });

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryGraphsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryGraphsList.tsx
@@ -9,7 +9,10 @@ import {isAssetGroup} from '../asset-graph/Utils';
 import {repoAddressAsString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
-import {RepositoryGraphsListQuery} from './types/RepositoryGraphsListQuery';
+import {
+  RepositoryGraphsListQuery,
+  RepositoryGraphsListQueryVariables,
+} from './types/RepositoryGraphsListQuery';
 import {workspacePath} from './workspacePath';
 
 const REPOSITORY_GRAPHS_LIST_QUERY = gql`
@@ -66,7 +69,10 @@ export const RepositoryGraphsList: React.FC<Props> = (props) => {
   const {repoAddress} = props;
   const repositorySelector = repoAddressToSelector(repoAddress);
 
-  const {data, error, loading} = useQuery<RepositoryGraphsListQuery>(REPOSITORY_GRAPHS_LIST_QUERY, {
+  const {data, error, loading} = useQuery<
+    RepositoryGraphsListQuery,
+    RepositoryGraphsListQueryVariables
+  >(REPOSITORY_GRAPHS_LIST_QUERY, {
     fetchPolicy: 'cache-and-network',
     variables: {repositorySelector},
   });

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryPipelinesList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryPipelinesList.tsx
@@ -8,7 +8,10 @@ import {PipelineTable, PIPELINE_TABLE_FRAGMENT} from '../pipelines/PipelineTable
 import {repoAddressAsString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
-import {RepositoryPipelinesListQuery} from './types/RepositoryPipelinesListQuery';
+import {
+  RepositoryPipelinesListQuery,
+  RepositoryPipelinesListQueryVariables,
+} from './types/RepositoryPipelinesListQuery';
 
 const REPOSITORY_PIPELINES_LIST_QUERY = gql`
   query RepositoryPipelinesListQuery($repositorySelector: RepositorySelector!) {
@@ -38,13 +41,13 @@ export const RepositoryPipelinesList: React.FC<Props> = (props) => {
   const {display, repoAddress} = props;
   const repositorySelector = repoAddressToSelector(repoAddress);
 
-  const {data, error, loading} = useQuery<RepositoryPipelinesListQuery>(
-    REPOSITORY_PIPELINES_LIST_QUERY,
-    {
-      fetchPolicy: 'cache-and-network',
-      variables: {repositorySelector},
-    },
-  );
+  const {data, error, loading} = useQuery<
+    RepositoryPipelinesListQuery,
+    RepositoryPipelinesListQueryVariables
+  >(REPOSITORY_PIPELINES_LIST_QUERY, {
+    fetchPolicy: 'cache-and-network',
+    variables: {repositorySelector},
+  });
 
   const repo = data?.repositoryOrError;
   const pipelinesForTable = React.useMemo(() => {


### PR DESCRIPTION
## Summary
The core fix here was re-adding the `runsFilter: {pipelineName}` variable to the `JobMetadata` query. 

This went unnoticed because the query was missing the type parameter for it's variables, so I fixed all remaining occurrences of that in the codebase. It looks like we've actually been a bit lazy about typing query + mutation variables, and while I didn't find any other glaring bugs I think we should probably use both type params from now on!


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.