### PR TITLE
[dagit] Show a better error on invalid run filters

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -9,6 +9,7 @@ import {isAssetGroup} from '../asset-graph/Utils';
 import {useSelectionReducer} from '../hooks/useSelectionReducer';
 import {PipelineSnapshotLink} from '../pipelines/PipelinePathUtils';
 import {PipelineReference} from '../pipelines/PipelineReference';
+import {RunsFilter} from '../types/globalTypes';
 import {
   findRepositoryAmongOptions,
   isThisThingAJob,
@@ -28,6 +29,7 @@ import {RunTableRunFragment} from './types/RunTableRunFragment';
 
 interface RunTableProps {
   runs: RunTableRunFragment[];
+  filter?: RunsFilter;
   onSetFilter: (search: RunFilterToken[]) => void;
   nonIdealState?: React.ReactNode;
   actionBarComponents?: React.ReactNode;
@@ -37,7 +39,7 @@ interface RunTableProps {
 }
 
 export const RunTable = (props: RunTableProps) => {
-  const {runs, onSetFilter, nonIdealState, highlightedIds, actionBarComponents} = props;
+  const {runs, filter, onSetFilter, nonIdealState, highlightedIds, actionBarComponents} = props;
   const allIds = runs.map((r) => r.runId);
 
   const [{checkedIds}, {onToggleFactory, onToggleAll}] = useSelectionReducer(allIds);
@@ -48,6 +50,7 @@ export const RunTable = (props: RunTableProps) => {
   const {options} = useRepositoryOptions();
 
   if (runs.length === 0) {
+    const anyFilter = Object.keys(filter || {}).length;
     return (
       <div>
         {actionBarComponents ? (
@@ -57,8 +60,12 @@ export const RunTable = (props: RunTableProps) => {
           {nonIdealState || (
             <NonIdealState
               icon="run"
-              title="No runs to display"
-              description="Use the Launchpad to launch a run."
+              title={anyFilter ? 'No matching runs' : 'No runs to display'}
+              description={
+                anyFilter
+                  ? 'No runs were found for this filter.'
+                  : 'Use the Launchpad to launch a run.'
+              }
             />
           )}
         </Box>


### PR DESCRIPTION
## Summary

Resolves #7219.

A handful of changes to handle errors a bit more gracefully on the Runs page.

- If filters are set but no matching runs are found, show a message that indicates this. Currently we just say that there are no runs and direct you to use the launchpad, but this isn't helpful if you *do* have runs but none of them match what you've searched.
- If a 400 error occurs during the filter request, show an error that represents this.
  - The current behavior is to show that a GraphQL error has occurred and continue spinning the page spinner indefinitely. This is a pretty bad experience given that the user might not realize that they have provided an invalid filter.
- Modify `Loading` to allow a custom error state. This is used in the error state described above.

## Test Plan

View Runs page. Set `status:foo`, verify that the new error appears instead of the page spinning forever.

Search for valid values, verify that they are retrieved correctly. Search for something that returns no runs, verify that the new empty state appears.
