### PR TITLE
Add runsFilter to JobMetadataQuery

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
@@ -29,6 +29,9 @@ export const JobMetadata: React.FC<Props> = (props) => {
         repositoryName: repoAddress.name,
         repositoryLocationName: repoAddress.location,
       },
+      runsFilter: {
+        pipelineName,
+      },
     },
   });
 


### PR DESCRIPTION
A user [reported a bug](https://dagster.slack.com/archives/C02PV2JNBNF/p1650371321911769) where the `RelatedAssets` module was displaying assets that were not generated within the job. The cause of this issue is that the `JOB_METADATA_QUERY` returned the last 5 runs without filtering for job name, and then displayed all assets that had events in the last 5 runs.

This PR fixes this issue by adding a `runsFilter` with `pipelineName` so only runs for the displayed job are selected.