### PR TITLE
[rfc] Resources on repos, resource overrides on job

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
@@ -12,7 +12,9 @@ from ..repository_definition import (
     CachingRepositoryData,
     RepositoryData,
     RepositoryDefinition,
+    is_resource_dict,
 )
+from ..resource_definition import ResourceDefinition
 from ..schedule_definition import ScheduleDefinition
 from ..sensor_definition import SensorDefinition
 
@@ -43,6 +45,7 @@ class _Repository:
                     or isinstance(definition, SensorDefinition)
                     or isinstance(definition, GraphDefinition)
                     or isinstance(definition, AssetGroup)
+                    or is_resource_dict(definition)
                 ):
                     bad_definitions.append((i, type(definition)))
             if bad_definitions:
@@ -55,7 +58,7 @@ class _Repository:
                 raise DagsterInvalidDefinitionError(
                     "Bad return value from repository construction function: all elements of list "
                     "must be of type JobDefinition, GraphDefinition, PipelineDefinition, "
-                    "PartitionSetDefinition, ScheduleDefinition, or SensorDefinition. "
+                    "PartitionSetDefinition, ScheduleDefinition, SensorDefinition, or dictionary of resources. "
                     f"Got {bad_definitions_str}."
                 )
             repository_data = CachingRepositoryData.from_list(repository_definitions)

--- a/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
@@ -14,7 +14,6 @@ from ..repository_definition import (
     RepositoryDefinition,
     is_resource_dict,
 )
-from ..resource_definition import ResourceDefinition
 from ..schedule_definition import ScheduleDefinition
 from ..sensor_definition import SensorDefinition
 

--- a/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
@@ -58,7 +58,7 @@ class _Repository:
                 raise DagsterInvalidDefinitionError(
                     "Bad return value from repository construction function: all elements of list "
                     "must be of type JobDefinition, GraphDefinition, PipelineDefinition, "
-                    "PartitionSetDefinition, ScheduleDefinition, SensorDefinition, or dictionary of resources. "
+                    "PartitionSetDefinition, ScheduleDefinition, SensorDefinition, or a dictionary mapping resource keys to ResourceDefinitions. "
                     f"Got {bad_definitions_str}."
                 )
             repository_data = CachingRepositoryData.from_list(repository_definitions)

--- a/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
@@ -26,6 +26,8 @@ class _Repository:
     def __call__(self, fn: Callable[[], Any]) -> RepositoryDefinition:
         from dagster.core.asset_defs import AssetGroup
 
+        from ..job_definition import PendingJobDefinition
+
         check.callable_param(fn, "fn")
 
         if not self.name:
@@ -44,6 +46,7 @@ class _Repository:
                     or isinstance(definition, SensorDefinition)
                     or isinstance(definition, GraphDefinition)
                     or isinstance(definition, AssetGroup)
+                    or isinstance(definition, PendingJobDefinition)
                     or is_resource_dict(definition)
                 ):
                     bad_definitions.append((i, type(definition)))

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
 
     from .asset_layer import AssetLayer
     from .executor_definition import ExecutorDefinition
-    from .job_definition import JobDefinition
+    from .job_definition import JobDefinition, PendingJobDefinition
     from .partition import PartitionedConfig, PartitionsDefinition
     from .solid_definition import SolidDefinition
 
@@ -517,7 +517,7 @@ class GraphDefinition(NodeDefinition):
             JobDefinition
         """
         from .executor_definition import ExecutorDefinition, multi_or_in_process_executor
-        from .job_definition import JobDefinition
+        from .job_definition import JobDefinition, PendingJobDefinition
         from .partition import PartitionedConfig, PartitionsDefinition
 
         job_name = check_valid_name(name or self.name)
@@ -567,13 +567,145 @@ class GraphDefinition(NodeDefinition):
                 f"config param must be a ConfigMapping, a PartitionedConfig, or a dictionary, but "
                 f"is an object of type {type(config)}"
             )
-
         return JobDefinition(
             name=job_name,
             description=description or self.description,
             graph_def=self,
             resource_defs=resource_defs_with_defaults,
             logger_defs=logger_defs,
+            executor_def=executor_def,
+            config_mapping=config_mapping,
+            partitioned_config=partitioned_config,
+            preset_defs=presets,
+            tags=tags,
+            hook_defs=hooks,
+            version_strategy=version_strategy,
+            op_retry_policy=op_retry_policy,
+            asset_layer=asset_layer,
+        ).get_job_def_for_op_selection(op_selection)
+
+    def to_partial_job(
+        self,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        resource_defs: Optional[Dict[str, ResourceDefinition]] = None,
+        config: Optional[Union[ConfigMapping, Dict[str, Any], "PartitionedConfig"]] = None,
+        tags: Optional[Dict[str, Any]] = None,
+        logger_defs: Optional[Dict[str, LoggerDefinition]] = None,
+        executor_def: Optional["ExecutorDefinition"] = None,
+        hooks: Optional[AbstractSet[HookDefinition]] = None,
+        op_retry_policy: Optional[RetryPolicy] = None,
+        version_strategy: Optional[VersionStrategy] = None,
+        op_selection: Optional[List[str]] = None,
+        partitions_def: Optional["PartitionsDefinition"] = None,
+        asset_layer: Optional["AssetLayer"] = None,
+    ) -> "PendingJobDefinition":
+        """
+        Make this graph into a partial (non-executable) Job by providing remaining components required for execution.
+
+        Args:
+            name (Optional[str]):
+                The name for the Job. Defaults to the name of the this graph.
+            resource_defs (Optional[Dict[str, ResourceDefinition]]):
+                Resources that are required by this graph for execution.
+                If not defined, `io_manager` will default to filesystem.
+            config:
+                Describes how the job is parameterized at runtime.
+
+                If no value is provided, then the schema for the job's run config is a standard
+                format based on its solids and resources.
+
+                If a dictionary is provided, then it must conform to the standard config schema, and
+                it will be used as the job's run config for the job whenever the job is executed.
+                The values provided will be viewable and editable in the Dagit playground, so be
+                careful with secrets.
+
+                If a :py:class:`ConfigMapping` object is provided, then the schema for the job's run config is
+                determined by the config mapping, and the ConfigMapping, which should return
+                configuration in the standard format to configure the job.
+
+                If a :py:class:`PartitionedConfig` object is provided, then it defines a discrete set of config
+                values that can parameterize the job, as well as a function for mapping those
+                values to the base config. The values provided will be viewable and editable in the
+                Dagit playground, so be careful with secrets.
+            tags (Optional[Dict[str, Any]]):
+                Arbitrary metadata for any execution of the Job.
+                Values that are not strings will be json encoded and must meet the criteria that
+                `json.loads(json.dumps(value)) == value`.  These tag values may be overwritten by tag
+                values provided at invocation time.
+            logger_defs (Optional[Dict[str, LoggerDefinition]]):
+                A dictionary of string logger identifiers to their implementations.
+            executor_def (Optional[ExecutorDefinition]):
+                How this Job will be executed. Defaults to :py:class:`multi_or_in_process_executor`,
+                which can be switched between multi-process and in-process modes of execution. The
+                default mode of execution is multi-process.
+            op_retry_policy (Optional[RetryPolicy]): The default retry policy for all ops in this job.
+                Only used if retry policy is not defined on the op definition or op invocation.
+            version_strategy (Optional[VersionStrategy]):
+                Defines how each solid (and optionally, resource) in the job can be versioned. If
+                provided, memoizaton will be enabled for this job.
+            partitions_def (Optional[PartitionsDefinition]): Defines a discrete set of partition
+                keys that can parameterize the job. If this argument is supplied, the config
+                argument can't also be supplied.
+            asset_layer (Optional[AssetLayer]): Top level information about the assets this job
+                will produce. Generally should not be set manually.
+
+        Returns:
+            PendingJobDefinition
+        """
+        from .executor_definition import ExecutorDefinition, multi_or_in_process_executor
+        from .job_definition import JobDefinition, PendingJobDefinition
+        from .partition import PartitionedConfig, PartitionsDefinition
+
+        job_name = check_valid_name(name or self.name)
+
+        tags = check.opt_dict_param(tags, "tags", key_type=str)
+        executor_def = check.opt_inst_param(
+            executor_def, "executor_def", ExecutorDefinition, default=multi_or_in_process_executor
+        )
+
+        resource_defs = check.opt_mapping_param(resource_defs, "resource_defs")
+
+        hooks = check.opt_set_param(hooks, "hooks", of_type=HookDefinition)
+        op_retry_policy = check.opt_inst_param(op_retry_policy, "op_retry_policy", RetryPolicy)
+        op_selection = check.opt_list_param(op_selection, "op_selection", of_type=str)
+        presets = []
+        config_mapping = None
+        partitioned_config = None
+
+        if partitions_def:
+            check.inst_param(partitions_def, "partitions_def", PartitionsDefinition)
+            check.invariant(
+                config is None, "Can't supply both the 'config' and 'partitions_def' arguments"
+            )
+            partitioned_config = PartitionedConfig(partitions_def, lambda _: {})
+
+        if isinstance(config, ConfigMapping):
+            config_mapping = config
+        elif isinstance(config, PartitionedConfig):
+            partitioned_config = config
+        elif isinstance(config, dict):
+            presets = [PresetDefinition(name="default", run_config=config)]
+            # Using config mapping here is a trick to make it so that the preset will be used even
+            # when no config is supplied for the job.
+            config_mapping = _config_mapping_with_default_value(
+                self._get_config_schema(resource_defs_with_defaults, executor_def, logger_defs),
+                config,
+                job_name,
+                self.name,
+            )
+        elif config is not None:
+            check.failed(
+                f"config param must be a ConfigMapping, a PartitionedConfig, or a dictionary, but "
+                f"is an object of type {type(config)}"
+            )
+
+        return PendingJobDefinition(
+            name=job_name,
+            description=description or self.description,
+            graph_def=self,
+            resource_defs=resource_defs,
+            loggers=logger_defs,
             executor_def=executor_def,
             config_mapping=config_mapping,
             partitioned_config=partitioned_config,
@@ -655,7 +787,7 @@ class GraphDefinition(NodeDefinition):
         from dagster.core.instance import DagsterInstance
 
         from .executor_definition import execute_in_process_executor
-        from .job_definition import JobDefinition
+        from .job_definition import JobDefinition, PendingJobDefinition
 
         instance = check.opt_inst_param(instance, "instance", DagsterInstance)
         resources = check.opt_dict_param(resources, "resources", key_type=str)

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -7,6 +7,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Mapping,
     Optional,
     Set,
     Tuple,
@@ -517,7 +518,7 @@ class GraphDefinition(NodeDefinition):
             JobDefinition
         """
         from .executor_definition import ExecutorDefinition, multi_or_in_process_executor
-        from .job_definition import JobDefinition, PendingJobDefinition
+        from .job_definition import JobDefinition
         from .partition import PartitionedConfig, PartitionsDefinition
 
         job_name = check_valid_name(name or self.name)
@@ -654,7 +655,7 @@ class GraphDefinition(NodeDefinition):
             PendingJobDefinition
         """
         from .executor_definition import ExecutorDefinition, multi_or_in_process_executor
-        from .job_definition import JobDefinition, PendingJobDefinition
+        from .job_definition import PendingJobDefinition
         from .partition import PartitionedConfig, PartitionsDefinition
 
         job_name = check_valid_name(name or self.name)
@@ -689,7 +690,7 @@ class GraphDefinition(NodeDefinition):
             # Using config mapping here is a trick to make it so that the preset will be used even
             # when no config is supplied for the job.
             config_mapping = _config_mapping_with_default_value(
-                self._get_config_schema(resource_defs_with_defaults, executor_def, logger_defs),
+                self._get_config_schema(resource_defs, executor_def, logger_defs),
                 config,
                 job_name,
                 self.name,
@@ -729,7 +730,7 @@ class GraphDefinition(NodeDefinition):
 
     def _get_config_schema(
         self,
-        resource_defs: Optional[Dict[str, ResourceDefinition]],
+        resource_defs: Optional[Mapping[str, ResourceDefinition]],
         executor_def: "ExecutorDefinition",
         logger_defs: Optional[Dict[str, LoggerDefinition]],
     ) -> ConfigType:
@@ -787,7 +788,7 @@ class GraphDefinition(NodeDefinition):
         from dagster.core.instance import DagsterInstance
 
         from .executor_definition import execute_in_process_executor
-        from .job_definition import JobDefinition, PendingJobDefinition
+        from .job_definition import JobDefinition
 
         instance = check.opt_inst_param(instance, "instance", DagsterInstance)
         resources = check.opt_dict_param(resources, "resources", key_type=str)

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -6,6 +6,7 @@ from typing import (
     Dict,
     List,
     Mapping,
+    NamedTuple,
     Optional,
     Tuple,
     Type,
@@ -35,6 +36,7 @@ from dagster.core.selector.subset_selector import (
 )
 from dagster.core.storage.fs_asset_io_manager import fs_asset_io_manager
 from dagster.core.utils import str_format_set
+from dagster.utils import merge_dicts
 
 from .asset_layer import AssetLayer
 from .config import ConfigMapping
@@ -51,6 +53,7 @@ from .run_request import RunRequest
 from .version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
+    from dagster.core.definitions.partition import PartitionedConfig
     from dagster.core.execution.execute_in_process_result import ExecuteInProcessResult
     from dagster.core.instance import DagsterInstance
     from dagster.core.snap import PipelineSnapshot
@@ -240,7 +243,7 @@ class JobDefinition(PipelineDefinition):
 
         op_selection = check.opt_list_param(op_selection, "op_selection", str)
 
-        resolved_op_selection_dict = parse_op_selection(self, op_selection)
+        resolved_op_selection_dict = parse_op_selection(self.graph, op_selection)
 
         sub_graph = get_subselected_graph_definition(self.graph, resolved_op_selection_dict)
 
@@ -468,3 +471,84 @@ def get_subselected_graph_definition(
             f"The attempted subset {str_format_set(resolved_op_selection_dict)} for graph "
             f"{graph.name} results in an invalid graph."
         ) from exc
+
+
+class PendingJobDefinition(NamedTuple):
+    resource_defs: Optional[Dict[str, ResourceDefinition]]
+    loggers: Optional[Dict[str, LoggerDefinition]]
+    executor_def: Optional[ExecutorDefinition]
+    config_mapping: Optional[ConfigMapping]
+    partitioned_config: Optional["PartitionedConfig"]
+    graph_def: GraphDefinition
+    name: Optional[str] = None
+    description: Optional[str] = None
+    preset_defs: Optional[List[PresetDefinition]] = None
+    tags: Optional[Dict[str, Any]] = None
+    hook_defs: Optional[AbstractSet[HookDefinition]] = None
+    op_retry_policy: Optional[RetryPolicy] = None
+    version_strategy: Optional[VersionStrategy] = None
+    op_selection_data: Optional[OpSelectionData] = None
+    asset_layer: Optional[AssetLayer] = None
+
+    def coerce_to_job_def(self, resource_defs: Dict[str, ResourceDefinition]) -> JobDefinition:
+        override_resource_defs = self.resource_defs
+        loggers = self.loggers
+        executor_def = self.executor_def
+
+        resource_defs = merge_dicts(
+            resource_defs, override_resource_defs if override_resource_defs else {}
+        )
+
+        return JobDefinition(
+            resource_defs=resource_defs,
+            logger_defs=self.loggers,
+            executor_def=self.executor_def,
+            config_mapping=self.config_mapping,
+            partitioned_config=self.partitioned_config,
+            graph_def=self.graph_def,
+            name=self.name,
+            description=self.description,
+            preset_defs=self.preset_defs,
+            tags=self.tags,
+            hook_defs=self.hook_defs,
+            op_retry_policy=self.op_retry_policy,
+            version_strategy=self.version_strategy,
+            _op_selection_data=self.op_selection_data,
+            asset_layer=self.asset_layer,
+        )
+
+    def get_job_def_for_op_selection(
+        self,
+        op_selection: Optional[List[str]] = None,
+    ) -> "PendingJobDefinition":
+        if not op_selection:
+            return self
+
+        op_selection = check.opt_list_param(op_selection, "op_selection", str)
+
+        resolved_op_selection_dict = parse_op_selection(self.graph_def, op_selection)
+
+        sub_graph = get_subselected_graph_definition(self.graph_def, resolved_op_selection_dict)
+
+        return PendingJobDefinition(
+            name=self.name,
+            description=self.description,
+            resource_defs=self.resource_defs,
+            loggers=self.loggers,
+            executor_defs=self.executor_defs,
+            config_mapping=self.config_mapping,
+            partitioned_config=self.partitioned_config,
+            preset_defs=self.preset_defs,
+            tags=self.tags,
+            hook_defs=self.hook_defs,
+            op_retry_policy=self.op_retry_policy,
+            graph_def=sub_graph,
+            version_strategy=self.version_strategy,
+            op_selection_data=OpSelectionData(
+                op_selection=op_selection,
+                resolved_op_selection=set(
+                    resolved_op_selection_dict.keys()
+                ),  # equivalent to solids_to_execute. currently only gets top level nodes.
+                parent_job_def=self,  # used by pipeline snapshot lineage
+            ),
+        )

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -63,7 +63,7 @@ class JobDefinition(PipelineDefinition):
     def __init__(
         self,
         graph_def: GraphDefinition,
-        resource_defs: Optional[Dict[str, ResourceDefinition]] = None,
+        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         executor_def: Optional[ExecutorDefinition] = None,
         logger_defs: Optional[Dict[str, LoggerDefinition]] = None,
         config_mapping: Optional[ConfigMapping] = None,
@@ -81,7 +81,7 @@ class JobDefinition(PipelineDefinition):
 
         # Exists for backcompat - JobDefinition is implemented as a single-mode pipeline.
         mode_def = ModeDefinition(
-            resource_defs=resource_defs,
+            resource_defs=cast(Optional[Dict[str, ResourceDefinition]], resource_defs),
             logger_defs=logger_defs,
             executor_defs=[executor_def] if executor_def else None,
             _config_mapping=config_mapping,
@@ -474,7 +474,7 @@ def get_subselected_graph_definition(
 
 
 class PendingJobDefinition(NamedTuple):
-    resource_defs: Optional[Dict[str, ResourceDefinition]]
+    resource_defs: Optional[Mapping[str, ResourceDefinition]]
     loggers: Optional[Dict[str, LoggerDefinition]]
     executor_def: Optional[ExecutorDefinition]
     config_mapping: Optional[ConfigMapping]
@@ -492,8 +492,6 @@ class PendingJobDefinition(NamedTuple):
 
     def coerce_to_job_def(self, resource_defs: Dict[str, ResourceDefinition]) -> JobDefinition:
         override_resource_defs = self.resource_defs
-        loggers = self.loggers
-        executor_def = self.executor_def
 
         resource_defs = merge_dicts(
             resource_defs, override_resource_defs if override_resource_defs else {}
@@ -535,7 +533,7 @@ class PendingJobDefinition(NamedTuple):
             description=self.description,
             resource_defs=self.resource_defs,
             loggers=self.loggers,
-            executor_defs=self.executor_defs,
+            executor_def=self.executor_def,
             config_mapping=self.config_mapping,
             partitioned_config=self.partitioned_config,
             preset_defs=self.preset_defs,

--- a/python_modules/dagster/dagster/core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/repository_definition.py
@@ -706,7 +706,7 @@ class CachingRepositoryData(RepositoryData):
                     default_resources_dict = definition
                 else:
                     check.failed(
-                        f"Provided multiple resource dictionaries to repository, please provide only one."
+                        "Provided multiple resource dictionaries to repository, please provide only one."
                     )
             else:
                 check.failed(f"Unexpected repository entry {definition}")

--- a/python_modules/dagster/dagster/core/definitions/target.py
+++ b/python_modules/dagster/dagster/core/definitions/target.py
@@ -1,9 +1,13 @@
-from typing import List, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Mapping, NamedTuple, Optional, Union, cast
 
 from dagster import check
 
 from .graph_definition import GraphDefinition
-from .pipeline_definition import PipelineDefinition
+from .resource_definition import ResourceDefinition
+
+if TYPE_CHECKING:
+    from .job_definition import JobDefinition, PendingJobDefinition
+    from .pipeline_definition import PipelineDefinition
 
 
 class RepoRelativeTarget(NamedTuple):
@@ -16,44 +20,53 @@ class RepoRelativeTarget(NamedTuple):
     solid_selection: Optional[List[str]]
 
 
-class DirectTarget(NamedTuple("_DirectTarget", [("pipeline", PipelineDefinition)])):
+class DirectTarget(
+    NamedTuple(
+        "_DirectTarget",
+        [("target", Union[GraphDefinition, "JobDefinition", "PendingJobDefinition"])],
+    )
+):
     """
     The thing to be executed by a schedule or sensor, referenced directly and loaded
     in to any repository the container is included in.
     """
 
-    def __new__(cls, graph: Union[GraphDefinition, PipelineDefinition]):
-        check.inst_param(graph, "graph", (GraphDefinition, PipelineDefinition))
+    def __new__(cls, target: Union[GraphDefinition, "JobDefinition", "PendingJobDefinition"]):
+        from .job_definition import JobDefinition, PendingJobDefinition
 
-        # pipeline will become job / execution target
-        if isinstance(graph, PipelineDefinition):
-            pipeline = graph
-        else:
-            pipeline = graph.to_job(resource_defs={})
-
-        check.invariant(
-            len(pipeline.mode_definitions) == 1,
-            f"Pipeline {pipeline.name} has more than one mode which makes it an invalid "
-            "execution target.",
-        )
+        check.inst_param(target, "target", (GraphDefinition, JobDefinition, PendingJobDefinition))
 
         return super().__new__(
             cls,
-            pipeline,
+            target,
         )
+
+    def load(self, resource_defs: Mapping[str, ResourceDefinition]) -> "PipelineDefinition":
+        from .job_definition import PendingJobDefinition
+
+        # Can probably memoize this.
+        if isinstance(self.target, GraphDefinition):
+            return self.target.to_job(
+                resource_defs=cast(Dict[str, ResourceDefinition], resource_defs)
+            )
+        elif isinstance(self.target, PendingJobDefinition):
+            return self.target.coerce_to_job_def(resource_defs=resource_defs)
+        else:
+            return self.target
 
     @property
     def pipeline_name(self) -> str:
-        return self.pipeline.name
+        return self.target.name
+
+    @property
+    def pipeline(self) -> Union[GraphDefinition, "JobDefinition", "PendingJobDefinition"]:
+        return self.target
 
     @property
     def mode(self) -> str:
-        return self.pipeline.mode_definitions[0].name
+        return "default"
 
     @property
     def solid_selection(self):
         # open question on how to direct target subset pipeline
         return None
-
-    def load(self) -> PipelineDefinition:
-        return self.pipeline

--- a/python_modules/dagster/dagster/core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/core/selector/subset_selector.py
@@ -1,14 +1,16 @@
 import re
 import sys
 from collections import defaultdict, deque
-from typing import TYPE_CHECKING, AbstractSet, Dict, List, NamedTuple
+from typing import TYPE_CHECKING, AbstractSet, Dict, List, NamedTuple, Union
 
 from dagster.core.definitions.dependency import DependencyStructure
 from dagster.core.errors import DagsterExecutionStepNotFoundError, DagsterInvalidSubsetError
 from dagster.utils import check
 
 if TYPE_CHECKING:
-    from dagster.core.definitions.job_definition import JobDefinition
+    from dagster.core.definitions.graph_definition import GraphDefinition
+
+    from ..definitions.job_definition import JobDefinition, PendingJobDefinition
 
 MAX_NUM = sys.maxsize
 
@@ -19,7 +21,7 @@ class OpSelectionData(
         [
             ("op_selection", List[str]),
             ("resolved_op_selection", AbstractSet[str]),
-            ("parent_job_def", "JobDefinition"),
+            ("parent_job_def", Union["JobDefinition", "PendingJobDefinition"]),
         ],
     )
 ):
@@ -33,7 +35,7 @@ class OpSelectionData(
     """
 
     def __new__(cls, op_selection, resolved_op_selection, parent_job_def):
-        from dagster.core.definitions.job_definition import JobDefinition
+        from dagster.core.definitions.job_definition import JobDefinition, PendingJobDefinition
 
         return super(OpSelectionData, cls).__new__(
             cls,
@@ -45,7 +47,7 @@ class OpSelectionData(
         )
 
 
-def generate_dep_graph(pipeline_def):
+def generate_dep_graph(graph_def):
     """'pipeline to dependency graph. It currently only supports top-level solids.
 
     Args:
@@ -71,9 +73,9 @@ def generate_dep_graph(pipeline_def):
             ```
     """
     dependency_structure = check.inst_param(
-        pipeline_def.dependency_structure, "dependency_structure", DependencyStructure
+        graph_def.dependency_structure, "dependency_structure", DependencyStructure
     )
-    item_names = [i.name for i in pipeline_def.solids]
+    item_names = [i.name for i in graph_def.solids]
 
     # defaultdict isn't appropriate because we also want to include items without dependencies
     graph = {"upstream": {}, "downstream": {}}
@@ -210,7 +212,7 @@ def convert_dot_seperated_string_to_dict(tree, splits):
     return tree
 
 
-def parse_op_selection(job_def: "JobDefinition", op_selection: List[str]) -> Dict:
+def parse_op_selection(graph_def: "GraphDefinition", op_selection: List[str]) -> Dict:
     """
     Examples:
         ["subgraph.return_one", "subgraph.adder", "subgraph.add_one", "add_one"]
@@ -230,11 +232,11 @@ def parse_op_selection(job_def: "JobDefinition", op_selection: List[str]) -> Dic
 
     return {
         top_level_op: LeafNodeSelection
-        for top_level_op in parse_solid_selection(job_def, op_selection)
+        for top_level_op in parse_solid_selection(graph_def, op_selection)
     }
 
 
-def parse_solid_selection(pipeline_def, solid_selection):
+def parse_solid_selection(graph_def, solid_selection):
     """Take pipeline definition and a list of solid selection queries (inlcuding names of solid
         invocations. See syntax examples below) and return a set of the qualified solid names.
 
@@ -265,9 +267,9 @@ def parse_solid_selection(pipeline_def, solid_selection):
 
     # special case: select all
     if len(solid_selection) == 1 and solid_selection[0] == "*":
-        return frozenset(pipeline_def.graph.node_names())
+        return frozenset(graph_def.node_names())
 
-    graph = generate_dep_graph(pipeline_def)
+    graph = generate_dep_graph(graph_def)
     solids_set = set()
 
     # loop over clauses
@@ -275,10 +277,8 @@ def parse_solid_selection(pipeline_def, solid_selection):
         subset = clause_to_subset(graph, clause)
         if len(subset) == 0:
             raise DagsterInvalidSubsetError(
-                "No qualified {node_type} to execute found for {selection_type}={requested}".format(
-                    requested=solid_selection,
-                    node_type="ops" if pipeline_def.is_job else "solids",
-                    selection_type="op_selection" if pipeline_def.is_job else "solid_selection",
+                "No qualified ops to execute found for op_selection={requested}".format(
+                    requested=solid_selection
                 )
             )
         solids_set.update(subset)

--- a/python_modules/dagster/dagster/core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/core/selector/subset_selector.py
@@ -35,7 +35,7 @@ class OpSelectionData(
     """
 
     def __new__(cls, op_selection, resolved_op_selection, parent_job_def):
-        from dagster.core.definitions.job_definition import JobDefinition, PendingJobDefinition
+        from dagster.core.definitions.job_definition import JobDefinition
 
         return super(OpSelectionData, cls).__new__(
             cls,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -22,6 +22,7 @@ from dagster import (
     op,
     pipeline,
     repository,
+    resource,
     schedule,
     sensor,
     solid,
@@ -644,3 +645,22 @@ def test_multiple_asset_groups_one_repo():
         AssetKey(["asset1"]),
         AssetKey(["asset2"]),
     }
+
+
+def test_repo_with_resources():
+    @resource
+    def the_resource():
+        pass
+
+    @repository
+    def the_repo():
+        return [{"foo": the_resource}]
+
+    with pytest.raises(
+        CheckError,
+        match="Provided multiple resource dictionaries to repository, please provide only one.",
+    ):
+
+        @repository
+        def the_repo_multiple_resource_dicts():
+            return [{"foo": the_resource}, {"foo": the_resource}]

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -243,7 +243,7 @@ def my_pipeline_started_sensor(context):
     assert isinstance(context.instance, DagsterInstance)
 
 
-config_job = config_graph.to_job()
+config_job = config_graph.to_job(name="config_job")
 
 
 @sensor(jobs=[the_job, config_job])


### PR DESCRIPTION
One possible implementation world for resources on repositories and partial resources for jobs. In the 0.15.0 timeframe, this could be opt-in via a flag.

- I went with a `PartialJobDefinition` implementation of partial resources. Ideally, I'd like to go for an approach where any JobDefinition can just have partial resource sets defined, but since job definition is still built on top of pipeline definition, this would also end up affecting pipeline users. (If pipeline was built on top of job, then we could just gate on all resources being satisfied at pipeline construction time).
- Since resources are just provided in a bare dictionary here, it's difficult to configure them. I think people generally prefer supplying one big blob of config (a config argument on a `ResourceSet` class or something) rather than a bunch of tiny blobs of config (using configured on every item in a dictionary).