### PR TITLE
Create runs during event log tests

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -3,7 +3,9 @@ import logging  # pylint: disable=unused-import; used by mock in string form
 import re
 import time
 from collections import Counter
-from contextlib import ExitStack
+from contextlib import ExitStack, contextmanager, nullcontext
+from typing import Generator, List, Optional
+from venv import create
 
 import mock
 import pendulum
@@ -23,6 +25,8 @@ from dagster import (
     RetryRequested,
     asset,
     build_assets_job,
+    check,
+    job,
     op,
     pipeline,
     resource,
@@ -48,6 +52,7 @@ from dagster.core.execution.stats import StepEventStatus
 from dagster.core.storage.event_log import InMemoryEventLogStorage, SqlEventLogStorage
 from dagster.core.storage.event_log.base import (
     EventLogRecord,
+    EventLogStorage,
     EventRecordsFilter,
     RunShardedEventsCursor,
 )
@@ -56,13 +61,11 @@ from dagster.core.storage.event_log.migration import (
     migrate_asset_key_data,
 )
 from dagster.core.storage.event_log.sqlite.sqlite_event_log import SqliteEventLogStorage
-from dagster.core.test_utils import instance_for_test
+from dagster.core.test_utils import create_run_for_test, instance_for_test
 from dagster.core.utils import make_new_run_id
 from dagster.loggers import colored_console_logger
 from dagster.serdes import deserialize_json_to_dagster_namedtuple
 from dagster.utils import datetime_as_float
-
-DEFAULT_RUN_ID = "foo"
 
 TEST_TIMEOUT = 5
 
@@ -70,7 +73,20 @@ TEST_TIMEOUT = 5
 # pylint: disable=unnecessary-lambda
 
 
-def create_test_event_log_record(message: str, run_id: str = DEFAULT_RUN_ID):
+@contextmanager
+def create_and_delete_test_runs(instance: DagsterInstance, run_ids: List[str]):
+    check.opt_inst_param(instance, "instance", DagsterInstance)
+    check.list_param(run_ids, "run_ids", of_type=str)
+    if instance:
+        for run_id in run_ids:
+            create_run_for_test(instance, run_id=run_id)
+    yield
+    if instance:
+        for run_id in run_ids:
+            instance.delete_run(run_id)
+
+
+def create_test_event_log_record(message: str, run_id):
     return EventLogEntry(
         error_info=None,
         user_message=message,
@@ -209,10 +225,11 @@ def _synthesize_events(solids_fn, run_id=None, check_success=True, instance=None
             **(run_config if run_config else {}),
         }
 
+        print(instance.get_runs())
         pipeline_run = instance.create_run_for_pipeline(
             a_pipe, run_id=run_id, run_config=run_config
         )
-
+        print(instance.get_runs())
         result = execute_run(InMemoryPipeline(a_pipe), pipeline_run, instance)
 
         if check_success:
@@ -276,8 +293,8 @@ def cursor_datetime_args():
     yield datetime.datetime.now()
 
 
-def _execute_job_and_store_events(instance, storage, job):
-    result = job.execute_in_process(instance=instance, raise_on_error=False)
+def _execute_job_and_store_events(instance, storage, job, run_id):
+    result = job.execute_in_process(instance=instance, raise_on_error=False, run_id=run_id)
     events = instance.all_logs(run_id=result.run_id)
     for event in events:
         storage.store_event(event)
@@ -312,6 +329,16 @@ class TestEventLogStorage:
             finally:
                 s.dispose()
 
+    @pytest.fixture(name="instance")
+    def instance(self, request) -> Optional[DagsterInstance]:
+        return None
+
+    @pytest.fixture(scope="function", name="test_run_id")
+    def create_run_and_get_run_id(self, instance):
+        run_id = make_new_run_id()
+        with create_and_delete_test_runs(instance, [run_id]):
+            yield run_id
+
     def test_init_log_storage(self, storage):
         if isinstance(storage, InMemoryEventLogStorage):
             assert not storage.is_persistent
@@ -329,14 +356,14 @@ class TestEventLogStorage:
         # Whether the storage is allowed to watch the event log
         return True
 
-    def test_event_log_storage_store_events_and_wipe(self, storage):
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID)) == 0
+    def test_event_log_storage_store_events_and_wipe(self, test_run_id, storage):
+        assert len(storage.get_logs_for_run(test_run_id)) == 0
         storage.store_event(
             EventLogEntry(
                 error_info=None,
                 level="debug",
                 user_message="",
-                run_id=DEFAULT_RUN_ID,
+                run_id=test_run_id,
                 timestamp=time.time(),
                 dagster_event=DagsterEvent(
                     DagsterEventType.ENGINE_EVENT.value,
@@ -345,15 +372,18 @@ class TestEventLogStorage:
                 ),
             )
         )
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID)) == 1
-        assert storage.get_stats_for_run(DEFAULT_RUN_ID)
+        assert len(storage.get_logs_for_run(test_run_id)) == 1
+        assert storage.get_stats_for_run(test_run_id)
 
         if self.can_wipe():
             storage.wipe()
-            assert len(storage.get_logs_for_run(DEFAULT_RUN_ID)) == 0
+            assert len(storage.get_logs_for_run(test_run_id)) == 0
 
-    def test_event_log_storage_store_with_multiple_runs(self, storage):
+    def test_event_log_storage_store_with_multiple_runs(self, instance, storage):
         runs = ["foo", "bar", "baz"]
+        if instance:
+            for run in runs:
+                create_run_for_test(instance, run_id=run)
         for run_id in runs:
             assert len(storage.get_logs_for_run(run_id)) == 0
             storage.store_event(
@@ -380,24 +410,28 @@ class TestEventLogStorage:
             for run_id in runs:
                 assert len(storage.get_logs_for_run(run_id)) == 0
 
-    def test_event_log_storage_watch(self, storage):
+        if instance:
+            for run in runs:
+                instance.delete_run(run)
+
+    def test_event_log_storage_watch(self, test_run_id, storage):
         if not self.can_watch():
             pytest.skip("storage cannot watch runs")
 
         watched = []
         watcher = lambda x: watched.append(x)  # pylint: disable=unnecessary-lambda
 
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID)) == 0
+        assert len(storage.get_logs_for_run(test_run_id)) == 0
 
-        storage.store_event(create_test_event_log_record(str(1)))
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID)) == 1
+        storage.store_event(create_test_event_log_record(str(1), test_run_id))
+        assert len(storage.get_logs_for_run(test_run_id)) == 1
         assert len(watched) == 0
 
-        storage.watch(DEFAULT_RUN_ID, 0, watcher)
+        storage.watch(test_run_id, 0, watcher)
 
-        storage.store_event(create_test_event_log_record(str(2)))
-        storage.store_event(create_test_event_log_record(str(3)))
-        storage.store_event(create_test_event_log_record(str(4)))
+        storage.store_event(create_test_event_log_record(str(2), test_run_id))
+        storage.store_event(create_test_event_log_record(str(3), test_run_id))
+        storage.store_event(create_test_event_log_record(str(4), test_run_id))
 
         attempts = 10
         while len(watched) < 3 and attempts > 0:
@@ -405,54 +439,55 @@ class TestEventLogStorage:
             attempts -= 1
         assert len(watched) == 3
 
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID)) == 4
+        assert len(storage.get_logs_for_run(test_run_id)) == 4
 
-        storage.end_watch(DEFAULT_RUN_ID, watcher)
+        storage.end_watch(test_run_id, watcher)
         time.sleep(0.3)  # this value scientifically selected from a range of attractive values
-        storage.store_event(create_test_event_log_record(str(5)))
+        storage.store_event(create_test_event_log_record(str(5), test_run_id))
 
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID)) == 5
+        assert len(storage.get_logs_for_run(test_run_id)) == 5
         assert len(watched) == 3
 
-        storage.delete_events(DEFAULT_RUN_ID)
+        storage.delete_events(test_run_id)
 
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID)) == 0
+        assert len(storage.get_logs_for_run(test_run_id)) == 0
         assert len(watched) == 3
 
         assert [int(evt.user_message) for evt in watched] == [2, 3, 4]
 
-    def test_event_log_storage_pagination(self, storage):
-        # interleave two runs events to ensure pagination is not affected by other runs
-        storage.store_event(create_test_event_log_record("A"))
-        storage.store_event(create_test_event_log_record(str(0), run_id="other_run"))
-        storage.store_event(create_test_event_log_record("B"))
-        storage.store_event(create_test_event_log_record(str(1), run_id="other_run"))
-        storage.store_event(create_test_event_log_record("C"))
-        storage.store_event(create_test_event_log_record(str(2), run_id="other_run"))
-        storage.store_event(create_test_event_log_record("D"))
+    def test_event_log_storage_pagination(self, test_run_id, instance, storage):
+        with create_and_delete_test_runs(instance, ["other_run"]):
+            # two runs events to ensure pagination is not affected by other runs
+            storage.store_event(create_test_event_log_record("A", run_id=test_run_id))
+            storage.store_event(create_test_event_log_record(str(0), run_id="other_run"))
+            storage.store_event(create_test_event_log_record("B", run_id=test_run_id))
+            storage.store_event(create_test_event_log_record(str(1), run_id="other_run"))
+            storage.store_event(create_test_event_log_record("C", run_id=test_run_id))
+            storage.store_event(create_test_event_log_record(str(2), run_id="other_run"))
+            storage.store_event(create_test_event_log_record("D", run_id=test_run_id))
 
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID)) == 4
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID, -1)) == 4
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID, 0)) == 3
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID, 1)) == 2
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID, 2)) == 1
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID, 3)) == 0
+            assert len(storage.get_logs_for_run(test_run_id)) == 4
+            assert len(storage.get_logs_for_run(test_run_id, -1)) == 4
+            assert len(storage.get_logs_for_run(test_run_id, 0)) == 3
+            assert len(storage.get_logs_for_run(test_run_id, 1)) == 2
+            assert len(storage.get_logs_for_run(test_run_id, 2)) == 1
+            assert len(storage.get_logs_for_run(test_run_id, 3)) == 0
 
-    def test_event_log_delete(self, storage):
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID)) == 0
-        storage.store_event(create_test_event_log_record(str(0)))
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID)) == 1
-        assert storage.get_stats_for_run(DEFAULT_RUN_ID)
-        storage.delete_events(DEFAULT_RUN_ID)
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID)) == 0
+    def test_event_log_delete(self, test_run_id, storage):
+        assert len(storage.get_logs_for_run(test_run_id)) == 0
+        storage.store_event(create_test_event_log_record(str(0), test_run_id))
+        assert len(storage.get_logs_for_run(test_run_id)) == 1
+        assert storage.get_stats_for_run(test_run_id)
+        storage.delete_events(test_run_id)
+        assert len(storage.get_logs_for_run(test_run_id)) == 0
 
-    def test_event_log_get_stats_without_start_and_success(self, storage):
+    def test_event_log_get_stats_without_start_and_success(self, test_run_id, storage):
         # When an event log doesn't have a PIPELINE_START or PIPELINE_SUCCESS | PIPELINE_FAILURE event,
         # we want to ensure storage.get_stats_for_run(...) doesn't throw an error.
-        assert len(storage.get_logs_for_run(DEFAULT_RUN_ID)) == 0
-        assert storage.get_stats_for_run(DEFAULT_RUN_ID)
+        assert len(storage.get_logs_for_run(test_run_id)) == 0
+        assert storage.get_stats_for_run(test_run_id)
 
-    def test_event_log_get_stats_for_run(self, storage):
+    def test_event_log_get_stats_for_run(self, test_run_id, storage):
         import math
 
         enqueued_time = time.time()
@@ -463,7 +498,7 @@ class TestEventLogStorage:
                 error_info=None,
                 level="debug",
                 user_message="",
-                run_id=DEFAULT_RUN_ID,
+                run_id=test_run_id,
                 timestamp=enqueued_time,
                 dagster_event=DagsterEvent(
                     DagsterEventType.PIPELINE_ENQUEUED.value,
@@ -476,7 +511,7 @@ class TestEventLogStorage:
                 error_info=None,
                 level="debug",
                 user_message="",
-                run_id=DEFAULT_RUN_ID,
+                run_id=test_run_id,
                 timestamp=launched_time,
                 dagster_event=DagsterEvent(
                     DagsterEventType.PIPELINE_STARTING.value,
@@ -489,7 +524,7 @@ class TestEventLogStorage:
                 error_info=None,
                 level="debug",
                 user_message="",
-                run_id=DEFAULT_RUN_ID,
+                run_id=test_run_id,
                 timestamp=start_time,
                 dagster_event=DagsterEvent(
                     DagsterEventType.PIPELINE_START.value,
@@ -497,18 +532,18 @@ class TestEventLogStorage:
                 ),
             )
         )
-        assert math.isclose(storage.get_stats_for_run(DEFAULT_RUN_ID).enqueued_time, enqueued_time)
-        assert math.isclose(storage.get_stats_for_run(DEFAULT_RUN_ID).launch_time, launched_time)
-        assert math.isclose(storage.get_stats_for_run(DEFAULT_RUN_ID).start_time, start_time)
+        assert math.isclose(storage.get_stats_for_run(test_run_id).enqueued_time, enqueued_time)
+        assert math.isclose(storage.get_stats_for_run(test_run_id).launch_time, launched_time)
+        assert math.isclose(storage.get_stats_for_run(test_run_id).start_time, start_time)
 
-    def test_event_log_step_stats(self, storage):
+    def test_event_log_step_stats(self, test_run_id, storage):
         # When an event log doesn't have a PIPELINE_START or PIPELINE_SUCCESS | PIPELINE_FAILURE event,
         # we want to ensure storage.get_stats_for_run(...) doesn't throw an error.
 
-        for record in _stats_records(run_id=DEFAULT_RUN_ID):
+        for record in _stats_records(run_id=test_run_id):
             storage.store_event(record)
 
-        step_stats = storage.get_step_stats_for_run(DEFAULT_RUN_ID)
+        step_stats = storage.get_step_stats_for_run(test_run_id)
         assert len(step_stats) == 4
 
         a_stats = [stats for stats in step_stats if stats.step_key == "A"][0]
@@ -555,16 +590,16 @@ class TestEventLogStorage:
         assert storage.has_secondary_index("_A")
         assert storage.has_secondary_index("_B")
 
-    def test_basic_event_store(self, storage):
+    def test_basic_event_store(self, test_run_id, storage):
         if not isinstance(storage, SqlEventLogStorage):
             pytest.skip("This test is for SQL-backed Event Log behavior")
 
-        events, _result = _synthesize_events(return_one_solid_func, run_id=DEFAULT_RUN_ID)
+        events, _result = _synthesize_events(return_one_solid_func, run_id=test_run_id)
 
         for event in events:
             storage.store_event(event)
 
-        rows = _fetch_all_events(storage, run_id=DEFAULT_RUN_ID)
+        rows = _fetch_all_events(storage, run_id=test_run_id)
 
         out_events = list(map(lambda r: deserialize_json_to_dagster_namedtuple(r[0]), rows))
 
@@ -573,20 +608,19 @@ class TestEventLogStorage:
         assert event_type_counts
         assert Counter(_event_types(out_events)) == Counter(_event_types(events))
 
-    def test_basic_get_logs_for_run(self, storage):
+    def test_basic_get_logs_for_run(self, test_run_id, storage):
 
-        events, result = _synthesize_events(return_one_solid_func)
+        events, result = _synthesize_events(return_one_solid_func, run_id=test_run_id)
 
         for event in events:
             storage.store_event(event)
-
         out_events = storage.get_logs_for_run(result.run_id)
 
         assert _event_types(out_events) == _event_types(events)
 
-    def test_get_logs_for_run_cursor_limit(self, storage):
+    def test_get_logs_for_run_cursor_limit(self, test_run_id, storage):
 
-        events, result = _synthesize_events(return_one_solid_func)
+        events, result = _synthesize_events(return_one_solid_func, run_id=test_run_id)
 
         for event in events:
             storage.store_event(event)
@@ -607,9 +641,9 @@ class TestEventLogStorage:
 
         assert _event_types(out_events) == _event_types(events)
 
-    def test_wipe_sql_backed_event_log(self, storage):
+    def test_wipe_sql_backed_event_log(self, test_run_id, storage):
 
-        events, result = _synthesize_events(return_one_solid_func)
+        events, result = _synthesize_events(return_one_solid_func, run_id=test_run_id)
 
         for event in events:
             storage.store_event(event)
@@ -623,9 +657,9 @@ class TestEventLogStorage:
 
             assert storage.get_logs_for_run(result.run_id) == []
 
-    def test_delete_sql_backed_event_log(self, storage):
+    def test_delete_sql_backed_event_log(self, test_run_id, storage):
 
-        events, result = _synthesize_events(return_one_solid_func)
+        events, result = _synthesize_events(return_one_solid_func, run_id=test_run_id)
 
         for event in events:
             storage.store_event(event)
@@ -638,9 +672,9 @@ class TestEventLogStorage:
 
         assert storage.get_logs_for_run(result.run_id) == []
 
-    def test_get_logs_for_run_of_type(self, storage):
+    def test_get_logs_for_run_of_type(self, test_run_id, storage):
 
-        events, result = _synthesize_events(return_one_solid_func)
+        events, result = _synthesize_events(return_one_solid_func, run_id=test_run_id)
 
         for event in events:
             storage.store_event(event)
@@ -660,9 +694,9 @@ class TestEventLogStorage:
             )
         ) == [DagsterEventType.STEP_SUCCESS, DagsterEventType.PIPELINE_SUCCESS]
 
-    def test_basic_get_logs_for_run_cursor(self, storage):
+    def test_basic_get_logs_for_run_cursor(self, test_run_id, storage):
 
-        events, result = _synthesize_events(return_one_solid_func)
+        events, result = _synthesize_events(return_one_solid_func, run_id=test_run_id)
 
         for event in events:
             storage.store_event(event)
@@ -671,70 +705,72 @@ class TestEventLogStorage:
             events
         )
 
-    def test_basic_get_logs_for_run_multiple_runs(self, storage):
+    def test_basic_get_logs_for_run_multiple_runs(self, instance, storage):
 
         events_one, result_one = _synthesize_events(return_one_solid_func)
-        for event in events_one:
-            storage.store_event(event)
-
         events_two, result_two = _synthesize_events(return_one_solid_func)
-        for event in events_two:
-            storage.store_event(event)
 
-        out_events_one = storage.get_logs_for_run(result_one.run_id)
-        assert len(out_events_one) == len(events_one)
+        with create_and_delete_test_runs(instance, [result_one.run_id, result_two.run_id]):
+            for event in events_one:
+                storage.store_event(event)
 
-        assert set(_event_types(out_events_one)) == set(_event_types(events_one))
+            for event in events_two:
+                storage.store_event(event)
 
-        assert set(map(lambda e: e.run_id, out_events_one)) == {result_one.run_id}
+            out_events_one = storage.get_logs_for_run(result_one.run_id)
+            assert len(out_events_one) == len(events_one)
 
-        stats_one = storage.get_stats_for_run(result_one.run_id)
-        assert stats_one.steps_succeeded == 1
+            assert set(_event_types(out_events_one)) == set(_event_types(events_one))
 
-        out_events_two = storage.get_logs_for_run(result_two.run_id)
-        assert len(out_events_two) == len(events_two)
+            assert set(map(lambda e: e.run_id, out_events_one)) == {result_one.run_id}
 
-        assert set(_event_types(out_events_two)) == set(_event_types(events_two))
+            stats_one = storage.get_stats_for_run(result_one.run_id)
+            assert stats_one.steps_succeeded == 1
 
-        assert set(map(lambda e: e.run_id, out_events_two)) == {result_two.run_id}
+            out_events_two = storage.get_logs_for_run(result_two.run_id)
+            assert len(out_events_two) == len(events_two)
 
-        stats_two = storage.get_stats_for_run(result_two.run_id)
-        assert stats_two.steps_succeeded == 1
+            assert set(_event_types(out_events_two)) == set(_event_types(events_two))
 
-    def test_basic_get_logs_for_run_multiple_runs_cursors(self, storage):
+            assert set(map(lambda e: e.run_id, out_events_two)) == {result_two.run_id}
+
+            stats_two = storage.get_stats_for_run(result_two.run_id)
+            assert stats_two.steps_succeeded == 1
+
+    def test_basic_get_logs_for_run_multiple_runs_cursors(self, instance, storage):
 
         events_one, result_one = _synthesize_events(return_one_solid_func)
-        for event in events_one:
-            storage.store_event(event)
-
         events_two, result_two = _synthesize_events(return_one_solid_func)
-        for event in events_two:
-            storage.store_event(event)
 
-        out_events_one = storage.get_logs_for_run(result_one.run_id, cursor=-1)
-        assert len(out_events_one) == len(events_one)
+        with create_and_delete_test_runs(instance, [result_one.run_id, result_two.run_id]):
+            for event in events_one:
+                storage.store_event(event)
 
-        assert set(_event_types(out_events_one)) == set(_event_types(events_one))
+            for event in events_two:
+                storage.store_event(event)
 
-        assert set(map(lambda e: e.run_id, out_events_one)) == {result_one.run_id}
+            out_events_one = storage.get_logs_for_run(result_one.run_id, cursor=-1)
+            assert len(out_events_one) == len(events_one)
 
-        out_events_two = storage.get_logs_for_run(result_two.run_id, cursor=-1)
-        assert len(out_events_two) == len(events_two)
-        assert set(_event_types(out_events_two)) == set(_event_types(events_one))
+            assert set(_event_types(out_events_one)) == set(_event_types(events_one))
 
-        assert set(map(lambda e: e.run_id, out_events_two)) == {result_two.run_id}
+            assert set(map(lambda e: e.run_id, out_events_one)) == {result_one.run_id}
 
-    def test_event_watcher_single_run_event(self, storage):
+            out_events_two = storage.get_logs_for_run(result_two.run_id, cursor=-1)
+            assert len(out_events_two) == len(events_two)
+            assert set(_event_types(out_events_two)) == set(_event_types(events_one))
+
+            assert set(map(lambda e: e.run_id, out_events_two)) == {result_two.run_id}
+
+    def test_event_watcher_single_run_event(self, storage, test_run_id):
         if not self.can_watch():
             pytest.skip("storage cannot watch runs")
 
         event_list = []
 
-        run_id = make_new_run_id()
+        storage.watch(test_run_id, -1, lambda x: event_list.append(x))
 
-        storage.watch(run_id, -1, lambda x: event_list.append(x))
-
-        events, _ = _synthesize_events(return_one_solid_func, run_id=run_id)
+        events, _ = _synthesize_events(return_one_solid_func, run_id=test_run_id)
         for event in events:
             storage.store_event(event)
 
@@ -745,33 +781,34 @@ class TestEventLogStorage:
         assert len(event_list) == len(events)
         assert all([isinstance(event, EventLogEntry) for event in event_list])
 
-    def test_event_watcher_filter_run_event(self, storage):
+    def test_event_watcher_filter_run_event(self, instance, storage):
         if not self.can_watch():
             pytest.skip("storage cannot watch runs")
 
         run_id_one = make_new_run_id()
         run_id_two = make_new_run_id()
 
-        # only watch one of the runs
-        event_list = []
-        storage.watch(run_id_two, -1, lambda x: event_list.append(x))
+        with create_and_delete_test_runs(instance, [run_id_one, run_id_two]):
+            # only watch one of the runs
+            event_list = []
+            storage.watch(run_id_two, -1, lambda x: event_list.append(x))
 
-        events_one, _result_one = _synthesize_events(return_one_solid_func, run_id=run_id_one)
-        for event in events_one:
-            storage.store_event(event)
+            events_one, _result_one = _synthesize_events(return_one_solid_func, run_id=run_id_one)
+            for event in events_one:
+                storage.store_event(event)
 
-        events_two, _result_two = _synthesize_events(return_one_solid_func, run_id=run_id_two)
-        for event in events_two:
-            storage.store_event(event)
+            events_two, _result_two = _synthesize_events(return_one_solid_func, run_id=run_id_two)
+            for event in events_two:
+                storage.store_event(event)
 
-        start = time.time()
-        while len(event_list) < len(events_two) and time.time() - start < TEST_TIMEOUT:
-            time.sleep(0.01)
+            start = time.time()
+            while len(event_list) < len(events_two) and time.time() - start < TEST_TIMEOUT:
+                time.sleep(0.01)
 
-        assert len(event_list) == len(events_two)
-        assert all([isinstance(event, EventLogEntry) for event in event_list])
+            assert len(event_list) == len(events_two)
+            assert all([isinstance(event, EventLogEntry) for event in event_list])
 
-    def test_event_watcher_filter_two_runs_event(self, storage):
+    def test_event_watcher_filter_two_runs_event(self, storage, instance):
         if not self.can_watch():
             pytest.skip("storage cannot watch runs")
 
@@ -781,36 +818,38 @@ class TestEventLogStorage:
         run_id_one = make_new_run_id()
         run_id_two = make_new_run_id()
 
-        storage.watch(run_id_one, -1, lambda x: event_list_one.append(x))
-        storage.watch(run_id_two, -1, lambda x: event_list_two.append(x))
+        with create_and_delete_test_runs(instance, [run_id_one, run_id_two]):
 
-        events_one, _result_one = _synthesize_events(return_one_solid_func, run_id=run_id_one)
-        for event in events_one:
-            storage.store_event(event)
+            storage.watch(run_id_one, -1, lambda x: event_list_one.append(x))
+            storage.watch(run_id_two, -1, lambda x: event_list_two.append(x))
 
-        events_two, _result_two = _synthesize_events(return_one_solid_func, run_id=run_id_two)
-        for event in events_two:
-            storage.store_event(event)
+            events_one, _result_one = _synthesize_events(return_one_solid_func, run_id=run_id_one)
+            for event in events_one:
+                storage.store_event(event)
 
-        start = time.time()
-        while (
-            len(event_list_one) < len(events_one) or len(event_list_two) < len(events_two)
-        ) and time.time() - start < TEST_TIMEOUT:
-            pass
+            events_two, _result_two = _synthesize_events(return_one_solid_func, run_id=run_id_two)
+            for event in events_two:
+                storage.store_event(event)
 
-        assert len(event_list_one) == len(events_one)
-        assert len(event_list_two) == len(events_two)
-        assert all([isinstance(event, EventLogEntry) for event in event_list_one])
-        assert all([isinstance(event, EventLogEntry) for event in event_list_two])
+            start = time.time()
+            while (
+                len(event_list_one) < len(events_one) or len(event_list_two) < len(events_two)
+            ) and time.time() - start < TEST_TIMEOUT:
+                pass
 
-    def test_correct_timezone(self, storage):
+            assert len(event_list_one) == len(events_one)
+            assert len(event_list_two) == len(events_two)
+            assert all([isinstance(event, EventLogEntry) for event in event_list_one])
+            assert all([isinstance(event, EventLogEntry) for event in event_list_two])
+
+    def test_correct_timezone(self, test_run_id, storage):
         curr_time = time.time()
 
         event = EventLogEntry(
             error_info=None,
             level="debug",
             user_message="",
-            run_id="foo",
+            run_id=test_run_id,
             timestamp=curr_time,
             dagster_event=DagsterEvent(
                 DagsterEventType.PIPELINE_START.value,
@@ -821,18 +860,18 @@ class TestEventLogStorage:
 
         storage.store_event(event)
 
-        logs = storage.get_logs_for_run("foo")
+        logs = storage.get_logs_for_run(test_run_id)
 
         assert len(logs) == 1
 
         log = logs[0]
 
-        stats = storage.get_stats_for_run("foo")
+        stats = storage.get_stats_for_run(test_run_id)
 
         assert int(log.timestamp) == int(stats.start_time)
         assert int(log.timestamp) == int(curr_time)
 
-    def test_asset_materialization(self, storage):
+    def test_asset_materialization(self, storage, test_run_id):
         asset_key = AssetKey(["path", "to", "asset_one"])
 
         @solid
@@ -851,11 +890,13 @@ class TestEventLogStorage:
         def _solids():
             materialize_one()
 
-        with instance_for_test() as instance:
+        with instance_for_test() as created_instance:
             if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(instance)
+                storage.register_instance(created_instance)
 
-            events_one, _ = _synthesize_events(_solids, instance=instance)
+            events_one, result = _synthesize_events(
+                _solids, instance=created_instance, run_id=test_run_id
+            )
 
             for event in events_one:
                 storage.store_event(event)
@@ -896,7 +937,7 @@ class TestEventLogStorage:
         with instance_for_test() as instance:
             if not storage._instance:  # pylint: disable=protected-access
                 storage.register_instance(instance)
-            events_one, _ = _synthesize_events(_solids, instance=instance)
+            events_one, _ = _synthesize_events(_solids)
             for event in events_one:
                 storage.store_event(event)
 
@@ -957,9 +998,12 @@ class TestEventLogStorage:
                 assert len(_logs) == 1
                 assert re.match("Could not parse event record id", _logs[0])
 
-    def test_secondary_index_asset_keys(self, storage):
+    def test_secondary_index_asset_keys(self, storage, instance):
         asset_key_one = AssetKey(["one"])
         asset_key_two = AssetKey(["two"])
+
+        run_id_1 = make_new_run_id()
+        run_id_2 = make_new_run_id()
 
         @solid
         def materialize_one(_):
@@ -977,26 +1021,27 @@ class TestEventLogStorage:
         def _two():
             materialize_two()
 
-        events_one, _ = _synthesize_events(_one)
-        for event in events_one:
-            storage.store_event(event)
+        with create_and_delete_test_runs(instance, [run_id_1, run_id_2]):
+            events_one, _ = _synthesize_events(_one, run_id=run_id_1)
+            for event in events_one:
+                storage.store_event(event)
 
-        asset_keys = storage.all_asset_keys()
-        assert len(asset_keys) == 1
-        assert asset_key_one in set(asset_keys)
-        migrate_asset_key_data(storage)
-        asset_keys = storage.all_asset_keys()
-        assert len(asset_keys) == 1
-        assert asset_key_one in set(asset_keys)
-        events_two, _ = _synthesize_events(_two)
-        for event in events_two:
-            storage.store_event(event)
-        asset_keys = storage.all_asset_keys()
-        assert len(asset_keys) == 2
-        assert asset_key_one in set(asset_keys)
-        assert asset_key_two in set(asset_keys)
+            asset_keys = storage.all_asset_keys()
+            assert len(asset_keys) == 1
+            assert asset_key_one in set(asset_keys)
+            migrate_asset_key_data(storage)
+            asset_keys = storage.all_asset_keys()
+            assert len(asset_keys) == 1
+            assert asset_key_one in set(asset_keys)
+            events_two, _ = _synthesize_events(_two, run_id=run_id_2)
+            for event in events_two:
+                storage.store_event(event)
+            asset_keys = storage.all_asset_keys()
+            assert len(asset_keys) == 2
+            assert asset_key_one in set(asset_keys)
+            assert asset_key_two in set(asset_keys)
 
-    def test_run_step_stats(self, storage):
+    def test_run_step_stats(self, storage, test_run_id):
         @solid(input_defs=[InputDefinition("_input", str)], output_defs=[OutputDefinition(str)])
         def should_fail(context, _input):
             context.log.info("fail")
@@ -1005,7 +1050,7 @@ class TestEventLogStorage:
         def _one():
             should_fail(should_succeed())
 
-        events, result = _synthesize_events(_one, check_success=False)
+        events, result = _synthesize_events(_one, check_success=False, run_id=test_run_id)
         for event in events:
             storage.store_event(event)
 
@@ -1022,7 +1067,7 @@ class TestEventLogStorage:
         assert step_stats[1].attempts == 1
         assert len(step_stats[1].attempts_list) == 1
 
-    def test_run_step_stats_with_retries(self, storage):
+    def test_run_step_stats_with_retries(self, storage, test_run_id):
         @solid(input_defs=[InputDefinition("_input", str)], output_defs=[OutputDefinition(str)])
         def should_retry(context, _input):
             raise RetryRequested(max_retries=3)
@@ -1030,7 +1075,7 @@ class TestEventLogStorage:
         def _one():
             should_retry(should_succeed())
 
-        events, result = _synthesize_events(_one, check_success=False)
+        events, result = _synthesize_events(_one, check_success=False, run_id=test_run_id)
         for event in events:
             storage.store_event(event)
 
@@ -1045,7 +1090,7 @@ class TestEventLogStorage:
     # After adding the IN_PROGRESS field to the StepEventStatus enum, tests in internal fail
     # Temporarily skipping this test
     @pytest.mark.skip
-    def test_run_step_stats_with_in_progress(self, storage):
+    def test_run_step_stats_with_in_progress(self, test_run_id, storage):
         def _in_progress_run_records(run_id):
             now = time.time()
             return [
@@ -1059,10 +1104,10 @@ class TestEventLogStorage:
                 _event_record(run_id, "E", now - 125, DagsterEventType.STEP_RESTARTED),
             ]
 
-        for record in _in_progress_run_records(run_id=DEFAULT_RUN_ID):
+        for record in _in_progress_run_records(run_id=test_run_id):
             storage.store_event(record)
 
-        step_stats = storage.get_step_stats_for_run(DEFAULT_RUN_ID)
+        step_stats = storage.get_step_stats_for_run(test_run_id)
 
         assert len(step_stats) == 4
 
@@ -1090,7 +1135,7 @@ class TestEventLogStorage:
         assert step_stats[3].attempts == 2
         assert len(step_stats[3].attempts_list) == 2
 
-    def test_run_step_stats_with_resource_markers(self, storage):
+    def test_run_step_stats_with_resource_markers(self, storage, test_run_id):
         @solid(required_resource_keys={"foo"})
         def foo_solid():
             pass
@@ -1098,7 +1143,7 @@ class TestEventLogStorage:
         def _pipeline():
             foo_solid()
 
-        events, result = _synthesize_events(_pipeline, check_success=False)
+        events, result = _synthesize_events(_pipeline, check_success=False, run_id=test_run_id)
         for event in events:
             storage.store_event(event)
 
@@ -1113,7 +1158,7 @@ class TestEventLogStorage:
     @pytest.mark.parametrize(
         "cursor_dt", cursor_datetime_args()
     )  # test both tz-aware and naive datetimes
-    def test_get_event_records(self, storage, cursor_dt):
+    def test_get_event_records(self, storage, cursor_dt, test_run_id):
         if isinstance(storage, SqliteEventLogStorage):
             # test sqlite in test_get_event_records_sqlite
             pytest.skip()
@@ -1136,7 +1181,7 @@ class TestEventLogStorage:
         def _solids():
             materialize_one()
 
-        events, _ = _synthesize_events(_solids)
+        events, _ = _synthesize_events(_solids, run_id=test_run_id)
 
         for event in events:
             storage.store_event(event)
@@ -1412,7 +1457,7 @@ class TestEventLogStorage:
             for entry in logs:
                 assert entry.step_key == "return_one"
 
-    def test_latest_materializations(self, storage):
+    def test_latest_materializations(self, storage, instance):
         @solid
         def one(_):
             yield AssetMaterialization(AssetKey("a"), tags={"num": str(1)})
@@ -1442,192 +1487,224 @@ class TestEventLogStorage:
                 ]
             )
 
-        events, _ = _synthesize_events(lambda: one())
-        for event in events:
-            storage.store_event(event)
+        run_id_1 = make_new_run_id()
+        run_id_2 = make_new_run_id()
 
-        events_by_key = _fetch_events(storage)
-        assert len(events_by_key) == 4
-        assert _event_tags(events_by_key[AssetKey("a")])["num"] == "1"
-        assert _event_tags(events_by_key[AssetKey("b")])["num"] == "1"
-        assert _event_tags(events_by_key[AssetKey("c")])["num"] == "1"
-        assert _event_tags(events_by_key[AssetKey("d")])["num"] == "1"
+        with create_and_delete_test_runs(instance, [run_id_1, run_id_2]):
 
-        # wipe 2 of the assets, make sure we respect that
-        if self.can_wipe():
-            storage.wipe_asset(AssetKey("a"))
-            storage.wipe_asset(AssetKey("b"))
+            events, _ = _synthesize_events(lambda: one(), run_id_1)
+            for event in events:
+                storage.store_event(event)
+
             events_by_key = _fetch_events(storage)
-            assert events_by_key.get(AssetKey("a")) is None
-            assert events_by_key.get(AssetKey("b")) is None
+            assert len(events_by_key) == 4
+            assert _event_tags(events_by_key[AssetKey("a")])["num"] == "1"
+            assert _event_tags(events_by_key[AssetKey("b")])["num"] == "1"
             assert _event_tags(events_by_key[AssetKey("c")])["num"] == "1"
             assert _event_tags(events_by_key[AssetKey("d")])["num"] == "1"
 
-            # rematerialize one of the wiped assets, one of the existing assets
-            events, _ = _synthesize_events(lambda: two())
-            for event in events:
-                storage.store_event(event)
+            # wipe 2 of the assets, make sure we respect that
+            if self.can_wipe():
+                storage.wipe_asset(AssetKey("a"))
+                storage.wipe_asset(AssetKey("b"))
+                events_by_key = _fetch_events(storage)
+                assert events_by_key.get(AssetKey("a")) is None
+                assert events_by_key.get(AssetKey("b")) is None
+                assert _event_tags(events_by_key[AssetKey("c")])["num"] == "1"
+                assert _event_tags(events_by_key[AssetKey("d")])["num"] == "1"
 
-            events_by_key = _fetch_events(storage)
-            assert events_by_key.get(AssetKey("a")) is None
-            assert _event_tags(events_by_key[AssetKey("b")])["num"] == "2"
-            assert _event_tags(events_by_key[AssetKey("c")])["num"] == "2"
-            assert _event_tags(events_by_key[AssetKey("d")])["num"] == "1"
+                # rematerialize one of the wiped assets, one of the existing assets
+                events, _ = _synthesize_events(lambda: two(), run_id=run_id_2)
+                for event in events:
+                    storage.store_event(event)
 
-        else:
-            events, _ = _synthesize_events(lambda: two())
-            for event in events:
-                storage.store_event(event)
-            events_by_key = _fetch_events(storage)
-            assert _event_tags(events_by_key[AssetKey("a")])["num"] == "1"
-            assert _event_tags(events_by_key[AssetKey("b")])["num"] == "2"
-            assert _event_tags(events_by_key[AssetKey("c")])["num"] == "2"
-            assert _event_tags(events_by_key[AssetKey("d")])["num"] == "1"
+                events_by_key = _fetch_events(storage)
+                assert events_by_key.get(AssetKey("a")) is None
+                assert _event_tags(events_by_key[AssetKey("b")])["num"] == "2"
+                assert _event_tags(events_by_key[AssetKey("c")])["num"] == "2"
+                assert _event_tags(events_by_key[AssetKey("d")])["num"] == "1"
 
-    def test_asset_keys(self, storage):
-        with instance_for_test() as instance:
+            else:
+                events, _ = _synthesize_events(lambda: two(), run_id=run_id_2)
+                for event in events:
+                    storage.store_event(event)
+                events_by_key = _fetch_events(storage)
+                assert _event_tags(events_by_key[AssetKey("a")])["num"] == "1"
+                assert _event_tags(events_by_key[AssetKey("b")])["num"] == "2"
+                assert _event_tags(events_by_key[AssetKey("c")])["num"] == "2"
+                assert _event_tags(events_by_key[AssetKey("d")])["num"] == "1"
+
+    def test_asset_keys(self, storage, instance):
+        with instance_for_test() as created_instance:
             if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(instance)
+                storage.register_instance(created_instance)
 
-            events_one, _ = _synthesize_events(lambda: one_asset_solid(), instance=instance)
-            events_two, _ = _synthesize_events(lambda: two_asset_solids(), instance=instance)
-
-            for event in events_one + events_two:
-                storage.store_event(event)
-
-            asset_keys = storage.all_asset_keys()
-            assert len(asset_keys) == 3
-            assert set([asset_key.to_string() for asset_key in asset_keys]) == set(
-                ['["asset_1"]', '["asset_2"]', '["path", "to", "asset_3"]']
+            events_one, result1 = _synthesize_events(
+                lambda: one_asset_solid(), instance=created_instance
+            )
+            events_two, result2 = _synthesize_events(
+                lambda: two_asset_solids(), instance=created_instance
             )
 
-    def test_has_asset_key(self, storage):
-        with instance_for_test() as instance:
+            with create_and_delete_test_runs(instance, [result1.run_id, result2.run_id]):
+
+                for event in events_one + events_two:
+                    storage.store_event(event)
+
+                asset_keys = storage.all_asset_keys()
+                assert len(asset_keys) == 3
+                assert set([asset_key.to_string() for asset_key in asset_keys]) == set(
+                    ['["asset_1"]', '["asset_2"]', '["path", "to", "asset_3"]']
+                )
+
+    def test_has_asset_key(self, storage, instance):
+        with instance_for_test() as created_instance:
             if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(instance)
+                storage.register_instance(created_instance)
 
-            events_one, _ = _synthesize_events(lambda: one_asset_solid(), instance=instance)
-            events_two, _ = _synthesize_events(lambda: two_asset_solids(), instance=instance)
+            events_one, result_1 = _synthesize_events(
+                lambda: one_asset_solid(), instance=created_instance
+            )
+            events_two, result_2 = _synthesize_events(
+                lambda: two_asset_solids(), instance=created_instance
+            )
 
-            for event in events_one + events_two:
-                storage.store_event(event)
+            with create_and_delete_test_runs(instance, [result_1.run_id, result_2.run_id]):
 
-            assert storage.has_asset_key(AssetKey(["path", "to", "asset_3"]))
-            assert not storage.has_asset_key(AssetKey(["path", "to", "bogus", "asset"]))
+                for event in events_one + events_two:
+                    storage.store_event(event)
 
-    def test_asset_events(self, storage):
-        with instance_for_test() as instance:
+                assert storage.has_asset_key(AssetKey(["path", "to", "asset_3"]))
+                assert not storage.has_asset_key(AssetKey(["path", "to", "bogus", "asset"]))
+
+    def test_asset_events(self, storage, instance):
+        with instance_for_test() as created_instance:
             if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(instance)
+                storage.register_instance(created_instance)
 
-            events_one, _ = _synthesize_events(lambda: one_asset_solid(), instance=instance)
-            events_two, _ = _synthesize_events(lambda: two_asset_solids(), instance=instance)
+            events_one, result_1 = _synthesize_events(
+                lambda: one_asset_solid(), instance=created_instance
+            )
+            events_two, result_2 = _synthesize_events(
+                lambda: two_asset_solids(), instance=created_instance
+            )
 
-            for event in events_one + events_two:
-                storage.store_event(event)
+            with create_and_delete_test_runs(instance, [result_1.run_id, result_2.run_id]):
 
-            asset_events = storage.get_asset_events(AssetKey("asset_1"))
-            assert len(asset_events) == 2
-            for event in asset_events:
-                assert isinstance(event, EventLogEntry)
-                assert event.is_dagster_event
-                assert event.dagster_event.event_type == DagsterEventType.ASSET_MATERIALIZATION
-                assert event.dagster_event.asset_key
+                for event in events_one + events_two:
+                    storage.store_event(event)
 
-            asset_events = storage.get_asset_events(AssetKey(["path", "to", "asset_3"]))
-            assert len(asset_events) == 1
+                asset_events = storage.get_asset_events(AssetKey("asset_1"))
+                assert len(asset_events) == 2
+                for event in asset_events:
+                    assert isinstance(event, EventLogEntry)
+                    assert event.is_dagster_event
+                    assert event.dagster_event.event_type == DagsterEventType.ASSET_MATERIALIZATION
+                    assert event.dagster_event.asset_key
 
-    def test_asset_events_range(self, storage):
-        with instance_for_test() as instance:
+                asset_events = storage.get_asset_events(AssetKey(["path", "to", "asset_3"]))
+                assert len(asset_events) == 1
+
+    def test_asset_events_range(self, storage, instance):
+        with instance_for_test() as created_instance:
             if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(instance)
+                storage.register_instance(created_instance)
 
-            events_one, _ = _synthesize_events(lambda: one_asset_solid(), instance=instance)
-            two_asset_solids_first, _ = _synthesize_events(
-                lambda: two_asset_solids(), instance=instance
+            events_one, result_1 = _synthesize_events(
+                lambda: one_asset_solid(), instance=created_instance
             )
-            two_asset_solids_second, _ = _synthesize_events(
-                lambda: two_asset_solids(), instance=instance
+            two_asset_solids_first, result_2 = _synthesize_events(
+                lambda: two_asset_solids(), instance=created_instance
+            )
+            two_asset_solids_second, result_3 = _synthesize_events(
+                lambda: two_asset_solids(), instance=created_instance
             )
 
-            for event in events_one + two_asset_solids_first + two_asset_solids_second:
-                storage.store_event(event)
+            with create_and_delete_test_runs(
+                instance, [result_1.run_id, result_2.run_id, result_3.run_id]
+            ):
 
-            # descending
-            asset_events = storage.get_asset_events(AssetKey("asset_1"), include_cursor=True)
-            assert len(asset_events) == 3
-            [id_three, id_two, id_one] = [id for id, event in asset_events]
+                for event in events_one + two_asset_solids_first + two_asset_solids_second:
+                    storage.store_event(event)
 
-            after_events = storage.get_asset_events(
-                AssetKey("asset_1"), include_cursor=True, after_cursor=id_one
-            )
-            assert len(after_events) == 2
-            assert [id for id, event in after_events] == [id_three, id_two]
+                # descending
+                asset_events = storage.get_asset_events(AssetKey("asset_1"), include_cursor=True)
+                assert len(asset_events) == 3
+                [id_three, id_two, id_one] = [id for id, event in asset_events]
 
-            before_events = storage.get_asset_events(
-                AssetKey("asset_1"), include_cursor=True, before_cursor=id_three
-            )
-            assert len(before_events) == 2
-            assert [id for id, event in before_events] == [id_two, id_one]
+                after_events = storage.get_asset_events(
+                    AssetKey("asset_1"), include_cursor=True, after_cursor=id_one
+                )
+                assert len(after_events) == 2
+                assert [id for id, event in after_events] == [id_three, id_two]
 
-            between_events = storage.get_asset_events(
-                AssetKey("asset_1"),
-                include_cursor=True,
-                before_cursor=id_three,
-                after_cursor=id_one,
-            )
-            assert len(between_events) == 1
-            assert [id for id, event in between_events] == [id_two]
+                before_events = storage.get_asset_events(
+                    AssetKey("asset_1"), include_cursor=True, before_cursor=id_three
+                )
+                assert len(before_events) == 2
+                assert [id for id, event in before_events] == [id_two, id_one]
 
-            # ascending
-            asset_events = storage.get_asset_events(
-                AssetKey("asset_1"), include_cursor=True, ascending=True
-            )
-            assert len(asset_events) == 3
-            [id_one, id_two, id_three] = [id for id, event in asset_events]
+                between_events = storage.get_asset_events(
+                    AssetKey("asset_1"),
+                    include_cursor=True,
+                    before_cursor=id_three,
+                    after_cursor=id_one,
+                )
+                assert len(between_events) == 1
+                assert [id for id, event in between_events] == [id_two]
 
-            after_events = storage.get_asset_events(
-                AssetKey("asset_1"), include_cursor=True, after_cursor=id_one, ascending=True
-            )
-            assert len(after_events) == 2
-            assert [id for id, event in after_events] == [id_two, id_three]
+                # ascending
+                asset_events = storage.get_asset_events(
+                    AssetKey("asset_1"), include_cursor=True, ascending=True
+                )
+                assert len(asset_events) == 3
+                [id_one, id_two, id_three] = [id for id, event in asset_events]
 
-            before_events = storage.get_asset_events(
-                AssetKey("asset_1"), include_cursor=True, before_cursor=id_three, ascending=True
-            )
-            assert len(before_events) == 2
-            assert [id for id, event in before_events] == [id_one, id_two]
+                after_events = storage.get_asset_events(
+                    AssetKey("asset_1"), include_cursor=True, after_cursor=id_one, ascending=True
+                )
+                assert len(after_events) == 2
+                assert [id for id, event in after_events] == [id_two, id_three]
 
-            between_events = storage.get_asset_events(
-                AssetKey("asset_1"),
-                include_cursor=True,
-                before_cursor=id_three,
-                after_cursor=id_one,
-                ascending=True,
-            )
-            assert len(between_events) == 1
-            assert [id for id, event in between_events] == [id_two]
+                before_events = storage.get_asset_events(
+                    AssetKey("asset_1"), include_cursor=True, before_cursor=id_three, ascending=True
+                )
+                assert len(before_events) == 2
+                assert [id for id, event in before_events] == [id_one, id_two]
 
-    def test_asset_run_ids(self, storage):
-        with instance_for_test() as instance:
+                between_events = storage.get_asset_events(
+                    AssetKey("asset_1"),
+                    include_cursor=True,
+                    before_cursor=id_three,
+                    after_cursor=id_one,
+                    ascending=True,
+                )
+                assert len(between_events) == 1
+                assert [id for id, event in between_events] == [id_two]
+
+    def test_asset_run_ids(self, storage, instance):
+        with instance_for_test() as created_instance:
             if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(instance)
+                storage.register_instance(created_instance)
 
             one_run_id = "one"
             two_run_id = "two"
+
             one_events, _ = _synthesize_events(
-                lambda: one_asset_solid(), run_id=one_run_id, instance=instance
+                lambda: one_asset_solid(), run_id=one_run_id, instance=created_instance
             )
             two_events, _ = _synthesize_events(
-                lambda: two_asset_solids(), run_id=two_run_id, instance=instance
+                lambda: two_asset_solids(), run_id=two_run_id, instance=created_instance
             )
-            for event in one_events + two_events:
-                storage.store_event(event)
 
-            run_ids = storage.get_asset_run_ids(AssetKey("asset_1"))
-            assert set(run_ids) == set([one_run_id, two_run_id])
+            with create_and_delete_test_runs(instance, [one_run_id, two_run_id]):
+                for event in one_events + two_events:
+                    storage.store_event(event)
 
-    def test_asset_normalization(self, storage):
+                run_ids = storage.get_asset_run_ids(AssetKey("asset_1"))
+                assert set(run_ids) == set([one_run_id, two_run_id])
+
+    def test_asset_normalization(self, storage, test_run_id):
         with instance_for_test() as instance:
             if not storage._instance:  # pylint: disable=protected-access
                 storage.register_instance(instance)
@@ -1637,7 +1714,9 @@ class TestEventLogStorage:
                 yield AssetMaterialization(asset_key="path/to-asset_4")
                 yield Output(1)
 
-            events, _ = _synthesize_events(lambda: solid_normalization(), instance=instance)
+            events, _ = _synthesize_events(
+                lambda: solid_normalization(), instance=instance, run_id=test_run_id
+            )
             for event in events:
                 storage.store_event(event)
 
@@ -1647,96 +1726,104 @@ class TestEventLogStorage:
             assert asset_key.to_string() == '["path", "to", "asset_4"]'
             assert asset_key.path == ["path", "to", "asset_4"]
 
-    def test_asset_wipe(self, storage):
-        with instance_for_test() as instance:
+    def test_asset_wipe(self, storage, instance):
+        with instance_for_test() as created_instance:
             if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(instance)
+                storage.register_instance(created_instance)
 
             one_run_id = "one_run_id"
             two_run_id = "two_run_id"
             events_one, _ = _synthesize_events(
-                lambda: one_asset_solid(), run_id=one_run_id, instance=instance
+                lambda: one_asset_solid(), run_id=one_run_id, instance=created_instance
             )
             events_two, _ = _synthesize_events(
-                lambda: two_asset_solids(), run_id=two_run_id, instance=instance
+                lambda: two_asset_solids(), run_id=two_run_id, instance=created_instance
             )
-            for event in events_one + events_two:
-                storage.store_event(event)
 
-            asset_keys = storage.all_asset_keys()
-            assert len(asset_keys) == 3
-            assert storage.has_asset_key(AssetKey("asset_1"))
-            asset_events = storage.get_asset_events(AssetKey("asset_1"))
-            assert len(asset_events) == 2
-            asset_run_ids = storage.get_asset_run_ids(AssetKey("asset_1"))
-            assert set(asset_run_ids) == set([one_run_id, two_run_id])
-
-            log_count = len(storage.get_logs_for_run(one_run_id))
-            if self.can_wipe():
-                for asset_key in asset_keys:
-                    storage.wipe_asset(asset_key)
+            with create_and_delete_test_runs(instance, [one_run_id, two_run_id]):
+                for event in events_one + events_two:
+                    storage.store_event(event)
 
                 asset_keys = storage.all_asset_keys()
-                assert len(asset_keys) == 0
-                assert not storage.has_asset_key(AssetKey("asset_1"))
+                assert len(asset_keys) == 3
+                assert storage.has_asset_key(AssetKey("asset_1"))
                 asset_events = storage.get_asset_events(AssetKey("asset_1"))
-                assert len(asset_events) == 0
+                assert len(asset_events) == 2
                 asset_run_ids = storage.get_asset_run_ids(AssetKey("asset_1"))
-                assert set(asset_run_ids) == set()
-                assert log_count == len(storage.get_logs_for_run(one_run_id))
+                assert set(asset_run_ids) == set([one_run_id, two_run_id])
 
-                one_run_id = "one_run_id_2"
-                events_one, _ = _synthesize_events(
-                    lambda: one_asset_solid(), run_id=one_run_id, instance=instance
-                )
+                log_count = len(storage.get_logs_for_run(one_run_id))
+                if self.can_wipe():
+                    for asset_key in asset_keys:
+                        storage.wipe_asset(asset_key)
+
+                    asset_keys = storage.all_asset_keys()
+                    assert len(asset_keys) == 0
+                    assert not storage.has_asset_key(AssetKey("asset_1"))
+                    asset_events = storage.get_asset_events(AssetKey("asset_1"))
+                    assert len(asset_events) == 0
+                    asset_run_ids = storage.get_asset_run_ids(AssetKey("asset_1"))
+                    assert set(asset_run_ids) == set()
+                    assert log_count == len(storage.get_logs_for_run(one_run_id))
+
+                    one_run_id = "one_run_id_2"
+                    events_one, _ = _synthesize_events(
+                        lambda: one_asset_solid(), run_id=one_run_id, instance=created_instance
+                    )
+                    with create_and_delete_test_runs(instance, [one_run_id]):
+                        for event in events_one:
+                            storage.store_event(event)
+
+                        asset_keys = storage.all_asset_keys()
+                        assert len(asset_keys) == 1
+                        assert storage.has_asset_key(AssetKey("asset_1"))
+                        asset_events = storage.get_asset_events(AssetKey("asset_1"))
+                        assert len(asset_events) == 1
+                        asset_run_ids = storage.get_asset_run_ids(AssetKey("asset_1"))
+                        assert set(asset_run_ids) == set([one_run_id])
+
+    def test_asset_secondary_index(self, storage, instance):
+        with instance_for_test() as created_instance:
+            if not storage._instance:  # pylint: disable=protected-access
+                storage.register_instance(created_instance)
+
+            events_one, result = _synthesize_events(
+                lambda: one_asset_solid(), instance=created_instance
+            )
+
+            with create_and_delete_test_runs(instance, [result.run_id]):
                 for event in events_one:
                     storage.store_event(event)
 
                 asset_keys = storage.all_asset_keys()
                 assert len(asset_keys) == 1
-                assert storage.has_asset_key(AssetKey("asset_1"))
-                asset_events = storage.get_asset_events(AssetKey("asset_1"))
-                assert len(asset_events) == 1
-                asset_run_ids = storage.get_asset_run_ids(AssetKey("asset_1"))
-                assert set(asset_run_ids) == set([one_run_id])
+                migrate_asset_key_data(storage)
 
-    def test_asset_secondary_index(self, storage):
-        with instance_for_test() as instance:
-            if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(instance)
+                two_first_run_id = "first"
+                two_second_run_id = "second"
+                events_two, _ = _synthesize_events(
+                    lambda: two_asset_solids(), run_id=two_first_run_id, instance=created_instance
+                )
+                events_two_two, _ = _synthesize_events(
+                    lambda: two_asset_solids(), run_id=two_second_run_id, instance=created_instance
+                )
 
-            events_one, _ = _synthesize_events(lambda: one_asset_solid(), instance=instance)
+                with create_and_delete_test_runs(instance, [two_first_run_id, two_second_run_id]):
+                    for event in events_two + events_two_two:
+                        storage.store_event(event)
 
-            for event in events_one:
-                storage.store_event(event)
+                    asset_keys = storage.all_asset_keys()
+                    assert len(asset_keys) == 3
 
-            asset_keys = storage.all_asset_keys()
-            assert len(asset_keys) == 1
-            migrate_asset_key_data(storage)
+                    storage.delete_events(two_first_run_id)
+                    asset_keys = storage.all_asset_keys()
+                    assert len(asset_keys) == 3
 
-            two_first_run_id = "first"
-            two_second_run_id = "second"
-            events_two, _ = _synthesize_events(
-                lambda: two_asset_solids(), run_id=two_first_run_id, instance=instance
-            )
-            events_two_two, _ = _synthesize_events(
-                lambda: two_asset_solids(), run_id=two_second_run_id, instance=instance
-            )
-            for event in events_two + events_two_two:
-                storage.store_event(event)
+                    storage.delete_events(two_second_run_id)
+                    asset_keys = storage.all_asset_keys()
+                    assert len(asset_keys) == 1
 
-            asset_keys = storage.all_asset_keys()
-            assert len(asset_keys) == 3
-
-            storage.delete_events(two_first_run_id)
-            asset_keys = storage.all_asset_keys()
-            assert len(asset_keys) == 3
-
-            storage.delete_events(two_second_run_id)
-            asset_keys = storage.all_asset_keys()
-            assert len(asset_keys) == 1
-
-    def test_asset_partition_query(self, storage):
+    def test_asset_partition_query(self, storage, instance):
         @solid(config_schema={"partition": Field(str, is_required=False)})
         def solid_partitioned(context):
             yield AssetMaterialization(
@@ -1744,32 +1831,36 @@ class TestEventLogStorage:
             )
             yield Output(1)
 
-        with instance_for_test() as instance:
+        with instance_for_test() as created_instance:
             if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(instance)
+                storage.register_instance(created_instance)
 
             get_partitioned_config = lambda partition: {
                 "solids": {"solid_partitioned": {"config": {"partition": partition}}}
             }
 
-            for partition in [f"partition_{x}" for x in ["a", "a", "b", "c"]]:
-                run_events, _ = _synthesize_events(
-                    lambda: solid_partitioned(),
-                    instance=instance,
-                    run_config=get_partitioned_config(partition),
+            partitions = ["a", "a", "b", "c"]
+            run_ids = [make_new_run_id() for _ in partitions]
+            with create_and_delete_test_runs(instance, run_ids):
+                for partition, run_id in zip([f"partition_{x}" for x in partitions], run_ids):
+                    run_events, result = _synthesize_events(
+                        lambda: solid_partitioned(),
+                        instance=created_instance,
+                        run_config=get_partitioned_config(partition),
+                        run_id=run_id,
+                    )
+                    for event in run_events:
+                        storage.store_event(event)
+
+                events = storage.get_asset_events(AssetKey("asset_key"))
+                assert len(events) == 4
+
+                events = storage.get_asset_events(
+                    AssetKey("asset_key"), partitions=["partition_a", "partition_b"]
                 )
-                for event in run_events:
-                    storage.store_event(event)
+                assert len(events) == 3
 
-            events = storage.get_asset_events(AssetKey("asset_key"))
-            assert len(events) == 4
-
-            events = storage.get_asset_events(
-                AssetKey("asset_key"), partitions=["partition_a", "partition_b"]
-            )
-            assert len(events) == 3
-
-    def test_get_asset_keys(self, storage):
+    def test_get_asset_keys(self, storage, test_run_id):
         @op
         def gen_op():
             yield AssetMaterialization(asset_key=AssetKey(["a"]))
@@ -1780,11 +1871,13 @@ class TestEventLogStorage:
             yield AssetMaterialization(asset_key=AssetKey(["b", "z"]))
             yield Output(1)
 
-        with instance_for_test() as instance:
+        with instance_for_test() as created_instance:
             if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(instance)
+                storage.register_instance(created_instance)
 
-            events, _ = _synthesize_events(lambda: gen_op(), instance=instance)
+            events, _ = _synthesize_events(
+                lambda: gen_op(), instance=created_instance, run_id=test_run_id
+            )
             for event in events:
                 storage.store_event(event)
 
@@ -1814,7 +1907,7 @@ class TestEventLogStorage:
                 '["b", "z"]',
             ]
 
-    def test_get_materialization_count_by_partition(self, storage):
+    def test_get_materialization_count_by_partition(self, storage, instance):
         a = AssetKey("no_materializations_asset")
         b = AssetKey("no_partitions_asset")
         c = AssetKey("two_partitions_asset")
@@ -1836,45 +1929,61 @@ class TestEventLogStorage:
         def _fetch_counts(storage):
             return storage.get_materialization_count_by_partition([c, d])
 
-        with instance_for_test() as instance:
+        with instance_for_test() as created_instance:
             if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(instance)
+                storage.register_instance(created_instance)
 
-            events_one, _ = _synthesize_events(lambda: materialize(), instance=instance)
-            for event in events_one:
-                storage.store_event(event)
+            run_id_1 = make_new_run_id()
+            run_id_2 = make_new_run_id()
+            run_id_3 = make_new_run_id()
 
-            materialization_count_by_key = storage.get_materialization_count_by_partition([a, b, c])
+            with create_and_delete_test_runs(instance, [run_id_1, run_id_2, run_id_3]):
 
-            assert materialization_count_by_key.get(a) == {}
-            assert materialization_count_by_key.get(b) == {}
-            assert materialization_count_by_key.get(c)["a"] == 1
-            assert len(materialization_count_by_key.get(c)) == 1
-
-            events_two, _ = _synthesize_events(lambda: materialize_two(), instance=instance)
-            for event in events_two:
-                storage.store_event(event)
-
-            materialization_count_by_key = storage.get_materialization_count_by_partition([a, b, c])
-            assert materialization_count_by_key.get(c)["a"] == 2
-            assert materialization_count_by_key.get(c)["b"] == 1
-
-            # wipe asset, make sure we respect that
-            if self.can_wipe():
-                storage.wipe_asset(c)
-                materialization_count_by_partition = _fetch_counts(storage)
-                assert materialization_count_by_partition.get(c) == {}
-
-                # rematerialize wiped asset
-                events, _ = _synthesize_events(lambda: materialize_two(), instance=instance)
-                for event in events:
+                events_one, _ = _synthesize_events(
+                    lambda: materialize(), instance=created_instance, run_id=run_id_1
+                )
+                for event in events_one:
                     storage.store_event(event)
 
-                materialization_count_by_partition = _fetch_counts(storage)
-                assert materialization_count_by_partition.get(c)["a"] == 1
-                assert materialization_count_by_partition.get(d)["x"] == 2
+                materialization_count_by_key = storage.get_materialization_count_by_partition(
+                    [a, b, c]
+                )
 
-    def test_get_observation(self, storage):
+                assert materialization_count_by_key.get(a) == {}
+                assert materialization_count_by_key.get(b) == {}
+                assert materialization_count_by_key.get(c)["a"] == 1
+                assert len(materialization_count_by_key.get(c)) == 1
+
+                events_two, _ = _synthesize_events(
+                    lambda: materialize_two(), instance=created_instance, run_id=run_id_2
+                )
+                for event in events_two:
+                    storage.store_event(event)
+
+                materialization_count_by_key = storage.get_materialization_count_by_partition(
+                    [a, b, c]
+                )
+                assert materialization_count_by_key.get(c)["a"] == 2
+                assert materialization_count_by_key.get(c)["b"] == 1
+
+                # wipe asset, make sure we respect that
+                if self.can_wipe():
+                    storage.wipe_asset(c)
+                    materialization_count_by_partition = _fetch_counts(storage)
+                    assert materialization_count_by_partition.get(c) == {}
+
+                    # rematerialize wiped asset
+                    events, _ = _synthesize_events(
+                        lambda: materialize_two(), instance=created_instance, run_id=run_id_3
+                    )
+                    for event in events:
+                        storage.store_event(event)
+
+                    materialization_count_by_partition = _fetch_counts(storage)
+                    assert materialization_count_by_partition.get(c)["a"] == 1
+                    assert materialization_count_by_partition.get(d)["x"] == 2
+
+    def test_get_observation(self, storage, test_run_id):
         a = AssetKey(["key_a"])
 
         @op
@@ -1886,7 +1995,9 @@ class TestEventLogStorage:
             if not storage._instance:  # pylint: disable=protected-access
                 storage.register_instance(instance)
 
-            events_one, _ = _synthesize_events(lambda: gen_op(), instance=instance)
+            events_one, _ = _synthesize_events(
+                lambda: gen_op(), instance=instance, run_id=test_run_id
+            )
             for event in events_one:
                 storage.store_event(event)
 
@@ -1899,7 +2010,7 @@ class TestEventLogStorage:
 
             assert len(records) == 1
 
-    def test_asset_key_exists_on_observation(self, storage):
+    def test_asset_key_exists_on_observation(self, storage, instance):
 
         key = AssetKey("hello")
 
@@ -1908,28 +2019,35 @@ class TestEventLogStorage:
             yield AssetObservation(key)
             yield Output(5)
 
-        with instance_for_test() as instance:
-            if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(instance)
+        run_id_1 = make_new_run_id()
+        run_id_2 = make_new_run_id()
+        with create_and_delete_test_runs(instance, [run_id_1, run_id_2]):
+            with instance_for_test() as created_instance:
+                if not storage._instance:  # pylint: disable=protected-access
+                    storage.register_instance(created_instance)
 
-            events, _ = _synthesize_events(lambda: my_op(), instance=instance)
-            for event in events:
-                storage.store_event(event)
-
-            assert [key] == storage.all_asset_keys()
-
-            if self.can_wipe():
-                storage.wipe_asset(key)
-
-                assert len(storage.all_asset_keys()) == 0
-
-                events, _ = _synthesize_events(lambda: my_op(), instance=instance)
+                events, _ = _synthesize_events(
+                    lambda: my_op(), instance=created_instance, run_id=run_id_1
+                )
                 for event in events:
                     storage.store_event(event)
 
                 assert [key] == storage.all_asset_keys()
 
-    def test_get_asset_records(self, storage):
+                if self.can_wipe():
+                    storage.wipe_asset(key)
+
+                    assert len(storage.all_asset_keys()) == 0
+
+                    events, _ = _synthesize_events(
+                        lambda: my_op(), instance=created_instance, run_id=run_id_2
+                    )
+                    for event in events:
+                        storage.store_event(event)
+
+                    assert [key] == storage.all_asset_keys()
+
+    def test_get_asset_records(self, storage, instance):
         @asset
         def my_asset():
             return 1
@@ -1938,9 +2056,9 @@ class TestEventLogStorage:
         def second_asset(my_asset):  # pylint: disable=unused-argument
             return 2
 
-        with instance_for_test() as instance:
+        with instance_for_test() as created_instance:
             if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(instance)
+                storage.register_instance(created_instance)
 
             my_asset_key = AssetKey("my_asset")
             second_asset_key = AssetKey("second_asset")  # pylint: disable=unused-variable
@@ -1948,39 +2066,20 @@ class TestEventLogStorage:
 
             assert len(storage.get_asset_records()) == 0
 
-            asset_group = AssetGroup([my_asset, second_asset])
-            result = _execute_job_and_store_events(
-                instance,
-                storage,
-                asset_group.build_job(name="one_asset_job", selection=["my_asset"]),
-            )
-            records = storage.get_asset_records([my_asset_key])
+            run_id_1 = make_new_run_id()
+            run_id_2 = make_new_run_id()
+            with create_and_delete_test_runs(instance, [run_id_1, run_id_2]):
 
-            assert len(records) == 1
-            asset_entry = records[0].asset_entry
-            assert asset_entry.asset_key == my_asset_key
-            materialize_event = [
-                event for event in result.all_events if event.is_step_materialization
-            ][0]
-            assert asset_entry.last_materialization.dagster_event == materialize_event
-            assert asset_entry.last_run_id == result.run_id
-            assert asset_entry.asset_details == None
-
-            if self.can_wipe():
-                storage.wipe_asset(my_asset_key)
-
-                # confirm that last_run_id == None when asset is wiped
-                assert len(storage.get_asset_records([my_asset_key])) == 0
-
+                asset_group = AssetGroup([my_asset, second_asset])
                 result = _execute_job_and_store_events(
-                    instance, storage, asset_group.build_job(name="two_asset_job")
+                    created_instance,
+                    storage,
+                    asset_group.build_job(name="one_asset_job", selection=["my_asset"]),
+                    run_id=run_id_1,
                 )
                 records = storage.get_asset_records([my_asset_key])
-                assert len(records) == 1
-                records = storage.get_asset_records()  # should select all assets
-                assert len(records) == 2
 
-                records.sort(key=lambda record: record.asset_entry.asset_key)  # order by asset key
+                assert len(records) == 1
                 asset_entry = records[0].asset_entry
                 assert asset_entry.asset_key == my_asset_key
                 materialize_event = [
@@ -1988,9 +2087,38 @@ class TestEventLogStorage:
                 ][0]
                 assert asset_entry.last_materialization.dagster_event == materialize_event
                 assert asset_entry.last_run_id == result.run_id
-                assert isinstance(asset_entry.asset_details, AssetDetails)
+                assert asset_entry.asset_details == None
 
-    def test_asset_record_run_id_wiped(self, storage):
+                if self.can_wipe():
+                    storage.wipe_asset(my_asset_key)
+
+                    # confirm that last_run_id == None when asset is wiped
+                    assert len(storage.get_asset_records([my_asset_key])) == 0
+
+                    result = _execute_job_and_store_events(
+                        created_instance,
+                        storage,
+                        asset_group.build_job(name="two_asset_job"),
+                        run_id=run_id_2,
+                    )
+                    records = storage.get_asset_records([my_asset_key])
+                    assert len(records) == 1
+                    records = storage.get_asset_records()  # should select all assets
+                    assert len(records) == 2
+
+                    records.sort(
+                        key=lambda record: record.asset_entry.asset_key
+                    )  # order by asset key
+                    asset_entry = records[0].asset_entry
+                    assert asset_entry.asset_key == my_asset_key
+                    materialize_event = [
+                        event for event in result.all_events if event.is_step_materialization
+                    ][0]
+                    assert asset_entry.last_materialization.dagster_event == materialize_event
+                    assert asset_entry.last_run_id == result.run_id
+                    assert isinstance(asset_entry.asset_details, AssetDetails)
+
+    def test_asset_record_run_id_wiped(self, storage, instance):
         asset_key = AssetKey("foo")
 
         @op
@@ -2003,60 +2131,79 @@ class TestEventLogStorage:
             yield AssetObservation("foo")
             yield Output(5)
 
-        with instance_for_test() as instance:
-            if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(instance)
+        run_id_1 = make_new_run_id()
+        run_id_2 = make_new_run_id()
+        run_id_3 = make_new_run_id()
+        with create_and_delete_test_runs(instance, [run_id_1, run_id_2, run_id_3]):
 
-            events, result = _synthesize_events(lambda: observe_asset(), instance=instance)
-            for event in events:
-                storage.store_event(event)
-            asset_entry = storage.get_asset_records([asset_key])[0].asset_entry
-            assert asset_entry.last_run_id == None
+            with instance_for_test() as created_instance:
+                if not storage._instance:  # pylint: disable=protected-access
+                    storage.register_instance(created_instance)
 
-            events, result = _synthesize_events(lambda: materialize_asset(), instance=instance)
-            for event in events:
-                storage.store_event(event)
-            asset_entry = storage.get_asset_records([asset_key])[0].asset_entry
-            assert asset_entry.last_run_id == result.run_id
-
-            if self.can_wipe():
-                storage.wipe_asset(asset_key)
-                assert len(storage.get_asset_records([asset_key])) == 0
-
-                events, result = _synthesize_events(lambda: observe_asset(), instance=instance)
+                events, result = _synthesize_events(
+                    lambda: observe_asset(), instance=created_instance, run_id=run_id_1
+                )
                 for event in events:
                     storage.store_event(event)
                 asset_entry = storage.get_asset_records([asset_key])[0].asset_entry
                 assert asset_entry.last_run_id == None
 
-    def test_last_run_id_updates_on_materialization_planned(self, storage):
+                events, result = _synthesize_events(
+                    lambda: materialize_asset(), instance=created_instance, run_id=run_id_2
+                )
+                for event in events:
+                    storage.store_event(event)
+                asset_entry = storage.get_asset_records([asset_key])[0].asset_entry
+                assert asset_entry.last_run_id == result.run_id
+
+                if self.can_wipe():
+                    storage.wipe_asset(asset_key)
+                    assert len(storage.get_asset_records([asset_key])) == 0
+
+                    events, result = _synthesize_events(
+                        lambda: observe_asset(), instance=created_instance, run_id=run_id_3
+                    )
+                    for event in events:
+                        storage.store_event(event)
+                    asset_entry = storage.get_asset_records([asset_key])[0].asset_entry
+                    assert asset_entry.last_run_id == None
+
+    def test_last_run_id_updates_on_materialization_planned(self, storage, instance):
         @asset
         def never_materializes_asset():
             raise Exception("foo")
 
-        with instance_for_test() as instance:
-            if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(instance)
+        run_id_1 = make_new_run_id()
+        run_id_2 = make_new_run_id()
+        with create_and_delete_test_runs(instance, [run_id_1, run_id_2]):
 
-            asset_key = AssetKey("never_materializes_asset")
-            never_materializes_job = build_assets_job(
-                "never_materializes_job", [never_materializes_asset]
-            )
+            with instance_for_test() as created_instance:
+                if not storage._instance:  # pylint: disable=protected-access
+                    storage.register_instance(created_instance)
 
-            result = _execute_job_and_store_events(instance, storage, never_materializes_job)
-            records = storage.get_asset_records([asset_key])
+                asset_key = AssetKey("never_materializes_asset")
+                never_materializes_job = build_assets_job(
+                    "never_materializes_job", [never_materializes_asset]
+                )
 
-            assert len(records) == 1
-            asset_record = records[0]
-            assert result.run_id == asset_record.asset_entry.last_run_id
-
-            if self.can_wipe():
-                storage.wipe_asset(asset_key)
-
-                # confirm that last_run_id == None when asset is wiped
-                assert len(storage.get_asset_records([asset_key])) == 0
-
-                result = _execute_job_and_store_events(instance, storage, never_materializes_job)
+                result = _execute_job_and_store_events(
+                    created_instance, storage, never_materializes_job, run_id=run_id_1
+                )
                 records = storage.get_asset_records([asset_key])
+
                 assert len(records) == 1
-                assert result.run_id == records[0].asset_entry.last_run_id
+                asset_record = records[0]
+                assert result.run_id == asset_record.asset_entry.last_run_id
+
+                if self.can_wipe():
+                    storage.wipe_asset(asset_key)
+
+                    # confirm that last_run_id == None when asset is wiped
+                    assert len(storage.get_asset_records([asset_key])) == 0
+
+                    result = _execute_job_and_store_events(
+                        created_instance, storage, never_materializes_job, run_id=run_id_2
+                    )
+                    records = storage.get_asset_records([asset_key])
+                    assert len(records) == 1
+                    assert result.run_id == records[0].asset_entry.last_run_id


### PR DESCRIPTION
https://github.com/dagster-io/internal/pull/1634?no-redirect=1 adds the constraint in cloud that a run needs to exist for you to write an event for it. Options for getting these tests to pass:

- mock out run storage when testing cloud gql. I think this could make these tests less valuable
- Create runs for the events written in these tests (this diff)