### PR TITLE
[dagit] More cleanup of query callsites performing background polling

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -15,6 +15,7 @@ import * as React from 'react';
 import {
   FIFTEEN_SECONDS,
   QueryRefreshCountdown,
+  useMergedRefresh,
   useQueryRefreshAtInterval,
 } from '../app/QueryRefresh';
 import {Timestamp} from '../app/time/Timestamp';
@@ -88,8 +89,10 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
     notifyOnNetworkStatusChange: true,
   });
 
-  const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
-  useQueryRefreshAtInterval(liveQueryResult, FIFTEEN_SECONDS);
+  const refreshState = useMergedRefresh(
+    useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS),
+    useQueryRefreshAtInterval(liveQueryResult, FIFTEEN_SECONDS),
+  );
 
   // Refresh immediately when a run is launched from this page
   useDidLaunchEvent(queryResult.refetch);

--- a/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components/macro';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {SidebarSection} from '../pipelines/SidebarComponents';
 import {RunStatusIndicator} from '../runs/RunStatusDots';
 import {DagsterTag} from '../runs/RunTag';
@@ -28,14 +29,17 @@ export const RunGroupPanel: React.FC<{runId: string; runStatusLastChangedAt: num
   runId,
   runStatusLastChangedAt,
 }) => {
-  const {data, refetch} = useQuery<RunGroupPanelQuery, RunGroupPanelQueryVariables>(
+  const queryResult = useQuery<RunGroupPanelQuery, RunGroupPanelQueryVariables>(
     RUN_GROUP_PANEL_QUERY,
     {
       variables: {runId},
       fetchPolicy: 'cache-and-network',
-      pollInterval: 15000, // 15s
+      notifyOnNetworkStatusChange: true,
     },
   );
+
+  const {data, refetch} = queryResult;
+  useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
 
   // Because the RunGroupPanel makes it's own query for the runs and their statuses,
   // the log + gantt chart UI can show that the run is "completed" for up to 15s before

--- a/js_modules/dagit/packages/core/src/hooks/useDocumentVisibility.tsx
+++ b/js_modules/dagit/packages/core/src/hooks/useDocumentVisibility.tsx
@@ -1,14 +1,26 @@
 import React from 'react';
 
+// Note: This is a workaround for a problem observed in Firefox - registering
+// two visibilitychange event listeners is fine, but if you add a third one
+// it is not called reliably (maybe there's an execution time limit before
+// the page's JS is paused?)
+//
+let callbacks: (() => void)[] = [];
+document.addEventListener('visibilitychange', () => {
+  callbacks.forEach((c) => c());
+});
+
 export function useDocumentVisibility() {
-  const [documentVisible, setDocumentVisible] = React.useState(true);
+  const [documentVisible, setDocumentVisible] = React.useState(
+    document.visibilityState !== 'hidden',
+  );
   React.useEffect(() => {
     const handler = () => {
-      setDocumentVisible(!document.hidden);
+      setDocumentVisible(document.visibilityState !== 'hidden');
     };
-    document.addEventListener('visibilitychange', handler);
+    callbacks.push(handler);
     return () => {
-      document.removeEventListener('visibilitychange', handler);
+      callbacks = callbacks.filter((c) => c !== handler);
     };
   });
 

--- a/js_modules/dagit/packages/core/src/instance/InstanceConfig.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceConfig.tsx
@@ -27,6 +27,7 @@ const InstanceConfigStyle = createGlobalStyle`
 export const InstanceConfig = React.memo(() => {
   const queryResult = useQuery<InstanceConfigQuery>(INSTANCE_CONFIG_QUERY, {
     fetchPolicy: 'cache-and-network',
+    notifyOnNetworkStatusChange: true,
   });
 
   const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);

--- a/js_modules/dagit/packages/core/src/nav/InstanceWarningIcon.tsx
+++ b/js_modules/dagit/packages/core/src/nav/InstanceWarningIcon.tsx
@@ -2,6 +2,7 @@ import {gql, useQuery} from '@apollo/client';
 import {Colors, Icon} from '@dagster-io/ui';
 import * as React from 'react';
 
+import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
 import {useRepositoryOptions} from '../workspace/WorkspaceContext';
 
@@ -10,10 +11,14 @@ import {InstanceWarningQuery} from './types/InstanceWarningQuery';
 
 export const InstanceWarningIcon = React.memo(() => {
   const {options} = useRepositoryOptions();
-  const {data: healthData} = useQuery<InstanceWarningQuery>(INSTANCE_WARNING_QUERY, {
+  const queryResult = useQuery<InstanceWarningQuery>(INSTANCE_WARNING_QUERY, {
     fetchPolicy: 'cache-and-network',
-    pollInterval: 15 * 1000,
+    notifyOnNetworkStatusChange: true,
   });
+
+  useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
+
+  const {data: healthData} = queryResult;
 
   const {anySchedules, anySensors} = React.useMemo(() => {
     let anySchedules = false;

--- a/js_modules/dagit/packages/core/src/nav/LatestRunTag.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LatestRunTag.tsx
@@ -17,7 +17,7 @@ const TIME_FORMAT = {showSeconds: true, showTimezone: false};
 export const LatestRunTag: React.FC<{pipelineName: string}> = ({pipelineName}) => {
   const lastRunQuery = useQuery<LatestRunTagQuery, LatestRunTagQueryVariables>(
     LATEST_RUN_TAG_QUERY,
-    {variables: {runsFilter: {pipelineName}}},
+    {variables: {runsFilter: {pipelineName}}, notifyOnNetworkStatusChange: true},
   );
 
   useQueryRefreshAtInterval(lastRunQuery, FIFTEEN_SECONDS);

--- a/js_modules/dagit/packages/core/src/runs/AllScheduledTicks.tsx
+++ b/js_modules/dagit/packages/core/src/runs/AllScheduledTicks.tsx
@@ -17,6 +17,7 @@ export const AllScheduledTicks = () => {
   const queryResult = useQuery<SchedulerInfoQuery>(SCHEDULER_INFO_QUERY, {
     fetchPolicy: 'cache-and-network',
     partialRefetch: true,
+    notifyOnNetworkStatusChange: true,
   });
 
   useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleDetails.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleDetails.tsx
@@ -2,12 +2,9 @@ import {
   Box,
   ButtonLink,
   Colors,
-  CountdownStatus,
-  useCountdown,
   Group,
   MetadataTableWIP,
   PageHeader,
-  RefreshableCountdown,
   Tag,
   Code,
   Heading,
@@ -16,6 +13,7 @@ import {
 } from '@dagster-io/ui';
 import * as React from 'react';
 
+import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {useCopyToClipboard} from '../app/browser';
 import {TickTag} from '../instigation/InstigationTick';
 import {RepositoryLink} from '../nav/RepositoryLink';
@@ -35,11 +33,9 @@ const TIME_FORMAT = {showSeconds: false, showTimezone: true};
 export const ScheduleDetails: React.FC<{
   schedule: ScheduleFragment;
   repoAddress: RepoAddress;
-  countdownDuration: number;
-  countdownStatus: CountdownStatus;
-  onRefresh: () => void;
+  refreshState: QueryRefreshState;
 }> = (props) => {
-  const {repoAddress, schedule, countdownDuration, countdownStatus, onRefresh} = props;
+  const {repoAddress, schedule, refreshState} = props;
   const {cronSchedule, executionTimezone, futureTicks, name, partitionSet, pipelineName} = schedule;
   const copyToClipboard = useCopyToClipboard();
 
@@ -47,11 +43,6 @@ export const ScheduleDetails: React.FC<{
   const isJob = isThisThingAJob(repo, pipelineName);
 
   const [copyText, setCopyText] = React.useState('Click to copy');
-
-  const timeRemaining = useCountdown({
-    duration: countdownDuration,
-    status: countdownStatus,
-  });
 
   // Restore the tooltip text after a delay.
   React.useEffect(() => {
@@ -76,8 +67,6 @@ export const ScheduleDetails: React.FC<{
   };
 
   const running = status === InstigationStatus.RUNNING;
-  const countdownRefreshing = countdownStatus === 'idle' || timeRemaining === 0;
-  const seconds = Math.floor(timeRemaining / 1000);
 
   return (
     <>
@@ -112,13 +101,7 @@ export const ScheduleDetails: React.FC<{
             </Box>
           </>
         }
-        right={
-          <RefreshableCountdown
-            refreshing={countdownRefreshing}
-            seconds={seconds}
-            onRefresh={onRefresh}
-          />
-        }
+        right={<QueryRefreshCountdown refreshState={refreshState} />}
       />
       <MetadataTableWIP>
         <tbody>

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesRoot.tsx
@@ -3,6 +3,7 @@ import {Box, Colors, NonIdealState, Subheading} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
+import {useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {UnloadableSchedules} from '../instigation/Unloadable';
 import {InstigationType} from '../types/globalTypes';
@@ -28,10 +29,12 @@ export const SchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
         instigationType: InstigationType.SCHEDULE,
       },
       fetchPolicy: 'cache-and-network',
-      pollInterval: 50 * 1000,
       partialRefetch: true,
+      notifyOnNetworkStatusChange: true,
     },
   );
+
+  useQueryRefreshAtInterval(queryResult, 50 * 1000);
 
   return (
     <Loading queryResult={queryResult} allowStaleData={true}>

--- a/js_modules/dagit/packages/core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorDetails.tsx
@@ -1,18 +1,16 @@
 import {
   Box,
   Button,
-  CountdownStatus,
-  useCountdown,
   Group,
   MetadataTableWIP,
   PageHeader,
-  RefreshableCountdown,
   Tag,
   Heading,
   FontFamily,
 } from '@dagster-io/ui';
 import * as React from 'react';
 
+import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {AssetLink} from '../assets/AssetLink';
 import {TickTag} from '../instigation/InstigationTick';
 import {RepositoryLink} from '../nav/RepositoryLink';
@@ -53,10 +51,8 @@ export const SensorDetails: React.FC<{
   sensor: SensorFragment;
   repoAddress: RepoAddress;
   daemonHealth: boolean | null;
-  countdownDuration: number;
-  countdownStatus: CountdownStatus;
-  onRefresh: () => void;
-}> = ({sensor, repoAddress, daemonHealth, countdownDuration, countdownStatus, onRefresh}) => {
+  refreshState: QueryRefreshState;
+}> = ({sensor, repoAddress, daemonHealth, refreshState}) => {
   const {
     name,
     sensorState: {status, ticks},
@@ -72,14 +68,6 @@ export const SensorDetails: React.FC<{
   };
   const repo = useRepository(repoAddress);
   const pipelinesAndJobs = repo?.repository.pipelines;
-
-  const timeRemaining = useCountdown({
-    duration: countdownDuration,
-    status: countdownStatus,
-  });
-
-  const countdownRefreshing = countdownStatus === 'idle' || timeRemaining === 0;
-  const seconds = Math.floor(timeRemaining / 1000);
 
   const latestTick = ticks.length ? ticks[0] : null;
   const targetCount = targets?.length || 0;
@@ -131,11 +119,7 @@ export const SensorDetails: React.FC<{
         }
         right={
           <Box margin={{top: 4}}>
-            <RefreshableCountdown
-              refreshing={countdownRefreshing}
-              seconds={seconds}
-              onRefresh={onRefresh}
-            />
+            <QueryRefreshCountdown refreshState={refreshState} />
           </Box>
         }
       />

--- a/js_modules/dagit/packages/core/src/sensors/SensorsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorsRoot.tsx
@@ -3,6 +3,7 @@ import {Box, NonIdealState} from '@dagster-io/ui';
 import React from 'react';
 
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
 import {INSTIGATION_STATE_FRAGMENT} from '../instigation/InstigationUtils';
@@ -32,9 +33,11 @@ export const SensorsRoot = (props: Props) => {
       instigationType: InstigationType.SENSOR,
     },
     fetchPolicy: 'cache-and-network',
-    pollInterval: 50 * 1000,
     partialRefetch: true,
+    notifyOnNetworkStatusChange: true,
   });
+
+  useQueryRefreshAtInterval(queryResult, 50 * 1000);
 
   return (
     <Loading queryResult={queryResult} allowStaleData={true}>


### PR DESCRIPTION
## Summary
There were a few callsites in Dagit that evaded my last sweep for `useQuery({pollInterval})` (maybe because of merges?)

This PR cleans these up and fixes a few specific bugs:

- I added a utility hook that can combine multiple `useQueryRefreshAtInterval` calls, making it easy to bind one refresh button to several queries.

- The useQueryRefreshAtInterval hook only works if you pass `notifyOnNetworkStatusChange: true` to the useQuery. It needs to be able to "see" the refresh start and end by observing the queryResult.networkStatus. This wasn't super noticeable because it also works if you set `fetchPolicy: "cache-and-network"`. Unfortunately we can't enforce it statically because the useQuery variables aren't present in the query result, but it's at least a documented requirement now.

- The "document visibility" check was not working correctly in Firefox on the sensor details page because registering 3+ listeners to `document.addEventListener('visibilitychange')` does not seem to work. I spent a couple hours chasing this and I have no idea why - the third handler is not called reliably, and my guess is Firefox is only giving the page a certain amount of JS time to handle the event. This meant the hook wouldn't "see" the page come back into the foreground and trigger a refresh. Registering one handler that calls an array of callbacks works reliably. 

- The "document visibility" check needed to check `document.visibilityState === 'hidden'` and not `document.hidden` because hidden also returns true in a new "prerender" visibility state in Chrome (during the first few milliseconds of page time when the page is not actually hidden?) 


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.