### PR TITLE
 Reexecute run mutation using just parent run

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1790,8 +1790,14 @@ type GraphenePermission {
 type DagitMutation {
   launchPipelineExecution(executionParams: ExecutionParams!): LaunchRunResult!
   launchRun(executionParams: ExecutionParams!): LaunchRunResult!
-  launchPipelineReexecution(executionParams: ExecutionParams!): LaunchRunReexecutionResult!
-  launchRunReexecution(executionParams: ExecutionParams!): LaunchRunReexecutionResult!
+  launchPipelineReexecution(
+    executionParams: ExecutionParams
+    reexecutionParams: ReexecutionParams
+  ): LaunchRunReexecutionResult!
+  launchRunReexecution(
+    executionParams: ExecutionParams
+    reexecutionParams: ReexecutionParams
+  ): LaunchRunReexecutionResult!
   startSchedule(scheduleSelector: ScheduleSelector!): ScheduleMutationResult!
   stopRunningSchedule(
     scheduleOriginId: String!
@@ -1907,6 +1913,16 @@ union LaunchRunReexecutionResult =
   | PresetNotFoundError
   | ConflictingExecutionParamsError
   | NoModeProvidedError
+
+input ReexecutionParams {
+  parentRunId: String!
+  policy: ReexecutionPolicy!
+}
+
+enum ReexecutionPolicy {
+  FROM_FAILURE
+  ALL_OPS
+}
 
 union ScheduleMutationResult = PythonError | UnauthorizedError | ScheduleStateResult
 

--- a/python_modules/dagster-graphql/dagster_graphql/client/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/query.py
@@ -316,8 +316,8 @@ mutation($executionParams: ExecutionParams!) {
 LAUNCH_PIPELINE_REEXECUTION_MUTATION = (
     ERROR_FRAGMENT
     + """
-mutation($executionParams: ExecutionParams!) {
-  launchPipelineReexecution(executionParams: $executionParams) {
+mutation($executionParams: ExecutionParams, $reexecutionParams: ReexecutionParams) {
+  launchPipelineReexecution(executionParams: $executionParams, reexecutionParams: $reexecutionParams) {
     __typename
 
     ... on PythonError {

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -20,7 +20,11 @@ from .backfill import (
     create_and_launch_partition_backfill,
     resume_partition_backfill,
 )
-from .launch_execution import launch_pipeline_execution, launch_pipeline_reexecution
+from .launch_execution import (
+    launch_pipeline_execution,
+    launch_pipeline_reexecution,
+    launch_reexecution_from_parent_run,
+)
 
 
 def _force_mark_as_canceled(instance, run_id):

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -1,6 +1,8 @@
 from graphql.execution.base import ResolveInfo
 
 from dagster import check
+from dagster.core.host_representation.selector import PipelineSelector
+from dagster.core.instance import DagsterInstance
 from dagster.core.storage.pipeline_run import RunsFilter
 
 from ..external import get_external_pipeline_or_raise
@@ -52,4 +54,45 @@ def _launch_pipeline_execution(graphene_info, execution_params, is_reexecuted=Fa
     run = do_launch(graphene_info, execution_params, is_reexecuted)
     records = graphene_info.context.instance.get_run_records(RunsFilter(run_ids=[run.run_id]))
 
+    return GrapheneLaunchRunSuccess(run=GrapheneRun(records[0]))
+
+
+@capture_error
+def launch_reexecution_from_parent_run(graphene_info, parent_run_id: str, policy):
+    """
+    Launch a re-execution by referencing the parent run id
+    """
+    from ...schema.inputs import GrapheneReexecutionPolicy
+    from ...schema.pipelines.pipeline import GrapheneRun
+    from ...schema.runs import GrapheneLaunchRunSuccess
+
+    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
+    check.str_param(parent_run_id, "parent_run_id")
+
+    check.invariant(
+        policy == GrapheneReexecutionPolicy.FROM_FAILURE, "Only FROM_FAILURE is currently supported"
+    )
+
+    instance: DagsterInstance = graphene_info.context.instance
+    parent_run = instance.get_run_by_id(parent_run_id)
+    check.invariant(parent_run, "Could not find parent run with id: %s" % parent_run_id)
+
+    selector = PipelineSelector(
+        location_name=parent_run.external_pipeline_origin.external_repository_origin.repository_location_origin.location_name,
+        repository_name=parent_run.external_pipeline_origin.external_repository_origin.repository_name,
+        pipeline_name=parent_run.pipeline_name,
+        solid_selection=None,
+    )
+
+    repo_location = graphene_info.context.get_repository_location(selector.location_name)
+    external_pipeline = get_external_pipeline_or_raise(graphene_info, selector)
+
+    run = instance.create_reexecuted_run_from_failure(parent_run, repo_location, external_pipeline)
+    graphene_info.context.instance.submit_run(
+        run.run_id,
+        workspace=graphene_info.context,
+    )
+
+    # return run with updateTime
+    records = graphene_info.context.instance.get_run_records(RunsFilter(run_ids=[run.run_id]))
     return GrapheneLaunchRunSuccess(run=GrapheneRun(records[0]))

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -209,6 +209,22 @@ class GrapheneExecutionParams(graphene.InputObjectType):
         name = "ExecutionParams"
 
 
+class GrapheneReexecutionPolicy(graphene.Enum):
+    FROM_FAILURE = "FROM_FAILURE"
+    ALL_OPS = "ALL_OPS"
+
+    class Meta:
+        name = "ReexecutionPolicy"
+
+
+class GrapheneReexecutionParams(graphene.InputObjectType):
+    parentRunId = graphene.NonNull(graphene.String)
+    policy = graphene.NonNull(GrapheneReexecutionPolicy)
+
+    class Meta:
+        name = "ReexecutionParams"
+
+
 class GrapheneMarshalledInput(graphene.InputObjectType):
     input_name = graphene.NonNull(graphene.String)
     key = graphene.NonNull(graphene.String)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/johann
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/johann
@@ -1,0 +1,23 @@
+from collections import OrderedDict
+
+
+{
+    "data": OrderedDict(
+        [
+            (
+                "launchPipelineReexecution",
+                {
+                    "__typename": "PythonError",
+                    "message": 'dagster.core.errors.DagsterInvalidConfigError: Error in config for pipeline\n    Error 1: Received unexpected config entry "bad" at the root. Expected: "{ execution?: { in_process?: { config?: { marker_to_close?: String retries?: { disabled?: { } enabled?: { } } } } multiprocess?: { config?: { max_concurrent?: Int retries?: { disabled?: { } enabled?: { } } start_method?: { forkserver?: { preload_modules?: [String] } spawn?: { } } } } } loggers?: { console?: { config?: { log_level?: String name?: String } } } resources?: { io_manager?: { config?: { base_dir?: (String | { env: String }) } } } solids?: { after_failure?: { config?: Any outputs?: [{ result?: { json: { path: String } pickle: { path: String } } }] } always_succeed?: { config?: Any outputs?: [{ result?: { json: { path: String } pickle: { path: String } } }] } conditionally_fail?: { config?: Any outputs?: [{ result?: { json: { path: String } pickle: { path: String } } }] } } }".\n',
+                    "className": "DagsterInvalidConfigError",
+                    "stack": [
+                        '  File "/Users/johann/dagster/python_modules/dagster/dagster/grpc/impl.py", line 366, in get_external_execution_plan_snapshot\n    create_execution_plan(\n',
+                        '  File "/Users/johann/dagster/python_modules/dagster/dagster/core/execution/api.py", line 757, in create_execution_plan\n    resolved_run_config = ResolvedRunConfig.build(pipeline_def, run_config, mode=mode)\n',
+                        '  File "/Users/johann/dagster/python_modules/dagster/dagster/core/system_config/objects.py", line 160, in build\n    raise DagsterInvalidConfigError(\n',
+                    ],
+                    "cause": None,
+                },
+            )
+        ]
+    )
+}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_reexecution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_reexecution.py
@@ -78,6 +78,24 @@ snapshots['TestReexecution.test_full_pipeline_reexecution_fs_storage[sqlite_with
     }
 }
 
+snapshots['TestReexecution.test_full_pipeline_reexecution_fs_storage_with_reexecution_params[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
+    'launchPipelineExecution': {
+        '__typename': 'LaunchRunSuccess',
+        'run': {
+            'mode': 'default',
+            'pipeline': {
+                'name': 'csv_hello_world'
+            },
+            'resolvedOpSelection': None,
+            'runConfigYaml': '<runConfigYaml dummy value>',
+            'runId': '<runId dummy value>',
+            'status': 'STARTING',
+            'tags': [
+            ]
+        }
+    }
+}
+
 snapshots['TestReexecution.test_full_pipeline_reexecution_in_memory_storage[postgres_with_default_run_launcher_deployed_grpc_env] 1'] = {
     'launchPipelineExecution': {
         '__typename': 'LaunchRunSuccess',


### PR DESCRIPTION
Provide a simpler interface for the front end to re-execute: just pass a parent run id and selector, rather than putting together the various bits of a re-execution with tags, root run, etc.

If this looks like a reasonable approach will add tests