### PR TITLE
[dagit] Show asset “compute kind” in the global asset graph

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -31,7 +31,6 @@ import {
 } from '../pipelines/GraphNotices';
 import {ExplorerPath} from '../pipelines/PipelinePathUtils';
 import {SidebarPipelineOrJobOverview} from '../pipelines/SidebarPipelineOrJobOverview';
-import {GraphExplorerSolidHandleFragment} from '../pipelines/types/GraphExplorerSolidHandleFragment';
 import {useDidLaunchEvent} from '../runs/RunUtils';
 import {PipelineSelector} from '../types/globalTypes';
 import {GraphQueryInput} from '../ui/GraphQueryInput';
@@ -63,11 +62,6 @@ interface Props {
 
   pipelineSelector?: PipelineSelector;
   filterNodes?: (assetNode: AssetGraphQuery_assetNodes) => boolean;
-
-  // Optionally pass op handles to display op metadata on the assets linked to each op.
-  // (eg: the "ipynb" tag annotation). Right now, we already have this data loaded for
-  // individual jobs, and the global asset graph quietly doesn't display these.
-  handles?: GraphExplorerSolidHandleFragment[];
 
   explorerPath: ExplorerPath;
   onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
@@ -141,7 +135,6 @@ const AssetGraphExplorerWithData: React.FC<
   } & Props
 > = (props) => {
   const {
-    handles = [],
     options,
     setOptions,
     explorerPath,
@@ -306,10 +299,6 @@ const AssetGraphExplorerWithData: React.FC<
                           <AssetNode
                             definition={graphNode.definition}
                             liveData={liveDataByNode[graphNode.id]}
-                            metadata={
-                              handles.find((h) => h.handleID === graphNode.definition.opName)?.solid
-                                .definition.metadata || []
-                            }
                             selected={selectedGraphNodes.includes(graphNode)}
                           />
                         )}

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -26,11 +26,9 @@ const MISSING_LIVE_DATA = {
 export const AssetNode: React.FC<{
   definition: AssetNodeFragment;
   liveData?: LiveDataForNode;
-  metadata: {key: string; value: string}[];
   selected: boolean;
   inAssetCatalog?: boolean;
-}> = React.memo(({definition, metadata, selected, liveData, inAssetCatalog}) => {
-  const kind = metadata.find((m) => m.key === 'kind')?.value;
+}> = React.memo(({definition, selected, liveData, inAssetCatalog}) => {
   const stepKey = definition.opName || '';
 
   const displayName = withMiddleTruncation(displayNameForAssetKey(definition.assetKey), {
@@ -138,13 +136,13 @@ export const AssetNode: React.FC<{
             )}
           </StatsRow>
         </Stats>
-        {kind && (
+        {definition.computeKind && (
           <OpTags
             minified={false}
             style={{right: -2, paddingTop: 5}}
             tags={[
               {
-                label: kind,
+                label: definition.computeKind,
                 onClick: () => {
                   window.requestAnimationFrame(() =>
                     document.dispatchEvent(new Event('show-kind-info')),
@@ -195,6 +193,7 @@ export const ASSET_NODE_FRAGMENT = gql`
     opName
     description
     partitionDefinition
+    computeKind
     assetKey {
       path
     }

--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -19,10 +19,8 @@ import {Description} from '../pipelines/Description';
 import {SidebarSection, SidebarTitle} from '../pipelines/SidebarComponents';
 import {pluginForMetadata} from '../plugins';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {RepoAddress} from '../workspace/types';
 
 import {LiveDataForNode, displayNameForAssetKey} from './Utils';
-import {SidebarAssetFragment} from './types/SidebarAssetFragment';
 import {SidebarAssetQuery, SidebarAssetQueryVariables} from './types/SidebarAssetQuery';
 
 export const SidebarAssetInfo: React.FC<{
@@ -50,6 +48,9 @@ export const SidebarAssetInfo: React.FC<{
 
   const repoAddress = buildRepoAddress(asset.repository.name, asset.repository.location.name);
   const {assetMetadata, assetType} = metadataForAssetNode(asset);
+  const hasAssetMetadata = assetType || assetMetadata.length > 0;
+
+  const OpMetadataPlugin = asset.op?.metadata && pluginForMetadata(asset.op.metadata);
 
   return (
     <>
@@ -68,8 +69,15 @@ export const SidebarAssetInfo: React.FC<{
 
       <div style={{borderBottom: `2px solid ${Colors.Gray300}`}} />
 
-      {(asset.description || !(asset.description || assetType || assetMetadata)) && (
-        <DescriptionSidebarSection asset={asset} repoAddress={repoAddress} />
+      {(asset.description || OpMetadataPlugin?.SidebarComponent || !hasAssetMetadata) && (
+        <SidebarSection title="Description">
+          <Box padding={{vertical: 16, horizontal: 24}}>
+            <Description description={asset.description || 'No description provided.'} />
+          </Box>
+          {asset.op && OpMetadataPlugin?.SidebarComponent && (
+            <OpMetadataPlugin.SidebarComponent definition={asset.op} repoAddress={repoAddress} />
+          )}
+        </SidebarSection>
       )}
 
       {assetMetadata.length > 0 && (
@@ -89,24 +97,6 @@ export const SidebarAssetInfo: React.FC<{
         </SidebarSection>
       )}
     </>
-  );
-};
-
-const DescriptionSidebarSection: React.FC<{
-  asset: SidebarAssetFragment;
-  repoAddress: RepoAddress;
-}> = ({asset, repoAddress}) => {
-  const Plugin = asset.op?.metadata && pluginForMetadata(asset.op.metadata);
-
-  return (
-    <SidebarSection title="Description">
-      <Box padding={{vertical: 16, horizontal: 24}}>
-        <Description description={asset.description || 'No description provided.'} />
-      </Box>
-      {asset.op && Plugin && Plugin.SidebarComponent && (
-        <Plugin.SidebarComponent definition={asset.op} repoAddress={repoAddress} />
-      )}
-    </SidebarSection>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphQuery.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphQuery.ts
@@ -43,6 +43,7 @@ export interface AssetGraphQuery_assetNodes {
   opName: string | null;
   description: string | null;
   partitionDefinition: string | null;
+  computeKind: string | null;
   assetKey: AssetGraphQuery_assetNodes_assetKey;
   repository: AssetGraphQuery_assetNodes_repository;
   jobNames: string[];

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetNodeFragment.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetNodeFragment.ts
@@ -31,6 +31,7 @@ export interface AssetNodeFragment {
   opName: string | null;
   description: string | null;
   partitionDefinition: string | null;
+  computeKind: string | null;
   assetKey: AssetNodeFragment_assetKey;
   repository: AssetNodeFragment_repository;
 }

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeList.tsx
@@ -38,7 +38,6 @@ export const AssetNodeList: React.FC<{
             {asset.jobNames.length ? (
               <AssetNode
                 definition={asset}
-                metadata={[]}
                 inAssetCatalog
                 selected={false}
                 liveData={liveDataByNode[toGraphId(asset.assetKey)]}

--- a/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
@@ -2372,6 +2372,7 @@ export interface AssetNodeDefinitionFragment_dependencies_asset {
   jobNames: string[];
   description: string | null;
   partitionDefinition: string | null;
+  computeKind: string | null;
   assetKey: AssetNodeDefinitionFragment_dependencies_asset_assetKey;
   repository: AssetNodeDefinitionFragment_dependencies_asset_repository;
   assetMaterializations: AssetNodeDefinitionFragment_dependencies_asset_assetMaterializations[];
@@ -2413,6 +2414,7 @@ export interface AssetNodeDefinitionFragment_dependedBy_asset {
   jobNames: string[];
   description: string | null;
   partitionDefinition: string | null;
+  computeKind: string | null;
   assetKey: AssetNodeDefinitionFragment_dependedBy_asset_assetKey;
   repository: AssetNodeDefinitionFragment_dependedBy_asset_repository;
   assetMaterializations: AssetNodeDefinitionFragment_dependedBy_asset_assetMaterializations[];
@@ -2431,6 +2433,7 @@ export interface AssetNodeDefinitionFragment {
   jobNames: string[];
   repository: AssetNodeDefinitionFragment_repository;
   partitionDefinition: string | null;
+  computeKind: string | null;
   assetKey: AssetNodeDefinitionFragment_assetKey;
   assetMaterializations: AssetNodeDefinitionFragment_assetMaterializations[];
   metadataEntries: AssetNodeDefinitionFragment_metadataEntries[];

--- a/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
@@ -2426,6 +2426,7 @@ export interface AssetQuery_assetOrError_Asset_definition_dependencies_asset {
   jobNames: string[];
   description: string | null;
   partitionDefinition: string | null;
+  computeKind: string | null;
   assetKey: AssetQuery_assetOrError_Asset_definition_dependencies_asset_assetKey;
   repository: AssetQuery_assetOrError_Asset_definition_dependencies_asset_repository;
   assetMaterializations: AssetQuery_assetOrError_Asset_definition_dependencies_asset_assetMaterializations[];
@@ -2467,6 +2468,7 @@ export interface AssetQuery_assetOrError_Asset_definition_dependedBy_asset {
   jobNames: string[];
   description: string | null;
   partitionDefinition: string | null;
+  computeKind: string | null;
   assetKey: AssetQuery_assetOrError_Asset_definition_dependedBy_asset_assetKey;
   repository: AssetQuery_assetOrError_Asset_definition_dependedBy_asset_repository;
   assetMaterializations: AssetQuery_assetOrError_Asset_definition_dependedBy_asset_assetMaterializations[];
@@ -2486,6 +2488,7 @@ export interface AssetQuery_assetOrError_Asset_definition {
   description: string | null;
   opName: string | null;
   jobNames: string[];
+  computeKind: string | null;
   assetKey: AssetQuery_assetOrError_Asset_definition_assetKey;
   assetMaterializations: AssetQuery_assetOrError_Asset_definition_assetMaterializations[];
   metadataEntries: AssetQuery_assetOrError_Asset_definition_metadataEntries[];

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -217,6 +217,7 @@ type AssetNode {
     beforeTimestampMillis: String
     limit: Int
   ): [MaterializationEvent!]!
+  computeKind: String
   dependedBy: [AssetDependency!]!
   dependedByKeys: [AssetKey!]!
   dependencies: [AssetDependency!]!

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
@@ -89,7 +89,6 @@ export const PipelineExplorerContainer: React.FC<{
               options={options}
               setOptions={setOptions}
               pipelineSelector={pipelineSelector}
-              handles={displayedHandles}
               explorerPath={explorerPath}
               onChangeExplorerPath={onChangeExplorerPath}
             />

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -84,7 +84,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         beforeTimestampMillis=graphene.String(),
         limit=graphene.Int(),
     )
-    computeKind: graphene.String
+    computeKind = graphene.String()
     dependedBy = non_null_list(GrapheneAssetDependency)
     dependedByKeys = non_null_list(GrapheneAssetKey)
     dependencies = non_null_list(GrapheneAssetDependency)

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/partitioned_assets.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/partitioned_assets.py
@@ -12,12 +12,18 @@ from dagster import (
 daily_partitions_def = DailyPartitionsDefinition(start_date="2020-01-01")
 
 
-@asset(metadata={"owner": "alice@example.com"}, partitions_def=daily_partitions_def)
+@asset(
+    metadata={"owner": "alice@example.com"},
+    compute_kind="ipynb",
+    partitions_def=daily_partitions_def,
+)
 def upstream_daily_partitioned_asset():
     pass
 
 
-@asset(metadata={"owner": "alice@example.com"}, partitions_def=daily_partitions_def)
+@asset(
+    metadata={"owner": "alice@example.com"}, compute_kind="sql", partitions_def=daily_partitions_def
+)
 def downstream_daily_partitioned_asset(upstream_daily_partitioned_asset):
     assert upstream_daily_partitioned_asset is None
 


### PR DESCRIPTION
## Summary
This addresses https://github.com/dagster-io/dagster/issues/6956 (details about the implementation there) to show the  kind tag is shown on assets in the global asset graph.

I also added a few explicit compute kinds to assets in our toys repo so this is easier to see in action.

![image](https://user-images.githubusercontent.com/1037212/164510803-2a56aef3-f376-4e6f-843d-d302b7104b06.png)

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.