### PR TITLE
[dagit] Display repositories in a stable order

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
@@ -1,4 +1,5 @@
 import {ApolloQueryResult, gql, useQuery} from '@apollo/client';
+import sortBy from 'lodash/sortBy';
 import * as React from 'react';
 
 import {AppContext} from '../app/AppContext';
@@ -153,16 +154,21 @@ const useWorkspaceState = (): WorkspaceState => {
       return {allRepos, error: workspaceOrError};
     }
 
-    allRepos = workspaceOrError.locationEntries.reduce((accum, locationEntry) => {
-      if (locationEntry.locationOrLoadError?.__typename !== 'RepositoryLocation') {
-        return accum;
-      }
-      const repositoryLocation = locationEntry.locationOrLoadError;
-      const reposForLocation = repositoryLocation.repositories.map((repository) => {
-        return {repository, repositoryLocation};
-      });
-      return [...accum, ...reposForLocation];
-    }, [] as DagsterRepoOption[]);
+    allRepos = sortBy(
+      workspaceOrError.locationEntries.reduce((accum, locationEntry) => {
+        if (locationEntry.locationOrLoadError?.__typename !== 'RepositoryLocation') {
+          return accum;
+        }
+        const repositoryLocation = locationEntry.locationOrLoadError;
+        const reposForLocation = repositoryLocation.repositories.map((repository) => {
+          return {repository, repositoryLocation};
+        });
+        return [...accum, ...reposForLocation];
+      }, [] as DagsterRepoOption[]),
+
+      // Sort by repo location, then by repo
+      (r) => `${r.repositoryLocation.name}:${r.repository.name}`,
+    );
 
     return {error: null, allRepos};
   }, [workspaceOrError]);


### PR DESCRIPTION

## Summary
This is a small fix for https://github.com/dagster-io/dagster/issues/7517. Each time you start Dagit, the sort order of the repositories is random. Sorting on the backend was my first thought, but it's tricky because our desired sort order is based on both repo location AND repo name, so it's much easier to implement on the front-end.



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.