### PR TITLE
[dagit] Avoid resetting hidden repos on each page load #7519

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
@@ -203,7 +203,7 @@ const useVisibleRepos = (
 
   // TODO: Remove this logic eventually...
   const migratedOldHiddenKeys = React.useRef(false);
-  if (oldHiddenKeys && !migratedOldHiddenKeys.current) {
+  if (oldHiddenKeys.length && !migratedOldHiddenKeys.current) {
     setHiddenKeys(oldHiddenKeys);
     setOldHiddenKeys(undefined);
     migratedOldHiddenKeys.current = true;


### PR DESCRIPTION
This is a fix for the bug demonstrated here:  https://www.loom.com/share/44ece0e1175b41e893af6c68d8971f4c / https://github.com/dagster-io/dagster/issues/7519. Hiding a repo and then reloading the page unhides the repo.

## Summary
The reason this is happening is because our migration to `basePath`-based hidden keys calls `setOldHiddenKeys(undefined)` to unset the value, but the `useStateWithStorage` validates it's value to a `string[]` array via validateHiddenKeys, so `undefined` reads as `[]` . This causes the migration code to run again the next time the useVisibleRepos hook loads, since `[] == true` (sidenote: which is awful)...


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.