### PR TITLE
[dagit] Move yarn analyze to packages/app

### DIFF
--- a/js_modules/dagit/packages/app/package.json
+++ b/js_modules/dagit/packages/app/package.json
@@ -31,6 +31,7 @@
     "eslint": "8.7.0",
     "eslint-webpack-plugin": "3.1.1",
     "prettier": "2.2.1",
+    "source-map-explorer": "^2.5.0",
     "typescript": "^4.5.4"
   },
   "scripts": {
@@ -38,7 +39,8 @@
     "build": "react-scripts build",
     "lint": "eslint src/ --ext=.tsx,.ts,.js --fix -c .eslintrc.js",
     "test": "react-scripts test",
-    "ts": "tsc -p ."
+    "ts": "tsc -p .",
+    "analyze": "source-map-explorer 'build/static/js/*.js'"
   },
   "browserslist": {
     "production": [

--- a/js_modules/dagit/packages/core/package.json
+++ b/js_modules/dagit/packages/core/package.json
@@ -15,8 +15,7 @@
     "generate-graphql": "ts-node -O '{\"module\": \"commonjs\"}' ./src/scripts/generateGraphQLTypes.ts",
     "generate-perms": "ts-node -O '{\"module\": \"commonjs\"}' ./src/scripts/generatePermissions.ts",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
-    "analyze": "source-map-explorer 'build/static/js/*.js'"
+    "build-storybook": "build-storybook"
   },
   "peerDependencies": {
     "@apollo/client": "3.3.16",
@@ -132,7 +131,6 @@
     "react-router": "^5.2.1",
     "react-router-dom": "^5.3.0",
     "rgb-hex": "^4.0.0",
-    "source-map-explorer": "^2.5.0",
     "styled-components": "^5.3.3",
     "ts-node": "9.1.1",
     "ts-prune": "0.8.9",

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -5023,6 +5023,7 @@ __metadata:
     react-dom: ^17.0.2
     react-router: ^5.2.1
     react-router-dom: ^5.3.0
+    source-map-explorer: ^2.5.0
     typescript: ^4.5.4
     web-vitals: ^2.1.3
   languageName: unknown
@@ -5128,7 +5129,6 @@ __metadata:
     remark-gfm: 1.0.0
     remark-plain-text: ^0.2.0
     rgb-hex: ^4.0.0
-    source-map-explorer: ^2.5.0
     styled-components: ^5.3.3
     subscriptions-transport-ws: ^0.9.15
     ts-node: 9.1.1


### PR DESCRIPTION
## Summary

The `yarn analyze` script is on `core`, which no longer produces its own build. It should be on `app`.

## Test Plan

Run `yarn build`, then `yarn analyze` in `packages/app`. Verify that it produces a bundle analysis page.
