### PR TITLE
[dagit] Clean up lodash imports

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -1,5 +1,8 @@
 import {Box, Checkbox, NonIdealState, SplitPanelContainer} from '@dagster-io/ui';
-import _, {flatMap, uniq, uniqBy, without} from 'lodash';
+import flatMap from 'lodash/flatMap';
+import uniq from 'lodash/uniq';
+import uniqBy from 'lodash/uniqBy';
+import without from 'lodash/without';
 import React from 'react';
 import styled from 'styled-components/macro';
 

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -1,6 +1,6 @@
 import {gql} from '@apollo/client';
 import {Colors, Icon, Spinner, Tooltip, FontFamily, Box, CaptionMono} from '@dagster-io/ui';
-import {isEqual} from 'lodash';
+import isEqual from 'lodash/isEqual';
 import React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeInstigatorTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeInstigatorTag.tsx
@@ -1,5 +1,5 @@
 import {gql} from '@apollo/client';
-import {flatMap} from 'lodash';
+import flatMap from 'lodash/flatMap';
 import React from 'react';
 
 import {ScheduleOrSensorTag} from '../nav/ScheduleOrSensorTag';

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -10,7 +10,8 @@ import {
   DialogFooter,
   Alert,
 } from '@dagster-io/ui';
-import {pick, reject} from 'lodash';
+import pick from 'lodash/pick';
+import reject from 'lodash/reject';
 import React from 'react';
 import {useHistory} from 'react-router-dom';
 import * as yaml from 'yaml';

--- a/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
@@ -1,6 +1,6 @@
 import {gql, useApolloClient} from '@apollo/client';
 import {Tooltip, Spinner, Box, Colors} from '@dagster-io/ui';
-import {fromPairs} from 'lodash';
+import fromPairs from 'lodash/fromPairs';
 import React from 'react';
 
 import {displayNameForAssetKey} from '../asset-graph/Utils';

--- a/js_modules/dagit/packages/core/src/assets/groupByPartition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/groupByPartition.tsx
@@ -1,4 +1,4 @@
-import {groupBy} from 'lodash';
+import groupBy from 'lodash/groupBy';
 
 import {AssetMaterializationFragment} from './types/AssetMaterializationFragment';
 import {AssetObservationFragment} from './types/AssetObservationFragment';

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
@@ -9,7 +9,7 @@ import {
   SplitPanelContainer,
 } from '@dagster-io/ui';
 import merge from 'deepmerge';
-import {uniqBy} from 'lodash';
+import uniqBy from 'lodash/uniqBy';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 import * as yaml from 'yaml';

--- a/js_modules/dagit/packages/core/src/partitions/PartitionGraphUtils.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionGraphUtils.tsx
@@ -1,6 +1,6 @@
 import {gql} from '@apollo/client';
 import {Colors} from '@dagster-io/ui';
-import {isEqual} from 'lodash';
+import isEqual from 'lodash/isEqual';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 

--- a/js_modules/dagit/packages/core/src/pipelines/GraphNotices.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphNotices.tsx
@@ -1,5 +1,5 @@
 import {Box, Colors, Icon, NonIdealState, Spinner} from '@dagster-io/ui';
-import {capitalize} from 'lodash';
+import capitalize from 'lodash/capitalize';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 

--- a/js_modules/dagit/packages/eslint-config/index.js
+++ b/js_modules/dagit/packages/eslint-config/index.js
@@ -65,6 +65,10 @@ module.exports = {
             message: 'Please import from `@apollo/client`.',
           },
           {
+            name: 'lodash',
+            message: 'Please import specific lodash modules, e.g. `lodash/throttle`.',
+          },
+          {
             name: 'styled-components',
             message: 'Please import from `styled-components/macro`.',
           },

--- a/js_modules/dagit/packages/ui/package.json
+++ b/js_modules/dagit/packages/ui/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "deepmerge": "^4.2.2",
-    "lodash.isequal": "^4.5.0",
     "react-markdown": "6.0.3",
     "react-virtualized": "^9.22.3",
     "remark-gfm": "1.0.0"
@@ -66,7 +65,6 @@
     "@types/babel__core": "^7",
     "@types/babel__preset-env": "^7",
     "@types/jest": "^27.4.0",
-    "@types/lodash.isequal": "^4",
     "@types/lru-cache": "^7",
     "@types/mdx-js__react": "^1",
     "@types/react-is": "^17",

--- a/js_modules/dagit/packages/ui/src/components/TokenizingField.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TokenizingField.tsx
@@ -1,6 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
 import {TagInput} from '@blueprintjs/core';
-import isEqual from 'lodash.isequal';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
@@ -93,6 +92,9 @@ export const tokensAsStringArray = (value: TokenizingFieldValue[]) =>
 
 export const stringFromValue = (value: TokenizingFieldValue[]) =>
   tokensAsStringArray(value).join(',');
+
+const isEqual = (a: TokenizingFieldValue, b?: TokenizingFieldValue) =>
+  b && a.token === b.token && a.value === b.value;
 
 /** Provides a text field with typeahead autocompletion for key value pairs,
 where the key is one of a known set of "suggestion provider tokens". Provide

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -5277,7 +5277,6 @@ __metadata:
     "@types/babel__core": ^7
     "@types/babel__preset-env": ^7
     "@types/jest": ^27.4.0
-    "@types/lodash.isequal": ^4
     "@types/lru-cache": ^7
     "@types/mdx-js__react": ^1
     "@types/react-is": ^17
@@ -5292,7 +5291,6 @@ __metadata:
     eslint: ^8.6.0
     eslint-plugin-storybook: ^0.5.5
     jest: ^27.4.7
-    lodash.isequal: ^4.5.0
     nearest-color: ^0.4.4
     prettier: 2.2.1
     react-markdown: 6.0.3
@@ -8776,22 +8774,6 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: e60b153664572116dfea673c5bda7778dbff150498f44f998e34b5886d8afc47f16799280e4b6e241c0472aef1bc36add771c569c68fc5125fc2ae519a3eb9ac
-  languageName: node
-  linkType: hard
-
-"@types/lodash.isequal@npm:^4":
-  version: 4.5.5
-  resolution: "@types/lodash.isequal@npm:4.5.5"
-  dependencies:
-    "@types/lodash": "*"
-  checksum: 9dd22ceb5453a711e3ce6cd5a31d0ba8fe2263b3c989bc3b64e398933dbe7e9fd22a77a585ab7ee4f27d80a00845e15602b2a4a4b113f01291e2fd236a7707f7
-  languageName: node
-  linkType: hard
-
-"@types/lodash@npm:*":
-  version: 4.14.181
-  resolution: "@types/lodash@npm:4.14.181"
-  checksum: 0d1863d8383fd2f8bb42e9e3fc1d6255bb88ff034d6df848941063698944313dae944fc1270315613e3d303fae7c7a9a86085ad3235ed6204c56c4b0b3699aa9
   languageName: node
   linkType: hard
 
@@ -20502,13 +20484,6 @@ __metadata:
   version: 3.0.0
   resolution: "lodash.identity@npm:3.0.0"
   checksum: cd0365f99cafba23237e7c7d33123ac670ebbaacb4e9213fdddb7a68f317a261bedea93c9b57500942bbccb3fa2dc4e42a388c6024cc00a18937a922dacd68a1
-  languageName: node
-  linkType: hard
-
-"lodash.isequal@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "lodash.isequal@npm:4.5.0"
-  checksum: da27515dc5230eb1140ba65ff8de3613649620e8656b19a6270afe4866b7bd461d9ba2ac8a48dcc57f7adac4ee80e1de9f965d89d4d81a0ad52bb3eec2609644
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Update lodash imports to be specific slash-imports. We aren't currently tree-shaking these correctly for the bundle, but this looks like it will reliably trim down our lodash usage a good amount.

Also:

- Added a lint rule to prevent top-level `lodash` requires.
- Removed `lodash.isEqual` from `@dagster-io/ui` and replaced it with a simple implementation of the use case. This import pattern is deprecated, and without the dependency it can be removed from `ui` entirely.

## Test Plan

Lint, ts, jest.

Run `yarn build`, then `yarn analyze`. Note that the lodash dependency size is a fair amount smaller than before.
