### PR TITLE
[dagit] Fix InstigationTick "Skipped" message if zero runs

### DIFF
--- a/js_modules/dagit/packages/core/src/instigation/InstigationTick.test.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationTick.test.tsx
@@ -1,0 +1,51 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+
+import {InstigationTickStatus} from '../types/globalTypes';
+
+import {TickTag} from './InstigationTick';
+import {TickTagFragment} from './types/TickTagFragment';
+
+describe('TickTag', () => {
+  const tick: TickTagFragment = {
+    __typename: 'InstigationTick',
+    id: 'foobar',
+    status: InstigationTickStatus.SUCCESS,
+    timestamp: Date.now(),
+    skipReason: 'lol skipped',
+    runIds: [],
+    runKeys: [],
+    error: null,
+  };
+
+  describe('Skipped', () => {
+    it('renders skip reason if no run keys', async () => {
+      const skippedTick = {...tick, status: InstigationTickStatus.SKIPPED};
+
+      render(<TickTag tick={skippedTick} />);
+
+      const tag = screen.queryByText(/skipped/i);
+      expect(tag).toBeVisible();
+
+      userEvent.hover(tag as HTMLElement);
+      await waitFor(() => {
+        expect(screen.queryByText('lol skipped')).toBeVisible();
+      });
+    });
+
+    it('renders info about requested run count if run keys', async () => {
+      const skippedTick = {...tick, status: InstigationTickStatus.SKIPPED, runKeys: ['foo', 'bar']};
+
+      render(<TickTag tick={skippedTick} />);
+
+      const tag = screen.queryByText(/skipped/i);
+      expect(tag).toBeVisible();
+
+      userEvent.hover(tag as HTMLElement);
+      await waitFor(() => {
+        expect(screen.queryByText(/2 runs requested, but skipped/i)).toBeVisible();
+      });
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
@@ -74,7 +74,7 @@ export const TickTag: React.FC<{
       return tag;
 
     case InstigationTickStatus.SKIPPED:
-      if (tick.runKeys) {
+      if (tick.runKeys.length) {
         const message = `${tick.runKeys.length} runs requested, but skipped because the runs already exist for the requested keys.`;
         return (
           <Tooltip position="right" content={message}>


### PR DESCRIPTION
## Summary

Resolves #7274.

The "Skipped" tag on instigation tick tags shows an incorrect tooltip when there are no run keys. Just a JS error, the array is always truthy.

## Test Plan

Added a jest test.
