### PR TITLE
[hooks] fix resource reqs in nested graphs

### DIFF
--- a/python_modules/dagster/dagster/core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/core/execution/resources_init.py
@@ -175,6 +175,12 @@ def _core_resource_initialization_event_generator(
                 resource_instances,
                 resource_init_times,
             )
+
+        delta_res_keys = resource_keys_to_init - set(resource_instances.keys())
+        check.invariant(
+            not delta_res_keys,
+            f"resources instances do not align with resource to init, difference: {delta_res_keys}",
+        )
         yield ScopedResourcesBuilder(resource_instances, contains_generator)
     except DagsterUserCodeExecutionError as dagster_user_error:
         # Can only end up in this state if we attempt to initialize a resource, so


### PR DESCRIPTION
the hook def resources for mode calculation did not traverse the node invocation heirarchy, only the recursive definitions. This fixes that.

## Test Plan

added test that previously failed and invariant to prevent future similar problems