### PR TITLE
fix tick tag tooltip for skipped ticks

### DIFF
--- a/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
@@ -74,7 +74,7 @@ export const TickTag: React.FC<{
       return tag;
 
     case InstigationTickStatus.SKIPPED:
-      if (tick.runKeys) {
+      if (tick.runKeys && tick.runKeys.length) {
         const message = `${tick.runKeys.length} runs requested, but skipped because the runs already exist for the requested keys.`;
         return (
           <Tooltip position="right" content={message}>


### PR DESCRIPTION
Fixes https://github.com/dagster-io/dagster/issues/7528

## Summary
#7131 broke the skip reason when it added the idempotence warning check.  This handles it correctly by ignoring the empty `run_key` list case.

## Test Plan
Viewed skipped tick, hovered, saw appropriate skip reason message.

