### PR TITLE
[RFC] lighter weight pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,3 @@
-<!--- Hello Dagster contributor! It's great to have you with us! -->
-<!-- Make sure to read https://docs.dagster.io/community/contributing -->
+### Summary & Motivation
 
-## Summary
-<!-- Describe your changes here, include the motivation/context, test coverage, -->
-<!-- the type of change i.e. breaking change, new feature, or bug fix -->
-<!-- and related GitHub issue or screenshots (if applicable). -->
-
-
-
-
-## Test Plan
-<!--- Please describe the tests you have added and your testing environment (if applicable). -->
-
-
-
-
-## Checklist
-<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->
-
-- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
-- [ ] I have added tests to cover my changes.
+### How I Tested These Changes


### PR DESCRIPTION
The existing template was created when we were internally using phabricator, so the target audience was only external contributors.

Now that we are using GH, I feel the template should strike a better balance between having enough information for external contributors but also being stream lined for us internally.

Personally, this was motiviated by seeing internal PRs that submit without filling out the template (or editing it away).

Very open to feedback on this, just wanted to start a discussion. 




