### PR TITLE
Fix issue where we were calling the partition function n times, where n is the number of partitions returned by the function

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/partition.py
+++ b/python_modules/dagster/dagster/core/definitions/partition.py
@@ -594,10 +594,12 @@ class PartitionSetDefinition(Generic[T]):
                 yield SkipReason("Partition selector returned an empty list of partitions.")
                 return
 
+            partition_names = self.get_partition_names(context.scheduled_execution_time)
+
             missing_partition_names = [
                 partition.name
                 for partition in selected_partitions
-                if partition.name not in self.get_partition_names(context.scheduled_execution_time)
+                if partition.name not in partition_names
             ]
 
             if missing_partition_names:


### PR DESCRIPTION
Summary:
The old logic is not efficient when this function does non-trivial work.

Test Plan: Existing BK, run a schedule that returns multiple partitions and verify with logs that it is no longer called in a loop

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.