### PR TITLE
[dagit] Repair localStorage for Launchpad

### DIFF
--- a/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
@@ -176,7 +176,7 @@ export function useExecutionSessionStorage(
 
   // TODO: Remove this migration logic in a few patches when we know the old namespace is likely no longer being used
   const oldDataMigrated = React.useRef(false);
-  if (oldData && !oldDataMigrated.current) {
+  if (!oldDataMigrated.current && window.localStorage.getItem(getKey(oldNamespace))) {
     onSave(oldData);
     window.localStorage.removeItem(getKey(oldNamespace));
     oldDataMigrated.current = true;

--- a/js_modules/dagit/packages/core/src/app/__tests__/ExecutionSessionStorage.test.tsx
+++ b/js_modules/dagit/packages/core/src/app/__tests__/ExecutionSessionStorage.test.tsx
@@ -85,5 +85,19 @@ describe('ExecutionSessionStorage', () => {
 
     // old key is deleted
     expect(window.localStorage.getItem(oldFormat)).toEqual(null);
+
+    // Render it again, expect the data to still be there
+
+    render(
+      <TestProvider>
+        <TestComponent />
+      </TestProvider>,
+    );
+
+    // Its at the new key
+    expect(JSON.parse(window.localStorage.getItem(newFormat) as any)).toEqual(testData);
+
+    // old key is deleted
+    expect(window.localStorage.getItem(oldFormat)).toEqual(null);
   });
 });


### PR DESCRIPTION
## Summary

FIxes issue where launchpad config gets wiped out whenever you load the launchpad.

## Test Plan

jest

Load Dagit, open Launchpad for a job with a default config.

- Verify that the tab populates with config.
- Create a new tab to ensure that we have something in localStorage.
- Change localStorage manually to use the old key format.
- Reload the page, verify that the localStorage values are moved over to the new key, and that the old key is removed.