### PR TITLE
annotate dagster.builtins.Nothing with correct type

### DIFF
--- a/python_modules/dagster/dagster/builtins.py
+++ b/python_modules/dagster/dagster/builtins.py
@@ -4,7 +4,7 @@ Any = typing.Any
 Bool = bool
 Float = float
 Int = int
-Nothing = type(None)
+Nothing: typing.Type[None] = type(None)
 String = str
 
 


### PR DESCRIPTION
This fixes the type inference for `Nothing` that is an issue in #7135.
