### PR TITLE
[draft][rfc] Resource lineage

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1091,12 +1091,12 @@ type Resource {
   name: String!
   description: String
   configField: ConfigTypeField
-  source: ResourceSource
+  origin: ResourceOrigin
 }
 
-enum ResourceSource {
-  FROM_OVERRIDE
-  FROM_DEFAULT
+enum ResourceOrigin {
+  FROM_REPO_DEFAULT
+  FROM_SYSTEM_DEFAULT
 }
 
 type Logger {

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1090,6 +1090,12 @@ type Resource {
   name: String!
   description: String
   configField: ConfigTypeField
+  source: ResourceSource
+}
+
+enum ResourceSource {
+  FROM_OVERRIDE
+  FROM_DEFAULT
 }
 
 type Logger {

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -88,6 +88,7 @@ type Repository {
   displayMetadata: [RepositoryMetadata!]!
   inProgressRunsByStep: [InProgressRunsByStep!]!
   latestRunByStep: [LatestRun!]!
+  defaultResources: [Resource!]!
 }
 
 type RepositoryLocation {

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarModeSection.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarModeSection.tsx
@@ -1,5 +1,5 @@
 import {gql} from '@apollo/client';
-import {Colors, Icon, IconWrapper} from '@dagster-io/ui';
+import {Colors, Icon, IconWrapper, FontFamily} from '@dagster-io/ui';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
@@ -24,7 +24,7 @@ export const SidebarModeSection: React.FC<{
           <div>
             <ContextResourceHeader>{resource.name}</ContextResourceHeader>
             <Description description={resource.description || NO_DESCRIPTION} />
-            <Description description={resource.source || NO_DESCRIPTION} />
+            <ResourceSourceTag>{resource.source || NO_DESCRIPTION}</ResourceSourceTag>
             {resource.configField && (
               <ConfigTypeSchema
                 type={resource.configField.configType}
@@ -120,4 +120,18 @@ const ContextLoggerContainer = styled.div`
   & ${IconWrapper} {
     margin-right: 8px;
   }
+`;
+
+const ResourceSourceTag = styled.div`
+  background: ${Colors.Gray10};
+  color: ${Colors.Gray600};
+  font-family: ${FontFamily.default};
+  font-size: 14px;
+  border-radius: 7px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  padding: 5px;
+  user-select: none;
+  margin: -3px 0;
+  font-size: 11px;
 `;

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarModeSection.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarModeSection.tsx
@@ -1,5 +1,5 @@
 import {gql} from '@apollo/client';
-import {Colors, Icon, IconWrapper, FontFamily} from '@dagster-io/ui';
+import {Colors, Icon, IconWrapper, FontFamily, Tag} from '@dagster-io/ui';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
@@ -23,7 +23,7 @@ export const SidebarModeSection: React.FC<{
           <Icon name="resource" color={Colors.Gray700} />
           <div>
             <ContextResourceHeader>{resource.name}</ContextResourceHeader>
-            <ResourceSourceTag>{resource.source || NO_DESCRIPTION}</ResourceSourceTag>
+            {resource.origin ? <Tag>{resource.origin}</Tag> : null}
             <Description description={resource.description || NO_DESCRIPTION} />
             {resource.configField && (
               <ConfigTypeSchema
@@ -69,7 +69,7 @@ export const SIDEBAR_MODE_INFO_FRAGMENT = gql`
           }
         }
       }
-      source
+      origin
     }
     loggers {
       name
@@ -120,18 +120,4 @@ const ContextLoggerContainer = styled.div`
   & ${IconWrapper} {
     margin-right: 8px;
   }
-`;
-
-const ResourceSourceTag = styled.div`
-  background: ${Colors.Gray10};
-  color: ${Colors.Gray600};
-  font-family: ${FontFamily.default};
-  font-size: 14px;
-  border-radius: 7px;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  padding: 5px;
-  user-select: none;
-  margin: -3px 0;
-  font-size: 11px;
 `;

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarModeSection.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarModeSection.tsx
@@ -9,7 +9,7 @@ import {Description} from './Description';
 import {SectionHeader, SectionItemContainer} from './SidebarComponents';
 import {SidebarModeInfoFragment} from './types/SidebarModeInfoFragment';
 
-const NO_DESCRIPTION = '';
+export const NO_DESCRIPTION = '';
 
 export const SidebarModeSection: React.FC<{
   mode: SidebarModeInfoFragment;
@@ -88,7 +88,7 @@ export const SIDEBAR_MODE_INFO_FRAGMENT = gql`
   ${CONFIG_TYPE_SCHEMA_FRAGMENT}
 `;
 
-const ContextResourceHeader = styled(SectionHeader)`
+export const ContextResourceHeader = styled(SectionHeader)`
   font-size: 16px;
   margin: 4px 0;
 `;

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarModeSection.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarModeSection.tsx
@@ -1,5 +1,5 @@
 import {gql} from '@apollo/client';
-import {Colors, Icon, IconWrapper, FontFamily, Tooltip} from '@dagster-io/ui';
+import {Colors, Icon, IconWrapper, FontFamily} from '@dagster-io/ui';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
@@ -21,21 +21,17 @@ export const SidebarModeSection: React.FC<{
       {mode.resources.map((resource) => (
         <ContextResourceContainer key={resource.name}>
           <Icon name="resource" color={Colors.Gray700} />
-          <Tooltip
-            content={<ResourceSourceTag>{resource.source || NO_DESCRIPTION}</ResourceSourceTag>}
-            placement="top"
-          >
-            <div>
-              <ContextResourceHeader>{resource.name}</ContextResourceHeader>
-              <Description description={resource.description || NO_DESCRIPTION} />
-              {resource.configField && (
-                <ConfigTypeSchema
-                  type={resource.configField.configType}
-                  typesInScope={resource.configField.configType.recursiveConfigTypes}
-                />
-              )}
-            </div>
-          </Tooltip>
+          <div>
+            <ContextResourceHeader>{resource.name}</ContextResourceHeader>
+            <ResourceSourceTag>{resource.source || NO_DESCRIPTION}</ResourceSourceTag>
+            <Description description={resource.description || NO_DESCRIPTION} />
+            {resource.configField && (
+              <ConfigTypeSchema
+                type={resource.configField.configType}
+                typesInScope={resource.configField.configType.recursiveConfigTypes}
+              />
+            )}
+          </div>
         </ContextResourceContainer>
       ))}
       {mode.loggers.map((logger) => (

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarModeSection.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarModeSection.tsx
@@ -1,5 +1,5 @@
 import {gql} from '@apollo/client';
-import {Colors, Icon, IconWrapper, FontFamily} from '@dagster-io/ui';
+import {Colors, Icon, IconWrapper, FontFamily, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
@@ -21,17 +21,21 @@ export const SidebarModeSection: React.FC<{
       {mode.resources.map((resource) => (
         <ContextResourceContainer key={resource.name}>
           <Icon name="resource" color={Colors.Gray700} />
-          <div>
-            <ContextResourceHeader>{resource.name}</ContextResourceHeader>
-            <Description description={resource.description || NO_DESCRIPTION} />
-            <ResourceSourceTag>{resource.source || NO_DESCRIPTION}</ResourceSourceTag>
-            {resource.configField && (
-              <ConfigTypeSchema
-                type={resource.configField.configType}
-                typesInScope={resource.configField.configType.recursiveConfigTypes}
-              />
-            )}
-          </div>
+          <Tooltip
+            content={<ResourceSourceTag>{resource.source || NO_DESCRIPTION}</ResourceSourceTag>}
+            placement="top"
+          >
+            <div>
+              <ContextResourceHeader>{resource.name}</ContextResourceHeader>
+              <Description description={resource.description || NO_DESCRIPTION} />
+              {resource.configField && (
+                <ConfigTypeSchema
+                  type={resource.configField.configType}
+                  typesInScope={resource.configField.configType.recursiveConfigTypes}
+                />
+              )}
+            </div>
+          </Tooltip>
         </ContextResourceContainer>
       ))}
       {mode.loggers.map((logger) => (

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarModeSection.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarModeSection.tsx
@@ -24,6 +24,7 @@ export const SidebarModeSection: React.FC<{
           <div>
             <ContextResourceHeader>{resource.name}</ContextResourceHeader>
             <Description description={resource.description || NO_DESCRIPTION} />
+            <Description description={resource.source || NO_DESCRIPTION} />
             {resource.configField && (
               <ConfigTypeSchema
                 type={resource.configField.configType}
@@ -68,6 +69,7 @@ export const SIDEBAR_MODE_INFO_FRAGMENT = gql`
           }
         }
       }
+      source
     }
     loggers {
       name

--- a/js_modules/dagit/packages/core/src/pipelines/types/GraphExplorerFragment.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/GraphExplorerFragment.ts
@@ -3,6 +3,8 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
+import { ResourceSource } from "./../../types/globalTypes";
+
 // ====================================================
 // GraphQL fragment: GraphExplorerFragment
 // ====================================================
@@ -471,6 +473,7 @@ export interface GraphExplorerFragment_modes_resources {
   name: string;
   description: string | null;
   configField: GraphExplorerFragment_modes_resources_configField | null;
+  source: ResourceSource | null;
 }
 
 export interface GraphExplorerFragment_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {

--- a/js_modules/dagit/packages/core/src/pipelines/types/GraphExplorerFragment.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/GraphExplorerFragment.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { ResourceSource } from "./../../types/globalTypes";
+import { ResourceOrigin } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: GraphExplorerFragment
@@ -473,7 +473,7 @@ export interface GraphExplorerFragment_modes_resources {
   name: string;
   description: string | null;
   configField: GraphExplorerFragment_modes_resources_configField | null;
-  source: ResourceSource | null;
+  origin: ResourceOrigin | null;
 }
 
 export interface GraphExplorerFragment_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {

--- a/js_modules/dagit/packages/core/src/pipelines/types/JobOverviewSidebarQuery.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/JobOverviewSidebarQuery.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { PipelineSelector, ResourceSource } from "./../../types/globalTypes";
+import { PipelineSelector, ResourceOrigin } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: JobOverviewSidebarQuery
@@ -473,7 +473,7 @@ export interface JobOverviewSidebarQuery_pipelineSnapshotOrError_PipelineSnapsho
   name: string;
   description: string | null;
   configField: JobOverviewSidebarQuery_pipelineSnapshotOrError_PipelineSnapshot_modes_resources_configField | null;
-  source: ResourceSource | null;
+  origin: ResourceOrigin | null;
 }
 
 export interface JobOverviewSidebarQuery_pipelineSnapshotOrError_PipelineSnapshot_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {

--- a/js_modules/dagit/packages/core/src/pipelines/types/JobOverviewSidebarQuery.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/JobOverviewSidebarQuery.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { PipelineSelector } from "./../../types/globalTypes";
+import { PipelineSelector, ResourceSource } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: JobOverviewSidebarQuery
@@ -473,6 +473,7 @@ export interface JobOverviewSidebarQuery_pipelineSnapshotOrError_PipelineSnapsho
   name: string;
   description: string | null;
   configField: JobOverviewSidebarQuery_pipelineSnapshotOrError_PipelineSnapshot_modes_resources_configField | null;
+  source: ResourceSource | null;
 }
 
 export interface JobOverviewSidebarQuery_pipelineSnapshotOrError_PipelineSnapshot_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {

--- a/js_modules/dagit/packages/core/src/pipelines/types/PipelineExplorerRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/PipelineExplorerRootQuery.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { PipelineSelector, ResourceSource } from "./../../types/globalTypes";
+import { PipelineSelector, ResourceOrigin } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: PipelineExplorerRootQuery
@@ -473,7 +473,7 @@ export interface PipelineExplorerRootQuery_pipelineSnapshotOrError_PipelineSnaps
   name: string;
   description: string | null;
   configField: PipelineExplorerRootQuery_pipelineSnapshotOrError_PipelineSnapshot_modes_resources_configField | null;
-  source: ResourceSource | null;
+  origin: ResourceOrigin | null;
 }
 
 export interface PipelineExplorerRootQuery_pipelineSnapshotOrError_PipelineSnapshot_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {

--- a/js_modules/dagit/packages/core/src/pipelines/types/PipelineExplorerRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/PipelineExplorerRootQuery.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { PipelineSelector } from "./../../types/globalTypes";
+import { PipelineSelector, ResourceSource } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: PipelineExplorerRootQuery
@@ -473,6 +473,7 @@ export interface PipelineExplorerRootQuery_pipelineSnapshotOrError_PipelineSnaps
   name: string;
   description: string | null;
   configField: PipelineExplorerRootQuery_pipelineSnapshotOrError_PipelineSnapshot_modes_resources_configField | null;
+  source: ResourceSource | null;
 }
 
 export interface PipelineExplorerRootQuery_pipelineSnapshotOrError_PipelineSnapshot_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {

--- a/js_modules/dagit/packages/core/src/pipelines/types/SidebarModeInfoFragment.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/SidebarModeInfoFragment.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { ResourceSource } from "./../../types/globalTypes";
+import { ResourceOrigin } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: SidebarModeInfoFragment
@@ -473,7 +473,7 @@ export interface SidebarModeInfoFragment_resources {
   name: string;
   description: string | null;
   configField: SidebarModeInfoFragment_resources_configField | null;
-  source: ResourceSource | null;
+  origin: ResourceOrigin | null;
 }
 
 export interface SidebarModeInfoFragment_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {

--- a/js_modules/dagit/packages/core/src/pipelines/types/SidebarModeInfoFragment.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/SidebarModeInfoFragment.ts
@@ -3,6 +3,8 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
+import { ResourceSource } from "./../../types/globalTypes";
+
 // ====================================================
 // GraphQL fragment: SidebarModeInfoFragment
 // ====================================================
@@ -471,6 +473,7 @@ export interface SidebarModeInfoFragment_resources {
   name: string;
   description: string | null;
   configField: SidebarModeInfoFragment_resources_configField | null;
+  source: ResourceSource | null;
 }
 
 export interface SidebarModeInfoFragment_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {

--- a/js_modules/dagit/packages/core/src/pipelines/types/SidebarOpContainerInfoFragment.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/SidebarOpContainerInfoFragment.ts
@@ -3,6 +3,8 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
+import { ResourceSource } from "./../../types/globalTypes";
+
 // ====================================================
 // GraphQL fragment: SidebarOpContainerInfoFragment
 // ====================================================
@@ -471,6 +473,7 @@ export interface SidebarOpContainerInfoFragment_modes_resources {
   name: string;
   description: string | null;
   configField: SidebarOpContainerInfoFragment_modes_resources_configField | null;
+  source: ResourceSource | null;
 }
 
 export interface SidebarOpContainerInfoFragment_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {

--- a/js_modules/dagit/packages/core/src/pipelines/types/SidebarOpContainerInfoFragment.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/SidebarOpContainerInfoFragment.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { ResourceSource } from "./../../types/globalTypes";
+import { ResourceOrigin } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: SidebarOpContainerInfoFragment
@@ -473,7 +473,7 @@ export interface SidebarOpContainerInfoFragment_modes_resources {
   name: string;
   description: string | null;
   configField: SidebarOpContainerInfoFragment_modes_resources_configField | null;
-  source: ResourceSource | null;
+  origin: ResourceOrigin | null;
 }
 
 export interface SidebarOpContainerInfoFragment_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {

--- a/js_modules/dagit/packages/core/src/pipelines/types/SidebarTabbedContainerPipelineFragment.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/SidebarTabbedContainerPipelineFragment.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { ResourceSource } from "./../../types/globalTypes";
+import { ResourceOrigin } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: SidebarTabbedContainerPipelineFragment
@@ -473,7 +473,7 @@ export interface SidebarTabbedContainerPipelineFragment_modes_resources {
   name: string;
   description: string | null;
   configField: SidebarTabbedContainerPipelineFragment_modes_resources_configField | null;
-  source: ResourceSource | null;
+  origin: ResourceOrigin | null;
 }
 
 export interface SidebarTabbedContainerPipelineFragment_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {

--- a/js_modules/dagit/packages/core/src/pipelines/types/SidebarTabbedContainerPipelineFragment.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/SidebarTabbedContainerPipelineFragment.ts
@@ -3,6 +3,8 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
+import { ResourceSource } from "./../../types/globalTypes";
+
 // ====================================================
 // GraphQL fragment: SidebarTabbedContainerPipelineFragment
 // ====================================================
@@ -471,6 +473,7 @@ export interface SidebarTabbedContainerPipelineFragment_modes_resources {
   name: string;
   description: string | null;
   configField: SidebarTabbedContainerPipelineFragment_modes_resources_configField | null;
+  source: ResourceSource | null;
 }
 
 export interface SidebarTabbedContainerPipelineFragment_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {

--- a/js_modules/dagit/packages/core/src/types/globalTypes.ts
+++ b/js_modules/dagit/packages/core/src/types/globalTypes.ts
@@ -127,9 +127,9 @@ export enum RepositoryLocationLoadStatus {
   LOADING = "LOADING",
 }
 
-export enum ResourceSource {
-  FROM_DEFAULT = "FROM_DEFAULT",
-  FROM_OVERRIDE = "FROM_OVERRIDE",
+export enum ResourceOrigin {
+  FROM_REPO_DEFAULT = "FROM_REPO_DEFAULT",
+  FROM_SYSTEM_DEFAULT = "FROM_SYSTEM_DEFAULT",
 }
 
 export enum RunStatus {

--- a/js_modules/dagit/packages/core/src/types/globalTypes.ts
+++ b/js_modules/dagit/packages/core/src/types/globalTypes.ts
@@ -127,6 +127,11 @@ export enum RepositoryLocationLoadStatus {
   LOADING = "LOADING",
 }
 
+export enum ResourceSource {
+  FROM_DEFAULT = "FROM_DEFAULT",
+  FROM_OVERRIDE = "FROM_OVERRIDE",
+}
+
 export enum RunStatus {
   CANCELED = "CANCELED",
   CANCELING = "CANCELING",

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryResourcesList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryResourcesList.tsx
@@ -1,0 +1,151 @@
+import {gql, useQuery} from '@apollo/client';
+import {Box, Colors, Group, NonIdealState, Table} from '@dagster-io/ui';
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+import styled from 'styled-components/macro';
+
+import {isAssetGroup} from '../asset-graph/Utils';
+
+import {repoAddressAsString} from './repoAddressAsString';
+import {repoAddressToSelector} from './repoAddressToSelector';
+import {RepoAddress} from './types';
+import {
+  RepositoryResourcesListQuery,
+  RepositoryResourcesListQueryVariables,
+} from './types/RepositoryResourcesListQuery';
+import {workspacePath} from './workspacePath';
+
+const REPOSITORY_RESOURCES_LIST_QUERY = gql`
+  query RepositoryResourcesListQuery($repositorySelector: RepositorySelector!) {
+    repositoryOrError(repositorySelector: $repositorySelector) {
+      __typename
+      ... on Repository {
+        id
+        usedSolids {
+          definition {
+            __typename
+            ... on CompositeSolidDefinition {
+              id
+              name
+              description
+            }
+          }
+          invocations {
+            pipeline {
+              id
+              name
+            }
+            solidHandle {
+              handleID
+            }
+          }
+        }
+        pipelines {
+          id
+          description
+          name
+          isJob
+          graphName
+        }
+      }
+      ... on RepositoryNotFoundError {
+        message
+      }
+    }
+  }
+`;
+
+interface Props {
+  repoAddress: RepoAddress;
+}
+
+interface Item {
+  name: string;
+  description: string | null;
+  path: string;
+  repoAddress: RepoAddress;
+}
+export const RepositoryResourcesList: React.FC<Props> = (props) => {
+  const {repoAddress} = props;
+  const repositorySelector = repoAddressToSelector(repoAddress);
+
+  const {data, error, loading} = useQuery<
+    RepositoryResourcesListQuery,
+    RepositoryResourcesListQueryVariables
+  >(REPOSITORY_RESOURCES_LIST_QUERY, {
+    fetchPolicy: 'cache-and-network',
+    variables: {repositorySelector},
+  });
+
+  const repo = data?.repositoryOrError;
+  const graphsForTable = React.useMemo(() => {
+    if (!repo || repo.__typename !== 'Repository') {
+      return null;
+    }
+    const jobGraphNames = new Set<string>(
+      repo.pipelines.filter((p) => p.isJob && !isAssetGroup(p.name)).map((p) => p.graphName),
+    );
+    const items: Item[] = Array.from(jobGraphNames).map((graphName) => ({
+      name: graphName,
+      path: `/graphs/${graphName}`,
+      description: null,
+      repoAddress,
+    }));
+
+    repo.usedSolids.forEach((s) => {
+      if (s.definition.__typename === 'CompositeSolidDefinition') {
+        items.push({
+          name: s.definition.name,
+          path: `/graphs/${s.invocations[0].pipeline.name}/${s.invocations[0].solidHandle.handleID}/`,
+          description: s.definition.description,
+          repoAddress,
+        });
+      }
+    });
+
+    return items.sort((a, b) => a.name.localeCompare(b.name));
+  }, [repo, repoAddress]);
+
+  if (loading) {
+    return null;
+  }
+
+  if (error || !graphsForTable) {
+    return (
+      <Box padding={{vertical: 64}}>
+        <NonIdealState
+          icon="error"
+          title="Unable to load graphs"
+          description={`Could not load graphs for ${repoAddressAsString(repoAddress)}`}
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th>Graph</th>
+        </tr>
+      </thead>
+      <tbody>
+        {graphsForTable.map(({name, description, path, repoAddress}) => (
+          <tr key={`${name}-${repoAddressAsString(repoAddress)}`}>
+            <td>
+              <Group direction="column" spacing={4}>
+                <Link to={workspacePath(repoAddress.name, repoAddress.location, path)}>{name}</Link>
+                <Description>{description}</Description>
+              </Group>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+};
+
+const Description = styled.div`
+  color: ${Colors.Gray400};
+  font-size: 12px;
+`;

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceRepoRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceRepoRoot.tsx
@@ -48,6 +48,10 @@ export const WorkspaceRepoRoot: React.FC<Props> = (props) => {
         text: 'Assets',
         href: workspacePathFromAddress(repoAddress, '/assets'),
       },
+      {
+        text: 'Default Resources',
+        href: workspacePathFromAddress(repoAddress, '/resources'),
+      },
     ];
 
     return tabList.filter(Boolean) as {text: string; href: string}[];
@@ -71,6 +75,8 @@ export const WorkspaceRepoRoot: React.FC<Props> = (props) => {
         return 'Pipelines';
       case 'assets':
         return 'Assets';
+      case 'resources':
+        return 'Resources';
       default:
         return 'Jobs';
     }
@@ -115,6 +121,9 @@ export const WorkspaceRepoRoot: React.FC<Props> = (props) => {
           </Route>
           <Route path="/workspace/:repoPath/graphs" exact>
             <RepositoryGraphsList repoAddress={repoAddress} />
+          </Route>
+          <Route path="/workspace/:repoPath/resources" exact>
+            <RepositoryResourcesList repoAddress={repoAddress} />
           </Route>
           <Route
             path="/workspace/:repoPath/(.*)?"

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceRepoRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceRepoRoot.tsx
@@ -11,6 +11,7 @@ import {TabLink} from '../ui/TabLink';
 import {RepositoryAssetsList} from './RepositoryAssetsList';
 import {RepositoryGraphsList} from './RepositoryGraphsList';
 import {RepositoryPipelinesList} from './RepositoryPipelinesList';
+import {RepositoryResourcesList} from './RepositoryResourcesList';
 import {useRepository} from './WorkspaceContext';
 import {repoAddressAsString} from './repoAddressAsString';
 import {RepoAddress} from './types';

--- a/js_modules/dagit/packages/core/src/workspace/types/GraphExplorerRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/GraphExplorerRootQuery.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { GraphSelector } from "./../../types/globalTypes";
+import { GraphSelector, ResourceSource } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: GraphExplorerRootQuery
@@ -473,6 +473,7 @@ export interface GraphExplorerRootQuery_graphOrError_Graph_modes_resources {
   name: string;
   description: string | null;
   configField: GraphExplorerRootQuery_graphOrError_Graph_modes_resources_configField | null;
+  source: ResourceSource | null;
 }
 
 export interface GraphExplorerRootQuery_graphOrError_Graph_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {

--- a/js_modules/dagit/packages/core/src/workspace/types/GraphExplorerRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/GraphExplorerRootQuery.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { GraphSelector, ResourceSource } from "./../../types/globalTypes";
+import { GraphSelector, ResourceOrigin } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: GraphExplorerRootQuery
@@ -473,7 +473,7 @@ export interface GraphExplorerRootQuery_graphOrError_Graph_modes_resources {
   name: string;
   description: string | null;
   configField: GraphExplorerRootQuery_graphOrError_Graph_modes_resources_configField | null;
-  source: ResourceSource | null;
+  origin: ResourceOrigin | null;
 }
 
 export interface GraphExplorerRootQuery_graphOrError_Graph_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {

--- a/js_modules/dagit/packages/core/src/workspace/types/RepositoryResourcesListQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/RepositoryResourcesListQuery.ts
@@ -13,56 +13,476 @@ export interface RepositoryResourcesListQuery_repositoryOrError_PythonError {
   __typename: "PythonError";
 }
 
-export interface RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_definition_SolidDefinition {
-  __typename: "SolidDefinition";
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
 }
 
-export interface RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_definition_CompositeSolidDefinition {
-  __typename: "CompositeSolidDefinition";
-  id: string;
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
   name: string;
   description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
 }
 
-export type RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_definition = RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_definition_SolidDefinition | RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_definition_CompositeSolidDefinition;
-
-export interface RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_invocations_pipeline {
-  __typename: "Pipeline";
-  id: string;
-  name: string;
-}
-
-export interface RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_invocations_solidHandle {
-  __typename: "SolidHandle";
-  handleID: string;
-}
-
-export interface RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_invocations {
-  __typename: "NodeInvocationSite";
-  pipeline: RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_invocations_pipeline;
-  solidHandle: RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_invocations_solidHandle;
-}
-
-export interface RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids {
-  __typename: "UsedSolid";
-  definition: RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_definition;
-  invocations: RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_invocations[];
-}
-
-export interface RepositoryResourcesListQuery_repositoryOrError_Repository_pipelines {
-  __typename: "Pipeline";
-  id: string;
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
   description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType_recursiveConfigTypes = RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType_recursiveConfigTypes_EnumConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType_recursiveConfigTypes_RegularConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType_recursiveConfigTypes_ScalarUnionConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  recursiveConfigTypes: RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType_recursiveConfigTypes[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
   name: string;
-  isJob: boolean;
-  graphName: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType_recursiveConfigTypes = RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType_recursiveConfigTypes_ArrayConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType_recursiveConfigTypes_EnumConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType_recursiveConfigTypes_RegularConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType_recursiveConfigTypes_ScalarUnionConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  recursiveConfigTypes: RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType_recursiveConfigTypes[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType_recursiveConfigTypes = RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType_recursiveConfigTypes_ArrayConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType_recursiveConfigTypes_EnumConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType_recursiveConfigTypes_RegularConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType_recursiveConfigTypes_ScalarUnionConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  recursiveConfigTypes: RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType_recursiveConfigTypes[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_recursiveConfigTypes = RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_recursiveConfigTypes_ArrayConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_recursiveConfigTypes_EnumConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_recursiveConfigTypes_RegularConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_recursiveConfigTypes_ScalarUnionConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_fields[];
+  recursiveConfigTypes: RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType_recursiveConfigTypes[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes = RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ArrayConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_EnumConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_RegularConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ScalarUnionConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+  recursiveConfigTypes: RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType_recursiveConfigTypes = RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType_recursiveConfigTypes_ArrayConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType_recursiveConfigTypes_EnumConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType_recursiveConfigTypes_RegularConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType_recursiveConfigTypes_ScalarUnionConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+  recursiveConfigTypes: RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType_recursiveConfigTypes[];
+}
+
+export type RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType = RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ArrayConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_EnumConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_RegularConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_CompositeConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_ScalarUnionConfigType | RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType_MapConfigType;
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField {
+  __typename: "ConfigTypeField";
+  configType: RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField_configType;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources {
+  __typename: "Resource";
+  name: string;
+  description: string | null;
+  configField: RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources_configField | null;
 }
 
 export interface RepositoryResourcesListQuery_repositoryOrError_Repository {
   __typename: "Repository";
   id: string;
-  usedSolids: RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids[];
-  pipelines: RepositoryResourcesListQuery_repositoryOrError_Repository_pipelines[];
+  defaultResources: RepositoryResourcesListQuery_repositoryOrError_Repository_defaultResources[];
 }
 
 export interface RepositoryResourcesListQuery_repositoryOrError_RepositoryNotFoundError {

--- a/js_modules/dagit/packages/core/src/workspace/types/RepositoryResourcesListQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/RepositoryResourcesListQuery.ts
@@ -1,0 +1,81 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { RepositorySelector } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: RepositoryResourcesListQuery
+// ====================================================
+
+export interface RepositoryResourcesListQuery_repositoryOrError_PythonError {
+  __typename: "PythonError";
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_definition_SolidDefinition {
+  __typename: "SolidDefinition";
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_definition_CompositeSolidDefinition {
+  __typename: "CompositeSolidDefinition";
+  id: string;
+  name: string;
+  description: string | null;
+}
+
+export type RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_definition = RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_definition_SolidDefinition | RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_definition_CompositeSolidDefinition;
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_invocations_pipeline {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_invocations_solidHandle {
+  __typename: "SolidHandle";
+  handleID: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_invocations {
+  __typename: "NodeInvocationSite";
+  pipeline: RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_invocations_pipeline;
+  solidHandle: RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_invocations_solidHandle;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids {
+  __typename: "UsedSolid";
+  definition: RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_definition;
+  invocations: RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids_invocations[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository_pipelines {
+  __typename: "Pipeline";
+  id: string;
+  description: string | null;
+  name: string;
+  isJob: boolean;
+  graphName: string;
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_Repository {
+  __typename: "Repository";
+  id: string;
+  usedSolids: RepositoryResourcesListQuery_repositoryOrError_Repository_usedSolids[];
+  pipelines: RepositoryResourcesListQuery_repositoryOrError_Repository_pipelines[];
+}
+
+export interface RepositoryResourcesListQuery_repositoryOrError_RepositoryNotFoundError {
+  __typename: "RepositoryNotFoundError";
+  message: string;
+}
+
+export type RepositoryResourcesListQuery_repositoryOrError = RepositoryResourcesListQuery_repositoryOrError_PythonError | RepositoryResourcesListQuery_repositoryOrError_Repository | RepositoryResourcesListQuery_repositoryOrError_RepositoryNotFoundError;
+
+export interface RepositoryResourcesListQuery {
+  repositoryOrError: RepositoryResourcesListQuery_repositoryOrError;
+}
+
+export interface RepositoryResourcesListQueryVariables {
+  repositorySelector: RepositorySelector;
+}

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/resource.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/resource.py
@@ -6,19 +6,19 @@ from dagster.core.snap import ConfigSchemaSnapshot, ResourceDefSnap
 from ..config_types import GrapheneConfigTypeField
 
 
-class GrapheneResourceSource(graphene.Enum):
-    FROM_OVERRIDE = "FROM_OVERRIDE"
-    FROM_DEFAULT = "FROM_DEFAULT"
+class GrapheneResourceOrigin(graphene.Enum):
+    FROM_REPO_DEFAULT = "FROM_REPO_DEFAULT"
+    FROM_SYSTEM_DEFAULT = "FROM_SYSTEM_DEFAULT"
 
     class Meta:
-        name = "ResourceSource"
+        name = "ResourceOrigin"
 
 
 class GrapheneResource(graphene.ObjectType):
     name = graphene.NonNull(graphene.String)
     description = graphene.String()
     configField = graphene.Field(GrapheneConfigTypeField)
-    source = graphene.Field(GrapheneResourceSource)
+    origin = graphene.Field(GrapheneResourceOrigin)
 
     class Meta:
         name = "Resource"
@@ -49,5 +49,5 @@ class GrapheneResource(graphene.ObjectType):
 
         return None
 
-    def resolve_source(self, _graphene_info):
-        return self._resource_def_snap.source
+    def resolve_origin(self, _graphene_info):
+        return self._resource_def_snap.origin

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/resource.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/resource.py
@@ -10,11 +10,12 @@ class GrapheneResource(graphene.ObjectType):
     name = graphene.NonNull(graphene.String)
     description = graphene.String()
     configField = graphene.Field(GrapheneConfigTypeField)
+    source = graphene.NonNull(GrapheneResourceSource)
 
     class Meta:
         name = "Resource"
 
-    def __init__(self, config_schema_snapshot, resource_def_snap):
+    def __init__(self, config_schema_snapshot, resource_def_snap, resource_source):
         super().__init__()
         self._config_schema_snapshot = check.inst_param(
             config_schema_snapshot, "config_schema_snapshot", ConfigSchemaSnapshot
@@ -24,6 +25,7 @@ class GrapheneResource(graphene.ObjectType):
         )
         self.name = resource_def_snap.name
         self.description = resource_def_snap.description
+        self.source = resource_def_snap.source
 
     def resolve_configField(self, _graphene_info):
         if (
@@ -39,3 +41,8 @@ class GrapheneResource(graphene.ObjectType):
             )
 
         return None
+
+
+class GrapheneResourceSource(graphene.Enum):
+    FROM_OVERRIDE = "FROM_OVERRIDE"
+    FROM_DEFAULT = "FROM_DEFAULT"

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/resource.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/resource.py
@@ -25,7 +25,7 @@ class GrapheneResource(graphene.ObjectType):
 
     def __init__(self, config_schema_snapshot, resource_def_snap):
         super().__init__()
-        self._config_schema_snapshot = check.inst_param(
+        self._config_schema_snapshot = check.opt_inst_param(
             config_schema_snapshot, "config_schema_snapshot", ConfigSchemaSnapshot
         )
         self._resource_def_snap = check.inst_param(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/resource.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/resource.py
@@ -23,7 +23,7 @@ class GrapheneResource(graphene.ObjectType):
     class Meta:
         name = "Resource"
 
-    def __init__(self, config_schema_snapshot, resource_def_snap, resource_source):
+    def __init__(self, config_schema_snapshot, resource_def_snap):
         super().__init__()
         self._config_schema_snapshot = check.inst_param(
             config_schema_snapshot, "config_schema_snapshot", ConfigSchemaSnapshot

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/resource.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/resource.py
@@ -6,11 +6,19 @@ from dagster.core.snap import ConfigSchemaSnapshot, ResourceDefSnap
 from ..config_types import GrapheneConfigTypeField
 
 
+class GrapheneResourceSource(graphene.Enum):
+    FROM_OVERRIDE = "FROM_OVERRIDE"
+    FROM_DEFAULT = "FROM_DEFAULT"
+
+    class Meta:
+        name = "ResourceSource"
+
+
 class GrapheneResource(graphene.ObjectType):
     name = graphene.NonNull(graphene.String)
     description = graphene.String()
     configField = graphene.Field(GrapheneConfigTypeField)
-    source = graphene.NonNull(GrapheneResourceSource)
+    source = graphene.Field(GrapheneResourceSource)
 
     class Meta:
         name = "Resource"
@@ -25,7 +33,6 @@ class GrapheneResource(graphene.ObjectType):
         )
         self.name = resource_def_snap.name
         self.description = resource_def_snap.description
-        self.source = resource_def_snap.source
 
     def resolve_configField(self, _graphene_info):
         if (
@@ -42,7 +49,5 @@ class GrapheneResource(graphene.ObjectType):
 
         return None
 
-
-class GrapheneResourceSource(graphene.Enum):
-    FROM_OVERRIDE = "FROM_OVERRIDE"
-    FROM_DEFAULT = "FROM_DEFAULT"
+    def resolve_source(self, _graphene_info):
+        return self._resource_def_snap.source

--- a/python_modules/dagster-test/dagster_test/toys/many_resources.py
+++ b/python_modules/dagster-test/dagster_test/toys/many_resources.py
@@ -1,4 +1,4 @@
-from dagster import resource, op, graph, ResourceDefinition
+from dagster import ResourceDefinition, graph, op, resource
 
 
 @op(required_resource_keys={"date", "s3_client", "snowflake_client"})
@@ -15,7 +15,20 @@ many_resources_job = many_resources.to_job(
     partial=True, resource_defs={"date": ResourceDefinition.hardcoded_resource("2022-2-22")}
 )
 
+
+@resource(description="Lorem ipsum dolor sit amet")
+def s3_client():
+    pass
+
+
+@resource(
+    description="consectetur adipiscing elit", config_schema={"username": str, "password": str}
+)
+def snowflake_client():
+    pass
+
+
 many_resources_default_set = {
-    "s3_client": ResourceDefinition.hardcoded_resource("blah"),
-    "snowflake_client": ResourceDefinition.hardcoded_resource("blah"),
+    "s3_client": s3_client,
+    "snowflake_client": snowflake_client,
 }

--- a/python_modules/dagster-test/dagster_test/toys/many_resources.py
+++ b/python_modules/dagster-test/dagster_test/toys/many_resources.py
@@ -1,0 +1,21 @@
+from dagster import resource, op, graph, ResourceDefinition
+
+
+@op(required_resource_keys={"date", "s3_client", "snowflake_client"})
+def upload_data():
+    pass
+
+
+@graph
+def many_resources():
+    upload_data()
+
+
+many_resources_job = many_resources.to_job(
+    partial=True, resource_defs={"date": ResourceDefinition.hardcoded_resource("2022-2-22")}
+)
+
+many_resources_default_set = {
+    "s3_client": ResourceDefinition.hardcoded_resource("blah"),
+    "snowflake_client": ResourceDefinition.hardcoded_resource("blah"),
+}

--- a/python_modules/dagster-test/dagster_test/toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/toys/repo.py
@@ -11,11 +11,11 @@ from dagster_test.toys.log_s3 import log_s3_pipeline
 from dagster_test.toys.log_spew import log_spew
 from dagster_test.toys.longitudinal import longitudinal_pipeline
 from dagster_test.toys.many_events import many_events
+from dagster_test.toys.many_resources import many_resources_default_set, many_resources_job
 from dagster_test.toys.notebooks import hello_world_notebook_pipeline
 from dagster_test.toys.retries import retry_pipeline
 from dagster_test.toys.sleepy import sleepy_pipeline
 from dagster_test.toys.unreliable import unreliable_pipeline
-from dagster_test.toys.many_resources import many_resources_job, many_resources_default_set
 
 from dagster import AssetMaterialization, Output, pipeline, repository, solid
 

--- a/python_modules/dagster-test/dagster_test/toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/toys/repo.py
@@ -15,6 +15,7 @@ from dagster_test.toys.notebooks import hello_world_notebook_pipeline
 from dagster_test.toys.retries import retry_pipeline
 from dagster_test.toys.sleepy import sleepy_pipeline
 from dagster_test.toys.unreliable import unreliable_pipeline
+from dagster_test.toys.many_resources import many_resources_job, many_resources_default_set
 
 from dagster import AssetMaterialization, Output, pipeline, repository, solid
 
@@ -56,6 +57,8 @@ def toys_repository():
             asset_lineage_partition_set,
             model_pipeline,
             hello_world_notebook_pipeline,
+            many_resources_job,
+            many_resources_default_set,
         ]
         + get_toys_schedules()
         + get_toys_sensors()

--- a/python_modules/dagster/dagster/core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/__init__.py
@@ -110,7 +110,7 @@ from .reconstruct import (
     reconstructable,
 )
 from .repository_definition import RepositoryData, RepositoryDefinition
-from .resource_definition import ResourceDefinition, make_values_resource, resource
+from .resource_definition import ResourceDefinition, make_values_resource, resource, ResourceSource
 from .run_config_schema import RunConfigSchema, create_run_config_schema
 from .run_request import InstigatorType, RunRequest, SkipReason
 from .run_status_sensor_definition import (

--- a/python_modules/dagster/dagster/core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/__init__.py
@@ -110,7 +110,7 @@ from .reconstruct import (
     reconstructable,
 )
 from .repository_definition import RepositoryData, RepositoryDefinition
-from .resource_definition import ResourceDefinition, make_values_resource, resource, ResourceSource
+from .resource_definition import ResourceDefinition, ResourceSource, make_values_resource, resource
 from .run_config_schema import RunConfigSchema, create_run_config_schema
 from .run_request import InstigatorType, RunRequest, SkipReason
 from .run_status_sensor_definition import (

--- a/python_modules/dagster/dagster/core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/__init__.py
@@ -110,7 +110,7 @@ from .reconstruct import (
     reconstructable,
 )
 from .repository_definition import RepositoryData, RepositoryDefinition
-from .resource_definition import ResourceDefinition, ResourceSource, make_values_resource, resource
+from .resource_definition import ResourceDefinition, ResourceOrigin, make_values_resource, resource
 from .run_config_schema import RunConfigSchema, create_run_config_schema
 from .run_request import InstigatorType, RunRequest, SkipReason
 from .run_status_sensor_definition import (

--- a/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
@@ -12,7 +12,9 @@ from ..repository_definition import (
     CachingRepositoryData,
     RepositoryData,
     RepositoryDefinition,
+    is_resource_dict,
 )
+from ..resource_definition import ResourceDefinition
 from ..schedule_definition import ScheduleDefinition
 from ..sensor_definition import SensorDefinition
 
@@ -43,6 +45,7 @@ class _Repository:
                     or isinstance(definition, SensorDefinition)
                     or isinstance(definition, GraphDefinition)
                     or isinstance(definition, AssetGroup)
+                    or is_resource_dict(definition)
                 ):
                     bad_definitions.append((i, type(definition)))
             if bad_definitions:
@@ -55,7 +58,7 @@ class _Repository:
                 raise DagsterInvalidDefinitionError(
                     "Bad return value from repository construction function: all elements of list "
                     "must be of type JobDefinition, GraphDefinition, PipelineDefinition, "
-                    "PartitionSetDefinition, ScheduleDefinition, or SensorDefinition. "
+                    "PartitionSetDefinition, ScheduleDefinition, SensorDefinition, or dictionary of resources. "
                     f"Got {bad_definitions_str}."
                 )
             repository_data = CachingRepositoryData.from_list(repository_definitions)

--- a/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
@@ -70,7 +70,7 @@ class _Repository:
             if not set(repository_definitions.keys()).issubset(VALID_REPOSITORY_DATA_DICT_KEYS):
                 raise DagsterInvalidDefinitionError(
                     "Bad return value from repository construction function: dict must not contain "
-                    "keys other than {{'pipelines', 'partition_sets', 'schedules', 'jobs'}}: found "
+                    "keys other than {{'pipelines', 'partition_sets', 'schedules', 'jobs', 'resources'}}: found "
                     "{bad_keys}".format(
                         bad_keys=", ".join(
                             [

--- a/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
@@ -27,6 +27,8 @@ class _Repository:
     def __call__(self, fn: Callable[[], Any]) -> RepositoryDefinition:
         from dagster.core.asset_defs import AssetGroup
 
+        from ..job_definition import PartialJobDefinition
+
         check.callable_param(fn, "fn")
 
         if not self.name:
@@ -45,6 +47,7 @@ class _Repository:
                     or isinstance(definition, SensorDefinition)
                     or isinstance(definition, GraphDefinition)
                     or isinstance(definition, AssetGroup)
+                    or isinstance(definition, PartialJobDefinition)
                     or is_resource_dict(definition)
                 ):
                     bad_definitions.append((i, type(definition)))

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -23,7 +23,7 @@ from dagster.config.validate import validate_config
 from dagster.core.definitions.config import ConfigMapping
 from dagster.core.definitions.definition_config_schema import IDefinitionConfigSchema
 from dagster.core.definitions.policy import RetryPolicy
-from dagster.core.definitions.resource_definition import ResourceDefinition
+from dagster.core.definitions.resource_definition import ResourceDefinition, ResourceSource
 from dagster.core.definitions.utils import check_valid_name
 from dagster.core.errors import DagsterInvalidConfigError, DagsterInvalidDefinitionError
 from dagster.core.storage.io_manager import io_manager
@@ -461,6 +461,7 @@ class GraphDefinition(NodeDefinition):
         op_selection: Optional[List[str]] = None,
         partitions_def: Optional["PartitionsDefinition"] = None,
         partial: Optional[bool] = False,
+        _resource_sources: Optional[Dict[str, ResourceSource]] = None,
     ) -> Union["JobDefinition", "PartialJobDefinition"]:
         """
         Make this graph in to an executable Job by providing remaining components required for execution.
@@ -566,6 +567,7 @@ class GraphDefinition(NodeDefinition):
             )
 
         if partial:
+            check.invariant(not _resource_sources)
             return PartialJobDefinition(
                 name=job_name,
                 description=description or self.description,
@@ -580,6 +582,10 @@ class GraphDefinition(NodeDefinition):
                 hook_defs=hooks,
                 version_strategy=version_strategy,
                 op_retry_policy=op_retry_policy,
+                resource_sources={
+                    name: ResourceSource("FROM_OVERRIDE")
+                    for name in resource_defs_with_defaults.keys()
+                },
             ).get_job_def_for_op_selection(op_selection)
         else:
             return JobDefinition(
@@ -596,6 +602,7 @@ class GraphDefinition(NodeDefinition):
                 hook_defs=hooks,
                 version_strategy=version_strategy,
                 op_retry_policy=op_retry_policy,
+                _resource_sources=_resource_sources,
             ).get_job_def_for_op_selection(op_selection)
 
     def coerce_to_job(self):

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -47,7 +47,7 @@ from .mode import ModeDefinition
 from .partition import PartitionSetDefinition, PartitionedConfig
 from .pipeline_definition import PipelineDefinition
 from .preset import PresetDefinition
-from .resource_definition import ResourceDefinition
+from .resource_definition import ResourceDefinition, ResourceSource
 from .run_request import RunRequest
 from .version_strategy import VersionStrategy
 
@@ -75,6 +75,7 @@ class JobDefinition(PipelineDefinition):
         op_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
         _op_selection_data: Optional[OpSelectionData] = None,
+        _resource_sources: Optional[Dict[str, ResourceSource]] = None,
     ):
 
         # Exists for backcompat - JobDefinition is implemented as a single-mode pipeline.
@@ -84,6 +85,7 @@ class JobDefinition(PipelineDefinition):
             executor_defs=[executor_def] if executor_def else None,
             _config_mapping=config_mapping,
             _partitioned_config=partitioned_config,
+            _resource_sources=_resource_sources,
         )
 
         self._cached_partition_set: Optional["PartitionSetDefinition"] = None

--- a/python_modules/dagster/dagster/core/definitions/mode.py
+++ b/python_modules/dagster/dagster/core/definitions/mode.py
@@ -7,7 +7,7 @@ from dagster.utils.merger import merge_dicts
 
 from .config import ConfigMapping
 from .logger_definition import LoggerDefinition
-from .resource_definition import ResourceDefinition
+from .resource_definition import ResourceDefinition, ResourceSource
 from .utils import check_valid_name
 
 DEFAULT_MODE_NAME = "default"
@@ -27,6 +27,7 @@ class ModeDefinition(
             ("description", Optional[str]),
             ("config_mapping", Optional[ConfigMapping]),
             ("partitioned_config", Optional["PartitionedConfig"]),
+            ("resource_sources", Optional[Dict[str, ResourceSource]]),
         ],
     )
 ):
@@ -49,6 +50,7 @@ class ModeDefinition(
         description (Optional[str]): A human-readable description of the mode.
         _config_mapping (Optional[ConfigMapping]): Only for internal use.
         _partitions (Optional[PartitionedConfig]): Only for internal use.
+        _resource_sources (Optional[Dict[str, ResourceSource]]): Only for internal use.
     """
 
     def __new__(
@@ -60,6 +62,7 @@ class ModeDefinition(
         description: Optional[str] = None,
         _config_mapping: Optional[ConfigMapping] = None,
         _partitioned_config: Optional["PartitionedConfig"] = None,
+        _resource_sources: Optional[Dict[str, ResourceSource]] = None,
     ):
 
         from .partition import PartitionedConfig
@@ -100,6 +103,9 @@ class ModeDefinition(
             config_mapping=check.opt_inst_param(_config_mapping, "_config_mapping", ConfigMapping),
             partitioned_config=check.opt_inst_param(
                 _partitioned_config, "_partitioned_config", PartitionedConfig
+            ),
+            resource_sources=check.opt_dict_param(
+                _resource_sources, "_resource_sources", key_type=str, value_type=ResourceSource
             ),
         )
 

--- a/python_modules/dagster/dagster/core/definitions/mode.py
+++ b/python_modules/dagster/dagster/core/definitions/mode.py
@@ -7,7 +7,7 @@ from dagster.utils.merger import merge_dicts
 
 from .config import ConfigMapping
 from .logger_definition import LoggerDefinition
-from .resource_definition import ResourceDefinition, ResourceSource
+from .resource_definition import ResourceDefinition, ResourceOrigin
 from .utils import check_valid_name
 
 DEFAULT_MODE_NAME = "default"
@@ -27,7 +27,6 @@ class ModeDefinition(
             ("description", Optional[str]),
             ("config_mapping", Optional[ConfigMapping]),
             ("partitioned_config", Optional["PartitionedConfig"]),
-            ("resource_sources", Optional[Dict[str, ResourceSource]]),
         ],
     )
 ):
@@ -50,7 +49,6 @@ class ModeDefinition(
         description (Optional[str]): A human-readable description of the mode.
         _config_mapping (Optional[ConfigMapping]): Only for internal use.
         _partitions (Optional[PartitionedConfig]): Only for internal use.
-        _resource_sources (Optional[Dict[str, ResourceSource]]): Only for internal use.
     """
 
     def __new__(
@@ -62,7 +60,6 @@ class ModeDefinition(
         description: Optional[str] = None,
         _config_mapping: Optional[ConfigMapping] = None,
         _partitioned_config: Optional["PartitionedConfig"] = None,
-        _resource_sources: Optional[Dict[str, ResourceSource]] = None,
     ):
 
         from .partition import PartitionedConfig
@@ -103,9 +100,6 @@ class ModeDefinition(
             config_mapping=check.opt_inst_param(_config_mapping, "_config_mapping", ConfigMapping),
             partitioned_config=check.opt_inst_param(
                 _partitioned_config, "_partitioned_config", PartitionedConfig
-            ),
-            resource_sources=check.opt_dict_param(
-                _resource_sources, "_resource_sources", key_type=str, value_type=ResourceSource
             ),
         )
 

--- a/python_modules/dagster/dagster/core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/repository_definition.py
@@ -625,6 +625,7 @@ class CachingRepositoryData(RepositoryData):
         from dagster.core.asset_defs import AssetGroup
 
         pipelines_or_jobs: Dict[str, Union[PipelineDefinition, JobDefinition]] = {}
+        graph_defs: Dict[str, GraphDefinition] = {}
         partition_sets: Dict[str, PartitionSetDefinition] = {}
         schedules: Dict[str, ScheduleDefinition] = {}
         sensors: Dict[str, SensorDefinition] = {}
@@ -686,14 +687,14 @@ class CachingRepositoryData(RepositoryData):
                         )
                     partition_sets[partition_set_def.name] = partition_set_def
             elif isinstance(definition, GraphDefinition):
-                coerced = definition.coerce_to_job()
-                if coerced.name in pipelines_or_jobs:
+                graph_def = definition
+                if graph_def.name in graph_defs:
                     raise DagsterInvalidDefinitionError(
-                        "Duplicate {target_type} definition found for graph '{name}'".format(
-                            target_type=coerced.target_type, name=coerced.name
+                        "Duplicate graph definition found for graph '{name}'".format(
+                            name=graph_def.name
                         )
                     )
-                pipelines_or_jobs[coerced.name] = coerced
+                graph_defs[definition.name] = graph_def
 
             elif isinstance(definition, AssetGroup):
                 if encountered_asset_group:
@@ -724,11 +725,24 @@ class CachingRepositoryData(RepositoryData):
 
         pipelines: Dict[str, PipelineDefinition] = {}
         jobs: Dict[str, JobDefinition] = {}
+
         for name, pipeline_or_job in pipelines_or_jobs.items():
             if isinstance(pipeline_or_job, JobDefinition):
                 jobs[name] = pipeline_or_job
             else:
                 pipelines[name] = pipeline_or_job
+
+        for name, graph_def in graph_defs.items():
+            coerced_with_defaults = graph_def.to_job(resource_defs=default_resources_dict)
+            if name in jobs:
+                check.failed(
+                    f"Error when coercing graph '{name}' to job: A job already exists with name '{name}'."
+                )
+            if name in pipelines:
+                check.failed(
+                    f"Error when coercing graph '{name}' to job: A pipeline already exists with name '{name}'."
+                )
+            jobs[name] = coerced_with_defaults
 
         return CachingRepositoryData(
             pipelines=pipelines,

--- a/python_modules/dagster/dagster/core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/repository_definition.py
@@ -26,7 +26,7 @@ from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .job_definition import JobDefinition, PartialJobDefinition
 from .partition import PartitionScheduleDefinition, PartitionSetDefinition
 from .pipeline_definition import PipelineDefinition
-from .resource_definition import ResourceDefinition
+from .resource_definition import ResourceDefinition, ResourceSource
 from .schedule_definition import ScheduleDefinition
 from .sensor_definition import SensorDefinition
 from .utils import check_valid_name
@@ -745,8 +745,14 @@ class CachingRepositoryData(RepositoryData):
             else:
                 pipelines[name] = pipeline_or_job
 
+        default_resources_dict = default_resources_dict or {}
         for name, graph_def in graph_defs.items():
-            coerced_with_defaults = graph_def.to_job(resource_defs=default_resources_dict)
+            coerced_with_defaults = graph_def.to_job(
+                resource_defs=default_resources_dict,
+                _resource_sources={
+                    name: ResourceSource("FROM_DEFAULT") for name in default_resources_dict.keys()
+                },
+            )
             if name in jobs:
                 check.failed(
                     f"Error when coercing graph '{name}' to job: A job already exists with name '{name}'."
@@ -759,7 +765,10 @@ class CachingRepositoryData(RepositoryData):
 
         for name, partial_job_def in partial_job_defs.items():
             job_def_defaults_applied = partial_job_def.coerce_to_job_def(
-                resource_defs=default_resources_dict or {}
+                resource_defs=default_resources_dict,
+                resource_sources={
+                    name: ResourceSource("FROM_DEFAULT") for name in default_resources_dict.keys()
+                },
             )
             jobs[name] = job_def_defaults_applied
 

--- a/python_modules/dagster/dagster/core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/repository_definition.py
@@ -23,7 +23,7 @@ from dagster.utils import merge_dicts
 
 from .events import AssetKey
 from .graph_definition import GraphDefinition, SubselectedGraphDefinition
-from .job_definition import JobDefinition
+from .job_definition import JobDefinition, PartialJobDefinition
 from .partition import PartitionScheduleDefinition, PartitionSetDefinition
 from .pipeline_definition import PipelineDefinition
 from .resource_definition import ResourceDefinition
@@ -625,6 +625,7 @@ class CachingRepositoryData(RepositoryData):
         from dagster.core.asset_defs import AssetGroup
 
         pipelines_or_jobs: Dict[str, Union[PipelineDefinition, JobDefinition]] = {}
+        partial_job_defs: Dict[str, PartialJobDefinition] = {}
         graph_defs: Dict[str, GraphDefinition] = {}
         partition_sets: Dict[str, PartitionSetDefinition] = {}
         schedules: Dict[str, ScheduleDefinition] = {}
@@ -713,6 +714,18 @@ class CachingRepositoryData(RepositoryData):
                     source_asset.key: source_asset for source_asset in asset_group.source_assets
                 }
 
+            elif isinstance(definition, PartialJobDefinition):
+                partial_job_def = definition
+                if partial_job_def.name in partial_job_defs:
+                    raise DagsterInvalidDefinitionError(
+                        f"Duplicate job definition found for job '{partial_job_def.name}'"
+                    )
+                elif partial_job_def.name in pipelines_or_jobs:
+                    raise DagsterInvalidDefinitionError(
+                        f"Duplicate {pipelines_or_jobs[partial_job_def.name].target_type} found for job '{name}'"
+                    )
+                partial_job_defs[partial_job_def.name] = partial_job_def
+
             elif is_resource_dict(definition):
                 if not default_resources_dict:
                     default_resources_dict = definition
@@ -742,7 +755,13 @@ class CachingRepositoryData(RepositoryData):
                 check.failed(
                     f"Error when coercing graph '{name}' to job: A pipeline already exists with name '{name}'."
                 )
-            jobs[name] = coerced_with_defaults
+            jobs[name] = cast(JobDefinition, coerced_with_defaults)
+
+        for name, partial_job_def in partial_job_defs.items():
+            job_def_defaults_applied = partial_job_def.coerce_to_job_def(
+                resource_defs=default_resources_dict or {}
+            )
+            jobs[name] = job_def_defaults_applied
 
         return CachingRepositoryData(
             pipelines=pipelines,

--- a/python_modules/dagster/dagster/core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/repository_definition.py
@@ -26,6 +26,7 @@ from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .job_definition import JobDefinition
 from .partition import PartitionScheduleDefinition, PartitionSetDefinition
 from .pipeline_definition import PipelineDefinition
+from .resource_definition import ResourceDefinition
 from .schedule_definition import ScheduleDefinition
 from .sensor_definition import SensorDefinition
 from .utils import check_valid_name
@@ -629,6 +630,7 @@ class CachingRepositoryData(RepositoryData):
         sensors: Dict[str, SensorDefinition] = {}
         source_assets: Dict[AssetKey, SourceAsset] = {}
         encountered_asset_group = False
+        default_resources_dict: Optional[Dict[str, ResourceDefinition]] = None
         for definition in repository_definitions:
             if isinstance(definition, PipelineDefinition):
                 if (
@@ -710,6 +712,13 @@ class CachingRepositoryData(RepositoryData):
                     source_asset.key: source_asset for source_asset in asset_group.source_assets
                 }
 
+            elif is_resource_dict(definition):
+                if not default_resources_dict:
+                    default_resources_dict = definition
+                else:
+                    check.failed(
+                        f"Provided multiple resource dictionaries to repository, please provide only one."
+                    )
             else:
                 check.failed(f"Unexpected repository entry {definition}")
 
@@ -1164,3 +1173,16 @@ class RepositoryDefinition:
     # overwritten. Therefore, we want to maintain the call-ability of repository definitions.
     def __call__(self, *args, **kwargs):
         return self
+
+
+def is_resource_dict(defn: Any) -> bool:
+    if not isinstance(defn, dict):
+        return False
+
+    the_dict = defn
+    return all(
+        [
+            isinstance(key, str) and isinstance(val, ResourceDefinition)
+            for key, val in the_dict.items()
+        ]
+    )

--- a/python_modules/dagster/dagster/core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/repository_definition.py
@@ -26,7 +26,7 @@ from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .job_definition import JobDefinition, PartialJobDefinition
 from .partition import PartitionScheduleDefinition, PartitionSetDefinition
 from .pipeline_definition import PipelineDefinition
-from .resource_definition import ResourceDefinition, ResourceSource
+from .resource_definition import ResourceDefinition, ResourceOrigin
 from .schedule_definition import ScheduleDefinition
 from .sensor_definition import SensorDefinition
 from .utils import check_valid_name
@@ -40,6 +40,7 @@ VALID_REPOSITORY_DATA_DICT_KEYS = {
     "schedules",
     "sensors",
     "jobs",
+    "resources",
 }
 
 RepositoryLevelDefinition = TypeVar(
@@ -758,9 +759,6 @@ class CachingRepositoryData(RepositoryData):
         for name, graph_def in graph_defs.items():
             coerced_with_defaults = graph_def.to_job(
                 resource_defs=default_resources_dict,
-                _resource_sources={
-                    name: ResourceSource("FROM_DEFAULT") for name in default_resources_dict.keys()
-                },
             )
             if name in jobs:
                 check.failed(
@@ -775,9 +773,6 @@ class CachingRepositoryData(RepositoryData):
         for name, partial_job_def in partial_job_defs.items():
             job_def_defaults_applied = partial_job_def.coerce_to_job_def(
                 resource_defs=default_resources_dict,
-                resource_sources={
-                    name: ResourceSource("FROM_DEFAULT") for name in default_resources_dict.keys()
-                },
             )
             jobs[name] = job_def_defaults_applied
 

--- a/python_modules/dagster/dagster/core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_definition.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from enum import Enum
 from functools import update_wrapper
 from typing import (
     TYPE_CHECKING,
@@ -14,7 +15,6 @@ from typing import (
     cast,
     overload,
 )
-from enum import Enum
 
 from dagster import check
 from dagster.core.decorator_utils import format_docstring_for_description
@@ -25,6 +25,7 @@ from dagster.core.errors import (
     DagsterInvalidInvocationError,
     DagsterUnknownResourceError,
 )
+from dagster.serdes import whitelist_for_serdes
 from dagster.seven import funcsigs
 from dagster.utils.backcompat import experimental_arg_warning
 
@@ -446,6 +447,7 @@ def make_values_resource(**kwargs: Any) -> ResourceDefinition:
     )
 
 
+@whitelist_for_serdes
 class ResourceSource(Enum):
     FROM_OVERRIDE = "FROM_OVERRIDE"
     FROM_DEFAULT = "FROM_DEFAULT"

--- a/python_modules/dagster/dagster/core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_definition.py
@@ -14,6 +14,7 @@ from typing import (
     cast,
     overload,
 )
+from enum import Enum
 
 from dagster import check
 from dagster.core.decorator_utils import format_docstring_for_description

--- a/python_modules/dagster/dagster/core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_definition.py
@@ -443,3 +443,8 @@ def make_values_resource(**kwargs: Any) -> ResourceDefinition:
         resource_fn=lambda init_context: init_context.resource_config,
         config_schema=kwargs or Any,
     )
+
+
+class ResourceSource(Enum):
+    FROM_OVERRIDE = "FROM_OVERRIDE"
+    FROM_DEFAULT = "FROM_DEFAULT"

--- a/python_modules/dagster/dagster/core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_definition.py
@@ -448,6 +448,6 @@ def make_values_resource(**kwargs: Any) -> ResourceDefinition:
 
 
 @whitelist_for_serdes
-class ResourceSource(Enum):
-    FROM_OVERRIDE = "FROM_OVERRIDE"
-    FROM_DEFAULT = "FROM_DEFAULT"
+class ResourceOrigin(Enum):
+    FROM_REPO_DEFAULT = "FROM_REPO_DEFAULT"
+    FROM_SYSTEM_DEFAULT = "FROM_SYSTEM_DEFAULT"

--- a/python_modules/dagster/dagster/core/host_representation/external.py
+++ b/python_modules/dagster/dagster/core/host_representation/external.py
@@ -84,6 +84,10 @@ class ExternalRepository:
                     _asset_jobs[job_name].append(asset_node)
         # pylint: disable=unsubscriptable-object
         self._asset_jobs: OrderedDict[str, Sequence[ExternalAssetNode]] = OrderedDict(_asset_jobs)
+        self._default_resources = OrderedDict(
+            (external_resource.resource_def_snap.name, external_resource)
+            for external_resource in external_repository_data.external_default_resource_data
+        )
 
     @property
     def name(self):
@@ -122,6 +126,9 @@ class ExternalRepository:
             ExternalSensor(external_sensor_data, self._handle)
             for external_sensor_data in self.external_repository_data.external_sensor_datas
         ]
+
+    def get_external_default_resources(self):
+        return
 
     def has_external_schedule(self, schedule_name):
         return isinstance(self._instigation_map.get(schedule_name), ExternalScheduleData)
@@ -213,6 +220,9 @@ class ExternalRepository:
 
     def get_display_metadata(self):
         return self.handle.display_metadata
+
+    def get_external_default_resource_data(self):
+        return self._default_resources
 
 
 class ExternalPipeline(RepresentedPipeline):
@@ -673,6 +683,10 @@ class ExternalSensor:
             if self._external_sensor_data
             else DefaultSensorStatus.STOPPED
         )
+
+
+class ExternalResource:
+    pass
 
 
 class ExternalPartitionSet:

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -32,7 +32,7 @@ from dagster.core.definitions.metadata import MetadataEntry
 from dagster.core.definitions.mode import DEFAULT_MODE_NAME
 from dagster.core.definitions.node_definition import NodeDefinition
 from dagster.core.definitions.partition import PartitionScheduleDefinition, ScheduleType
-from dagster.core.definitions.resource_definition import ResourceSource
+from dagster.core.definitions.resource_definition import ResourceOrigin
 from dagster.core.definitions.schedule_definition import DefaultScheduleStatus
 from dagster.core.definitions.sensor_definition import (
     AssetSensorDefinition,
@@ -810,9 +810,7 @@ def external_default_resource_data_from_defs(
             raise DagsterInvalidDefinitionError("Resource definition has no config type")
         external_resource_data.append(
             ExternalDefaultResourceData(
-                resource_def_snap=build_resource_def_snap(
-                    name, resource_def, ResourceSource.FROM_DEFAULT
-                ),
+                resource_def_snap=build_resource_def_snap(name, resource_def, None),
                 config_schema_snap=config_schema_snapshot_from_config_type(
                     cast(ConfigType, resource_config_type)
                 ),

--- a/python_modules/dagster/dagster/core/snap/mode.py
+++ b/python_modules/dagster/dagster/core/snap/mode.py
@@ -99,7 +99,7 @@ class ResourceDefSnap(
         name: str,
         description: Optional[str],
         config_field_snap: Optional[ConfigFieldSnap],
-        source: Optional[str] = None,
+        source: Optional[ResourceSource] = None,
     ):
         return super(ResourceDefSnap, cls).__new__(
             cls,

--- a/python_modules/dagster/dagster/core/snap/mode.py
+++ b/python_modules/dagster/dagster/core/snap/mode.py
@@ -1,6 +1,6 @@
 # Contains mode, resources, loggers
-from typing import List, NamedTuple, Optional, cast
 from enum import Enum
+from typing import List, NamedTuple, Optional, cast
 
 from dagster import check
 from dagster.config.snap import ConfigFieldSnap, snap_from_field
@@ -22,7 +22,7 @@ def build_mode_def_snap(mode_def, root_config_key):
         description=mode_def.description,
         resource_def_snaps=sorted(
             [
-                build_resource_def_snap(name, rd, mode_def.resource_sources[name])
+                build_resource_def_snap(name, rd, mode_def.resource_sources.get(name))
                 for name, rd in mode_def.resource_defs.items()
             ],
             key=lambda item: item.name,
@@ -79,6 +79,7 @@ def build_resource_def_snap(name, resource_def, source):
         config_field_snap=snap_from_field("config", resource_def.config_field)
         if resource_def.has_config_field
         else None,
+        source=source or ResourceSource.FROM_OVERRIDE,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -300,7 +300,10 @@ def test_bare_graph_with_resources():
     def bare():
         needy()
 
-    with pytest.raises(DagsterInvalidDefinitionError, match="Failed attempting to coerce Graph"):
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="resource key 'stuff' is required by solid 'needy', but is not provided.",
+    ):
 
         @repository
         def _test():
@@ -348,12 +351,12 @@ def test_job_with_partitions():
 
 
 def test_dupe_graph_defs():
-    @solid
+    @op
     def noop():
         pass
 
-    @pipeline(name="foo")
-    def pipe_foo():
+    @job(name="foo")
+    def job_foo():
         noop()
 
     @graph(name="foo")
@@ -361,22 +364,22 @@ def test_dupe_graph_defs():
         noop()
 
     with pytest.raises(
-        DagsterInvalidDefinitionError,
-        # expect to change as migrate to graph/job
-        match="Duplicate pipeline definition found for pipeline 'foo'",
+        CheckError,
+        match="Error when coercing graph 'foo' to job: A job already exists with name 'foo'.",
     ):
 
         @repository
-        def _pipe_collide():
-            return [graph_foo, pipe_foo]
+        def _job_collide():
+            return [graph_foo, job_foo]
+
+    @pipeline(name="foo")
+    def pipe_foo():
+        noop()
 
     def get_collision_repo():
         @repository
         def graph_collide():
-            return [
-                graph_foo.to_job(name="bar"),
-                pipe_foo,
-            ]
+            return [graph_foo.to_job(name="bar"), pipe_foo]
 
         return graph_collide
 
@@ -386,13 +389,6 @@ def test_dupe_graph_defs():
     ):
 
         get_collision_repo().get_all_pipelines()
-
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match="Op/Graph/Solid definition names must be unique within a repository",
-    ):
-
-        get_collision_repo().get_all_jobs()
 
 
 def test_job_pipeline_collision():
@@ -518,7 +514,8 @@ def test_list_dupe_graph():
         pass
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match="Duplicate job definition found for graph 'foo'"
+        CheckError,
+        match="Error when coercing graph 'foo' to job: A job already exists with name 'foo'.",
     ):
 
         @repository
@@ -639,3 +636,36 @@ def test_repo_with_resources():
         @repository
         def the_repo_multiple_resource_dicts():
             return [{"foo": the_resource}, {"foo": the_resource}]
+
+
+def test_graph_default_resources():
+    @resource
+    def the_resource():
+        return "hello"
+
+    @op(required_resource_keys={"foo"})
+    def the_op(context):
+        assert context.resources.foo == "hello"
+
+    @graph
+    def the_graph():
+        the_op()
+
+    @repository
+    def the_repo():
+        return [{"foo": the_resource}, the_graph]
+
+    jobs = the_repo.get_all_jobs()
+    coerced_job = jobs[0]
+    assert coerced_job.name == "the_graph"
+    result = coerced_job.execute_in_process()
+    assert result.success
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="resource key 'foo' is required by op 'the_op', but is not provided.",
+    ):
+
+        @repository
+        def the_repo_doesnt_satisfy_resource_reqs():
+            return [{"bar": the_resource}, the_graph]

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -21,6 +21,7 @@ from dagster import (
     op,
     pipeline,
     repository,
+    resource,
     schedule,
     sensor,
     solid,
@@ -619,3 +620,22 @@ def test_source_assets():
         return [AssetGroup(assets=[], source_assets=[foo, bar])]
 
     assert my_repo.source_assets_by_key == {AssetKey("foo"): foo, AssetKey("bar"): bar}
+
+
+def test_repo_with_resources():
+    @resource
+    def the_resource():
+        pass
+
+    @repository
+    def the_repo():
+        return [{"foo": the_resource}]
+
+    with pytest.raises(
+        CheckError,
+        match="Provided multiple resource dictionaries to repository, please provide only one.",
+    ):
+
+        @repository
+        def the_repo_multiple_resource_dicts():
+            return [{"foo": the_resource}, {"foo": the_resource}]

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -9,6 +9,7 @@ from dagster import (
     DagsterInvalidDefinitionError,
     DagsterInvariantViolationError,
     PipelineDefinition,
+    ResourceDefinition,
     SensorDefinition,
     SolidDefinition,
     SourceAsset,
@@ -669,3 +670,22 @@ def test_graph_default_resources():
         @repository
         def the_repo_doesnt_satisfy_resource_reqs():
             return [{"bar": the_resource}, the_graph]
+
+
+def test_job_partial_resource_spec():
+    @op(required_resource_keys={"foo", "bar"})
+    def the_op(context):
+        assert context.resources.foo == "hello"
+        assert context.resources.bar == "goodbye"
+
+    @job(resource_defs={"foo": ResourceDefinition.hardcoded_resource("hello")})
+    def the_job():
+        the_op()
+
+    @repository
+    def the_repo():
+        [{"bar": ResourceDefinition.hardcoded_resource("goodbye")}, the_job]
+
+    job_with_defaults_applied = the_repo.get_all_jobs()[0]
+    result = job_with_defaults_applied.execute_in_process()
+    assert result.success


### PR DESCRIPTION
**I expect this PR to be broken up significantly before landing, but would like thoughts on the full experience.**
This PR shows what the dagit experience might look like when resources are defined on repositories. Two main pieces:
1. On a given job, having visibility into the lineage. In this PR, I did this via a tag in the front end.:
<img width="419" alt="Screen Shot 2022-04-25 at 5 09 06 PM" src="https://user-images.githubusercontent.com/17576880/165638161-c48e05e3-bb56-45af-ba5c-b2a0978eddca.png">

2. On a repo, having visibility into the default resources available. I chose to do this with a default resources tab.
![Screen Shot 2022-04-27 at 2 47 58 PM](https://user-images.githubusercontent.com/17576880/165638181-0487a867-2b19-465e-a213-a6d506bd2ee6.png)

A few considerations:
- On the jobs page, instead of tagging with FROM_DEFAULT or FROM_OVERRIDE, we could link to the default resource page on the repo itself. In that case, should we still display all of the other information? Or just the link?
- Resources that are provided by default from the job present an interesting dilemma. I think we can re-orient the ontology to say that those default resources (ie default io manager) are now provided by the repo.
