### PR TITLE
add DEFAULT_PYTHON_VERSIONS env var for BK

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -98,12 +98,20 @@ def is_release_branch(branch_name: str):
     return branch_name.startswith("release-")
 
 
+# To customize the tested Python versions for a branch, set environment variable
+# $DEFAULT_PYTHON_VERSIONS to a comma-separated list of python version specifiers of the form VX_Y
+# (i.e. attributes of `SupportedPython`).
+_versions = os.environ.get("DEFAULT_PYTHON_VERSIONS", "V3_9")
+DEFAULT_PYTHON_VERSIONS = [getattr(SupportedPython, ver) for ver in _versions.split(",")]
+
+
 def get_python_versions_for_branch(pr_versions=None):
-    pr_versions = pr_versions if pr_versions != None else [SupportedPython.V3_9]
+    pr_versions = pr_versions if pr_versions != None else DEFAULT_PYTHON_VERSIONS
 
     # Run one representative version on PRs, the full set of python versions on master after
     # landing and on release branches before shipping
     branch_name = os.getenv("BUILDKITE_BRANCH")
+    assert branch_name is not None, "$BUILDKITE_BRANCH env var must be set"
     if branch_name == "master" or is_release_branch(branch_name):
         return SupportedPythons
     else:


### PR DESCRIPTION
This adds an API to customize the Python versions tested for a particular branch on Buildkite. You can set the `DEFAULT_PYTHON_VERSIONS` env var in the BK console when launching a build to override the default (currently just 3.9). Example to test both Python 3.6 and 3.9:

```
DEFAULT_PYTHON_VERSIONS=V3_6,V3_9
```

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
