### PR TITLE
Add typing-extensions 3.10 as dependency.

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -82,6 +82,7 @@ if __name__ == "__main__":
             "tabulate",
             "tqdm",
             "typing_compat",
+            "typing_extensions>4,<5",
             "sqlalchemy>=1.0",
             "toposort>=1.0",
             "watchdog>=0.8.3",

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -82,7 +82,7 @@ if __name__ == "__main__":
             "tabulate",
             "tqdm",
             "typing_compat",
-            "typing_extensions>4,<5",
+            "typing_extensions>=3.10",
             "sqlalchemy>=1.0",
             "toposort>=1.0",
             "watchdog>=0.8.3",


### PR DESCRIPTION
Had to create another PR for this after the last one got screwed up when I edited my graphite stack (it somehow got merged into the downstack branch). Refer to #7137 for the discussion.

Based on feedback from @sryza and @alangenfeld, am setting the version lower bound to 3.10 (rather than previous 4.1.1). It can be raised in the future if we specifically need later features.
