### PR TITLE
[dagit] Hide __asset_group partition sets from search bar

### DIFF
--- a/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
+++ b/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
@@ -44,6 +44,7 @@ const bootstrapDataToSearchResults = (data?: SearchBootstrapQuery) => {
         const repoPath = buildRepoPath(repoName, locationName);
 
         const allPipelinesAndJobs = pipelines
+          .filter((item) => !isAssetGroup(item.name))
           .reduce((flat, pipelineOrJob) => {
             const {name, isJob} = pipelineOrJob;
             return [
@@ -64,8 +65,7 @@ const bootstrapDataToSearchResults = (data?: SearchBootstrapQuery) => {
                 type: SearchResultType.Pipeline,
               },
             ];
-          }, [] as SearchResult[])
-          .filter((item) => !isAssetGroup(item.label));
+          }, [] as SearchResult[]);
 
         const allSchedules: SearchResult[] = schedules.map((schedule) => ({
           key: `${repoPath}-${schedule.name}`,
@@ -83,17 +83,19 @@ const bootstrapDataToSearchResults = (data?: SearchBootstrapQuery) => {
           type: SearchResultType.Sensor,
         }));
 
-        const allPartitionSets: SearchResult[] = partitionSets.map((partitionSet) => ({
-          key: `${repoPath}-${partitionSet.name}`,
-          label: partitionSet.name,
-          description: manyRepos ? `Partition set in ${repoPath}` : 'Partition set',
-          href: workspacePath(
-            repoName,
-            locationName,
-            `/pipeline_or_job/${partitionSet.pipelineName}/partitions?partitionSet=${partitionSet.name}`,
-          ),
-          type: SearchResultType.PartitionSet,
-        }));
+        const allPartitionSets: SearchResult[] = partitionSets
+          .filter((item) => !isAssetGroup(item.pipelineName))
+          .map((partitionSet) => ({
+            key: `${repoPath}-${partitionSet.name}`,
+            label: partitionSet.name,
+            description: manyRepos ? `Partition set in ${repoPath}` : 'Partition set',
+            href: workspacePath(
+              repoName,
+              locationName,
+              `/pipeline_or_job/${partitionSet.pipelineName}/partitions?partitionSet=${partitionSet.name}`,
+            ),
+            type: SearchResultType.PartitionSet,
+          }));
 
         return [
           ...inner,


### PR DESCRIPTION
## Summary
This is a small patch to prevent the behavior shown below:

<img width="936" alt="image" src="https://user-images.githubusercontent.com/1037212/165016963-1a986b1c-c914-4c6b-a9e4-8080de75dd5e.png">

SIdenote - it might be a bit weird that parititon sets appear in this search bar at all, since they aren't really "top level" objects in our workspace tab or elsewhere. Doesn't seem there's any harm in having them, but maybe a future design question.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.