### PR TITLE
[dagit] Refactor ExecutionSessionStorage

### DIFF
--- a/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 
-import {getJSONForKey} from '../hooks/useStateWithStorage';
+import {getJSONForKey, useStateWithStorage} from '../hooks/useStateWithStorage';
+import {buildRepoAddress} from '../workspace/buildRepoAddress';
+import {RepoAddress} from '../workspace/types';
+
+import {AppContext} from './AppContext';
 
 // Internal LocalStorage data format and mutation helpers
 
@@ -105,26 +109,10 @@ export function applyCreateSession(
   };
 }
 
-// StorageProvider component that vends `IStorageData` via a render prop
-
 type StorageHook = [IStorageData, (data: IStorageData) => void];
 
-let _data: IStorageData | null = null;
-let _dataNamespace = '';
-
-function getKey(namespace: string) {
-  return `dagit.v2.${namespace}`;
-}
-
-function getStorageDataForNamespace(namespace: string, initial: Partial<IExecutionSession> = {}) {
-  if (_data && _dataNamespace === namespace) {
-    return _data;
-  }
-
-  let data: IStorageData = Object.assign(
-    {sessions: {}, current: ''},
-    getJSONForKey(getKey(namespace)),
-  );
+const buildValidator = (initial: Partial<IExecutionSession> = {}) => (json: any): IStorageData => {
+  let data: IStorageData = Object.assign({sessions: {}, current: ''}, json);
 
   if (Object.keys(data.sessions).length === 0) {
     data = applyCreateSession(data, initial);
@@ -134,74 +122,96 @@ function getStorageDataForNamespace(namespace: string, initial: Partial<IExecuti
     data.current = Object.keys(data.sessions)[0];
   }
 
-  _data = data;
-  _dataNamespace = namespace;
-
   return data;
-}
+};
 
-function writeStorageDataForNamespace(namespace: string, data: IStorageData) {
-  _data = data;
-  _dataNamespace = namespace;
-  window.localStorage.setItem(getKey(namespace), JSON.stringify(data));
-}
+export const makeKey = (basePath: string, repoAddress: RepoAddress, pipelineOrJobName: string) =>
+  `dagit.v2.${basePath}-${repoAddress.location}-${repoAddress.name}-${pipelineOrJobName}`;
 
-/* React hook that provides local storage to the caller. A previous version of this
-loaded data into React state, but changing namespaces caused the data to be out-of-sync
-for one render (until a useEffect could update the data in state). Now we keep the
-current localStorage namespace in memory (in _data above) and React keeps a simple
-version flag it can use to trigger a re-render after changes are saved, so changing
-namespaces changes the returned data immediately.
-*/
+export const makeOldKey = (repoAddress: RepoAddress, pipelineOrJobName: string) =>
+  `dagit.v2.${repoAddress.name}.${pipelineOrJobName}`;
+
+// todo DPE: Clean up the migration logic.
 export function useExecutionSessionStorage(
-  repositoryName: string,
-  pipelineName: string,
+  repoAddress: RepoAddress,
+  pipelineOrJobName: string,
   initial: Partial<IExecutionSession> = {},
 ): StorageHook {
-  const namespace = `${repositoryName}.${pipelineName}`;
-  const [version, setVersion] = React.useState<number>(0);
+  const {basePath} = React.useContext(AppContext);
 
-  const onSave = (newData: IStorageData) => {
-    writeStorageDataForNamespace(namespace, newData);
-    setVersion(version + 1); // trigger a React render
-  };
+  const key = makeKey(basePath, repoAddress, pipelineOrJobName);
+  const oldKey = makeOldKey(repoAddress, pipelineOrJobName);
 
-  return [getStorageDataForNamespace(namespace, initial), onSave];
+  // Bind the validator function to the provided `initial` value. Convert to a JSON string
+  // because we can't trust that the `initial` object is memoized.
+  const initialAsJSON = JSON.stringify(initial);
+  const validator = React.useMemo(
+    () => buildValidator(JSON.parse(initialAsJSON) as Partial<IExecutionSession>),
+    [initialAsJSON],
+  );
+  const [newState, setNewState] = useStateWithStorage(key, validator);
+
+  // Read stored value for the old key. If a value is present, we will use it
+  // for the new key, then remove the old key entirely.
+  const oldValidator = React.useCallback((json: any) => json, []);
+  const [oldState, setOldState] = useStateWithStorage(oldKey, oldValidator);
+
+  React.useEffect(() => {
+    if (oldState) {
+      setNewState(oldState);
+
+      // Delete data at old key.
+      setOldState(undefined);
+    }
+  }, [oldState, setNewState, setOldState]);
+
+  return [newState, setNewState];
 }
 
-type Repository = {
+const writeStorageDataForKey = (key: string, data: IStorageData) => {
+  window.localStorage.setItem(key, JSON.stringify(data));
+};
+
+export type RepositoryToInvalidate = {
+  locationName: string;
   name: string;
   pipelines: {name: string}[];
 };
 
 export const useInvalidateConfigsForRepo = () => {
   const [_, setVersion] = React.useState<number>(0);
+  const {basePath} = React.useContext(AppContext);
 
-  const onSave = React.useCallback((repositories: Repository[]) => {
-    repositories.forEach((repo) => {
-      const {name, pipelines} = repo;
-      const pipelineNames = pipelines.map((pipeline) => pipeline.name);
+  const onSave = React.useCallback(
+    (repositories: RepositoryToInvalidate[]) => {
+      repositories.forEach((repo) => {
+        const {locationName, name, pipelines} = repo;
+        const pipelineNames = pipelines.map((pipeline) => pipeline.name);
+        const repoAddress = buildRepoAddress(name, locationName);
 
-      pipelineNames.forEach((pipelineName) => {
-        const namespace = `${name}.${pipelineName}`;
-        const data: IStorageData | undefined = getJSONForKey(getKey(namespace));
-        if (data) {
-          const withBase = Object.keys(data.sessions).filter(
-            (sessionKey) => data.sessions[sessionKey].base !== null,
-          );
-          if (withBase.length) {
-            const withUpdates = withBase.reduce(
-              (accum, sessionKey) => applyChangesToSession(accum, sessionKey, {needsRefresh: true}),
-              data,
+        pipelineNames.forEach((pipelineName) => {
+          const key = makeKey(basePath, repoAddress, pipelineName);
+          const data: IStorageData | undefined = getJSONForKey(key);
+          if (data) {
+            const withBase = Object.keys(data.sessions).filter(
+              (sessionKey) => data.sessions[sessionKey].base !== null,
             );
-            writeStorageDataForNamespace(namespace, withUpdates);
+            if (withBase.length) {
+              const withUpdates = withBase.reduce(
+                (accum, sessionKey) =>
+                  applyChangesToSession(accum, sessionKey, {needsRefresh: true}),
+                data,
+              );
+              writeStorageDataForKey(key, withUpdates);
+            }
           }
-        }
+        });
       });
-    });
 
-    setVersion((current) => current + 1);
-  }, []);
+      setVersion((current) => current + 1);
+    },
+    [basePath],
+  );
 
   return onSave;
 };

--- a/js_modules/dagit/packages/core/src/app/__tests__/ExecutionSessionStorage.test.tsx
+++ b/js_modules/dagit/packages/core/src/app/__tests__/ExecutionSessionStorage.test.tsx
@@ -1,0 +1,153 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import * as React from 'react';
+
+import {
+  IExecutionSession,
+  makeKey,
+  makeOldKey,
+  useExecutionSessionStorage,
+} from '../ExecutionSessionStorage';
+
+describe('ExecutionSessionStorage', () => {
+  const BASE_PATH = '';
+  const REPO_ADDRESS = {
+    name: 'test-name',
+    location: 'test-location',
+  };
+  const JOB_NAME = 'test-job';
+
+  const oldKey = makeOldKey(REPO_ADDRESS, JOB_NAME);
+  const newKey = makeKey(BASE_PATH, REPO_ADDRESS, JOB_NAME);
+
+  const TestComponent = (props: {initial?: Partial<IExecutionSession>}) => {
+    const [data] = useExecutionSessionStorage(REPO_ADDRESS, JOB_NAME, props.initial);
+    return (
+      <>
+        <div>Current: {data.current}</div>
+        <div>{`YAML: "${data.sessions[data.current].runConfigYaml}"`}</div>
+      </>
+    );
+  };
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  describe('Migration', () => {
+    it('Migrates old localStorage data from old format', async () => {
+      const testData = {sessions: {test: 'test'}, current: 'test'};
+      window.localStorage.setItem(oldKey, JSON.stringify(testData));
+
+      const {rerender} = render(<TestComponent />);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/current: test/i)).toBeVisible();
+      });
+
+      // Data is at the new key, and the old key is deleted.
+      expect(JSON.parse(window.localStorage.getItem(newKey) as any)).toEqual(testData);
+      expect(window.localStorage.getItem(oldKey)).toEqual(null);
+
+      // Render it again, expect the data to still be there.
+      rerender(<TestComponent />);
+
+      // Data is at the new key, and the old key remains deleted.
+      expect(JSON.parse(window.localStorage.getItem(newKey) as any)).toEqual(testData);
+      expect(window.localStorage.getItem(oldKey)).toEqual(null);
+    });
+  });
+
+  describe('Initialization', () => {
+    it('initializes with `initial`, if provided', async () => {
+      const testData = {runConfigYaml: 'hello yaml'};
+      render(<TestComponent initial={testData} />);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/current: s[0-9]+/i)).toBeVisible();
+        expect(screen.queryByText(/yaml: "hello yaml"/i)).toBeVisible();
+      });
+    });
+
+    it('initializes without `initial`, if none provided', async () => {
+      render(<TestComponent />);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/current: s[0-9]+/i)).toBeVisible();
+        expect(screen.queryByText(/yaml: ""/i)).toBeVisible();
+      });
+    });
+  });
+
+  describe('Preserve session object', () => {
+    let storedObject: any = null;
+    const TestComponent = (props: {initial?: Partial<IExecutionSession>}) => {
+      const [data] = useExecutionSessionStorage(REPO_ADDRESS, JOB_NAME, props.initial);
+      storedObject = data;
+      return (
+        <>
+          <div>Current: {data.current}</div>
+          <div>{`YAML: "${data.sessions[data.current].runConfigYaml}"`}</div>
+        </>
+      );
+    };
+
+    beforeEach(() => {
+      storedObject = null;
+    });
+
+    it('no initial: tracks the same stored object across multiple renders', async () => {
+      const {rerender} = render(<TestComponent />);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/current: s[0-9]+/i)).toBeVisible();
+      });
+
+      const storedObjectA = storedObject;
+      rerender(<TestComponent />);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/current: s[0-9]+/i)).toBeVisible();
+      });
+
+      const storedObjectB = storedObject;
+      expect(storedObjectA).toBe(storedObjectB);
+
+      rerender(<TestComponent />);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/current: s[0-9]+/i)).toBeVisible();
+      });
+
+      const storedObjectC = storedObject;
+      expect(storedObjectC).toBe(storedObjectA);
+    });
+
+    it('with initial: tracks the same stored object across multiple renders', async () => {
+      const testData = {runConfigYaml: 'hello yaml'};
+      const {rerender} = render(<TestComponent initial={testData} />);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/current: s[0-9]+/i)).toBeVisible();
+      });
+
+      const storedObjectA = storedObject;
+      rerender(<TestComponent initial={testData} />);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/current: s[0-9]+/i)).toBeVisible();
+      });
+
+      const storedObjectB = storedObject;
+      expect(storedObjectA).toBe(storedObjectB);
+
+      rerender(<TestComponent initial={testData} />);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/current: s[0-9]+/i)).toBeVisible();
+      });
+
+      const storedObjectC = storedObject;
+      expect(storedObjectC).toBe(storedObjectA);
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
@@ -173,11 +173,7 @@ const LaunchpadSessionContainer: React.FC<LaunchpadSessionContainerProps> = (pro
     return {};
   }, [isJob, partitionSets.results, presets]);
 
-  const [data, onSave] = useExecutionSessionStorage(
-    repoAddress.name || '',
-    pipeline.name,
-    initialDataForMode,
-  );
+  const [data, onSave] = useExecutionSessionStorage(repoAddress, pipeline.name, initialDataForMode);
 
   const currentSession = data.sessions[data.current];
   const tagsFromSession = React.useMemo(() => currentSession.tags || [], [currentSession]);

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupFromRunRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupFromRunRoot.tsx
@@ -62,7 +62,7 @@ const LaunchpadSetupFromRunAllowedRoot: React.FC<Props> = (props) => {
 
   useJobTitle(explorerPath, isJob);
 
-  const [storageData, onSave] = useExecutionSessionStorage(repoAddress.name, pipelineName);
+  const [storageData, onSave] = useExecutionSessionStorage(repoAddress, pipelineName);
 
   const {data, loading} = useQuery<ConfigForRunQuery, ConfigForRunQueryVariables>(
     CONFIG_FOR_RUN_QUERY,

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupRoot.tsx
@@ -41,7 +41,7 @@ const LaunchpadSetupAllowedRoot: React.FC<Props> = (props) => {
 
   useJobTitle(explorerPath, isJob);
 
-  const [data, onSave] = useExecutionSessionStorage(repoAddress.name, pipelineName);
+  const [data, onSave] = useExecutionSessionStorage(repoAddress, pipelineName);
   const queryString = qs.parse(window.location.search, {ignoreQueryPrefix: true});
 
   React.useEffect(() => {

--- a/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
@@ -134,7 +134,7 @@ export const useRepositoryLocationReload = (location: string) => {
             ? match.locationOrLoadError.repositories
             : [];
 
-        invalidateConfigs(repositories);
+        invalidateConfigs(repositories.map((repo) => ({...repo, locationName: match.id})));
 
         // Clear and refetch all the queries bound to the UI.
         apollo.resetStore();


### PR DESCRIPTION
## Summary

Refactor ExecutionSessionStorage.

- Reimplement `useExecutionSessionStorage` to use `useStateWithStorage`, thus allowing us to eliminate the local caching logic with module-level vars.
- Change signature of hook to use `RepoAddress`, as intended in the reverted PR.
- Implement old-to-new migration for updated keys, as intended in the reverted PR.
- Fix up `useInvalidateConfigsForRepo` to use the updated localStorage key.

This should ideally resolve a bunch of things:

- The original migration work from old keys to new keys (with basePath and repo location info)
- Failures to load default config on fresh tabs
- Config invalidation for reloaded repos

## Test Plan

Jest test for execution session storage.

- Load Job with default config. Verify that default config shows up in the editor, but does not save to LS immediately. Modify the config, verify that it saves to LS.
- Create a new config tab, verify that it saves.
- Rename LS key to use old key format, reload page. Verify that on render, the data is migrated to the new key.

...still need to test repo invalidation, coming shortly.