### PR TITLE
Add py.typed to dagster and all extension libs

### DIFF
--- a/examples/hacker_news/hacker_news/ops/id_range_for_time.py
+++ b/examples/hacker_news/hacker_news/ops/id_range_for_time.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timezone
-from typing import Tuple
 
-from dagster import Out, Output, check, op
+from dagster import Out, Output, Tuple, check, op
 
 
 def binary_search_nearest_left(get_value, start, end, min_target):
@@ -91,7 +90,7 @@ def _id_range_for_time(start, end, hn_client):
 @op(
     required_resource_keys={"hn_client", "partition_bounds"},
     out=Out(
-        Tuple[int, int],  # type: ignore
+        Tuple[int, int],
         description="The lower (inclusive) and upper (exclusive) ids that bound the range for the partition",
     ),
 )

--- a/examples/hacker_news/hacker_news/ops/id_range_for_time.py
+++ b/examples/hacker_news/hacker_news/ops/id_range_for_time.py
@@ -91,7 +91,7 @@ def _id_range_for_time(start, end, hn_client):
 @op(
     required_resource_keys={"hn_client", "partition_bounds"},
     out=Out(
-        Tuple[int, int],
+        Tuple[int, int],  # type: ignore
         description="The lower (inclusive) and upper (exclusive) ids that bound the range for the partition",
     ),
 )

--- a/examples/hacker_news/hacker_news_tests/test_schedules.py
+++ b/examples/hacker_news/hacker_news_tests/test_schedules.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 
 from hacker_news.jobs.hacker_news_api_download import download_prod_job, download_staging_job
 
+import dagster.check as check
 from dagster import Partition
 from dagster.core.definitions import JobDefinition
 from dagster.core.execution.api import create_execution_plan
@@ -13,7 +14,7 @@ def assert_partitioned_schedule_builds(
     start: datetime,
     end: datetime,
 ):
-    partition_set = job_def.get_partition_set_def()
+    partition_set = check.not_none(job_def.get_partition_set_def())
     run_config = partition_set.run_config_for_partition(Partition((start, end)))
     create_execution_plan(job_def, run_config=run_config)
 

--- a/examples/hacker_news_assets/hacker_news_assets/resources/parquet_io_manager.py
+++ b/examples/hacker_news_assets/hacker_news_assets/resources/parquet_io_manager.py
@@ -53,7 +53,7 @@ class PartitionedParquetIOManager(IOManager):
         )
 
     def _get_path(self, context: OutputContext):
-        key = context.asset_key.path[-1]
+        key = context.asset_key.path[-1]  # type: ignore
 
         if context.has_asset_partitions:
             start, end = context.asset_partitions_time_window

--- a/examples/modern_data_stack_assets/modern_data_stack_assets/setup_airbyte.py
+++ b/examples/modern_data_stack_assets/modern_data_stack_assets/setup_airbyte.py
@@ -5,6 +5,7 @@ create an Airbyte Connection between the source database and destination databas
 """
 # pylint: disable=print-call
 import random
+from typing import Any, Dict
 
 import numpy as np
 import pandas as pd
@@ -19,14 +20,20 @@ from .constants import PG_DESTINATION_CONFIG, PG_SOURCE_CONFIG
 N_USERS = 100
 N_ORDERS = 10000
 
+def _safe_request(client: AirbyteResource, endpoint: str, data: Dict[str, object]) -> Dict[str, Any]:
+    response = client.make_request(endpoint, data)
+    assert response, "Request returned null response"
+    return response
+    
 
 def _create_ab_source(client: AirbyteResource) -> str:
-    workspace_id = client.make_request("/workspaces/list", data={})["workspaces"][0]["workspaceId"]
+    workspace_id = _safe_request(client, "/workspaces/list", data={})["workspaces"][0]["workspaceId"]
 
     # get latest available Postgres source definition
     source_defs = client.make_request(
         "/source_definitions/list_latest", data={"workspaceId": workspace_id}
     )
+    assert source_defs
     postgres_definitions = [
         sd for sd in source_defs["sourceDefinitions"] if sd["name"] == "Postgres"
     ]
@@ -35,7 +42,8 @@ def _create_ab_source(client: AirbyteResource) -> str:
     source_definition_id = postgres_definitions[0]["sourceDefinitionId"]
 
     # create Postgres source
-    source_id = client.make_request(
+    source_id = _safe_request(
+        client,
         "/sources/create",
         data={
             "sourceDefinitionId": source_definition_id,
@@ -49,10 +57,11 @@ def _create_ab_source(client: AirbyteResource) -> str:
 
 
 def _create_ab_destination(client: AirbyteResource) -> str:
-    workspace_id = client.make_request("/workspaces/list", data={})["workspaces"][0]["workspaceId"]
+    workspace_id = _safe_request(client, "/workspaces/list", data={})["workspaces"][0]["workspaceId"]
 
     # get the latest available Postgres destination definition
-    destination_defs = client.make_request(
+    destination_defs = _safe_request(
+        client,
         "/destination_definitions/list_latest", data={"workspaceId": workspace_id}
     )
     postgres_definitions = [
@@ -63,7 +72,8 @@ def _create_ab_destination(client: AirbyteResource) -> str:
     destination_definition_id = postgres_definitions[0]["destinationDefinitionId"]
 
     # create Postgres destination
-    destination_id = client.make_request(
+    destination_id = _safe_request(
+        client,
         "/destinations/create",
         data={
             "destinationDefinitionId": destination_definition_id,
@@ -81,12 +91,13 @@ def setup_airbyte():
     source_id = _create_ab_source(client)
     destination_id = _create_ab_destination(client)
 
-    source_catalog = client.make_request("/sources/discover_schema", data={"sourceId": source_id})[
+    source_catalog = _safe_request(client, "/sources/discover_schema", data={"sourceId": source_id})[
         "catalog"
     ]
 
     # create a connection between the new source and destination
-    connection_id = client.make_request(
+    connection_id = _safe_request(
+        client,
         "/connections/create",
         data={
             "name": "Example Connection",

--- a/examples/modern_data_stack_assets/modern_data_stack_assets/setup_airbyte.py
+++ b/examples/modern_data_stack_assets/modern_data_stack_assets/setup_airbyte.py
@@ -20,14 +20,19 @@ from .constants import PG_DESTINATION_CONFIG, PG_SOURCE_CONFIG
 N_USERS = 100
 N_ORDERS = 10000
 
-def _safe_request(client: AirbyteResource, endpoint: str, data: Dict[str, object]) -> Dict[str, Any]:
+
+def _safe_request(
+    client: AirbyteResource, endpoint: str, data: Dict[str, object]
+) -> Dict[str, Any]:
     response = client.make_request(endpoint, data)
     assert response, "Request returned null response"
     return response
-    
+
 
 def _create_ab_source(client: AirbyteResource) -> str:
-    workspace_id = _safe_request(client, "/workspaces/list", data={})["workspaces"][0]["workspaceId"]
+    workspace_id = _safe_request(client, "/workspaces/list", data={})["workspaces"][0][
+        "workspaceId"
+    ]
 
     # get latest available Postgres source definition
     source_defs = client.make_request(
@@ -57,12 +62,13 @@ def _create_ab_source(client: AirbyteResource) -> str:
 
 
 def _create_ab_destination(client: AirbyteResource) -> str:
-    workspace_id = _safe_request(client, "/workspaces/list", data={})["workspaces"][0]["workspaceId"]
+    workspace_id = _safe_request(client, "/workspaces/list", data={})["workspaces"][0][
+        "workspaceId"
+    ]
 
     # get the latest available Postgres destination definition
     destination_defs = _safe_request(
-        client,
-        "/destination_definitions/list_latest", data={"workspaceId": workspace_id}
+        client, "/destination_definitions/list_latest", data={"workspaceId": workspace_id}
     )
     postgres_definitions = [
         dd for dd in destination_defs["destinationDefinitions"] if dd["name"] == "Postgres"
@@ -91,9 +97,9 @@ def setup_airbyte():
     source_id = _create_ab_source(client)
     destination_id = _create_ab_destination(client)
 
-    source_catalog = _safe_request(client, "/sources/discover_schema", data={"sourceId": source_id})[
-        "catalog"
-    ]
+    source_catalog = _safe_request(
+        client, "/sources/discover_schema", data={"sourceId": source_id}
+    )["catalog"]
 
     # create a connection between the new source and destination
     connection_id = _safe_request(

--- a/examples/nyt-feed/nyt_feed/nyt_feed_job.py
+++ b/examples/nyt-feed/nyt_feed/nyt_feed_job.py
@@ -32,7 +32,7 @@ class DataframeToCSVIOManager(IOManager):
         obj.to_csv(self._get_path(context), index=False)
 
     def load_input(self, context: InputContext) -> pd.DataFrame:
-        return pd.read_csv(self._get_path(context.upstream_output))
+        return pd.read_csv(self._get_path(context.upstream_output))  # type: ignore
 
 
 @io_manager(config_schema={"base_dir": str})

--- a/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
+++ b/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
@@ -143,7 +143,7 @@ def assert_runs_and_exists(client: DagsterGraphQLClient, name, subset_selection=
         run_config={},
         solid_selection=subset_selection,
     )
-    assert_run_success(client, run_id)
+    assert_run_success(client, int(run_id))
 
     locations = (
         client._get_repo_locations_and_names_with_pipeline(  # pylint: disable=protected-access

--- a/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
+++ b/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
@@ -29,7 +29,7 @@ RELEASE_TEST_MAP = {
 }
 
 
-def assert_run_success(client, run_id: int):
+def assert_run_success(client, run_id):
     start_time = time.time()
     while True:
         if time.time() - start_time > MAX_TIMEOUT_SECONDS:
@@ -143,7 +143,7 @@ def assert_runs_and_exists(client: DagsterGraphQLClient, name, subset_selection=
         run_config={},
         solid_selection=subset_selection,
     )
-    assert_run_success(client, int(run_id))
+    assert_run_success(client, run_id)
 
     locations = (
         client._get_repo_locations_and_names_with_pipeline(  # pylint: disable=protected-access

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1030,7 +1030,7 @@ type AssetLineageInfo {
 
 type AssetDependency {
   asset: AssetNode!
-  inputName: String!
+  inputName: String
 }
 
 type MaterializationCountByPartition {

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1030,7 +1030,7 @@ type AssetLineageInfo {
 
 type AssetDependency {
   asset: AssetNode!
-  inputName: String
+  inputName: String!
 }
 
 type MaterializationCountByPartition {

--- a/python_modules/dagit/MANIFEST.in
+++ b/python_modules/dagit/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.rst
 include LICENSE
+include dagit/py.typed
 recursive-include dagit/graphql-playground *
 recursive-include dagit/webapp/build *
 recursive-include dagit/templates/assets *

--- a/python_modules/dagit/dagit/webserver.py
+++ b/python_modules/dagit/dagit/webserver.py
@@ -29,10 +29,7 @@ from dagster import __version__ as dagster_version
 from dagster import check
 from dagster.core.debug import DebugRunPayload
 from dagster.core.storage.compute_log_manager import ComputeIOType
-from dagster.core.workspace.context import (
-    BaseWorkspaceRequestContext,
-    IWorkspaceProcessContext,
-)
+from dagster.core.workspace.context import BaseWorkspaceRequestContext, IWorkspaceProcessContext
 from dagster.seven import json
 from dagster.utils import Counter, traced_counter
 

--- a/python_modules/dagit/dagit/webserver.py
+++ b/python_modules/dagit/dagit/webserver.py
@@ -32,8 +32,6 @@ from dagster.core.storage.compute_log_manager import ComputeIOType
 from dagster.core.workspace.context import (
     BaseWorkspaceRequestContext,
     IWorkspaceProcessContext,
-    WorkspaceProcessContext,
-    WorkspaceRequestContext,
 )
 from dagster.seven import json
 from dagster.utils import Counter, traced_counter

--- a/python_modules/dagit/dagit/webserver.py
+++ b/python_modules/dagit/dagit/webserver.py
@@ -2,7 +2,7 @@ import gzip
 import io
 import uuid
 from os import path
-from typing import List
+from typing import Generic, List, TypeVar
 
 import nbformat
 from dagster_graphql import __version__ as dagster_graphql_version
@@ -29,7 +29,12 @@ from dagster import __version__ as dagster_version
 from dagster import check
 from dagster.core.debug import DebugRunPayload
 from dagster.core.storage.compute_log_manager import ComputeIOType
-from dagster.core.workspace.context import WorkspaceProcessContext, WorkspaceRequestContext
+from dagster.core.workspace.context import (
+    BaseWorkspaceRequestContext,
+    IWorkspaceProcessContext,
+    WorkspaceProcessContext,
+    WorkspaceRequestContext,
+)
 from dagster.seven import json
 from dagster.utils import Counter, traced_counter
 
@@ -48,9 +53,14 @@ ROOT_ADDRESS_STATIC_RESOURCES = [
     "/robots.txt",
 ]
 
+T_IWorkspaceProcessContext = TypeVar("T_IWorkspaceProcessContext", bound=IWorkspaceProcessContext)
 
-class DagitWebserver(GraphQLServer):
-    def __init__(self, process_context: WorkspaceProcessContext, app_path_prefix: str = ""):
+
+class DagitWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
+
+    _process_context: T_IWorkspaceProcessContext
+
+    def __init__(self, process_context: T_IWorkspaceProcessContext, app_path_prefix: str = ""):
         self._process_context = process_context
         super().__init__(app_path_prefix)
 
@@ -63,7 +73,7 @@ class DagitWebserver(GraphQLServer):
     def relative_path(self, rel: str) -> str:
         return path.join(path.dirname(__file__), rel)
 
-    def make_request_context(self, conn: HTTPConnection) -> WorkspaceRequestContext:
+    def make_request_context(self, conn: HTTPConnection) -> BaseWorkspaceRequestContext:
         return self._process_context.create_request_context(conn)
 
     def build_middleware(self) -> List[Middleware]:

--- a/python_modules/dagster-graphql/MANIFEST.in
+++ b/python_modules/dagster-graphql/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include dagster_graphql/py.typed

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from enum import Enum
 from functools import lru_cache
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple
 
 from dagster import DagsterInstance, check
 from dagster.core.definitions.events import AssetKey
@@ -278,13 +278,16 @@ class BatchMaterializationLoader:
         self._instance = instance
         self._asset_keys: List[AssetKey] = list(asset_keys)
         self._fetched = False
-        self._materializations: Dict[AssetKey, EventLogEntry] = {}
+        self._materializations: Mapping[AssetKey, Optional[EventLogEntry]] = {}
 
-    def get_latest_materialization_for_asset_key(self, asset_key: AssetKey) -> EventLogEntry:
+    def get_latest_materialization_for_asset_key(
+        self, asset_key: AssetKey
+    ) -> Optional[EventLogEntry]:
         if asset_key not in self._asset_keys:
             check.failed(
                 f"Asset key {asset_key} not recognized for this loader.  Expected one of: {self._asset_keys}"
             )
+
         if self._materializations.get(asset_key) is None:
             self._fetch()
         return self._materializations.get(asset_key)
@@ -394,7 +397,7 @@ class CrossRepoAssetDependedByLoader:
 
     def get_sink_asset(self, asset_key: AssetKey) -> ExternalAssetNode:
         sink_assets, _ = self._build_cross_repo_deps()
-        return sink_assets.get(asset_key)
+        return sink_assets[asset_key]
 
     def get_cross_repo_dependent_assets(
         self, repository_location_name: str, repository_name: str, asset_key: AssetKey

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -34,7 +34,7 @@ class GrapheneAssetDependency(graphene.ObjectType):
         name = "AssetDependency"
 
     asset = graphene.NonNull("dagster_graphql.schema.asset_graph.GrapheneAssetNode")
-    inputName = graphene.String()
+    inputName = graphene.NonNull(graphene.String)
 
     def __init__(
         self,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Sequence, Union
 
 import graphene
 from dagster_graphql.implementation.events import iterate_metadata_entries
@@ -34,13 +34,13 @@ class GrapheneAssetDependency(graphene.ObjectType):
         name = "AssetDependency"
 
     asset = graphene.NonNull("dagster_graphql.schema.asset_graph.GrapheneAssetNode")
-    inputName = graphene.NonNull(graphene.String)
+    inputName = graphene.String()
 
     def __init__(
         self,
         repository_location: RepositoryLocation,
         external_repository: ExternalRepository,
-        input_name: str,
+        input_name: Optional[str],
         asset_key: AssetKey,
         materialization_loader: Optional[BatchMaterializationLoader] = None,
         depended_by_loader: Optional[CrossRepoAssetDependedByLoader] = None,
@@ -155,7 +155,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     def external_asset_node(self) -> ExternalAssetNode:
         return self._external_asset_node
 
-    def get_partition_keys(self) -> List[str]:
+    def get_partition_keys(self) -> Sequence[str]:
         # TODO: Add functionality for dynamic partitions definition
         partitions_def_data = self._external_asset_node.partitions_def_data
         if partitions_def_data:
@@ -170,7 +170,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     def resolve_assetMaterializations(
         self, graphene_info, **kwargs
-    ) -> List[GrapheneMaterializationEvent]:
+    ) -> Sequence[GrapheneMaterializationEvent]:
         from ..implementation.fetch_assets import get_asset_materializations
 
         beforeTimestampMillis: Optional[str] = kwargs.get("beforeTimestampMillis")
@@ -218,12 +218,12 @@ class GrapheneAssetNode(graphene.ObjectType):
         # CrossRepoAssetDependedByLoader class loads cross-repo asset dependencies workspace-wide.
         # In order to avoid recomputing workspace-wide values per asset node, we add a loader
         # that batch loads all cross-repo dependencies for the whole workspace.
-        check.invariant(
+        _depended_by_loader = check.not_none(
             self._depended_by_loader,
             "depended_by_loader must exist in order to resolve dependedBy nodes",
         )
 
-        depended_by_asset_nodes = self._depended_by_loader.get_cross_repo_dependent_assets(
+        depended_by_asset_nodes = _depended_by_loader.get_cross_repo_dependent_assets(
             self._repository_location.name,
             self._external_repository.name,
             self._external_asset_node.asset_key,
@@ -245,21 +245,21 @@ class GrapheneAssetNode(graphene.ObjectType):
                 input_name=dep.input_name,
                 asset_key=dep.downstream_asset_key,
                 materialization_loader=materialization_loader,
-                depended_by_loader=self._depended_by_loader,
+                depended_by_loader=_depended_by_loader,
             )
             for dep in depended_by_asset_nodes
         ]
 
-    def resolve_dependedByKeys(self, _graphene_info) -> List[GrapheneAssetKey]:
+    def resolve_dependedByKeys(self, _graphene_info) -> Sequence[GrapheneAssetKey]:
         # CrossRepoAssetDependedByLoader class loads all cross-repo asset dependencies workspace-wide.
         # In order to avoid recomputing workspace-wide values per asset node, we add a loader
         # that batch loads all cross-repo dependencies for the whole workspace.
-        check.invariant(
+        depended_by_loader = check.not_none(
             self._depended_by_loader,
             "depended_by_loader must exist in order to resolve dependedBy nodes",
         )
 
-        depended_by_asset_nodes = self._depended_by_loader.get_cross_repo_dependent_assets(
+        depended_by_asset_nodes = depended_by_loader.get_cross_repo_dependent_assets(
             self._repository_location.name,
             self._external_repository.name,
             self._external_asset_node.asset_key,
@@ -276,7 +276,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             for dep in self._external_asset_node.dependencies
         ]
 
-    def resolve_dependencies(self, graphene_info) -> List[GrapheneAssetDependency]:
+    def resolve_dependencies(self, graphene_info) -> Sequence[GrapheneAssetDependency]:
         if not self._external_asset_node.dependencies:
             return []
 
@@ -302,10 +302,10 @@ class GrapheneAssetNode(graphene.ObjectType):
         else:
             return None
 
-    def resolve_jobNames(self, _graphene_info) -> List[str]:
+    def resolve_jobNames(self, _graphene_info) -> Sequence[str]:
         return self._external_asset_node.job_names
 
-    def resolve_jobs(self, _graphene_info) -> List[GraphenePipeline]:
+    def resolve_jobs(self, _graphene_info) -> Sequence[GraphenePipeline]:
         job_names = self._external_asset_node.job_names or []
         return [
             GraphenePipeline(self._external_repository.get_full_external_pipeline(job_name))
@@ -315,7 +315,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     def resolve_latestMaterializationByPartition(
         self, graphene_info, **kwargs
-    ) -> List[Optional[GrapheneMaterializationEvent]]:
+    ) -> Sequence[Optional[GrapheneMaterializationEvent]]:
         from ..implementation.fetch_assets import get_asset_materializations
 
         get_partition = (
@@ -351,7 +351,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     def resolve_materializationCountByPartition(
         self, graphene_info
-    ) -> List[GrapheneMaterializationCount]:
+    ) -> Sequence[GrapheneMaterializationCount]:
         asset_key = self._external_asset_node.asset_key
         partition_keys = self.get_partition_keys()
 
@@ -364,7 +364,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             for partition_key in partition_keys
         ]
 
-    def resolve_metadata_entries(self, _graphene_info) -> List[GrapheneMetadataEntry]:
+    def resolve_metadata_entries(self, _graphene_info) -> Sequence[GrapheneMetadataEntry]:
         return list(iterate_metadata_entries(self._external_asset_node.metadata_entries))
 
     def resolve_op(
@@ -390,7 +390,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             return str(partitions_def_data.get_partitions_definition())
         return None
 
-    def resolve_partitionKeys(self, _graphene_info) -> List[str]:
+    def resolve_partitionKeys(self, _graphene_info) -> Sequence[str]:
         return self.get_partition_keys()
 
     def resolve_repository(self, graphene_info) -> "GrapheneRepository":

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -46,7 +46,7 @@ class GrapheneRunsFilter(graphene.InputObjectType):
 
         if self.statuses:
             statuses = [
-                PipelineRunStatus[status]
+                PipelineRunStatus[status]  # type: ignore
                 for status in self.statuses  # pylint: disable=not-an-iterable
             ]
         else:

--- a/python_modules/dagster-test/dagster_test/toys/graph_job_repos.py
+++ b/python_modules/dagster-test/dagster_test/toys/graph_job_repos.py
@@ -1,8 +1,9 @@
-from typing import AbstractSet, Any, Optional
+from typing import Any, Optional, Set
 
 from dagster import (
     InputDefinition,
     ResourceDefinition,
+    SkipReason,
     SolidDefinition,
     graph,
     repository,
@@ -14,7 +15,7 @@ from dagster import (
 
 def make_solid(
     name: str,
-    required_resource_keys: Optional[AbstractSet[str]] = None,
+    required_resource_keys: Optional[Set[str]] = None,
     config_schema: Optional[Any] = None,
     num_inputs: int = 0,
 ) -> SolidDefinition:
@@ -52,8 +53,8 @@ def event_reports():
 
 
 @sensor(job=event_reports.to_job(resource_defs={"mode": ResourceDefinition.none_resource()}))
-def event_reports_sensor(_context):
-    pass
+def event_reports_sensor():
+    return SkipReason("dummy sensor")
 
 
 event_reports_dev = event_reports.to_job(resource_defs={"mode": ResourceDefinition.none_resource()})

--- a/python_modules/dagster-test/dagster_test/toys/graph_job_repos.py
+++ b/python_modules/dagster-test/dagster_test/toys/graph_job_repos.py
@@ -52,7 +52,7 @@ def event_reports():
 
 
 @sensor(job=event_reports.to_job(resource_defs={"mode": ResourceDefinition.none_resource()}))
-def event_reports_sensor():
+def event_reports_sensor(_context):
     pass
 
 

--- a/python_modules/dagster-test/dagster_test/toys/schedules.py
+++ b/python_modules/dagster-test/dagster_test/toys/schedules.py
@@ -127,7 +127,7 @@ def materialization_schedule():
     start_date=datetime.datetime(2021, 1, 1),
     execution_timezone=_toys_tz_info(),
 )
-def hourly_materialization_schedule():
+def hourly_materialization_schedule(_dt):
     return {}
 
 
@@ -136,7 +136,7 @@ def hourly_materialization_schedule():
     start_date=datetime.datetime(2021, 1, 1),
     execution_timezone=_toys_tz_info(),
 )
-def daily_materialization_schedule():
+def daily_materialization_schedule(_dt):
     return {}
 
 
@@ -145,7 +145,7 @@ def daily_materialization_schedule():
     start_date=datetime.datetime(2021, 1, 1),
     execution_timezone=_toys_tz_info(),
 )
-def weekly_materialization_schedule():
+def weekly_materialization_schedule(_dt):
     return {}
 
 
@@ -154,7 +154,7 @@ def weekly_materialization_schedule():
     start_date=datetime.datetime(2021, 1, 1),
     execution_timezone=_toys_tz_info(),
 )
-def monthly_materialization_schedule():
+def monthly_materialization_schedule(_dt):
     return {}
 
 

--- a/python_modules/dagster/MANIFEST.in
+++ b/python_modules/dagster/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.rst
 include LICENSE
 include COPYING
+include dagster/py.typed
 recursive-include dagster *.md
 recursive-include dagster/core/storage/alembic *
 recursive-include dagster/core/storage/event_log/sqlite/alembic *

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -1412,7 +1412,7 @@ def invariant(condition: Any, desc: Optional[str] = None) -> bool:
     return True
 
 
-def assert_never(value: NoReturn) -> NoReturn:
+def assert_never(value: object) -> NoReturn:
     failed(f"Unhandled value: {value} ({type(value).__name__})")
 
 

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -929,7 +929,7 @@ def not_none_param(
 
 def not_none(value: Optional[T], additional_message: Optional[str] = None) -> T:
     if value is None:
-        raise ValueError(f"Expected non-None value: {additional_message}")
+        raise CheckError(f"Expected non-None value: {additional_message}")
     return value
 
 

--- a/python_modules/dagster/dagster/config/config_schema.py
+++ b/python_modules/dagster/dagster/config/config_schema.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Dict, List, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Type, Union
 
 from typing_extensions import TypeAlias
 
@@ -18,8 +18,8 @@ ConfigSchemaType: TypeAlias = Union[
     Type[Union[dict, list]],
     "ConfigType",
     "Field",
-    Dict[str, object],
-    List[object],
+    Dict[str, Any],
+    List[Any],
 ]
 
 

--- a/python_modules/dagster/dagster/config/config_type.py
+++ b/python_modules/dagster/dagster/config/config_type.py
@@ -1,6 +1,6 @@
 import typing
 from enum import Enum as PythonEnum
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, cast
 
 from dagster import check
 from dagster.builtins import BuiltinEnum
@@ -176,10 +176,10 @@ class Noneable(ConfigType):
        config={}                 # Error
     """
 
-    def __init__(self, inner_type: ConfigType):
+    def __init__(self, inner_type: object):
         from .field import resolve_to_config_type
 
-        self.inner_type = resolve_to_config_type(inner_type)
+        self.inner_type = cast(ConfigType, resolve_to_config_type(inner_type))
         super(Noneable, self).__init__(
             key="Noneable.{inner_type}".format(inner_type=self.inner_type.key),
             kind=ConfigTypeKind.NONEABLE,

--- a/python_modules/dagster/dagster/core/definitions/decorators/solid_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/solid_decorator.py
@@ -156,13 +156,8 @@ def solid(
     description: Optional[str] = ...,
     input_defs: Optional[Sequence[InputDefinition]] = ...,
     output_defs: Optional[Sequence[OutputDefinition]] = ...,
-<<<<<<< HEAD
     config_schema: Optional[ConfigSchemaType] = ...,
-    required_resource_keys: Optional[Set[str]] = ...,
-=======
-    config_schema: Optional[Union[Any, Dict[str, Any]]] = ...,
     required_resource_keys: Optional[AbstractSet[str]] = ...,
->>>>>>> cd8966d46 (fixes)
     tags: Optional[Dict[str, Any]] = ...,
     version: Optional[str] = ...,
     retry_policy: Optional[RetryPolicy] = ...,
@@ -175,13 +170,8 @@ def solid(
     description: Optional[str] = None,
     input_defs: Optional[Sequence[InputDefinition]] = None,
     output_defs: Optional[Sequence[OutputDefinition]] = None,
-<<<<<<< HEAD
     config_schema: Optional[ConfigSchemaType] = None,
-    required_resource_keys: Optional[Set[str]] = None,
-=======
-    config_schema: Optional[Union[Any, Dict[str, Any]]] = None,
     required_resource_keys: Optional[AbstractSet[str]] = None,
->>>>>>> cd8966d46 (fixes)
     tags: Optional[Dict[str, Any]] = None,
     version: Optional[str] = None,
     retry_policy: Optional[RetryPolicy] = None,

--- a/python_modules/dagster/dagster/core/definitions/decorators/solid_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/solid_decorator.py
@@ -1,5 +1,6 @@
 from functools import lru_cache, update_wrapper
 from typing import (
+    AbstractSet,
     Any,
     Callable,
     Dict,
@@ -7,7 +8,6 @@ from typing import (
     NamedTuple,
     Optional,
     Sequence,
-    Set,
     Union,
     cast,
     overload,
@@ -74,7 +74,7 @@ class _Solid:
         input_defs: Optional[Sequence[InputDefinition]] = None,
         output_defs: Optional[Sequence[OutputDefinition]] = None,
         description: Optional[str] = None,
-        required_resource_keys: Optional[Set[str]] = None,
+        required_resource_keys: Optional[AbstractSet[str]] = None,
         config_schema: Optional[ConfigSchemaType] = None,
         tags: Optional[Dict[str, Any]] = None,
         version: Optional[str] = None,
@@ -156,8 +156,13 @@ def solid(
     description: Optional[str] = ...,
     input_defs: Optional[Sequence[InputDefinition]] = ...,
     output_defs: Optional[Sequence[OutputDefinition]] = ...,
+<<<<<<< HEAD
     config_schema: Optional[ConfigSchemaType] = ...,
     required_resource_keys: Optional[Set[str]] = ...,
+=======
+    config_schema: Optional[Union[Any, Dict[str, Any]]] = ...,
+    required_resource_keys: Optional[AbstractSet[str]] = ...,
+>>>>>>> cd8966d46 (fixes)
     tags: Optional[Dict[str, Any]] = ...,
     version: Optional[str] = ...,
     retry_policy: Optional[RetryPolicy] = ...,
@@ -170,8 +175,13 @@ def solid(
     description: Optional[str] = None,
     input_defs: Optional[Sequence[InputDefinition]] = None,
     output_defs: Optional[Sequence[OutputDefinition]] = None,
+<<<<<<< HEAD
     config_schema: Optional[ConfigSchemaType] = None,
     required_resource_keys: Optional[Set[str]] = None,
+=======
+    config_schema: Optional[Union[Any, Dict[str, Any]]] = None,
+    required_resource_keys: Optional[AbstractSet[str]] = None,
+>>>>>>> cd8966d46 (fixes)
     tags: Optional[Dict[str, Any]] = None,
     version: Optional[str] = None,
     retry_policy: Optional[RetryPolicy] = None,

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -212,7 +212,7 @@ class Output(
         cls,
         value: Any,
         output_name: Optional[str] = DEFAULT_OUTPUT,
-        metadata_entries: Optional[List[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
+        metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
         metadata: Optional[Dict[str, RawMetadataValue]] = None,
     ):
 
@@ -399,17 +399,17 @@ class AssetMaterialization(
         cls,
         asset_key: CoerceableToAssetKey,
         description: Optional[str] = None,
-        metadata_entries: Optional[List[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
+        metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
         partition: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
-        metadata: Optional[Dict[str, RawMetadataValue]] = None,
+        tags: Optional[Mapping[str, str]] = None,
+        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     ):
         if isinstance(asset_key, AssetKey):
             check.inst_param(asset_key, "asset_key", AssetKey)
         elif isinstance(asset_key, str):
             asset_key = AssetKey(parse_asset_key_string(asset_key))
         elif isinstance(asset_key, list):
-            check.list_param(asset_key, "asset_key", of_type=str)
+            check.sequence_param(asset_key, "asset_key", of_type=str)
             asset_key = AssetKey(asset_key)
         else:
             check.tuple_param(asset_key, "asset_key", of_type=str)
@@ -418,9 +418,9 @@ class AssetMaterialization(
         if tags:
             experimental_class_param_warning("tags", "AssetMaterialization")
 
-        metadata = check.opt_dict_param(metadata, "metadata", key_type=str)
-        metadata_entries = check.opt_list_param(
-            metadata_entries, "metadata_entries", of_type=MetadataEntry
+        metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
+        metadata_entries = check.opt_sequence_param(
+            metadata_entries, "metadata_entries", of_type=(MetadataEntry, PartitionMetadataEntry)
         )
 
         return super(AssetMaterialization, cls).__new__(

--- a/python_modules/dagster/dagster/core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_definition.py
@@ -270,10 +270,10 @@ def resource(config_schema=Callable[["InitResourceContext"], Any]) -> ResourceDe
 
 @overload
 def resource(
-    config_schema: Optional[Dict[str, Any]] = None,
-    description: Optional[str] = None,
-    required_resource_keys: Optional[AbstractSet[str]] = None,
-    version=None,
+    config_schema: Optional[Union[IDefinitionConfigSchema, Dict[str, Any]]] = ...,
+    description: Optional[str] = ...,
+    required_resource_keys: Optional[AbstractSet[str]] = ...,
+    version: Optional[str] = ...,
 ) -> Callable[[Callable[["InitResourceContext"], Any]], "ResourceDefinition"]:
     ...
 
@@ -284,7 +284,7 @@ def resource(
     ] = None,
     description: Optional[str] = None,
     required_resource_keys: Optional[AbstractSet[str]] = None,
-    version=None,
+    version: Optional[str] = None,
 ) -> Union[
     Callable[[Callable[["InitResourceContext"], Any]], "ResourceDefinition"], "ResourceDefinition"
 ]:

--- a/python_modules/dagster/dagster/core/definitions/solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_definition.py
@@ -1,5 +1,6 @@
 from typing import (
     TYPE_CHECKING,
+    AbstractSet,
     Any,
     Callable,
     Dict,
@@ -8,7 +9,6 @@ from typing import (
     List,
     Optional,
     Sequence,
-    Set,
     Tuple,
     Union,
     cast,
@@ -102,7 +102,7 @@ class SolidDefinition(NodeDefinition):
         config_schema: Optional[Union[ConfigSchemaType, IDefinitionConfigSchema]] = None,
         description: Optional[str] = None,
         tags: Optional[Dict[str, str]] = None,
-        required_resource_keys: Optional[Union[Set[str], FrozenSet[str]]] = None,
+        required_resource_keys: Optional[AbstractSet[str]] = None,
         version: Optional[str] = None,
         retry_policy: Optional[RetryPolicy] = None,
     ):

--- a/python_modules/dagster/dagster/core/execution/api.py
+++ b/python_modules/dagster/dagster/core/execution/api.py
@@ -1,6 +1,6 @@
 import sys
 from contextlib import contextmanager
-from typing import Any, Dict, FrozenSet, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, FrozenSet, Iterator, List, Mapping, Optional, Tuple, Union
 
 from dagster import check
 from dagster.core.definitions import IPipeline, JobDefinition, PipelineDefinition
@@ -738,7 +738,7 @@ def _get_execution_plan_from_run(
 
 def create_execution_plan(
     pipeline: Union[IPipeline, PipelineDefinition],
-    run_config: Optional[dict] = None,
+    run_config: Optional[Mapping[str, object]] = None,
     mode: Optional[str] = None,
     step_keys_to_execute: Optional[List[str]] = None,
     known_state: Optional[KnownExecutionState] = None,

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -190,8 +190,6 @@ T_DagsterInstance = TypeVar("T_DagsterInstance", bound="DagsterInstance")
 class MayHaveInstanceWeakref(Generic[T_DagsterInstance]):
     """Mixin for classes that can have a weakref back to a Dagster instance."""
 
-    _instance_weakref: Optional[weakref.ReferenceType[T_DagsterInstance]]
-
     def __init__(self):
         self._instance_weakref: Optional[weakref.ReferenceType[T_DagsterInstance]] = None
 
@@ -215,7 +213,7 @@ class MayHaveInstanceWeakref(Generic[T_DagsterInstance]):
         )
 
         # Store a weakref to avoid a circular reference / enable GC
-        self._instance_weakref = weakref.ref(instance)
+        self._instance_weakref = weakref.ref[T_DagsterInstance](instance)
 
 
 class DagsterInstance:

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1,4 +1,3 @@
-import inspect
 import logging
 import logging.config
 import os
@@ -29,7 +28,6 @@ from typing import (
 )
 
 import yaml
-from typing_extensions import Protocol
 
 from dagster import check
 from dagster.core.definitions.events import AssetKey
@@ -213,7 +211,7 @@ class MayHaveInstanceWeakref(Generic[T_DagsterInstance]):
         )
 
         # Store a weakref to avoid a circular reference / enable GC
-        self._instance_weakref = weakref.ref[T_DagsterInstance](instance)
+        self._instance_weakref = weakref.ref(instance)
 
 
 class DagsterInstance:

--- a/python_modules/dagster/dagster/core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/base.py
@@ -29,7 +29,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
         """
 
     @abc.abstractmethod
-    def get_instigator_state(self, origin_id: str, selector_id: str) -> InstigatorState:
+    def get_instigator_state(self, origin_id: str, selector_id: str) -> Optional[InstigatorState]:
         """Return the instigator state for the given id
 
         Args:

--- a/python_modules/dagster/dagster/py.typed
+++ b/python_modules/dagster/dagster/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -126,6 +126,7 @@ if __name__ == "__main__":
             ],
             "mypy": [
                 "mypy==0.950",
+                "types-chardet",  # chardet is a 2+-order dependency of some Dagster libs
                 "types-croniter",  # version will be resolved against croniter
                 "types-mock",  # version will be resolved against mock
                 "types-pkg-resources",  # version will be resolved against setuptools (contains pkg_resources)
@@ -134,6 +135,7 @@ if __name__ == "__main__":
                 "types-PyYAML",  # version will be resolved against PyYAML
                 "types-pytz",  # version will be resolved against pytz
                 "types-requests",  # version will be resolved against requests
+                "types-six",  # needed but not specified by grpcio
                 "types-tabulate",  # version will be resolved against tabulate
                 "types-toml",  # version will be resolved against toml
             ],

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -126,17 +126,24 @@ if __name__ == "__main__":
             ],
             "mypy": [
                 "mypy==0.950",
+                "types-backports",  # version will be resolved against backports
+                "types-certifi",  # version will be resolved against certifi
                 "types-chardet",  # chardet is a 2+-order dependency of some Dagster libs
                 "types-croniter",  # version will be resolved against croniter
+                "types-cryptography",  # version will be resolved against cryptography
                 "types-mock",  # version will be resolved against mock
+                "types-paramiko",  # version will be resolved against paramiko
                 "types-pkg-resources",  # version will be resolved against setuptools (contains pkg_resources)
                 "types-protobuf",  # version will be resolved against protobuf
+                "types-pyOpenSSL",  # version will be resolved against pyOpenSSL
                 "types-python-dateutil",  # version will be resolved against python-dateutil
                 "types-PyYAML",  # version will be resolved against PyYAML
                 "types-pytz",  # version will be resolved against pytz
                 "types-requests",  # version will be resolved against requests
+                "types-simplejson",  # version will be resolved against simplejson
                 "types-six",  # needed but not specified by grpcio
                 "types-tabulate",  # version will be resolved against tabulate
+                "types-tzlocal",  # version will be resolved against tzlocal
                 "types-toml",  # version will be resolved against toml
             ],
         },

--- a/python_modules/libraries/dagster-airbyte/MANIFEST.in
+++ b/python_modules/libraries/dagster-airbyte/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include dagster_airbyte/py.typed

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
@@ -7,7 +7,7 @@ from dagster import Array, Bool, Field, In, Noneable, Nothing, Out, Output, op
 
 @op(
     required_resource_keys={"airbyte"},
-    ins={"start_after": In(Nothing)},
+    ins={"start_after": In(Nothing)},  # type: ignore
     out=Out(
         AirbyteOutput,
         description="Parsed json dictionary representing the details of the Airbyte connector after "

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
@@ -7,7 +7,7 @@ from dagster import Array, Bool, Field, In, Noneable, Nothing, Out, Output, op
 
 @op(
     required_resource_keys={"airbyte"},
-    ins={"start_after": In(Nothing)},  # type: ignore
+    ins={"start_after": In(Nothing)},
     out=Out(
         AirbyteOutput,
         description="Parsed json dictionary representing the details of the Airbyte connector after "

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/py.typed
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -92,15 +92,15 @@ class AirbyteResource:
         raise Failure("Exceeded max number of retries.")
 
     def start_sync(self, connection_id: str) -> dict:
-        return check.is_dict(
+        return check.not_none(
             self.make_request(endpoint="/connections/sync", data={"connectionId": connection_id})
         )
 
     def get_job_status(self, job_id: int) -> dict:
-        return check.is_dict(self.make_request(endpoint="/jobs/get", data={"id": job_id}))
+        return check.not_none(self.make_request(endpoint="/jobs/get", data={"id": job_id}))
 
     def get_connection_details(self, connection_id: str) -> dict:
-        return check.is_dict(
+        return check.not_none(
             self.make_request(endpoint="/connections/get", data={"connectionId": connection_id})
         )
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -63,7 +63,7 @@ class AirbyteResource:
             data (Optional[str]): JSON-formatted data string to be included in the request.
 
         Returns:
-            Dict[str, Any]: Parsed json data from the response to this request
+            Optional[Dict[str, Any]]: Parsed json data from the response to this request
         """
 
         headers = {"accept": "application/json"}

--- a/python_modules/libraries/dagster-airflow/MANIFEST.in
+++ b/python_modules/libraries/dagster-airflow/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include dagster_airflow/py.typed

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/operators/airflow_operator_to_op.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/operators/airflow_operator_to_op.py
@@ -69,8 +69,8 @@ def airflow_operator_to_op(
 
     @op(
         name=airflow_op.task_id,
-        ins={"start_after": In(Nothing)},
-        out=Out(Any) if return_output else Out(Nothing),
+        ins={"start_after": In(Nothing)},  # type: ignore
+        out=Out(Any) if return_output else Out(Nothing),  # type: ignore
     )
     def converted_op(context):
         conn_names = []

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/operators/airflow_operator_to_op.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/operators/airflow_operator_to_op.py
@@ -69,8 +69,8 @@ def airflow_operator_to_op(
 
     @op(
         name=airflow_op.task_id,
-        ins={"start_after": In(Nothing)},  # type: ignore
-        out=Out(Any) if return_output else Out(Nothing),  # type: ignore
+        ins={"start_after": In(Nothing)},
+        out=Out(Any) if return_output else Out(Nothing),
     )
     def converted_op(context):
         conn_names = []

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/py.typed
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-aws/MANIFEST.in
+++ b/python_modules/libraries/dagster-aws/MANIFEST.in
@@ -3,3 +3,4 @@ recursive-include dagster_aws *.yaml
 recursive-include dagster_aws *.txt
 recursive-include dagster_aws *.template
 include LICENSE
+include dagster_aws/py.typed

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -166,13 +166,13 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         """
         run = context.pipeline_run
         family = sanitize_family(
-            run.external_pipeline_origin.external_repository_origin.repository_location_origin.location_name
+            run.external_pipeline_origin.external_repository_origin.repository_location_origin.location_name  # type: ignore
         )
 
         container_context = EcsContainerContext.create_for_run(run, self)
 
         metadata = self._task_metadata()
-        pipeline_origin = context.pipeline_code_origin
+        pipeline_origin = check.not_none(context.pipeline_code_origin)
         image = pipeline_origin.repository_origin.container_image
         task_definition = self._task_definition(family, metadata, image, container_context)[
             "family"

--- a/python_modules/libraries/dagster-aws/dagster_aws/py.typed
+++ b/python_modules/libraries/dagster-aws/dagster_aws/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/ops.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/ops.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from dagster import (
     AssetMaterialization,
     Field,
@@ -16,7 +18,7 @@ from dagster.core.types.dagster_type import PythonObjectDagsterType
 from .file_manager import S3FileHandle
 
 
-def dict_with_fields(name, fields):
+def dict_with_fields(name: str, fields: Dict[str, object]):
     check.str_param(name, "name")
     check.dict_param(fields, "fields", key_type=str)
     field_names = set(fields.keys())
@@ -43,7 +45,7 @@ S3Coordinate = dict_with_fields(
 )
 
 
-def last_key(key):
+def last_key(key: str) -> str:
     if "/" not in key:
         return key
     comps = key.split("/")

--- a/python_modules/libraries/dagster-azure/MANIFEST.in
+++ b/python_modules/libraries/dagster-azure/MANIFEST.in
@@ -3,3 +3,4 @@ recursive-include dagster_azure *.yaml
 recursive-include dagster_azure *.txt
 recursive-include dagster_azure *.template
 include LICENSE
+include dagster_azure/py.typed

--- a/python_modules/libraries/dagster-azure/dagster_azure/py.typed
+++ b/python_modules/libraries/dagster-azure/dagster_azure/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-celery-docker/MANIFEST.in
+++ b/python_modules/libraries/dagster-celery-docker/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include dagster_celery_docker/py.typed

--- a/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/py.typed
+++ b/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-celery-k8s/MANIFEST.in
+++ b/python_modules/libraries/dagster-celery-k8s/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include dagster_celery_k8s/py.typed

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -1,4 +1,5 @@
 import sys
+from typing import cast
 
 import kubernetes
 from dagster_k8s.job import (
@@ -16,6 +17,7 @@ from dagster.core.events import EngineEventData
 from dagster.core.execution.retries import RetryMode
 from dagster.core.launcher import LaunchRunContext, RunLauncher
 from dagster.core.launcher.base import CheckRunHealthResult, WorkerStatus
+from dagster.core.origin import PipelinePythonOrigin
 from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunStatus
 from dagster.core.storage.tags import DOCKER_IMAGE_TAG
 from dagster.serdes import ConfigurableClass, ConfigurableClassData
@@ -158,7 +160,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
 
         job_image_from_executor_config = exc_config.get("job_image")
 
-        pipeline_origin = context.pipeline_code_origin
+        pipeline_origin = cast(PipelinePythonOrigin, context.pipeline_code_origin)
         repository_origin = pipeline_origin.repository_origin
 
         job_image = repository_origin.container_image

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/py.typed
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-celery/MANIFEST.in
+++ b/python_modules/libraries/dagster-celery/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include dagster_celery/py.typed

--- a/python_modules/libraries/dagster-celery/dagster_celery/py.typed
+++ b/python_modules/libraries/dagster-celery/dagster_celery/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-dask/MANIFEST.in
+++ b/python_modules/libraries/dagster-dask/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include dagster_dask/py.typed

--- a/python_modules/libraries/dagster-dask/dagster_dask/py.typed
+++ b/python_modules/libraries/dagster-dask/dagster_dask/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-dask/dagster_dask/resources.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/resources.py
@@ -66,7 +66,7 @@ class DaskResource:
         self._client, self._cluster = None, None
 
 
-@resource(
+@resource(  # type: ignore
     description="Dask Client resource.",
     config_schema=Shape(
         {

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
@@ -5,7 +5,7 @@ from dagster import InputDefinition, execute_solid, file_relative_path, solid
 
 
 @solid(input_defs=[InputDefinition(dagster_type=DataFrame, name="input_df")])
-def passthrough(_, input_df: DataFrame) -> DataFrame:
+def passthrough(_, input_df: DataFrame) -> DataFrame:  # type: ignore
     return input_df
 
 

--- a/python_modules/libraries/dagster-databricks/MANIFEST.in
+++ b/python_modules/libraries/dagster-databricks/MANIFEST.in
@@ -3,3 +3,4 @@ recursive-include dagster_databricks *.yaml
 recursive-include dagster_databricks *.txt
 recursive-include dagster_databricks *.template
 include LICENSE
+include dagster_databricks/py.typed

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/py.typed
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-datadog/MANIFEST.in
+++ b/python_modules/libraries/dagster-datadog/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include dagster_datadog/py.typed

--- a/python_modules/libraries/dagster-datadog/dagster_datadog/py.typed
+++ b/python_modules/libraries/dagster-datadog/dagster_datadog/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-dbt/MANIFEST.in
+++ b/python_modules/libraries/dagster-dbt/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include dagster_dbt/py.typed

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/py.typed
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-docker/MANIFEST.in
+++ b/python_modules/libraries/dagster-docker/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include dagster_docker/py.typed

--- a/python_modules/libraries/dagster-docker/dagster_docker/py.typed
+++ b/python_modules/libraries/dagster-docker/dagster_docker/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-fivetran/MANIFEST.in
+++ b/python_modules/libraries/dagster-fivetran/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include dagster_fivetran/py.typed

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
@@ -7,7 +7,7 @@ from dagster import Array, AssetKey, Bool, Field, In, Noneable, Nothing, Out, Ou
 
 @op(
     required_resource_keys={"fivetran"},
-    ins={"start_after": In(Nothing)},  # type: ignore
+    ins={"start_after": In(Nothing)},
     out=Out(
         FivetranOutput,
         description="Parsed json dictionary representing the details of the Fivetran connector after "
@@ -102,7 +102,7 @@ def fivetran_sync_op(context):
 
 @op(
     required_resource_keys={"fivetran"},
-    ins={"start_after": In(Nothing)},  # type: ignore
+    ins={"start_after": In(Nothing)},
     out=Out(
         FivetranOutput,
         description="Parsed json dictionary representing the details of the Fivetran connector after "

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
@@ -7,7 +7,7 @@ from dagster import Array, AssetKey, Bool, Field, In, Noneable, Nothing, Out, Ou
 
 @op(
     required_resource_keys={"fivetran"},
-    ins={"start_after": In(Nothing)},
+    ins={"start_after": In(Nothing)},  # type: ignore
     out=Out(
         FivetranOutput,
         description="Parsed json dictionary representing the details of the Fivetran connector after "
@@ -102,7 +102,7 @@ def fivetran_sync_op(context):
 
 @op(
     required_resource_keys={"fivetran"},
-    ins={"start_after": In(Nothing)},
+    ins={"start_after": In(Nothing)},  # type: ignore
     out=Out(
         FivetranOutput,
         description="Parsed json dictionary representing the details of the Fivetran connector after "

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/py.typed
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-gcp/MANIFEST.in
+++ b/python_modules/libraries/dagster-gcp/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include dagster_gcp/py.typed

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/py.typed
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-ge/MANIFEST.in
+++ b/python_modules/libraries/dagster-ge/MANIFEST.in
@@ -1,1 +1,1 @@
-include LICENSE
+include LICENSEinclude dagster_ge/py.typed

--- a/python_modules/libraries/dagster-ge/dagster_ge/py.typed
+++ b/python_modules/libraries/dagster-ge/dagster_ge/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-github/MANIFEST.in
+++ b/python_modules/libraries/dagster-github/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include dagster_github/py.typed

--- a/python_modules/libraries/dagster-github/dagster_github/py.typed
+++ b/python_modules/libraries/dagster-github/dagster_github/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-k8s/MANIFEST.in
+++ b/python_modules/libraries/dagster-k8s/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include README.md
+include dagster_k8s/py.typed

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, cast
 
 import kubernetes
 
@@ -154,7 +154,7 @@ class K8sContainerContext(
                 run_k8s_container_context,
             )
 
-        processed_context_value = processed_container_context.value
+        processed_context_value = cast(Dict, processed_container_context.value)
 
         return K8sContainerContext(
             image_pull_policy=processed_context_value.get("image_pull_policy"),

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -134,7 +134,8 @@ class K8sStepHandler(StepHandler):
 
     def _get_container_context(self, step_handler_context: StepHandlerContext):
         run_target = K8sContainerContext.create_for_run(
-            step_handler_context.pipeline_run, cast(K8sRunLauncher, step_handler_context.instance.run_launcher)
+            step_handler_context.pipeline_run,
+            cast(K8sRunLauncher, step_handler_context.instance.run_launcher),
         )
         return run_target.merge(self._executor_container_context)
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -75,22 +75,22 @@ def k8s_job_executor(init_context: InitExecutorContext) -> Executor:
     exc_cfg = init_context.executor_config
 
     k8s_container_context = K8sContainerContext(
-        image_pull_policy=exc_cfg.get("image_pull_policy"),
-        image_pull_secrets=exc_cfg.get("image_pull_secrets"),
-        service_account_name=exc_cfg.get("service_account_name"),
-        env_config_maps=exc_cfg.get("env_config_maps"),
-        env_secrets=exc_cfg.get("env_secrets"),
-        env_vars=exc_cfg.get("env_vars"),
-        volume_mounts=exc_cfg.get("volume_mounts"),
-        volumes=exc_cfg.get("volumes"),
-        labels=exc_cfg.get("labels"),
-        namespace=exc_cfg.get("job_namespace"),
-        resources=exc_cfg.get("resources"),
+        image_pull_policy=exc_cfg.get("image_pull_policy"),  # type: ignore
+        image_pull_secrets=exc_cfg.get("image_pull_secrets"),  # type: ignore
+        service_account_name=exc_cfg.get("service_account_name"),  # type: ignore
+        env_config_maps=exc_cfg.get("env_config_maps"),  # type: ignore
+        env_secrets=exc_cfg.get("env_secrets"),  # type: ignore
+        env_vars=exc_cfg.get("env_vars"),  # type: ignore
+        volume_mounts=exc_cfg.get("volume_mounts"),  # type: ignore
+        volumes=exc_cfg.get("volumes"),  # type: ignore
+        labels=exc_cfg.get("labels"),  # type: ignore
+        namespace=exc_cfg.get("job_namespace"),  # type: ignore
+        resources=exc_cfg.get("resources"),  # type: ignore
     )
 
     return StepDelegatingExecutor(
         K8sStepHandler(
-            image=exc_cfg.get("job_image"),
+            image=exc_cfg.get("job_image"),  # type: ignore
             container_context=k8s_container_context,
             load_incluster_config=run_launcher.load_incluster_config,
             kubeconfig_file=run_launcher.kubeconfig_file,
@@ -134,7 +134,7 @@ class K8sStepHandler(StepHandler):
 
     def _get_container_context(self, step_handler_context: StepHandlerContext):
         run_target = K8sContainerContext.create_for_run(
-            step_handler_context.pipeline_run, step_handler_context.instance.run_launcher
+            step_handler_context.pipeline_run, cast(K8sRunLauncher, step_handler_context.instance.run_launcher)
         )
         return run_target.merge(self._executor_container_context)
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Dict, List, Optional
 
 import kubernetes
 
@@ -119,47 +120,47 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         return self._job_image
 
     @property
-    def image_pull_policy(self):
+    def image_pull_policy(self) -> str:
         return self._image_pull_policy
 
     @property
-    def image_pull_secrets(self):
+    def image_pull_secrets(self) -> List[Dict]:
         return self._image_pull_secrets
 
     @property
-    def service_account_name(self):
+    def service_account_name(self) -> str:
         return self._service_account_name
 
     @property
-    def env_config_maps(self):
+    def env_config_maps(self) -> List[str]:
         return self._env_config_maps
 
     @property
-    def env_secrets(self):
+    def env_secrets(self) -> List[str]:
         return self._env_secrets
 
     @property
-    def volume_mounts(self):
+    def volume_mounts(self) -> List:
         return self._volume_mounts
 
     @property
-    def volumes(self):
+    def volumes(self) -> List:
         return self._volumes
 
     @property
-    def resources(self):
+    def resources(self) -> Dict:
         return self._resources
 
     @property
-    def env_vars(self):
+    def env_vars(self) -> List[str]:
         return self._env_vars
 
     @property
-    def labels(self):
+    def labels(self) -> Dict[str, str]:
         return self._labels
 
     @property
-    def fail_pod_on_run_failure(self):
+    def fail_pod_on_run_failure(self) -> Optional[bool]:
         return self._fail_pod_on_run_failure
 
     @property
@@ -243,7 +244,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
     def launch_run(self, context: LaunchRunContext) -> None:
         run = context.pipeline_run
         job_name = get_job_name_from_run_id(run.run_id)
-        pipeline_origin = run.pipeline_code_origin
+        pipeline_origin = check.not_none(run.pipeline_code_origin)
 
         args = ExecuteRunArgs(
             pipeline_origin=pipeline_origin,
@@ -263,7 +264,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         job_name = get_job_name_from_run_id(
             run.run_id, resume_attempt_number=context.resume_attempt_number
         )
-        pipeline_origin = run.pipeline_code_origin
+        pipeline_origin = check.not_none(run.pipeline_code_origin)
 
         args = ResumeRunArgs(
             pipeline_origin=pipeline_origin,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/py.typed
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-mlflow/MANIFEST.in
+++ b/python_modules/libraries/dagster-mlflow/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include dagster_mlflow/py.typed

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/py.typed
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
@@ -17,20 +17,20 @@ from dagster import Field, Noneable, Permissive, resource
 CONFIG_SCHEMA = {
     "experiment_name": Field(str, is_required=True, description="MlFlow experiment name."),
     "mlflow_tracking_uri": Field(
-        Noneable(str),  # type: ignore
+        Noneable(str),
         default_value=None,
         is_required=False,
         description="MlFlow tracking server uri.",
     ),
     "parent_run_id": Field(
-        Noneable(str),  # type: ignore
+        Noneable(str),
         default_value=None,
         is_required=False,
         description="Mlflow run ID of parent run if this is a nested run.",
     ),
     "env": Field(Permissive(), description="Environment variables for mlflow setup."),
     "env_to_tag": Field(
-        Noneable(list),  # type: ignore
+        Noneable(list),
         default_value=None,
         is_required=False,
         description="List of environment variables to log as tags in mlflow.",

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
@@ -17,20 +17,20 @@ from dagster import Field, Noneable, Permissive, resource
 CONFIG_SCHEMA = {
     "experiment_name": Field(str, is_required=True, description="MlFlow experiment name."),
     "mlflow_tracking_uri": Field(
-        Noneable(str),
+        Noneable(str),  # type: ignore
         default_value=None,
         is_required=False,
         description="MlFlow tracking server uri.",
     ),
     "parent_run_id": Field(
-        Noneable(str),
+        Noneable(str),  # type: ignore
         default_value=None,
         is_required=False,
         description="Mlflow run ID of parent run if this is a nested run.",
     ),
     "env": Field(Permissive(), description="Environment variables for mlflow setup."),
     "env_to_tag": Field(
-        Noneable(list),
+        Noneable(list),  # type: ignore
         default_value=None,
         is_required=False,
         description="List of environment variables to log as tags in mlflow.",

--- a/python_modules/libraries/dagster-msteams/MANIFEST.in
+++ b/python_modules/libraries/dagster-msteams/MANIFEST.in
@@ -1,2 +1,2 @@
 include README.md
-include LICENSE
+include LICENSEinclude dagster_msteams/py.typed

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/hooks.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/hooks.py
@@ -71,7 +71,7 @@ def teams_on_failure(
             )
         card = Card()
         card.add_attachment(text_message=text)
-        context.resources.msteams.post_message(payload=card.payload)
+        context.resources.msteams.post_message(payload=card.payload)  # type: ignore
 
     return _hook
 
@@ -124,6 +124,6 @@ def teams_on_success(
             )
         card = Card()
         card.add_attachment(text_message=text)
-        context.resources.msteams.post_message(payload=card.payload)
+        context.resources.msteams.post_message(payload=card.payload)  # type: ignore
 
     return _hook

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/py.typed
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-mysql/MANIFEST.in
+++ b/python_modules/libraries/dagster-mysql/MANIFEST.in
@@ -2,3 +2,4 @@ include LICENSE
 graft dagster_mysql/alembic
 global-exclude __pycache__
 global-exclude *.py[co]
+include dagster_mysql/py.typed

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/py.typed
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-pagerduty/MANIFEST.in
+++ b/python_modules/libraries/dagster-pagerduty/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include dagster_pagerduty/py.typed

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/hooks.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/hooks.py
@@ -71,7 +71,7 @@ def pagerduty_on_failure(
                     base_url=dagit_base_url, run_id=context.run_id
                 )
             }
-        context.resources.pagerduty.EventV2_create(
+        context.resources.pagerduty.EventV2_create(  # type: ignore
             summary=summary_fn(context),
             source=_source_fn(context),
             severity=severity,

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/py.typed
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-pandas/MANIFEST.in
+++ b/python_modules/libraries/dagster-pandas/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include dagster_pandas *.yaml
 include LICENSE
+include dagster_pandas/py.typed

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/py.typed
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-pandera/MANIFEST.in
+++ b/python_modules/libraries/dagster-pandera/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include dagster_pandera/py.typed

--- a/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
@@ -16,6 +16,7 @@ from dagster import (
     TypeCheck,
     TypeCheckContext,
 )
+from dagster.core.definitions.metadata import MetadataValue
 from dagster.core.utils import check_dagster_package_version
 
 from .version import __version__
@@ -108,7 +109,7 @@ def pandera_schema_to_dagster_type(
         name=name,
         description=norm_schema.description,
         metadata_entries=[
-            MetadataEntry("schema", value=tschema),
+            MetadataEntry("schema", value=MetadataValue.table_schema(tschema)),
         ],
     )
 
@@ -216,7 +217,7 @@ def _pandera_column_to_table_column(pa_column: pa.Column) -> TableColumn:
         unique=pa_column.unique,
         other=[_pandera_check_to_column_constraint(pa_check) for pa_check in pa_column.checks],
     )
-    name = check.not_none(pa_column.name, "name")
+    name: str = check.not_none(pa_column.name, "name")
     return TableColumn(
         name=name,
         type=str(pa_column.dtype),

--- a/python_modules/libraries/dagster-pandera/dagster_pandera/py.typed
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-papertrail/MANIFEST.in
+++ b/python_modules/libraries/dagster-papertrail/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include README.md
+include dagster_papertrail/py.typed

--- a/python_modules/libraries/dagster-papertrail/dagster_papertrail/py.typed
+++ b/python_modules/libraries/dagster-papertrail/dagster_papertrail/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-postgres/MANIFEST.in
+++ b/python_modules/libraries/dagster-postgres/MANIFEST.in
@@ -2,3 +2,4 @@ include LICENSE
 graft dagster_postgres/alembic
 global-exclude __pycache__
 global-exclude *.py[co]
+include dagster_postgres/py.typed

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -16,11 +16,7 @@ from dagster.core.storage.event_log import (
 from dagster.core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster.core.storage.event_log.polling_event_watcher import CallbackAfterCursor
 from dagster.core.storage.sql import create_engine, run_alembic_upgrade, stamp_alembic_rev
-from dagster.serdes import (
-    ConfigurableClass,
-    ConfigurableClassData,
-    deserialize_as,
-)
+from dagster.serdes import ConfigurableClass, ConfigurableClassData, deserialize_as
 
 from ..pynotify import await_pg_notifications
 from ..utils import (
@@ -296,9 +292,7 @@ def watcher_thread(
                         SqlEventLogStorageTable.c.id == index
                     ),
                 )
-                dagster_event = deserialize_as(
-                    cursor_res.scalar(), EventLogEntry
-                )
+                dagster_event = deserialize_as(cursor_res.scalar(), EventLogEntry)
 
             for callback_with_cursor in handlers:
                 if callback_with_cursor.start_cursor < index:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -19,7 +19,7 @@ from dagster.core.storage.sql import create_engine, run_alembic_upgrade, stamp_a
 from dagster.serdes import (
     ConfigurableClass,
     ConfigurableClassData,
-    deserialize_json_to_dagster_namedtuple,
+    deserialize_as,
 )
 
 from ..pynotify import await_pg_notifications
@@ -296,8 +296,8 @@ def watcher_thread(
                         SqlEventLogStorageTable.c.id == index
                     ),
                 )
-                dagster_event: EventLogEntry = deserialize_json_to_dagster_namedtuple(
-                    cursor_res.scalar()
+                dagster_event = deserialize_as(
+                    cursor_res.scalar(), EventLogEntry
                 )
 
             for callback_with_cursor in handlers:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/py.typed
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-prometheus/MANIFEST.in
+++ b/python_modules/libraries/dagster-prometheus/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include README.md
+include dagster_prometheus/py.typed

--- a/python_modules/libraries/dagster-prometheus/dagster_prometheus/py.typed
+++ b/python_modules/libraries/dagster-prometheus/dagster_prometheus/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-pyspark/MANIFEST.in
+++ b/python_modules/libraries/dagster-pyspark/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include dagster_pyspark/py.typed

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark/py.typed
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-shell/MANIFEST.in
+++ b/python_modules/libraries/dagster-shell/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include dagster_shell/py.typed

--- a/python_modules/libraries/dagster-shell/dagster_shell/py.typed
+++ b/python_modules/libraries/dagster-shell/dagster_shell/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-slack/MANIFEST.in
+++ b/python_modules/libraries/dagster-slack/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include dagster_slack/py.typed

--- a/python_modules/libraries/dagster-slack/dagster_slack/hooks.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/hooks.py
@@ -66,7 +66,7 @@ def slack_on_failure(
                 base_url=dagit_base_url, run_id=context.run_id
             )
 
-        context.resources.slack.chat_postMessage(channel=channel, text=text)
+        context.resources.slack.chat_postMessage(channel=channel, text=text)  # type: ignore
 
     return _hook
 
@@ -116,6 +116,6 @@ def slack_on_success(
                 base_url=dagit_base_url, run_id=context.run_id
             )
 
-        context.resources.slack.chat_postMessage(channel=channel, text=text)
+        context.resources.slack.chat_postMessage(channel=channel, text=text)  # type: ignore
 
     return _hook

--- a/python_modules/libraries/dagster-slack/dagster_slack/py.typed
+++ b/python_modules/libraries/dagster-slack/dagster_slack/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-slack/dagster_slack/resources.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/resources.py
@@ -1,4 +1,4 @@
-from slack_sdk import WebClient
+from slack_sdk.web.client import WebClient
 
 from dagster import Field, StringSource, resource
 

--- a/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
@@ -1,21 +1,24 @@
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
-from slack_sdk import WebClient
+from slack_sdk.web.client import WebClient
 
 from dagster import DefaultSensorStatus
 from dagster.core.definitions import GraphDefinition, PipelineDefinition
 from dagster.core.definitions.run_status_sensor_definition import (
     PipelineFailureSensorContext,
     RunFailureSensorContext,
+    RunStatusSensorContext,
     pipeline_failure_sensor,
     run_failure_sensor,
 )
 
+T = TypeVar("T", bound=RunStatusSensorContext)
+
 
 def _build_slack_blocks_and_text(
-    context: RunFailureSensorContext,
-    text_fn: Callable[[RunFailureSensorContext], str],
-    blocks_fn: Optional[Callable[[RunFailureSensorContext], List[Dict]]],
+    context: T,
+    text_fn: Callable[[T], str],
+    blocks_fn: Optional[Callable[[T], List[Dict]]],
     dagit_base_url: Optional[str],
 ) -> Tuple[List[Dict[str, Any]], str]:
     blocks: List[Dict[str, Any]] = [
@@ -55,7 +58,9 @@ def _build_slack_blocks_and_text(
     return blocks, main_body_text
 
 
-def _default_failure_message_text_fn(context: PipelineFailureSensorContext) -> str:
+def _default_failure_message_text_fn(
+    context: Union[PipelineFailureSensorContext, RunFailureSensorContext]
+) -> str:
     return f"Error: ```{context.failure_event.message}```"
 
 

--- a/python_modules/libraries/dagster-snowflake/MANIFEST.in
+++ b/python_modules/libraries/dagster-snowflake/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include dagster_snowflake/py.typed

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/py.typed
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-spark/MANIFEST.in
+++ b/python_modules/libraries/dagster-spark/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include dagster_spark/py.typed

--- a/python_modules/libraries/dagster-spark/dagster_spark/py.typed
+++ b/python_modules/libraries/dagster-spark/dagster_spark/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-ssh/MANIFEST.in
+++ b/python_modules/libraries/dagster-ssh/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include dagster_ssh/py.typed

--- a/python_modules/libraries/dagster-ssh/dagster_ssh/py.typed
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-twilio/MANIFEST.in
+++ b/python_modules/libraries/dagster-twilio/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include dagster_twilio/py.typed

--- a/python_modules/libraries/dagster-twilio/dagster_twilio/py.typed
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagstermill/MANIFEST.in
+++ b/python_modules/libraries/dagstermill/MANIFEST.in
@@ -1,1 +1,1 @@
-include LICENSE
+include LICENSEinclude dagstermill/py.typed

--- a/python_modules/libraries/dagstermill/dagstermill/context.py
+++ b/python_modules/libraries/dagstermill/dagstermill/context.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Set
+from typing import Any, Dict, Optional, Set, cast
 
 from dagster import PipelineDefinition, PipelineRun, SolidDefinition, check
 from dagster.core.definitions.dependency import Node, NodeHandle
@@ -46,7 +46,7 @@ class DagstermillExecutionContext(AbstractComputeExecutionContext):
         check.str_param(key, "key")
         return self._pipeline_context.has_tag(key)
 
-    def get_tag(self, key: str) -> str:
+    def get_tag(self, key: str) -> Optional[str]:
         """Get a logging tag defined on the context.
 
         Args:
@@ -118,7 +118,7 @@ class DagstermillExecutionContext(AbstractComputeExecutionContext):
         In interactive contexts, this may be a dagstermill-specific shim, depending whether a
         solid definition was passed to ``dagstermill.get_context``.
         """
-        return self.pipeline_def.solid_def_named(self.solid_name)
+        return cast(SolidDefinition, self.pipeline_def.solid_def_named(self.solid_name))
 
     @property
     def solid(self) -> Node:

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -356,8 +356,8 @@ def define_dagstermill_solid(
     check.str_param(notebook_path, "notebook_path")
     input_defs = check.opt_list_param(input_defs, "input_defs", of_type=InputDefinition)
     output_defs = check.opt_list_param(output_defs, "output_defs", of_type=OutputDefinition)
-    required_resource_keys = check.opt_set_param(
-        required_resource_keys, "required_resource_keys", of_type=str
+    required_resource_keys = set(
+        check.opt_set_param(required_resource_keys, "required_resource_keys", of_type=str)
     )
 
     extra_output_defs = []
@@ -453,8 +453,8 @@ def define_dagstermill_op(
     check.str_param(notebook_path, "notebook_path")
     input_defs = check.opt_list_param(input_defs, "input_defs", of_type=InputDefinition)
     output_defs = check.opt_list_param(output_defs, "output_defs", of_type=OutputDefinition)
-    required_resource_keys = check.opt_set_param(
-        required_resource_keys, "required_resource_keys", of_type=str
+    required_resource_keys = set(
+        check.opt_set_param(required_resource_keys, "required_resource_keys", of_type=str)
     )
 
     extra_output_defs = []

--- a/python_modules/libraries/dagstermill/dagstermill/py.typed
+++ b/python_modules/libraries/dagstermill/dagstermill/py.typed
@@ -1,0 +1,1 @@
+partial


### PR DESCRIPTION
This is a continuation of #7135, which was merged into a downstack branch (and not sure how to/implications of reopening PR) due to a graphite bug (beware `gt downstack edit` for now...).

The PR adds `py.typed` to `dagster` and all extension libs, as well as includes a variety of type annotation improvements needed to get `mypy` to pass after this addition (without `py.typed`, type errors on the main `dagster` package from extension libs are silent).

It addresses all inline flags by @alangenfeld in the prior PR. See there for discussion.
