### PR TITLE
finish dagster-airbyte types

### DIFF
--- a/examples/modern_data_stack_assets/modern_data_stack_assets/setup_airbyte.py
+++ b/examples/modern_data_stack_assets/modern_data_stack_assets/setup_airbyte.py
@@ -35,10 +35,9 @@ def _create_ab_source(client: AirbyteResource) -> str:
     ]
 
     # get latest available Postgres source definition
-    source_defs = client.make_request(
-        "/source_definitions/list_latest", data={"workspaceId": workspace_id}
+    source_defs = _safe_request(
+        client, "/source_definitions/list_latest", data={"workspaceId": workspace_id}
     )
-    assert source_defs
     postgres_definitions = [
         sd for sd in source_defs["sourceDefinitions"] if sd["name"] == "Postgres"
     ]

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -102,7 +102,6 @@ class AirbyteResource:
             self.make_request(endpoint="/connections/sync", data={"connectionId": connection_id})
         )
 
-
     def get_connection_details(self, connection_id: str) -> Dict[str, object]:
         return check.not_none(
             self.make_request(endpoint="/connections/get", data={"connectionId": connection_id})
@@ -150,9 +149,7 @@ class AirbyteResource:
                 cur_attempt = len(attempts)
                 # spit out the available Airbyte log info
                 if cur_attempt:
-                    log_lines = (
-                        attempts[logged_attempts].get("logs", {}).get("logLines", [])
-                    )
+                    log_lines = attempts[logged_attempts].get("logs", {}).get("logLines", [])
 
                     for line in log_lines[logged_lines:]:
                         sys.stdout.write(line + "\n")

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 import time
-from typing import Any, Dict, List, Optional, cast
+from typing import Dict, List, Optional, cast
 
 import requests
 from dagster_airbyte.types import AirbyteOutput

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterator, List
 
 from dagster_airbyte.types import AirbyteOutput
 
@@ -29,7 +29,7 @@ def _materialization_for_stream(
     )
 
 
-def generate_materializations(output: AirbyteOutput, asset_key_prefix: List[str]):
+def generate_materializations(output: AirbyteOutput, asset_key_prefix: List[str]) -> Iterator[AssetMaterialization]:
     prefix = output.connection_details.get("prefix") or ""
     # all the streams that are set to be sync'd by this connection
     all_stream_props = {

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
@@ -29,7 +29,9 @@ def _materialization_for_stream(
     )
 
 
-def generate_materializations(output: AirbyteOutput, asset_key_prefix: List[str]) -> Iterator[AssetMaterialization]:
+def generate_materializations(
+    output: AirbyteOutput, asset_key_prefix: List[str]
+) -> Iterator[AssetMaterialization]:
     prefix = output.connection_details.get("prefix") or ""
     # all the streams that are set to be sync'd by this connection
     all_stream_props = {


### PR DESCRIPTION
Adds a few types to `dagster-airbyte` and brings it to 100% coverage (via `pyright --ignoreexternal --verifytypes dagster-airbyte`).
