### PR TITLE
finish dagster-fivetran types

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/utils.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from dagster_fivetran.types import FivetranOutput
 
@@ -40,7 +40,7 @@ def _table_data_to_materialization(
     )
 
 
-def generate_materializations(fivetran_output: FivetranOutput, asset_key_prefix: List[str]):
+def generate_materializations(fivetran_output: FivetranOutput, asset_key_prefix: List[str]) -> Iterator[AssetMaterialization]:
     for schema in fivetran_output.schema_config["schemas"].values():
         schema_name = schema["name_in_destination"]
         schema_prefix = fivetran_output.connector_details.get("config", {}).get("schema_prefix")

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/utils.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/utils.py
@@ -40,7 +40,9 @@ def _table_data_to_materialization(
     )
 
 
-def generate_materializations(fivetran_output: FivetranOutput, asset_key_prefix: List[str]) -> Iterator[AssetMaterialization]:
+def generate_materializations(
+    fivetran_output: FivetranOutput, asset_key_prefix: List[str]
+) -> Iterator[AssetMaterialization]:
     for schema in fivetran_output.schema_config["schemas"].values():
         schema_name = schema["name_in_destination"]
         schema_prefix = fivetran_output.connector_details.get("config", {}).get("schema_prefix")


### PR DESCRIPTION
Adds a few types to `dagster-fivetran` and brings it to 100% coverage (via `pyright --ignoreexternal --verifytypes dagster_fivetran`).
