### PR TITLE
Register a new task definition for IAM changes

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
@@ -90,10 +90,6 @@ def default_ecs_task_definition(
 
     # Register the task overridden task definition as a revision to the
     # "dagster-run" family.
-    # TODO: Only register the task definition if a matching one doesn't
-    # already exist. Otherwise, we risk exhausting the revisions limit
-    # (1,000,000 per family) with unnecessary revisions:
-    # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-quotas.html
     ecs.register_task_definition(**task_definition)
 
     return task_definition

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -138,7 +138,7 @@ def test_task_definition_registration(
     assert len(ecs.list_task_definitions()["taskDefinitionArns"]) == len(task_definitions) + 1
 
 
-def test_reuse_task_definition(instance, run, workspace):
+def test_reuse_task_definition(instance):
     image = "image"
     secrets = []
     original_task_definition = {


### PR DESCRIPTION
We no longer register a new task definition for every run:

https://github.com/dagster-io/dagster/pull/7009

This introduced a regression where changing the IAM role used by a task
definition doesn't re-register the task definition. So it tries to run
the task with an IAM role that doesn't exist. The easiest way to
reproduce this is to use our example `docker compose` functionality:

https://github.com/dagster-io/dagster/issues/7358

This change extends our logic for deciding when to reuse a task
definition. Now, we reuse a task definition if:

- The container definition's image, name, or secrets change
- The task definition's task role or execution role changes

For now, I've pulled the logic out into its own private method with a
separate test so we can more easily extend the logic. I think
eventually, this would benefit from a broader refactor - perhaps with
the introduction of a `TaskDefinition` class that implements `__eq__`.