### PR TITLE
[dagit] Add opNames field to AssetNode

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -170,11 +170,11 @@ const AssetGraphExplorerWithData: React.FC<
       e.stopPropagation();
 
       const token = tokenForAssetKey(assetKey);
-      let clicked: {opName: string | null; jobName: string | null} = {opName: null, jobName: null};
+      let clicked: {opNames: string[]; jobName: string | null} = {opNames: [], jobName: null};
 
       if (node?.definition) {
         // The asset's defintion was provided in our job.assetNodes query. Show it in the current graph.
-        clicked = {opName: node.definition.opName, jobName: explorerPath.pipelineName};
+        clicked = {opNames: node.definition.opNames, jobName: explorerPath.pipelineName};
       } else {
         // The asset's definition was not provided in our query for job.assetNodes. This means
         // it's in another job or is a source asset not defined in the repository at all.
@@ -185,7 +185,7 @@ const AssetGraphExplorerWithData: React.FC<
       let nextOpsNameSelection = token;
 
       // If no opName, this is a source asset.
-      if (clicked.jobName !== explorerPath.pipelineName || !clicked.opName) {
+      if (clicked.jobName !== explorerPath.pipelineName || !clicked.opNames.length) {
         nextOpsQuery = '';
       } else if (e.shiftKey || e.metaKey) {
         const existing = explorerPath.opNames[0].split(',');
@@ -296,7 +296,7 @@ const AssetGraphExplorerWithData: React.FC<
                         }}
                         style={{overflow: 'visible'}}
                       >
-                        {!graphNode || !graphNode.definition.opName ? (
+                        {!graphNode || !graphNode.definition.opNames.length ? (
                           <ForeignNode assetKey={{path}} />
                         ) : (
                           <AssetNode
@@ -323,8 +323,8 @@ const AssetGraphExplorerWithData: React.FC<
                     {
                       ...explorerPath,
                       opNames:
-                        selectedGraphNodes.length && selectedGraphNodes[0].definition.opName
-                          ? [selectedGraphNodes[0].definition.opName]
+                        selectedGraphNodes.length && selectedGraphNodes[0].definition.opNames.length
+                          ? selectedGraphNodes[0].definition.opNames
                           : [],
                     },
                     'replace',

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -174,6 +174,7 @@ export const ASSET_NODE_LIVE_FRAGMENT = gql`
   fragment AssetNodeLiveFragment on AssetNode {
     id
     opName
+    opNames
     repository {
       id
     }
@@ -191,6 +192,7 @@ export const ASSET_NODE_FRAGMENT = gql`
   fragment AssetNodeFragment on AssetNode {
     id
     opName
+    opNames
     description
     partitionDefinition
     computeKind

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetForNavigationQuery.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetForNavigationQuery.ts
@@ -17,6 +17,7 @@ export interface AssetForNavigationQuery_assetOrError_Asset_definition {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  opNames: string[];
   jobNames: string[];
 }
 

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphLiveQuery.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphLiveQuery.ts
@@ -84,6 +84,7 @@ export interface AssetGraphLiveQuery_assetNodes {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  opNames: string[];
   repository: AssetGraphLiveQuery_assetNodes_repository;
   assetKey: AssetGraphLiveQuery_assetNodes_assetKey;
   assetMaterializations: AssetGraphLiveQuery_assetNodes_assetMaterializations[];

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphQuery.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphQuery.ts
@@ -41,6 +41,7 @@ export interface AssetGraphQuery_assetNodes {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  opNames: string[];
   description: string | null;
   partitionDefinition: string | null;
   computeKind: string | null;

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetNodeFragment.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetNodeFragment.ts
@@ -29,6 +29,7 @@ export interface AssetNodeFragment {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  opNames: string[];
   description: string | null;
   partitionDefinition: string | null;
   computeKind: string | null;

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetNodeLiveFragment.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetNodeLiveFragment.ts
@@ -27,6 +27,7 @@ export interface AssetNodeLiveFragment {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  opNames: string[];
   repository: AssetNodeLiveFragment_repository;
   assetKey: AssetNodeLiveFragment_assetKey;
   assetMaterializations: AssetNodeLiveFragment_assetMaterializations[];

--- a/js_modules/dagit/packages/core/src/asset-graph/useFindAssetInWorkspace.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useFindAssetInWorkspace.tsx
@@ -12,16 +12,16 @@ export function useFindAssetInWorkspace() {
   const apollo = useApolloClient();
 
   return React.useCallback(
-    async (key: AssetKeyInput): Promise<{opName: string | null; jobName: string | null}> => {
+    async (key: AssetKeyInput): Promise<{opNames: string[]; jobName: string | null}> => {
       const {data} = await apollo.query<AssetForNavigationQuery, AssetForNavigationQueryVariables>({
         query: ASSET_FOR_NAVIGATION_QUERY,
         variables: {key},
       });
       if (data?.assetOrError.__typename === 'Asset' && data?.assetOrError.definition) {
         const def = data.assetOrError.definition;
-        return {opName: def.opName, jobName: def.jobNames[0] || null};
+        return {opNames: def.opNames, jobName: def.jobNames[0] || null};
       }
-      return {opName: null, jobName: null};
+      return {opNames: [], jobName: null};
     },
     [apollo],
   );
@@ -36,6 +36,7 @@ const ASSET_FOR_NAVIGATION_QUERY = gql`
         definition {
           id
           opName
+          opNames
           jobNames
         }
       }

--- a/js_modules/dagit/packages/core/src/assets/AssetDefinedInMultipleReposNotice.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetDefinedInMultipleReposNotice.tsx
@@ -60,6 +60,7 @@ const ASSET_ID_SCAN_QUERY = gql`
           assetNodes {
             id
             opName
+            opNames
           }
         }
       }

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -201,6 +201,7 @@ export const ASSET_NODE_DEFINITION_FRAGMENT = gql`
     id
     description
     opName
+    opNames
     jobNames
     repository {
       id
@@ -219,6 +220,7 @@ export const ASSET_NODE_DEFINITION_FRAGMENT = gql`
       asset {
         id
         opName
+        opNames
         jobNames
         ...AssetNodeFragment
         ...AssetNodeLiveFragment
@@ -228,6 +230,7 @@ export const ASSET_NODE_DEFINITION_FRAGMENT = gql`
       asset {
         id
         opName
+        opNames
         jobNames
         ...AssetNodeFragment
         ...AssetNodeLiveFragment

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -280,6 +280,7 @@ export const ASSET_TABLE_FRAGMENT = gql`
     definition {
       id
       opName
+      opNames
       description
       repository {
         id

--- a/js_modules/dagit/packages/core/src/assets/types/AssetCatalogTableQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetCatalogTableQuery.ts
@@ -29,6 +29,7 @@ export interface AssetCatalogTableQuery_assetsOrError_AssetConnection_nodes_defi
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  opNames: string[];
   description: string | null;
   repository: AssetCatalogTableQuery_assetsOrError_AssetConnection_nodes_definition_repository;
 }

--- a/js_modules/dagit/packages/core/src/assets/types/AssetIdScanQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetIdScanQuery.ts
@@ -21,6 +21,7 @@ export interface AssetIdScanQuery_repositoriesOrError_RepositoryConnection_nodes
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  opNames: string[];
 }
 
 export interface AssetIdScanQuery_repositoriesOrError_RepositoryConnection_nodes {

--- a/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
@@ -2369,6 +2369,7 @@ export interface AssetNodeDefinitionFragment_dependencies_asset {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  opNames: string[];
   jobNames: string[];
   description: string | null;
   partitionDefinition: string | null;
@@ -2411,6 +2412,7 @@ export interface AssetNodeDefinitionFragment_dependedBy_asset {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  opNames: string[];
   jobNames: string[];
   description: string | null;
   partitionDefinition: string | null;
@@ -2430,6 +2432,7 @@ export interface AssetNodeDefinitionFragment {
   id: string;
   description: string | null;
   opName: string | null;
+  opNames: string[];
   jobNames: string[];
   repository: AssetNodeDefinitionFragment_repository;
   partitionDefinition: string | null;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
@@ -2423,6 +2423,7 @@ export interface AssetQuery_assetOrError_Asset_definition_dependencies_asset {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  opNames: string[];
   jobNames: string[];
   description: string | null;
   partitionDefinition: string | null;
@@ -2465,6 +2466,7 @@ export interface AssetQuery_assetOrError_Asset_definition_dependedBy_asset {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  opNames: string[];
   jobNames: string[];
   description: string | null;
   partitionDefinition: string | null;
@@ -2487,6 +2489,7 @@ export interface AssetQuery_assetOrError_Asset_definition {
   jobs: AssetQuery_assetOrError_Asset_definition_jobs[];
   description: string | null;
   opName: string | null;
+  opNames: string[];
   jobNames: string[];
   computeKind: string | null;
   assetKey: AssetQuery_assetOrError_Asset_definition_assetKey;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetTableFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetTableFragment.ts
@@ -29,6 +29,7 @@ export interface AssetTableFragment_definition {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  opNames: string[];
   description: string | null;
   repository: AssetTableFragment_definition_repository;
 }

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -231,6 +231,7 @@ type AssetNode {
   metadataEntries: [MetadataEntry!]!
   op: SolidDefinition
   opName: String
+  opNames: [String!]!
   partitionKeys: [String!]!
   partitionDefinition: String
   repository: Repository!

--- a/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
@@ -319,6 +319,7 @@ export const GRAPH_EXPLORER_ASSET_NODE_FRAGMENT = gql`
   fragment GraphExplorerAssetNodeFragment on AssetNode {
     id
     opName
+    opNames
     assetKey {
       path
     }

--- a/js_modules/dagit/packages/core/src/pipelines/types/GraphExplorerAssetNodeFragment.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/GraphExplorerAssetNodeFragment.ts
@@ -16,5 +16,6 @@ export interface GraphExplorerAssetNodeFragment {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  opNames: string[];
   assetKey: GraphExplorerAssetNodeFragment_assetKey;
 }

--- a/js_modules/dagit/packages/core/src/pipelines/types/PipelineExplorerRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/PipelineExplorerRootQuery.ts
@@ -1212,6 +1212,7 @@ export interface PipelineExplorerRootQuery_pipelineSnapshotOrError_PipelineSnaps
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  opNames: string[];
   assetKey: PipelineExplorerRootQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_assetNodes_assetKey;
 }
 
@@ -1275,6 +1276,7 @@ export interface PipelineExplorerRootQuery_pipelineSnapshotOrError_PipelineSnaps
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  opNames: string[];
   assetKey: PipelineExplorerRootQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_assetNodes_assetKey;
 }
 

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
@@ -27,6 +27,7 @@ const REPOSITORY_ASSETS_LIST_QUERY = gql`
             path
           }
           opName
+          opNames
           description
           repository {
             id

--- a/js_modules/dagit/packages/core/src/workspace/types/RepositoryAssetsListQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/RepositoryAssetsListQuery.ts
@@ -36,6 +36,7 @@ export interface RepositoryAssetsListQuery_repositoryOrError_Repository_assetNod
   id: string;
   assetKey: RepositoryAssetsListQuery_repositoryOrError_Repository_assetNodes_assetKey;
   opName: string | null;
+  opNames: string[];
   description: string | null;
   repository: RepositoryAssetsListQuery_repositoryOrError_Repository_assetNodes_repository;
 }

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -101,6 +101,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     metadata_entries = non_null_list(GrapheneMetadataEntry)
     op = graphene.Field(GrapheneSolidDefinition)
     opName = graphene.String()
+    opNames = non_null_list(graphene.String)
     partitionKeys = non_null_list(graphene.String)
     partitionDefinition = graphene.String()
     repository = graphene.NonNull(lambda: external.GrapheneRepository)
@@ -367,6 +368,13 @@ class GrapheneAssetNode(graphene.ObjectType):
             return build_solid_definition(pipeline, self._external_asset_node.op_name)
         else:
             return None
+
+    def resolve_opNames(self, _graphene_info) -> List[str]:
+        # todo OwenKephart: Return the correct list of op names.
+        if self._external_asset_node.op_name:
+            return [self._external_asset_node.op_name]
+        else:
+            return []
 
     def resolve_partitionDefinition(self, _graphene_info) -> Optional[str]:
         partitions_def_data = self._external_asset_node.partitions_def_data


### PR DESCRIPTION
## Summary

Add `opNames` field to `AssetNode` type, as discussed earlier. I changed over a single callsite to start using the array, which is currently just the one op name wrapped in an array.

Followups should:

- Change the array to return the correct array of op names
- Replace all existing `opName` field references to use `opNames` instead
- Delete `opName` from the schema

## Test Plan

View asset graph in Dagit, verify rendering. Click on nodes, verify correct selection behavior.
