### PR TITLE
add dialect-specific update logic for schedule selector_id

### DIFF
--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -1,9 +1,11 @@
+import pendulum
 import sqlalchemy as db
 
 from dagster import check
 from dagster.core.storage.schedules import ScheduleStorageSqlMetadata, SqlScheduleStorage
+from dagster.core.storage.schedules.schema import InstigatorsTable
 from dagster.core.storage.sql import create_engine, run_alembic_upgrade, stamp_alembic_rev
-from dagster.serdes import ConfigurableClass, ConfigurableClassData
+from dagster.serdes import ConfigurableClass, ConfigurableClassData, serialize_dagster_namedtuple
 
 from ..utils import (
     create_pg_connection,
@@ -110,3 +112,25 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         alembic_config = pg_alembic_config(__file__)
         with self.connect() as conn:
             run_alembic_upgrade(alembic_config, conn)
+
+    def _add_or_update_instigators_table(self, conn, state):
+        selector_id = state.selector_id
+        conn.execute(
+            db.dialects.postgresql.insert(InstigatorsTable)
+            .values(  # pylint: disable=no-value-for-parameter
+                selector_id=selector_id,
+                repository_selector_id=state.repository_selector_id,
+                status=state.status.value,
+                instigator_type=state.instigator_type.value,
+                instigator_body=serialize_dagster_namedtuple(state),
+            )
+            .on_conflict_do_update(
+                index_elements=[InstigatorsTable.c.selector_id],
+                set_={
+                    "status": state.status.value,
+                    "instigator_type": state.instigator_type.value,
+                    "instigator_body": serialize_dagster_namedtuple(state),
+                    "update_timestamp": pendulum.now("UTC"),
+                },
+            )
+        )


### PR DESCRIPTION
## Summary
Proactively uses the correct sql dialect for updates instead of using Integrity checks using try/except for control flow.

## Test Plan
BK

