### PR TITLE
Support numeric type image tags

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -32,7 +32,7 @@ If release name contains chart name it will be used as a full name.
   {{- $ := index . 0 }}
 
   {{- with index . 1 }}
-    {{- $tag := .tag | toString | default $.Chart.Version }}
+    {{- $tag := .tag | default $.Chart.Version | toYaml }}
     {{- printf "%s:%s" .repository $tag }}
   {{- end }}
 {{- end }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -32,7 +32,7 @@ If release name contains chart name it will be used as a full name.
   {{- $ := index . 0 }}
 
   {{- with index . 1 }}
-    {{- $tag := .tag | default $.Chart.Version }}
+    {{- $tag := .tag | toString | default $.Chart.Version }}
     {{- printf "%s:%s" .repository $tag }}
   {{- end }}
 {{- end }}

--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -71,6 +71,9 @@
                             "type": "string"
                         },
                         {
+                            "type": "integer"
+                        },
+                        {
                             "type": "null"
                         }
                     ]

--- a/helm/dagster/schema/schema/charts/utils/kubernetes.py
+++ b/helm/dagster/schema/schema/charts/utils/kubernetes.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Extra  # pylint: disable=no-name-in-module
 
@@ -35,7 +35,7 @@ class PullPolicy(str, Enum):
 
 class Image(BaseModelWithNullableRequiredFields):
     repository: str
-    tag: Optional[str]
+    tag: Optional[Union[str, int]]
     pullPolicy: PullPolicy
 
     @property

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -1,6 +1,6 @@
 import json
 import subprocess
-from typing import List
+from typing import List, Union
 
 import pytest
 from dagster_k8s.models import k8s_model_from_dict, k8s_snake_case_dict
@@ -492,6 +492,31 @@ def test_user_deployment_default_image_tag_is_chart_version(
     assert image_tag == chart_version
 
 
+@pytest.mark.parametrize("tag", [5176135, "abc1234"])
+def test_user_deployment_tag_can_be_numeric(
+    template: HelmTemplate, tag: Union[str, int]
+):
+    deployment = create_simple_user_deployment("foo")
+    deployment.image.tag = tag
+
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments(
+            enabled=True,
+            enableSubchart=True,
+            deployments=[deployment],
+        )
+    )
+
+    user_deployments = template.render(helm_values)
+
+    assert len(user_deployments) == 1
+
+    image = user_deployments[0].spec.template.spec.containers[0].image
+    _, image_tag = image.split(":")
+
+    assert image_tag == str(tag)
+
+
 def _assert_no_container_context(user_deployment):
     # No container context set by default
     env_names = [env.name for env in user_deployment.spec.template.spec.containers[0].env]
@@ -793,3 +818,30 @@ def test_subchart_default_postgres_password(subchart_template: HelmTemplate):
 
     assert container.env[1].name == "DAGSTER_PG_PASSWORD"
     assert container.env[1].value_from.secret_key_ref.name == "dagster-postgresql-secret"
+
+
+@pytest.mark.parametrize("tag", [5176135, "abc1234"])
+def test_subchart_tag_can_be_numeric(
+    subchart_template: HelmTemplate, tag: Union[str, int]
+):
+    deployment_values = DagsterUserDeploymentsHelmValues.construct(
+        deployments=[UserDeployment.construct(
+            name="foo",
+            image=kubernetes.Image.construct(
+                repository="foo",
+                tag=tag,
+                pullPolicy="Always",
+            ),
+            dagsterApiGrpcArgs=[],
+            port=0,
+        )]
+    )
+
+    deployment_templates = subchart_template.render(deployment_values)
+
+    assert len(deployment_templates) == 1
+
+    image = deployment_templates[0].spec.template.spec.containers[0].image
+    _, image_tag = image.split(":")
+
+    assert image_tag == str(tag)

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -493,9 +493,7 @@ def test_user_deployment_default_image_tag_is_chart_version(
 
 
 @pytest.mark.parametrize("tag", [5176135, "abc1234"])
-def test_user_deployment_tag_can_be_numeric(
-    template: HelmTemplate, tag: Union[str, int]
-):
+def test_user_deployment_tag_can_be_numeric(template: HelmTemplate, tag: Union[str, int]):
     deployment = create_simple_user_deployment("foo")
     deployment.image.tag = tag
 
@@ -821,20 +819,20 @@ def test_subchart_default_postgres_password(subchart_template: HelmTemplate):
 
 
 @pytest.mark.parametrize("tag", [5176135, "abc1234"])
-def test_subchart_tag_can_be_numeric(
-    subchart_template: HelmTemplate, tag: Union[str, int]
-):
+def test_subchart_tag_can_be_numeric(subchart_template: HelmTemplate, tag: Union[str, int]):
     deployment_values = DagsterUserDeploymentsHelmValues.construct(
-        deployments=[UserDeployment.construct(
-            name="foo",
-            image=kubernetes.Image.construct(
-                repository="foo",
-                tag=tag,
-                pullPolicy="Always",
-            ),
-            dagsterApiGrpcArgs=[],
-            port=0,
-        )]
+        deployments=[
+            UserDeployment.construct(
+                name="foo",
+                image=kubernetes.Image.construct(
+                    repository="foo",
+                    tag=tag,
+                    pullPolicy="Always",
+                ),
+                dagsterApiGrpcArgs=[],
+                port=0,
+            )
+        ]
     )
 
     deployment_templates = subchart_template.render(deployment_values)

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -33,7 +33,7 @@ If release name contains chart name it will be used as a full name.
   {{- $ := index . 0 }}
 
   {{- with index . 1 }}
-    {{- $tag := .tag | default $.Chart.Version }}
+    {{- $tag := .tag | default $.Chart.Version | toYaml }}
     {{- printf "%s:%s" .repository $tag }}
   {{- end }}
 {{- end }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -118,6 +118,9 @@
                             "type": "string"
                         },
                         {
+                            "type": "integer"
+                        },
+                        {
                             "type": "null"
                         }
                     ]


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

Addresses https://github.com/dagster-io/dagster/issues/7578. Specifically, allows numeric image tags in Dagster Helm charts (including the user code deployment sub-chart).


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

Deployed one of our applications using the locally modified Helm chart with success:

```
$ helm upgrade mango-dagster ../../dagster/helm/dagster/charts/dagster-user-deployments --atomic --cleanup-on-fail --create-namespace --install --namespace dev --timeout 5m --wait  --values helm/mango-dagster/values.yaml --set "deployments[0].image.tag=5176135"
Release "mango-dagster" has been upgraded. Happy Helming!
NAME: mango-dagster
LAST DEPLOYED: Tue Apr 26 10:37:18 2022
NAMESPACE: dev
STATUS: deployed
REVISION: 42
TEST SUITE: None
```

And was able to verify that both the deployment image and the `DAGSTER_CURRENT_IMAGE` environment variable are respected.

```
$ k -n dev get deployments/mango-dagster-dagster-user-deployments-dagster-mango-bioinformatics -oyaml | grep -i image -A1
        - name: DAGSTER_CURRENT_IMAGE
          value: ghcr.io/zephyr-ai/mango/dagster:5176135
--
        image: ghcr.io/zephyr-ai/mango/dagster:5176135
        imagePullPolicy: Always
        name: dagster-user-deployments
--
      imagePullSecrets:
      - name: dagster-container-registry
```


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.