### PR TITLE
[@dagster-io/ui] Separate tsconfig for build

### DIFF
--- a/js_modules/dagit/packages/ui/CHANGES.md
+++ b/js_modules/dagit/packages/ui/CHANGES.md
@@ -1,3 +1,15 @@
+## 1.0.4 (April 28, 2022)
+
+- Create a build-specific `tsconfig` that excludes `stories` and `test` files
+- Clean up `lodash` imports
+- Update `workspaces` icon
+- Fix rendering of `Suggest` component lists
+- Add `topBorder` prop to `DialogFooter`
+- Remove `HighlightedCodeBlock`
+- Allow `:` character in tag values for `TokenizingField`
+- Add Slack icon
+- Use `@dagster-io/eslint-config`
+
 ## 1.0.3 (April 6, 2022)
 
 - Remove work-in-progress suffixes on components

--- a/js_modules/dagit/packages/ui/package.json
+++ b/js_modules/dagit/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dagster-io/ui",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Dagster UI Component Library",
   "license": "Apache-2.0",
   "main": "lib/index.js",
@@ -13,7 +13,7 @@
   "scripts": {
     "prepack": "yarn build",
     "prepublish": "yarn lint && yarn ts && yarn jest",
-    "build": "rm -rf lib && tsc --declaration --emitDeclarationOnly --noEmit false -p . && yarn rollup -c rollup.config.js",
+    "build": "rm -rf lib && tsc -p ./tsconfig.build.json && yarn rollup -c rollup.config.js",
     "lint": "eslint src/ --ext=.tsx,.ts,.js --fix -c .eslintrc.js",
     "jest": "jest",
     "ts": "tsc -p .",

--- a/js_modules/dagit/packages/ui/tsconfig.build.json
+++ b/js_modules/dagit/packages/ui/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "lib",
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "exclude": [
+    "node_modules",
+    "lib",
+    "**/*.stories.*",
+    "**/*.test.*"
+  ]
+}

--- a/js_modules/dagit/packages/ui/tsconfig.json
+++ b/js_modules/dagit/packages/ui/tsconfig.json
@@ -1,44 +1,44 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "es5",
-      "lib": [
-        "es6",
-        "dom",
-        "esnext.asynciterable"
-      ],
-      "outDir": "lib",
-      "rootDir": "src",
-      "noEmit": true,
-      "sourceMap": true,
-      "allowJs": true,
-      "jsx": "react",
-      "moduleResolution": "node",
-      "forceConsistentCasingInFileNames": true,
-      "noImplicitReturns": true,
-      "noImplicitThis": true,
-      "noImplicitAny": true,
-      "strictNullChecks": true,
-      "suppressImplicitAnyIndexErrors": true,
-      "noUncheckedIndexedAccess": true,
-      "allowSyntheticDefaultImports": true,
-      "types": [
-        "jest",
-        "node"
-      ],
-      "skipLibCheck": true,
-      "esModuleInterop": true,
-      "strict": true,
-      "resolveJsonModule": true,
-      "isolatedModules": true,
-      "noFallthroughCasesInSwitch": true
-    },
-    "exclude": [
-      "node_modules",
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es5",
+    "lib": [
+      "es6",
+      "dom",
+      "esnext.asynciterable"
     ],
-    "include": [
-      "src",
-      "types"
-    ]
-  }
+    "rootDir": "src",
+    "noEmit": true,
+    "sourceMap": true,
+    "allowJs": true,
+    "jsx": "react",
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "noUncheckedIndexedAccess": true,
+    "allowSyntheticDefaultImports": true,
+    "types": [
+      "jest",
+      "node"
+    ],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "exclude": [
+    "node_modules",
+    "lib",
+  ],
+  "include": [
+    "src",
+    "types"
+  ]
+}
   


### PR DESCRIPTION
## Summary

Create a separate `tsconfig.build.json` to produce built output, specifically excluding `stories.*` and `test.*` files, since we don't actually want to ship type declarations for these.

This should resolve an issue where an `internal` project that imports from `@dagster-io/ui` is ending up with incorrect types that are being affected by the creation of `stories` typedefs.

I'll publish this as 1.0.4, so I updated the changelog accordingly.

## Test Plan

`yarn build`, verify that `stories.d.ts` and `test.d.ts` files are no longer included in the build output.

`yarn ts`, verify that regular non-emitting TS check still works as exepcted.

In internal project, link to this package locally. Verify that the TS error goes away with the newly generated types.
