### PR TITLE
[docker] improve test time

### DIFF
--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
@@ -101,8 +101,16 @@ def docker_mode_defs():
     ]
 
 
-@solid(input_defs=[InputDefinition("word", String)], config_schema={"factor": IntSource})
+@solid(
+    input_defs=[InputDefinition("word", String)],
+    config_schema={
+        "factor": IntSource,
+        "should_segfault": Field(bool, is_required=False, default_value=False),
+    },
+)
 def multiply_the_word(context, word):
+    if context.solid_config.get("should_segfault"):
+        segfault()
     return word * context.solid_config["factor"]
 
 

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_docker_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_docker_executor.py
@@ -65,12 +65,11 @@ def test_docker_executor():
 
 
 def test_docker_executor_check_step_health():
-    # missing network causes step to fail
-
     executor_config = {
         "execution": {
             "docker": {
                 "config": {
+                    "networks": ["container:test-postgres-db-docker"],
                     "env_vars": [
                         "AWS_ACCESS_KEY_ID",
                         "AWS_SECRET_ACCESS_KEY",
@@ -97,6 +96,9 @@ def test_docker_executor_check_step_health():
         ),
         executor_config,
     )
+
+    # force a segfault to terminate the container unexpectedly, step health check should then fail the step
+    run_config["solids"]["multiply_the_word"]["config"]["should_segfault"] = True
 
     with environ({"DOCKER_LAUNCHER_NETWORK": "container:test-postgres-db-docker"}):
         with docker_postgres_instance() as instance:


### PR DESCRIPTION
the step health check test was taking 10+ minutes to fail in buildkite, likely due to timouts / retries in the scheme of causing failure via not connecting the db network. 

change scheme to explicitly segfault. 

## Test Plan

bk