### PR TITLE
fullbuild in branch name for full BK build

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -98,22 +98,32 @@ def is_release_branch(branch_name: str):
     return branch_name.startswith("release-")
 
 
-# To customize the tested Python versions for a branch, set environment variable
+# To test the full suite of Python versions on a PR, include this string anywhere in the branch name
+# or commit message.
+FULL_BUILD_MARKER_STR = "fullbuild"
+
+# To more specifically customize the tested Python versions for a branch, set environment variable
 # $DEFAULT_PYTHON_VERSIONS to a comma-separated list of python version specifiers of the form VX_Y
 # (i.e. attributes of `SupportedPython`).
 _versions = os.environ.get("DEFAULT_PYTHON_VERSIONS", "V3_9")
 DEFAULT_PYTHON_VERSIONS = [getattr(SupportedPython, ver) for ver in _versions.split(",")]
 
-
+# By default only one representative Python version is tested on PRs, and all versions are
+# tested on master or release branches.
 def get_python_versions_for_branch(pr_versions=None):
     pr_versions = pr_versions if pr_versions != None else DEFAULT_PYTHON_VERSIONS
 
-    # By default only one representative Python version is tested on PRs, and all versions are tested on
-    # master or release branches. To test the full suite of Python versions on a PR, include
-    # "fullbuild" anywhere in the branch name.
     branch_name = os.getenv("BUILDKITE_BRANCH")
-    assert branch_name is not None, "$BUILDKITE_BRANCH env var must be set"
-    if branch_name == "master" or is_release_branch(branch_name) or "fullbuild" in branch_name:
+    assert branch_name is not None, "$BUILDKITE_BRANCH env var must be set."
+    commit_message = os.getenv("BUILDKITE_MESSAGE")
+    assert commit_message is not None, "$BUILDKITE_MESSAGE env var must be set."
+
+    if (
+        branch_name == "master"
+        or is_release_branch(branch_name)
+        or FULL_BUILD_MARKER_STR in branch_name
+        or FULL_BUILD_MARKER_STR in commit_message
+    ):
         return SupportedPythons
     else:
         return pr_versions

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -108,11 +108,12 @@ DEFAULT_PYTHON_VERSIONS = [getattr(SupportedPython, ver) for ver in _versions.sp
 def get_python_versions_for_branch(pr_versions=None):
     pr_versions = pr_versions if pr_versions != None else DEFAULT_PYTHON_VERSIONS
 
-    # Run one representative version on PRs, the full set of python versions on master after
-    # landing and on release branches before shipping
+    # By default only one representative Python version is tested on PRs, and all versions are tested on
+    # master or release branches. To test the full suite of Python versions on a PR, include
+    # "fullbuild" anywhere in the branch name.
     branch_name = os.getenv("BUILDKITE_BRANCH")
     assert branch_name is not None, "$BUILDKITE_BRANCH env var must be set"
-    if branch_name == "master" or is_release_branch(branch_name):
+    if branch_name == "master" or is_release_branch(branch_name) or "fullbuild" in branch_name:
         return SupportedPythons
     else:
         return pr_versions


### PR DESCRIPTION
Small change where you can trigger a full BK build (including e.g. tests for Python 3.6) by including `fullbuild` in your branch name.

## Test Plan

The branch name of this PR includes "fullbuild", so the BK tests should be a full build if the PR works.
