### PR TITLE
Fixes for running the user-code-deployment helm chart in a different namespace than the system namespace

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
@@ -147,7 +147,7 @@ def build_spec_daemon_suite():
 
 
 def build_spec_k8s_suite():
-    tox_env_suffixes = ["-default"]
+    tox_env_suffixes = ["-default", "-subchart"]
     directory = os.path.join("integration_tests", "test_suites", "k8s-integration-test-suite")
     return build_steps_integration_suite(directory, tox_env_suffixes, upload_coverage=True)
 

--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -122,5 +122,7 @@ DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP: "{{ template "dagster.fullname" . }}-pip
     {{- if .labels }}
     labels: {{- .labels | toYaml | nindent 6 }}
     {{- end }}
+    namespace: {{ $.Release.Namespace }}
+    service_account_name: {{ include "dagsterUserDeployments.serviceAccountName" $ }}
   {{- end }}
 {{- end -}}

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -564,6 +564,8 @@ def test_user_deployment_include_config(template: HelmTemplate):
         "k8s": {
             "image_pull_policy": "Always",
             "env_config_maps": ["release-name-dagster-user-deployments-foo-user-env"],
+            "namespace": "default",
+            "service_account_name": "release-name-dagster-user-deployments-user-deployments",
         }
     }
 
@@ -645,6 +647,8 @@ def test_user_deployment_volumes(template: HelmTemplate, include_config_in_launc
                 "image_pull_policy": "Always",
                 "volume_mounts": volume_mounts,
                 "volumes": volumes,
+                "namespace": "default",
+                "service_account_name": "release-name-dagster-user-deployments-user-deployments",
             }
         }
     else:
@@ -699,6 +703,8 @@ def test_user_deployment_secrets_and_configmaps(
                     "my-configmap",
                     "my-other-configmap",
                 ],
+                "namespace": "default",
+                "service_account_name": "release-name-dagster-user-deployments-user-deployments",
             }
         }
     else:
@@ -744,6 +750,8 @@ def test_user_deployment_labels(template: HelmTemplate, include_config_in_launch
                     "release-name-dagster-user-deployments-foo-user-env",
                 ],
                 "labels": labels,
+                "namespace": "default",
+                "service_account_name": "release-name-dagster-user-deployments-user-deployments",
             }
         }
     else:

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/cluster.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/cluster.py
@@ -168,9 +168,9 @@ def local_port_forward_postgres(namespace):
 
 
 @pytest.fixture(scope="session")
-def helm_postgres_url_for_k8s_run_launcher(helm_namespace_for_k8s_run_launcher):
+def helm_postgres_url_for_k8s_run_launcher(system_namespace_for_k8s_run_launcher):
     with local_port_forward_postgres(
-        namespace=helm_namespace_for_k8s_run_launcher
+        namespace=system_namespace_for_k8s_run_launcher
     ) as local_forward_port:
         postgres_url = "postgresql://test:test@localhost:{local_forward_port}/test".format(
             local_forward_port=local_forward_port

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -4,7 +4,7 @@ import json
 import os
 import subprocess
 import time
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 
 import boto3
 import kubernetes
@@ -44,6 +44,30 @@ def should_cleanup(pytestconfig):
         return not pytestconfig.getoption("--no-cleanup")
 
 
+@contextmanager
+def _create_namespace(should_cleanup, existing_helm_namespace=None, prefix="dagster-test"):
+    # Will be something like dagster-test-3fcd70 to avoid ns collisions in shared test environment
+    namespace = get_test_namespace(prefix)
+
+    print("--- \033[32m:k8s: Creating test namespace %s\033[0m" % namespace)
+    kube_api = kubernetes.client.CoreV1Api()
+
+    if existing_helm_namespace:
+        namespace = existing_helm_namespace
+    else:
+        print("Creating namespace %s" % namespace)
+        kube_namespace = kubernetes.client.V1Namespace(
+            metadata=kubernetes.client.V1ObjectMeta(name=namespace)
+        )
+        kube_api.create_namespace(kube_namespace)
+
+    yield namespace
+
+    if should_cleanup:
+        print("Deleting namespace %s" % namespace)
+        kube_api.delete_namespace(name=namespace)
+
+
 @pytest.fixture(scope="session")
 def namespace(pytestconfig, should_cleanup):
     """If an existing Helm chart namespace is specified via pytest CLI with the argument
@@ -55,28 +79,8 @@ def namespace(pytestconfig, should_cleanup):
     """
     existing_helm_namespace = pytestconfig.getoption("--existing-helm-namespace")
 
-    if existing_helm_namespace:
-        namespace = existing_helm_namespace
-    else:
-        # Will be something like dagster-test-3fcd70 to avoid ns collisions in shared test environment
-        namespace = get_test_namespace()
-
-        print("--- \033[32m:k8s: Creating test namespace %s\033[0m" % namespace)
-        kube_api = kubernetes.client.CoreV1Api()
-
-        print("Creating namespace %s" % namespace)
-        kube_namespace = kubernetes.client.V1Namespace(
-            metadata=kubernetes.client.V1ObjectMeta(name=namespace)
-        )
-        kube_api.create_namespace(kube_namespace)
-
-    yield namespace
-
-    # Can skip this step as a time saver when we're going to destroy the cluster anyway, e.g.
-    # w/ a kind cluster
-    if should_cleanup:
-        print("Deleting namespace %s" % namespace)
-        kube_api.delete_namespace(name=namespace)
+    with _create_namespace(should_cleanup, existing_helm_namespace) as namespace:
+        yield namespace
 
 
 @pytest.fixture(scope="session")
@@ -333,20 +337,183 @@ def helm_namespace(
         yield namespace
 
 
-@pytest.fixture(scope="session")
-def helm_namespace_for_k8s_run_launcher(
+@contextmanager
+def create_cluster_admin_role_binding(namespace, service_account_name, should_cleanup):
+    # Allow the namespace to launch runs (this could probably be scoped down more)
+
+    kube_api = kubernetes.client.RbacAuthorizationV1Api()
+
+    subject = kubernetes.client.V1Subject(
+        namespace=namespace, name=service_account_name, kind="ServiceAccount"
+    )
+
+    role_binding_name = f"{namespace}-{service_account_name}-cluster-admin"
+
+    role_ref = kubernetes.client.V1RoleRef(
+        name="cluster-admin", api_group="rbac.authorization.k8s.io", kind="ClusterRole"
+    )
+
+    body = kubernetes.client.V1ClusterRoleBinding(
+        metadata=kubernetes.client.V1ObjectMeta(name=role_binding_name, labels={}),
+        role_ref=role_ref,
+        subjects=[subject],
+    )
+
+    kube_api.create_cluster_role_binding(body=body)
+
+    try:
+        yield
+    finally:
+        if should_cleanup:
+            kube_api.delete_cluster_role_binding(name=role_binding_name)
+
+
+@contextmanager
+def create_postgres_secret(namespace, should_cleanup):
+    kube_api = kubernetes.client.CoreV1Api()
+
+    secret_val = base64.b64encode(b"test").decode("utf-8")
+    secret = kubernetes.client.V1Secret(
+        api_version="v1",
+        kind="Secret",
+        data={"postgresql-password": secret_val},
+        metadata=kubernetes.client.V1ObjectMeta(name="dagster-postgresql-secret"),
+    )
+    kube_api.create_namespaced_secret(namespace=namespace, body=secret)
+
+    try:
+        yield
+    finally:
+        if should_cleanup:
+            kube_api.delete_namespaced_secret(name="dagster-postgresql-secret", namespace=namespace)
+
+
+@contextmanager
+def copy_configmaps(system_namespace, user_code_namespace, should_cleanup, configmap_names):
+    kube_api = kubernetes.client.CoreV1Api()
+
+    for configmap_name in configmap_names:
+        system_configmap = kube_api.read_namespaced_config_map(
+            name=configmap_name, namespace=system_namespace
+        )
+
+        new_configmap = kubernetes.client.V1ConfigMap(
+            api_version="v1",
+            kind="ConfigMap",
+            data=system_configmap.data,
+            metadata=kubernetes.client.V1ObjectMeta(name=configmap_name),
+        )
+        kube_api.create_namespaced_config_map(namespace=user_code_namespace, body=new_configmap)
+
+    try:
+        yield
+    finally:
+        if should_cleanup:
+            for configmap_name in configmap_names:
+                kube_api.create_namespaced_config_map(
+                    name=configmap_name, namespace=user_code_namespace
+                )
+
+
+@pytest.fixture(
+    scope="session",
+    params=[
+        pytest.param(False, marks=pytest.mark.default, id="no_subchart"),
+        pytest.param(True, marks=pytest.mark.subchart, id="with_subchart"),
+    ],
+)
+def helm_namespaces_for_k8s_run_launcher(
     dagster_docker_image,
     cluster_provider,
-    namespace,
+    namespace,  # Namespace where the user code runs
     should_cleanup,
     configmaps,
     aws_configmap,
     secrets,
+    request,
 ):  # pylint: disable=unused-argument
-    with helm_chart_for_k8s_run_launcher(
-        namespace, dagster_docker_image, should_cleanup, run_monitoring=True
-    ):
-        yield namespace
+    subchart_enabled = request.param
+    with ExitStack() as stack:
+        if subchart_enabled:
+            stack.enter_context(create_postgres_secret(namespace, should_cleanup))
+            system_namespace = stack.enter_context(
+                helm_chart_for_user_deployments_subchart(
+                    namespace, dagster_docker_image, should_cleanup
+                )
+            )
+
+            system_namespace = stack.enter_context(
+                _create_namespace(should_cleanup, prefix="dagster-system")
+            )
+
+            # Let the system namespace service account launch runs in other namespaces
+            stack.enter_context(
+                create_cluster_admin_role_binding(
+                    system_namespace,
+                    service_account_name="dagster",
+                    should_cleanup=should_cleanup,
+                )
+            )
+
+            # Let the dagster-user-deployments service account launch jobs
+            stack.enter_context(
+                create_cluster_admin_role_binding(
+                    namespace,
+                    service_account_name="dagster-user-deployments-user-deployments",
+                    should_cleanup=should_cleanup,
+                )
+            )
+
+            stack.enter_context(
+                helm_chart_for_k8s_run_launcher(
+                    system_namespace,
+                    namespace,
+                    dagster_docker_image,
+                    enable_subchart=False,
+                    should_cleanup=should_cleanup,
+                    run_monitoring=True,
+                )
+            )
+            stack.enter_context(
+                copy_configmaps(
+                    system_namespace,
+                    namespace,
+                    should_cleanup,
+                    configmap_names=["dagster-instance", "dagster-pipeline-env"],
+                )
+            )
+            yield (namespace, system_namespace)
+        else:
+            # Let the default service account used by the user code deployment launch jobs
+            # (needed for the k8s executor to be able to work since it uses that same service
+            # account when launching jobs)
+            stack.enter_context(
+                create_cluster_admin_role_binding(
+                    namespace,
+                    service_account_name="dagster-dagster-user-deployments-user-deployments",
+                    should_cleanup=should_cleanup,
+                )
+            )
+
+            with helm_chart_for_k8s_run_launcher(
+                namespace,
+                namespace,
+                dagster_docker_image,
+                enable_subchart=True,
+                should_cleanup=should_cleanup,
+                run_monitoring=True,
+            ):
+                yield (namespace, namespace)
+
+
+@pytest.fixture(scope="session")
+def user_code_namespace_for_k8s_run_launcher(helm_namespaces_for_k8s_run_launcher):
+    return helm_namespaces_for_k8s_run_launcher[0]
+
+
+@pytest.fixture(scope="session")
+def system_namespace_for_k8s_run_launcher(helm_namespaces_for_k8s_run_launcher):
+    return helm_namespaces_for_k8s_run_launcher[1]
 
 
 @contextmanager
@@ -565,7 +732,7 @@ def helm_chart(namespace, docker_image, celery_backend, should_cleanup=True):
     else:
         raise Exception(f"Unexpected Celery backend {celery_backend}")
 
-    helm_config = merge_dicts(_base_helm_config(docker_image), additional_config)
+    helm_config = merge_dicts(_base_helm_config(namespace, docker_image), additional_config)
 
     with _helm_chart_helper(namespace, should_cleanup, helm_config, helm_install_name="helm_chart"):
         yield
@@ -573,16 +740,26 @@ def helm_chart(namespace, docker_image, celery_backend, should_cleanup=True):
 
 @contextmanager
 def helm_chart_for_k8s_run_launcher(
-    namespace, docker_image, should_cleanup=True, run_monitoring=False
+    system_namespace,
+    user_code_namespace,
+    docker_image,
+    enable_subchart,
+    should_cleanup=True,
+    run_monitoring=False,
 ):
-    check.str_param(namespace, "namespace")
+    check.str_param(system_namespace, "user_code_namespace")
+    check.str_param(user_code_namespace, "user_code_namespace")
     check.str_param(docker_image, "docker_image")
     check.bool_param(should_cleanup, "should_cleanup")
 
     repository, tag = docker_image.split(":")
     pull_policy = image_pull_policy()
     helm_config = merge_dicts(
-        _base_helm_config(docker_image),
+        _base_helm_config(
+            system_namespace,
+            docker_image,
+            enable_subchart=enable_subchart,
+        ),
         {
             "flower": {
                 "enabled": False,
@@ -591,7 +768,7 @@ def helm_chart_for_k8s_run_launcher(
                 "type": "K8sRunLauncher",
                 "config": {
                     "k8sRunLauncher": {
-                        "jobNamespace": namespace,
+                        "jobNamespace": user_code_namespace,
                         "envConfigMaps": [{"name": TEST_CONFIGMAP_NAME}]
                         + ([{"name": TEST_AWS_CONFIGMAP_NAME}] if not IS_BUILDKITE else []),
                         "envSecrets": [{"name": TEST_SECRET_NAME}],
@@ -616,83 +793,66 @@ def helm_chart_for_k8s_run_launcher(
                     }
                 },
             },
-            "rabbitmq": {"enabled": False},
             "dagsterDaemon": {
                 "enabled": True,
                 "image": {"repository": repository, "tag": tag, "pullPolicy": pull_policy},
                 "heartbeatTolerance": 180,
                 "runCoordinator": {"enabled": False},  # No run queue
                 "env": ({"BUILDKITE": os.getenv("BUILDKITE")} if os.getenv("BUILDKITE") else {}),
-                "envConfigMaps": [{"name": TEST_CONFIGMAP_NAME}],
-                "envSecrets": [{"name": TEST_SECRET_NAME}],
                 "annotations": {"dagster-integration-tests": "daemon-pod-annotation"},
                 "runMonitoring": {"enabled": True, "pollIntervalSeconds": 5}
                 if run_monitoring
                 else {},
             },
-            "imagePullSecrets": [{"name": TEST_IMAGE_PULL_SECRET_NAME}],
-        },
-    )
-
-    with _helm_chart_helper(
-        namespace, should_cleanup, helm_config, helm_install_name="helm_chart_for_k8s_run_launcher"
-    ):
-        yield
-
-
-@contextmanager
-def helm_chart_for_user_deployments_subchart_disabled(namespace, docker_image, should_cleanup=True):
-    check.str_param(namespace, "namespace")
-    check.str_param(docker_image, "docker_image")
-    check.bool_param(should_cleanup, "should_cleanup")
-
-    repository, tag = docker_image.split(":")
-    pull_policy = image_pull_policy()
-    helm_config = merge_dicts(
-        _base_helm_config(docker_image),
-        {
-            "dagster-user-deployments": {
-                "enabled": True,
-                "enableSubchart": False,
-                "deployments": [
-                    {
-                        "name": "user-code-deployment-1",
-                        "image": {"repository": repository, "tag": tag, "pullPolicy": pull_policy},
-                        "dagsterApiGrpcArgs": [
-                            "-m",
-                            "dagster_test.test_project.test_pipelines.repo",
-                            "-a",
-                            "define_demo_execution_repo",
-                        ],
-                        "port": 3030,
-                        "env": (
-                            {"BUILDKITE": os.getenv("BUILDKITE")} if os.getenv("BUILDKITE") else {}
-                        ),
-                        "annotations": {"dagster-integration-tests": "ucd-1-pod-annotation"},
-                        "service": {
-                            "annotations": {"dagster-integration-tests": "ucd-1-svc-annotation"}
-                        },
-                        "volumeMounts": [
-                            {
-                                "name": "test-volume",
-                                "mountPath": "/opt/dagster/test_mount_path/volume_mounted_file.yaml",
-                                "subPath": "volume_mounted_file.yaml",
-                            }
-                        ],
-                        "volumes": [
-                            {
-                                "name": "test-volume",
-                                "configMap": {"name": TEST_VOLUME_CONFIGMAP_NAME},
-                            }
-                        ],
-                    }
-                ],
+            "dagit": {
+                "image": {"repository": repository, "tag": tag, "pullPolicy": pull_policy},
+                "env": {"TEST_SET_ENV_VAR": "test_dagit_env_var"},
+                "annotations": {"dagster-integration-tests": "dagit-pod-annotation"},
+                "service": {"annotations": {"dagster-integration-tests": "dagit-svc-annotation"}},
+                "workspace": {
+                    "enabled": not enable_subchart,
+                    "servers": [
+                        {
+                            "host": f"user-code-deployment-1.{user_code_namespace}.svc.cluster.local",
+                            "port": 3030,
+                            "name": "user-code-deployment-1",
+                        }
+                    ],
+                },
             },
         },
     )
 
     with _helm_chart_helper(
-        namespace,
+        system_namespace,
+        should_cleanup,
+        helm_config,
+        helm_install_name="helm_chart_for_k8s_run_launcher",
+    ):
+        yield
+
+
+@contextmanager
+def helm_chart_for_user_deployments_subchart_disabled(
+    system_namespace, docker_image, should_cleanup=True
+):
+    check.str_param(system_namespace, "system_namespace")
+    check.str_param(docker_image, "docker_image")
+    check.bool_param(should_cleanup, "should_cleanup")
+
+    helm_config = merge_dicts(
+        _base_helm_config(system_namespace, docker_image),
+        {
+            "dagster-user-deployments": {
+                "enabled": True,
+                "enableSubchart": False,
+                "deployments": _deployment_config(docker_image),
+            },
+        },
+    )
+
+    with _helm_chart_helper(
+        system_namespace,
         should_cleanup,
         helm_config,
         helm_install_name="helm_chart_for_user_deployments_subchart_disabled",
@@ -706,23 +866,7 @@ def helm_chart_for_user_deployments_subchart(namespace, docker_image, should_cle
     check.str_param(docker_image, "docker_image")
     check.bool_param(should_cleanup, "should_cleanup")
 
-    repository, tag = docker_image.split(":")
-    pull_policy = image_pull_policy()
-    helm_config = {
-        "deployments": [
-            {
-                "name": "user-code-deployment-1",
-                "image": {"repository": repository, "tag": tag, "pullPolicy": pull_policy},
-                "dagsterApiGrpcArgs": [
-                    "-m",
-                    "dagster_test.test_project.test_pipelines.repo",
-                    "-a",
-                    "define_demo_execution_repo",
-                ],
-                "port": 3030,
-            }
-        ],
-    }
+    helm_config = {"deployments": _deployment_config(docker_image)}
 
     with _helm_chart_helper(
         namespace,
@@ -734,56 +878,52 @@ def helm_chart_for_user_deployments_subchart(namespace, docker_image, should_cle
         yield
 
 
-def _base_helm_config(docker_image):
+def _deployment_config(docker_image):
+    pull_policy = image_pull_policy()
+    repository, tag = docker_image.split(":")
+    return [
+        {
+            "name": "user-code-deployment-1",
+            "image": {"repository": repository, "tag": tag, "pullPolicy": pull_policy},
+            "dagsterApiGrpcArgs": [
+                "-m",
+                "dagster_test.test_project.test_pipelines.repo",
+                "-a",
+                "define_demo_execution_repo",
+            ],
+            "port": 3030,
+            "includeConfigInLaunchedRuns": {
+                "enabled": True,
+            },
+            "env": ({"BUILDKITE": os.getenv("BUILDKITE")} if os.getenv("BUILDKITE") else {}),
+            "envConfigMaps": ([{"name": TEST_AWS_CONFIGMAP_NAME}] if not IS_BUILDKITE else []),
+            "envSecrets": [{"name": TEST_DEPLOYMENT_SECRET_NAME}],
+            "annotations": {"dagster-integration-tests": "ucd-1-pod-annotation"},
+            "service": {"annotations": {"dagster-integration-tests": "ucd-1-svc-annotation"}},
+            "volumeMounts": [
+                {
+                    "name": "test-volume",
+                    "mountPath": "/opt/dagster/test_mount_path/volume_mounted_file.yaml",
+                    "subPath": "volume_mounted_file.yaml",
+                }
+            ],
+            "volumes": [{"name": "test-volume", "configMap": {"name": TEST_VOLUME_CONFIGMAP_NAME}}],
+        },
+    ]
+
+
+def _base_helm_config(system_namespace, docker_image, enable_subchart=True):
     repository, tag = docker_image.split(":")
     pull_policy = image_pull_policy()
     return {
         "dagster-user-deployments": {
             "enabled": True,
-            "enableSubchart": True,
-            "deployments": [
-                {
-                    "name": "user-code-deployment-1",
-                    "image": {"repository": repository, "tag": tag, "pullPolicy": pull_policy},
-                    "dagsterApiGrpcArgs": [
-                        "-m",
-                        "dagster_test.test_project.test_pipelines.repo",
-                        "-a",
-                        "define_demo_execution_repo",
-                    ],
-                    "port": 3030,
-                    "includeConfigInLaunchedRuns": {
-                        "enabled": True,
-                    },
-                    "env": (
-                        {"BUILDKITE": os.getenv("BUILDKITE")} if os.getenv("BUILDKITE") else {}
-                    ),
-                    "envConfigMaps": (
-                        [{"name": TEST_AWS_CONFIGMAP_NAME}] if not IS_BUILDKITE else []
-                    ),
-                    "envSecrets": [{"name": TEST_DEPLOYMENT_SECRET_NAME}],
-                    "annotations": {"dagster-integration-tests": "ucd-1-pod-annotation"},
-                    "service": {
-                        "annotations": {"dagster-integration-tests": "ucd-1-svc-annotation"}
-                    },
-                    "volumeMounts": [
-                        {
-                            "name": "test-volume",
-                            "mountPath": "/opt/dagster/test_mount_path/volume_mounted_file.yaml",
-                            "subPath": "volume_mounted_file.yaml",
-                        }
-                    ],
-                    "volumes": [
-                        {"name": "test-volume", "configMap": {"name": TEST_VOLUME_CONFIGMAP_NAME}}
-                    ],
-                }
-            ],
+            "enableSubchart": enable_subchart,
+            "deployments": _deployment_config(docker_image),
         },
         "dagit": {
             "image": {"repository": repository, "tag": tag, "pullPolicy": pull_policy},
             "env": {"TEST_SET_ENV_VAR": "test_dagit_env_var"},
-            "envConfigMaps": [{"name": TEST_CONFIGMAP_NAME}],
-            "envSecrets": [{"name": TEST_SECRET_NAME}],
             "annotations": {"dagster-integration-tests": "dagit-pod-annotation"},
             "service": {"annotations": {"dagster-integration-tests": "dagit-svc-annotation"}},
         },
@@ -856,19 +996,16 @@ def _base_helm_config(docker_image):
             "dagit": {"host": "dagit.example.com"},
             "flower": {"flower": "flower.example.com"},
         },
-        "scheduler": {"type": "DagsterDaemonScheduler", "config": {}},
-        "serviceAccount": {"name": "dagit-admin"},
-        "postgresqlPassword": "test",
-        "postgresqlDatabase": "test",
-        "postgresqlUser": "test",
+        "postgresql": {
+            "createSecret": False,
+            "postgresqlHost": f"dagster-postgresql.{system_namespace}.svc.cluster.local",
+        },
         "dagsterDaemon": {
             "enabled": True,
             "image": {"repository": repository, "tag": tag, "pullPolicy": pull_policy},
             "heartbeatTolerance": 180,
             "runCoordinator": {"enabled": False},  # No run queue
             "env": ({"BUILDKITE": os.getenv("BUILDKITE")} if os.getenv("BUILDKITE") else {}),
-            "envConfigMaps": [{"name": TEST_CONFIGMAP_NAME}],
-            "envSecrets": [{"name": TEST_SECRET_NAME}],
             "annotations": {"dagster-integration-tests": "daemon-pod-annotation"},
             "runMonitoring": {
                 "enabled": True,
@@ -877,6 +1014,7 @@ def _base_helm_config(docker_image):
         },
         # Used to set the environment variables in dagster.shared_env that determine the run config
         "pipelineRun": {"image": {"repository": repository, "tag": tag, "pullPolicy": pull_policy}},
+        "imagePullSecrets": [{"name": TEST_IMAGE_PULL_SECRET_NAME}],
     }
 
 
@@ -890,7 +1028,7 @@ def helm_chart_for_daemon(namespace, docker_image, should_cleanup=True):
     pull_policy = image_pull_policy()
 
     helm_config = merge_dicts(
-        _base_helm_config(docker_image),
+        _base_helm_config(namespace, docker_image),
         {
             "dagsterDaemon": {
                 "enabled": True,
@@ -898,8 +1036,6 @@ def helm_chart_for_daemon(namespace, docker_image, should_cleanup=True):
                 "heartbeatTolerance": 180,
                 "runCoordinator": {"enabled": True},
                 "env": ({"BUILDKITE": os.getenv("BUILDKITE")} if os.getenv("BUILDKITE") else {}),
-                "envConfigMaps": [{"name": TEST_CONFIGMAP_NAME}],
-                "envSecrets": [{"name": TEST_SECRET_NAME}],
                 "annotations": {"dagster-integration-tests": "daemon-pod-annotation"},
             },
         },
@@ -923,8 +1059,10 @@ def dagit_url_for_daemon(helm_namespace_for_daemon):
 
 
 @pytest.fixture(scope="session")
-def dagit_url_for_k8s_run_launcher(helm_namespace_for_k8s_run_launcher):
-    with _port_forward_dagit(namespace=helm_namespace_for_k8s_run_launcher) as forwarded_dagit_url:
+def dagit_url_for_k8s_run_launcher(system_namespace_for_k8s_run_launcher):
+    with _port_forward_dagit(
+        namespace=system_namespace_for_k8s_run_launcher
+    ) as forwarded_dagit_url:
         yield forwarded_dagit_url
 
 

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
@@ -38,9 +38,9 @@ def which_(exe):
     return spawn.find_executable(exe)
 
 
-def get_test_namespace():
+def get_test_namespace(prefix="dagster-test"):
     namespace_suffix = hex(random.randint(0, 16**6))[2:]
-    return "dagster-test-%s" % namespace_suffix
+    return f"{prefix}-{namespace_suffix}"
 
 
 def within_docker():

--- a/integration_tests/test_suites/k8s-integration-test-suite/tests/test_integration.py
+++ b/integration_tests/test_suites/k8s-integration-test-suite/tests/test_integration.py
@@ -27,11 +27,11 @@ from dagster.utils.yaml_utils import merge_yamls
 @pytest.mark.integration
 def test_k8s_run_launcher_default(
     dagster_instance_for_k8s_run_launcher,
-    helm_namespace_for_k8s_run_launcher,
+    user_code_namespace_for_k8s_run_launcher,
     dagit_url_for_k8s_run_launcher,
 ):
     pods = DagsterKubernetesClient.production_client().core_api.list_namespaced_pod(
-        namespace=helm_namespace_for_k8s_run_launcher
+        namespace=user_code_namespace_for_k8s_run_launcher
     )
     celery_pod_names = [p.metadata.name for p in pods.items if "celery-workers" in p.metadata.name]
     check.invariant(not celery_pod_names)
@@ -44,7 +44,7 @@ def test_k8s_run_launcher_default(
     )
 
     result = wait_for_job_and_get_raw_logs(
-        job_name="dagster-run-%s" % run_id, namespace=helm_namespace_for_k8s_run_launcher
+        job_name="dagster-run-%s" % run_id, namespace=user_code_namespace_for_k8s_run_launcher
     )
 
     assert "PIPELINE_SUCCESS" in result, "no match, result: {}".format(result)
@@ -73,7 +73,7 @@ def get_celery_engine_config(dagster_docker_image, job_namespace):
 def test_k8s_run_launcher_with_celery_executor_fails(
     dagster_docker_image,
     dagster_instance_for_k8s_run_launcher,
-    helm_namespace_for_k8s_run_launcher,
+    user_code_namespace_for_k8s_run_launcher,
     dagit_url_for_k8s_run_launcher,
 ):
     run_config = merge_dicts(
@@ -85,7 +85,7 @@ def test_k8s_run_launcher_with_celery_executor_fails(
         ),
         get_celery_engine_config(
             dagster_docker_image=dagster_docker_image,
-            job_namespace=helm_namespace_for_k8s_run_launcher,
+            job_namespace=user_code_namespace_for_k8s_run_launcher,
         ),
     )
 
@@ -125,7 +125,7 @@ def test_k8s_run_launcher_with_celery_executor_fails(
 @pytest.mark.integration
 def test_failing_k8s_run_launcher(
     dagster_instance_for_k8s_run_launcher,
-    helm_namespace_for_k8s_run_launcher,
+    user_code_namespace_for_k8s_run_launcher,
     dagit_url_for_k8s_run_launcher,
 ):
     run_config = load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env.yaml"))
@@ -137,7 +137,7 @@ def test_failing_k8s_run_launcher(
     )
 
     result = wait_for_job_and_get_raw_logs(
-        job_name="dagster-run-%s" % run_id, namespace=helm_namespace_for_k8s_run_launcher
+        job_name="dagster-run-%s" % run_id, namespace=user_code_namespace_for_k8s_run_launcher
     )
 
     assert "PIPELINE_SUCCESS" not in result, "no match, result: {}".format(result)
@@ -150,7 +150,7 @@ def test_failing_k8s_run_launcher(
 @pytest.mark.integration
 def test_k8s_run_launcher_terminate(
     dagster_instance_for_k8s_run_launcher,
-    helm_namespace_for_k8s_run_launcher,
+    user_code_namespace_for_k8s_run_launcher,
     dagit_url_for_k8s_run_launcher,
 ):
     pipeline_name = "slow_pipeline"
@@ -163,7 +163,9 @@ def test_k8s_run_launcher_terminate(
         dagit_url_for_k8s_run_launcher, run_config=run_config, pipeline_name=pipeline_name
     )
 
-    wait_for_job(job_name="dagster-run-%s" % run_id, namespace=helm_namespace_for_k8s_run_launcher)
+    wait_for_job(
+        job_name="dagster-run-%s" % run_id, namespace=user_code_namespace_for_k8s_run_launcher
+    )
 
     timeout = datetime.timedelta(0, 30)
     start_time = datetime.datetime.now()
@@ -191,7 +193,7 @@ def test_k8s_run_launcher_terminate(
 
 @pytest.mark.integration
 def test_k8s_run_launcher_secret_from_deployment(
-    helm_namespace_for_k8s_run_launcher,
+    user_code_namespace_for_k8s_run_launcher,
     dagit_url_for_k8s_run_launcher,
 ):
     # This run_config requires that WORD_FACTOR be set on both the user code deployment
@@ -208,7 +210,7 @@ def test_k8s_run_launcher_secret_from_deployment(
     )
 
     result = wait_for_job_and_get_raw_logs(
-        job_name="dagster-run-%s" % run_id, namespace=helm_namespace_for_k8s_run_launcher
+        job_name="dagster-run-%s" % run_id, namespace=user_code_namespace_for_k8s_run_launcher
     )
 
     assert "PIPELINE_SUCCESS" in result, "no match, result: {}".format(result)

--- a/integration_tests/test_suites/k8s-integration-test-suite/tests/test_k8s_monitoring.py
+++ b/integration_tests/test_suites/k8s-integration-test-suite/tests/test_k8s_monitoring.py
@@ -20,7 +20,7 @@ def log_run_events(instance, run_id):
 @pytest.mark.integration
 def test_k8s_run_monitoring(
     dagster_instance_for_k8s_run_launcher,
-    helm_namespace_for_k8s_run_launcher,
+    user_code_namespace_for_k8s_run_launcher,
     dagit_url_for_k8s_run_launcher,
 ):
     run_config = merge_dicts(
@@ -29,7 +29,7 @@ def test_k8s_run_monitoring(
             "execution": {
                 "k8s": {
                     "config": {
-                        "job_namespace": helm_namespace_for_k8s_run_launcher,
+                        "job_namespace": user_code_namespace_for_k8s_run_launcher,
                         "image_pull_policy": image_pull_policy(),
                     }
                 }
@@ -40,7 +40,7 @@ def test_k8s_run_monitoring(
         dagit_url_for_k8s_run_launcher,
         run_config,
         dagster_instance_for_k8s_run_launcher,
-        helm_namespace_for_k8s_run_launcher,
+        user_code_namespace_for_k8s_run_launcher,
     )
 
 
@@ -51,6 +51,8 @@ def _launch_run_and_wait_for_resume(
     namespace,
     pipeline_name="slow_pipeline",
 ):
+
+    run_id = None
 
     try:
         run_id = launch_run_over_graphql(
@@ -75,4 +77,5 @@ def _launch_run_and_wait_for_resume(
         poll_for_finished_run(instance, run_id, timeout=120)
         assert instance.get_run_by_id(run_id).status == PipelineRunStatus.SUCCESS
     finally:
-        log_run_events(instance, run_id)
+        if run_id:
+            log_run_events(instance, run_id)

--- a/integration_tests/test_suites/k8s-integration-test-suite/tests/test_utils.py
+++ b/integration_tests/test_suites/k8s-integration-test-suite/tests/test_utils.py
@@ -35,6 +35,7 @@ def construct_job_manifest(name, cmd):
     )
 
 
+@pytest.mark.default
 def test_wait_for_pod(cluster_provider, namespace):  # pylint: disable=unused-argument
     api = kubernetes.client.CoreV1Api()
 
@@ -86,6 +87,7 @@ def test_wait_for_pod(cluster_provider, namespace):  # pylint: disable=unused-ar
                 pass
 
 
+@pytest.mark.default
 def test_wait_for_job(cluster_provider, namespace):  # pylint: disable=unused-argument
     # Without this sleep, we get the following error on kind:
     # HTTP response body:

--- a/integration_tests/test_suites/k8s-integration-test-suite/tox.ini
+++ b/integration_tests/test_suites/k8s-integration-test-suite/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}-{default},pylint
+envlist = py{39,38,37,36}-{unix,windows}-{default,subchart},pylint
 skipsdist = True
 
 [testenv]
@@ -29,7 +29,8 @@ commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
-  pytest -s -vv --junitxml=test_results.xml --cov=../../../python_modules/libraries/dagster-k8s --cov-append --cov-report= {posargs}
+  default: pytest --log-cli-level=INFO -m "default" --junitxml=test_results.xml --cov=../../../python_modules/libraries/dagster-k8s --cov-append --cov-report= {posargs}
+  subchart: pytest --log-cli-level=INFO -m "subchart" --junitxml=test_results.xml --cov=../../../python_modules/libraries/dagster-k8s --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'


### PR DESCRIPTION
Summary:
Added a test suite that runs the user code deployments in a separate namespace, and verifies that it can launch runs with includeConfigInLaunchedRuns on (which includes the namespace and service account in launched runs for that location).

Doing this in a way that worked out of the box required adding a way to let the service account launch jobs (similar to how the main helm chart can launch runs). It also exposed a few rough edges in our cross-namespace story, in that you need to be sure to include some additional configmaps in the user-deployments helm chart for things to work.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.