### PR TITLE
Asset key to node handle mapping

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -36,9 +36,10 @@ class AssetsDefinition:
         self._partition_mappings = partition_mappings or {}
 
         # if not specified assume all output assets depend on all input assets
-        all_asset_keys = output_names_by_asset_key.keys()
+        all_asset_keys = set(asset_keys_by_output_name.values())
         self._asset_deps = asset_deps or {
-            out_asset_key: set(input_names_by_asset_key.keys()) for out_asset_key in all_asset_keys
+            out_asset_key: set(asset_keys_by_input_name.values())
+            for out_asset_key in all_asset_keys
         }
         check.invariant(
             set(self._asset_deps.keys()) == all_asset_keys,

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -35,10 +35,18 @@ class AssetsDefinition:
         self._partitions_def = partitions_def
         self._partition_mappings = partition_mappings or {}
 
-        all_input_asset_keys = set(asset_keys_by_input_name.values())
+        # if not specified assume all output assets depend on all input assets
+        all_asset_keys = output_names_by_asset_key.keys()
         self._asset_deps = asset_deps or {
-            output_key: all_input_asset_keys for output_key in asset_keys_by_output_name.values()
+            out_asset_key: set(input_names_by_asset_key.keys()) for out_asset_key in all_asset_keys
         }
+        check.invariant(
+            set(self._asset_deps.keys()) == all_asset_keys,
+            "The set of asset keys with dependencies specified in the asset_deps argument must "
+            "equal the set of asset keys produced by this AssetsDefinition. \n"
+            f"asset_deps keys: {set(self._asset_deps.keys())} \n"
+            f"expected keys: {all_asset_keys}",
+        )
 
     def __call__(self, *args, **kwargs):
         return self._node_def(*args, **kwargs)

--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -85,26 +85,6 @@ def _resolve_input_to_destinations(
     return all_destinations
 
 
-def _map_node_handle_to_non_asset_node_handle_deps(mapping, node, non_asset_deps, parent_handle):
-    # within a graph, build mapping of node handle to all upstream node handles
-    curr_node_handle = NodeHandle(node.name, parent=parent_handle)
-    if curr_node_handle in mapping:
-        return mapping[curr_node_handle]
-
-    all_node_handle_deps = {NodeHandle(node.name, parent=parent_handle)}
-    for output_handle in non_asset_deps[node]:
-        curr_node = NodeHandle(output_handle.solid.name, parent=parent_handle)
-        all_node_handle_deps.add(curr_node)
-        all_node_handle_deps |= _map_node_handle_to_non_asset_node_handle_deps(
-            mapping,
-            output_handle.solid,
-            non_asset_deps,
-            parent_handle,
-        )
-    mapping[curr_node_handle] = all_node_handle_deps
-    return all_node_handle_deps
-
-
 def _build_graph_dependencies(
     graph_def: GraphDefinition,
     parent_handle: Union[NodeHandle, None],

--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -220,11 +220,11 @@ def _asset_key_to_dep_node_handles(
     that are upstream dependencies of the asset.
     """
     # A mapping of all node handles to all upstream node handles
-    # that are not assets. Each key is a node handle with tuple value (node_output_name, output_node)
+    # that are not assets. Each key is a node handle with node output handle value
     non_asset_inputs_by_node_handle: Dict[NodeHandle, Sequence[NodeOutputHandle]] = {}
 
     # A mapping of every graph node handle to a dictionary with each out
-    # name as a key and a tuple containing (op output name, op node handle) as the value
+    # name as a key and node output handle value
     outputs_by_graph_handle: Dict[NodeHandle, Dict[str, NodeOutputHandle]] = {}
     _build_graph_dependencies(
         graph_def=graph_def,

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -643,13 +643,12 @@ def test_all_assets_job():
         return 1
 
     @asset
-    def a2(a1):
+    def a2(a1):  # pylint: disable=unused-argument
         return 2
 
     job = build_assets_job("graph_asset_job", [a1, a2])
     node_handle_deps_by_asset = job.asset_layer.dependency_node_handles_by_asset_key
 
-    thing_handle = NodeHandle(name="thing", parent=None)
     assert node_handle_deps_by_asset[AssetKey("a1")] == {
         NodeHandle("a1", parent=None),
     }
@@ -669,7 +668,7 @@ def test_basic_graph():
     def thing():
         da = get_string()
         db = get_string()
-        o1, o2 = combine_strings_and_split(da, db)
+        o1, o2 = combine_strings_and_split(da, db)  # pylint: disable=unused-variable
         return o1
 
     @asset
@@ -758,7 +757,7 @@ def test_nested_graph():
     def thing():
         da = inside_thing()
         db = get_string()
-        o1, o2 = combine_strings_and_split(da, db)
+        o1, o2 = combine_strings_and_split(da, db)  # pylint: disable=unused-variable
         return o1
 
     thing_asset = AssetsDefinition(
@@ -851,7 +850,7 @@ def test_twice_nested_graph():
     def outer_thing(foo_asset):
         n1, output = middle_thing()
         n2 = transformer(output)
-        n3 = transformer(foo_asset)  # unused output
+        unused_output = transformer(foo_asset)  # pylint: disable=unused-variable
         return {"n1": n1, "n2": n2}
 
     @asset


### PR DESCRIPTION
This PR generates a mapping from asset key to the (non-asset) nodes required to run to generate the asset. This implementation works only for the new implementation of asset jobs, where asset definition information exists at the top level of the job, and not for the old implementation where asset keys exist on output definitions.

Example cases this PR handles:
- Every node in the job is an `@asset`:
    - Each asset key of each node is mapped to a set containing the node
- Graph contains ops in sequence and last op output is an asset
    - Returns map of asset key -> set containing all op node handles
- Graph contains 2 disconnected ops and each output is a different asset
    - Returns map of each asset key -> set containing the singular op that outputted the asset
- Graph has op `o1` that outputs asset `a1` and op `o2` that has input `o1` but no output
    - Returns map of `a1` to `o1`
- Nested case: graph `g1` with op `o1` is an input to outer graph `g2` that returns `o1` without mutating
    - Returns map of `o1` asset key -> set containing node handle of `o1`
- Internal asset deps
    - Job contains multi_asset `two_assets` with outputs `o1` and `o2`, where `o2` depends exclusively on `o1`
        - Returns map where assets for `o1` and `o2` are both mapped to `two_assets`
    - Job contains graph where op `o1` is an input to op `o2`, which outputs asset `a1` and `a2`. `a2` has defined `internal_asset_deps` to only `a1`
        - Returns `a1` mapped to `o1` and `o2`
        - Returns `a2` mapped to `o2`

Not independently mergeable until base branch has been merged.