### PR TITLE
[0.15.0] rm events_for_asset_key and get_asset_events

### DIFF
--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1383,50 +1383,6 @@ class DagsterInstance:
         return self._event_storage.get_asset_records(asset_keys)
 
     @traced
-    def events_for_asset_key(
-        self,
-        asset_key,
-        partitions=None,
-        before_cursor=None,
-        after_cursor=None,
-        cursor=None,
-        before_timestamp=None,
-        limit=None,
-        ascending=False,
-    ):
-        check.inst_param(asset_key, "asset_key", AssetKey)
-
-        warnings.warn(
-            """
-The method `events_for_asset_key` on DagsterInstance has been deprecated as of `0.12.0` in favor of
-the method `get_event_records`. The method `get_event_records` takes in an `EventRecordsFilter`
-argument that allows for filtering by asset key and asset key partitions. The return value is a
-list of `EventLogRecord` objects, each of which contains a storage_id and an event log entry.
-
-Example:
-records = instance.get_event_records(
-    EventRecordsFilter(
-        asset_key=asset_key,
-        asset_partitions=partitions,
-        after_cursor=after_cursor,
-    ),
-)
-"""
-        )
-
-        return self._event_storage.get_asset_events(
-            asset_key,
-            partitions,
-            before_cursor,
-            after_cursor,
-            limit,
-            before_timestamp=before_timestamp,
-            ascending=ascending,
-            include_cursor=True,
-            cursor=cursor,
-        )
-
-    @traced
     def run_ids_for_asset_key(self, asset_key):
         check.inst_param(asset_key, "asset_key", AssetKey)
         return self._event_storage.get_asset_run_ids(asset_key)

--- a/python_modules/dagster/dagster/core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/base.py
@@ -3,18 +3,7 @@ import warnings
 from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum
-from typing import (
-    Callable,
-    Iterable,
-    List,
-    Mapping,
-    NamedTuple,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import Callable, Iterable, List, Mapping, NamedTuple, Optional, Sequence, Set, Union
 
 import dagster._check as check
 from dagster.core.assets import AssetDetails
@@ -376,21 +365,6 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
         pass
 
     @abstractmethod
-    def get_asset_events(
-        self,
-        asset_key: AssetKey,
-        partitions: Optional[List[str]] = None,
-        before_cursor: Optional[int] = None,
-        after_cursor: Optional[int] = None,
-        limit: Optional[int] = None,
-        ascending: bool = False,
-        include_cursor: bool = False,
-        before_timestamp=None,
-        cursor: Optional[int] = None,  # deprecated
-    ) -> Union[Iterable[EventLogEntry], Iterable[Tuple[int, EventLogEntry]]]:
-        pass
-
-    @abstractmethod
     def get_asset_run_ids(self, asset_key: AssetKey) -> Iterable[str]:
         pass
 
@@ -406,28 +380,3 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
 
     def alembic_version(self):
         return None
-
-
-def extract_asset_events_cursor(cursor, before_cursor, after_cursor, ascending):
-    if cursor:
-        warnings.warn(
-            "Parameter `cursor` is a deprecated for `get_asset_events`. Use `before_cursor` or `after_cursor` instead"
-        )
-        if ascending and after_cursor is None:
-            after_cursor = cursor
-        if not ascending and before_cursor is None:
-            before_cursor = cursor
-
-    if after_cursor is not None:
-        try:
-            after_cursor = int(after_cursor)
-        except ValueError:
-            after_cursor = None
-
-    if before_cursor is not None:
-        try:
-            before_cursor = int(before_cursor)
-        except ValueError:
-            before_cursor = None
-
-    return before_cursor, after_cursor

--- a/python_modules/dagster/dagster/core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/in_memory.py
@@ -21,7 +21,6 @@ from .base import (
     EventLogStorage,
     EventRecordsFilter,
     RunShardedEventsCursor,
-    extract_asset_events_cursor,
 )
 
 
@@ -358,38 +357,6 @@ class InMemoryEventLogStorage(EventLogStorage, ConfigurableClass):
                 materializations_by_key[record.dagster_event.asset_key] = record
 
         return materializations_by_key
-
-    def get_asset_events(
-        self,
-        asset_key,
-        partitions=None,
-        before_cursor=None,
-        after_cursor=None,
-        limit=None,
-        ascending=False,
-        include_cursor=False,
-        before_timestamp=None,
-        cursor=None,
-    ):
-        before_cursor, after_cursor = extract_asset_events_cursor(
-            cursor, before_cursor, after_cursor, ascending
-        )
-        event_records = self.get_event_records(
-            EventRecordsFilter(
-                event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                asset_key=asset_key,
-                asset_partitions=partitions,
-                before_cursor=before_cursor,
-                after_cursor=after_cursor,
-                before_timestamp=before_timestamp,
-            ),
-            limit=limit,
-            ascending=ascending,
-        )
-        if include_cursor:
-            return [tuple([record.storage_id, record.event_log_entry]) for record in event_records]
-        else:
-            return [record.event_log_entry for record in event_records]
 
     def get_asset_run_ids(self, asset_key):
         asset_run_ids = set()

--- a/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
@@ -34,7 +34,6 @@ from .base import (
     EventLogStorage,
     EventRecordsFilter,
     RunShardedEventsCursor,
-    extract_asset_events_cursor,
 )
 from .migration import ASSET_DATA_MIGRATIONS, ASSET_KEY_INDEX_COLS, EVENT_LOG_DATA_MIGRATIONS
 from .schema import AssetKeyTable, SecondaryIndexMigrationTable, SqlEventLogStorageTable
@@ -1084,40 +1083,6 @@ class SqlEventLogStorage(EventLogStorage):
                 )
 
         return query
-
-    def get_asset_events(
-        self,
-        asset_key,
-        partitions=None,
-        before_cursor=None,
-        after_cursor=None,
-        limit=None,
-        ascending=False,
-        include_cursor=False,  # deprecated
-        before_timestamp=None,
-        cursor=None,  # deprecated
-    ):
-        check.inst_param(asset_key, "asset_key", AssetKey)
-        check.opt_list_param(partitions, "partitions", of_type=str)
-        before_cursor, after_cursor = extract_asset_events_cursor(
-            cursor, before_cursor, after_cursor, ascending
-        )
-        event_records = self.get_event_records(
-            EventRecordsFilter(
-                event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                asset_key=asset_key,
-                asset_partitions=partitions,
-                before_cursor=before_cursor,
-                after_cursor=after_cursor,
-                before_timestamp=before_timestamp,
-            ),
-            limit=limit,
-            ascending=ascending,
-        )
-        if include_cursor:
-            return [tuple([record.storage_id, record.event_log_entry]) for record in event_records]
-        else:
-            return [record.event_log_entry for record in event_records]
 
     def get_asset_run_ids(self, asset_key):
         check.inst_param(asset_key, "asset_key", AssetKey)

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -893,13 +893,6 @@ class TestEventLogStorage:
                 storage.store_event(event)
 
             assert asset_key in set(storage.all_asset_keys())
-            events = storage.get_asset_events(asset_key)
-            assert len(events) == 1
-            event = events[0]
-            assert isinstance(event, EventLogEntry)
-            assert (
-                event.dagster_event.event_type_value == DagsterEventType.ASSET_MATERIALIZATION.value
-            )
 
             records = storage.get_event_records(
                 EventRecordsFilter(
@@ -909,7 +902,7 @@ class TestEventLogStorage:
             assert len(records) == 1
             record = records[0]
             assert isinstance(record, EventLogRecord)
-            assert record.event_log_entry == event
+            assert record.event_log_entry.dagster_event.asset_key == asset_key
 
     def test_asset_events_error_parsing(self, storage):
         if not isinstance(storage, SqlEventLogStorage):
@@ -932,7 +925,7 @@ class TestEventLogStorage:
         with instance_for_test() as instance:
             if not storage._instance:  # pylint: disable=protected-access
                 storage.register_instance(instance)
-            events_one, _ = _synthesize_events(_solids)
+            events_one, _ = _synthesize_events(_solids, instance=instance)
             for event in events_one:
                 storage.store_event(event)
 
@@ -959,8 +952,7 @@ class TestEventLogStorage:
                 )
 
                 assert asset_key in set(storage.all_asset_keys())
-                events = storage.get_asset_events(asset_key)
-                assert len(events) == 0
+                _records = storage.get_event_records(EventRecordsFilter(asset_key=asset_key))
                 assert len(_logs) == 1
                 assert re.match("Could not resolve event record as EventLogEntry", _logs[0])
 
@@ -988,8 +980,7 @@ class TestEventLogStorage:
                     )
                 )
                 assert asset_key in set(storage.all_asset_keys())
-                events = storage.get_asset_events(asset_key)
-                assert len(events) == 0
+                _records = storage.get_event_records(EventRecordsFilter(asset_key=asset_key))
                 assert len(_logs) == 1
                 assert re.match("Could not parse event record id", _logs[0])
 
@@ -1575,111 +1566,6 @@ class TestEventLogStorage:
                 assert storage.has_asset_key(AssetKey(["path", "to", "asset_3"]))
                 assert not storage.has_asset_key(AssetKey(["path", "to", "bogus", "asset"]))
 
-    def test_asset_events(self, storage, instance):
-        with instance_for_test() as created_instance:
-            if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(created_instance)
-
-            events_one, result_1 = _synthesize_events(
-                lambda: one_asset_solid(), instance=created_instance
-            )
-            events_two, result_2 = _synthesize_events(
-                lambda: two_asset_solids(), instance=created_instance
-            )
-
-            with create_and_delete_test_runs(instance, [result_1.run_id, result_2.run_id]):
-
-                for event in events_one + events_two:
-                    storage.store_event(event)
-
-                asset_events = storage.get_asset_events(AssetKey("asset_1"))
-                assert len(asset_events) == 2
-                for event in asset_events:
-                    assert isinstance(event, EventLogEntry)
-                    assert event.is_dagster_event
-                    assert event.dagster_event.event_type == DagsterEventType.ASSET_MATERIALIZATION
-                    assert event.dagster_event.asset_key
-
-                asset_events = storage.get_asset_events(AssetKey(["path", "to", "asset_3"]))
-                assert len(asset_events) == 1
-
-    def test_asset_events_range(self, storage, instance):
-        with instance_for_test() as created_instance:
-            if not storage._instance:  # pylint: disable=protected-access
-                storage.register_instance(created_instance)
-
-            events_one, result_1 = _synthesize_events(
-                lambda: one_asset_solid(), instance=created_instance
-            )
-            two_asset_solids_first, result_2 = _synthesize_events(
-                lambda: two_asset_solids(), instance=created_instance
-            )
-            two_asset_solids_second, result_3 = _synthesize_events(
-                lambda: two_asset_solids(), instance=created_instance
-            )
-
-            with create_and_delete_test_runs(
-                instance, [result_1.run_id, result_2.run_id, result_3.run_id]
-            ):
-
-                for event in events_one + two_asset_solids_first + two_asset_solids_second:
-                    storage.store_event(event)
-
-                # descending
-                asset_events = storage.get_asset_events(AssetKey("asset_1"), include_cursor=True)
-                assert len(asset_events) == 3
-                [id_three, id_two, id_one] = [id for id, event in asset_events]
-
-                after_events = storage.get_asset_events(
-                    AssetKey("asset_1"), include_cursor=True, after_cursor=id_one
-                )
-                assert len(after_events) == 2
-                assert [id for id, event in after_events] == [id_three, id_two]
-
-                before_events = storage.get_asset_events(
-                    AssetKey("asset_1"), include_cursor=True, before_cursor=id_three
-                )
-                assert len(before_events) == 2
-                assert [id for id, event in before_events] == [id_two, id_one]
-
-                between_events = storage.get_asset_events(
-                    AssetKey("asset_1"),
-                    include_cursor=True,
-                    before_cursor=id_three,
-                    after_cursor=id_one,
-                )
-                assert len(between_events) == 1
-                assert [id for id, event in between_events] == [id_two]
-
-                # ascending
-                asset_events = storage.get_asset_events(
-                    AssetKey("asset_1"), include_cursor=True, ascending=True
-                )
-                assert len(asset_events) == 3
-                [id_one, id_two, id_three] = [id for id, event in asset_events]
-
-                after_events = storage.get_asset_events(
-                    AssetKey("asset_1"), include_cursor=True, after_cursor=id_one, ascending=True
-                )
-                assert len(after_events) == 2
-                assert [id for id, event in after_events] == [id_two, id_three]
-
-                before_events = storage.get_asset_events(
-                    AssetKey("asset_1"), include_cursor=True, before_cursor=id_three, ascending=True
-                )
-                assert len(before_events) == 2
-                assert [id for id, event in before_events] == [id_one, id_two]
-
-                between_events = storage.get_asset_events(
-                    AssetKey("asset_1"),
-                    include_cursor=True,
-                    before_cursor=id_three,
-                    after_cursor=id_one,
-                    ascending=True,
-                )
-                assert len(between_events) == 1
-                assert [id for id, event in between_events] == [id_two]
-
     def test_asset_run_ids(self, storage, instance):
         with instance_for_test() as created_instance:
             if not storage._instance:  # pylint: disable=protected-access
@@ -1745,8 +1631,6 @@ class TestEventLogStorage:
                 asset_keys = storage.all_asset_keys()
                 assert len(asset_keys) == 3
                 assert storage.has_asset_key(AssetKey("asset_1"))
-                asset_events = storage.get_asset_events(AssetKey("asset_1"))
-                assert len(asset_events) == 2
                 asset_run_ids = storage.get_asset_run_ids(AssetKey("asset_1"))
                 assert set(asset_run_ids) == set([one_run_id, two_run_id])
 
@@ -1758,8 +1642,6 @@ class TestEventLogStorage:
                     asset_keys = storage.all_asset_keys()
                     assert len(asset_keys) == 0
                     assert not storage.has_asset_key(AssetKey("asset_1"))
-                    asset_events = storage.get_asset_events(AssetKey("asset_1"))
-                    assert len(asset_events) == 0
                     asset_run_ids = storage.get_asset_run_ids(AssetKey("asset_1"))
                     assert set(asset_run_ids) == set()
                     assert log_count == len(storage.get_logs_for_run(one_run_id))
@@ -1775,8 +1657,6 @@ class TestEventLogStorage:
                         asset_keys = storage.all_asset_keys()
                         assert len(asset_keys) == 1
                         assert storage.has_asset_key(AssetKey("asset_1"))
-                        asset_events = storage.get_asset_events(AssetKey("asset_1"))
-                        assert len(asset_events) == 1
                         asset_run_ids = storage.get_asset_run_ids(AssetKey("asset_1"))
                         assert set(asset_run_ids) == set([one_run_id])
 
@@ -1850,13 +1730,18 @@ class TestEventLogStorage:
                     for event in run_events:
                         storage.store_event(event)
 
-                events = storage.get_asset_events(AssetKey("asset_key"))
-                assert len(events) == 4
-
-                events = storage.get_asset_events(
-                    AssetKey("asset_key"), partitions=["partition_a", "partition_b"]
+                records = storage.get_event_records(
+                    EventRecordsFilter(asset_key=AssetKey("asset_key"))
                 )
-                assert len(events) == 3
+                assert len(records) == 4
+
+                records = storage.get_event_records(
+                    EventRecordsFilter(
+                        asset_key=AssetKey("asset_key"),
+                        asset_partitions=["partition_a", "partition_b"],
+                    )
+                )
+                assert len(records) == 3
 
     def test_get_asset_keys(self, storage, test_run_id):
         @op


### PR DESCRIPTION
may need to wait for 0.15.0 branch cut for this, but this has been deprecated since 0.12.0 so should be safe to remove

## Test Plan

updated existing tests