### PR TITLE
[tests] set platform on docker build

### DIFF
--- a/python_modules/dagster-test/dagster_test/test_project/build.sh
+++ b/python_modules/dagster-test/dagster_test/test_project/build.sh
@@ -66,7 +66,9 @@ echo -e "--- \033[32m:docker: Building Docker image\033[0m"
 PYTHON_SLIM_IMAGE="python:${PYTHON_VERSION}-slim"
 BASE_IMAGE=${BASE_IMAGE:=$PYTHON_SLIM_IMAGE}
 
+# set platform explicitly since at this time some dagster deps dont work in arm (M1 macbook)
 docker build . \
     --build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
     --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+    --platform linux/amd64 \
     -t "${IMAGE_TAG}"


### PR DESCRIPTION
M1 support for tests that use this script 

## Test Plan
after ensuring image is removed:
`pytest python_modules/libraries/dagster-docker/dagster_docker_tests/test_docker_executor.py::test_docker_executor`
