### PR TITLE
[dagster-aws] update emr pyspark step launcher

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/emr_step_main.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/emr_step_main.py
@@ -9,8 +9,13 @@ from threading import Thread
 import boto3
 from dagster_aws.s3.file_manager import S3FileHandle, S3FileManager
 
-from dagster.core.execution.plan.external_step import PICKLED_EVENTS_FILE_NAME, run_step_from_ref
+from dagster.core.execution.plan.external_step import (
+    PICKLED_EVENTS_FILE_NAME,
+    external_instance_from_step_run_ref,
+    run_step_from_ref,
+)
 from dagster.core.instance import DagsterInstance
+from dagster.serdes import serialize_value
 
 DONE = object()
 
@@ -27,7 +32,7 @@ def main(step_run_ref_bucket, s3_dir_key):
     events_s3_key = os.path.dirname(s3_dir_key) + "/" + PICKLED_EVENTS_FILE_NAME
 
     def put_events(events):
-        file_obj = io.BytesIO(pickle.dumps(events))
+        file_obj = io.BytesIO(pickle.dumps(serialize_value(events)))
         session.put_object(Body=file_obj, Bucket=events_bucket, Key=events_s3_key)
 
     # Set up a thread to handle writing events back to the plan process, so execution doesn't get
@@ -39,13 +44,15 @@ def main(step_run_ref_bucket, s3_dir_key):
     )
     event_writing_thread.start()
 
-    with DagsterInstance.ephemeral() as instance:
-        try:
-            for event in run_step_from_ref(step_run_ref, instance):
-                events_queue.put(event)
-        finally:
-            events_queue.put(DONE)
-            event_writing_thread.join()
+    try:
+        instance = external_instance_from_step_run_ref(
+            step_run_ref, event_listener_fn=events_queue.put
+        )
+        # consume iterator
+        list(run_step_from_ref(step_run_ref, instance))
+    finally:
+        events_queue.put(DONE)
+        event_writing_thread.join()
 
 
 def event_writing_loop(events_queue, put_events_fn):

--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/emr_step_main.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/emr_step_main.py
@@ -14,7 +14,6 @@ from dagster.core.execution.plan.external_step import (
     external_instance_from_step_run_ref,
     run_step_from_ref,
 )
-from dagster.core.instance import DagsterInstance
 from dagster.serdes import serialize_value
 
 DONE = object()

--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
@@ -13,7 +13,6 @@ from dagster_aws.utils.mrjob.log4j import parse_hadoop_log4j_records
 from dagster import Field, StringSource, check, resource
 from dagster.core.definitions.step_launcher import StepLauncher
 from dagster.core.errors import DagsterInvariantViolationError, raise_execution_interrupts
-from dagster.core.events import log_step_event
 from dagster.core.execution.plan.external_step import (
     PICKLED_EVENTS_FILE_NAME,
     PICKLED_STEP_RUN_REF_FILE_NAME,

--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
@@ -19,6 +19,7 @@ from dagster.core.execution.plan.external_step import (
     PICKLED_STEP_RUN_REF_FILE_NAME,
     step_context_to_step_run_ref,
 )
+from dagster.serdes import deserialize_value
 
 # On EMR, Spark is installed here
 EMR_SPARK_HOME = "/usr/lib/spark/"
@@ -307,25 +308,24 @@ class EmrPySparkStepLauncher(StepLauncher):
             0
         ]
 
-        yield from self.wait_for_completion_and_log(
-            log, run_id, step_key, emr_step_id, step_context
-        )
+        yield from self.wait_for_completion_and_log(run_id, step_key, emr_step_id, step_context)
 
-    def wait_for_completion_and_log(self, log, run_id, step_key, emr_step_id, step_context):
+    def wait_for_completion_and_log(self, run_id, step_key, emr_step_id, step_context):
         s3 = boto3.resource("s3", region_name=self.region_name)
         try:
-            for event in self.wait_for_completion(log, s3, run_id, step_key, emr_step_id):
-                log_step_event(step_context, event)
+            for event in self.wait_for_completion(step_context, s3, run_id, step_key, emr_step_id):
                 yield event
         except EmrError as emr_error:
             if self.wait_for_logs:
-                self._log_logs_from_s3(log, emr_step_id)
+                self._log_logs_from_s3(step_context.log, emr_step_id)
             raise emr_error
 
         if self.wait_for_logs:
-            self._log_logs_from_s3(log, emr_step_id)
+            self._log_logs_from_s3(step_context.log, emr_step_id)
 
-    def wait_for_completion(self, log, s3, run_id, step_key, emr_step_id, check_interval=15):
+    def wait_for_completion(
+        self, step_context, s3, run_id, step_key, emr_step_id, check_interval=15
+    ):
         """We want to wait for the EMR steps to complete, and while that's happening, we want to
         yield any events that have been written to S3 for us by the remote process.
         After the the EMR steps complete, we want a final chance to fetch events before finishing
@@ -339,13 +339,19 @@ class EmrPySparkStepLauncher(StepLauncher):
         while not done:
             with raise_execution_interrupts():
                 time.sleep(check_interval)  # AWS rate-limits us if we poll it too often
-                done = self.emr_job_runner.is_emr_step_complete(log, self.cluster_id, emr_step_id)
+                done = self.emr_job_runner.is_emr_step_complete(
+                    step_context.log, self.cluster_id, emr_step_id
+                )
 
                 all_events_new = self.read_events(s3, run_id, step_key)
 
             if len(all_events_new) > len(all_events):
                 for i in range(len(all_events), len(all_events_new)):
-                    yield all_events_new[i]
+                    event = all_events_new[i]
+                    # write each event from the EMR instance to the local instance
+                    step_context.instance.handle_new_event(event)
+                    if event.is_dagster_event:
+                        yield event.dagster_event
                 all_events = all_events_new
 
     def read_events(self, s3, run_id, step_key):
@@ -355,7 +361,7 @@ class EmrPySparkStepLauncher(StepLauncher):
 
         try:
             events_data = events_s3_obj.get()["Body"].read()
-            return pickle.loads(events_data)
+            return deserialize_value(pickle.loads(events_data))
         except ClientError as ex:
             # The file might not be there yet, which is fine
             if ex.response["Error"]["Code"] == "NoSuchKey":
@@ -434,9 +440,20 @@ class EmrPySparkStepLauncher(StepLauncher):
     def _main_file_local_path(self):
         return emr_step_main.__file__
 
+    def _sanitize_step_key(self, step_key: str) -> str:
+        # step_keys of dynamic steps contain brackets, which are invalid characters
+        return step_key.replace("[", "__").replace("]", "__")
+
     def _artifact_s3_uri(self, run_id, step_key, filename):
-        key = self._artifact_s3_key(run_id, step_key, filename)
+        key = self._artifact_s3_key(run_id, self._sanitize_step_key(step_key), filename)
         return "s3://{bucket}/{key}".format(bucket=self.staging_bucket, key=key)
 
     def _artifact_s3_key(self, run_id, step_key, filename):
-        return "/".join([self.staging_prefix, run_id, step_key, os.path.basename(filename)])
+        return "/".join(
+            [
+                self.staging_prefix,
+                run_id,
+                self._sanitize_step_key(step_key),
+                os.path.basename(filename),
+            ]
+        )

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/emr_tests/test_pyspark.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/emr_tests/test_pyspark.py
@@ -12,9 +12,18 @@ from moto import mock_emr
 from pyspark.sql import Row
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
-from dagster import IOManager, execute_pipeline, graph, io_manager, op, reconstructable
+from dagster import (
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    execute_pipeline,
+    pipeline,
+    reconstructable,
+    solid,
+)
 from dagster.core.definitions.no_step_launcher import no_step_launcher
 from dagster.core.errors import DagsterSubprocessError
+from dagster.core.test_utils import instance_for_test
 from dagster.utils.merger import deep_merge_dicts
 from dagster.utils.test import create_test_pipeline_execution_context
 
@@ -30,103 +39,73 @@ BASE_EMR_PYSPARK_STEP_LAUNCHER_CONFIG = {
 }
 
 
-@io_manager(required_resource_keys={"pyspark"})
-def s3_io_manager(_):
-    class S3ParquetIOManager(IOManager):
-        def _get_path(self, context):
-            return f"s3a://{S3_BUCKET}/{context.run_id}_{context.step_key}_{context.name}"
-
-        def handle_output(self, context, obj):
-            # handle ints as well as dataframes (lol)
-            if isinstance(obj, int):
-                obj = context.resources.pyspark.spark_session.createDataFrame([[obj]], ["val"])
-            obj.write.parquet(self._get_path(context), mode="overwrite")
-
-        def load_input(self, context):
-            df = context.resources.pyspark.spark_session.read.parquet(
-                self._get_path(context.upstream_output)
-            )
-            if context.upstream_output.dagster_type != DataFrame:
-                return df.head()[0]
-            return df
-
-    return S3ParquetIOManager()
-
-
-@op(required_resource_keys={"pyspark_step_launcher", "pyspark"})
-def make_df_solid(context) -> DataFrame:
+@solid(
+    output_defs=[OutputDefinition(DataFrame)],
+    required_resource_keys={"pyspark_step_launcher", "pyspark"},
+)
+def make_df_solid(context):
     schema = StructType([StructField("name", StringType()), StructField("age", IntegerType())])
     rows = [Row(name="John", age=19), Row(name="Jennifer", age=29), Row(name="Henry", age=50)]
-    context.log.info("hello there!")
     return context.resources.pyspark.spark_session.createDataFrame(rows, schema)
 
 
-@op(
+@solid(
     name="blah",
     description="this is a test",
     config_schema={"foo": str, "bar": int},
+    input_defs=[InputDefinition("people", DataFrame)],
+    output_defs=[OutputDefinition(DataFrame)],
     required_resource_keys={"pyspark_step_launcher"},
 )
-def filter_df_solid(context, people: DataFrame) -> DataFrame:
-    context.log.info("im here!")
+def filter_df_solid(_, people):
     return people.filter(people["age"] < 30)
 
 
-RESOURCES_PROD = {
-    "pyspark_step_launcher": emr_pyspark_step_launcher,
-    "pyspark": pyspark_resource,
-    "s3": s3_resource,
-    "io_manager": s3_io_manager,
-}
+MODE_DEFS = [
+    ModeDefinition(
+        "prod",
+        resource_defs={
+            "pyspark_step_launcher": emr_pyspark_step_launcher,
+            "pyspark": pyspark_resource,
+            "s3": s3_resource,
+        },
+    ),
+    ModeDefinition(
+        "local",
+        resource_defs={"pyspark_step_launcher": no_step_launcher, "pyspark": pyspark_resource},
+    ),
+]
 
-RESOURCES_LOCAL = {"pyspark_step_launcher": no_step_launcher, "pyspark": pyspark_resource}
 
-
-@graph
+@pipeline(mode_defs=MODE_DEFS)
 def pyspark_pipe():
     filter_df_solid(make_df_solid())
 
 
-def define_pyspark_pipe_local():
-    return pyspark_pipe.to_job(name="ppl", resource_defs=RESOURCES_LOCAL)
+def define_pyspark_pipe():
+    return pyspark_pipe
 
 
-def define_pyspark_pipe_prod():
-    return pyspark_pipe.to_job(
-        name="ppp",
-        resource_defs=RESOURCES_PROD,
-        config={
-            "ops": {"blah": {"config": {"foo": "a string", "bar": 123}}},
-            "resources": {
-                "pyspark_step_launcher": {"config": BASE_EMR_PYSPARK_STEP_LAUNCHER_CONFIG},
-            },
-        },
-    )
-
-
-@op(required_resource_keys={"pyspark_step_launcher", "pyspark"})
+@solid(
+    required_resource_keys={"pyspark_step_launcher", "pyspark"},
+)
 def do_nothing_solid(_):
     pass
 
 
-@graph
+@pipeline(mode_defs=MODE_DEFS)
 def do_nothing_pipe():
     do_nothing_solid()
 
 
-def define_do_nothing_pipe_local():
-    return do_nothing_pipe.to_job(resource_defs=RESOURCES_LOCAL)
-
-
-def define_do_nothing_pipe_prod():
-    return do_nothing_pipe.to_job(
-        resource_defs=RESOURCES_PROD,
-    )
+def define_do_nothing_pipe():
+    return do_nothing_pipe
 
 
 def test_local():
     result = execute_pipeline(
-        pipeline=reconstructable(define_pyspark_pipe_local),
+        pipeline=pyspark_pipe,
+        mode="local",
         run_config={"solids": {"blah": {"config": {"foo": "a string", "bar": 123}}}},
     )
     assert result.success
@@ -136,9 +115,11 @@ def test_local():
 @mock.patch("dagster_aws.emr.pyspark_step_launcher.EmrPySparkStepLauncher.read_events")
 @mock.patch("dagster_aws.emr.emr.EmrJobRunner.is_emr_step_complete")
 def test_pyspark_emr(mock_is_emr_step_complete, mock_read_events, mock_s3_bucket):
-    mock_read_events.return_value = execute_pipeline(
-        reconstructable(define_do_nothing_pipe_local)
-    ).events_by_step_key["do_nothing_solid"]
+    with instance_for_test() as instance:
+        execute_pipeline(reconstructable(define_do_nothing_pipe), mode="local", instance=instance)
+        mock_read_events.return_value = [
+            record.event_log_entry for record in instance.get_event_records()
+        ]
 
     run_job_flow_args = dict(
         Instances={
@@ -162,7 +143,7 @@ def test_pyspark_emr(mock_is_emr_step_complete, mock_read_events, mock_s3_bucket
     cluster_id = job_runner.run_job_flow(context.log, run_job_flow_args)
 
     result = execute_pipeline(
-        pipeline=reconstructable(define_do_nothing_pipe_prod),
+        pipeline=reconstructable(define_do_nothing_pipe),
         mode="prod",
         run_config={
             "resources": {
@@ -185,13 +166,9 @@ def sync_code():
         "rsync",
         "-av",
         "-progress",
-        "--inplace",
         "--exclude='js_modules/'",
         "--exclude='.git/'",
         "--exclude='docs/'",
-        "--exclude='examples/'",
-        "--exclude='*.pyc'",
-        "--exclude='*/.tox/*'",
         "-e",
         '"ssh -i {aws_emr_pem_file}"'.format(aws_emr_pem_file=os.environ["AWS_EMR_PEM_FILE"]),
         os.environ["DAGSTER_DIR"],
@@ -208,7 +185,7 @@ def sync_code():
     # Install dagster packages on remote node
     remote_install_dagster_packages_command = ["sudo", "python3", "-m", "pip", "install"] + [
         token
-        for package_subpath in ["dagster", "libraries/dagster-pyspark", "libraries/dagster-aws"]
+        for package_subpath in ["dagster", "libraries/dagster-pyspark"]
         for token in ["-e", "/home/hadoop/dagster/python_modules/" + package_subpath]
     ]
 
@@ -238,11 +215,15 @@ def sync_code():
 def test_do_it_live_emr():
     sync_code()
 
-    del os.environ["AWS_ACCESS_KEY_ID"]
-    del os.environ["AWS_SECRET_ACCESS_KEY"]
     result = execute_pipeline(
-        reconstructable(define_pyspark_pipe_prod),
+        reconstructable(define_pyspark_pipe),
         mode="prod",
+        run_config={
+            "solids": {"blah": {"config": {"foo": "a string", "bar": 123}}},
+            "resources": {
+                "pyspark_step_launcher": {"config": BASE_EMR_PYSPARK_STEP_LAUNCHER_CONFIG},
+            },
+        },
     )
     assert result.success
 
@@ -254,7 +235,9 @@ def test_do_it_live_emr():
 def test_fetch_logs_on_fail(
     _mock_log_step_event, mock_log_logs, mock_wait_for_completion, _mock_boto3_resource
 ):
-    mock_context = mock.MagicMock()
+    mock_log = mock.MagicMock()
+    mock_step_context = mock.MagicMock()
+    mock_step_context.log = mock_log
     mock_wait_for_completion.side_effect = EmrError()
 
     step_launcher = EmrPySparkStepLauncher(
@@ -270,7 +253,7 @@ def test_fetch_logs_on_fail(
     )
 
     with pytest.raises(EmrError):
-        for _ in step_launcher.wait_for_completion_and_log(mock_context, None, None, None, None):
+        for _ in step_launcher.wait_for_completion_and_log(None, None, None, mock_step_context):
             pass
 
     assert mock_log_logs.call_count == 1


### PR DESCRIPTION
This allows the emr_pyspark_step_launcher to take advantage of all the fancy new improvements that the databricks_pyspark_step_launcher has. Basically:

- retry from failure now works
- context.log.info() calls (and similar) will be reflected in the event log
- events in the event log will have timestamps accurate to when the event was created, not when the event was read from the remote cluster
- dynamic orchestration will now work properly
- retry policies will work properly
- exceptions that happen during execution will show up in the event log (rather than just a generic "this emr step failed" message)

