### PR TITLE
[dagit] Add "shared key path" outlines, experimental asset graph flag

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Flags.tsx
+++ b/js_modules/dagit/packages/core/src/app/Flags.tsx
@@ -6,6 +6,7 @@ import {getJSONForKey} from '../hooks/useStateWithStorage';
 const DAGIT_FLAGS_KEY = 'DAGIT_FLAGS';
 
 export enum FeatureFlag {
+  flagExperimentalAssetDAG = 'flagExperimentalAssetDAG',
   flagDebugConsoleLogging = 'flagDebugConsoleLogging',
   flagAlwaysCollapseNavigation = 'flagAlwaysCollapseNavigation',
   flagDisableWebsockets = 'flagDisableWebsockets',

--- a/js_modules/dagit/packages/core/src/app/SettingsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/SettingsRoot.tsx
@@ -121,6 +121,16 @@ const SettingsRoot = () => {
                 />
               ),
             },
+            {
+              key: 'Experimental asset graph display',
+              value: (
+                <Checkbox
+                  format="switch"
+                  checked={flags.includes(FeatureFlag.flagExperimentalAssetDAG)}
+                  onChange={() => toggleFlag(FeatureFlag.flagExperimentalAssetDAG)}
+                />
+              ),
+            },
           ]}
         />
       </Box>

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetEdges.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetEdges.tsx
@@ -15,7 +15,7 @@ export const AssetEdges: React.FC<{edges: AssetLayoutEdge[]; extradark: boolean}
           refX="1"
           refY="5"
           markerUnits="strokeWidth"
-          markerWidth={extradark ? '10' : '4'}
+          markerWidth={extradark ? '6' : '4'}
           orient="auto"
         >
           <path d="M 0 0 L 8 5 L 0 10 z" fill={extradark ? Colors.Gray400 : Colors.KeylineGray} />
@@ -50,7 +50,7 @@ const StyledPath = styled('path')<{dashed: boolean}>`
 `;
 
 const ExtraDarkStyledPath = styled('path')<{dashed: boolean}>`
-  stroke-width: 20;
+  stroke-width: 8;
   stroke: ${Colors.Gray400};
   ${({dashed}) => (dashed ? `stroke-dasharray: 8 2;` : '')}
   fill: none;

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetEdges.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetEdges.tsx
@@ -1,57 +1,38 @@
-import {Colors} from '@dagster-io/ui';
 import React from 'react';
 import styled from 'styled-components/macro';
 
 import {buildSVGPath} from './Utils';
 import {AssetLayoutEdge} from './layout';
 
-export const AssetEdges: React.FC<{edges: AssetLayoutEdge[]; extradark: boolean}> = React.memo(
-  ({edges, extradark}) => (
+export const AssetEdges: React.FC<{edges: AssetLayoutEdge[]; color: string}> = React.memo(
+  ({edges, color}) => (
     <>
       <defs>
         <marker
-          id="arrow"
+          id={`arrow${btoa(color)}`}
           viewBox="0 0 8 10"
           refX="1"
           refY="5"
           markerUnits="strokeWidth"
-          markerWidth={extradark ? '6' : '4'}
+          markerWidth="4"
           orient="auto"
         >
-          <path d="M 0 0 L 8 5 L 0 10 z" fill={extradark ? Colors.Gray400 : Colors.KeylineGray} />
+          <path d="M 0 0 L 8 5 L 0 10 z" fill={color} />
         </marker>
       </defs>
-      {edges.map((edge, idx) =>
-        extradark ? (
-          <ExtraDarkStyledPath
-            key={idx}
-            d={buildSVGPath({source: edge.from, target: edge.to})}
-            dashed={edge.dashed}
-            markerEnd="url(#arrow)"
-          />
-        ) : (
-          <StyledPath
-            key={idx}
-            d={buildSVGPath({source: edge.from, target: edge.to})}
-            dashed={edge.dashed}
-            markerEnd="url(#arrow)"
-          />
-        ),
-      )}
+      {edges.map((edge, idx) => (
+        <StyledPath
+          key={idx}
+          d={buildSVGPath({source: edge.from, target: edge.to})}
+          stroke={color}
+          markerEnd={`url(#arrow${btoa(color)})`}
+        />
+      ))}
     </>
   ),
 );
 
-const StyledPath = styled('path')<{dashed: boolean}>`
+const StyledPath = styled('path')`
   stroke-width: 4;
-  stroke: ${Colors.KeylineGray};
-  ${({dashed}) => (dashed ? `stroke-dasharray: 8 2;` : '')}
-  fill: none;
-`;
-
-const ExtraDarkStyledPath = styled('path')<{dashed: boolean}>`
-  stroke-width: 8;
-  stroke: ${Colors.Gray400};
-  ${({dashed}) => (dashed ? `stroke-dasharray: 8 2;` : '')}
   fill: none;
 `;

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetEdges.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetEdges.tsx
@@ -5,35 +5,53 @@ import styled from 'styled-components/macro';
 import {buildSVGPath} from './Utils';
 import {AssetLayoutEdge} from './layout';
 
-export const AssetEdges: React.FC<{edges: AssetLayoutEdge[]}> = React.memo(({edges}) => (
-  <>
-    <defs>
-      <marker
-        id="arrow"
-        viewBox="0 0 8 10"
-        refX="1"
-        refY="5"
-        markerUnits="strokeWidth"
-        markerWidth="4"
-        orient="auto"
-      >
-        <path d="M 0 0 L 8 5 L 0 10 z" fill={Colors.KeylineGray} />
-      </marker>
-    </defs>
-    {edges.map((edge, idx) => (
-      <StyledPath
-        key={idx}
-        d={buildSVGPath({source: edge.from, target: edge.to})}
-        dashed={edge.dashed}
-        markerEnd="url(#arrow)"
-      />
-    ))}
-  </>
-));
+export const AssetEdges: React.FC<{edges: AssetLayoutEdge[]; extradark: boolean}> = React.memo(
+  ({edges, extradark}) => (
+    <>
+      <defs>
+        <marker
+          id="arrow"
+          viewBox="0 0 8 10"
+          refX="1"
+          refY="5"
+          markerUnits="strokeWidth"
+          markerWidth={extradark ? '10' : '4'}
+          orient="auto"
+        >
+          <path d="M 0 0 L 8 5 L 0 10 z" fill={extradark ? Colors.Gray400 : Colors.KeylineGray} />
+        </marker>
+      </defs>
+      {edges.map((edge, idx) =>
+        extradark ? (
+          <ExtraDarkStyledPath
+            key={idx}
+            d={buildSVGPath({source: edge.from, target: edge.to})}
+            dashed={edge.dashed}
+            markerEnd="url(#arrow)"
+          />
+        ) : (
+          <StyledPath
+            key={idx}
+            d={buildSVGPath({source: edge.from, target: edge.to})}
+            dashed={edge.dashed}
+            markerEnd="url(#arrow)"
+          />
+        ),
+      )}
+    </>
+  ),
+);
 
 const StyledPath = styled('path')<{dashed: boolean}>`
   stroke-width: 4;
   stroke: ${Colors.KeylineGray};
+  ${({dashed}) => (dashed ? `stroke-dasharray: 8 2;` : '')}
+  fill: none;
+`;
+
+const ExtraDarkStyledPath = styled('path')<{dashed: boolean}>`
+  stroke-width: 20;
+  stroke: ${Colors.Gray400};
   ${({dashed}) => (dashed ? `stroke-dasharray: 8 2;` : '')}
   fill: none;
 `;

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -335,7 +335,46 @@ const AssetGraphExplorerWithData: React.FC<
             >
               {({scale: _scale}, viewportRect) => (
                 <SVGContainer width={layout.width} height={layout.height}>
-                  <AssetEdges edges={layout.edges} />
+                  <AssetEdges edges={layout.edges} extradark={_scale < 0.4} />
+
+                  {Object.values(layout.bundles).map(({id, bounds}) => {
+                    return (
+                      <foreignObject
+                        x={bounds.x}
+                        y={bounds.y}
+                        width={bounds.width - 70}
+                        height={bounds.height - 30}
+                        key={id}
+                      >
+                        <h3 style={{opacity: _scale > 1 ? (_scale - 1) / 0.2 : 0}}>
+                          {JSON.parse(id)[0]}
+                        </h3>
+                        <div
+                          style={{
+                            width: '100%',
+                            height: '100%',
+                            background:
+                              _scale > 0.8 ? `rgba(220,220,250,0.4)` : 'rgba(220,220,250,1)',
+                            display: 'flex',
+                            borderRadius: 10,
+                          }}
+                        >
+                          <h3
+                            style={{
+                              alignSelf: 'center',
+                              width: '100%',
+                              textAlign: 'center',
+                              fontSize: 50,
+                              lineHeight: 0,
+                              opacity: 1 - _scale,
+                            }}
+                          >
+                            {JSON.parse(id)[0]}
+                          </h3>
+                        </div>
+                      </foreignObject>
+                    );
+                  })}
 
                   {Object.values(layout.nodes).map(({id, bounds}, index) => {
                     const graphNode = assetGraphData.nodes[id];
@@ -360,7 +399,7 @@ const AssetGraphExplorerWithData: React.FC<
                           viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
                           e.stopPropagation();
                         }}
-                        style={{overflow: 'visible'}}
+                        style={{overflow: 'visible', opacity: (_scale - 0.3) * 4}}
                       >
                         {!graphNode || !graphNode.definition.opNames.length ? (
                           <ForeignNode assetKey={{path}} />

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -373,7 +373,7 @@ const AssetGraphExplorerWithData: React.FC<
                             }}
                           >
                             <AssetNodeMinimal
-                              color="rgba(255, 222, 221, 0.4)"
+                              color="rgba(248, 223, 196, 0.4)"
                               definition={{assetKey: {path}}}
                               fontSize={18 / _scale}
                               selected={selectedGraphNodes.some((g) =>
@@ -408,10 +408,10 @@ const AssetGraphExplorerWithData: React.FC<
                               top: 24,
                               position: 'absolute',
                               borderRadius: 10,
-                              background: `rgba(255, 222, 221, ${
+                              border: `${3 / _scale}px dashed rgba(0,0,0,0.4)`,
+                              background: `rgba(248, 223, 196, ${
                                 0.4 - Math.max(0, _scale - EXPERIMENTAL_MINI_SCALE) * 0.3
                               })`,
-                              border: `${3 / _scale}px dashed rgba(0,0,0,0.4)`,
                             }}
                           />
                         </foreignObject>

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -346,9 +346,32 @@ const AssetGraphExplorerWithData: React.FC<
                     extradark={experiments && _scale < EXPERIMENTAL_MINI_SCALE}
                   />
 
-                  {Object.values(layout.bundles).map(({id, bounds}) => {
-                    if (experiments && _scale < EXPERIMENTAL_MINI_SCALE) {
-                      const path = JSON.parse(id);
+                  {Object.values(layout.bundles)
+                    .sort((a, b) => a.id.length - b.id.length)
+                    .map(({id, bounds}) => {
+                      if (experiments && _scale < EXPERIMENTAL_MINI_SCALE) {
+                        const path = JSON.parse(id);
+                        return (
+                          <foreignObject
+                            x={bounds.x}
+                            y={bounds.y}
+                            width={bounds.width}
+                            height={bounds.height + 10}
+                            key={id}
+                            onDoubleClick={(e) => {
+                              viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
+                              e.stopPropagation();
+                            }}
+                          >
+                            <AssetNodeMinimal
+                              definition={{assetKey: {path}}}
+                              selected={selectedGraphNodes.some((g) =>
+                                hasPathPrefix(g.assetKey.path, path),
+                              )}
+                            />
+                          </foreignObject>
+                        );
+                      }
                       return (
                         <foreignObject
                           x={bounds.x}
@@ -356,51 +379,30 @@ const AssetGraphExplorerWithData: React.FC<
                           width={bounds.width}
                           height={bounds.height + 10}
                           key={id}
-                          onDoubleClick={(e) => {
-                            viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
-                            e.stopPropagation();
-                          }}
                         >
-                          <AssetNodeMinimal
-                            definition={{assetKey: {path}}}
-                            selected={selectedGraphNodes.some((g) =>
-                              hasPathPrefix(g.assetKey.path, path),
-                            )}
+                          <Mono
+                            style={{
+                              opacity:
+                                _scale > EXPERIMENTAL_MINI_SCALE
+                                  ? (_scale - EXPERIMENTAL_MINI_SCALE) / 0.2
+                                  : 0,
+                              fontWeight: 600,
+                            }}
+                          >
+                            {displayNameForAssetKey({path: JSON.parse(id)})}
+                          </Mono>
+                          <div
+                            style={{
+                              inset: 0,
+                              top: 24,
+                              position: 'absolute',
+                              borderRadius: 10,
+                              border: `${3 / _scale}px dashed rgba(200,200,215,0.4)`,
+                            }}
                           />
                         </foreignObject>
                       );
-                    }
-                    return (
-                      <foreignObject
-                        x={bounds.x}
-                        y={bounds.y}
-                        width={bounds.width}
-                        height={bounds.height + 10}
-                        key={id}
-                      >
-                        <Mono
-                          style={{
-                            opacity:
-                              _scale > EXPERIMENTAL_MINI_SCALE
-                                ? (_scale - EXPERIMENTAL_MINI_SCALE) / 0.2
-                                : 0,
-                            fontWeight: 600,
-                          }}
-                        >
-                          {displayNameForAssetKey({path: JSON.parse(id)})}
-                        </Mono>
-                        <div
-                          style={{
-                            inset: 0,
-                            top: 24,
-                            position: 'absolute',
-                            borderRadius: 10,
-                            border: `${3 / _scale}px dashed rgba(200,200,215,0.4)`,
-                          }}
-                        />
-                      </foreignObject>
-                    );
-                  })}
+                    })}
 
                   {Object.values(layout.nodes).map(({id, bounds}, index) => {
                     const graphNode = assetGraphData.nodes[id];

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -1,6 +1,6 @@
-import {Box, Checkbox, Mono, NonIdealState, SplitPanelContainer} from '@dagster-io/ui';
-import {isEqual} from 'lodash';
+import {Box, Checkbox, Colors, Mono, NonIdealState, SplitPanelContainer} from '@dagster-io/ui';
 import flatMap from 'lodash/flatMap';
+import isEqual from 'lodash/isEqual';
 import pickBy from 'lodash/pickBy';
 import uniq from 'lodash/uniq';
 import uniqBy from 'lodash/uniqBy';
@@ -160,6 +160,8 @@ const AssetGraphExplorerWithData: React.FC<
   const history = useHistory();
   const findJobForAsset = useFindJobForAsset();
   const {flagExperimentalAssetDAG: experiments} = useFeatureFlags();
+
+  const [highlighted, setHighlighted] = React.useState<string | null>(null);
 
   const selectedAssetValues = explorerPath.opNames[explorerPath.opNames.length - 1].split(',');
   const selectedGraphNodes = Object.values(assetGraphData.nodes).filter((node) =>
@@ -343,7 +345,14 @@ const AssetGraphExplorerWithData: React.FC<
                 <SVGContainer width={layout.width} height={layout.height}>
                   <AssetEdges
                     edges={layout.edges}
-                    extradark={experiments && _scale < EXPERIMENTAL_MINI_SCALE}
+                    color={Colors.KeylineGray}
+                    // extradark={experiments && _scale < EXPERIMENTAL_MINI_SCALE}
+                  />
+                  <AssetEdges
+                    color={Colors.Blue500}
+                    edges={layout.edges.filter(
+                      ({fromId, toId}) => highlighted === fromId || highlighted === toId,
+                    )}
                   />
 
                   {Object.values(layout.bundles)
@@ -364,7 +373,9 @@ const AssetGraphExplorerWithData: React.FC<
                             }}
                           >
                             <AssetNodeMinimal
+                              color="rgba(255, 222, 221, 0.4)"
                               definition={{assetKey: {path}}}
+                              fontSize={18 / _scale}
                               selected={selectedGraphNodes.some((g) =>
                                 hasPathPrefix(g.assetKey.path, path),
                               )}
@@ -397,7 +408,10 @@ const AssetGraphExplorerWithData: React.FC<
                               top: 24,
                               position: 'absolute',
                               borderRadius: 10,
-                              border: `${3 / _scale}px dashed rgba(200,200,215,0.4)`,
+                              background: `rgba(255, 222, 221, ${
+                                0.4 - Math.max(0, _scale - EXPERIMENTAL_MINI_SCALE) * 0.3
+                              })`,
+                              border: `${3 / _scale}px dashed rgba(0,0,0,0.4)`,
                             }}
                           />
                         </foreignObject>
@@ -430,6 +444,8 @@ const AssetGraphExplorerWithData: React.FC<
                         <foreignObject
                           {...bounds}
                           key={id}
+                          onMouseEnter={() => setHighlighted(id)}
+                          onMouseLeave={() => setHighlighted(null)}
                           onClick={(e) => onSelectNode(e, {path}, graphNode)}
                           onDoubleClick={(e) => {
                             viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
@@ -439,6 +455,7 @@ const AssetGraphExplorerWithData: React.FC<
                           <AssetNodeMinimal
                             definition={graphNode.definition}
                             selected={selectedGraphNodes.includes(graphNode)}
+                            fontSize={18 / _scale}
                           />
                         </foreignObject>
                       );
@@ -448,6 +465,8 @@ const AssetGraphExplorerWithData: React.FC<
                       <foreignObject
                         {...bounds}
                         key={id}
+                        onMouseEnter={() => setHighlighted(id)}
+                        onMouseLeave={() => setHighlighted(null)}
                         onClick={(e) => onSelectNode(e, {path}, graphNode)}
                         onDoubleClick={(e) => {
                           viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -1,4 +1,5 @@
-import {Box, Checkbox, NonIdealState, SplitPanelContainer} from '@dagster-io/ui';
+import {Box, Checkbox, Mono, NonIdealState, SplitPanelContainer} from '@dagster-io/ui';
+import {isEqual} from 'lodash';
 import flatMap from 'lodash/flatMap';
 import pickBy from 'lodash/pickBy';
 import uniq from 'lodash/uniq';
@@ -8,6 +9,7 @@ import React from 'react';
 import {useHistory} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
+import {useFeatureFlags} from '../app/Flags';
 import {GraphQueryItem} from '../app/GraphQueryImpl';
 import {
   FIFTEEN_SECONDS,
@@ -42,7 +44,7 @@ import {GraphQueryInput} from '../ui/GraphQueryInput';
 import {Loading} from '../ui/Loading';
 
 import {AssetEdges} from './AssetEdges';
-import {AssetNode} from './AssetNode';
+import {AssetNode, AssetNodeMinimal} from './AssetNode';
 import {ForeignNode} from './ForeignNode';
 import {OmittedAssetsNotice} from './OmittedAssetsNotice';
 import {SidebarAssetInfo} from './SidebarAssetInfo';
@@ -53,6 +55,7 @@ import {
   GraphNode,
   isSourceAsset,
   tokenForAssetKey,
+  displayNameForAssetKey,
 } from './Utils';
 import {AssetGraphLayout} from './layout';
 import {AssetGraphQuery_assetNodes} from './types/AssetGraphQuery';
@@ -72,6 +75,8 @@ interface Props {
   explorerPath: ExplorerPath;
   onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
 }
+
+const EXPERIMENTAL_MINI_SCALE = 0.5;
 
 export const AssetGraphExplorer: React.FC<Props> = (props) => {
   const {
@@ -152,8 +157,9 @@ const AssetGraphExplorerWithData: React.FC<
     pipelineSelector,
   } = props;
 
-  const findJobForAsset = useFindJobForAsset();
   const history = useHistory();
+  const findJobForAsset = useFindJobForAsset();
+  const {flagExperimentalAssetDAG: experiments} = useFeatureFlags();
 
   const selectedAssetValues = explorerPath.opNames[explorerPath.opNames.length - 1].split(',');
   const selectedGraphNodes = Object.values(assetGraphData.nodes).filter((node) =>
@@ -335,43 +341,63 @@ const AssetGraphExplorerWithData: React.FC<
             >
               {({scale: _scale}, viewportRect) => (
                 <SVGContainer width={layout.width} height={layout.height}>
-                  <AssetEdges edges={layout.edges} extradark={_scale < 0.4} />
+                  <AssetEdges
+                    edges={layout.edges}
+                    extradark={experiments && _scale < EXPERIMENTAL_MINI_SCALE}
+                  />
 
                   {Object.values(layout.bundles).map(({id, bounds}) => {
+                    if (experiments && _scale < EXPERIMENTAL_MINI_SCALE) {
+                      const path = JSON.parse(id);
+                      return (
+                        <foreignObject
+                          x={bounds.x}
+                          y={bounds.y}
+                          width={bounds.width}
+                          height={bounds.height + 10}
+                          key={id}
+                          onDoubleClick={(e) => {
+                            viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
+                            e.stopPropagation();
+                          }}
+                        >
+                          <AssetNodeMinimal
+                            definition={{assetKey: {path}}}
+                            selected={selectedGraphNodes.some((g) =>
+                              hasPathPrefix(g.assetKey.path, path),
+                            )}
+                          />
+                        </foreignObject>
+                      );
+                    }
                     return (
                       <foreignObject
                         x={bounds.x}
                         y={bounds.y}
-                        width={bounds.width - 70}
-                        height={bounds.height - 30}
+                        width={bounds.width}
+                        height={bounds.height + 10}
                         key={id}
                       >
-                        <h3 style={{opacity: _scale > 1 ? (_scale - 1) / 0.2 : 0}}>
-                          {JSON.parse(id)[0]}
-                        </h3>
-                        <div
+                        <Mono
                           style={{
-                            width: '100%',
-                            height: '100%',
-                            background:
-                              _scale > 0.8 ? `rgba(220,220,250,0.4)` : 'rgba(220,220,250,1)',
-                            display: 'flex',
-                            borderRadius: 10,
+                            opacity:
+                              _scale > EXPERIMENTAL_MINI_SCALE
+                                ? (_scale - EXPERIMENTAL_MINI_SCALE) / 0.2
+                                : 0,
+                            fontWeight: 600,
                           }}
                         >
-                          <h3
-                            style={{
-                              alignSelf: 'center',
-                              width: '100%',
-                              textAlign: 'center',
-                              fontSize: 50,
-                              lineHeight: 0,
-                              opacity: 1 - _scale,
-                            }}
-                          >
-                            {JSON.parse(id)[0]}
-                          </h3>
-                        </div>
+                          {displayNameForAssetKey({path: JSON.parse(id)})}
+                        </Mono>
+                        <div
+                          style={{
+                            inset: 0,
+                            top: 24,
+                            position: 'absolute',
+                            borderRadius: 10,
+                            border: `${3 / _scale}px dashed rgba(200,200,215,0.4)`,
+                          }}
+                        />
                       </foreignObject>
                     );
                   })}
@@ -390,6 +416,32 @@ const AssetGraphExplorerWithData: React.FC<
                       ) : null;
                     }
 
+                    if (experiments && _scale < EXPERIMENTAL_MINI_SCALE) {
+                      const isWithinBundle = Object.keys(layout.bundles).some((bundleId) =>
+                        hasPathPrefix(path, JSON.parse(bundleId)),
+                      );
+                      if (isWithinBundle) {
+                        return null;
+                      }
+
+                      return (
+                        <foreignObject
+                          {...bounds}
+                          key={id}
+                          onClick={(e) => onSelectNode(e, {path}, graphNode)}
+                          onDoubleClick={(e) => {
+                            viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
+                            e.stopPropagation();
+                          }}
+                        >
+                          <AssetNodeMinimal
+                            definition={graphNode.definition}
+                            selected={selectedGraphNodes.includes(graphNode)}
+                          />
+                        </foreignObject>
+                      );
+                    }
+
                     return (
                       <foreignObject
                         {...bounds}
@@ -399,7 +451,7 @@ const AssetGraphExplorerWithData: React.FC<
                           viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
                           e.stopPropagation();
                         }}
-                        style={{overflow: 'visible', opacity: (_scale - 0.3) * 4}}
+                        style={{overflow: 'visible'}}
                       >
                         {!graphNode || !graphNode.definition.opNames.length ? (
                           <ForeignNode assetKey={{path}} />
@@ -506,6 +558,10 @@ const SVGContainer = styled.svg`
 `;
 
 // Helpers
+
+const hasPathPrefix = (path: string[], prefix: string[]) => {
+  return isEqual(prefix, path.slice(0, prefix.length));
+};
 
 const graphDirectionOf = ({
   graph,

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import {withMiddleTruncation} from '../app/Util';
+import {colorHash, withMiddleTruncation} from '../app/Util';
 import {AssetKey} from '../assets/types';
 import {NodeHighlightColors} from '../graph/OpNode';
 import {OpTags} from '../graph/OpTags';
@@ -161,7 +161,9 @@ export const AssetNode: React.FC<{
 export const AssetNodeMinimal: React.FC<{
   selected: boolean;
   definition: {assetKey: AssetKey};
-}> = ({selected, definition}) => {
+  fontSize: number;
+  color?: string;
+}> = ({selected, definition, fontSize, color}) => {
   const displayName = withMiddleTruncation(displayNameForAssetKey(definition.assetKey), {
     maxLength: 17,
   });
@@ -173,9 +175,10 @@ export const AssetNodeMinimal: React.FC<{
           borderRadius: 10,
           position: 'absolute',
           inset: 4,
+          background: color,
         }}
       >
-        <NameMinimal>{displayName}</NameMinimal>
+        <NameMinimal style={{fontSize}}>{displayName}</NameMinimal>
       </AssetNodeBox>
     </AssetNodeContainer>
   );
@@ -276,10 +279,10 @@ const Name = styled.div`
 `;
 
 const NameMinimal = styled(Name)`
-  font-size: 26px;
   font-weight: 600;
   white-space: nowrap;
   position: absolute;
+  background: none;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -166,8 +166,15 @@ export const AssetNodeMinimal: React.FC<{
     maxLength: 17,
   });
   return (
-    <AssetNodeContainer $selected={selected} style={{position: 'absolute'}}>
-      <AssetNodeBox style={{border: `4px solid ${Colors.Blue200}`, position: 'absolute', inset: 4}}>
+    <AssetNodeContainer $selected={selected} style={{position: 'absolute', borderRadius: 12}}>
+      <AssetNodeBox
+        style={{
+          border: `4px solid ${Colors.Blue200}`,
+          borderRadius: 10,
+          position: 'absolute',
+          inset: 4,
+        }}
+      >
         <NameMinimal>{displayName}</NameMinimal>
       </AssetNodeBox>
     </AssetNodeContainer>

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -6,6 +6,7 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {withMiddleTruncation} from '../app/Util';
+import {AssetKey} from '../assets/types';
 import {NodeHighlightColors} from '../graph/OpNode';
 import {OpTags} from '../graph/OpTags';
 import {linkToRunEvent, titleForRun} from '../runs/RunUtils';
@@ -157,6 +158,22 @@ export const AssetNode: React.FC<{
   );
 }, isEqual);
 
+export const AssetNodeMinimal: React.FC<{
+  selected: boolean;
+  definition: {assetKey: AssetKey};
+}> = ({selected, definition}) => {
+  const displayName = withMiddleTruncation(displayNameForAssetKey(definition.assetKey), {
+    maxLength: 17,
+  });
+  return (
+    <AssetNodeContainer $selected={selected} style={{position: 'absolute'}}>
+      <AssetNodeBox style={{border: `4px solid ${Colors.Blue200}`, position: 'absolute', inset: 4}}>
+        <NameMinimal>{displayName}</NameMinimal>
+      </AssetNodeBox>
+    </AssetNodeContainer>
+  );
+};
+
 export const AssetRunLink: React.FC<{
   runId: string;
   event?: Parameters<typeof linkToRunEvent>[1];
@@ -249,6 +266,16 @@ const Name = styled.div`
   border-top-right-radius: 5px;
   font-weight: 600;
   gap: 4px;
+`;
+
+const NameMinimal = styled(Name)`
+  font-size: 26px;
+  font-weight: 600;
+  white-space: nowrap;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 `;
 
 const Description = styled.div`

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import {colorHash, withMiddleTruncation} from '../app/Util';
+import {withMiddleTruncation} from '../app/Util';
 import {AssetKey} from '../assets/types';
 import {NodeHighlightColors} from '../graph/OpNode';
 import {OpTags} from '../graph/OpTags';

--- a/js_modules/dagit/packages/core/src/asset-graph/layout.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/layout.ts
@@ -163,7 +163,6 @@ export const layoutAssetGraph = (graphData: GraphData): AssetGraphLayout => {
       width: dagreNode.width,
       height: dagreNode.height,
     };
-    console.log(id, dagreNode);
     if (bundleMapping[id]) {
       bundles[id] = {id, bounds};
     } else {

--- a/js_modules/dagit/packages/core/src/asset-graph/layout.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/layout.ts
@@ -211,7 +211,7 @@ export const getForeignNodeDimensions = (id: string) => {
 };
 
 export const ASSET_NODE_ANNOTATIONS_MAX_WIDTH = 65;
-export const ASSET_NODE_NAME_MAX_LENGTH = 50;
+export const ASSET_NODE_NAME_MAX_LENGTH = 32;
 const DISPLAY_NAME_PX_PER_CHAR = 8.0;
 
 export const getAssetNodeDimensions = (def: {

--- a/js_modules/dagit/packages/core/src/asset-graph/layout.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/layout.ts
@@ -14,8 +14,9 @@ export interface AssetLayout {
 
 export type AssetLayoutEdge = {
   from: IPoint;
+  fromId: string;
   to: IPoint;
-  dashed: boolean;
+  toId: string;
 };
 
 export type AssetGraphLayout = {
@@ -180,14 +181,16 @@ export const layoutAssetGraph = (graphData: GraphData): AssetGraphLayout => {
     if (bundles[e.v] || bundles[e.w]) {
       bundleEdges.push({
         from: points[0],
+        fromId: e.v,
         to: points[points.length - 1],
-        dashed: false,
+        toId: e.w,
       });
     } else {
       edges.push({
         from: points[0],
+        fromId: e.v,
         to: points[points.length - 1],
-        dashed: false,
+        toId: e.w,
       });
     }
   });

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -141,8 +141,10 @@ const AssetEntryRow: React.FC<{
 }> = React.memo(({prefixPath, path, assets, isSelected, onToggleChecked, onWipe, canWipe}) => {
   const fullPath = [...prefixPath, ...path];
   const linkUrl = `/instance/assets/${fullPath.map(encodeURIComponent).join('/')}`;
+
   const representsSingleAsset =
     assets.length === 1 && fullPath.join('/') === assets[0].key.path.join('/');
+  const representsAtLeastOneSDA = assets.some((a) => !!a.definition);
   const asset = representsSingleAsset ? assets[0] : null;
 
   const onChange = (e: React.FormEvent<HTMLInputElement>) => {
@@ -217,6 +219,15 @@ const AssetEntryRow: React.FC<{
               <Button icon={<Icon name="expand_more" />} />
             </Popover>
           </Box>
+        ) : representsAtLeastOneSDA ? (
+          <Link
+            to={instanceAssetsExplorerPathToURL({
+              opsQuery: `+${tokenForAssetKey({path})}>+`,
+              opNames: [],
+            })}
+          >
+            <Button>View in Asset Graph</Button>
+          </Link>
         ) : (
           <span />
         )}


### PR DESCRIPTION
## Summary
This PR is a very small step toward a more concrete "folder" concept based on multi-component asset key paths.

- If you create assets with a shared asset key prefix, eg: `["prod", "foo"]` and `["prod", "bar"]` they will be clustered in the DAG (with the help of dagre) and a "prod" outline will be drawn around the two of them. 

- This is meant to match the existing presentation of folders in the asset catalog's 📁 display mode.  In the folder view, a new "View in Asset Graph" button allows you to jump to the corresponding folder outline in the DAG. (This is represented by `+prod>+` in the search bar.

- If you enable a new `experimental` flag in settings, you get a few more bonus features. Zooming out on the asset graph switches to a new "minimal" UI mode where asset keys and arrows are larger, details are gone, and folders of assets are rendered as single jumbo assets.

Note: This PR /does/ change the default asset graph behavior. Clustering together assets with the same key path prefix could have a negative impact for users whose graphs are poorly divided into folders. (eg: if you don't want to see all the "prod/" assets together, you won't like this.)

![image](https://user-images.githubusercontent.com/1037212/165439603-306ad8f3-65f0-448b-a17c-ea5c9f468249.png)

![image](https://user-images.githubusercontent.com/1037212/165439630-43bbac44-d21e-4c29-aa62-736c781229d1.png)


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.