### PR TITLE
Use explicitly set env vars rather than autoenvvar prefixes for the grpc command

### DIFF
--- a/python_modules/dagster/dagster/cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/cli/workspace/cli_target.py
@@ -32,6 +32,7 @@ from dagster.utils.hosted_user_process import recon_repository_from_origin
 
 if TYPE_CHECKING:
     from dagster.core.workspace.context import WorkspaceProcessContext
+
 from dagster.core.host_representation.external import ExternalPipeline
 
 WORKSPACE_TARGET_WARNING = "Can only use ONE of --workspace/-w, --python-file/-f, --module-name/-m, --grpc-port, --grpc-socket."
@@ -197,6 +198,7 @@ def python_target_click_options(is_using_job_op_graph_apis: bool = False):
             "--working-directory",
             "-d",
             help=f"Specify working directory to use when loading the repository or {'job' if is_using_job_op_graph_apis else 'pipeline/job'}.",
+            envvar="DAGSTER_WORKING_DIRECTORY",
         ),
         click.option(
             "--python-file",
@@ -205,15 +207,18 @@ def python_target_click_options(is_using_job_op_graph_apis: bool = False):
             # are better equipped to surface errors
             type=click.Path(exists=False),
             help=f"Specify python file where repository or {'job' if is_using_job_op_graph_apis else 'pipeline/job'} function lives",
+            envvar="DAGSTER_PYTHON_FILE",
         ),
         click.option(
             "--package-name",
             help=f"Specify Python package where repository or {'job' if is_using_job_op_graph_apis else 'pipeline/job'} function lives",
+            envvar="DAGSTER_PACKAGE_NAME",
         ),
         click.option(
             "--module-name",
             "-m",
             help=f"Specify module where repository or {'job' if is_using_job_op_graph_apis else 'pipeline/job'} function lives",
+            envvar="DAGSTER_MODULE_NAME",
         ),
         click.option(
             "--attribute",
@@ -222,6 +227,7 @@ def python_target_click_options(is_using_job_op_graph_apis: bool = False):
                 f"Attribute that is either a 1) repository or {'job' if is_using_job_op_graph_apis else 'pipeline/job'} or "
                 f"2) a function that returns a repository or {'job' if is_using_job_op_graph_apis else 'pipeline/job'}"
             ),
+            envvar="DAGSTER_ATTRIBUTE",
         ),
     ]
 

--- a/python_modules/dagster/dagster/core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/core/host_representation/repository_location.py
@@ -272,7 +272,9 @@ class InProcessRepositoryLocation(RepositoryLocation):
 
         loadable_target_origin = self._origin.loadable_target_origin
         self._loaded_repositories = LoadedRepositories(
-            loadable_target_origin, self._origin.entry_point
+            loadable_target_origin,
+            self._origin.entry_point,
+            self._origin.container_image,
         )
 
         self._repository_code_pointer_dict = self._loaded_repositories.code_pointers_by_repo_name

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -138,20 +138,73 @@ def test_load_grpc_server_python_env():
         process.terminate()
 
 
+def test_load_via_auto_env_var_prefix():
+    port = find_free_port()
+    python_file = file_relative_path(__file__, "grpc_repo.py")
+
+    subprocess_args = ["dagster", "api", "grpc"]
+
+    container_context = {
+        "k8s": {
+            "image_pull_policy": "Never",
+            "image_pull_secrets": [{"name": "your_secret"}],
+        }
+    }
+
+    container_image = "myregistry/my_image:latest"
+
+    with environ(
+        {
+            "DAGSTER_CLI_API_GRPC_HOST": "localhost",
+            "DAGSTER_CLI_API_GRPC_PORT": str(port),
+            "DAGSTER_CLI_API_GRPC_PYTHON_FILE": python_file,
+            "DAGSTER_CLI_API_GRPC_CONTAINER_IMAGE": container_image,
+            "DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT": json.dumps(container_context),
+        }
+    ):
+        process = subprocess.Popen(
+            subprocess_args,
+            stdout=subprocess.PIPE,
+        )
+
+        try:
+            wait_for_grpc_server(
+                process, DagsterGrpcClient(port=port, host="localhost"), subprocess_args
+            )
+            client = DagsterGrpcClient(port=port)
+            assert client.ping("foobar") == "foobar"
+
+            list_repositories_response = sync_list_repositories_grpc(client)
+            assert list_repositories_response.container_image == container_image
+            assert list_repositories_response.container_context == container_context
+
+        finally:
+            process.terminate()
+
+
 def test_load_via_env_var():
     port = find_free_port()
     python_file = file_relative_path(__file__, "grpc_repo.py")
 
-    subprocess_args = [
-        "dagster",
-        "api",
-        "grpc",
-        "--python-file",
-        python_file,
-    ]
+    subprocess_args = ["dagster", "api", "grpc"]
+
+    container_context = {
+        "k8s": {
+            "image_pull_policy": "Never",
+            "image_pull_secrets": [{"name": "your_secret"}],
+        }
+    }
+
+    container_image = "myregistry/my_image:latest"
 
     with environ(
-        {"DAGSTER_CLI_API_GRPC_HOST": "localhost", "DAGSTER_CLI_API_GRPC_PORT": str(port)}
+        {
+            "DAGSTER_PYTHON_FILE": python_file,
+            "DAGSTER_GRPC_HOST": "localhost",
+            "DAGSTER_GRPC_PORT": str(port),
+            "DAGSTER_CONTAINER_IMAGE": container_image,
+            "DAGSTER_CONTAINER_CONTEXT": json.dumps(container_context),
+        }
     ):
         process = subprocess.Popen(
             subprocess_args,


### PR DESCRIPTION
Summary:
We make use of this kind of buried click feature that auto-creates env vars for you, but I feel weird recommending that people set the DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT env var to use container context - it's a weird name, and its not really greppable. This gives us a more natural env var name to recommend.

I added a "GRPC" prefix for the options that are specifically about the server (host/socket/port) as opposed to the code loaded by the server where I just went with DAGSTER_XXX.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.