### PR TITLE
[Testing] Support for resolvers in ApolloTestProvider

### DIFF
--- a/js_modules/dagit/packages/core/src/testing/ApolloTestProvider.tsx
+++ b/js_modules/dagit/packages/core/src/testing/ApolloTestProvider.tsx
@@ -42,23 +42,7 @@ export const ApolloTestProvider: React.FC<Props> = (props) => {
       schema,
       mocks: mocksWithMerge,
       resolvers: () => {
-        const merged = mergeResolvers(resolvers);
-        const resolver = new Proxy(merged, {
-          get(target: any, prop: string) {
-            if (target[prop] === undefined && target === merged && prop.endsWith('Result')) {
-              target[prop] = {
-                __resolveType: (obj: any) => {
-                  if (obj.$ref) {
-                    return obj.$ref.typeName;
-                  }
-                  return obj.__typename;
-                },
-              };
-            }
-            return target[prop];
-          },
-        });
-        return resolver;
+        return mergeResolvers(resolvers);
       },
     });
     const cache = createAppCache();

--- a/js_modules/dagit/packages/core/src/testing/ApolloTestProvider.tsx
+++ b/js_modules/dagit/packages/core/src/testing/ApolloTestProvider.tsx
@@ -45,7 +45,7 @@ export const ApolloTestProvider: React.FC<Props> = (props) => {
         const merged = mergeResolvers(resolvers);
         const resolver = new Proxy(merged, {
           get(target: any, prop: string) {
-            if (target[prop] == null && target === merged && prop.endsWith('Result')) {
+            if (target[prop] === undefined && target === merged && prop.endsWith('Result')) {
               target[prop] = {
                 __resolveType: (obj: any) => {
                   if (obj.$ref) {


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

We need to support resolvers in TestProvider so that we can test that queries/mutations are receiving the expected variables. 
Mocks are not sufficient because they are static so they don't get query/mutation variables passed in.

The proxy is there to make using resolvers a little less cumbersome by defaulting to  obj.__typename as the typename for any resolved objects. This default behavior can be overrode by explicitly providing a value through the resolver. See: https://github.com/ardatan/graphql-tools/issues/171



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

Using this in the Alerting cloud PR



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.