### PR TITLE
fix(helm): allow max concurrent runs to be 0

### DIFF
--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -310,8 +310,10 @@ def test_celery_k8s_run_launcher_config(template: HelmTemplate):
 
 
 @pytest.mark.parametrize("enabled", [True, False])
-def test_queued_run_coordinator_config(template: HelmTemplate, enabled: bool):
-    max_concurrent_runs = 50
+@pytest.mark.parametrize("max_concurrent_runs", [0, 50])
+def test_queued_run_coordinator_config(
+    template: HelmTemplate, enabled: bool, max_concurrent_runs: int
+):
     tag_concurrency_limits = [TagConcurrencyLimit(key="key", value="value", limit=10)]
     dequeue_interval_seconds = 50
     helm_values = DagsterHelmValues.construct(

--- a/helm/dagster/templates/helpers/instance/_run-coordinator.tpl
+++ b/helm/dagster/templates/helpers/instance/_run-coordinator.tpl
@@ -4,7 +4,9 @@ module: dagster.core.run_coordinator
 class: QueuedRunCoordinator
 {{- if not (empty (compact (values $queuedRunCoordinatorConfig))) }}
 config:
-  {{- if $queuedRunCoordinatorConfig.maxConcurrentRuns }}
+  # Workaround to prevent 0 from being interpreted as falsey:
+  # https://github.com/helm/helm/issues/3164#issuecomment-709537506
+  {{- if not (kindIs "invalid" $queuedRunCoordinatorConfig.maxConcurrentRuns) }}
   max_concurrent_runs: {{ $queuedRunCoordinatorConfig.maxConcurrentRuns }}
   {{- end }}
 


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
As the title. Helm was interpreting `0` as a falsey value, so use this workaround.

## Test Plan
pytest, test failed before this change.
