### PR TITLE
AssetsDefinition.from_graph

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -4,7 +4,6 @@ from dagster import check
 from dagster.core.definitions import GraphDefinition, NodeDefinition, OpDefinition
 from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.partition import PartitionsDefinition
-from dagster.core.errors import DagsterInvalidDefinitionError
 
 from .partition_mapping import PartitionMapping
 

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import AbstractSet, Dict, Iterable, Mapping, Optional, cast, Set
+from typing import AbstractSet, Dict, Iterable, Mapping, Optional, Set, cast
 
 from dagster import check
 from dagster.core.definitions import GraphDefinition, NodeDefinition, OpDefinition

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -4,6 +4,7 @@ from dagster import check
 from dagster.core.definitions import NodeDefinition, OpDefinition
 from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.partition import PartitionsDefinition
+from dagster.core.errors import DagsterInvalidDefinitionError
 
 from .partition_mapping import PartitionMapping
 
@@ -42,6 +43,24 @@ class AssetsDefinition:
 
     def __call__(self, *args, **kwargs):
         return self._node_def(*args, **kwargs)
+
+    @staticmethod
+    def from_graph(
+        graph_def: GraphDefinition,
+        asset_keys_by_input_name: Mapping[str, AssetKey],
+        asset_keys_by_output_name: Mapping[str, AssetKey],
+        internal_asset_deps: Optional[Mapping[str, SetAssetKey]] = None,
+    ):
+        AssetsDefinition(
+            asset_keys_by_input_name=_infer_asset_keys_by_input_names(
+                graph_def,
+                asset_keys_by_input_name or {},
+            ),
+            asset_keys_by_output_name=_infer_asset_keys_by_output_names(
+                graph_def, asset_keys_by_output_name or {}
+            ),
+            op=graph_def,  # TODO: change this arg name to node_def once dependent PR merged
+        )
 
     @property
     def op(self) -> OpDefinition:
@@ -83,3 +102,53 @@ class AssetsDefinition:
             in_asset_key,
             self._partitions_def.get_default_partition_mapping(),
         )
+
+
+def _infer_asset_keys_by_input_names(
+    graph_def: GraphDefinition, asset_keys_by_input_name: Mapping[str, AssetKey]
+) -> Mapping[str, AssetKey]:
+    all_input_names = {graph_input.definition.name for graph_input in graph_def.input_mappings}
+    for in_key in asset_keys_by_input_name.keys():
+        if in_key not in all_input_names:
+            raise DagsterInvalidDefinitionError(
+                f"Key '{in_key}' in provided asset_keys_by_input_name dict does not correspond to "
+                "any key provided in the ins dictionary of the decorated op or any argument "
+                "to the decorated function"
+            )
+
+    # If asset key is not supplied in asset_keys_by_input_name, create asset key
+    # from input name
+    inferred_input_names_by_asset_key: Dict[str, AssetKey] = {
+        input_name: asset_keys_by_input_name.get(input_name, AssetKey([input_name]))
+        for input_name in all_input_names
+    }
+
+    return inferred_input_names_by_asset_key
+
+
+def _infer_asset_keys_by_output_names(
+    graph_def: GraphDefinition, asset_keys_by_output_name: Mapping[str, AssetKey]
+) -> Mapping[str, AssetKey]:
+    inferred_asset_keys_by_output_names: Dict[AssetKey, str] = asset_keys_by_output_name.copy()
+    output_names = [output.definition.name for output in graph_def.output_mappings]
+
+    if (
+        len(output_names) == 1
+        and output_names[0] not in asset_keys_by_output_name
+        and output_names[0] == "result"
+    ):
+        # If there is only one output and the name is the default "result", generate asset key
+        # from the name of the node
+        inferred_asset_keys_by_output_names[output_names[0]] = AssetKey([node_def.name])
+
+    for output_name in asset_keys_by_output_name.keys():
+        if output_name not in output_names:
+            raise DagsterInvalidDefinitionError(
+                f"Key {output_name} in provided asset_keys_by_output_name does not correspond "
+                "to any key provided in the out dictionary of the decorated op"
+            )
+
+    for output_name in output_names:
+        if output_name not in inferred_asset_keys_by_output_names:
+            inferred_asset_keys_by_output_names[output_name] = AssetKey([output_name])
+    return inferred_asset_keys_by_output_names

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -5,7 +5,7 @@ from dagster import check
 from dagster.core.definitions import GraphDefinition, NodeDefinition, OpDefinition
 from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.partition import PartitionsDefinition
-from dagster.utils.backcompat import ExperimentalWarning
+from dagster.utils.backcompat import ExperimentalWarning, experimental
 
 from .partition_mapping import PartitionMapping
 
@@ -56,12 +56,30 @@ class AssetsDefinition:
         return self._node_def(*args, **kwargs)
 
     @staticmethod
+    @experimental
     def from_graph(
         graph_def: GraphDefinition,
         asset_keys_by_input_name: Optional[Mapping[str, AssetKey]] = None,
         asset_keys_by_output_name: Optional[Mapping[str, AssetKey]] = None,
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
-    ):
+    ) -> "AssetsDefinition":
+        """
+        Constructs an AssetsDefinition from a GraphDefinition.
+
+        Args:
+            graph_def (GraphDefinition): The GraphDefinition that is an asset.
+            asset_keys_by_input_name (Optional[Mapping[str, AssetKey]]): A mapping of the input
+                names of the decorated graph to their corresponding asset keys. If not provided,
+                the input asset keys will be created from the graph input names.
+            asset_keys_by_output_name (Optional[Mapping[str, AssetKey]]): A mapping of the output
+                names of the decorated graph to their corresponding asset keys. If not provided,
+                the output asset keys will be created from the graph output names.
+            internal_asset_deps (Optional[Mapping[str, Set[AssetKey]]]): By default, it is assumed
+                that all assets produced by the graph depend on all assets that are consumed by that
+                graph. If this default is not correct, you pass in a map of output names to a
+                corrected set of AssetKeys that they depend on. Any AssetKeys in this list must be
+                either used as input to the asset or produced within the graph.
+        """
         asset_keys_by_input_name = check.opt_dict_param(
             asset_keys_by_input_name, "asset_keys_by_input_name", key_type=str, value_type=AssetKey
         )

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -696,7 +696,7 @@ def test_asset_def_from_graph_outputs():
 
 def test_graph_asset_decorator_no_args():
     @op
-    def my_op(x, y): # pylint: disable=unused-argument
+    def my_op(x, y):  # pylint: disable=unused-argument
         return x
 
     @graph

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -659,17 +659,17 @@ def test_asset_def_from_graph_inputs():
     def my_op(x, y):
         return x
 
-    @graph(ins={"x": GraphIn()})
+    @graph(ins={"x": GraphIn(), "y": GraphIn()})
     def my_graph(x, y):
         my_op(x, y)
 
     assets_def = AssetsDefinition.from_graph(
         graph_def=my_graph,
-        asset_keys_by_input_name={"x": AssetKey("x_asset")},
+        asset_keys_by_input_name={"x": AssetKey("x_asset"), "y": AssetKey("y_asset")},
     )
 
     assert assets_def.asset_keys_by_input_name["x"] == AssetKey("x_asset")
-    assert assets_def.asset_keys_by_input_name["y"] == AssetKey("y")
+    assert assets_def.asset_keys_by_input_name["y"] == AssetKey("y_asset")
 
 
 def test_asset_def_from_graph_outputs():
@@ -687,11 +687,11 @@ def test_asset_def_from_graph_outputs():
 
     assets_def = AssetsDefinition.from_graph(
         graph_def=my_graph,
-        asset_keys_by_output_name={"y": AssetKey("y_asset")},
+        asset_keys_by_output_name={"y": AssetKey("y_asset"), "x": AssetKey("x_asset")},
     )
 
     assert assets_def.asset_keys_by_output_name["y"] == AssetKey("y_asset")
-    assert assets_def.asset_keys_by_output_name["x"] == AssetKey("x")
+    assert assets_def.asset_keys_by_output_name["x"] == AssetKey("x_asset")
 
 
 def test_graph_asset_decorator_no_args():

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -642,21 +642,21 @@ def test_internal_asset_deps():
     with pytest.raises(Exception, match="output_name non_exist_output_name"):
 
         @op
-        def my_op(x, y):
+        def my_op(x, y):  # pylint: disable=unused-argument
             return x
 
         @graph(ins={"x": GraphIn()})
         def my_graph(x, y):
             my_op(x, y)
 
-        assets_def = AssetsDefinition.from_graph(
+        AssetsDefinition.from_graph(
             graph_def=my_graph, internal_asset_deps={"non_exist_output_name": {AssetKey("b")}}
         )
 
 
 def test_asset_def_from_graph_inputs():
     @op
-    def my_op(x, y):
+    def my_op(x, y):  # pylint: disable=unused-argument
         return x
 
     @graph(ins={"x": GraphIn(), "y": GraphIn()})

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -3,12 +3,12 @@ import os
 import pytest
 
 from dagster import (
-    GraphIn,
     AssetKey,
     AssetsDefinition,
     DagsterInvalidDefinitionError,
     DagsterInvariantViolationError,
     DependencyDefinition,
+    GraphIn,
     GraphOut,
     IOManager,
     Out,
@@ -638,15 +638,20 @@ def test_fail_with_get_output_asset_key():
         job.execute_in_process()
 
 
-<<<<<<< HEAD
-# def test_internal_asset_deps():
-#     with pytest.raises(Exception):
+def test_internal_asset_deps():
+    with pytest.raises(Exception, match="output_name non_exist_output_name"):
 
-#         @assets_definition(internal_asset_deps={"non_exist_output_name": AssetKey("b")})
-#         @op(out={"a": Out(), "b": Out()})
-#         def multi_asset_op(context):
-#             yield Output(1, "a")
-#             yield Output(2, "b")
+        @op
+        def my_op(x, y):
+            return x
+
+        @graph(ins={"x": GraphIn()})
+        def my_graph(x, y):
+            my_op(x, y)
+
+        assets_def = AssetsDefinition.from_graph(
+            graph_def=my_graph, internal_asset_deps={"non_exist_output_name": {AssetKey("b")}}
+        )
 
 
 def test_asset_def_from_graph_inputs():
@@ -705,7 +710,8 @@ def test_graph_asset_decorator_no_args():
     assert assets_def.asset_keys_by_input_name["x"] == AssetKey("x")
     assert assets_def.asset_keys_by_input_name["y"] == AssetKey("y")
     assert assets_def.asset_keys_by_output_name["result"] == AssetKey("my_graph")
-=======
+
+
 def test_all_assets_job():
     @asset
     def a1():
@@ -1008,4 +1014,3 @@ def test_internal_asset_deps_assets():
     assert node_handle_deps_by_asset[AssetKey("my_other_out_name")] == {
         NodeHandle(name="multi_asset_with_internal_deps", parent=None)
     }
->>>>>>> 3bcb7574e01badfecc086dc2d413d0c1241da42a

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -696,7 +696,7 @@ def test_asset_def_from_graph_outputs():
 
 def test_graph_asset_decorator_no_args():
     @op
-    def my_op(x, y):
+    def my_op(x, y): # pylint: disable=unused-argument
         return x
 
     @graph


### PR DESCRIPTION
Adapted from #7524.

Adds a `from_graph` method to the `AssetsDefinition` class. Accepts optional `asset_keys_by_output_name`, `asset_keys_by_input_name`, and `internal_asset_deps` args. If args are not provided, the output/input names specified on `out`/`ins` will automatically become the asset keys.

If the graph does not define `out`, then the output asset key is the name of the graph.