### PR TITLE
Make dagster-user-deployments service account set up a role and role binding by default, like the main dagster chart service account

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/role.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/role.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.rbacEnabled }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "dagster.fullname" . }}-role
+  labels: {{ include "dagster.labels" . | nindent 4 }}
+
+#
+# It is tricky to figure out the correct rules to use here, because K8s sub-resources are not
+# documented. See https://stackoverflow.com/a/51289417/11295366 for notes on how to get a list of
+# available subresources.
+#
+# The CLI command `kubectl api-resources -o wide` is also useful for understanding resources/verbs.
+#
+# The auth CLI can also be useful for verifying that access has been applied correctly. Note that
+# you MUST ensure you've fully-qualified the service account as shown below, or else kubectl will
+# lie to you about permissions.
+#
+# kubectl auth can-i --list --as system:serviceaccount:default:<release name>-dagster
+#
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs", "jobs/status", "cronjobs"]
+  verbs: ["*"]
+# The empty arg "" corresponds to the core API group
+- apiGroups: [""]
+  resources: ["pods", "pods/log", "pods/status"]
+  verbs: ["*"]
+{{- end -}}

--- a/helm/dagster/charts/dagster-user-deployments/templates/rolebinding.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbacEnabled }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "dagster.fullname" . }}-rolebinding
+  labels: {{ include "dagster.labels" . | nindent 4 }}
+
+subjects:
+- kind: ServiceAccount
+  name: {{ include "dagsterUserDeployments.serviceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "dagster.fullname" . }}-role
+{{- end -}}

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -140,6 +140,9 @@ serviceAccount:
 
   annotations: {}
 
+# Whether to bind a role to the service account that allows it to create Kubernetes jobs
+rbacEnabled: true
+
 ####################################################################################################
 # Extra Manifests: (Optional) Create additional k8s resources within this chart
 ####################################################################################################

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -484,17 +484,6 @@ def helm_namespaces_for_k8s_run_launcher(
             )
             yield (namespace, system_namespace)
         else:
-            # Let the default service account used by the user code deployment launch jobs
-            # (needed for the k8s executor to be able to work since it uses that same service
-            # account when launching jobs)
-            stack.enter_context(
-                create_cluster_admin_role_binding(
-                    namespace,
-                    service_account_name="dagster-dagster-user-deployments-user-deployments",
-                    should_cleanup=should_cleanup,
-                )
-            )
-
             with helm_chart_for_k8s_run_launcher(
                 namespace,
                 namespace,


### PR DESCRIPTION
Summary:
By default the helm chart creates a service account for both the main chart and the subchart. The first one has a role binding assigned by default, but the subchart does not. This PR gives them both the same permissions by default. which means that once we start launching runs in the user code deployment's namespace and service account, we'll be able to launch runs out of the box (e.g. if we are using the k8s_job_executor and the run worker will need to launch other jobs).

Test Plan: BK (see the gross cluster rule binding check in the test I was able to take out now, because permissions are being set automatically as part of the helm chart now)

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.