### PR TITLE
add option to GraphQueryInput to apply changes without hitting enter

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1258,7 +1258,9 @@ type PartitionSet {
   partitionsOrError(cursor: String, limit: Int, reverse: Boolean): PartitionsOrError!
   partition(partitionName: String!): Partition
   partitionStatusesOrError: PartitionStatusesOrError!
+  partitionRuns: [PartitionRun!]!
   repositoryOrigin: RepositoryOrigin!
+  backfills(cursor: String, limit: Int): [PartitionBackfill!]!
 }
 
 union PartitionsOrError = Partitions | PythonError
@@ -1316,6 +1318,33 @@ type PartitionStatus {
   id: String!
   partitionName: String!
   runStatus: RunStatus
+}
+
+type PartitionRun {
+  id: String!
+  partitionName: String!
+  run: Run
+}
+
+type PartitionBackfill {
+  backfillId: String!
+  status: BulkActionStatus!
+  partitionNames: [String!]!
+  numRequested: Int!
+  fromFailure: Boolean!
+  reexecutionSteps: [String!]!
+  partitionSetName: String!
+  timestamp: Float!
+  partitionSet: PartitionSet
+  runs(limit: Int): [Run!]!
+  error: PythonError
+}
+
+enum BulkActionStatus {
+  REQUESTED
+  COMPLETED
+  FAILED
+  CANCELED
 }
 
 type FutureInstigationTicks {
@@ -1756,27 +1785,6 @@ input AssetKeyInput {
 union AssetNodeOrError = AssetNode | AssetNotFoundError
 
 union PartitionBackfillOrError = PartitionBackfill | PythonError
-
-type PartitionBackfill {
-  backfillId: String!
-  status: BulkActionStatus!
-  numRequested: Int!
-  numTotal: Int!
-  fromFailure: Boolean!
-  reexecutionSteps: [String!]!
-  partitionSetName: String!
-  timestamp: Float!
-  partitionSet: PartitionSet
-  runs(limit: Int): [Run!]!
-  error: PythonError
-}
-
-enum BulkActionStatus {
-  REQUESTED
-  COMPLETED
-  FAILED
-  CANCELED
-}
 
 union PartitionBackfillsOrError = PartitionBackfills | PythonError
 

--- a/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
@@ -26,7 +26,7 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
   if (!backfill) {
     return null;
   }
-  const numUnscheduled = (backfill.numTotal || 0) - (backfill.numRequested || 0);
+  const numUnscheduled = (backfill.partitionNames.length || 0) - (backfill.numRequested || 0);
   const cancelableRuns = backfill.runs.filter(
     (run) => !doneStatuses.has(run?.status) && run.canTerminate,
   );

--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -446,14 +446,15 @@ const getProgressCounts = (backfill: Backfill) => {
     {numQueued: 0, numInProgress: 0, numSucceeded: 0, numFailed: 0},
   );
 
+  const numTotal = backfill.partitionNames.length;
   return {
     numQueued,
     numInProgress,
     numSucceeded,
     numFailed,
-    numUnscheduled: backfill.numTotal - backfill.numRequested,
+    numUnscheduled: numTotal - backfill.numRequested,
     numSkipped: backfill.numRequested - latestPartitionRuns.length,
-    numTotal: backfill.numTotal,
+    numTotal,
   };
 };
 
@@ -596,7 +597,7 @@ const BACKFILLS_QUERY = gql`
           backfillId
           status
           numRequested
-          numTotal
+          partitionNames
           runs {
             id
             canTerminate

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceBackfillsQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceBackfillsQuery.ts
@@ -57,7 +57,7 @@ export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackf
   backfillId: string;
   status: BulkActionStatus;
   numRequested: number;
-  numTotal: number;
+  partitionNames: string[];
   runs: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_runs[];
   timestamp: number;
   partitionSetName: string;

--- a/js_modules/dagit/packages/core/src/partitions/PartitionProgress.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionProgress.tsx
@@ -134,10 +134,10 @@ export const PartitionProgress = (props: Props) => {
     numTotalRuns,
   } = counts;
   const numFinished = numSucceeded + numFailed;
-  const unscheduled = results.numTotal - results.numRequested;
+  const numTotal = results.partitionNames.length;
+  const unscheduled = numTotal - results.numRequested;
 
   const skipped = results.numRequested - numPartitionRuns;
-  const numTotal = results.numTotal;
 
   const table = (
     <TooltipTable>
@@ -291,7 +291,7 @@ const PARTITION_PROGRESS_QUERY = gql`
         backfillId
         status
         numRequested
-        numTotal
+        partitionNames
         runs(limit: $limit) {
           id
           canTerminate

--- a/js_modules/dagit/packages/core/src/partitions/types/PartitionProgressQuery.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/PartitionProgressQuery.ts
@@ -28,7 +28,7 @@ export interface PartitionProgressQuery_partitionBackfillOrError_PartitionBackfi
   backfillId: string;
   status: BulkActionStatus;
   numRequested: number;
-  numTotal: number;
+  partitionNames: string[];
   runs: PartitionProgressQuery_partitionBackfillOrError_PartitionBackfill_runs[];
 }
 

--- a/js_modules/dagit/packages/core/src/ui/GraphQueryInput.tsx
+++ b/js_modules/dagit/packages/core/src/ui/GraphQueryInput.tsx
@@ -49,6 +49,7 @@ interface GraphQueryInputProps {
   onKeyDown?: (e: React.KeyboardEvent<any>) => void;
   onFocus?: () => void;
   onBlur?: (value: string) => void;
+  autoApplyChanges?: boolean;
 }
 
 interface ActiveSuggestionInfo {
@@ -319,7 +320,10 @@ export const GraphQueryInput = React.memo(
               strokeColor={intentToStrokeColor(props.intent)}
               autoFocus={props.autoFocus}
               placeholder={placeholderTextForItems(props.placeholder, props.items)}
-              onChange={(e: React.ChangeEvent<any>) => setPendingValue(e.target.value)}
+              onChange={(e: React.ChangeEvent<any>) => {
+                setPendingValue(e.target.value);
+                props.autoApplyChanges && props.onChange(e.target.value);
+              }}
               onFocus={() => {
                 if (!flattenGraphsEnabled) {
                   // Defer focus to be manually managed

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -204,6 +204,7 @@ def get_partition_set_partition_statuses(graphene_info, repository_handle, parti
         ]
     )
 
+
 def get_partition_set_partition_runs(graphene_info, partition_set):
     from ..schema.partition_sets import GraphenePartitionRun
     from ..schema.pipelines.pipeline import GrapheneRun
@@ -228,7 +229,9 @@ def get_partition_set_partition_runs(graphene_info, partition_set):
         GraphenePartitionRun(
             id=f"{partition_set.name}:{partition_name}",
             partitionName=partition_name,
-            run=GrapheneRun(by_partition[partition_name]) if partition_name in by_partition else None,
+            run=GrapheneRun(by_partition[partition_name])
+            if partition_name in by_partition
+            else None,
         )
         # for partition_name, run_record in by_partition.items()
         for partition_name in result.partition_names

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -172,6 +172,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             return GraphenePythonError(self._backfill_job.error)
         return None
 
+
 class GraphenePartitionBackfillOrError(graphene.Union):
     class Meta:
         types = (GraphenePartitionBackfill, GraphenePythonError)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -87,8 +87,8 @@ class GraphenePartitionBackfill(graphene.ObjectType):
 
     backfillId = graphene.NonNull(graphene.String)
     status = graphene.NonNull(GrapheneBulkActionStatus)
+    partitionNames = non_null_list(graphene.String)
     numRequested = graphene.NonNull(graphene.Int)
-    numTotal = graphene.NonNull(graphene.Int)
     fromFailure = graphene.NonNull(graphene.Boolean)
     reexecutionSteps = non_null_list(graphene.String)
     partitionSetName = graphene.NonNull(graphene.String)
@@ -107,9 +107,9 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             backfillId=backfill_job.backfill_id,
             partitionSetName=backfill_job.partition_set_origin.partition_set_name,
             status=backfill_job.status,
-            numTotal=len(backfill_job.partition_names),
             fromFailure=bool(backfill_job.from_failure),
             reexecutionSteps=backfill_job.reexecution_steps,
+            partitionNames=backfill_job.partition_names,
             timestamp=backfill_job.backfill_timestamp,
         )
 
@@ -171,7 +171,6 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         if self._backfill_job.error:
             return GraphenePythonError(self._backfill_job.error)
         return None
-
 
 class GraphenePartitionBackfillOrError(graphene.Union):
     class Meta:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -2,8 +2,8 @@ import graphene
 from dagster_graphql.implementation.fetch_partition_sets import (
     get_partition_by_name,
     get_partition_config,
-    get_partition_set_partition_statuses,
     get_partition_set_partition_runs,
+    get_partition_set_partition_statuses,
     get_partition_tags,
     get_partitions,
 )
@@ -15,6 +15,7 @@ from dagster.core.storage.pipeline_run import RunsFilter
 from dagster.core.storage.tags import PARTITION_NAME_TAG, PARTITION_SET_TAG
 from dagster.utils import merge_dicts
 
+from .backfill import GraphenePartitionBackfill
 from .errors import (
     GraphenePartitionSetNotFoundError,
     GraphenePipelineNotFoundError,
@@ -26,7 +27,6 @@ from .pipelines.status import GrapheneRunStatus
 from .repository_origin import GrapheneRepositoryOrigin
 from .tags import GraphenePipelineTag
 from .util import non_null_list
-from .backfill import GraphenePartitionBackfill
 
 
 class GraphenePartitionTags(graphene.ObjectType):
@@ -56,6 +56,7 @@ class GraphenePartitionStatus(graphene.ObjectType):
 
     class Meta:
         name = "PartitionStatus"
+
 
 class GraphenePartitionRun(graphene.ObjectType):
     id = graphene.NonNull(graphene.String)
@@ -250,9 +251,11 @@ class GraphenePartitionSet(graphene.ObjectType):
                 cursor=kwargs.get("cursor"),
             )
             if backfill.partition_set_origin.partition_set_name == self._external_partition_set.name
-            and backfill.partition_set_origin.external_repository_origin.repository_name == self._external_repository_handle.repository_name
+            and backfill.partition_set_origin.external_repository_origin.repository_name
+            == self._external_repository_handle.repository_name
         ]
-        return [GraphenePartitionBackfill(backfill) for backfill in matching[:kwargs.get("limit")]]
+        return [GraphenePartitionBackfill(backfill) for backfill in matching[: kwargs.get("limit")]]
+
 
 class GraphenePartitionSetOrError(graphene.Union):
     class Meta:

--- a/python_modules/dagster/dagster/core/host_representation/external.py
+++ b/python_modules/dagster/dagster/core/host_representation/external.py
@@ -700,6 +700,10 @@ class ExternalPartitionSet:
     def pipeline_name(self):
         return self._external_partition_set_data.pipeline_name
 
+    @property
+    def repository_handle(self):
+        return self._handle.repository_handle
+
     def get_external_origin(self):
         return self._handle.get_external_origin()
 


### PR DESCRIPTION
## Summary
The launch backfill selector flow allows for an option to quickly select a set of steps. This
reuses the GraphQueryInput, but the selection is currently awkward because it requires a blur
before applying the changes.

Resurrected from mis-merged https://github.com/dagster-io/dagster/pull/7615


## Test Plan
Tested locally


