### PR TITLE
[dagit] Add dummy graphName field to AssetNode

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -218,6 +218,7 @@ export const ASSET_NODE_LIVE_FRAGMENT = gql`
 export const ASSET_NODE_FRAGMENT = gql`
   fragment AssetNodeFragment on AssetNode {
     id
+    graphName
     opName
     opNames
     description

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphQuery.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphQuery.ts
@@ -40,6 +40,7 @@ export interface AssetGraphQuery_assetNodes_dependedByKeys {
 export interface AssetGraphQuery_assetNodes {
   __typename: "AssetNode";
   id: string;
+  graphName: string | null;
   opName: string | null;
   opNames: string[];
   description: string | null;

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetNodeFragment.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetNodeFragment.ts
@@ -28,6 +28,7 @@ export interface AssetNodeFragment_repository {
 export interface AssetNodeFragment {
   __typename: "AssetNode";
   id: string;
+  graphName: string | null;
   opName: string | null;
   opNames: string[];
   description: string | null;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
@@ -2399,6 +2399,7 @@ export interface AssetNodeDefinitionFragment_dependencies_asset {
   opName: string | null;
   opNames: string[];
   jobNames: string[];
+  graphName: string | null;
   description: string | null;
   partitionDefinition: string | null;
   computeKind: string | null;
@@ -2442,6 +2443,7 @@ export interface AssetNodeDefinitionFragment_dependedBy_asset {
   opName: string | null;
   opNames: string[];
   jobNames: string[];
+  graphName: string | null;
   description: string | null;
   partitionDefinition: string | null;
   computeKind: string | null;
@@ -2463,6 +2465,7 @@ export interface AssetNodeDefinitionFragment {
   opNames: string[];
   jobNames: string[];
   repository: AssetNodeDefinitionFragment_repository;
+  graphName: string | null;
   partitionDefinition: string | null;
   computeKind: string | null;
   assetKey: AssetNodeDefinitionFragment_assetKey;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
@@ -2453,6 +2453,7 @@ export interface AssetQuery_assetOrError_Asset_definition_dependencies_asset {
   opName: string | null;
   opNames: string[];
   jobNames: string[];
+  graphName: string | null;
   description: string | null;
   partitionDefinition: string | null;
   computeKind: string | null;
@@ -2496,6 +2497,7 @@ export interface AssetQuery_assetOrError_Asset_definition_dependedBy_asset {
   opName: string | null;
   opNames: string[];
   jobNames: string[];
+  graphName: string | null;
   description: string | null;
   partitionDefinition: string | null;
   computeKind: string | null;
@@ -2519,6 +2521,7 @@ export interface AssetQuery_assetOrError_Asset_definition {
   opName: string | null;
   opNames: string[];
   jobNames: string[];
+  graphName: string | null;
   computeKind: string | null;
   assetKey: AssetQuery_assetOrError_Asset_definition_assetKey;
   assetMaterializations: AssetQuery_assetOrError_Asset_definition_assetMaterializations[];

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -223,6 +223,7 @@ type AssetNode {
   dependencies: [AssetDependency!]!
   dependencyKeys: [AssetKey!]!
   description: String
+  graphName: String
   id: ID!
   jobNames: [String!]!
   jobs: [Pipeline!]!

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -90,6 +90,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     dependencies = non_null_list(GrapheneAssetDependency)
     dependencyKeys = non_null_list(GrapheneAssetKey)
     description = graphene.String()
+    graphName = graphene.String()
     id = graphene.NonNull(graphene.ID)
     jobNames = non_null_list(graphene.String)
     jobs = non_null_list(GraphenePipeline)
@@ -293,6 +294,13 @@ class GrapheneAssetNode(graphene.ObjectType):
             )
             for dep in self._external_asset_node.dependencies
         ]
+
+    def resolve_graphName(self, _graphene_info) -> Optional[str]:
+        # todo OwenKephart - return the correct graph name here
+        if self._external_asset_node.op_name:
+            return self._external_asset_node.op_name
+        else:
+            return None
 
     def resolve_jobNames(self, _graphene_info) -> List[str]:
         return self._external_asset_node.job_names


### PR DESCRIPTION
## Summary

Add a `graphName` field to `AssetNode`. Just returns the first op name for now.

## Test Plan

Load Dagit, view an asset, verify that `graphName` has been populated in the query response.
