### PR TITLE
to_source_assets and extra_source_assets

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -193,6 +193,7 @@ class _Asset:
                 metadata=self.metadata or {},
                 io_manager_key=self.io_manager_key,
                 dagster_type=self.dagster_type if self.dagster_type else NoValueSentinel,
+                description=self.description,
             )
 
             op = _Op(

--- a/python_modules/dagster/dagster/core/definitions/output.py
+++ b/python_modules/dagster/dagster/core/definitions/output.py
@@ -319,6 +319,10 @@ class OutputPointer(NamedTuple("_OutputPointer", [("solid_name", str), ("output_
             check.opt_str_param(output_name, "output_name", DEFAULT_OUTPUT),
         )
 
+    @property
+    def node_name(self):
+        return self.solid_name
+
 
 class OutputMapping(
     NamedTuple("_OutputMapping", [("definition", OutputDefinition), ("maps_from", OutputPointer)])

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
@@ -1,0 +1,80 @@
+from dagster import AssetKey, Out, Output
+from dagster.core.asset_defs import AssetIn, SourceAsset, asset, multi_asset
+
+
+def test_with_replaced_asset_keys():
+    @asset(ins={"input2": AssetIn(namespace="something_else")})
+    def asset1(input1, input2):
+        assert input1
+        assert input2
+
+    replaced = asset1.with_replaced_asset_keys(
+        output_asset_key_replacements={
+            AssetKey(["asset1"]): AssetKey(["prefix1", "asset1_changed"])
+        },
+        input_asset_key_replacements={
+            AssetKey(["something_else", "input2"]): AssetKey(["apple", "banana"])
+        },
+    )
+
+    assert set(replaced.dependency_asset_keys) == {
+        AssetKey("input1"),
+        AssetKey(["apple", "banana"]),
+    }
+    assert replaced.asset_keys == {AssetKey(["prefix1", "asset1_changed"])}
+
+    assert replaced.asset_keys_by_input_name["input1"] == AssetKey("input1")
+
+    assert replaced.asset_keys_by_input_name["input2"] == AssetKey(["apple", "banana"])
+
+    assert replaced.asset_keys_by_output_name["result"] == AssetKey(["prefix1", "asset1_changed"])
+
+
+def test_to_source_assets():
+    @asset(metadata={"a": "b"}, io_manager_key="abc", description="blablabla")
+    def my_asset():
+        ...
+
+    assert my_asset.to_source_assets() == [
+        SourceAsset(
+            AssetKey(["my_asset"]),
+            metadata={"a": "b"},
+            io_manager_key="abc",
+            description="blablabla",
+        )
+    ]
+
+    @multi_asset(
+        outs={
+            "my_out_name": Out(
+                asset_key=AssetKey("my_asset_name"),
+                metadata={"a": "b"},
+                io_manager_key="abc",
+                description="blablabla",
+            ),
+            "my_other_out_name": Out(
+                asset_key=AssetKey("my_other_asset"),
+                metadata={"c": "d"},
+                io_manager_key="def",
+                description="ablablabl",
+            ),
+        }
+    )
+    def my_multi_asset():
+        yield Output(1, "my_out_name")
+        yield Output(2, "my_other_out_name")
+
+    assert my_multi_asset.to_source_assets() == [
+        SourceAsset(
+            AssetKey(["my_asset_name"]),
+            metadata={"a": "b"},
+            io_manager_key="abc",
+            description="blablabla",
+        ),
+        SourceAsset(
+            AssetKey(["my_other_asset"]),
+            metadata={"c": "d"},
+            io_manager_key="def",
+            description="ablablabl",
+        ),
+    ]

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -345,31 +345,3 @@ def test_op_tags():
         ...
 
     assert my_asset.op.tags == tags_stringified
-
-
-def test_with_replaced_asset_keys():
-    @asset(ins={"input2": AssetIn(namespace="something_else")})
-    def asset1(input1, input2):
-        assert input1
-        assert input2
-
-    replaced = asset1.with_replaced_asset_keys(
-        output_asset_key_replacements={
-            AssetKey(["asset1"]): AssetKey(["prefix1", "asset1_changed"])
-        },
-        input_asset_key_replacements={
-            AssetKey(["something_else", "input2"]): AssetKey(["apple", "banana"])
-        },
-    )
-
-    assert set(replaced.dependency_asset_keys) == {
-        AssetKey("input1"),
-        AssetKey(["apple", "banana"]),
-    }
-    assert replaced.asset_keys == {AssetKey(["prefix1", "asset1_changed"])}
-
-    assert replaced.asset_keys_by_input_name["input1"] == AssetKey("input1")
-
-    assert replaced.asset_keys_by_input_name["input2"] == AssetKey(["apple", "banana"])
-
-    assert replaced.asset_keys_by_output_name["result"] == AssetKey(["prefix1", "asset1_changed"])


### PR DESCRIPTION
### Summary & Motivation

These changes aim to make it easy to have an asset group with assets that depend on assets in another asset group. E.g.

```
asset_group = AssetGroup.from_package_module(
    package_module=...,
    extra_source_assets=upstream_asset_group.to_source_assets(),
)
```

### How I Tested These Changes

Unit tests. Used them inside the hacker news asset demo.