### PR TITLE
Fix mypy config for dagster main package

### DIFF
--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 import tempfile
 import threading
-from collections import OrderedDict, defaultdict, namedtuple
+from collections import OrderedDict
 from datetime import timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, ContextManager, Generator, Generic, Iterator
@@ -188,7 +188,7 @@ class frozendict(dict):
     popitem = __readonly__
     clear = __readonly__
     update = __readonly__  # type: ignore[assignment]
-    setdefault = __readonly__
+    setdefault = __readonly__   # type: ignore[assignment]
     del __readonly__
 
     def __hash__(self):

--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -188,7 +188,7 @@ class frozendict(dict):
     popitem = __readonly__
     clear = __readonly__
     update = __readonly__  # type: ignore[assignment]
-    setdefault = __readonly__   # type: ignore[assignment]
+    setdefault = __readonly__  # type: ignore[assignment]
     del __readonly__
 
     def __hash__(self):

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -4,6 +4,7 @@ envlist = py{39,38,37,36}-{unix,windows}-{api_tests,cli_tests,core_tests,definit
 [testenv]
 usedevelop = true
 extras =
+  mypy
   test
 setenv =
   VIRTUALENV_PIP=21.3.1


### PR DESCRIPTION
Makes sure that the dagster main package is tested with the mypy in `[mypy]` extras instead of the `mypy` in the image.

### How I Tested These Changes

Existing BK tests
