### PR TITLE
allow multiple asset groups on a repository

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -3,6 +3,7 @@ from typing import (
     AbstractSet,
     Callable,
     Dict,
+    Iterable,
     List,
     Mapping,
     NamedTuple,
@@ -445,6 +446,10 @@ class AssetLayer:
     @property
     def dependency_node_handles_by_asset_key(self) -> Mapping[AssetKey, Sequence[NodeOutputHandle]]:
         return self._dependency_node_handles_by_asset_key
+
+    @property
+    def asset_keys(self) -> Iterable[AssetKey]:
+        return self._dependency_node_handles_by_asset_key.keys()
 
     def asset_key_for_input(self, node_handle: NodeHandle, input_name: str) -> Optional[AssetKey]:
         return self._asset_keys_by_node_input_handle.get(NodeInputHandle(node_handle, input_name))

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
@@ -442,18 +442,6 @@ def test_default_io_manager():
     )
 
 
-def test_repo_with_multiple_asset_groups():
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match="When constructing repository, attempted to pass multiple "
-        "AssetGroups. There can only be one AssetGroup per repository.",
-    ):
-
-        @repository
-        def the_repo():  # pylint: disable=unused-variable
-            return [AssetGroup(assets=[]), AssetGroup(assets=[])]
-
-
 def test_job_with_reserved_name():
     @graph
     def the_graph():


### PR DESCRIPTION
### Summary & Motivation

When splitting up the hacker news repositories into multiple groups, I found this useful / necessary for avoiding ugliness.

### How I Tested These Changes

Unit tests.