### PR TITLE
Fix configmaps that need to be manually set when running the user deployments helm chart in a different namespace

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -89,7 +89,7 @@ DAGSTER_HOME: {{ $dagsterHome | quote }}
 DAGSTER_K8S_PG_PASSWORD_SECRET: {{ include "dagsterUserDeployments.postgresql.secretName" . | quote }}
 DAGSTER_K8S_INSTANCE_CONFIG_MAP: "{{ template "dagster.fullname" .}}-instance"
 DAGSTER_K8S_PIPELINE_RUN_NAMESPACE: "{{ .Release.Namespace }}"
-DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP: "{{ template "dagster.fullname" . }}-pipeline-env"
+DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP: "{{ template "dagster.fullname" . }}-user-deployments-shared-env"
 {{- end -}}
 
 

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -388,33 +388,6 @@ def create_postgres_secret(namespace, should_cleanup):
             kube_api.delete_namespaced_secret(name="dagster-postgresql-secret", namespace=namespace)
 
 
-@contextmanager
-def copy_configmaps(system_namespace, user_code_namespace, should_cleanup, configmap_names):
-    kube_api = kubernetes.client.CoreV1Api()
-
-    for configmap_name in configmap_names:
-        system_configmap = kube_api.read_namespaced_config_map(
-            name=configmap_name, namespace=system_namespace
-        )
-
-        new_configmap = kubernetes.client.V1ConfigMap(
-            api_version="v1",
-            kind="ConfigMap",
-            data=system_configmap.data,
-            metadata=kubernetes.client.V1ObjectMeta(name=configmap_name),
-        )
-        kube_api.create_namespaced_config_map(namespace=user_code_namespace, body=new_configmap)
-
-    try:
-        yield
-    finally:
-        if should_cleanup:
-            for configmap_name in configmap_names:
-                kube_api.create_namespaced_config_map(
-                    name=configmap_name, namespace=user_code_namespace
-                )
-
-
 @pytest.fixture(
     scope="session",
     params=[
@@ -472,14 +445,6 @@ def helm_namespaces_for_k8s_run_launcher(
                     enable_subchart=False,
                     should_cleanup=should_cleanup,
                     run_monitoring=True,
-                )
-            )
-            stack.enter_context(
-                copy_configmaps(
-                    system_namespace,
-                    namespace,
-                    should_cleanup,
-                    configmap_names=["dagster-instance", "dagster-pipeline-env"],
                 )
             )
             yield (namespace, system_namespace)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -624,19 +624,7 @@ def construct_dagster_k8s_job(
 
     user_defined_resources = container_config.pop("resources", {})
 
-    volume_mounts = (
-        [
-            {
-                "name": "dagster-instance",
-                "mount_path": "{dagster_home}/dagster.yaml".format(
-                    dagster_home=job_config.dagster_home
-                ),
-                "sub_path": "dagster.yaml",
-            }
-        ]
-        + job_config.volume_mounts
-        + user_defined_k8s_volume_mounts
-    )
+    volume_mounts = job_config.volume_mounts + user_defined_k8s_volume_mounts
 
     resources = user_defined_resources if user_defined_resources else job_config.resources
 
@@ -658,11 +646,7 @@ def construct_dagster_k8s_job(
 
     user_defined_volumes = pod_spec_config.pop("volumes", [])
 
-    volumes = (
-        [{"name": "dagster-instance", "config_map": {"name": job_config.instance_config_map}}]
-        + job_config.volumes
-        + user_defined_volumes
-    )
+    volumes = job_config.volumes + user_defined_volumes
 
     # If the user has defined custom labels, remove them from the pod_template_spec_metadata
     # key and merge them with the dagster labels


### PR DESCRIPTION
Summary:
- We were requiring the dagster-instance configmap, even though for a long time now we have been passing through the dagster.yaml file as an instanceref instead. Instead, just don't pass through the dagster-instance configmap naymore. I tried to think it through and I don't actually think there's a back-compat issue here? As long as the pod with the run launcher is using the new version of the helm chart, it'll be passing through the instance ref (and we've been checking for a passed in instanceref in the entry point for execute_run for a very long time now)

- We were using the wrong configmap name for DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP for the user code deployments - it's intended to refer to the configmap in which it is defined. Since dagsterUserDeployments.sharedEnv is defined in the -user-deployments-shared-env configmap, that's the one tha it should use here.

These two fixes allow us to remove the requirement in the integration tests that the configmaps need to be copied over from one namespace to the other.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
