### PR TITLE
Keep firing hooks even if a framework exception is raised mid-execution

### DIFF
--- a/python_modules/dagster/dagster/core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_plan.py
@@ -191,17 +191,15 @@ def dagster_event_sequence_for_step(
             The run was interrupted in the middle of execution (typically by a
             termination request).
 
-        (5) User error:
+        (5) Dagster framework error:
             The framework raised a DagsterError that indicates a usage error
             or some other error not communicated by a user-thrown exception. For example,
             if the user yields an object out of a compute function that is not a
             proper event (not an Output, ExpectationResult, etc).
 
-        (6) Framework failure:
-            An unexpected error occurred. This is a framework error. Either there
-            has been an internal error in the framework OR we have forgotten to put a
-            user code error boundary around invoked user-space code. These terminate
-            the computation immediately (by re-raising).
+        (6) All other errors:
+            An unexpected error occurred. Either there has been an internal error in the framework
+            OR we have forgotten to put a user code error boundary around invoked user-space code.
 
 
     The "raised_dagster_errors" context manager can be used to force these errors to be
@@ -313,24 +311,16 @@ def dagster_event_sequence_for_step(
         )
         raise interrupt_error
 
-    # case (5) in top comment
-    except DagsterError as dagster_error:
-        step_context.capture_step_exception(dagster_error)
+    # cases (5) and (6) in top comment
+    except BaseException as error:
+        step_context.capture_step_exception(error)
         yield step_failure_event_from_exc_info(
             step_context,
             sys.exc_info(),
-            error_source=ErrorSource.FRAMEWORK_ERROR,
+            error_source=ErrorSource.FRAMEWORK_ERROR
+            if isinstance(error, DagsterError)
+            else ErrorSource.UNEXPECTED_ERROR,
         )
 
         if step_context.raise_on_error:
-            raise dagster_error
-
-    # case (6) in top comment
-    except BaseException as unexpected_exception:
-        step_context.capture_step_exception(unexpected_exception)
-        yield step_failure_event_from_exc_info(
-            step_context,
-            sys.exc_info(),
-            error_source=ErrorSource.UNEXPECTED_ERROR,
-        )
-        raise unexpected_exception
+            raise error

--- a/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_default_run_launcher.py
@@ -385,7 +385,7 @@ def test_exity_run(run_config):  # pylint: disable=redefined-outer-name
             assert _message_exists(event_records, 'Execution of step "exity_solid" failed.')
             assert _message_exists(
                 event_records,
-                'Execution of run for "exity_pipeline" failed. An exception was thrown during execution.',
+                "Execution of run for \"exity_pipeline\" failed. Steps failed: ['exity_solid']",
             )
 
 


### PR DESCRIPTION
Summary:
We should still fire a failure hook even if there's a framework error.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
