### PR TITLE
[not going to merge] dagit changes for graph-backed assets

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -12,6 +12,7 @@ import {AssetKey} from './types';
 type AssetMinimal = {
   assetKey: {path: string[]};
   opName: string | null;
+  opNames: string[];
   jobNames: string[];
   partitionDefinition: string | null;
   repository: {name: string; location: {name: string}};
@@ -102,12 +103,16 @@ export const LaunchAssetExecutionButton: React.FC<{
                 tags: [
                   {
                     key: DagsterTag.StepSelection,
-                    value: assets.map((o) => o.opName!).join(','),
+                    value: assets.map((o) => o.opNames!).reduce((accumulator, array) => {
+                      return [...accumulator, ...array];
+                    }, []).join(','),
                   },
                 ],
               },
               runConfigData: {},
-              stepKeys: assets.map((o) => o.opName!),
+              stepKeys: assets.map((o) => o.opNames!).reduce((accumulator, array) => {
+                return [...accumulator, ...array];
+              }, []),
               selector: {
                 repositoryLocationName: repoAddress.location,
                 repositoryName: repoAddress.name,

--- a/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
@@ -222,22 +222,6 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
                   }}
                 />
               )}
-              {explodeCompositesEnabled && (
-                <OptionsOverlay>
-                  <Checkbox
-                    format="switch"
-                    label="Explode graphs"
-                    checked={options.explodeComposites}
-                    onChange={() => {
-                      handleQueryChange('');
-                      setOptions({
-                        ...options,
-                        explodeComposites: !options.explodeComposites,
-                      });
-                    }}
-                  />
-                </OptionsOverlay>
-              )}
             </OptionsOverlay>
           )}
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -370,9 +370,8 @@ class GrapheneAssetNode(graphene.ObjectType):
             return None
 
     def resolve_opNames(self, _graphene_info) -> List[str]:
-        # todo OwenKephart: Return the correct list of op names.
-        if self._external_asset_node.op_name:
-            return [self._external_asset_node.op_name]
+        if self._external_asset_node.op_names:
+            return list(self._external_asset_node.op_names)
         else:
             return []
 

--- a/python_modules/dagster/dagster/core/asset_defs/asset_group.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_group.py
@@ -683,7 +683,9 @@ def _validate_resource_reqs_for_asset_group(
 ):
     present_resource_keys = set(resource_defs.keys())
     for asset_def in asset_list:
-        resource_keys = set(asset_def.op.required_resource_keys or {})
+        resource_keys = set()
+        for op in asset_def.node_def.iterate_solid_defs():
+            resource_keys.update(op.required_resource_keys or {})
         missing_resource_keys = list(set(resource_keys) - present_resource_keys)
         if missing_resource_keys:
             raise DagsterInvalidDefinitionError(

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -869,7 +869,7 @@ def external_asset_graph_from_defs(
                 dependencies=list(deps[asset_key].values()),
                 depended_by=list(dep_by[asset_key].values()),
                 compute_kind=node_def.tags.get("kind"),
-                op_name=node_output_handle.node_handle.name,
+                op_name=str(node_output_handle.node_handle).split(".")[0],
                 op_names=op_names_by_asset_key[asset_key],
                 op_description=node_def.description,
                 job_names=job_names,

--- a/python_modules/dagster/dagster/core/storage/fs_asset_io_manager.py
+++ b/python_modules/dagster/dagster/core/storage/fs_asset_io_manager.py
@@ -81,4 +81,7 @@ def fs_asset_io_manager(init_context):
 
 class AssetPickledObjectFilesystemIOManager(PickledObjectFilesystemIOManager):
     def _get_path(self, context):
-        return os.path.join(self.base_dir, *context.get_asset_output_identifier())
+        if context.asset_key:
+            return os.path.join(self.base_dir, *context.get_asset_output_identifier())
+        else:
+            return super()._get_path(context)


### PR DESCRIPTION
I removed the toggle to explode graphs because a) it overlaps the Show Asset Graph toggle and idk how to fix that (lol) and b) the view seems bugged (the graph inputs do not correctly map to the lower level op inputs)