### PR TITLE
[dagit] Asset details: Graph/op links

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
@@ -2482,11 +2482,11 @@ export interface AssetNodeDefinitionFragment {
   __typename: "AssetNode";
   id: string;
   description: string | null;
+  graphName: string | null;
   opName: string | null;
   opNames: string[];
   jobNames: string[];
   repository: AssetNodeDefinitionFragment_repository;
-  graphName: string | null;
   partitionDefinition: string | null;
   computeKind: string | null;
   assetKey: AssetNodeDefinitionFragment_assetKey;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
@@ -2539,10 +2539,10 @@ export interface AssetQuery_assetOrError_Asset_definition {
   repository: AssetQuery_assetOrError_Asset_definition_repository;
   jobs: AssetQuery_assetOrError_Asset_definition_jobs[];
   description: string | null;
+  graphName: string | null;
   opName: string | null;
   opNames: string[];
   jobNames: string[];
-  graphName: string | null;
   computeKind: string | null;
   assetKey: AssetQuery_assetOrError_Asset_definition_assetKey;
   assetMaterializations: AssetQuery_assetOrError_Asset_definition_assetMaterializations[];


### PR DESCRIPTION
### Summary & Motivation

Link to relevant Graph from asset node definition header.

### How I Tested These Changes

Load `test.py` provided by @sryza, view asset node definition. Verify rendering of graph name, click on graph name. Verify that I'm taken to the graph view.
