### PR TITLE
Lazily load run launcher and run coordinator in DagsterInstance

### DIFF
--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/cluster.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/cluster.py
@@ -18,11 +18,11 @@ from dagster import check
 from dagster.cli.debug import export_run
 from dagster.core.instance import DagsterInstance, InstanceType
 from dagster.core.instance.ref import InstanceRef
-from dagster.core.run_coordinator import DefaultRunCoordinator, QueuedRunCoordinator
 from dagster.core.scheduler import DagsterDaemonScheduler
 from dagster.core.storage.noop_compute_log_manager import NoOpComputeLogManager
 from dagster.core.storage.root import LocalArtifactStorage
-from dagster.core.test_utils import ExplodingRunLauncher, environ
+from dagster.core.test_utils import environ
+from dagster.serdes import ConfigurableClassData
 from dagster.utils import find_free_port
 
 from .integration_utils import IS_BUILDKITE, check_output
@@ -207,8 +207,14 @@ def dagster_instance_for_user_deployments_subchart_disabled(
             helm_postgres_url_for_user_deployments_subchart_disabled
         ),
         compute_log_manager=NoOpComputeLogManager(),
-        run_coordinator=DefaultRunCoordinator(),
-        run_launcher=ExplodingRunLauncher(),
+        run_coordinator_data=ConfigurableClassData(
+            module_name="dagster.core.run_coordinator",
+            class_name="DefaultRunCoordinator",
+        ),
+        run_launcher_data=ConfigurableClassData(
+            module_name="dagster.core.test_utils",
+            class_name="ExplodingRunLauncher",
+        ),
     ) as instance:
         yield instance
 
@@ -238,8 +244,14 @@ def dagster_instance_for_daemon(
         event_storage=PostgresEventLogStorage(helm_postgres_url_for_daemon),
         schedule_storage=PostgresScheduleStorage(helm_postgres_url_for_daemon),
         compute_log_manager=NoOpComputeLogManager(),
-        run_coordinator=QueuedRunCoordinator(),
-        run_launcher=ExplodingRunLauncher(),
+        run_coordinator_data=ConfigurableClassData(
+            module_name="dagster.core.run_coordinator",
+            class_name="QueuedRunCoordinator",
+        ),
+        run_launcher_data=ConfigurableClassData(
+            module_name="dagster.core.test_utils",
+            class_name="ExplodingRunLauncher",
+        ),
         scheduler=DagsterDaemonScheduler(),
     ) as instance:
         yield instance
@@ -262,8 +274,14 @@ def dagster_instance_for_k8s_run_launcher(
         event_storage=PostgresEventLogStorage(helm_postgres_url_for_k8s_run_launcher),
         schedule_storage=PostgresScheduleStorage(helm_postgres_url_for_k8s_run_launcher),
         compute_log_manager=NoOpComputeLogManager(),
-        run_coordinator=DefaultRunCoordinator(),
-        run_launcher=ExplodingRunLauncher(),
+        run_coordinator_data=ConfigurableClassData(
+            module_name="dagster.core.run_coordinator",
+            class_name="DefaultRunCoordinator",
+        ),
+        run_launcher_data=ConfigurableClassData(
+            module_name="dagster.core.test_utils",
+            class_name="ExplodingRunLauncher",
+        ),
         ref=instance_ref,
     ) as instance:
         yield instance
@@ -293,8 +311,14 @@ def dagster_instance(helm_postgres_url):  # pylint: disable=redefined-outer-name
                 run_storage=PostgresRunStorage(helm_postgres_url),
                 event_storage=PostgresEventLogStorage(helm_postgres_url),
                 compute_log_manager=NoOpComputeLogManager(),
-                run_coordinator=DefaultRunCoordinator(),
-                run_launcher=ExplodingRunLauncher(),  # use graphql to launch any runs
+                run_coordinator_data=ConfigurableClassData(
+                    module_name="dagster.core.run_coordinator",
+                    class_name="DefaultRunCoordinator",
+                ),
+                run_launcher_data=ConfigurableClassData(
+                    module_name="dagster.core.test_utils",
+                    class_name="ExplodingRunLauncher",  # use graphql to launch any runs
+                ),
                 ref=InstanceRef.from_dir(tempdir),
             ) as instance:
                 yield instance

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
@@ -10,15 +10,13 @@ from dagster_graphql.test.utils import execute_dagster_graphql
 
 from dagster import check, file_relative_path
 from dagster.core.instance import DagsterInstance, InstanceType
-from dagster.core.launcher.sync_in_memory_run_launcher import SyncInMemoryRunLauncher
-from dagster.core.run_coordinator import DefaultRunCoordinator
 from dagster.core.storage.event_log import InMemoryEventLogStorage
 from dagster.core.storage.event_log.sqlite import ConsolidatedSqliteEventLogStorage
 from dagster.core.storage.local_compute_log_manager import LocalComputeLogManager
 from dagster.core.storage.root import LocalArtifactStorage
 from dagster.core.storage.runs import InMemoryRunStorage
 from dagster.core.storage.schedules.sqlite.sqlite_schedule_storage import SqliteScheduleStorage
-from dagster.core.test_utils import ExplodingRunLauncher, instance_for_test
+from dagster.core.test_utils import instance_for_test
 from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster.core.workspace import WorkspaceProcessContext
 from dagster.core.workspace.load_target import (
@@ -28,6 +26,7 @@ from dagster.core.workspace.load_target import (
     WorkspaceFileTarget,
 )
 from dagster.grpc.server import GrpcServerProcess
+from dagster.serdes import ConfigurableClassData
 from dagster.utils import merge_dicts
 from dagster.utils.test import FilesystemTestScheduler
 from dagster.utils.test.postgres_instance import TestPostgresInstance
@@ -111,8 +110,14 @@ class InstanceManagers:
                     run_storage=InMemoryRunStorage(),
                     event_storage=InMemoryEventLogStorage(),
                     compute_log_manager=LocalComputeLogManager(temp_dir),
-                    run_launcher=SyncInMemoryRunLauncher(),
-                    run_coordinator=DefaultRunCoordinator(),
+                    run_coordinator_data=ConfigurableClassData(
+                        module_name="dagster.core.run_coordinator",
+                        class_name="DefaultRunCoordinator",
+                    ),
+                    run_launcher_data=ConfigurableClassData(
+                        module_name="dagster.core.launcher",
+                        class_name="SyncInMemoryRunLauncher",
+                    ),
                     schedule_storage=SqliteScheduleStorage.from_local(temp_dir),
                     scheduler=FilesystemTestScheduler(temp_dir),
                 )
@@ -130,8 +135,14 @@ class InstanceManagers:
                     run_storage=InMemoryRunStorage(),
                     event_storage=InMemoryEventLogStorage(),
                     compute_log_manager=LocalComputeLogManager(temp_dir),
-                    run_launcher=ExplodingRunLauncher(),
-                    run_coordinator=DefaultRunCoordinator(),
+                    run_coordinator_data=ConfigurableClassData(
+                        module_name="dagster.core.run_coordinator",
+                        class_name="DefaultRunCoordinator",
+                    ),
+                    run_launcher_data=ConfigurableClassData(
+                        module_name="dagster.core.test_utils",
+                        class_name="ExplodingRunLauncher",
+                    ),
                     schedule_storage=SqliteScheduleStorage.from_local(temp_dir),
                     scheduler=FilesystemTestScheduler(temp_dir),
                 )
@@ -316,8 +327,14 @@ class InstanceManagers:
                     run_storage=InMemoryRunStorage(),
                     event_storage=ConsolidatedSqliteEventLogStorage(temp_dir),
                     compute_log_manager=LocalComputeLogManager(temp_dir),
-                    run_coordinator=DefaultRunCoordinator(),
-                    run_launcher=SyncInMemoryRunLauncher(),
+                    run_coordinator_data=ConfigurableClassData(
+                        module_name="dagster.core.run_coordinator",
+                        class_name="DefaultRunCoordinator",
+                    ),
+                    run_launcher_data=ConfigurableClassData(
+                        module_name="dagster.core.launcher",
+                        class_name="SyncInMemoryRunLauncher",
+                    ),
                     scheduler=FilesystemTestScheduler(temp_dir),
                 )
                 yield instance

--- a/python_modules/dagster/dagster/core/instance/ref.py
+++ b/python_modules/dagster/dagster/core/instance/ref.py
@@ -266,14 +266,6 @@ class InstanceRef(
         return self.scheduler_data.rehydrate() if self.scheduler_data else None
 
     @property
-    def run_coordinator(self):
-        return self.run_coordinator_data.rehydrate() if self.run_coordinator_data else None
-
-    @property
-    def run_launcher(self):
-        return self.run_launcher_data.rehydrate() if self.run_launcher_data else None
-
-    @property
     def custom_instance_class(self):
         return (
             class_from_code_pointer(

--- a/python_modules/dagster/dagster/core/launcher/__init__.py
+++ b/python_modules/dagster/dagster/core/launcher/__init__.py
@@ -6,3 +6,4 @@ from .base import (
     WorkerStatus,
 )
 from .default_run_launcher import DefaultRunLauncher
+from .sync_in_memory_run_launcher import SyncInMemoryRunLauncher

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_compute_log_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_compute_log_manager.py
@@ -3,8 +3,6 @@ from contextlib import contextmanager
 
 from dagster import check, job, op
 from dagster.core.instance import DagsterInstance, InstanceRef, InstanceType
-from dagster.core.launcher import DefaultRunLauncher
-from dagster.core.run_coordinator import DefaultRunCoordinator
 from dagster.core.storage.compute_log_manager import (
     MAX_BYTES_FILE_READ,
     ComputeLogFileData,
@@ -14,6 +12,7 @@ from dagster.core.storage.event_log import SqliteEventLogStorage
 from dagster.core.storage.root import LocalArtifactStorage
 from dagster.core.storage.runs import SqliteRunStorage
 from dagster.core.test_utils import environ, instance_for_test
+from dagster.serdes import ConfigurableClassData
 
 
 def test_compute_log_manager_instance():
@@ -66,8 +65,14 @@ def broken_compute_log_manager_instance(fail_on_setup=False, fail_on_teardown=Fa
                 compute_log_manager=BrokenComputeLogManager(
                     fail_on_setup=fail_on_setup, fail_on_teardown=fail_on_teardown
                 ),
-                run_coordinator=DefaultRunCoordinator(),
-                run_launcher=DefaultRunLauncher(),
+                run_coordinator_data=ConfigurableClassData(
+                    module_name="dagster.core.run_coordinator",
+                    class_name="DefaultRunCoordinator",
+                ),
+                run_launcher_data=ConfigurableClassData(
+                    module_name="dagster.core.launcher",
+                    class_name="DefaultRunLauncher",
+                ),
                 ref=InstanceRef.from_dir(temp_dir),
             )
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_local_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_local_instance.py
@@ -20,14 +20,13 @@ from dagster import (
 from dagster.core.definitions.events import RetryRequested
 from dagster.core.execution.stats import StepEventStatus
 from dagster.core.instance import DagsterInstance, InstanceRef, InstanceType
-from dagster.core.launcher import DefaultRunLauncher
-from dagster.core.run_coordinator import DefaultRunCoordinator
 from dagster.core.storage.event_log import SqliteEventLogStorage
 from dagster.core.storage.local_compute_log_manager import LocalComputeLogManager
 from dagster.core.storage.pipeline_run import PipelineRunStatus
 from dagster.core.storage.root import LocalArtifactStorage
 from dagster.core.storage.runs import SqliteRunStorage
 from dagster.core.test_utils import environ
+from dagster.serdes import ConfigurableClassData
 
 
 def test_fs_stores():
@@ -51,8 +50,14 @@ def test_fs_stores():
                 run_storage=run_store,
                 event_storage=event_store,
                 compute_log_manager=compute_log_manager,
-                run_coordinator=DefaultRunCoordinator(),
-                run_launcher=DefaultRunLauncher(),
+                run_coordinator_data=ConfigurableClassData(
+                    module_name="dagster.core.run_coordinator",
+                    class_name="DefaultRunCoordinator",
+                ),
+                run_launcher_data=ConfigurableClassData(
+                    module_name="dagster.core.launcher",
+                    class_name="DefaultRunLauncher",
+                ),
                 ref=InstanceRef.from_dir(temp_dir),
                 settings={"telemetry": {"enabled": False}},
             )

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
@@ -19,8 +19,6 @@ from dagster.core.host_representation import (
     ManagedGrpcPythonEnvRepositoryLocationOrigin,
 )
 from dagster.core.instance import DagsterInstance, InstanceType
-from dagster.core.launcher.sync_in_memory_run_launcher import SyncInMemoryRunLauncher
-from dagster.core.run_coordinator import DefaultRunCoordinator
 from dagster.core.snap import create_pipeline_snapshot_id
 from dagster.core.storage.event_log import InMemoryEventLogStorage
 from dagster.core.storage.noop_compute_log_manager import NoOpComputeLogManager
@@ -39,7 +37,7 @@ from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster.core.utils import make_new_run_id
 from dagster.daemon.daemon import SensorDaemon
 from dagster.daemon.types import DaemonHeartbeat
-from dagster.serdes import serialize_pp
+from dagster.serdes import ConfigurableClassData, serialize_pp
 from dagster.seven.compat.pendulum import create_pendulum_time, to_timezone
 
 win_py36 = seven.IS_WINDOWS and sys.version_info[0] == 3 and sys.version_info[1] == 6
@@ -1354,8 +1352,14 @@ class TestRunStorage:
                     run_storage=storage,
                     event_storage=InMemoryEventLogStorage(),
                     compute_log_manager=NoOpComputeLogManager(),
-                    run_coordinator=DefaultRunCoordinator(),
-                    run_launcher=SyncInMemoryRunLauncher(),
+                    run_coordinator_data=ConfigurableClassData(
+                        module_name="dagster.core.run_coordinator",
+                        class_name="DefaultRunCoordinator",
+                    ),
+                    run_launcher_data=ConfigurableClassData(
+                        module_name="dagster.core.launcher",
+                        class_name="SyncInMemoryRunLauncher",
+                    ),
                 )
 
             freeze_datetime = to_timezone(

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
@@ -8,13 +8,12 @@ from dagster_aws.s3 import S3ComputeLogManager
 
 from dagster import DagsterEventType, job, op
 from dagster.core.instance import DagsterInstance, InstanceRef, InstanceType
-from dagster.core.launcher import DefaultRunLauncher
-from dagster.core.run_coordinator import DefaultRunCoordinator
 from dagster.core.storage.compute_log_manager import ComputeIOType
 from dagster.core.storage.event_log import SqliteEventLogStorage
 from dagster.core.storage.root import LocalArtifactStorage
 from dagster.core.storage.runs import SqliteRunStorage
 from dagster.core.test_utils import environ
+from dagster.serdes import ConfigurableClassData
 
 HELLO_WORLD = "Hello World"
 SEPARATOR = os.linesep if (os.name == "nt" and sys.version_info < (3,)) else "\n"
@@ -49,8 +48,14 @@ def test_compute_log_manager(mock_s3_bucket):
                 run_storage=run_store,
                 event_storage=event_store,
                 compute_log_manager=manager,
-                run_coordinator=DefaultRunCoordinator(),
-                run_launcher=DefaultRunLauncher(),
+                run_coordinator_data=ConfigurableClassData(
+                    module_name="dagster.core.run_coordinator",
+                    class_name="DefaultRunCoordinator",
+                ),
+                run_launcher_data=ConfigurableClassData(
+                    module_name="dagster.core.launcher",
+                    class_name="DefaultRunLauncher",
+                ),
                 ref=InstanceRef.from_dir(temp_dir),
             )
             result = simple.execute_in_process(instance=instance)
@@ -140,8 +145,14 @@ def test_compute_log_manager_skip_empty_upload(mock_s3_bucket):
                 run_storage=run_store,
                 event_storage=event_store,
                 compute_log_manager=manager,
-                run_coordinator=DefaultRunCoordinator(),
-                run_launcher=DefaultRunLauncher(),
+                run_coordinator_data=ConfigurableClassData(
+                    module_name="dagster.core.run_coordinator",
+                    class_name="DefaultRunCoordinator",
+                ),
+                run_launcher_data=ConfigurableClassData(
+                    module_name="dagster.core.launcher",
+                    class_name="DefaultRunLauncher",
+                ),
                 ref=InstanceRef.from_dir(temp_dir),
             )
             result = simple.execute_in_process(instance=instance)

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
@@ -7,13 +7,12 @@ from dagster_azure.blob import AzureBlobComputeLogManager, FakeBlobServiceClient
 
 from dagster import DagsterEventType, graph, op
 from dagster.core.instance import DagsterInstance, InstanceRef, InstanceType
-from dagster.core.launcher.sync_in_memory_run_launcher import SyncInMemoryRunLauncher
-from dagster.core.run_coordinator import DefaultRunCoordinator
 from dagster.core.storage.compute_log_manager import ComputeIOType
 from dagster.core.storage.event_log import SqliteEventLogStorage
 from dagster.core.storage.root import LocalArtifactStorage
 from dagster.core.storage.runs import SqliteRunStorage
 from dagster.core.test_utils import environ
+from dagster.serdes import ConfigurableClassData
 
 HELLO_WORLD = "Hello World"
 SEPARATOR = os.linesep if (os.name == "nt" and sys.version_info < (3,)) else "\n"
@@ -60,8 +59,14 @@ def test_compute_log_manager(
                 run_storage=run_store,
                 event_storage=event_store,
                 compute_log_manager=manager,
-                run_coordinator=DefaultRunCoordinator(),
-                run_launcher=SyncInMemoryRunLauncher(),
+                run_coordinator_data=ConfigurableClassData(
+                    module_name="dagster.core.run_coordinator",
+                    class_name="DefaultRunCoordinator",
+                ),
+                run_launcher_data=ConfigurableClassData(
+                    module_name="dagster.core.launcher",
+                    class_name="SyncInMemoryRunLauncher",
+                ),
                 ref=InstanceRef.from_dir(temp_dir),
             )
             result = simple.execute_in_process(instance=instance)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
@@ -7,13 +7,12 @@ from google.cloud import storage  # type: ignore
 
 from dagster import DagsterEventType, job, op
 from dagster.core.instance import DagsterInstance, InstanceRef, InstanceType
-from dagster.core.launcher import DefaultRunLauncher
-from dagster.core.run_coordinator import DefaultRunCoordinator
 from dagster.core.storage.compute_log_manager import ComputeIOType
 from dagster.core.storage.event_log import SqliteEventLogStorage
 from dagster.core.storage.root import LocalArtifactStorage
 from dagster.core.storage.runs import SqliteRunStorage
 from dagster.core.test_utils import environ
+from dagster.serdes import ConfigurableClassData
 
 HELLO_WORLD = "Hello World"
 SEPARATOR = os.linesep if (os.name == "nt" and sys.version_info < (3,)) else "\n"
@@ -48,8 +47,14 @@ def test_compute_log_manager(gcs_bucket):
                 run_storage=run_store,
                 event_storage=event_store,
                 compute_log_manager=manager,
-                run_coordinator=DefaultRunCoordinator(),
-                run_launcher=DefaultRunLauncher(),
+                run_coordinator_data=ConfigurableClassData(
+                    module_name="dagster.core.run_coordinator",
+                    class_name="DefaultRunCoordinator",
+                ),
+                run_launcher_data=ConfigurableClassData(
+                    module_name="dagster.core.launcher",
+                    class_name="DefaultRunLauncher",
+                ),
                 ref=InstanceRef.from_dir(temp_dir),
             )
             result = simple.execute_in_process(instance=instance)
@@ -121,8 +126,14 @@ def test_compute_log_manager_with_envvar(gcs_bucket):
                     run_storage=run_store,
                     event_storage=event_store,
                     compute_log_manager=manager,
-                    run_coordinator=DefaultRunCoordinator(),
-                    run_launcher=DefaultRunLauncher(),
+                    run_coordinator_data=ConfigurableClassData(
+                        module_name="dagster.core.run_coordinator",
+                        class_name="DefaultRunCoordinator",
+                    ),
+                    run_launcher_data=ConfigurableClassData(
+                        module_name="dagster.core.launcher",
+                        class_name="DefaultRunLauncher",
+                    ),
                     ref=InstanceRef.from_dir(temp_dir),
                 )
                 result = simple.execute_in_process(instance=instance)


### PR DESCRIPTION
Summary:
User code processes generally don't need to load the RunLauncher or the RunCoordinator, so load them lazily

(an exception is the k8s_job_executor and docker_executor - we should investigate ways to eliminate this dependency though)

### Summary & Motivation

### How I Tested These Changes
