### PR TITLE
Switch new partition page to use more efficient partition status query

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1392,6 +1392,7 @@ type PartitionStatus {
   id: String!
   partitionName: String!
   runStatus: RunStatus
+  runDuration: Float
 }
 
 type PartitionRun {

--- a/js_modules/dagit/packages/core/src/partitions/BackfillSelector.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/BackfillSelector.tsx
@@ -33,6 +33,8 @@ import {
 } from '../instance/types/LaunchPartitionBackfill';
 import {LaunchButton} from '../launchpad/LaunchButton';
 import {TagContainer, TagEditor} from '../launchpad/TagEditor';
+import {explodeCompositesInHandleGraph} from '../pipelines/CompositeSupport';
+import {GRAPH_EXPLORER_SOLID_HANDLE_FRAGMENT} from '../pipelines/GraphExplorer';
 import {RunStatus} from '../types/globalTypes';
 import {GraphQueryInput} from '../ui/GraphQueryInput';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
@@ -128,7 +130,9 @@ export const BackfillPartitionSelector: React.FC<{
   }
 
   const {pipelineSnapshotOrError: pipelineSnapshot, instance} = data;
-  const solids = pipelineSnapshot.solidHandles.map((h: any) => h.solid);
+  const solids = explodeCompositesInHandleGraph(pipelineSnapshot.solidHandles).map(
+    (h: any) => h.solid,
+  );
   const solidsFiltered = filterByQuery(solids, query);
   const layout = buildLayout({nodes: solidsFiltered.all, mode: GanttChartMode.FLAT});
   const stepRows = layout.boxes.map((box) => ({
@@ -456,6 +460,7 @@ const BACKFILL_SELECTOR_QUERY = gql`
         name
         solidHandles {
           handleID
+          ...GraphExplorerSolidHandleFragment
           solid {
             name
             definition {
@@ -493,6 +498,7 @@ const BACKFILL_SELECTOR_QUERY = gql`
       runQueuingSupported
     }
   }
+  ${GRAPH_EXPLORER_SOLID_HANDLE_FRAGMENT}
 `;
 
 function messageForLaunchBackfillError(data: LaunchPartitionBackfill | null | undefined) {

--- a/js_modules/dagit/packages/core/src/partitions/PartitionViewNew.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionViewNew.tsx
@@ -28,7 +28,6 @@ import {PartitionStepStatus} from './PartitionStepStatus';
 import {
   PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionStatusesOrError_PartitionStatuses_results,
   PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionsOrError_Partitions_results,
-  PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionRuns,
   PartitionsStatusQuery_partitionSetOrError_PartitionSet,
   PartitionsStatusQuery,
   PartitionsStatusQueryVariables,
@@ -143,17 +142,12 @@ const PartitionViewContent: React.FC<{
     });
   });
   const statusData: {[name: string]: RunStatus | null} = {};
-  partitionSet.partitionRuns.forEach(
-    (partition: PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionRuns) => {
-      statusData[partition.partitionName] = partition.run ? partition.run.status : null;
-      if (selectedPartitions.includes(partition.partitionName)) {
-        runDurationData[partition.partitionName] =
-          partition.run && partition.run.startTime && partition.run.endTime
-            ? partition.run.endTime - partition.run.startTime
-            : undefined;
-      }
-    },
-  );
+  partitionSet.partitionStatusesOrError.results.forEach((p) => {
+    statusData[p.partitionName] = p.runStatus;
+    if (selectedPartitions.includes(p.partitionName)) {
+      runDurationData[p.partitionName] = p.runDuration;
+    }
+  });
 
   const onSubmit = React.useCallback(() => setBlockDialog(true), []);
 
@@ -409,22 +403,13 @@ const PARTITIONS_STATUS_QUERY = gql`
             }
           }
         }
-        partitionRuns {
-          id
-          partitionName
-          run {
-            id
-            status
-            startTime
-            endTime
-          }
-        }
         partitionStatusesOrError {
           ... on PartitionStatuses {
             results {
               id
               partitionName
               runStatus
+              runDuration
             }
           }
           ...PythonErrorFragment

--- a/js_modules/dagit/packages/core/src/partitions/PartitionViewNew.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionViewNew.tsx
@@ -142,10 +142,13 @@ const PartitionViewContent: React.FC<{
     });
   });
   const statusData: {[name: string]: RunStatus | null} = {};
-  partitionSet.partitionStatusesOrError.results.forEach((p) => {
+  (partitionSet.partitionStatusesOrError.__typename === 'PartitionStatuses'
+    ? partitionSet.partitionStatusesOrError.results
+    : []
+  ).forEach((p) => {
     statusData[p.partitionName] = p.runStatus;
     if (selectedPartitions.includes(p.partitionName)) {
-      runDurationData[p.partitionName] = p.runDuration;
+      runDurationData[p.partitionName] = p.runDuration || undefined;
     }
   });
 
@@ -404,6 +407,7 @@ const PARTITIONS_STATUS_QUERY = gql`
           }
         }
         partitionStatusesOrError {
+          __typename
           ... on PartitionStatuses {
             results {
               id

--- a/js_modules/dagit/packages/core/src/partitions/types/BackfillSelectorQuery.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/BackfillSelectorQuery.ts
@@ -13,9 +13,20 @@ export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineNotFoundE
   __typename: "PipelineNotFoundError" | "PipelineSnapshotNotFoundError" | "PythonError";
 }
 
-export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition {
-  __typename: "SolidDefinition" | "CompositeSolidDefinition";
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_inputs_definition {
+  __typename: "InputDefinition";
   name: string;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_inputs_dependsOn_definition_type {
+  __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
+  displayName: string;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_inputs_dependsOn_definition {
+  __typename: "OutputDefinition";
+  name: string;
+  type: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_inputs_dependsOn_definition_type;
 }
 
 export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_inputs_dependsOn_solid {
@@ -25,12 +36,20 @@ export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_
 
 export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_inputs_dependsOn {
   __typename: "Output";
+  definition: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_inputs_dependsOn_definition;
   solid: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_inputs_dependsOn_solid;
 }
 
 export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_inputs {
   __typename: "Input";
+  definition: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_inputs_definition;
+  isDynamicCollect: boolean;
   dependsOn: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_inputs_dependsOn[];
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_outputs_definition {
+  __typename: "OutputDefinition";
+  name: string;
 }
 
 export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_outputs_dependedBy_solid {
@@ -38,22 +57,207 @@ export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_
   name: string;
 }
 
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_outputs_dependedBy_definition_type {
+  __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
+  displayName: string;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_outputs_dependedBy_definition {
+  __typename: "InputDefinition";
+  name: string;
+  type: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_outputs_dependedBy_definition_type;
+}
+
 export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_outputs_dependedBy {
   __typename: "Input";
   solid: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_outputs_dependedBy_solid;
+  definition: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_outputs_dependedBy_definition;
 }
 
 export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_outputs {
   __typename: "Output";
+  definition: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_outputs_definition;
   dependedBy: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_outputs_dependedBy[];
 }
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_metadata {
+  __typename: "MetadataItemDefinition";
+  key: string;
+  value: string;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_assetNodes_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_assetNodes {
+  __typename: "AssetNode";
+  id: string;
+  assetKey: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_assetNodes_assetKey;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_inputDefinitions_type {
+  __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
+  displayName: string;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_inputDefinitions {
+  __typename: "InputDefinition";
+  name: string;
+  type: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_inputDefinitions_type;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_outputDefinitions_type {
+  __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
+  displayName: string;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_outputDefinitions {
+  __typename: "OutputDefinition";
+  name: string;
+  isDynamic: boolean | null;
+  type: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_outputDefinitions_type;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_configField_configType {
+  __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "ArrayConfigType" | "NullableConfigType" | "ScalarUnionConfigType" | "MapConfigType";
+  key: string;
+  description: string | null;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_configField {
+  __typename: "ConfigTypeField";
+  configType: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_configField_configType;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition {
+  __typename: "SolidDefinition";
+  name: string;
+  description: string | null;
+  metadata: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_metadata[];
+  assetNodes: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_assetNodes[];
+  inputDefinitions: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_inputDefinitions[];
+  outputDefinitions: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_outputDefinitions[];
+  configField: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition_configField | null;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_metadata {
+  __typename: "MetadataItemDefinition";
+  key: string;
+  value: string;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_assetNodes_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_assetNodes {
+  __typename: "AssetNode";
+  id: string;
+  assetKey: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_assetNodes_assetKey;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_inputDefinitions_type {
+  __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
+  displayName: string;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_inputDefinitions {
+  __typename: "InputDefinition";
+  name: string;
+  type: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_inputDefinitions_type;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_outputDefinitions_type {
+  __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
+  displayName: string;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_outputDefinitions {
+  __typename: "OutputDefinition";
+  name: string;
+  isDynamic: boolean | null;
+  type: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_outputDefinitions_type;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_definition {
+  __typename: "InputDefinition";
+  name: string;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput_definition {
+  __typename: "InputDefinition";
+  name: string;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput_solid {
+  __typename: "Solid";
+  name: string;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput {
+  __typename: "Input";
+  definition: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput_definition;
+  solid: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput_solid;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings {
+  __typename: "InputMapping";
+  definition: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_definition;
+  mappedInput: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_definition {
+  __typename: "OutputDefinition";
+  name: string;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput_definition {
+  __typename: "OutputDefinition";
+  name: string;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput_solid {
+  __typename: "Solid";
+  name: string;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput {
+  __typename: "Output";
+  definition: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput_definition;
+  solid: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput_solid;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings {
+  __typename: "OutputMapping";
+  definition: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_definition;
+  mappedOutput: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput;
+}
+
+export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition {
+  __typename: "CompositeSolidDefinition";
+  name: string;
+  description: string | null;
+  metadata: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_metadata[];
+  assetNodes: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_assetNodes[];
+  inputDefinitions: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_inputDefinitions[];
+  outputDefinitions: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_outputDefinitions[];
+  id: string;
+  inputMappings: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings[];
+  outputMappings: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings[];
+}
+
+export type BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition = BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_SolidDefinition | BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition_CompositeSolidDefinition;
 
 export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid {
   __typename: "Solid";
   name: string;
-  definition: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition;
+  isDynamicMapped: boolean;
   inputs: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_inputs[];
   outputs: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_outputs[];
+  definition: BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles_solid_definition;
 }
 
 export interface BackfillSelectorQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles {

--- a/js_modules/dagit/packages/core/src/partitions/types/PartitionsStatusQuery.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/PartitionsStatusQuery.ts
@@ -29,26 +29,12 @@ export interface PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitio
 
 export type PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionsOrError = PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionsOrError_PythonError | PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionsOrError_Partitions;
 
-export interface PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionRuns_run {
-  __typename: "Run";
-  id: string;
-  status: RunStatus;
-  startTime: number | null;
-  endTime: number | null;
-}
-
-export interface PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionRuns {
-  __typename: "PartitionRun";
-  id: string;
-  partitionName: string;
-  run: PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionRuns_run | null;
-}
-
 export interface PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionStatusesOrError_PartitionStatuses_results {
   __typename: "PartitionStatus";
   id: string;
   partitionName: string;
   runStatus: RunStatus | null;
+  runDuration: number | null;
 }
 
 export interface PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionStatusesOrError_PartitionStatuses {
@@ -77,7 +63,6 @@ export interface PartitionsStatusQuery_partitionSetOrError_PartitionSet {
   name: string;
   pipelineName: string;
   partitionsOrError: PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionsOrError;
-  partitionRuns: PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionRuns[];
   partitionStatusesOrError: PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionStatusesOrError;
 }
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -171,36 +171,25 @@ def _apply_cursor_limit_reverse(items, cursor, limit, reverse):
 
 
 @capture_error
-def get_partition_set_partition_statuses(graphene_info, repository_handle, partition_set_name):
+def get_partition_set_partition_statuses(
+    graphene_info, repository_handle, partition_set_name, job_name
+):
     from ..schema.partition_sets import GraphenePartitionStatus, GraphenePartitionStatuses
 
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
     check.str_param(partition_set_name, "partition_set_name")
-    result = graphene_info.context.get_external_partition_names(
-        repository_handle, partition_set_name
+    run_partition_data = graphene_info.context.instance.run_storage.get_run_partition_data(
+        partition_set_name, job_name
     )
-    all_partition_set_runs = graphene_info.context.instance.get_runs(
-        RunsFilter(tags={PARTITION_SET_TAG: partition_set_name})
-    )
-    runs_by_partition = {}
-    for run in all_partition_set_runs:
-        partition_name = run.tags.get(PARTITION_NAME_TAG)
-        if not partition_name or partition_name in runs_by_partition:
-            # all_partition_set_runs is in descending order by creation time, we should ignore
-            # runs for the same partition if we've already considered the partition
-            continue
-        runs_by_partition[partition_name] = run
-
     return GraphenePartitionStatuses(
         results=[
             GraphenePartitionStatus(
-                id=f"{partition_set_name}:{partition_name}",
-                partitionName=partition_name,
-                runStatus=runs_by_partition[partition_name].status
-                if runs_by_partition.get(partition_name)
-                else None,
+                id=f"{partition_set_name}:{p.partition}",
+                partitionName=p.partition,
+                runStatus=p.status,
+                runDuration=p.end_time - p.start_time if p.end_time and p.start_time else None,
             )
-            for partition_name in result.partition_names
+            for p in run_partition_data
         ]
     )
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -179,7 +179,7 @@ def get_partition_set_partition_statuses(
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
     check.str_param(partition_set_name, "partition_set_name")
     run_partition_data = graphene_info.context.instance.run_storage.get_run_partition_data(
-        partition_set_name, job_name
+        partition_set_name, job_name, repository_handle.get_external_origin().get_id()
     )
     return GraphenePartitionStatuses(
         results=[

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -54,6 +54,7 @@ class GraphenePartitionStatus(graphene.ObjectType):
     id = graphene.NonNull(graphene.String)
     partitionName = graphene.NonNull(graphene.String)
     runStatus = graphene.Field(GrapheneRunStatus)
+    runDuration = graphene.Field(graphene.Float)
 
     class Meta:
         name = "PartitionStatus"
@@ -238,7 +239,10 @@ class GraphenePartitionSet(graphene.ObjectType):
 
     def resolve_partitionStatusesOrError(self, graphene_info):
         return get_partition_set_partition_statuses(
-            graphene_info, self._external_repository_handle, self._external_partition_set.name
+            graphene_info,
+            self._external_repository_handle,
+            self._external_partition_set.name,
+            self._external_partition_set.pipeline_name,
         )
 
     def resolve_repositoryOrigin(self, _):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_sets.py
@@ -271,7 +271,7 @@ class TestPartitionSetRuns(ExecutingGraphQLContextTestMatrix):
         partitionStatuses = result.data["partitionSetOrError"]["partitionStatusesOrError"][
             "results"
         ]
-        assert len(partitionStatuses) == 10
+        assert len(partitionStatuses) == 2
         for partitionStatus in partitionStatuses:
             if partitionStatus["partitionName"] in ("2", "3"):
                 assert partitionStatus["runStatus"] == "SUCCESS"

--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from collections import defaultdict
 from datetime import datetime
 from enum import Enum
-from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import Callable, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple, Union
 
 import pendulum
 import sqlalchemy as db

--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from collections import defaultdict
 from datetime import datetime
 from enum import Enum
-from typing import Callable, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple, Union
+from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import pendulum
 import sqlalchemy as db


### PR DESCRIPTION
### Summary & Motivation
The new run storage method calculates partition status without deserializing all of the runs.  This hooks up the new partitions page to use this run storage method instead of fetching all runs.

### How I Tested These Changes
Loaded new partitions page.
