### PR TITLE
Add all repos to hacker_news __init__.py

### DIFF
--- a/examples/hacker_news/hacker_news/__init__.py
+++ b/examples/hacker_news/hacker_news/__init__.py
@@ -1,1 +1,1 @@
-from .repo import hacker_news_prod
+from .repo import hacker_news_local, hacker_news_prod, hacker_news_staging

--- a/examples/hacker_news/workspace.yaml
+++ b/examples/hacker_news/workspace.yaml
@@ -1,2 +1,5 @@
 load_from:
   - python_package: hacker_news
+    # Scopes down the repository to use in this Dagster deployment - this can be varied in
+    # different environments to allow the same code to be used in different environments
+    attribute: hacker_news_prod


### PR DESCRIPTION
Summary:
User expressed confusion about why this only included a single repo. Include all repos, but make the workspace.yaml scope down to a single repo using the attribute tag.

Test Plan: Run dagit in hacker-news repo

### Summary & Motivation

### How I Tested These Changes
