### PR TITLE
remove usable_as_dagster_type from integrations

### DIFF
--- a/python_modules/dagster/dagster/core/storage/file_manager.py
+++ b/python_modules/dagster/dagster/core/storage/file_manager.py
@@ -11,14 +11,12 @@ from dagster.config import Field
 from dagster.config.source import StringSource
 from dagster.core.definitions.resource_definition import resource
 from dagster.core.instance import DagsterInstance
-from dagster.core.types.decorator import usable_as_dagster_type
 from dagster.utils import mkdir_p
 
 from .temp_file_manager import TempfileManager
 
 
 # pylint: disable=no-init
-@usable_as_dagster_type
 class FileHandle(ABC):
     """A reference to a file as manipulated by a FileManager
 
@@ -38,7 +36,6 @@ class FileHandle(ABC):
         raise NotImplementedError()
 
 
-@usable_as_dagster_type
 class LocalFileHandle(FileHandle):
     """A reference to a file on a local filesystem."""
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/types.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/types.py
@@ -1,9 +1,6 @@
 from typing import Any, Dict, NamedTuple
 
-from dagster import usable_as_dagster_type
 
-
-@usable_as_dagster_type
 class AirbyteOutput(
     NamedTuple(
         "_AirbyteOutput",

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/file_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/file_manager.py
@@ -2,7 +2,7 @@ import io
 import uuid
 from contextlib import contextmanager
 
-from dagster import check, usable_as_dagster_type
+from dagster import check
 from dagster.core.storage.file_manager import (
     FileHandle,
     FileManager,
@@ -11,7 +11,6 @@ from dagster.core.storage.file_manager import (
 )
 
 
-@usable_as_dagster_type
 class S3FileHandle(FileHandle):
     """A reference to a file on S3."""
 

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/file_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/file_manager.py
@@ -2,7 +2,7 @@ import io
 import uuid
 from contextlib import contextmanager
 
-from dagster import check, usable_as_dagster_type
+from dagster import check
 from dagster.core.storage.file_manager import (
     FileHandle,
     FileManager,
@@ -11,7 +11,6 @@ from dagster.core.storage.file_manager import (
 )
 
 
-@usable_as_dagster_type
 class ADLS2FileHandle(FileHandle):
     """A reference to a file on ADLS2."""
 

--- a/python_modules/libraries/dagster-census/dagster_census/types.py
+++ b/python_modules/libraries/dagster-census/dagster_census/types.py
@@ -1,9 +1,6 @@
 from typing import Any, Dict, NamedTuple
 
-from dagster import usable_as_dagster_type
 
-
-@usable_as_dagster_type
 class CensusOutput(
     NamedTuple(
         "_CensusOutput",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/types.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/types.py
@@ -1,11 +1,10 @@
 from typing import Any, Dict, List
 
-from dagster import check, usable_as_dagster_type
+from dagster import check
 
 from ..types import DbtOutput
 
 
-@usable_as_dagster_type
 class DbtCliOutput(DbtOutput):
     """The results of executing a dbt command, along with additional metadata about the dbt CLI
     process that was run.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/types.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/types.py
@@ -3,12 +3,11 @@ from typing import Any, Dict, Optional
 
 from dateutil.parser import isoparse
 
-from dagster import check, usable_as_dagster_type
+from dagster import check
 
 from ..types import DbtOutput
 
 
-@usable_as_dagster_type
 class DbtCloudOutput(DbtOutput):
     """The results of executing a dbt Cloud job, along with additional metadata produced from the
     job run.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/types.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/types.py
@@ -2,12 +2,9 @@ from typing import Any, Dict
 
 import requests
 
-from dagster import usable_as_dagster_type
-
 from ..types import DbtOutput
 
 
-@usable_as_dagster_type
 class DbtRpcOutput(DbtOutput):
     """The output from executing a dbt command via the dbt RPC server.
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/types.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/types.py
@@ -1,9 +1,6 @@
 from typing import Any, Dict, NamedTuple
 
-from dagster import usable_as_dagster_type
 
-
-@usable_as_dagster_type
 class FivetranOutput(
     NamedTuple(
         "_FivetranOutput",

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/file_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/file_manager.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 
 from google.cloud import storage  # type: ignore
 
-from dagster import check, usable_as_dagster_type
+from dagster import check
 from dagster.core.storage.file_manager import (
     FileHandle,
     FileManager,
@@ -13,7 +13,6 @@ from dagster.core.storage.file_manager import (
 )
 
 
-@usable_as_dagster_type
 class GCSFileHandle(FileHandle):
     """A reference to a file on GCS."""
 


### PR DESCRIPTION
### Summary & Motivation

All python types are now usable as dagster type.

### How I Tested These Changes
