### PR TITLE
Add platform arg and other improvements to dagster-docker CLI

### DIFF
--- a/python_modules/automation/automation/docker/cli.py
+++ b/python_modules/automation/automation/docker/cli.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import click
 
@@ -26,14 +26,19 @@ def list():  # pylint: disable=redefined-builtin
         print(image.image)  # pylint: disable=print-call
 
 
-@cli.command()
-@click.option("--name", required=True, help="Name of image to build")
-@click.option(
+# Shared options between `build` and `build_all`
+opt_build_name =  click.option("--name", required=True, help="Name of image to build")
+opt_build_dagster_version =  click.option(
     "--dagster-version",
     required=True,
     help="Version of image to build",
 )
-@click.option(
+opt_build_platform = click.option(
+    "--platform",
+    required=False,
+    help="Target platform name to pass to `docker build`",
+)
+opt_build_timestamp = click.option(
     "-t",
     "--timestamp",
     type=click.STRING,
@@ -41,53 +46,56 @@ def list():  # pylint: disable=redefined-builtin
     default=current_time_str(),
     help="Timestamp to build in format 2020-07-11T040642 (defaults to now UTC)",
 )
+
+@cli.command()
+@opt_build_name
+@opt_build_dagster_version
+@opt_build_platform
+@opt_build_timestamp
 @click.option("-v", "--python-version", type=click.STRING, required=True)
-def build(name, dagster_version, timestamp, python_version):
+def build(name: str, dagster_version: str, timestamp: str, python_version: str):
     get_image(name).build(timestamp, dagster_version, python_version)
 
 
 @cli.command()
-@click.option("--name", required=True, help="Name of image to build")
-@click.option(
-    "--dagster-version",
-    required=True,
-    help="Version of image to build, must match current dagster version",
-)
-@click.option(
-    "-t",
-    "--timestamp",
-    type=click.STRING,
-    required=False,
-    default=current_time_str(),
-    help="Timestamp to build in format 2020-07-11T040642 (defaults to now UTC)",
-)
-def build_all(name, dagster_version, timestamp):
+@opt_build_name
+@opt_build_dagster_version
+@opt_build_platform
+@opt_build_timestamp
+def build_all(name: str, dagster_version: str, timestamp: str):
     """Build all supported python versions for image"""
     image = get_image(name)
 
     for python_version in image.python_versions:
         image.build(timestamp, dagster_version, python_version)
 
+# Shared push options
+opt_push_name = click.option("--name", required=True, help="Name of image to push")
+opt_push_dagster_version = click.option(
+    "--dagster-version",
+    required=True,
+    help="Version of image to push",
+)
 
 @cli.command()
-@click.option("--name", required=True, help="Name of image to push")
+@opt_push_name
 @click.option("-v", "--python-version", type=click.STRING, required=True)
-@click.option("-v", "--custom-tag", type=click.STRING, required=False)
-def push(name, python_version, custom_tag):
+@click.option("--custom-tag", type=click.STRING, required=False)
+def push(name: str, python_version: str, custom_tag: Optional[str]):
     ensure_ecr_login()
     get_image(name).push(python_version, custom_tag=custom_tag)
 
 
 @cli.command()
-@click.option("--name", required=True, help="Name of image to push")
-def push_all(name):
+@opt_push_name
+def push_all(name: str):
     ensure_ecr_login()
     image = get_image(name)
     for python_version in image.python_versions:
         image.push(python_version)
 
 
-def push_to_registry(name: str, tags: List[str]):
+def push_to_registry(name: str, tags: List[str]) -> None:
     check.str_param(name, "name")
     check.list_param(tags, "tags", of_type=str)
 
@@ -103,13 +111,9 @@ def push_to_registry(name: str, tags: List[str]):
 
 
 @cli.command()
-@click.option("--name", required=True, help="Name of image to push")
-@click.option(
-    "--dagster-version",
-    required=True,
-    help="Version of image to push",
-)
-def push_dockerhub(name, dagster_version):
+@opt_push_name
+@opt_push_dagster_version
+def push_dockerhub(name: str, dagster_version: str):
     """Used for pushing k8s images to Docker Hub. Must be logged in to Docker Hub for this to
     succeed.
     """
@@ -120,13 +124,9 @@ def push_dockerhub(name, dagster_version):
 
 
 @cli.command()
-@click.option("--name", required=True, help="Name of image to push")
-@click.option(
-    "--dagster-version",
-    required=True,
-    help="Version of image to push",
-)
-def push_ecr(name, dagster_version):
+@opt_push_name
+@opt_push_dagster_version
+def push_ecr(name: str, dagster_version: str):
     """Used for pushing k8s images to our public ECR.
 
     You must be authed for ECR. Run:

--- a/python_modules/automation/automation/docker/cli.py
+++ b/python_modules/automation/automation/docker/cli.py
@@ -50,24 +50,24 @@ opt_build_timestamp = click.option(
 @cli.command()
 @opt_build_name
 @opt_build_dagster_version
-@opt_build_platform
 @opt_build_timestamp
 @click.option("-v", "--python-version", type=click.STRING, required=True)
-def build(name: str, dagster_version: str, timestamp: str, python_version: str):
-    get_image(name).build(timestamp, dagster_version, python_version)
+@opt_build_platform
+def build(name: str, dagster_version: str, timestamp: str, python_version: str, platform: Optional[str]):
+    get_image(name).build(timestamp, dagster_version, python_version, platform)
 
 
 @cli.command()
 @opt_build_name
 @opt_build_dagster_version
-@opt_build_platform
 @opt_build_timestamp
-def build_all(name: str, dagster_version: str, timestamp: str):
+@opt_build_platform
+def build_all(name: str, dagster_version: str, timestamp: str, platform: Optional[str]):
     """Build all supported python versions for image"""
     image = get_image(name)
 
     for python_version in image.python_versions:
-        image.build(timestamp, dagster_version, python_version)
+        image.build(timestamp, dagster_version, python_version, platform)
 
 # Shared push options
 opt_push_name = click.option("--name", required=True, help="Name of image to push")

--- a/python_modules/automation/automation/docker/cli.py
+++ b/python_modules/automation/automation/docker/cli.py
@@ -27,8 +27,8 @@ def list():  # pylint: disable=redefined-builtin
 
 
 # Shared options between `build` and `build_all`
-opt_build_name =  click.option("--name", required=True, help="Name of image to build")
-opt_build_dagster_version =  click.option(
+opt_build_name = click.option("--name", required=True, help="Name of image to build")
+opt_build_dagster_version = click.option(
     "--dagster-version",
     required=True,
     help="Version of image to build",
@@ -47,13 +47,16 @@ opt_build_timestamp = click.option(
     help="Timestamp to build in format 2020-07-11T040642 (defaults to now UTC)",
 )
 
+
 @cli.command()
 @opt_build_name
 @opt_build_dagster_version
 @opt_build_timestamp
 @click.option("-v", "--python-version", type=click.STRING, required=True)
 @opt_build_platform
-def build(name: str, dagster_version: str, timestamp: str, python_version: str, platform: Optional[str]):
+def build(
+    name: str, dagster_version: str, timestamp: str, python_version: str, platform: Optional[str]
+):
     get_image(name).build(timestamp, dagster_version, python_version, platform)
 
 
@@ -69,6 +72,7 @@ def build_all(name: str, dagster_version: str, timestamp: str, platform: Optiona
     for python_version in image.python_versions:
         image.build(timestamp, dagster_version, python_version, platform)
 
+
 # Shared push options
 opt_push_name = click.option("--name", required=True, help="Name of image to push")
 opt_push_dagster_version = click.option(
@@ -76,6 +80,7 @@ opt_push_dagster_version = click.option(
     required=True,
     help="Version of image to push",
 )
+
 
 @cli.command()
 @opt_push_name

--- a/python_modules/automation/automation/docker/image_defs.py
+++ b/python_modules/automation/automation/docker/image_defs.py
@@ -2,6 +2,7 @@
 import contextlib
 import os
 import shutil
+from typing import Callable, Dict, Iterator, List, Optional
 
 from automation.git import git_repo_root
 
@@ -10,12 +11,14 @@ from dagster import check
 from .dagster_docker import DagsterDockerImage
 
 
-def get_dagster_repo():
+def get_dagster_repo() -> str:
     return git_repo_root()
 
 
 @contextlib.contextmanager
-def copy_directories(paths, cwd, destination="build_cache"):
+def copy_directories(
+    paths: List[str], cwd: str, destination: str = "build_cache"
+) -> Iterator[None]:
     check.invariant(os.path.exists(cwd), "Image directory does not exist")
     build_cache_dir = os.path.join(cwd, destination)
 
@@ -47,7 +50,7 @@ def copy_directories(paths, cwd, destination="build_cache"):
 
 
 @contextlib.contextmanager
-def k8s_example_cm(cwd):
+def k8s_example_cm(cwd: str) -> Iterator[None]:
     with copy_directories(
         [
             "examples/deploy_k8s/example_project",
@@ -57,7 +60,7 @@ def k8s_example_cm(cwd):
         yield
 
 
-def get_core_celery_k8s_dirs():
+def get_core_celery_k8s_dirs() -> List[str]:
     return [
         "python_modules/dagster",
         "python_modules/libraries/dagster-postgres",
@@ -67,7 +70,7 @@ def get_core_celery_k8s_dirs():
     ]
 
 
-def get_core_k8s_dirs():
+def get_core_k8s_dirs() -> List[str]:
     return [
         "python_modules/dagster",
         "python_modules/libraries/dagster-postgres",
@@ -76,7 +79,7 @@ def get_core_k8s_dirs():
 
 
 @contextlib.contextmanager
-def k8s_example_editable_cm(cwd):
+def k8s_example_editable_cm(cwd: str) -> Iterator[None]:
     with copy_directories(
         get_core_celery_k8s_dirs()
         + [
@@ -91,7 +94,7 @@ def k8s_example_editable_cm(cwd):
 
 
 @contextlib.contextmanager
-def k8s_dagit_editable_cm(cwd):
+def k8s_dagit_editable_cm(cwd: str) -> Iterator[None]:
     print("!!!!! WARNING: You must call `make rebuild_dagit` after making changes to Dagit !!!!\n")
     with copy_directories(
         get_core_celery_k8s_dirs()
@@ -105,7 +108,7 @@ def k8s_dagit_editable_cm(cwd):
 
 
 @contextlib.contextmanager
-def k8s_dagit_example_cm(cwd):
+def k8s_dagit_example_cm(cwd: str) -> Iterator[None]:
     with copy_directories(
         get_core_celery_k8s_dirs()
         + [
@@ -122,7 +125,7 @@ def k8s_dagit_example_cm(cwd):
 
 
 @contextlib.contextmanager
-def k8s_celery_worker_editable_cm(cwd):
+def k8s_celery_worker_editable_cm(cwd: str) -> Iterator[None]:
     with copy_directories(
         get_core_celery_k8s_dirs(),
         cwd,
@@ -131,7 +134,7 @@ def k8s_celery_worker_editable_cm(cwd):
 
 
 @contextlib.contextmanager
-def user_code_example_cm(cwd):
+def user_code_example_cm(cwd: str) -> Iterator[None]:
     with copy_directories(
         [
             "examples/deploy_k8s/example_project",
@@ -142,7 +145,7 @@ def user_code_example_cm(cwd):
 
 
 @contextlib.contextmanager
-def user_code_example_editable_cm(cwd):
+def user_code_example_editable_cm(cwd: str) -> Iterator[None]:
     with copy_directories(
         get_core_celery_k8s_dirs() + ["python_modules/libraries/dagster-aws"],
         cwd,
@@ -154,7 +157,7 @@ def user_code_example_editable_cm(cwd):
 
 
 @contextlib.contextmanager
-def dagster_k8s_editable_cm(cwd):
+def dagster_k8s_editable_cm(cwd: str) -> Iterator[None]:
     print("!!!!! WARNING: You must call `make rebuild_dagit` after making changes to Dagit !!!!\n")
     with copy_directories(
         get_core_k8s_dirs()
@@ -169,7 +172,7 @@ def dagster_k8s_editable_cm(cwd):
 
 
 @contextlib.contextmanager
-def dagster_celery_k8s_editable_cm(cwd):
+def dagster_celery_k8s_editable_cm(cwd: str) -> Iterator[None]:
     print("!!!!! WARNING: You must call `make rebuild_dagit` after making changes to Dagit !!!!\n")
     with copy_directories(
         get_core_celery_k8s_dirs()
@@ -184,7 +187,7 @@ def dagster_celery_k8s_editable_cm(cwd):
 
 
 # Some images have custom build context manager functions, listed here
-CUSTOM_BUILD_CONTEXTMANAGERS = {
+CUSTOM_BUILD_CONTEXTMANAGERS: Dict[str, Callable] = {
     "k8s-example": k8s_example_cm,
     "k8s-example-editable": k8s_example_editable_cm,
     "k8s-dagit-editable": k8s_dagit_editable_cm,
@@ -197,7 +200,7 @@ CUSTOM_BUILD_CONTEXTMANAGERS = {
 }
 
 
-def list_images(images_path=None):
+def list_images(images_path: Optional[str] = None) -> List[DagsterDockerImage]:
     """List all images that we manage.
 
     Returns:
@@ -216,8 +219,7 @@ def list_images(images_path=None):
     return images
 
 
-def get_image(name, images_path=None):
+def get_image(name: str, images_path: Optional[str] = None) -> DagsterDockerImage:
     """Retrieve the image information from the list defined above."""
     image = next((img for img in list_images(images_path=images_path) if img.image == name), None)
-    check.invariant(image is not None, "could not find image {}".format(name))
-    return image
+    return check.not_none(image, "could not find image {}".format(name))

--- a/python_modules/automation/automation/docker/images/README.md
+++ b/python_modules/automation/automation/docker/images/README.md
@@ -18,6 +18,12 @@ Then, `dagster-image build-all --name <YOUR IMAGE>` will build your image.
 For all of the steps below, you should first ensure you are authed for ECR, e.g. by running
 `aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 968703565975.dkr.ecr.us-west-2.amazonaws.com`.
 
+If you are on an M1 mac, you may need to specify `--platform=linux/amd64` when
+building images.
+
+When building images for use in Buildkite (i.e. imagse for testing the tips of
+branches), specify the version for the editable install of dagster, `0+dev`.
+
 ### Publishing new integration images
 
 1. Run with the appropriate Dagster version:

--- a/python_modules/automation/automation/docker/utils.py
+++ b/python_modules/automation/automation/docker/utils.py
@@ -2,13 +2,15 @@
 import subprocess
 import sys
 from datetime import datetime, timezone
+from typing import Dict, Optional
 
 from dagster import check
 
 
-def execute_docker_build(image, docker_args=None, cwd=None):
+def execute_docker_build(image: str, docker_args: Optional[Dict[str, str]]=None, cwd: Optional[str]=None, platform: Optional[str] = None):
     check.str_param(image, "image")
     docker_args = check.opt_dict_param(docker_args, "docker_args", key_type=str, value_type=str)
+    cwd = check.opt_str_param(cwd, "cwd")
 
     print("Building image {}".format(image))
 
@@ -19,13 +21,16 @@ def execute_docker_build(image, docker_args=None, cwd=None):
 
     args += ["-t", image]
 
+    if platform:
+        args += ["--platform", platform]
+
     print(" ".join(args))
 
     retval = subprocess.call(args, stderr=sys.stderr, stdout=sys.stdout, cwd=cwd)
     check.invariant(retval == 0, "Process must exit successfully")
 
 
-def execute_docker_push(image):
+def execute_docker_push(image: str) -> None:
     check.str_param(image, "image")
 
     print("Pushing image {}".format(image))
@@ -33,7 +38,7 @@ def execute_docker_push(image):
     check.invariant(retval == 0, "docker push must succeed")
 
 
-def execute_docker_tag(local_image, remote_image):
+def execute_docker_tag(local_image: str, remote_image: str) -> None:
     """Re-tag an existing image"""
     check.str_param(local_image, "local_image")
     check.str_param(remote_image, "remote_image")
@@ -45,13 +50,13 @@ def execute_docker_tag(local_image, remote_image):
     check.invariant(retval == 0, "docker tag must succeed")
 
 
-def python_version_image_tag(python_version, image_version):
+def python_version_image_tag(python_version: str, image_version: str) -> str:
     """Dagster images are typically tagged as py<PYTHON VERSION>-<IMAGE VERSION>"""
     check.str_param(python_version, "python_version")
     check.str_param(image_version, "image_version")
     return "py{}-{}".format(python_version, image_version)
 
 
-def current_time_str():
+def current_time_str() -> str:
     """Should be UTC date string like 2020-07-11T035005"""
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%S")

--- a/python_modules/automation/automation/docker/utils.py
+++ b/python_modules/automation/automation/docker/utils.py
@@ -7,7 +7,12 @@ from typing import Dict, Optional
 from dagster import check
 
 
-def execute_docker_build(image: str, docker_args: Optional[Dict[str, str]]=None, cwd: Optional[str]=None, platform: Optional[str] = None):
+def execute_docker_build(
+    image: str,
+    docker_args: Optional[Dict[str, str]] = None,
+    cwd: Optional[str] = None,
+    platform: Optional[str] = None,
+):
     check.str_param(image, "image")
     docker_args = check.opt_dict_param(docker_args, "docker_args", key_type=str, value_type=str)
     cwd = check.opt_str_param(cwd, "cwd")


### PR DESCRIPTION
# Summary and Motivation

- Add `platform` argument to Dagster image CLI for use when building images
- Light refactoring of the `dagster-image` CLI
- Clarifications to README for building images

### How I Tested These Changes

- Existing BK tests
- Using the new `--platform` option for an image build
