### PR TITLE
Additional asset graph improvements

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetEdges.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetEdges.tsx
@@ -1,8 +1,106 @@
+import {Colors} from '@dagster-io/ui';
 import React from 'react';
 import styled from 'styled-components/macro';
 
+import {IPoint, isPointWayOffscreen} from '../graph/common';
+
+import {ForeignNode} from './ForeignNode';
 import {buildSVGPath} from './Utils';
-import {AssetLayoutEdge} from './layout';
+import {AssetGraphLayout, AssetLayoutEdge, getForeignNodeDimensions} from './layout';
+
+export const AssetConnectedEdges: React.FC<{
+  edges: AssetLayoutEdge[];
+  highlighted: string | null;
+}> = ({edges, highlighted}) => {
+  // Note: we render the highlighted edges twice, but it's so that the first item with
+  // all the edges in it can remain memoized.
+  return (
+    <React.Fragment key="connected">
+      <AssetEdges color={Colors.KeylineGray} edges={edges} />
+      <AssetEdges
+        color={Colors.Blue500}
+        edges={edges.filter(({fromId, toId}) => highlighted === fromId || highlighted === toId)}
+      />
+    </React.Fragment>
+  );
+};
+
+// No use memoizing this because disconnected edges depend on `viewport`
+export const AssetDisconnectedEdges: React.FC<{
+  layout: AssetGraphLayout;
+  highlighted: string | null;
+  setHighlighted: (h: string | null) => void;
+  onGoToPoint: (p: IPoint) => void;
+  viewport: {
+    top: number;
+    left: number;
+    bottom: number;
+    right: number;
+  };
+}> = ({layout, viewport, highlighted, setHighlighted, onGoToPoint}) => {
+  const placedLabels: {[otherId: string]: IPoint} = {};
+  const offsetIncrements: {[anchorId: string]: number} = {};
+  const nodes: React.ReactNode[] = [];
+  const edges: React.ReactNode[] = [];
+
+  for (const e of layout.edges) {
+    const fromOff = isPointWayOffscreen(e.from, viewport);
+    const toOff = isPointWayOffscreen(e.to, viewport);
+
+    const anchor = fromOff && toOff ? null : fromOff ? e.to : toOff ? e.from : null;
+    const anchorId = anchor === e.to ? e.toId : e.fromId;
+    const other = anchor === e.to ? e.from : e.to;
+    const otherId = anchor === e.to ? e.fromId : e.toId;
+
+    if (!anchor) {
+      continue;
+    }
+    const angle = Math.atan2(other.y - anchor.y, other.x - anchor.x);
+    const increment = offsetIncrements[anchorId] || 0;
+    offsetIncrements[anchorId] = increment + 40;
+
+    const size = getForeignNodeDimensions(otherId);
+    const ray = {
+      x: anchor.x + Math.cos(angle) * (30 + size.width),
+      y: anchor.y + (anchor === e.from ? 50 : -50) + (anchor === e.from ? increment : -increment),
+    };
+
+    if (!placedLabels[otherId]) {
+      placedLabels[otherId] = ray;
+
+      nodes.push(
+        <foreignObject
+          key={`${e.fromId}->${e.toId}`}
+          x={ray.x - size.width / 2}
+          y={ray.y}
+          onMouseEnter={() => setHighlighted(otherId)}
+          onMouseLeave={() => setHighlighted(null)}
+          onClick={() => onGoToPoint(other)}
+          {...size}
+        >
+          <ForeignNode assetKey={{path: JSON.parse(otherId)}} backgroundColor="white" />
+        </foreignObject>,
+      );
+    }
+
+    edges.push(
+      <DashedStyledPath
+        key={`${e.fromId}->${e.toId}`}
+        d={buildSVGPath({source: anchor, target: placedLabels[otherId]})}
+        stroke={
+          e.fromId === highlighted || e.toId === highlighted ? Colors.Blue500 : 'rgba(0,0,0,0.2)'
+        }
+      />,
+    );
+  }
+
+  return (
+    <>
+      {edges}
+      {nodes}
+    </>
+  );
+};
 
 export const AssetEdges: React.FC<{edges: AssetLayoutEdge[]; color: string}> = React.memo(
   ({edges, color}) => (
@@ -34,5 +132,11 @@ export const AssetEdges: React.FC<{edges: AssetLayoutEdge[]; color: string}> = R
 
 const StyledPath = styled('path')`
   stroke-width: 4;
+  fill: none;
+`;
+
+const DashedStyledPath = styled('path')`
+  stroke-width: 4;
+  stroke-dasharray: 2 4;
   fill: none;
 `;

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetEdges.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetEdges.tsx
@@ -15,7 +15,7 @@ export const AssetConnectedEdges: React.FC<{
   // Note: we render the highlighted edges twice, but it's so that the first item with
   // all the edges in it can remain memoized.
   return (
-    <React.Fragment key="connected">
+    <React.Fragment>
       <AssetEdges color={Colors.KeylineGray} edges={edges} />
       <AssetEdges
         color={Colors.Blue500}

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -93,6 +93,7 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
     assetGraphData,
     graphQueryItems,
     graphAssetKeys,
+    allAssetKeys,
     applyingEmptyDefault,
   } = useAssetGraphData(props.pipelineSelector, props.explorerPath.opsQuery, props.filterNodes);
 
@@ -110,12 +111,11 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
   return (
     <Loading allowStaleData queryResult={fetchResult}>
       {() => {
-        if (!assetGraphData) {
+        if (!assetGraphData || !allAssetKeys) {
           return <NonIdealState icon="error" title="Query Error" />;
         }
 
         const hasCycles = graphHasCycles(assetGraphData);
-        const assetKeys = fetchResult.data?.assetNodes.map((a) => a.assetKey) || [];
 
         if (hasCycles) {
           return (
@@ -129,8 +129,8 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
         return (
           <AssetGraphExplorerWithData
             key={props.explorerPath.pipelineName}
-            assetKeys={assetKeys}
             assetGraphData={assetGraphData}
+            allAssetKeys={allAssetKeys}
             graphQueryItems={graphQueryItems}
             applyingEmptyDefault={applyingEmptyDefault}
             liveDataRefreshState={liveDataRefreshState}
@@ -145,7 +145,7 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
 
 const AssetGraphExplorerWithData: React.FC<
   {
-    assetKeys: AssetKey[];
+    allAssetKeys: AssetKey[];
     assetGraphData: GraphData;
     graphQueryItems: GraphQueryItem[];
     liveDataByNode: LiveData;
@@ -325,8 +325,8 @@ const AssetGraphExplorerWithData: React.FC<
   );
 
   const allBundleNames = React.useMemo(() => {
-    return Object.keys(identifyBundles(props.assetKeys.map((a) => JSON.stringify(a.path))));
-  }, [props.assetKeys]);
+    return Object.keys(identifyBundles(props.allAssetKeys.map((a) => JSON.stringify(a.path))));
+  }, [props.allAssetKeys]);
 
   return (
     <SplitPanelContainer
@@ -553,7 +553,7 @@ const AssetGraphExplorerWithData: React.FC<
                 )}
               />
             </Box>
-            {!props.pipelineSelector && <OmittedAssetsNotice assetKeys={props.assetKeys} />}
+            {!props.pipelineSelector && <OmittedAssetsNotice assetKeys={props.allAssetKeys} />}
           </Box>
           <QueryOverlay>
             <GraphQueryInput

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -432,33 +432,13 @@ const AssetGraphExplorerWithData: React.FC<
                       ) : null;
                     }
 
-                    if (experiments && _scale < EXPERIMENTAL_MINI_SCALE) {
+                    if (experiments) {
                       const isWithinBundle = Object.keys(layout.bundles).some((bundleId) =>
                         hasPathPrefix(path, JSON.parse(bundleId)),
                       );
-                      if (isWithinBundle) {
+                      if (isWithinBundle && _scale < EXPERIMENTAL_MINI_SCALE) {
                         return null;
                       }
-
-                      return (
-                        <foreignObject
-                          {...bounds}
-                          key={id}
-                          onMouseEnter={() => setHighlighted(id)}
-                          onMouseLeave={() => setHighlighted(null)}
-                          onClick={(e) => onSelectNode(e, {path}, graphNode)}
-                          onDoubleClick={(e) => {
-                            viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
-                            e.stopPropagation();
-                          }}
-                        >
-                          <AssetNodeMinimal
-                            definition={graphNode.definition}
-                            selected={selectedGraphNodes.includes(graphNode)}
-                            fontSize={18 / _scale}
-                          />
-                        </foreignObject>
-                      );
                     }
 
                     return (
@@ -476,6 +456,12 @@ const AssetGraphExplorerWithData: React.FC<
                       >
                         {!graphNode || !graphNode.definition.opNames.length ? (
                           <ForeignNode assetKey={{path}} />
+                        ) : experiments && _scale < EXPERIMENTAL_MINI_SCALE ? (
+                          <AssetNodeMinimal
+                            definition={graphNode.definition}
+                            selected={selectedGraphNodes.includes(graphNode)}
+                            fontSize={18 / _scale}
+                          />
                         ) : (
                           <AssetNode
                             definition={graphNode.definition}

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -1,4 +1,12 @@
-import {Box, Checkbox, Mono, NonIdealState, SplitPanelContainer} from '@dagster-io/ui';
+import {
+  Box,
+  Checkbox,
+  MenuItem,
+  Mono,
+  NonIdealState,
+  SplitPanelContainer,
+  Suggest,
+} from '@dagster-io/ui';
 import flatMap from 'lodash/flatMap';
 import isEqual from 'lodash/isEqual';
 import pickBy from 'lodash/pickBy';
@@ -57,7 +65,7 @@ import {
   tokenForAssetKey,
   displayNameForAssetKey,
 } from './Utils';
-import {AssetGraphLayout} from './layout';
+import {AssetGraphLayout, identifyBundles} from './layout';
 import {AssetGraphQuery_assetNodes} from './types/AssetGraphQuery';
 import {useAssetGraphData} from './useAssetGraphData';
 import {useFindJobForAsset} from './useFindJobForAsset';
@@ -549,6 +557,37 @@ const AssetGraphExplorerWithData: React.FC<
               placeholder="Type an asset subset…"
               onChange={(opsQuery) => onChangeExplorerPath({...explorerPath, opsQuery}, 'replace')}
               popoverPosition="bottom-left"
+            />
+            <Suggest<string>
+              inputProps={{placeholder: 'View a folder'}}
+              items={Object.keys(
+                identifyBundles(props.assetKeys.map((c) => JSON.stringify(c.path))),
+              )}
+              itemRenderer={(folder, props) => (
+                <MenuItem
+                  text={displayNameForAssetKey({path: JSON.parse(folder)})}
+                  active={props.modifiers.active}
+                  onClick={props.handleClick}
+                  key={folder}
+                />
+              )}
+              noResults={<MenuItem disabled={true} text="Loading..." />}
+              inputValueRenderer={(str) => str}
+              selectedItem=""
+              onItemSelect={(item) => {
+                onChangeExplorerPath(
+                  {
+                    ...explorerPath,
+                    opsQuery: [
+                      explorerPath.opsQuery,
+                      `${displayNameForAssetKey({path: JSON.parse(item)})}>`,
+                    ]
+                      .filter(Boolean)
+                      .join(','),
+                  },
+                  'replace',
+                );
+              }}
             />
           </QueryOverlay>
         </>

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -64,8 +64,9 @@ import {
   isSourceAsset,
   tokenForAssetKey,
   displayNameForAssetKey,
+  identifyBundles,
 } from './Utils';
-import {AssetGraphLayout, identifyBundles} from './layout';
+import {AssetGraphLayout} from './layout';
 import {AssetGraphQuery_assetNodes} from './types/AssetGraphQuery';
 import {useAssetGraphData} from './useAssetGraphData';
 import {useFindJobForAsset} from './useFindJobForAsset';
@@ -323,6 +324,10 @@ const AssetGraphExplorerWithData: React.FC<
     [viewportEl],
   );
 
+  const allBundleNames = React.useMemo(() => {
+    return Object.keys(identifyBundles(props.assetKeys.map((a) => JSON.stringify(a.path))));
+  }, [props.assetKeys]);
+
   return (
     <SplitPanelContainer
       identifier="explorer"
@@ -558,37 +563,37 @@ const AssetGraphExplorerWithData: React.FC<
               onChange={(opsQuery) => onChangeExplorerPath({...explorerPath, opsQuery}, 'replace')}
               popoverPosition="bottom-left"
             />
-            <Suggest<string>
-              inputProps={{placeholder: 'View a folder'}}
-              items={Object.keys(
-                identifyBundles(props.assetKeys.map((c) => JSON.stringify(c.path))),
-              )}
-              itemRenderer={(folder, props) => (
-                <MenuItem
-                  text={displayNameForAssetKey({path: JSON.parse(folder)})}
-                  active={props.modifiers.active}
-                  onClick={props.handleClick}
-                  key={folder}
-                />
-              )}
-              noResults={<MenuItem disabled={true} text="Loading..." />}
-              inputValueRenderer={(str) => str}
-              selectedItem=""
-              onItemSelect={(item) => {
-                onChangeExplorerPath(
-                  {
-                    ...explorerPath,
-                    opsQuery: [
-                      explorerPath.opsQuery,
-                      `${displayNameForAssetKey({path: JSON.parse(item)})}>`,
-                    ]
-                      .filter(Boolean)
-                      .join(','),
-                  },
-                  'replace',
-                );
-              }}
-            />
+            {allBundleNames.length > 0 && (
+              <Suggest<string>
+                inputProps={{placeholder: 'View a folder'}}
+                items={allBundleNames}
+                itemRenderer={(folder, props) => (
+                  <MenuItem
+                    text={displayNameForAssetKey({path: JSON.parse(folder)})}
+                    active={props.modifiers.active}
+                    onClick={props.handleClick}
+                    key={folder}
+                  />
+                )}
+                noResults={<MenuItem disabled={true} text="Loading..." />}
+                inputValueRenderer={(str) => str}
+                selectedItem=""
+                onItemSelect={(item) => {
+                  onChangeExplorerPath(
+                    {
+                      ...explorerPath,
+                      opsQuery: [
+                        explorerPath.opsQuery,
+                        `${displayNameForAssetKey({path: JSON.parse(item)})}>`,
+                      ]
+                        .filter(Boolean)
+                        .join(','),
+                    },
+                    'replace',
+                  );
+                }}
+              />
+            )}
           </QueryOverlay>
         </>
       }

--- a/js_modules/dagit/packages/core/src/asset-graph/ForeignNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/ForeignNode.tsx
@@ -4,8 +4,11 @@ import styled from 'styled-components/macro';
 
 import {displayNameForAssetKey} from './Utils';
 
-export const ForeignNode: React.FC<{assetKey: {path: string[]}}> = React.memo(({assetKey}) => (
-  <ForeignNodeLink>
+export const ForeignNode: React.FC<{
+  assetKey: {path: string[]};
+  backgroundColor?: string;
+}> = React.memo(({assetKey, backgroundColor}) => (
+  <ForeignNodeLink style={{backgroundColor}}>
     <span className="label">{displayNameForAssetKey(assetKey)}</span>
     <Icon name="open_in_new" color={Colors.Gray500} />
   </ForeignNodeLink>

--- a/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
@@ -89,11 +89,17 @@ export function identifyBundles(assetIds: string[]) {
   // }
 
   for (const prefixId of Object.keys(pathPrefixes).sort((a, b) => b.length - a.length)) {
-    finalBundlePrefixes[prefixId] = uniq(
+    const contents = uniq(
       pathPrefixes[prefixId].map((p) =>
         finalBundleIdForNodeId[p] ? finalBundleIdForNodeId[p] : p,
       ),
     );
+    if (contents.length === 1 && finalBundlePrefixes[contents[0]]) {
+      // If this bundle contains exactly one bundle, no need to show both outlines.
+      // Just show the inner one. eg: a > b > asset1, a > b > asset2, just show a > b.
+      continue;
+    }
+    finalBundlePrefixes[prefixId] = contents;
     finalBundlePrefixes[prefixId].forEach((id) => (finalBundleIdForNodeId[id] = prefixId));
   }
   return finalBundlePrefixes;

--- a/js_modules/dagit/packages/core/src/asset-graph/layout.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/layout.ts
@@ -242,6 +242,7 @@ export const extendBounds = (a: IBounds, b: IBounds) => {
   return {x: xmin, y: ymin, width: xmax - xmin, height: ymax - ymin};
 };
 
+export const ASSET_NODE_ICON_WIDTH = 20;
 export const ASSET_NODE_ANNOTATIONS_MAX_WIDTH = 65;
 export const ASSET_NODE_NAME_MAX_LENGTH = 32;
 const DISPLAY_NAME_PX_PER_CHAR = 8.0;
@@ -264,7 +265,9 @@ export const getAssetNodeDimensions = (def: {
       Math.max(
         200,
         Math.min(ASSET_NODE_NAME_MAX_LENGTH, displayName.length) * DISPLAY_NAME_PX_PER_CHAR,
-      ) + ASSET_NODE_ANNOTATIONS_MAX_WIDTH,
+      ) +
+      ASSET_NODE_ICON_WIDTH +
+      ASSET_NODE_ANNOTATIONS_MAX_WIDTH,
     height,
   };
 };

--- a/js_modules/dagit/packages/core/src/asset-graph/layout.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/layout.ts
@@ -34,7 +34,7 @@ const opts: {margin: number; mini: boolean} = {
   mini: false,
 };
 
-function identifyBundles(nodeIds: string[]) {
+export function identifyBundles(nodeIds: string[]) {
   const pathPrefixes: {[prefixId: string]: string[]} = {};
 
   for (const nodeId of nodeIds) {

--- a/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
@@ -43,6 +43,7 @@ export function useAssetGraphData(
     assetGraphData,
     graphQueryItems,
     graphAssetKeys,
+    allAssetKeys,
     applyingEmptyDefault,
   } = React.useMemo(() => {
     if (fetchResultFilteredNodes === undefined) {
@@ -57,6 +58,7 @@ export function useAssetGraphData(
     const {all, applyingEmptyDefault} = filterByQuery(graphQueryItems, opsQuery);
 
     return {
+      allAssetKeys: fetchResultFilteredNodes.map((n) => n.assetKey),
       graphAssetKeys: all.map((n) => ({path: n.node.assetKey.path})),
       assetGraphData: buildGraphData(all.map((n) => n.node)),
       graphQueryItems,
@@ -69,6 +71,7 @@ export function useAssetGraphData(
     assetGraphData,
     graphQueryItems,
     graphAssetKeys,
+    allAssetKeys,
     applyingEmptyDefault,
   };
 }

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -222,7 +222,7 @@ const AssetEntryRow: React.FC<{
         ) : representsAtLeastOneSDA ? (
           <Link
             to={instanceAssetsExplorerPathToURL({
-              opsQuery: `+${tokenForAssetKey({path})}>+`,
+              opsQuery: `${tokenForAssetKey({path})}>`,
               opNames: [],
             })}
           >

--- a/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
@@ -102,9 +102,13 @@ const PanAndZoomInteractor: SVGViewportInteractor = {
       return;
     }
 
-    const targetScale = viewport.state.scale * (1 - event.deltaY * 0.0025);
-    const scale = Math.max(MIN_ZOOM, Math.min(viewport.getMaxZoom(), targetScale));
-    viewport.adjustZoomRelativeToScreenPoint(scale, cursorPosition);
+    if (event.altKey || event.shiftKey) {
+      viewport.shiftXY(-event.deltaX, -event.deltaY);
+    } else {
+      const targetScale = viewport.state.scale * (1 - event.deltaY * 0.0025);
+      const scale = Math.max(MIN_ZOOM, Math.min(viewport.getMaxZoom(), targetScale));
+      viewport.adjustZoomRelativeToScreenPoint(scale, cursorPosition);
+    }
   },
 
   render(viewport: SVGViewport) {
@@ -320,6 +324,11 @@ export class SVGViewport extends React.Component<SVGViewportProps, SVGViewportSt
     }
     const ownerRect = el.getBoundingClientRect();
     return {x: e.clientX - ownerRect.left, y: e.clientY - ownerRect.top};
+  }
+
+  public shiftXY(dx: number, dy: number) {
+    const {x, y, scale} = this.state;
+    this.setState({x: x + dx, y: y + dy, scale});
   }
 
   public adjustZoomRelativeToScreenPoint(nextScale: number, point: Point) {

--- a/js_modules/dagit/packages/core/src/graph/common.ts
+++ b/js_modules/dagit/packages/core/src/graph/common.ts
@@ -22,6 +22,19 @@ export const isHighlighted = (edges: Edge[], {a, b}: Edge) =>
 export const isOpHighlighted = (edges: Edge[], name: string) =>
   edges.some((h) => h.a.split(':')[0] === name || h.b.split(':')[0] === name);
 
+export const isPointWayOffscreen = (
+  p: {x: number; y: number},
+  viewportRect: {top: number; left: number; right: number; bottom: number},
+  thresholdDistanceOffscreen = viewportRect.right - viewportRect.left,
+) => {
+  return (
+    p.x < viewportRect.left - thresholdDistanceOffscreen ||
+    p.x > viewportRect.right + thresholdDistanceOffscreen ||
+    p.y < viewportRect.top - thresholdDistanceOffscreen ||
+    p.y > viewportRect.bottom + thresholdDistanceOffscreen
+  );
+};
+
 export const isNodeOffscreen = (
   layoutNode: {x: number; y: number; width: number; height: number},
   viewportRect: {top: number; left: number; right: number; bottom: number},

--- a/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
@@ -386,6 +386,8 @@ export const QueryOverlay = styled.div`
   top: 10px;
   left: 20px;
   white-space: nowrap;
+  display: flex;
+  gap: 10px;
 `;
 
 export const BreadcrumbsOverlay = styled.div`


### PR DESCRIPTION
### Summary & Motivation
This includes several of the low hanging / mergeable changes that we demoed last Friday:

- On all DAGs, you can hold shift on the keyboard to switch from mouse wheel / touch pad zooming to panning. This makes it much easier to scroll horizontally at high speed without click-drag-click-drag-click-drag. 
-   With a mouse, you need to additionally hold option to switch from vertical scroll to horizontal scroll.

- With the `experimental` assset graph feature flag enabled, the graph now replaces super long dependency lines with two foreign node links. (So you can actually see where the line is going!) This cleans up the UI considerably for large horizontal DAGs, but can result in a bit of flickering as you scroll and start removing lines. It's behind the experimental flag because I am not sure it will be preferable in all scenarios.

- If you have folders in your graph, a new filter appears beside the query input in the asset graph that is a shortcut for adding "folder>" to the search string.

Note: This code calls uses the term "bundle" for an asset folders / group / shared path prefix. I figured this would be easy to find and replace if we come up with a final name for this concept. 

### How I Tested These Changes

- Viewed asset graph with various filter options in the main workspace and sample large workspace 