### PR TITLE
[dagit] Add Reload All button to the asset catalog, remove repo filter

### DIFF
--- a/js_modules/dagit/packages/core/src/app/QueryRefresh.tsx
+++ b/js_modules/dagit/packages/core/src/app/QueryRefresh.tsx
@@ -144,7 +144,13 @@ export function useMergedRefresh(
   }, args);
 }
 
-export const QueryRefreshCountdown = ({refreshState}: {refreshState: QueryRefreshState}) => {
+export const QueryRefreshCountdown = ({
+  refreshState,
+  dataDescription,
+}: {
+  refreshState: QueryRefreshState;
+  dataDescription?: string;
+}) => {
   const status = refreshState.networkStatus === NetworkStatus.ready ? 'counting' : 'idle';
   const timeRemaining = useCountdown({duration: refreshState.nextFireDelay, status});
 
@@ -153,6 +159,7 @@ export const QueryRefreshCountdown = ({refreshState}: {refreshState: QueryRefres
       refreshing={status === 'idle' || timeRemaining === 0}
       seconds={Math.floor(timeRemaining / 1000)}
       onRefresh={() => refreshState.refetch()}
+      dataDescription={dataDescription}
     />
   );
 };

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -85,7 +85,7 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
     graphQueryItems,
     graphAssetKeys,
     applyingEmptyDefault,
-  } = useAssetGraphData(props.pipelineSelector, props.explorerPath.opsQuery, props.filterNodes);
+  } = useAssetGraphData(props.pipelineSelector, props.explorerPath.opsQuery);
 
   const {liveResult, liveDataByNode} = useLiveDataForAssetKeys(
     props.pipelineSelector,

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -521,7 +521,10 @@ const AssetGraphExplorerWithData: React.FC<
             style={{position: 'absolute', right: 12, top: 12}}
           >
             <Box flex={{alignItems: 'center', gap: 12}}>
-              <QueryRefreshCountdown refreshState={liveDataRefreshState} />
+              <QueryRefreshCountdown
+                refreshState={liveDataRefreshState}
+                dataDescription="materializations"
+              />
 
               <LaunchAssetExecutionButton
                 title={titleForLaunch(selectedGraphNodes, liveDataByNode)}

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -11,6 +11,7 @@ import {RepositoryLink} from '../nav/RepositoryLink';
 import {instanceAssetsExplorerPathToURL} from '../pipelines/PipelinePathUtils';
 import {MenuLink} from '../ui/MenuLink';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';
+import {ReloadAllButton} from '../workspace/ReloadAllButton';
 
 import {AssetLink} from './AssetLink';
 import {AssetWipeDialog} from './AssetWipeDialog';
@@ -64,6 +65,7 @@ export const AssetTable = ({
           selected={Array.from(checkedAssets)}
           clearSelection={() => onToggleAll(false)}
         />
+        <ReloadAllButton />
       </Box>
       <Table>
         <thead>

--- a/js_modules/dagit/packages/core/src/assets/InstanceAssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/assets/InstanceAssetGraphExplorer.tsx
@@ -41,7 +41,7 @@ export const InstanceAssetGraphExplorer: React.FC = () => {
           }}
         />
         <div style={{flex: 1}} />
-        <ReloadAllButton />
+        <ReloadAllButton label="Reload definitions" />
       </Box>
       <AssetGraphExplorer
         options={{preferAssetRendering: true, explodeComposites: true}}

--- a/js_modules/dagit/packages/core/src/assets/InstanceAssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/assets/InstanceAssetGraphExplorer.tsx
@@ -4,14 +4,11 @@ import {useParams} from 'react-router';
 import {useHistory} from 'react-router-dom';
 
 import {AssetGraphExplorer} from '../asset-graph/AssetGraphExplorer';
-import {AssetGraphQuery_assetNodes} from '../asset-graph/types/AssetGraphQuery';
-import {RepoFilterButton} from '../instance/RepoFilterButton';
 import {
   instanceAssetsExplorerPathFromString,
   instanceAssetsExplorerPathToURL,
 } from '../pipelines/PipelinePathUtils';
-import {WorkspaceContext} from '../workspace/WorkspaceContext';
-import {buildRepoPath} from '../workspace/buildRepoAddress';
+import {ReloadAllButton} from '../workspace/ReloadAllButton';
 
 import {AssetViewModeSwitch} from './AssetViewModeSwitch';
 import {useAssetView} from './useAssetView';
@@ -20,18 +17,7 @@ export const InstanceAssetGraphExplorer: React.FC = () => {
   const params = useParams();
   const history = useHistory();
   const [_, _setView] = useAssetView();
-  const {visibleRepos} = React.useContext(WorkspaceContext);
   const explorerPath = instanceAssetsExplorerPathFromString(params[0]);
-
-  const filterNodes = React.useMemo(() => {
-    const visibleRepoAddresses = visibleRepos.map((v) =>
-      buildRepoPath(v.repository.name, v.repositoryLocation.name),
-    );
-    return (node: AssetGraphQuery_assetNodes) =>
-      visibleRepoAddresses.includes(
-        buildRepoPath(node.repository.name, node.repository.location.name),
-      );
-  }, [visibleRepos]);
 
   return (
     <Box
@@ -41,7 +27,7 @@ export const InstanceAssetGraphExplorer: React.FC = () => {
       <PageHeader title={<Heading>Assets</Heading>} />
       <Box
         background={Colors.White}
-        padding={{horizontal: 24, vertical: 8}}
+        padding={{left: 24, right: 12, vertical: 8}}
         border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
         flex={{direction: 'row', gap: 12}}
       >
@@ -54,11 +40,11 @@ export const InstanceAssetGraphExplorer: React.FC = () => {
             }
           }}
         />
-        <RepoFilterButton />
+        <div style={{flex: 1}} />
+        <ReloadAllButton />
       </Box>
       <AssetGraphExplorer
         options={{preferAssetRendering: true, explodeComposites: true}}
-        filterNodes={filterNodes}
         explorerPath={explorerPath}
         onChangeExplorerPath={(path, mode) => {
           history[mode](instanceAssetsExplorerPathToURL(path));

--- a/js_modules/dagit/packages/core/src/hooks/useQueryPersistedState.tsx
+++ b/js_modules/dagit/packages/core/src/hooks/useQueryPersistedState.tsx
@@ -7,6 +7,7 @@ type QueryPersistedDataType =
   | {[key: string]: any}
   | Array<any>
   | (string | undefined | number)
+  | (boolean | undefined)
   | null;
 
 let currentQueryString: {[key: string]: any} = {};

--- a/js_modules/dagit/packages/core/src/workspace/ReloadAllButton.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/ReloadAllButton.tsx
@@ -5,7 +5,7 @@ import {DISABLED_MESSAGE, usePermissions} from '../app/Permissions';
 
 import {useReloadWorkspace} from './useReloadWorkspace';
 
-export const ReloadAllButton = () => {
+export const ReloadAllButton: React.FC<{label?: string}> = ({label = 'Reload all'}) => {
   const {reloading, onClick} = useReloadWorkspace();
   const {canReloadWorkspace} = usePermissions();
 
@@ -13,7 +13,7 @@ export const ReloadAllButton = () => {
     return (
       <Tooltip content={DISABLED_MESSAGE}>
         <Button icon={<Icon name="refresh" />} disabled intent="none">
-          Reload all
+          {label}
         </Button>
       </Tooltip>
     );
@@ -21,7 +21,7 @@ export const ReloadAllButton = () => {
 
   return (
     <Button onClick={onClick} icon={<Icon name="refresh" />} loading={reloading} intent="none">
-      Reload all
+      {label}
     </Button>
   );
 };

--- a/js_modules/dagit/packages/ui/src/components/RefreshableCountdown.tsx
+++ b/js_modules/dagit/packages/ui/src/components/RefreshableCountdown.tsx
@@ -10,16 +10,19 @@ interface Props {
   refreshing: boolean;
   seconds: number;
   onRefresh: () => void;
+  dataDescription?: string;
 }
 
 export const RefreshableCountdown = (props: Props) => {
-  const {refreshing, seconds, onRefresh} = props;
+  const {refreshing, seconds, onRefresh, dataDescription = 'data'} = props;
   return (
     <Group direction="row" spacing={8} alignItems="center">
       <span
         style={{color: Colors.Gray400, fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap'}}
       >
-        {refreshing ? 'Refreshing data…' : `0:${seconds < 10 ? `0${seconds}` : seconds}`}
+        {refreshing
+          ? `Refreshing ${dataDescription}…`
+          : `0:${seconds < 10 ? `0${seconds}` : seconds}`}
       </span>
       <Tooltip content={<span style={{whiteSpace: 'nowrap'}}>Refresh now</span>} position="bottom">
         <RefreshButton onClick={onRefresh}>


### PR DESCRIPTION
### Summary & Motivation

Per our discussion yesterday, this PR:

- Adds the "Reload All" button to the top right of the instance-wide asset graph and asset catalog. This button is the same as the top instance-level reload button on the Workspace page and reloads the view when it's done.

- Removes the repository filter from the asset graph and catalog. We'd like to encourage people to use asset folders / groups instead of thinking of their repositories as units of organization.

### How I Tested These Changes

![image](https://user-images.githubusercontent.com/1037212/166487106-e38505ec-802c-4de7-8780-fd70383063ba.png)
![image](https://user-images.githubusercontent.com/1037212/166487227-d5907109-aca7-4889-80c8-fb07509990f5.png)
