### PR TITLE
Add a guard around dagit's JSON parsing of incoming requests

### DIFF
--- a/python_modules/dagit/dagit/graphql.py
+++ b/python_modules/dagit/dagit/graphql.py
@@ -88,7 +88,14 @@ class GraphQLServer(ABC):
             content_type = request.headers.get("Content-Type", "")
 
             if "application/json" in content_type:
-                data = await request.json()
+                try:
+                    data = await request.json()
+                except json.JSONDecodeError:
+                    body = await request.body()
+                    return PlainTextResponse(
+                        f"GraphQL request is invalid JSON:\n{body.decode()}",
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                    )
             elif "application/graphql" in content_type:
                 body = await request.body()
                 text = body.decode()

--- a/python_modules/dagit/dagit_tests/webserver/test_app.py
+++ b/python_modules/dagit/dagit_tests/webserver/test_app.py
@@ -107,6 +107,18 @@ def test_graphql_get(instance, test_client: TestClient):  # pylint: disable=unus
     assert response.status_code == 400, response.text
 
 
+def test_graphql_invalid_json(instance, test_client: TestClient):  # pylint: disable=unused-argument
+    # base case
+    response = test_client.post(
+        "/graphql", data='{"query": "foo}', headers={"Content-Type": "application/json"}
+    )
+
+    print(str(response.text))
+
+    assert response.status_code == 400, response.text
+    assert 'GraphQL request is invalid JSON:\n{"query": "foo}' in response.text
+
+
 def test_graphql_post(test_client: TestClient):
     # base case
     response = test_client.post(


### PR DESCRIPTION
Summary:
Before, malformed JSON bubbled all the way up to the top and manifested as a 500/Internal Server Error. Now, it is caught and raises a 400.

### Summary & Motivation

### How I Tested These Changes
