### PR TITLE
[dagit] Support special cron strings

### DIFF
--- a/js_modules/dagit/packages/core/src/schedules/humanCronString.test.ts
+++ b/js_modules/dagit/packages/core/src/schedules/humanCronString.test.ts
@@ -1,0 +1,9 @@
+import {humanCronString} from './humanCronString';
+
+describe('humanCronString', () => {
+  it('parses special strings correctly', () => {
+    expect(humanCronString('@daily')).toBe('At 12:00 AM');
+    expect(humanCronString('@weekly')).toBe('At 12:00 AM, only on Sunday');
+    expect(humanCronString('@monthly')).toBe('At 12:00 AM, on day 1 of the month');
+  });
+});

--- a/js_modules/dagit/packages/core/src/schedules/humanCronString.ts
+++ b/js_modules/dagit/packages/core/src/schedules/humanCronString.ts
@@ -1,9 +1,30 @@
 import cronstrue from 'cronstrue';
 
 export const humanCronString = (cronSchedule: string) => {
+  const standardCronString = convertIfSpecial(cronSchedule);
   try {
-    return cronstrue.toString(cronSchedule);
+    return cronstrue.toString(standardCronString);
   } catch {
     return 'Invalid cron string';
+  }
+};
+
+// https://en.wikipedia.org/wiki/Cron#Nonstandard_predefined_scheduling_definitions
+const convertIfSpecial = (maybeSpecial: string) => {
+  switch (maybeSpecial) {
+    case '@yearly':
+    case '@annually':
+      return '0 0 1 1 *';
+    case '@monthly':
+      return '0 0 1 * *';
+    case '@weekly':
+      return '0 0 * * 0';
+    case '@daily':
+    case '@midnight':
+      return '0 0 * * *';
+    case '@hourly':
+      return '0 * * * *';
+    default:
+      return maybeSpecial;
   }
 };


### PR DESCRIPTION
### Summary & Motivation

Support special cron strings like `@daily`, which are parsed as invalid by `cronstrue`.

### How I Tested These Changes

Force aliases to be the values for all rendered cron strings, verify that the parsed result is correct.
