### PR TITLE
snowflake IO manager and pandas type handler

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -463,6 +463,18 @@ DAGSTER_PACKAGES_WITH_CUSTOM_TESTS = [
         ),
     ),
     ModuleBuildSpec(
+        "python_modules/libraries/dagster-snowflake-pandas",
+        supported_pythons=(  # dropped python 3.6 support
+            [
+                SupportedPython.V3_7,
+                SupportedPython.V3_8,
+                SupportedPython.V3_9,
+            ]
+            if (branch_name == "master" or is_release_branch(branch_name))
+            else [SupportedPython.V3_9]
+        ),
+    ),
+    ModuleBuildSpec(
         "python_modules/libraries/dagster-postgres", extra_cmds_fn=postgres_extra_cmds_fn
     ),
     ModuleBuildSpec(

--- a/docs/content/_apidocs.mdx
+++ b/docs/content/_apidocs.mdx
@@ -124,7 +124,9 @@ Dagster also provides a growing set of optional add-on libraries to integrate wi
 
 - [Slack](/\_apidocs/libraries/dagster-slack) (`dagster-slack`) Provides a simple integration with Slack.
 
-- [Snowflake](/\_apidocs/libraries/dagster-snowflake) (`dagster-snowflake`) Provides a resource for querying Snowflake from Dagster.
+- [Snowflake](/\_apidocs/libraries/dagster-snowflake) (`dagster-snowflake`) Provides resources for querying Snowflake from Dagster.
+
+- [Snowflake+Pandas](/\_apidocs/libraries/dagster-snowflake-pandas) (`dagster-snowflake-pandas`) Provides support for storing Pandas DataFrames in Snowflake.
 
 - [Spark](/\_apidocs/libraries/dagster-spark) (`dagster-spark`) Provides an integration for working with Spark in Dagster.
 

--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -685,6 +685,10 @@
             "path": "/_apidocs/libraries/dagster-snowflake"
           },
           {
+            "title": "Snowflake + Pandas (dagster-snowflake-pandas)",
+            "path": "/_apidocs/libraries/dagster-snowflake-pandas"
+          },
+          {
             "title": "Spark (dagster-spark)",
             "path": "/_apidocs/libraries/dagster-spark"
           },

--- a/docs/content/integrations.mdx
+++ b/docs/content/integrations.mdx
@@ -25,38 +25,39 @@ This section includes guides on how to use Dagster with other tools.
 
 Here is a complete list of Dagster's integration libraries. See full documentation in [API Reference](/\_apidocs#libraries).
 
-| Integration        | Library                                                            |
-| ------------------ | ------------------------------------------------------------------ |
-| Airbyte            | [dagster-airbyte](/_apidocs/libraries/dagster-airbyte)             |
-| Airflow            | [dagster-airflow](/_apidocs/libraries/dagster-airflow)             |
-| AWS                | [dagster-aws](/_apidocs/libraries/dagster-aws)                     |
-| Azure              | [dagster-azure](/_apidocs/libraries/dagster-azure)                 |
-| Celery             | [dagster-celery](/_apidocs/libraries/dagster-celery)               |
-| Celery + Docker    | [dagster-celery-docker](/_apidocs/libraries/dagster-celery-docker) |
-| Dask               | [dagster-dask](/_apidocs/libraries/dagster-dask)                   |
-| Databricks         | [dagster-databricks](/_apidocs/libraries/dagster-databricks)       |
-| Datadog            | [dagster-datadog](/_apidocs/libraries/dagster-datadog)             |
-| Docker             | [dagster-docker](/_apidocs/libraries/dagster-docker)               |
-| dbt                | [dagster-dbt](/_apidocs/libraries/dagster-dbt)                     |
-| Fivetran           | [dagster-fivetran](/_apidocs/libraries/dagster-fivetran)           |
-| GCP                | [dagster-gcp](/_apidocs/libraries/dagster-gcp)                     |
-| Great Expectations | [dagster-ge](/_apidocs/libraries/dagster-ge)                       |
-| Github             | [dagster-github](/_apidocs/libraries/dagster-github)               |
-| Kubernetes         | [dagster-k8s](/_apidocs/libraries/dagster-k8s)                     |
-| Microsoft Teams    | [dagster-msteams](/_apidocs/libraries/dagster-msteams)             |
-| MLflow             | [dagster-mlflow](/_apidocs/libraries/dagster-mlflow)               |
-| MySQL              | [dagster-mysql](/_apidocs/libraries/dagster-mysql)                 |
-| PagerDuty          | [dagster-pagerduty](/_apidocs/libraries/dagster-pagerduty)         |
-| Pandas             | [dagster-pandas](/_apidocs/libraries/dagster-pandas)               |
-| Pandera            | [dagster-pandera](/_apidocs/libraries/dagster-pandera)             |
-| Papermill          | [dagstermill](/_apidocs/libraries/dagstermill)                     |
-| Papertrail         | [dagster-papertrail](/_apidocs/libraries/dagster-papertrail)       |
-| PostgreSQL         | [dagster-postgres](/_apidocs/libraries/dagster-postgres)           |
-| Prometheus         | [dagster-prometheus](/_apidocs/libraries/dagster-prometheus)       |
-| Pyspark            | [dagster-pyspark](/_apidocs/libraries/dagster-pyspark)             |
-| Shell              | [dagster-shell](/_apidocs/libraries/dagster-shell)                 |
-| Slack              | [dagster-slack](/_apidocs/libraries/dagster-slack)                 |
-| Snowflake          | [dagster-snowflake](/_apidocs/libraries/dagster-snowflake)         |
-| Spark              | [dagster-spark](/_apidocs/libraries/dagster-spark)                 |
-| SSH / SFTP         | [dagster-ssh](/_apidocs/libraries/dagster-ssh)                     |
-| Twilio             | [dagster-twilio](/_apidocs/libraries/dagster-twilio)               |
+| Integration        | Library                                                                  |
+| ------------------ | ------------------------------------------------------------------------ |
+| Airbyte            | [dagster-airbyte](/_apidocs/libraries/dagster-airbyte)                   |
+| Airflow            | [dagster-airflow](/_apidocs/libraries/dagster-airflow)                   |
+| AWS                | [dagster-aws](/_apidocs/libraries/dagster-aws)                           |
+| Azure              | [dagster-azure](/_apidocs/libraries/dagster-azure)                       |
+| Celery             | [dagster-celery](/_apidocs/libraries/dagster-celery)                     |
+| Celery + Docker    | [dagster-celery-docker](/_apidocs/libraries/dagster-celery-docker)       |
+| Dask               | [dagster-dask](/_apidocs/libraries/dagster-dask)                         |
+| Databricks         | [dagster-databricks](/_apidocs/libraries/dagster-databricks)             |
+| Datadog            | [dagster-datadog](/_apidocs/libraries/dagster-datadog)                   |
+| Docker             | [dagster-docker](/_apidocs/libraries/dagster-docker)                     |
+| dbt                | [dagster-dbt](/_apidocs/libraries/dagster-dbt)                           |
+| Fivetran           | [dagster-fivetran](/_apidocs/libraries/dagster-fivetran)                 |
+| GCP                | [dagster-gcp](/_apidocs/libraries/dagster-gcp)                           |
+| Great Expectations | [dagster-ge](/_apidocs/libraries/dagster-ge)                             |
+| Github             | [dagster-github](/_apidocs/libraries/dagster-github)                     |
+| Kubernetes         | [dagster-k8s](/_apidocs/libraries/dagster-k8s)                           |
+| Microsoft Teams    | [dagster-msteams](/_apidocs/libraries/dagster-msteams)                   |
+| MLflow             | [dagster-mlflow](/_apidocs/libraries/dagster-mlflow)                     |
+| MySQL              | [dagster-mysql](/_apidocs/libraries/dagster-mysql)                       |
+| PagerDuty          | [dagster-pagerduty](/_apidocs/libraries/dagster-pagerduty)               |
+| Pandas             | [dagster-pandas](/_apidocs/libraries/dagster-pandas)                     |
+| Pandera            | [dagster-pandera](/_apidocs/libraries/dagster-pandera)                   |
+| Papermill          | [dagstermill](/_apidocs/libraries/dagstermill)                           |
+| Papertrail         | [dagster-papertrail](/_apidocs/libraries/dagster-papertrail)             |
+| PostgreSQL         | [dagster-postgres](/_apidocs/libraries/dagster-postgres)                 |
+| Prometheus         | [dagster-prometheus](/_apidocs/libraries/dagster-prometheus)             |
+| Pyspark            | [dagster-pyspark](/_apidocs/libraries/dagster-pyspark)                   |
+| Shell              | [dagster-shell](/_apidocs/libraries/dagster-shell)                       |
+| Slack              | [dagster-slack](/_apidocs/libraries/dagster-slack)                       |
+| Snowflake          | [dagster-snowflake](/_apidocs/libraries/dagster-snowflake)               |
+| Snowflake + Pandas | [dagster-snowflake-pandas](/_apidocs/libraries/dagster-snowflake-pandas) |
+| Spark              | [dagster-spark](/_apidocs/libraries/dagster-spark)                       |
+| SSH / SFTP         | [dagster-ssh](/_apidocs/libraries/dagster-ssh)                           |
+| Twilio             | [dagster-twilio](/_apidocs/libraries/dagster-twilio)                     |

--- a/docs/docs-dagster-requirements.txt
+++ b/docs/docs-dagster-requirements.txt
@@ -24,6 +24,7 @@
 -e ../python_modules/libraries/dagster-shell
 -e ../python_modules/libraries/dagster-slack
 -e ../python_modules/libraries/dagster-snowflake
+-e ../python_modules/libraries/dagster-snowflake-pandas
 -e ../python_modules/libraries/dagster-spark
 -e ../python_modules/libraries/dagster-ssh
 -e ../python_modules/libraries/dagster-twilio

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -56,6 +56,7 @@
    sections/api/apidocs/libraries/dagster-shell
    sections/api/apidocs/libraries/dagster-slack
    sections/api/apidocs/libraries/dagster-snowflake
+   sections/api/apidocs/libraries/dagster-snowflake-pandas
    sections/api/apidocs/libraries/dagster-spark
    sections/api/apidocs/libraries/dagster-ssh
    sections/api/apidocs/libraries/dagster-twilio

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-snowflake-pandas.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-snowflake-pandas.rst
@@ -1,0 +1,15 @@
+Snowflake with Pandas (dagster-snowflake-pandas)
+------------------------------------------------
+
+This library provides an integration with the `Snowflake <https://www.snowflake.com/>`_ data
+warehouse and Pandas data processing library.
+
+To use this library, you should first ensure that you have an appropriate `Snowflake user
+<https://docs.snowflake.net/manuals/user-guide/admin-user-management.html>`_ configured to access
+your data warehouse.
+
+
+.. currentmodule:: dagster_snowflake_pandas
+
+.. autoclass:: SnowflakePandasTypeHandler
+

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-snowflake.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-snowflake.rst
@@ -4,10 +4,6 @@ Snowflake (dagster-snowflake)
 This library provides an integration with the `Snowflake <https://www.snowflake.com/>`_ data
 warehouse.
 
-It provides a ``snowflake_resource``, which is a Dagster resource for configuring
-Snowflake connections and issuing queries, as well as a ``snowflake_op_for_query`` function for
-constructing ops that execute Snowflake queries.
-
 To use this library, you should first ensure that you have an appropriate `Snowflake user
 <https://docs.snowflake.net/manuals/user-guide/admin-user-management.html>`_ configured to access
 your data warehouse.
@@ -18,8 +14,11 @@ your data warehouse.
 .. autoconfigurable:: snowflake_resource
   :annotation: ResourceDefinition
 
+.. autofunction:: build_snowflake_io_manager
+
 .. autofunction:: snowflake_op_for_query
 
 .. autoclass:: SnowflakeConnection
   :members:
   :undoc-members:
+

--- a/python_modules/libraries/dagster-snowflake-pandas/.coveragerc
+++ b/python_modules/libraries/dagster-snowflake-pandas/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+branch = True

--- a/python_modules/libraries/dagster-snowflake-pandas/LICENSE
+++ b/python_modules/libraries/dagster-snowflake-pandas/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/python_modules/libraries/dagster-snowflake-pandas/MANIFEST.in
+++ b/python_modules/libraries/dagster-snowflake-pandas/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include LICENSE
+include dagster_snowflake_pandas/py.typed

--- a/python_modules/libraries/dagster-snowflake-pandas/README.md
+++ b/python_modules/libraries/dagster-snowflake-pandas/README.md
@@ -1,0 +1,4 @@
+# dagster-snowflake-pandas
+
+The docs for `dagster-snowflake-pandas` can be found
+[here](https://docs.dagster.io/_apidocs/libraries/dagster-snowflake-pandas).

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/__init__.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/__init__.py
@@ -1,0 +1,8 @@
+from dagster.core.utils import check_dagster_package_version
+
+from .snowflake_pandas_type_handler import SnowflakePandasTypeHandler
+from .version import __version__
+
+check_dagster_package_version("dagster-snowflake-pandas", __version__)
+
+__all__ = ["SnowflakePandasTypeHandler"]

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/py.typed
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -1,0 +1,74 @@
+from typing import Mapping, Union, cast
+
+from dagster_snowflake import DbTypeHandler
+from dagster_snowflake.resources import SnowflakeConnection
+from dagster_snowflake.snowflake_io_manager import SnowflakeDbClient, TableSlice
+from pandas import DataFrame, read_sql
+from snowflake.connector.pandas_tools import pd_writer
+
+from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
+from dagster.core.definitions.metadata import RawMetadataValue
+
+
+def _connect_snowflake(context: Union[InputContext, OutputContext], table_slice: TableSlice):
+    return SnowflakeConnection(
+        dict(
+            schema=table_slice.schema,
+            connector="sqlalchemy",
+            **cast(Mapping[str, str], context.resource_config),
+        ),
+        context.log,
+    ).get_connection()
+
+
+class SnowflakePandasTypeHandler(DbTypeHandler[DataFrame]):
+    """
+    Defines how to translate between slices of Snowflake tables and Pandas DataFrames.
+
+    Examples:
+
+    .. code-block:: python
+
+        from dagster_snowflake import build_snowflake_io_manager
+        from dagster_snowflake_pandas import SnowflakePandasTypeHandler
+
+        snowflake_io_manager = build_snowflake_io_manager([SnowflakePandasTypeHandler()])
+
+        @job(resource_defs={'io_manager': snowflake_io_manager})
+        def my_job():
+            ...
+    """
+
+    def handle_output(
+        self, context: OutputContext, table_slice: TableSlice, obj: DataFrame
+    ) -> Mapping[str, RawMetadataValue]:
+        from snowflake import connector  # pylint: disable=no-name-in-module
+
+        connector.paramstyle = "pyformat"
+        with _connect_snowflake(context, table_slice) as con:
+            with_uppercase_cols = obj.rename(str.upper, copy=False, axis="columns")
+            with_uppercase_cols.to_sql(
+                table_slice.table,
+                con=con,
+                if_exists="append",
+                index=False,
+                method=pd_writer,
+            )
+
+        return {
+            "row_count": obj.shape[0],
+            "dataframe_columns": MetadataValue.table_schema(
+                TableSchema(
+                    columns=[
+                        TableColumn(name=name, type=str(dtype))
+                        for name, dtype in obj.dtypes.iteritems()
+                    ]
+                )
+            ),
+        }
+
+    def load_input(self, context: InputContext, table_slice: TableSlice) -> DataFrame:
+        with _connect_snowflake(context, table_slice) as con:
+            result = read_sql(sql=SnowflakeDbClient.get_select_statement(table_slice), con=con)
+            result.columns = map(str.lower, result.columns)
+            return result

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/version.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/version.py
@@ -1,0 +1,1 @@
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -1,0 +1,72 @@
+from unittest.mock import patch
+
+from dagster_snowflake.snowflake_io_manager import TableSlice
+from dagster_snowflake_pandas import SnowflakePandasTypeHandler
+from pandas import DataFrame
+
+from dagster import (
+    MetadataValue,
+    TableColumn,
+    TableSchema,
+    build_input_context,
+    build_output_context,
+)
+
+resource_config = {
+    "database": "database_abc",
+    "account": "account_abc",
+    "user": "user_abc",
+    "password": "password_abc",
+    "warehouse": "warehouse_abc",
+}
+
+
+def test_handle_output():
+    with patch("dagster_snowflake_pandas.snowflake_pandas_type_handler._connect_snowflake"):
+        handler = SnowflakePandasTypeHandler()
+        df = DataFrame([{"col1": "a", "col2": 1}])
+        output_context = build_output_context(resource_config=resource_config)
+
+        metadata = handler.handle_output(
+            output_context,
+            TableSlice(
+                table="my_table",
+                schema="my_schema",
+                database="my_db",
+                columns=None,
+                partition=None,
+            ),
+            df,
+        )
+
+        assert metadata == {
+            "dataframe_columns": MetadataValue.table_schema(
+                TableSchema(columns=[TableColumn("col1", "object"), TableColumn("col2", "int64")])
+            ),
+            "row_count": 1,
+        }
+
+
+def test_load_input():
+    with patch("dagster_snowflake_pandas.snowflake_pandas_type_handler._connect_snowflake"), patch(
+        "dagster_snowflake_pandas.snowflake_pandas_type_handler.read_sql"
+    ) as mock_read_sql:
+        mock_read_sql.return_value = DataFrame([{"COL1": "a", "COL2": 1}])
+
+        handler = SnowflakePandasTypeHandler()
+        input_context = build_input_context()
+        df = handler.load_input(
+            input_context,
+            TableSlice(
+                table="my_table",
+                schema="my_schema",
+                database="my_db",
+                columns=None,
+                partition=None,
+            ),
+        )
+        assert (
+            mock_read_sql.call_args_list[0].kwargs["sql"]
+            == "SELECT * FROM my_db.my_schema.my_table"
+        )
+        assert df.equals(DataFrame([{"col1": "a", "col2": 1}]))

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_version.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_version.py
@@ -1,0 +1,5 @@
+from dagster_snowflake_pandas.version import __version__
+
+
+def test_version():
+    assert __version__

--- a/python_modules/libraries/dagster-snowflake-pandas/setup.cfg
+++ b/python_modules/libraries/dagster-snowflake-pandas/setup.cfg
@@ -1,0 +1,9 @@
+[metadata]
+license_files = LICENSE
+
+[check-manifest]
+ignore =
+    .coveragerc
+    tox.ini
+    pytest.ini
+    dagster_snowflake_pandas_tests/**

--- a/python_modules/libraries/dagster-snowflake-pandas/setup.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/setup.py
@@ -1,0 +1,44 @@
+from typing import Dict
+
+from setuptools import find_packages, setup
+
+
+def get_version() -> str:
+    version: Dict[str, str] = {}
+    with open("dagster_snowflake_pandas/version.py", encoding="utf8") as fp:
+        exec(fp.read(), version)  # pylint: disable=W0122
+
+    return version["__version__"]
+
+
+if __name__ == "__main__":
+    ver = get_version()
+    # dont pin dev installs to avoid pip dep resolver issues
+    pin = "" if ver == "0+dev" else f"=={ver}"
+    setup(
+        name="dagster-snowflake-pandas",
+        version=ver,
+        author="Elementl",
+        author_email="hello@elementl.com",
+        license="Apache-2.0",
+        description="Package for integrating Snowflake and Pandas with Dagster.",
+        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-snowflake-pandas",
+        classifiers=[
+            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
+            "License :: OSI Approved :: Apache Software License",
+            "Operating System :: OS Independent",
+        ],
+        packages=find_packages(exclude=["dagster_snowflake_pandas_tests*"]),
+        install_requires=[
+            f"dagster{pin}",
+            f"dagster-snowflake{pin}",
+            "pandas",
+            "requests",
+            "snowflake-connector-python[pandas]",
+            "snowflake-sqlalchemy",
+        ],
+        zip_safe=False,
+    )

--- a/python_modules/libraries/dagster-snowflake-pandas/tox.ini
+++ b/python_modules/libraries/dagster-snowflake-pandas/tox.ini
@@ -1,0 +1,28 @@
+[tox]
+envlist = py{38,37,36}-{unix,windows},pylint
+
+[testenv]
+usedevelop = true
+passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
+deps =
+  -e ../../dagster[test]
+  -e ../dagster-snowflake
+allowlist_externals =
+  /bin/bash
+  echo
+commands =
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  coverage erase
+  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
+  pytest -vv --junitxml=test_results.xml --cov=dagster_snowflake_pandas --cov-append --cov-report= {posargs}
+  coverage report --omit='.tox/*,**/test_*.py' --skip-covered
+  coverage html --omit='.tox/*,**/test_*.py'
+  coverage xml --omit='.tox/*,**/test_*.py'
+
+[testenv:pylint]
+commands =
+  pylint -j0 --rcfile=../../../pyproject.toml dagster_snowflake_pandas dagster_snowflake_pandas_tests
+
+[testenv:mypy]
+commands =
+  mypy --config=../../../pyproject.toml --non-interactive .

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/__init__.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/__init__.py
@@ -1,6 +1,7 @@
 from dagster.core.utils import check_dagster_package_version
 
 from .resources import SnowflakeConnection, snowflake_resource
+from .snowflake_io_manager import DbTypeHandler, build_snowflake_io_manager
 from .solids import snowflake_op_for_query, snowflake_solid_for_query
 from .version import __version__
 
@@ -10,5 +11,7 @@ __all__ = [
     "snowflake_op_for_query",
     "snowflake_solid_for_query",
     "snowflake_resource",
+    "build_snowflake_io_manager",
     "SnowflakeConnection",
+    "DbTypeHandler",
 ]

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/db_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/db_io_manager.py
@@ -1,0 +1,151 @@
+from abc import ABC, abstractmethod
+from typing import (
+    Dict,
+    Generic,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
+
+from dagster import IOManager, InputContext, OutputContext, check
+from dagster.core.definitions.metadata import RawMetadataValue
+from dagster.core.definitions.time_window_partitions import TimeWindow
+
+SNOWFLAKE_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+T = TypeVar("T")
+
+
+class TablePartition(NamedTuple):
+    time_window: TimeWindow
+    partition_expr: str
+
+
+class TableSlice(NamedTuple):
+    table: str
+    schema: str
+    database: str
+    columns: Optional[Sequence[str]] = None
+    partition: Optional[TablePartition] = None
+
+
+class DbTypeHandler(ABC, Generic[T]):
+    @abstractmethod
+    def handle_output(
+        self, context: OutputContext, table_slice: TableSlice, obj: T
+    ) -> Optional[Mapping[str, RawMetadataValue]]:
+        """Stores the given object at the given table in the given schema."""
+
+    @abstractmethod
+    def load_input(self, context: InputContext, table_slice: TableSlice) -> T:
+        """Loads the contents of the given table in the given schema."""
+
+    @property
+    def supported_types(self) -> Sequence[Type]:
+        ...
+
+
+class DbClient:
+    @staticmethod
+    @abstractmethod
+    def delete_table_slice(context: OutputContext, table_slice: TableSlice) -> None:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def get_select_statement(table_slice: TableSlice) -> str:
+        ...
+
+
+class DbIOManager(IOManager):
+    def __init__(self, type_handlers: Sequence[DbTypeHandler], db_client: DbClient):
+        self._handlers_by_type: Dict[Optional[Type], DbTypeHandler] = {}
+        for type_handler in type_handlers:
+            for handled_type in type_handler.supported_types:
+                check.invariant(
+                    handled_type not in self._handlers_by_type,
+                    "DbIOManager provided with two handlers for the same type. "
+                    f"Type: '{handled_type}'. Handler classes: '{type(type_handler)}' and "
+                    f"'{type(self._handlers_by_type.get(handled_type))}'.",
+                )
+
+                self._handlers_by_type[handled_type] = type_handler
+
+        self._db_client = db_client
+
+    def handle_output(self, context: OutputContext, obj: object) -> None:
+        table_slice = self._get_table_slice(context, context)
+        self._db_client.delete_table_slice(context, table_slice)
+
+        obj_type = type(obj)
+        check.invariant(
+            obj_type in self._handlers_by_type,
+            f"DbIOManager does not have a handler for type '{obj_type}'. Has handlers "
+            f"for types '{', '.join([str(handler_type) for handler_type in self._handlers_by_type.keys()])}'",
+        )
+        handler_metadata = (
+            self._handlers_by_type[obj_type].handle_output(context, table_slice, obj) or {}
+        )
+
+        context.add_output_metadata(
+            {**handler_metadata, "Query": self._db_client.get_select_statement(table_slice)}
+        )
+
+    def load_input(self, context: InputContext) -> object:
+        obj_type = context.dagster_type.typing_type
+        check.invariant(
+            obj_type in self._handlers_by_type,
+            f"DbIOManager does not have a handler for type '{obj_type}'. Has handlers "
+            f"for types '{', '.join([str(handler_type) for handler_type in self._handlers_by_type.keys()])}'",
+        )
+        return self._handlers_by_type[obj_type].load_input(
+            context, self._get_table_slice(context, cast(OutputContext, context.upstream_output))
+        )
+
+    def _get_table_slice(
+        self, context: Union[OutputContext, InputContext], output_context: OutputContext
+    ) -> TableSlice:
+        output_context_metadata = output_context.metadata or {}
+
+        if context.has_asset_key:
+            asset_key_path = context.asset_key.path
+            table = asset_key_path[-1]
+            if len(asset_key_path) > 1:
+                schema = asset_key_path[-2]
+            else:
+                schema = "public"
+            time_window = (
+                context.asset_partitions_time_window if context.has_asset_partitions else None
+            )
+        else:
+            table = output_context.name
+            schema = output_context_metadata.get("schema", "public")
+            time_window = None
+
+        if time_window is not None:
+            partition_expr = output_context_metadata.get("partition_expr")
+            if partition_expr is None:
+                raise ValueError(
+                    f"Asset '{context.asset_key}' has partitions, but no 'partition_expr' metadata "
+                    "value, so we don't know what column to filter it on."
+                )
+            partition = TablePartition(
+                time_window=time_window,
+                partition_expr=partition_expr,
+            )
+        else:
+            partition = None
+
+        return TableSlice(
+            table=table,
+            schema=schema,
+            database=cast(Mapping[str, str], context.resource_config)["database"],
+            partition=partition,
+            columns=(context.metadata or {}).get("columns"),
+        )

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -1,6 +1,7 @@
 import sys
 import warnings
 from contextlib import closing, contextmanager
+from typing import Mapping
 
 from dagster import check, resource
 
@@ -21,15 +22,15 @@ except ImportError:
 
 
 class SnowflakeConnection:
-    def __init__(self, context):  # pylint: disable=too-many-locals
+    def __init__(self, config: Mapping[str, str], log):  # pylint: disable=too-many-locals
         # Extract parameters from resource config. Note that we can't pass None values to
         # snowflake.connector.connect() because they will override the default values set within the
         # connector; remove them from the conn_args dict.
-        self.connector = context.resource_config.get("connector", None)
+        self.connector = config.get("connector", None)
 
         if self.connector == "sqlalchemy":
             self.conn_args = {
-                k: context.resource_config.get(k)
+                k: config.get(k)
                 for k in (
                     "account",
                     "user",
@@ -41,12 +42,12 @@ class SnowflakeConnection:
                     "cache_column_metadata",
                     "numpy",
                 )
-                if context.resource_config.get(k) is not None
+                if config.get(k) is not None
             }
 
         else:
             self.conn_args = {
-                k: context.resource_config.get(k)
+                k: config.get(k)
                 for k in (
                     "account",
                     "user",
@@ -66,11 +67,11 @@ class SnowflakeConnection:
                     "timezone",
                     "authenticator",
                 )
-                if context.resource_config.get(k) is not None
+                if config.get(k) is not None
             }
 
         self.autocommit = self.conn_args.get("autocommit", False)
-        self.log = context.log
+        self.log = log
 
     @contextmanager
     def get_connection(self, raw_conn=True):
@@ -183,7 +184,7 @@ def snowflake_resource(context):
         )
 
     """
-    return SnowflakeConnection(context)
+    return SnowflakeConnection(context.resource_config, context.log)
 
 
 def _filter_password(args):

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -1,0 +1,89 @@
+from typing import Sequence
+
+from dagster import Field, IOManagerDefinition, OutputContext, StringSource, io_manager
+
+from .db_io_manager import DbClient, DbIOManager, DbTypeHandler, TablePartition, TableSlice
+from .resources import SnowflakeConnection
+
+SNOWFLAKE_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+def build_snowflake_io_manager(type_handlers: Sequence[DbTypeHandler]) -> IOManagerDefinition:
+    """
+    Builds an IO manager definition that reads inputs from and writes outputs to Snowflake.
+
+    Args:
+        type_handlers (Sequence[DbTypeHandler]): Each handler defines how to translate between
+            slices of Snowflake tables and an in-memory type - e.g. a Pandas DataFrame.
+
+    Returns:
+        IOManagerDefinition
+
+    Examples:
+
+        .. code-block:: python
+
+            from dagster_snowflake import build_snowflake_io_manager
+            from dagster_snowflake_pandas import SnowflakePandasTypeHandler
+
+            snowflake_io_manager = build_snowflake_io_manager([SnowflakePandasTypeHandler()])
+
+            @job(resource_defs={'io_manager': snowflake_io_manager})
+            def my_job():
+                ...
+    """
+
+    @io_manager(
+        config_schema={
+            "database": StringSource,
+            "account": StringSource,
+            "user": StringSource,
+            "password": StringSource,
+            "warehouse": Field(StringSource, is_required=False),
+        }
+    )
+    def snowflake_io_manager():
+        return DbIOManager(type_handlers=type_handlers, db_client=SnowflakeDbClient())
+
+    return snowflake_io_manager
+
+
+class SnowflakeDbClient(DbClient):
+    @staticmethod
+    def delete_table_slice(context: OutputContext, table_slice: TableSlice) -> None:
+        with SnowflakeConnection(
+            dict(**(context.resource_config or {}), schema=table_slice.schema), context.log
+        ).get_connection() as con:
+            con.execute(_get_cleanup_statement(table_slice))
+
+    @staticmethod
+    def get_select_statement(table_slice: TableSlice) -> str:
+        col_str = ", ".join(table_slice.columns) if table_slice.columns else "*"
+        if table_slice.partition:
+            return (
+                f"SELECT {col_str} FROM {table_slice.database}.{table_slice.schema}.{table_slice.table}\n"
+                + _time_window_where_clause(table_slice.partition)
+            )
+        else:
+            return f"""SELECT {col_str} FROM {table_slice.database}.{table_slice.schema}.{table_slice.table}"""
+
+
+def _get_cleanup_statement(table_slice: TableSlice) -> str:
+    """
+    Returns a SQL statement that deletes data in the given table to make way for the output data
+    being written.
+    """
+    if table_slice.partition:
+        return (
+            f"DELETE FROM {table_slice.database}.{table_slice.schema}.{table_slice.table}\n"
+            + _time_window_where_clause(table_slice.partition)
+        )
+    else:
+        return f"DELETE FROM {table_slice.database}.{table_slice.schema}.{table_slice.table}"
+
+
+def _time_window_where_clause(table_partition: TablePartition) -> str:
+    start_dt, end_dt = table_partition.time_window
+    start_dt_str = start_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
+    end_dt_str = end_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
+    return f"""WHERE {table_partition.partition_expr} BETWEEN '{start_dt_str}' AND '{end_dt_str}'"""

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_db_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_db_io_manager.py
@@ -1,0 +1,201 @@
+from unittest.mock import MagicMock
+
+from dagster_snowflake import DbTypeHandler
+from dagster_snowflake.db_io_manager import DbClient, DbIOManager, TablePartition, TableSlice
+from pendulum import datetime
+
+from dagster import AssetKey, InputContext, OutputContext, build_output_context
+from dagster.core.definitions.time_window_partitions import TimeWindow
+from dagster.core.types.dagster_type import resolve_dagster_type
+
+resource_config = {
+    "database": "database_abc",
+    "account": "account_abc",
+    "user": "user_abc",
+    "password": "password_abc",
+    "warehouse": "warehouse_abc",
+}
+
+
+class IntHandler(DbTypeHandler[int]):
+    def __init__(self):
+        self.handle_input_calls = []
+        self.handle_output_calls = []
+
+    def handle_output(self, context: OutputContext, table_slice: TableSlice, obj: int):
+        self.handle_output_calls.append((context, table_slice, obj))
+
+    def load_input(self, context: InputContext, table_slice: TableSlice) -> int:
+        self.handle_input_calls.append((context, table_slice))
+        return 7
+
+    @property
+    def supported_types(self):
+        return [int]
+
+
+class StringHandler(DbTypeHandler[str]):
+    def __init__(self):
+        self.handle_input_calls = []
+        self.handle_output_calls = []
+
+    def handle_output(self, context: OutputContext, table_slice: TableSlice, obj: str):
+        self.handle_output_calls.append((context, table_slice, obj))
+
+    def load_input(self, context: InputContext, table_slice: TableSlice) -> str:
+        self.handle_input_calls.append((context, table_slice))
+        return "8"
+
+    @property
+    def supported_types(self):
+        return [str]
+
+
+def test_asset_out():
+    handler = IntHandler()
+    db_client = MagicMock(spec=DbClient)
+    manager = DbIOManager(type_handlers=[handler], db_client=db_client)
+    asset_key = AssetKey(["schema1", "table1"])
+    output_context = build_output_context(asset_key=asset_key, resource_config=resource_config)
+    manager.handle_output(output_context, 5)
+    input_context = MagicMock(
+        upstream_output=output_context,
+        resource_config=resource_config,
+        dagster_type=resolve_dagster_type(int),
+        asset_key=asset_key,
+        has_asset_partitions=False,
+        metadata=None,
+    )
+    assert manager.load_input(input_context) == 7
+
+    assert len(handler.handle_output_calls) == 1
+    table_slice = TableSlice(database="database_abc", schema="schema1", table="table1")
+    assert handler.handle_output_calls[0][1:] == (table_slice, 5)
+    db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
+
+    assert len(handler.handle_input_calls) == 1
+    assert handler.handle_input_calls[0][1] == table_slice
+
+
+def test_asset_out_columns():
+    handler = IntHandler()
+    db_client = MagicMock(spec=DbClient)
+    manager = DbIOManager(type_handlers=[handler], db_client=db_client)
+    asset_key = AssetKey(["schema1", "table1"])
+    output_context = build_output_context(asset_key=asset_key, resource_config=resource_config)
+    manager.handle_output(output_context, 5)
+    input_context = MagicMock(
+        asset_key=asset_key,
+        upstream_output=output_context,
+        resource_config=resource_config,
+        dagster_type=resolve_dagster_type(int),
+        has_asset_partitions=False,
+        metadata={"columns": ["apple", "banana"]},
+    )
+    assert manager.load_input(input_context) == 7
+
+    assert len(handler.handle_output_calls) == 1
+    table_slice = TableSlice(database="database_abc", schema="schema1", table="table1")
+    assert handler.handle_output_calls[0][1:] == (table_slice, 5)
+    db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
+
+    assert len(handler.handle_input_calls) == 1
+    assert handler.handle_input_calls[0][1] == TableSlice(
+        database="database_abc", schema="schema1", table="table1", columns=["apple", "banana"]
+    )
+
+
+def test_asset_out_partitioned():
+    handler = IntHandler()
+    db_client = MagicMock(spec=DbClient)
+    manager = DbIOManager(type_handlers=[handler], db_client=db_client)
+    asset_key = AssetKey(["schema1", "table1"])
+    output_context = MagicMock(
+        asset_key=asset_key,
+        resource_config=resource_config,
+        asset_partition_key="2020-01-02",
+        asset_partitions_time_window=TimeWindow(datetime(2020, 1, 2), datetime(2020, 1, 3)),
+        metadata={"partition_expr": "abc"},
+    )
+    manager.handle_output(output_context, 5)
+    input_context = MagicMock(
+        asset_key=asset_key,
+        upstream_output=output_context,
+        resource_config=resource_config,
+        dagster_type=resolve_dagster_type(int),
+        asset_partition_key="2020-01-02",
+        asset_partitions_time_window=TimeWindow(datetime(2020, 1, 2), datetime(2020, 1, 3)),
+        metadata=None,
+    )
+    assert manager.load_input(input_context) == 7
+
+    assert len(handler.handle_output_calls) == 1
+    table_slice = TableSlice(
+        database="database_abc",
+        schema="schema1",
+        table="table1",
+        partition=TablePartition(
+            time_window=TimeWindow(datetime(2020, 1, 2), datetime(2020, 1, 3)), partition_expr="abc"
+        ),
+    )
+    assert handler.handle_output_calls[0][1:] == (table_slice, 5)
+    db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
+
+    assert len(handler.handle_input_calls) == 1
+    assert handler.handle_input_calls[0][1] == table_slice
+
+
+def test_different_output_and_input_types():
+    int_handler = IntHandler()
+    str_handler = StringHandler()
+    db_client = MagicMock(spec=DbClient)
+    manager = DbIOManager(type_handlers=[int_handler, str_handler], db_client=db_client)
+    asset_key = AssetKey(["schema1", "table1"])
+    output_context = build_output_context(asset_key=asset_key, resource_config=resource_config)
+    manager.handle_output(output_context, 5)
+    assert len(int_handler.handle_output_calls) == 1
+    assert len(str_handler.handle_output_calls) == 0
+    table_slice = TableSlice(database="database_abc", schema="schema1", table="table1")
+    assert int_handler.handle_output_calls[0][1:] == (table_slice, 5)
+    db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
+
+    input_context = MagicMock(
+        asset_key=asset_key,
+        upstream_output=output_context,
+        resource_config=resource_config,
+        dagster_type=resolve_dagster_type(str),
+        has_asset_partitions=False,
+        metadata=None,
+    )
+    assert manager.load_input(input_context) == "8"
+
+    assert len(str_handler.handle_input_calls) == 1
+    assert len(int_handler.handle_input_calls) == 0
+    assert str_handler.handle_input_calls[0][1] == table_slice
+
+
+def test_non_asset_out():
+    handler = IntHandler()
+    db_client = MagicMock(spec=DbClient)
+    manager = DbIOManager(type_handlers=[handler], db_client=db_client)
+    output_context = build_output_context(
+        name="table1", metadata={"schema": "schema1"}, resource_config=resource_config
+    )
+    manager.handle_output(output_context, 5)
+    input_context = MagicMock(
+        upstream_output=output_context,
+        resource_config=resource_config,
+        dagster_type=resolve_dagster_type(int),
+        has_asset_key=False,
+        has_asset_partitions=False,
+        metadata=None,
+    )
+    assert manager.load_input(input_context) == 7
+
+    assert len(handler.handle_output_calls) == 1
+    table_slice = TableSlice(database="database_abc", schema="schema1", table="table1")
+    assert handler.handle_output_calls[0][1:] == (table_slice, 5)
+    db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
+
+    assert len(handler.handle_input_calls) == 1
+    assert handler.handle_input_calls[0][1] == table_slice

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
@@ -1,0 +1,71 @@
+from datetime import datetime
+
+from dagster_snowflake.db_io_manager import TablePartition, TableSlice
+from dagster_snowflake.snowflake_io_manager import SnowflakeDbClient, _get_cleanup_statement
+
+
+def test_get_select_statement():
+    assert (
+        SnowflakeDbClient.get_select_statement(
+            TableSlice(database="database_abc", schema="schema1", table="table1")
+        )
+        == "SELECT * FROM database_abc.schema1.table1"
+    )
+
+
+def test_get_select_statement_columns():
+    assert (
+        SnowflakeDbClient.get_select_statement(
+            TableSlice(
+                database="database_abc",
+                schema="schema1",
+                table="table1",
+                columns=["apple", "banana"],
+            )
+        )
+        == "SELECT apple, banana FROM database_abc.schema1.table1"
+    )
+
+
+def test_get_select_statement_partitioned():
+    assert SnowflakeDbClient.get_select_statement(
+        TableSlice(
+            database="database_abc",
+            schema="schema1",
+            table="table1",
+            partition=TablePartition(
+                time_window=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
+                partition_expr="my_timestamp_col",
+            ),
+            columns=["apple", "banana"],
+        )
+    ) == (
+        "SELECT apple, banana FROM database_abc.schema1.table1\n"
+        "WHERE my_timestamp_col BETWEEN '2020-01-02 00:00:00' AND '2020-02-03 00:00:00'"
+    )
+
+
+def test_get_cleanup_statement():
+    assert (
+        _get_cleanup_statement(
+            TableSlice(database="database_abc", schema="schema1", table="table1")
+        )
+        == "DELETE FROM database_abc.schema1.table1"
+    )
+
+
+def test_get_cleanup_statement_partitioned():
+    assert _get_cleanup_statement(
+        TableSlice(
+            database="database_abc",
+            schema="schema1",
+            table="table1",
+            partition=TablePartition(
+                time_window=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
+                partition_expr="my_timestamp_col",
+            ),
+        )
+    ) == (
+        "DELETE FROM database_abc.schema1.table1\n"
+        "WHERE my_timestamp_col BETWEEN '2020-01-02 00:00:00' AND '2020-02-03 00:00:00'"
+    )

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -49,6 +49,7 @@ def main(quiet):
         "-e python_modules/libraries/dagster-shell",
         "-e python_modules/libraries/dagster-slack",
         "-e python_modules/libraries/dagster-snowflake",
+        "-e python_modules/libraries/dagster-snowflake-pandas",
         "-e python_modules/libraries/dagster-spark",
         "-e python_modules/libraries/dagster-ssh",
         "-e python_modules/libraries/dagster-twilio",


### PR DESCRIPTION
### Summary & Motivation

Snowflake is probably the most common data warehouse among our users, but the current integration we provide for it doesn't fit our preferred pattern of sequestering IO inside IO managers.  This has come up with recent questions on Slack a few times.

Snowflake tables can correspond to multiple in-memory formats. E.g. Pandas DataFrames, Spark DataFrames. This PR proposes a pluggable interface for in-memory formats that allows users to only load the dependencies for the in-memory formats / processing frameworks that they use.

This PR includes the Snowflake IO manager and a pandas type handler implementation. It's possible that the underlying abstractions like TableSlice and DbIOManager could be used for integrating with other databases as well, but for now they're kept private to limit surface area and allow iteration.

Followups to this PR would include:
* A Spark type handler
* dbt
* Using this in the hacker news demo

### How I Tested These Changes

Unit tests.