### PR TITLE
Workaround for mypy cache bug

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_definition.py
@@ -31,7 +31,13 @@ from .definition_config_schema import (
     convert_user_facing_definition_config_schema,
 )
 from .resource_invocation import resource_invocation_result
-from .scoped_resources_builder import IContainsGenerator, Resources, ScopedResourcesBuilder  # type: ignore
+
+# pylint: disable=unused-import
+from .scoped_resources_builder import (  # type: ignore
+    IContainsGenerator,
+    Resources,
+    ScopedResourcesBuilder,
+)
 
 if TYPE_CHECKING:
     from dagster.core.execution.resources_init import InitResourceContext

--- a/python_modules/dagster/dagster/core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_definition.py
@@ -31,7 +31,7 @@ from .definition_config_schema import (
     convert_user_facing_definition_config_schema,
 )
 from .resource_invocation import resource_invocation_result
-from .scoped_resources_builder import Resources, ScopedResourcesBuilder  # type: ignore
+from .scoped_resources_builder import IContainsGenerator, Resources, ScopedResourcesBuilder  # type: ignore
 
 if TYPE_CHECKING:
     from dagster.core.execution.resources_init import InitResourceContext
@@ -317,11 +317,6 @@ def resource(
         )(resource_fn)
 
     return _wrap
-
-
-class IContainsGenerator:
-    """This class adds an additional tag to indicate that the resources object has at least one
-    resource that has been yielded from a generator, and thus may require teardown."""
 
 
 def make_values_resource(**kwargs: Any) -> ResourceDefinition:

--- a/python_modules/dagster/dagster/core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_definition.py
@@ -6,8 +6,6 @@ from typing import (
     Callable,
     Dict,
     List,
-    Mapping,
-    NamedTuple,
     Optional,
     Union,
     cast,
@@ -18,11 +16,7 @@ from dagster import check
 from dagster.core.decorator_utils import format_docstring_for_description
 from dagster.core.definitions.config import is_callable_valid_config_arg
 from dagster.core.definitions.configurable import AnonymousConfigurableDefinition
-from dagster.core.errors import (
-    DagsterInvalidDefinitionError,
-    DagsterInvalidInvocationError,
-    DagsterUnknownResourceError,
-)
+from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
 from dagster.seven import funcsigs
 from dagster.utils.backcompat import experimental_arg_warning
 
@@ -37,7 +31,7 @@ from .definition_config_schema import (
     convert_user_facing_definition_config_schema,
 )
 from .resource_invocation import resource_invocation_result
-from .scoped_resources_builder import Resources, ScopedResourcesBuilder   # type: ignore
+from .scoped_resources_builder import Resources, ScopedResourcesBuilder  # type: ignore
 
 if TYPE_CHECKING:
     from dagster.core.execution.resources_init import InitResourceContext

--- a/python_modules/dagster/dagster/core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_definition.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from functools import update_wrapper
 from typing import (
     TYPE_CHECKING,
@@ -38,6 +37,7 @@ from .definition_config_schema import (
     convert_user_facing_definition_config_schema,
 )
 from .resource_invocation import resource_invocation_result
+from .scoped_resources_builder import Resources, ScopedResourcesBuilder   # type: ignore
 
 if TYPE_CHECKING:
     from dagster.core.execution.resources_init import InitResourceContext
@@ -325,92 +325,9 @@ def resource(
     return _wrap
 
 
-class Resources:
-    """This class functions as a "tag" that we can use to type the namedtuple returned by
-    ScopedResourcesBuilder.build(). The way that we create the namedtuple returned by build() is
-    incompatible with type annotations on its own due to its dynamic attributes, so this tag class
-    provides a workaround."""
-
-
 class IContainsGenerator:
     """This class adds an additional tag to indicate that the resources object has at least one
     resource that has been yielded from a generator, and thus may require teardown."""
-
-
-class ScopedResourcesBuilder(
-    NamedTuple(
-        "_ScopedResourcesBuilder",
-        [("resource_instance_dict", Mapping[str, object]), ("contains_generator", bool)],
-    )
-):
-    """There are concepts in the codebase (e.g. ops, system storage) that receive
-    only the resources that they have specified in required_resource_keys.
-    ScopedResourcesBuilder is responsible for dynamically building a class with
-    only those required resources and returning an instance of that class."""
-
-    def __new__(
-        cls,
-        resource_instance_dict: Optional[Mapping[str, object]] = None,
-        contains_generator: bool = False,
-    ):
-        return super(ScopedResourcesBuilder, cls).__new__(
-            cls,
-            resource_instance_dict=check.opt_dict_param(
-                resource_instance_dict, "resource_instance_dict", key_type=str
-            ),
-            contains_generator=contains_generator,
-        )
-
-    def build(self, required_resource_keys: Optional[AbstractSet[str]]) -> Resources:
-
-        """We dynamically create a type that has the resource keys as properties, to enable dotting into
-        the resources from a context.
-
-        For example, given:
-
-        resources = {'foo': <some resource>, 'bar': <some other resource>}
-
-        then this will create the type Resource(namedtuple('foo bar'))
-
-        and then binds the specified resources into an instance of this object, which can be consumed
-        as, e.g., context.resources.foo.
-        """
-        required_resource_keys = check.opt_set_param(
-            required_resource_keys, "required_resource_keys", of_type=str
-        )
-        # it is possible that the surrounding context does NOT have the required resource keys
-        # because we are building a context for steps that we are not going to execute (e.g. in the
-        # resume/retry case, in order to generate copy intermediates events)
-        resource_instance_dict = {
-            key: self.resource_instance_dict[key]
-            for key in required_resource_keys
-            if key in self.resource_instance_dict
-        }
-
-        # If any of the resources are generators, add the IContainsGenerator subclass to flag that
-        # this is the case.
-        if self.contains_generator:
-
-            class _ScopedResourcesContainsGenerator(
-                namedtuple("_ScopedResourcesContainsGenerator", list(resource_instance_dict.keys())),  # type: ignore[misc]
-                Resources,
-                IContainsGenerator,
-            ):
-                def __getattr__(self, attr):
-                    raise DagsterUnknownResourceError(attr)
-
-            return _ScopedResourcesContainsGenerator(**resource_instance_dict)  # type: ignore[call-arg]
-
-        else:
-
-            class _ScopedResources(
-                namedtuple("_ScopedResources", list(resource_instance_dict.keys())),  # type: ignore[misc]
-                Resources,
-            ):
-                def __getattr__(self, attr):
-                    raise DagsterUnknownResourceError(attr)
-
-            return _ScopedResources(**resource_instance_dict)  # type: ignore[call-arg]
 
 
 def make_values_resource(**kwargs: Any) -> ResourceDefinition:

--- a/python_modules/dagster/dagster/core/definitions/scoped_resources_builder.py
+++ b/python_modules/dagster/dagster/core/definitions/scoped_resources_builder.py
@@ -8,7 +8,11 @@
 # See: https://github.com/python/mypy/issues/7281
 
 from collections import namedtuple
-from typing import AbstractSet, NamedTuple, Optional
+from typing import AbstractSet, Mapping, NamedTuple, Optional
+
+import dagster.check as check
+from dagster.core.definitions.resource_definition import IContainsGenerator
+from dagster.core.errors import DagsterUnknownResourceError
 
 
 class Resources:

--- a/python_modules/dagster/dagster/core/definitions/scoped_resources_builder.py
+++ b/python_modules/dagster/dagster/core/definitions/scoped_resources_builder.py
@@ -1,0 +1,94 @@
+# type: ignore
+
+# NOTE: This file has been factored out from "resource_definition" and type-ignored due to a mypy bug
+# when processing dynamically generated namedtuples. This code corrupts the mypy cache and causes
+# mypy to fail. When mypy fixes this bug, the type-ignore can be removed and the file contents
+# folded back into "resource_definition".
+#
+# See: https://github.com/python/mypy/issues/7281
+
+from collections import namedtuple
+from typing import AbstractSet, NamedTuple, Optional
+
+
+class Resources:
+    """This class functions as a "tag" that we can use to type the namedtuple returned by
+    ScopedResourcesBuilder.build(). The way that we create the namedtuple returned by build() is
+    incompatible with type annotations on its own due to its dynamic attributes, so this tag class
+    provides a workaround."""
+
+
+class ScopedResourcesBuilder(
+    NamedTuple(
+        "_ScopedResourcesBuilder",
+        [("resource_instance_dict", Mapping[str, object]), ("contains_generator", bool)],
+    )
+):
+    """There are concepts in the codebase (e.g. ops, system storage) that receive
+    only the resources that they have specified in required_resource_keys.
+    ScopedResourcesBuilder is responsible for dynamically building a class with
+    only those required resources and returning an instance of that class."""
+
+    def __new__(
+        cls,
+        resource_instance_dict: Optional[Mapping[str, object]] = None,
+        contains_generator: bool = False,
+    ):
+        return super(ScopedResourcesBuilder, cls).__new__(
+            cls,
+            resource_instance_dict=check.opt_dict_param(
+                resource_instance_dict, "resource_instance_dict", key_type=str
+            ),
+            contains_generator=contains_generator,
+        )
+
+    def build(self, required_resource_keys: Optional[AbstractSet[str]]) -> Resources:
+
+        """We dynamically create a type that has the resource keys as properties, to enable dotting into
+        the resources from a context.
+
+        For example, given:
+
+        resources = {'foo': <some resource>, 'bar': <some other resource>}
+
+        then this will create the type Resource(namedtuple('foo bar'))
+
+        and then binds the specified resources into an instance of this object, which can be consumed
+        as, e.g., context.resources.foo.
+        """
+        required_resource_keys = check.opt_set_param(
+            required_resource_keys, "required_resource_keys", of_type=str
+        )
+        # it is possible that the surrounding context does NOT have the required resource keys
+        # because we are building a context for steps that we are not going to execute (e.g. in the
+        # resume/retry case, in order to generate copy intermediates events)
+        resource_instance_dict = {
+            key: self.resource_instance_dict[key]
+            for key in required_resource_keys
+            if key in self.resource_instance_dict
+        }
+
+        # If any of the resources are generators, add the IContainsGenerator subclass to flag that
+        # this is the case.
+        if self.contains_generator:
+
+            class _ScopedResourcesContainsGenerator(
+                namedtuple("_ScopedResourcesContainsGenerator", list(resource_instance_dict.keys())),  # type: ignore[misc]
+                Resources,
+                IContainsGenerator,
+            ):
+                def __getattr__(self, attr):
+                    raise DagsterUnknownResourceError(attr)
+
+            return _ScopedResourcesContainsGenerator(**resource_instance_dict)  # type: ignore[call-arg]
+
+        else:
+
+            class _ScopedResources(
+                namedtuple("_ScopedResources", list(resource_instance_dict.keys())),  # type: ignore[misc]
+                Resources,
+            ):
+                def __getattr__(self, attr):
+                    raise DagsterUnknownResourceError(attr)
+
+            return _ScopedResources(**resource_instance_dict)  # type: ignore[call-arg]

--- a/python_modules/dagster/dagster/core/definitions/scoped_resources_builder.py
+++ b/python_modules/dagster/dagster/core/definitions/scoped_resources_builder.py
@@ -11,8 +11,12 @@ from collections import namedtuple
 from typing import AbstractSet, Mapping, NamedTuple, Optional
 
 import dagster.check as check
-from dagster.core.definitions.resource_definition import IContainsGenerator
 from dagster.core.errors import DagsterUnknownResourceError
+
+
+class IContainsGenerator:
+    """This class adds an additional tag to indicate that the resources object has at least one
+    resource that has been yielded from a generator, and thus may require teardown."""
 
 
 class Resources:


### PR DESCRIPTION
### Summary & Motivation

There is an annoying recurring mypy bug where it chokes on the cache contents after processing the `ScopedResourcesBuilder` class, which dynamically generates namedtuples. This bug has caused problems for both local dev and in CI, where it is triggered whenever a type stub package is automatically installed, because `mypy` must run twice-- once to detect the missing stubs (generates the cache), and once to detect errors with the acquired stubs (chokes on corrupted cache).

This PR factors the probelmatic code into its own file, which has a `type: ignore` at the top, causing mypy to ignore it and never include its contents in the cache (unfortunately mypy lacks the ability to target `type: ignore` to a class, and I didn't have any luck ignoring individual lines-- it appears the only solution here is to ignore the file containing the class). This avoids corrupting the cache.

### How I Tested These Changes

Ran mypy multiple times, did not trigger the cache corruption.