### PR TITLE
Update Error Message for Nothing Inputs to Graphs

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -997,7 +997,7 @@ def do_composition(
         fn_name=graph_name,
         compute_fn=compute_fn,
         explicit_input_defs=provided_input_defs,
-        exclude_nothing=False,
+        is_composition_fn=True,
     )
 
     kwargs = {input_def.name: InputMappingNode(input_def) for input_def in actual_input_defs}

--- a/python_modules/dagster/dagster/core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/op_decorator.py
@@ -118,7 +118,7 @@ class _Op:
             fn_name=self.name,
             compute_fn=compute_fn,
             explicit_input_defs=input_defs,
-            exclude_nothing=True,
+            is_composition_fn=False,
         )
 
         op_def = OpDefinition(

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -1072,3 +1072,14 @@ def test_graphs_break_type_checks():
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
         repro_2.execute_in_process()
+
+
+def test_nothing_inputs():
+    @op(ins={"dummy": In(Nothing)})
+    def foo():
+        return "foo"
+
+    with pytest.raises(DagsterInvalidDefinitionError, match="Nothing-type"):
+        @graph(ins={"dummy": In(dagster_type=Nothing)})
+        def g():
+            return foo()

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -1080,6 +1080,7 @@ def test_nothing_inputs():
         return "foo"
 
     with pytest.raises(DagsterInvalidDefinitionError, match="Nothing-type"):
+
         @graph(ins={"dummy": In(dagster_type=Nothing)})
         def g():
             return foo()


### PR DESCRIPTION
Motivated by https://github.com/dagster-io/dagster/issues/7610.

I've also seen similar questions in dagster-support where users anticipate `Nothing` inputs to graphs don't need to be specified as input args (which is true for ops). I think it's worth clarifying this behavior and making the error message much more specific.