### PR TITLE
[rfc] generic + returnable dynamic outputs

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -214,7 +214,7 @@ class Output(Generic[T]):
     ):
 
         metadata = check.opt_dict_param(metadata, "metadata", key_type=str)
-        self._metadata_entries = check.opt_list_param(
+        metadata_entries = check.opt_list_param(
             metadata_entries,
             "metadata_entries",
             of_type=(MetadataEntry, PartitionMetadataEntry),

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -236,7 +236,7 @@ class Output(Generic[T]):
         return self._output_name
 
 
-class DynamicOutput:
+class DynamicOutput(Generic[T]):
     """
     Variant of :py:class:`Output <dagster.Output>` used to support
     dynamic mapping & collect. Each ``DynamicOutput`` produced by an op represents
@@ -265,7 +265,7 @@ class DynamicOutput:
 
     def __init__(
         self,
-        value: Any,
+        value: T,
         mapping_key: str,
         output_name: Optional[str] = DEFAULT_OUTPUT,
         metadata_entries: Optional[List[Union[PartitionMetadataEntry, MetadataEntry]]] = None,
@@ -290,7 +290,7 @@ class DynamicOutput:
         return self._mapping_key
 
     @property
-    def value(self) -> Any:
+    def value(self) -> T:
         return self._value
 
     @property

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -214,7 +214,7 @@ class Output(Generic[T]):
     ):
 
         metadata = check.opt_dict_param(metadata, "metadata", key_type=str)
-        metadata_entries = check.opt_list_param(
+        self._metadata_entries = check.opt_list_param(
             metadata_entries,
             "metadata_entries",
             of_type=(MetadataEntry, PartitionMetadataEntry),

--- a/python_modules/dagster/dagster/core/definitions/output.py
+++ b/python_modules/dagster/dagster/core/definitions/output.py
@@ -17,7 +17,11 @@ import dagster._check as check
 from dagster.core.definitions.events import AssetKey, DynamicAssetKey
 from dagster.core.definitions.metadata import MetadataEntry, MetadataUserInput, normalize_metadata
 from dagster.core.errors import DagsterError, DagsterInvalidDefinitionError
-from dagster.core.types.dagster_type import DagsterType, resolve_dagster_type
+from dagster.core.types.dagster_type import (
+    DagsterType,
+    is_dynamic_output_annotation,
+    resolve_dagster_type,
+)
 from dagster.utils.backcompat import experimental_arg_warning
 
 from .inference import InferredOutputProps
@@ -231,10 +235,16 @@ class OutputDefinition:
 
     @staticmethod
     def create_from_inferred(inferred: InferredOutputProps) -> "OutputDefinition":
-        return OutputDefinition(
-            dagster_type=_checked_inferred_type(inferred.annotation),
-            description=inferred.description,
-        )
+        if is_dynamic_output_annotation(inferred.annotation):
+            return DynamicOutputDefinition(
+                dagster_type=_checked_inferred_type(inferred.annotation),
+                description=inferred.description,
+            )
+        else:
+            return OutputDefinition(
+                dagster_type=_checked_inferred_type(inferred.annotation),
+                description=inferred.description,
+            )
 
     def combine_with_inferred(self: TOut, inferred: InferredOutputProps) -> TOut:
         dagster_type = self.dagster_type

--- a/python_modules/dagster/dagster/core/execution/execute_in_process_result.py
+++ b/python_modules/dagster/dagster/core/execution/execute_in_process_result.py
@@ -238,5 +238,7 @@ def _filter_outputs_by_handle(
             mapped_outputs[step_output_handle.mapping_key] = value
 
     if not output_found:
-        raise DagsterInvariantViolationError(f"No outputs found for node '{node_handle}'.")
+        raise DagsterInvariantViolationError(
+            f"No outputs found for output '{output_name}' from node '{node_handle}'."
+        )
     return mapped_outputs

--- a/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
@@ -135,6 +135,30 @@ def _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):
                     value=element.value,
                     metadata_entries=element.metadata_entries,
                 )
+            elif isinstance(element, list) and all(
+                [isinstance(event, DynamicOutput) for event in element]
+            ):
+                if not output_def.is_dynamic:
+                    raise DagsterInvariantViolationError(
+                        f"Received a list of DynamicOutputs for output named '{output_def.name}', but output is not dynamic."
+                    )
+                for dynamic_output in element:
+                    if (
+                        not dynamic_output.output_name == DEFAULT_OUTPUT
+                        and not dynamic_output.output_name == output_def.name
+                    ):
+                        raise DagsterInvariantViolationError(
+                            f"Bad state: Received a tuple of outputs. An output was "
+                            f"explicitly named '{dynamic_output.output_name}', which does "
+                            "not match the dynamic output definition specified for "
+                            f"position {position}: '{output_def.name}'."
+                        )
+                    yield DynamicOutput(
+                        output_name=output_def.name,
+                        value=dynamic_output.value,
+                        mapping_key=dynamic_output.mapping_key,
+                        metadata_entries=dynamic_output.metadata_entries,
+                    )
             else:
                 # If an output object was not returned, then construct one from any metadata that has been logged within the op's body.
                 metadata = context.get_output_metadata(output_def.name)

--- a/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
@@ -89,9 +89,14 @@ def _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):
             yield event
     elif isinstance(result, Output):
         yield result
-    elif isinstance(result, list) and all([isinstance(event, DynamicOutput) for event in result]):
-        for event in result:
-            yield event
+    elif len(output_defs) == 1 and output_defs[0].is_dynamic:
+        if isinstance(result, list) and all([isinstance(event, DynamicOutput) for event in result]):
+            for event in result:
+                yield event
+        elif result is not None:
+            check.failed(
+                f"{context.describe_op()} has a single dynamic output named '{output_defs[0].name}', which expects either a list of DynamicOutputs to be returned, or DynamicOutput objects to be yielded. Received instead an object of type {type(result)}"
+            )
     elif len(output_defs) == 1:
         if result is None and output_defs[0].is_required is False:
             context.log.warn(

--- a/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
@@ -5,6 +5,7 @@ from typing import Generator, cast
 import dagster._check as check
 from dagster.core.definitions import (
     AssetMaterialization,
+    DynamicOutput,
     ExpectationResult,
     Materialization,
     Output,
@@ -88,6 +89,9 @@ def _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):
             yield event
     elif isinstance(result, Output):
         yield result
+    elif isinstance(result, list) and all([isinstance(event, DynamicOutput) for event in result]):
+        for event in result:
+            yield event
     elif len(output_defs) == 1:
         if result is None and output_defs[0].is_required is False:
             context.log.warn(

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -894,8 +894,14 @@ def is_dynamic_output_annotation(dagster_type: object) -> bool:
         "Do not pass runtime type classes. Got {}".format(dagster_type),
     )
 
+    if dagster_type == DynamicOutput or get_origin(dagster_type) == DynamicOutput:
+        raise DagsterInvariantViolationError(
+            "Op annotated with return type DynamicOutput. DynamicOutputs can only be returned in the context of a List or Mapping. If only one output is needed, use the Output API."
+        )
+
     if get_origin(dagster_type) == list and len(get_args(dagster_type)) == 1:
-        return get_origin(get_args(dagster_type)[0]) == DynamicOutput
+        list_inner_type = get_args(dagster_type)[0]
+        return list_inner_type == DynamicOutput or get_origin(list_inner_type) == DynamicOutput
     return False
 
 

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -804,7 +804,7 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
         is_supported_runtime_python_builtin,
         remap_python_builtin_for_runtime,
     )
-    from dagster.seven.typing import get_args, get_origin
+    from dagster.seven.typing import get_args
     from dagster.utils.typing_api import is_typing_type
 
     from .python_dict import Dict, PythonDict
@@ -896,7 +896,7 @@ def is_dynamic_output_annotation(dagster_type: object) -> bool:
 
     if dagster_type == DynamicOutput or get_origin(dagster_type) == DynamicOutput:
         raise DagsterInvariantViolationError(
-            "Op annotated with return type DynamicOutput. DynamicOutputs can only be returned in the context of a List or Mapping. If only one output is needed, use the Output API."
+            "Op annotated with return type DynamicOutput. DynamicOutputs can only be returned in the context of a List. If only one output is needed, use the Output API."
         )
 
     if get_origin(dagster_type) == list and len(get_args(dagster_type)) == 1:

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -998,7 +998,7 @@ def test_generic_dynamic_output_bare():
 
     with pytest.raises(
         DagsterInvariantViolationError,
-        match="Op annotated with return type DynamicOutput. DynamicOutputs can only be returned in the context of a List or Mapping. If only one output is needed, use the Output API.",
+        match="Op annotated with return type DynamicOutput. DynamicOutputs can only be returned in the context of a List. If only one output is needed, use the Output API.",
     ):
 
         @op
@@ -1007,7 +1007,7 @@ def test_generic_dynamic_output_bare():
 
     with pytest.raises(
         DagsterInvariantViolationError,
-        match="Op annotated with return type DynamicOutput. DynamicOutputs can only be returned in the context of a List or Mapping. If only one output is needed, use the Output API.",
+        match="Op annotated with return type DynamicOutput. DynamicOutputs can only be returned in the context of a List. If only one output is needed, use the Output API.",
     ):
 
         @op
@@ -1052,8 +1052,6 @@ def test_generic_dynamic_output_empty_with_type():
 
     result = execute_op_in_graph(basic_yield)
     assert result.success
-
-    execute_op_in_graph(basic_yield_not_optional)
 
 
 def test_generic_dynamic_multiple_outputs_empty():

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -1029,6 +1029,9 @@ def test_generic_dynamic_output_empty():
     ):
         result.output_for_node("basic")
 
+    # This behavior isn't exactly correct - we should be erroring when a
+    # required dynamic output yields no outputs.
+    # https://github.com/dagster-io/dagster/issues/5948#issuecomment-997037163
     @op(out=DynamicOut())
     def basic_yield():
         pass
@@ -1045,7 +1048,9 @@ def test_generic_dynamic_output_empty_with_type():
     result = execute_op_in_graph(basic)
     assert result.success
 
-    # Equivalent behavior in the dynamic yield case
+    # Equivalent behavior in the dynamic yield case. is_required doesn't
+    # actually do anything on a DynamicOut right now:
+    # https://github.com/dagster-io/dagster/issues/5948#issuecomment-997037163
     @op(out=DynamicOut(dagster_type=str, is_required=False))
     def basic_yield():
         pass

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_dynamic_output.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_dynamic_output.py
@@ -4,11 +4,9 @@ from typing import NamedTuple
 import objgraph
 import pytest
 
+from dagster import DynamicOut, DynamicOutput, DynamicOutputDefinition, Out
+from dagster import _check as check
 from dagster import (
-    DynamicOut,
-    DynamicOutput,
-    DynamicOutputDefinition,
-    Out,
     build_solid_context,
     execute_pipeline,
     execute_solid,
@@ -76,7 +74,10 @@ def test_fails_with_wrong_output():
     def should_also_fail(_):
         return 1
 
-    with pytest.raises(DagsterInvariantViolationError, match="must yield DynamicOutput"):
+    with pytest.raises(
+        check.CheckError,
+        match="expects either a list of DynamicOutputs to be returned, or DynamicOutput objects to be yielded. Received instead an object of type <class 'int'>",
+    ):
         execute_solid(should_also_fail)
 
 


### PR DESCRIPTION
Allows DynamicOutput to be used as a generic return type on ops. When using DynamicOut, a list of dynamic outputs is the expected return. Annotating as just a single DynamicOut will result in an error.