### PR TITLE
Rename ReexecutionPolicy -> ReexecutionStrategy

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2164,10 +2164,10 @@ union LaunchRunReexecutionResult =
 
 input ReexecutionParams {
   parentRunId: String!
-  policy: ReexecutionPolicy!
+  strategy: ReexecutionStrategy!
 }
 
-enum ReexecutionPolicy {
+enum ReexecutionStrategy {
   FROM_FAILURE
   ALL_STEPS
 }

--- a/js_modules/dagit/packages/core/src/runs/ReexecutionDialog.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ReexecutionDialog.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
 import {TestProvider} from '../testing/TestProvider';
-import {ReexecutionPolicy} from '../types/globalTypes';
+import {ReexecutionStrategy} from '../types/globalTypes';
 
 import {ReexecutionDialog} from './ReexecutionDialog';
 
@@ -14,20 +14,20 @@ describe('ReexecutionDialog', () => {
     'ijkl-9012': 'ijkl-9012',
   };
 
-  const Test = (props: {policy: ReexecutionPolicy}) => (
+  const Test = (props: {strategy: ReexecutionStrategy}) => (
     <ReexecutionDialog
       isOpen
       onClose={jest.fn()}
       onComplete={jest.fn()}
       selectedRuns={selectedMap}
-      reexecutionPolicy={props.policy}
+      reexecutionStrategy={props.strategy}
     />
   );
 
   it('prompts the user with the number of runs to re-execute', async () => {
     render(
       <TestProvider>
-        <Test policy={ReexecutionPolicy.FROM_FAILURE} />
+        <Test strategy={ReexecutionStrategy.FROM_FAILURE} />
       </TestProvider>,
     );
 
@@ -41,7 +41,7 @@ describe('ReexecutionDialog', () => {
   it('moves into loading state upon re-execution', async () => {
     render(
       <TestProvider>
-        <Test policy={ReexecutionPolicy.FROM_FAILURE} />
+        <Test strategy={ReexecutionStrategy.FROM_FAILURE} />
       </TestProvider>,
     );
 
@@ -71,7 +71,7 @@ describe('ReexecutionDialog', () => {
 
     render(
       <TestProvider apolloProps={{mocks: [mocks]}}>
-        <Test policy={ReexecutionPolicy.FROM_FAILURE} />
+        <Test strategy={ReexecutionStrategy.FROM_FAILURE} />
       </TestProvider>,
     );
 
@@ -94,7 +94,7 @@ describe('ReexecutionDialog', () => {
 
     render(
       <TestProvider apolloProps={{mocks: [mocks]}}>
-        <Test policy={ReexecutionPolicy.FROM_FAILURE} />
+        <Test strategy={ReexecutionStrategy.FROM_FAILURE} />
       </TestProvider>,
     );
 

--- a/js_modules/dagit/packages/core/src/runs/ReexecutionDialog.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ReexecutionDialog.tsx
@@ -4,7 +4,7 @@ import {ProgressBar} from '@blueprintjs/core';
 import {Button, Colors, DialogBody, DialogFooter, Dialog, Group, Icon, Mono} from '@dagster-io/ui';
 import * as React from 'react';
 
-import {ReexecutionPolicy} from '../types/globalTypes';
+import {ReexecutionStrategy} from '../types/globalTypes';
 
 import {NavigationBlock} from './NavitationBlock';
 import {LAUNCH_PIPELINE_REEXECUTION_MUTATION} from './RunUtils';
@@ -22,7 +22,7 @@ export interface Props {
   onClose: () => void;
   onComplete: (reexecutionState: ReexecutionState) => void;
   selectedRuns: {[id: string]: string};
-  reexecutionPolicy: ReexecutionPolicy;
+  reexecutionStrategy: ReexecutionStrategy;
 }
 
 type Error =
@@ -122,7 +122,7 @@ const reexecutionDialogReducer = (
 };
 
 export const ReexecutionDialog = (props: Props) => {
-  const {isOpen, onClose, onComplete, reexecutionPolicy, selectedRuns} = props;
+  const {isOpen, onClose, onComplete, reexecutionStrategy, selectedRuns} = props;
 
   // Freeze the selected IDs, since the list may change as runs continue processing and
   // re-executing. We want to preserve the list we're given.
@@ -165,7 +165,7 @@ export const ReexecutionDialog = (props: Props) => {
         variables: {
           reexecutionParams: {
             parentRunId: runId,
-            policy: reexecutionPolicy,
+            strategy: reexecutionStrategy,
           },
         },
       });
@@ -194,7 +194,7 @@ export const ReexecutionDialog = (props: Props) => {
         }
 
         const message = () => {
-          if (reexecutionPolicy === ReexecutionPolicy.ALL_STEPS) {
+          if (reexecutionStrategy === ReexecutionStrategy.ALL_STEPS) {
             return (
               <span>
                 {`${count} ${count === 1 ? 'run' : 'runs'} will be re-executed `}
@@ -324,7 +324,7 @@ export const ReexecutionDialog = (props: Props) => {
     <Dialog
       isOpen={isOpen}
       title={
-        reexecutionPolicy === ReexecutionPolicy.ALL_STEPS
+        reexecutionStrategy === ReexecutionStrategy.ALL_STEPS
           ? 'Re-execute runs'
           : 'Re-execute runs from failure'
       }

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
@@ -19,7 +19,7 @@ import {AppContext} from '../app/AppContext';
 import {SharedToaster} from '../app/DomUtils';
 import {usePermissions} from '../app/Permissions';
 import {useCopyToClipboard} from '../app/browser';
-import {ReexecutionPolicy} from '../types/globalTypes';
+import {ReexecutionStrategy} from '../types/globalTypes';
 import {DagitReadOnlyCodeMirror} from '../ui/DagitCodeMirror';
 import {MenuLink} from '../ui/MenuLink';
 import {isThisThingAJob} from '../workspace/WorkspaceContext';
@@ -361,14 +361,14 @@ export const RunBulkActionsMenu: React.FC<{
         onClose={closeDialogs}
         onComplete={onComplete}
         selectedRuns={failedMap}
-        reexecutionPolicy={ReexecutionPolicy.FROM_FAILURE}
+        reexecutionStrategy={ReexecutionStrategy.FROM_FAILURE}
       />
       <ReexecutionDialog
         isOpen={visibleDialog === 'reexecute'}
         onClose={closeDialogs}
         onComplete={onComplete}
         selectedRuns={reexecutableMap}
-        reexecutionPolicy={ReexecutionPolicy.ALL_STEPS}
+        reexecutionStrategy={ReexecutionStrategy.ALL_STEPS}
       />
     </>
   );

--- a/js_modules/dagit/packages/core/src/types/globalTypes.ts
+++ b/js_modules/dagit/packages/core/src/types/globalTypes.ts
@@ -117,7 +117,7 @@ export enum ObjectStoreOperationType {
   SET_OBJECT = "SET_OBJECT",
 }
 
-export enum ReexecutionPolicy {
+export enum ReexecutionStrategy {
   ALL_STEPS = "ALL_STEPS",
   FROM_FAILURE = "FROM_FAILURE",
 }
@@ -226,7 +226,7 @@ export interface PipelineSelector {
 
 export interface ReexecutionParams {
   parentRunId: string;
-  policy: ReexecutionPolicy;
+  strategy: ReexecutionStrategy;
 }
 
 export interface RepositorySelector {

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -1,7 +1,7 @@
 from graphql.execution.base import ResolveInfo
 
 from dagster import check
-from dagster.core.execution.plan.resume_retry import ReexecutionPolicy
+from dagster.core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster.core.host_representation.selector import PipelineSelector
 from dagster.core.instance import DagsterInstance
 from dagster.core.storage.pipeline_run import RunsFilter
@@ -59,7 +59,7 @@ def _launch_pipeline_execution(graphene_info, execution_params, is_reexecuted=Fa
 
 
 @capture_error
-def launch_reexecution_from_parent_run(graphene_info, parent_run_id: str, policy):
+def launch_reexecution_from_parent_run(graphene_info, parent_run_id: str, strategy):
     """
     Launch a re-execution by referencing the parent run id
     """
@@ -68,7 +68,7 @@ def launch_reexecution_from_parent_run(graphene_info, parent_run_id: str, policy
 
     check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.str_param(parent_run_id, "parent_run_id")
-    check.str_param(policy, "policy")
+    check.str_param(strategy, "strategy")
 
     instance: DagsterInstance = graphene_info.context.instance
     parent_run = instance.get_run_by_id(parent_run_id)
@@ -88,7 +88,7 @@ def launch_reexecution_from_parent_run(graphene_info, parent_run_id: str, policy
         parent_run,
         repo_location,
         external_pipeline,
-        ReexecutionPolicy[policy],
+        ReexecutionStrategy[strategy],
         use_parent_run_tags=True,  # inherit whatever tags were set on the parent run at launch time
     )
     graphene_info.context.instance.submit_run(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -210,17 +210,17 @@ class GrapheneExecutionParams(graphene.InputObjectType):
         name = "ExecutionParams"
 
 
-class GrapheneReexecutionPolicy(graphene.Enum):
+class GrapheneReexecutionStrategy(graphene.Enum):
     FROM_FAILURE = "FROM_FAILURE"
     ALL_STEPS = "ALL_STEPS"
 
     class Meta:
-        name = "ReexecutionPolicy"
+        name = "ReexecutionStrategy"
 
 
 class GrapheneReexecutionParams(graphene.InputObjectType):
     parentRunId = graphene.NonNull(graphene.String)
-    policy = graphene.NonNull(GrapheneReexecutionPolicy)
+    strategy = graphene.NonNull(GrapheneReexecutionStrategy)
 
     class Meta:
         name = "ReexecutionParams"

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -346,7 +346,7 @@ class GrapheneLaunchRunReexecutionMutation(graphene.Mutation):
             return launch_reexecution_from_parent_run(
                 graphene_info,
                 reexecution_params["parentRunId"],
-                reexecution_params["policy"],
+                reexecution_params["strategy"],
             )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
@@ -6,14 +6,14 @@ from dagster_graphql.client.query import (
     LAUNCH_PIPELINE_REEXECUTION_MUTATION,
     PIPELINE_REEXECUTION_INFO_QUERY,
 )
-from dagster_graphql.schema.inputs import GrapheneReexecutionPolicy
+from dagster_graphql.schema.inputs import GrapheneReexecutionStrategy
 from dagster_graphql.test.utils import (
     execute_dagster_graphql,
     execute_dagster_graphql_and_finish_runs,
     infer_pipeline_selector,
 )
 
-from dagster.core.execution.plan.resume_retry import ReexecutionPolicy
+from dagster.core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster.core.storage.pipeline_run import PipelineRunStatus
 from dagster.core.storage.tags import RESUME_RETRY_TAG
 from dagster.core.test_utils import poll_for_finished_run
@@ -534,7 +534,7 @@ class TestHardFailures(ExecutingGraphQLContextTestMatrix):
         retry = execute_dagster_graphql_and_finish_runs(
             graphql_context,
             LAUNCH_PIPELINE_REEXECUTION_MUTATION,
-            variables={"reexecutionParams": {"parentRunId": run_id, "policy": "ALL_STEPS"}},
+            variables={"reexecutionParams": {"parentRunId": run_id, "strategy": "ALL_STEPS"}},
         )
 
         run_id = retry.data["launchPipelineReexecution"]["run"]["runId"]
@@ -583,7 +583,7 @@ class TestHardFailures(ExecutingGraphQLContextTestMatrix):
             graphql_context,
             LAUNCH_PIPELINE_REEXECUTION_MUTATION,
             variables={
-                "reexecutionParams": {"parentRunId": parent_run_id, "policy": "FROM_FAILURE"}
+                "reexecutionParams": {"parentRunId": parent_run_id, "strategy": "FROM_FAILURE"}
             },
         )
         assert "DagsterInvalidConfigError" in str(
@@ -621,7 +621,7 @@ class TestHardFailures(ExecutingGraphQLContextTestMatrix):
         retry = execute_dagster_graphql_and_finish_runs(
             graphql_context,
             LAUNCH_PIPELINE_REEXECUTION_MUTATION,
-            variables={"reexecutionParams": {"parentRunId": run_id, "policy": "FROM_FAILURE"}},
+            variables={"reexecutionParams": {"parentRunId": run_id, "strategy": "FROM_FAILURE"}},
         )
 
         run_id = retry.data["launchPipelineReexecution"]["run"]["runId"]
@@ -634,10 +634,10 @@ class TestHardFailures(ExecutingGraphQLContextTestMatrix):
         assert step_did_succeed(logs, "after_failure")
 
 
-def test_graphene_reexecution_policy():
-    """Check that graphene enum has corresponding values in the ReexecutionPolicy enum"""
-    for policy in GrapheneReexecutionPolicy.__enum__:
-        assert ReexecutionPolicy[policy.value]
+def test_graphene_reexecution_strategy():
+    """Check that graphene enum has corresponding values in the ReexecutionStrategy enum"""
+    for strategy in GrapheneReexecutionStrategy.__enum__:
+        assert ReexecutionStrategy[strategy.value]
 
 
 def _do_retry_intermediates_test(graphql_context, run_id, reexecution_run_id):

--- a/python_modules/dagster/dagster/core/execution/backfill.py
+++ b/python_modules/dagster/dagster/core/execution/backfill.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Dict, List, NamedTuple, Optional
 
 from dagster import check
-from dagster.core.execution.plan.resume_retry import ReexecutionPolicy
+from dagster.core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster.core.execution.plan.state import KnownExecutionState
 from dagster.core.host_representation import (
     ExternalPartitionSet,
@@ -230,7 +230,7 @@ def create_backfill_run(
             last_run,
             repo_location,
             external_pipeline,
-            ReexecutionPolicy.FROM_FAILURE,
+            ReexecutionStrategy.FROM_FAILURE,
             extra_tags=tags,
             run_config=partition_data.run_config,
             mode=external_partition_set.mode,

--- a/python_modules/dagster/dagster/core/execution/plan/resume_retry.py
+++ b/python_modules/dagster/dagster/core/execution/plan/resume_retry.py
@@ -31,7 +31,7 @@ def _in_tracking_dict(handle, tracking):
         return handle.to_key() in tracking
 
 
-class ReexecutionPolicy(enum.Enum):
+class ReexecutionStrategy(enum.Enum):
     ALL_STEPS = "ALL_STEPS"
     FROM_FAILURE = "FROM_FAILURE"
 

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -82,7 +82,7 @@ if TYPE_CHECKING:
     from dagster.core.debug import DebugRunPayload
     from dagster.core.events import DagsterEvent, DagsterEventType
     from dagster.core.events.log import EventLogEntry
-    from dagster.core.execution.plan.resume_retry import ReexecutionPolicy
+    from dagster.core.execution.plan.resume_retry import ReexecutionStrategy
     from dagster.core.execution.stats import RunStepKeyStatsSnapshot
     from dagster.core.host_representation import (
         ExternalPipeline,
@@ -1025,14 +1025,14 @@ class DagsterInstance:
         parent_run: PipelineRun,
         repo_location: "RepositoryLocation",
         external_pipeline: "ExternalPipeline",
-        policy: "ReexecutionPolicy",
+        strategy: "ReexecutionStrategy",
         extra_tags: Optional[Dict[str, Any]] = None,
         run_config: Optional[Dict[str, Any]] = None,
         mode: Optional[str] = None,
         use_parent_run_tags: bool = False,
     ) -> PipelineRun:
         from dagster.core.execution.plan.resume_retry import (
-            ReexecutionPolicy,
+            ReexecutionStrategy,
             get_retry_steps_from_parent_run,
         )
         from dagster.core.host_representation import ExternalPipeline, RepositoryLocation
@@ -1040,7 +1040,7 @@ class DagsterInstance:
         check.inst_param(parent_run, "parent_run", PipelineRun)
         check.inst_param(repo_location, "repo_location", RepositoryLocation)
         check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
-        check.inst_param(policy, "policy", ReexecutionPolicy)
+        check.inst_param(strategy, "strategy", ReexecutionStrategy)
         check.opt_dict_param(extra_tags, "extra_tags", key_type=str)
         check.opt_dict_param(run_config, "run_config", key_type=str)
         check.opt_str_param(mode, "mode")
@@ -1064,7 +1064,7 @@ class DagsterInstance:
         mode = cast(str, mode if mode is not None else parent_run.mode)
         run_config = run_config if run_config is not None else parent_run.run_config
 
-        if policy == ReexecutionPolicy.FROM_FAILURE:
+        if strategy == ReexecutionStrategy.FROM_FAILURE:
             check.invariant(
                 parent_run.status == PipelineRunStatus.FAILURE,
                 "Cannot reexecute from failure a run that is not failed",
@@ -1074,11 +1074,11 @@ class DagsterInstance:
                 self, parent_run=parent_run
             )
             tags[RESUME_RETRY_TAG] = "true"
-        elif policy == ReexecutionPolicy.ALL_STEPS:
+        elif strategy == ReexecutionStrategy.ALL_STEPS:
             step_keys_to_execute = None
             known_state = None
         else:
-            raise DagsterInvariantViolationError(f"Unknown reexecution policy: {policy}")
+            raise DagsterInvariantViolationError(f"Unknown reexecution strategy: {strategy}")
 
         external_execution_plan = repo_location.get_external_execution_plan(
             external_pipeline,

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from dagster import DagsterInstance, execute_pipeline, job, op, reconstructable, repository
-from dagster.core.execution.plan.resume_retry import ReexecutionPolicy
+from dagster.core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster.core.storage.pipeline_run import PipelineRunStatus
 from dagster.core.storage.tags import RESUME_RETRY_TAG
 from dagster.core.test_utils import (
@@ -100,7 +100,7 @@ def test_create_reexecuted_run_from_failure(
     failed_run,
 ):
     run = instance.create_reexecuted_run(
-        failed_run, repo_location, external_pipeline, ReexecutionPolicy.FROM_FAILURE
+        failed_run, repo_location, external_pipeline, ReexecutionStrategy.FROM_FAILURE
     )
 
     assert run.tags[RESUME_RETRY_TAG] == "true"
@@ -122,7 +122,7 @@ def test_create_reexecuted_run_from_failure_tags(
     failed_run,
 ):
     run = instance.create_reexecuted_run(
-        failed_run, repo_location, external_pipeline, ReexecutionPolicy.FROM_FAILURE
+        failed_run, repo_location, external_pipeline, ReexecutionStrategy.FROM_FAILURE
     )
 
     assert run.tags["foo"] == "bar"
@@ -132,7 +132,7 @@ def test_create_reexecuted_run_from_failure_tags(
         failed_run,
         repo_location,
         external_pipeline,
-        ReexecutionPolicy.FROM_FAILURE,
+        ReexecutionStrategy.FROM_FAILURE,
         use_parent_run_tags=True,
     )
 
@@ -143,7 +143,7 @@ def test_create_reexecuted_run_from_failure_tags(
         failed_run,
         repo_location,
         external_pipeline,
-        ReexecutionPolicy.FROM_FAILURE,
+        ReexecutionStrategy.FROM_FAILURE,
         use_parent_run_tags=True,
         extra_tags={"fizz": "not buzz!!"},
     )
@@ -156,7 +156,7 @@ def test_create_reexecuted_run_all_steps(
     instance: DagsterInstance, workspace, repo_location, external_pipeline, failed_run
 ):
     run = instance.create_reexecuted_run(
-        failed_run, repo_location, external_pipeline, ReexecutionPolicy.ALL_STEPS
+        failed_run, repo_location, external_pipeline, ReexecutionStrategy.ALL_STEPS
     )
 
     assert RESUME_RETRY_TAG not in run.tags


### PR DESCRIPTION
I want to correct a potentially confusing name before it's too late:

ReexecutionPolicy: options of {'from_failure', 'all_steps'}
v.s.
RetryPolicy (on ops): {max_retries: int, backoff: int, etc.}

If we ever want to support a JobRetryPolicy (or just RetryPolicy attached to Jobs), it would need the currently named `ReexecutionPolicy` as a field. Calling this `strategy` instead avoids the name conflict.

This landed over the past 2 weeks, I would be very surprised if any users are calling it directly yet.