### PR TITLE
[dagit] Add hover actions to run Tags

### DIFF
--- a/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
@@ -151,7 +151,7 @@ export const RunList: React.FC<{
   }
   return (
     <div>
-      <RunTable runs={data.pipelineRunsOrError.results} onSetFilter={() => {}} />
+      <RunTable runs={data.pipelineRunsOrError.results} />
     </div>
   );
 };

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRunListForStep.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRunListForStep.tsx
@@ -65,7 +65,6 @@ export const PartitionRunListForStep: React.FC<PartitionRunListForStepProps> = (
     <div>
       <RunTable
         runs={data.pipelineRunsOrError.results}
-        onSetFilter={() => {}}
         additionalColumnHeaders={[
           <th key="context" style={{maxWidth: 150}}>
             Step Info

--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -30,7 +30,7 @@ import {RunTableRunFragment} from './types/RunTableRunFragment';
 interface RunTableProps {
   runs: RunTableRunFragment[];
   filter?: RunsFilter;
-  onSetFilter: (search: RunFilterToken[]) => void;
+  onSetFilter?: (search: RunFilterToken[]) => void;
   nonIdealState?: React.ReactNode;
   actionBarComponents?: React.ReactNode;
   highlightedIds?: string[];
@@ -178,7 +178,7 @@ export const RUN_TABLE_RUN_FRAGMENT = gql`
 const RunRow: React.FC<{
   run: RunTableRunFragment;
   canTerminateOrDelete: boolean;
-  onSetFilter: (search: RunFilterToken[]) => void;
+  onSetFilter?: (search: RunFilterToken[]) => void;
   checked?: boolean;
   onToggleChecked?: (values: {checked: boolean; shiftKey: boolean}) => void;
   additionalColumns?: React.ReactNode[];

--- a/js_modules/dagit/packages/core/src/runs/RunTag.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTag.tsx
@@ -1,4 +1,4 @@
-import {Tag} from '@dagster-io/ui';
+import {Box, Caption, Colors, Popover, Tag} from '@dagster-io/ui';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
@@ -17,56 +17,86 @@ export enum DagsterTag {
   SensorName = 'dagster/sensor_name',
 }
 
+export type TagType = {
+  key: string;
+  value: string;
+};
+
+type TagAction = {
+  label: React.ReactNode;
+  onClick: (tag: TagType) => void;
+};
+
 interface IRunTagProps {
-  tag: {
-    key: string;
-    value: string;
-  };
-  onClick?: (tag: {key: string; value: string}) => void;
+  tag: TagType;
+  actions?: TagAction[];
 }
 
-export const RunTag = ({tag, onClick}: IRunTagProps) => {
-  const isDagsterTag = tag.key.startsWith(DagsterTag.Namespace);
-  const displayTag = isDagsterTag
-    ? {key: tag.key.substr(DagsterTag.Namespace.length), value: tag.value}
-    : tag;
+export const RunTag = ({tag, actions}: IRunTagProps) => {
+  const {key, value} = tag;
+  const isDagsterTag = key.startsWith(DagsterTag.Namespace);
 
-  const onTagClick = () => {
-    onClick && onClick(tag);
-  };
-
-  return <TagDeprecated isDagsterTag={isDagsterTag} onClick={onTagClick} tag={displayTag} />;
-};
-
-interface ITagProps {
-  tag: {
-    key: string;
-    value: string;
-  };
-  onClick?: (tag: {key: string; value: string}) => void;
-  isDagsterTag?: boolean;
-}
-
-export const TagDeprecated = ({tag, onClick, isDagsterTag}: ITagProps) => {
-  const onTagClick = () => onClick && onClick(tag);
-
-  return (
-    <TagButton onClick={onTagClick}>
-      <Tag intent={isDagsterTag ? 'none' : 'primary'} interactive>
-        {`${tag.key}: ${tag.value}`}
-      </Tag>
-    </TagButton>
+  const displayedTag = React.useMemo(
+    () => (isDagsterTag ? {key: key.slice(DagsterTag.Namespace.length), value} : {key, value}),
+    [isDagsterTag, key, value],
   );
+
+  const button = (
+    <Tag intent={isDagsterTag ? 'none' : 'primary'} interactive>
+      {`${displayedTag.key}: ${displayedTag.value}`}
+    </Tag>
+  );
+
+  if (actions?.length) {
+    return (
+      <Popover
+        content={<TagActions actions={actions} tag={displayedTag} />}
+        hoverOpenDelay={100}
+        hoverCloseDelay={100}
+        placement="top"
+        interactionKind="hover"
+      >
+        {button}
+      </Popover>
+    );
+  }
+
+  return button;
 };
+
+const TagActions = ({tag, actions}: {tag: TagType; actions: TagAction[]}) => (
+  <ActionContainer background={Colors.Gray900} flex={{direction: 'row'}}>
+    {actions.map(({label, onClick}, ii) => (
+      <TagButton key={ii} onClick={() => onClick(tag)}>
+        <Caption>{label}</Caption>
+      </TagButton>
+    ))}
+  </ActionContainer>
+);
+
+const ActionContainer = styled(Box)`
+  border-radius: 8px;
+  overflow: hidden;
+`;
 
 const TagButton = styled.button`
   border: none;
-  background: none;
-  padding: 0;
-  margin: 0;
+  background: ${Colors.Dark};
+  color: ${Colors.Gray200};
+  cursor: pointer;
+  padding: 8px 12px;
   text-align: left;
+
+  :not(:last-child) {
+    box-shadow: -1px 0 0 inset ${Colors.Gray600};
+  }
 
   :focus {
     outline: none;
+  }
+
+  :hover {
+    background-color: ${Colors.Gray800};
+    color: ${Colors.White};
   }
 `;

--- a/js_modules/dagit/packages/core/src/runs/RunTags.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTags.tsx
@@ -1,32 +1,51 @@
 import {Box} from '@dagster-io/ui';
 import * as React from 'react';
 
-import {RunTag} from './RunTag';
+import {SharedToaster} from '../app/DomUtils';
+import {useCopyToClipboard} from '../app/browser';
+
+import {RunTag, TagType} from './RunTag';
 import {RunFilterToken} from './RunsFilterInput';
 
-interface RunTagType {
-  key: string;
-  value: string;
-}
-
 export const RunTags: React.FC<{
-  tags: RunTagType[];
+  tags: TagType[];
   mode: string | null;
   onSetFilter?: (search: RunFilterToken[]) => void;
 }> = React.memo(({tags, onSetFilter, mode}) => {
+  const copy = useCopyToClipboard();
+
+  const actions = React.useMemo(() => {
+    const list = [
+      {
+        label: 'Copy tag',
+        onClick: (tag: TagType) => {
+          copy(`${tag.key}:${tag.value}`);
+          SharedToaster.show({intent: 'success', message: 'Copied tag!'});
+        },
+      },
+    ];
+
+    if (onSetFilter) {
+      list.push({
+        label: 'Add tag to filter',
+        onClick: (tag: TagType) => {
+          onSetFilter([{token: 'tag', value: `${tag.key}=${tag.value}`}]);
+        },
+      });
+    }
+
+    return list;
+  }, [copy, onSetFilter]);
+
   if (!tags.length) {
     return null;
   }
-
-  const onClick = (tag: RunTagType) => {
-    onSetFilter && onSetFilter([{token: 'tag', value: `${tag.key}=${tag.value}`}]);
-  };
 
   return (
     <Box flex={{direction: 'row', wrap: 'wrap', gap: 4}}>
       {mode ? <RunTag tag={{key: 'mode', value: mode}} /> : null}
       {tags.map((tag, idx) => (
-        <RunTag tag={tag} key={idx} onClick={onClick} />
+        <RunTag tag={tag} key={idx} actions={actions} />
       ))}
     </Box>
   );

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleRoot.tsx
@@ -137,14 +137,7 @@ export const SchedulePreviousRuns: React.FC<{
   }
 
   const runs = data?.pipelineRunsOrError.results;
-  return (
-    <RunTable
-      actionBarComponents={tabs}
-      onSetFilter={() => {}}
-      runs={runs}
-      highlightedIds={highlightedIds}
-    />
-  );
+  return <RunTable actionBarComponents={tabs} runs={runs} highlightedIds={highlightedIds} />;
 };
 
 const SCHEDULE_ROOT_QUERY = gql`

--- a/js_modules/dagit/packages/core/src/sensors/SensorPreviousRuns.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorPreviousRuns.tsx
@@ -39,14 +39,7 @@ export const SensorPreviousRuns: React.FC<{
   }
 
   const runs = data?.pipelineRunsOrError.results;
-  return (
-    <RunTable
-      actionBarComponents={tabs}
-      onSetFilter={() => {}}
-      runs={runs}
-      highlightedIds={highlightedIds}
-    />
-  );
+  return <RunTable actionBarComponents={tabs} runs={runs} highlightedIds={highlightedIds} />;
 };
 
 export const NoTargetSensorPreviousRuns: React.FC<{


### PR DESCRIPTION
### Summary & Motivation

Add hover actions to the `RunTag` component, and two basic actions in `RunTags`:

- `Copy tag` to allow copying the `key:value` string
- Optionally a `Add tag to filter` for run filtering

<img width="268" alt="Screen Shot 2022-05-05 at 1 34 38 PM" src="https://user-images.githubusercontent.com/2823852/166996200-5c5f3299-5966-4e30-9d5c-d2f7b4cfaa99.png">

### How I Tested These Changes

View Run table, hover on a tag. Click to copy, verify success. Click to add filter, verify same.

View tags on an executed run, verify copy.
