### PR TITLE
enable returning lists of run requests from sensor/schedule evaluation functions

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/schedule_decorator.py
@@ -73,6 +73,7 @@ def schedule(
     3. Return a `SkipReason` object, providing a descriptive message of why no runs were requested.
     4. Return nothing (skipping without providing a reason)
     5. Return a run config dictionary.
+    6. Yield a `SkipReason` or yield one ore more `RunRequest` objects.
 
     Returns a :py:class:`~dagster.ScheduleDefinition`.
 

--- a/python_modules/dagster/dagster/core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/schedule_decorator.py
@@ -69,10 +69,9 @@ def schedule(
     argument, and does one of the following:
 
     1. Return a `RunRequest` object.
-    2. Yield multiple of `RunRequest` objects.
-    3. Return or yield a `SkipReason` object, providing a descriptive message of why no runs were
-       requested.
-    4. Return or yield nothing (skipping without providing a reason)
+    2. Return a list of `RunRequest` objects.
+    3. Return a `SkipReason` object, providing a descriptive message of why no runs were requested.
+    4. Return nothing (skipping without providing a reason)
     5. Return a run config dictionary.
 
     Returns a :py:class:`~dagster.ScheduleDefinition`.
@@ -160,6 +159,8 @@ def schedule(
                         run_config=evaluated_run_config,
                         tags=evaluated_tags,
                     )
+                elif isinstance(result, list):
+                    yield from cast(List[RunRequest], result)
                 else:
                     # this is a run-request based decorated function
                     yield from cast(RunRequestIterator, ensure_gen(result))

--- a/python_modules/dagster/dagster/core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/sensor_decorator.py
@@ -44,10 +44,9 @@ def sensor(
     decorated function may:
 
     1. Return a `RunRequest` object.
-    2. Yield multiple of `RunRequest` objects.
-    3. Return or yield a `SkipReason` object, providing a descriptive message of why no runs were
-       requested.
-    4. Return or yield nothing (skipping without providing a reason)
+    2. Return a list of `RunRequest` objects.
+    3. Return a `SkipReason` object, providing a descriptive message of why no runs were requested.
+    4. Return nothing (skipping without providing a reason)
 
     Takes a :py:class:`~dagster.SensorEvaluationContext`.
 
@@ -113,10 +112,9 @@ def asset_sensor(
     function.  The decorated function may:
 
     1. Return a `RunRequest` object.
-    2. Yield multiple of `RunRequest` objects.
-    3. Return or yield a `SkipReason` object, providing a descriptive message of why no runs were
-       requested.
-    4. Return or yield nothing (skipping without providing a reason)
+    2. Return a list of `RunRequest` objects.
+    3. Return a `SkipReason` object, providing a descriptive message of why no runs were requested.
+    4. Return nothing (skipping without providing a reason)
 
     Takes a :py:class:`~dagster.SensorEvaluationContext` and an EventLogEntry corresponding to an
     AssetMaterialization event.
@@ -151,7 +149,7 @@ def asset_sensor(
         def _wrapped_fn(context, event):
             result = fn(context, event)
 
-            if inspect.isgenerator(result):
+            if inspect.isgenerator(result) or isinstance(result, list):
                 for item in result:
                     yield item
             elif isinstance(result, (RunRequest, SkipReason)):

--- a/python_modules/dagster/dagster/core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/sensor_decorator.py
@@ -47,6 +47,7 @@ def sensor(
     2. Return a list of `RunRequest` objects.
     3. Return a `SkipReason` object, providing a descriptive message of why no runs were requested.
     4. Return nothing (skipping without providing a reason)
+    5. Yield a `SkipReason` or yield one ore more `RunRequest` objects.
 
     Takes a :py:class:`~dagster.SensorEvaluationContext`.
 
@@ -115,6 +116,7 @@ def asset_sensor(
     2. Return a list of `RunRequest` objects.
     3. Return a `SkipReason` object, providing a descriptive message of why no runs were requested.
     4. Return nothing (skipping without providing a reason)
+    5. Yield a `SkipReason` or yield one ore more `RunRequest` objects.
 
     Takes a :py:class:`~dagster.SensorEvaluationContext` and an EventLogEntry corresponding to an
     AssetMaterialization event.

--- a/python_modules/dagster/dagster/core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/schedule_definition.py
@@ -99,7 +99,9 @@ ScheduleExecutionContext = ScheduleEvaluationContext
 RunConfig = Dict[str, Any]
 RunRequestIterator = Iterator[Union[RunRequest, SkipReason]]
 
-ScheduleEvaluationFunctionReturn = Union[RunRequest, SkipReason, RunConfig, RunRequestIterator]
+ScheduleEvaluationFunctionReturn = Union[
+    RunRequest, SkipReason, RunConfig, RunRequestIterator, List[RunRequest]
+]
 RawScheduleEvaluationFunction = Union[
     Callable[[ScheduleEvaluationContext], ScheduleEvaluationFunctionReturn],
     Callable[[], ScheduleEvaluationFunctionReturn],

--- a/python_modules/dagster/dagster/core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/sensor_definition.py
@@ -5,7 +5,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Generator,
     Iterator,
     List,
     NamedTuple,
@@ -557,7 +556,7 @@ def build_sensor_context(
 
 
 AssetMaterializationFunctionReturn = Union[
-    Iterator[Union[RunRequest, SkipReason]], RunRequest, SkipReason
+    Iterator[Union[RunRequest, SkipReason]], List[RunRequest], RunRequest, SkipReason
 ]
 AssetMaterializationFunction = Callable[
     ["SensorExecutionContext", "EventLogEntry"],
@@ -574,7 +573,7 @@ class AssetSensorDefinition(SensorDefinition):
         asset_key (AssetKey): The asset_key this sensor monitors.
         pipeline_name (Optional[str]): (legacy) The name of the pipeline to execute when the sensor
             fires. Cannot be used in conjunction with `job` or `jobs` parameters.
-        asset_materialization_fn (Callable[[SensorEvaluationContext, EventLogEntry], Union[Generator[Union[RunRequest, SkipReason], None, None], RunRequest, SkipReason]]): The core
+        asset_materialization_fn (Callable[[SensorEvaluationContext, EventLogEntry], Union[Iterator[Union[RunRequest, SkipReason]], RunRequest, SkipReason]]): The core
             evaluation function for the sensor, which is run at an interval to determine whether a
             run should be launched or not. Takes a :py:class:`~dagster.SensorEvaluationContext` and
             an EventLogEntry corresponding to an AssetMaterialization event.

--- a/python_modules/dagster/dagster/core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/sensor_definition.py
@@ -141,14 +141,14 @@ class SensorEvaluationContext:
 SensorExecutionContext = SensorEvaluationContext
 
 RawSensorEvaluationFunctionReturn = Union[
-    Iterator[Union[SkipReason, RunRequest]], SkipReason, RunRequest
+    Iterator[Union[SkipReason, RunRequest]], Iterable[RunRequest], SkipReason, RunRequest
 ]
 RawSensorEvaluationFunction = Union[
     Callable[[], RawSensorEvaluationFunctionReturn],
     Callable[[SensorEvaluationContext], RawSensorEvaluationFunctionReturn],
 ]
 SensorEvaluationFunction = Callable[
-    [SensorEvaluationContext], Iterator[Union[SkipReason, RunRequest]]
+    [SensorEvaluationContext], Union[SkipReason, RunRequest, Iterable[RunRequest]]
 ]
 
 
@@ -501,11 +501,9 @@ def wrap_sensor_evaluation(
             result = fn()  # type: ignore
 
         if inspect.isgenerator(result):
-            for item in result:
-                yield item
+            return list(result)
         elif isinstance(result, (SkipReason, RunRequest)):
-            yield result
-
+            return [result]
         elif result is not None:
             raise Exception(
                 (


### PR DESCRIPTION
### Summary & Motivation
The yield syntax falsely represents schedules/sensors as working like generators (streaming requests) when they are really being coerced into lists that are bulk processed by the sensor/schedule daemons.

This makes this clearer, by using lists instead of `yield` calls to request multiple runs.

### How I Tested These Changes
