### PR TITLE
[dagit] Add more security headers

### DIFF
--- a/js_modules/dagit/packages/app/.dagster.js
+++ b/js_modules/dagit/packages/app/.dagster.js
@@ -65,6 +65,8 @@ module.exports = {
         'style-src': isEnvDevelopment
           ? [`'unsafe-inline'`, `'self'`, `'unsafe-eval'`]
           : [`'self'`, `'nonce-NONCE-PLACEHOLDER'`],
+        // `frame-ancestors` is not supported in `meta` tags.
+        ...(isEnvDevelopment ? {} : {'frame-ancestors': `'none'`}),
       },
       options: {
         hashEnabled: {

--- a/python_modules/dagit/dagit/webserver.py
+++ b/python_modules/dagit/dagit/webserver.py
@@ -74,6 +74,16 @@ class DagitWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
     def build_middleware(self) -> List[Middleware]:
         return [Middleware(DagsterTracedCounterMiddleware)]
 
+    def make_security_headers(self) -> dict:
+        return {
+            "Cache-Control": "no-store",
+            "Clear-Site-Data": "*",
+            "Feature-Policy": "microphone 'none'; camera 'none'",
+            "Referrer-Policy": "strict-origin-when-cross-origin",
+            "X-Content-Type-Options": "nosniff",
+            "X-Frame-Options": "deny",
+        }
+
     def make_csp_header(self, nonce: str) -> str:
         csp_conf_path = self.relative_path("webapp/build/csp-header.conf")
         try:
@@ -167,7 +177,10 @@ class DagitWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
             with open(index_path, encoding="utf8") as f:
                 rendered_template = f.read()
                 nonce = uuid.uuid4().hex
-                headers = {"Content-Security-Policy": self.make_csp_header(nonce)}
+                headers = {
+                    **{"Content-Security-Policy": self.make_csp_header(nonce)},
+                    **self.make_security_headers(),
+                }
                 return HTMLResponse(
                     rendered_template.replace('href="/', f'href="{self._app_path_prefix}/')
                     .replace('src="/', f'src="{self._app_path_prefix}/')


### PR DESCRIPTION
### Summary & Motivation

Add a few more security headers to Dagit.

Also include `frame-ancestors`, which wasn't available as a meta tag. This is specifically not enabled for dev, because the browser will complain about the invalid directive if it's in the JS dev meta tag.

### How I Tested These Changes

`yarn build`, load Dagit. Verify that newly added headers are present.

Run JS dev build, verify that `frame-ancestors` error does not appear in the console.
