### PR TITLE
[dagit] Better indentation guide in our CodeMirrors

### DIFF
--- a/js_modules/dagit/packages/core/src/configeditor/ConfigEditor.tsx
+++ b/js_modules/dagit/packages/core/src/configeditor/ConfigEditor.tsx
@@ -33,7 +33,8 @@ import {ConfigEditorRunConfigSchemaFragment} from './types/ConfigEditorRunConfig
 interface ConfigEditorProps {
   configCode: string;
   readOnly: boolean;
-  showWhitespace: boolean;
+  // todo dish: Remove this prop
+  showWhitespace?: boolean;
   runConfigSchema?: ConfigEditorRunConfigSchemaFragment;
 
   checkConfig: YamlModeValidateFunction;
@@ -52,24 +53,6 @@ const ConfigEditorStyle = createGlobalStyle`
     position: absolute;
     inset: 0;
   }
-`;
-
-const CodeMirrorWhitespaceStyle = createGlobalStyle`
-.cm-whitespace {
-  /*
-    Note: background is a 16x16px PNG containing a semi-transparent gray dot. 8.4px
-    is the exact width of a character in Codemirror's monospace font. It's consistent
-    in Firefox and Chrome and doesn't change on zoom in / out, but may need to be
-    modified if we change the Codemirror font.
-  */
-  background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAEKADAAQAAAABAAAAEAAAAAA0VXHyAAAAm0lEQVQ4Ee2RMQ7DIAxFMVIvBEvm7FXXniIXak4RhnTujMSBkKDfCgPCzg2whAzf9hN8jJlBmgUxxgf0DWvFykR0Ouc+yGXsFwAeRuOv1rr0zdACIC/k2uu2P7T9Ng6zDu2ZUnqP/RqAr61GKUXUNEBWpy9R1AQAbzzvAFpNAJrbQYHs3nuhi1/gQRhGbFh7c7bWfgE+FOiU4MAfhpIwd0LjE+wAAAAASUVORK5CYII=') center left / 8.0px 8.0px repeat-x;
-  opacity: 1;
-  background-position-x: 0px;
-  background-position-y: 5.5px;
-}
-.cm-whitespace.CodeMirror-lint-mark-error {
-  background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAEKADAAQAAAABAAAAEAAAAAA0VXHyAAAAm0lEQVQ4Ee2RMQ7DIAxFMVIvBEvm7FXXniIXak4RhnTujMSBkKDfCgPCzg2whAzf9hN8jJlBmgUxxgf0DWvFykR0Ouc+yGXsFwAeRuOv1rr0zdACIC/k2uu2P7T9Ng6zDu2ZUnqP/RqAr61GKUXUNEBWpy9R1AQAbzzvAFpNAJrbQYHs3nuhi1/gQRhGbFh7c7bWfgE+FOiU4MAfhpIwd0LjE+wAAAAASUVORK5CYII=') center left / 8.0px 8.0px repeat-x;
-}
 `;
 
 export class ConfigEditor extends React.Component<ConfigEditorProps> {
@@ -92,8 +75,7 @@ export class ConfigEditor extends React.Component<ConfigEditorProps> {
     return (
       prevProps.configCode !== this.props.configCode ||
       prevProps.readOnly !== this.props.readOnly ||
-      prevProps.runConfigSchema !== this.props.runConfigSchema ||
-      prevProps.showWhitespace !== this.props.showWhitespace
+      prevProps.runConfigSchema !== this.props.runConfigSchema
     );
   }
 
@@ -153,7 +135,6 @@ export class ConfigEditor extends React.Component<ConfigEditorProps> {
     return (
       <div style={{flex: 1, position: 'relative'}}>
         <ConfigEditorStyle />
-        {this.props.showWhitespace ? <CodeMirrorWhitespaceStyle /> : null}
         <DagitCodeMirror
           value={this.props.configCode}
           theme={['config-editor']}

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
@@ -33,7 +33,6 @@ import {
   responseToYamlValidationResult,
 } from '../configeditor/ConfigEditorUtils';
 import {isHelpContextEqual} from '../configeditor/isHelpContextEqual';
-import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {DagsterTag} from '../runs/RunTag';
 import {RepositorySelector} from '../types/globalTypes';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
@@ -145,11 +144,6 @@ const LaunchpadSessionContainer: React.FC<LaunchpadSessionContainerProps> = (pro
   const editor = React.useRef<ConfigEditor | null>(null);
   const editorSplitPanelContainer = React.useRef<SplitPanelContainer | null>(null);
   const previewCounter = React.useRef(0);
-
-  const [showWhitespace, setShowWhitespace] = useStateWithStorage(
-    'launchpad-whitespace',
-    (json: any) => (typeof json === 'boolean' ? json : true),
-  );
 
   const {isJob, presets} = pipeline;
 
@@ -601,16 +595,6 @@ const LaunchpadSessionContainer: React.FC<LaunchpadSessionContainerProps> = (pro
                   <SessionSettingsSpacer />
                 </>
               )}
-              <Button
-                title="Toggle whitespace"
-                icon={<Icon name="toggle_whitespace" />}
-                active={showWhitespace}
-                onClick={() =>
-                  setShowWhitespace((current: boolean | undefined) =>
-                    current === undefined ? true : !current,
-                  )
-                }
-              />
               <SessionSettingsSpacer />
               <SecondPanelToggle axis="horizontal" container={editorSplitPanelContainer} />
             </SessionSettingsBar>
@@ -666,7 +650,6 @@ const LaunchpadSessionContainer: React.FC<LaunchpadSessionContainerProps> = (pro
                       dispatch({type: 'set-editor-help-context', payload: next});
                     }
                   }}
-                  showWhitespace={showWhitespace}
                   checkConfig={checkConfig}
                 />
               }

--- a/js_modules/dagit/packages/core/src/ui/DagitCodeMirror.tsx
+++ b/js_modules/dagit/packages/core/src/ui/DagitCodeMirror.tsx
@@ -77,6 +77,38 @@ export const DagitCodeMirrorStyle = createGlobalStyle`
     .CodeMirror-gutters {
       background-color: ${Colors.Gray50};
     }
+
+    .cm-indent {
+      display: inline-block;
+
+      &.cm-zero {
+        box-shadow: -1px 0 0 ${Colors.Green200};
+      }
+
+      &.cm-one {
+        box-shadow: -1px 0 0 ${Colors.Blue100};
+      }
+
+      &.cm-two {
+        box-shadow: -1px 0 0 ${Colors.LightPurple};
+      }
+
+      &.cm-three {
+        box-shadow: -1px 0 0 ${Colors.Red200};
+      }
+
+      &.cm-four {
+        box-shadow: -1px 0 0 ${Colors.Yellow200};
+      }
+
+      &.cm-five {
+        box-shadow: -1px 0 0 ${Colors.Olive200};
+      }
+
+      &.cm-six {
+        box-shadow: -1px 0 0 ${Colors.Gray300};
+      }
+    }
   }
 
   div.CodeMirror-lint-tooltip {


### PR DESCRIPTION
### Summary & Motivation

Resolves #3006.

Replace whitespace markers with indentation guides in our CodeMirror usage. This is a longstanding request for improving the UX of the editor experience.

- Guides are rainbowed to make it a bit clearer which indentation level is which. I tried to alternate the contrast a little bit too.
- The existing whitespace toggle has been removed. IMO the indentation guides are strictly better than having nothing at all, so I don't think we need to bother making it toggleable.

<img width="336" alt="Screen Shot 2022-05-06 at 10 48 09 AM" src="https://user-images.githubusercontent.com/2823852/167168925-4da3aa12-4e51-4082-abae-325f3fbb9f34.png">

(Note that in this screenshot, I have aded newlines to demonstrate the guide colors. They don't stretch all the way to the bottom of the editor window.)

### How I Tested These Changes

View Launchpad editor, add a bunch of content to test out indentation levels. Verify proper rendering of guides.

View instance config and post-run config (read-only CodeMirrors), verify same.
