### PR TITLE
Add a static method on DefaultRunLauncher that launches a run without a workspace

### DIFF
--- a/python_modules/dagster/dagster/grpc/client.py
+++ b/python_modules/dagster/dagster/grpc/client.py
@@ -78,6 +78,10 @@ class DagsterGrpcClient:
         else:
             self._server_address = "unix:" + os.path.abspath(socket)
 
+    @property
+    def use_ssl(self) -> bool:
+        return self._use_ssl
+
     @contextmanager
     def _channel(self):
         options = [


### PR DESCRIPTION
Summary:
In a hypothetical situation where one wanted to use the DefaultRunLauncher but did not have access to a workspace, this method would give one a way to do so.

Test Plan:
Existing DefaultRunLauncher test cases

### Summary & Motivation

### How I Tested These Changes
