### PR TITLE
Allow TextInput to have a type of number

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/TextInput.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TextInput.tsx
@@ -5,7 +5,7 @@ import {Colors} from './Colors';
 import {IconName, Icon, IconWrapper} from './Icon';
 import {FontFamily} from './styles';
 
-interface Props extends Omit<React.ComponentPropsWithRef<'input'>, 'type' | 'onChange'> {
+interface Props extends Omit<React.ComponentPropsWithRef<'input'>, 'onChange'> {
   icon?: IconName;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   strokeColor?: string;
@@ -14,7 +14,14 @@ interface Props extends Omit<React.ComponentPropsWithRef<'input'>, 'type' | 'onC
 
 export const TextInput = React.forwardRef(
   (props: Props, ref: React.ForwardedRef<HTMLInputElement>) => {
-    const {icon, disabled, strokeColor = Colors.Gray300, rightElement, ...rest} = props;
+    const {
+      icon,
+      disabled,
+      strokeColor = Colors.Gray300,
+      rightElement,
+      type = 'text',
+      ...rest
+    } = props;
 
     return (
       <Container $disabled={!!disabled}>
@@ -25,7 +32,7 @@ export const TextInput = React.forwardRef(
           disabled={disabled}
           ref={ref}
           $hasIcon={!!icon}
-          type="text"
+          type={type}
         />
         {rightElement ? rightElement : null}
       </Container>


### PR DESCRIPTION
### Summary & Motivation

Sometimes we need a number input. I didn't see one in the codebase, the easiest option would be to allow a type of `number` to the existing `TextInput`. A number is technically a subset of text  🤔. We could alternatively create a separate NumberInput component that shares a Base with the current TextInput component in case we want to treat them differently in the future. I thought it might be overkill to do that right now though

### How I Tested These Changes
I rendered an input with a type of "number" for a cloud PR