### PR TITLE
[dagster-dbt] dbt build + AssetObservations from tests

### DIFF
--- a/examples/docs_snippets/docs_snippets/integrations/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt.py
@@ -40,9 +40,7 @@ def scope_dbt_cli_run():
 
     from dagster import job
 
-    my_dbt_resource = dbt_cli_resource.configured(
-        {"project_dir": "path/to/dbt/project"}
-    )
+    my_dbt_resource = dbt_cli_resource.configured({"project_dir": "path/to/dbt/project"})
 
     @job(resource_defs={"dbt": my_dbt_resource})
     def my_dbt_job():
@@ -117,9 +115,7 @@ def scope_dbt_cli_run_after_another_op():
 
     from dagster import job
 
-    my_dbt_resource = dbt_cli_resource.configured(
-        {"project_dir": "path/to/dbt/project"}
-    )
+    my_dbt_resource = dbt_cli_resource.configured({"project_dir": "path/to/dbt/project"})
 
     @job(resource_defs={"dbt": my_dbt_resource})
     def my_dbt_job():
@@ -179,9 +175,7 @@ def scope_dbt_rpc_run_and_wait():
 
     from dagster import job, op
 
-    my_remote_sync_rpc = dbt_rpc_sync_resource.configured(
-        {"host": "80.80.80.80", "port": 8080}
-    )
+    my_remote_sync_rpc = dbt_rpc_sync_resource.configured({"host": "80.80.80.80", "port": 8080})
 
     @op(required_resource_keys={"dbt_sync"})
     def run_staging_models_and_wait(context):

--- a/examples/docs_snippets/docs_snippets/integrations/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt.py
@@ -40,7 +40,9 @@ def scope_dbt_cli_run():
 
     from dagster import job
 
-    my_dbt_resource = dbt_cli_resource.configured({"project_dir": "path/to/dbt/project"})
+    my_dbt_resource = dbt_cli_resource.configured(
+        {"project_dir": "path/to/dbt/project"}
+    )
 
     @job(resource_defs={"dbt": my_dbt_resource})
     def my_dbt_job():
@@ -115,7 +117,9 @@ def scope_dbt_cli_run_after_another_op():
 
     from dagster import job
 
-    my_dbt_resource = dbt_cli_resource.configured({"project_dir": "path/to/dbt/project"})
+    my_dbt_resource = dbt_cli_resource.configured(
+        {"project_dir": "path/to/dbt/project"}
+    )
 
     @job(resource_defs={"dbt": my_dbt_resource})
     def my_dbt_job():
@@ -175,7 +179,9 @@ def scope_dbt_rpc_run_and_wait():
 
     from dagster import job, op
 
-    my_remote_sync_rpc = dbt_rpc_sync_resource.configured({"host": "80.80.80.80", "port": 8080})
+    my_remote_sync_rpc = dbt_rpc_sync_resource.configured(
+        {"host": "80.80.80.80", "port": 8080}
+    )
 
     @op(required_resource_keys={"dbt_sync"})
     def run_staging_models_and_wait(context):

--- a/python_modules/dagster/dagster/core/definitions/solid_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_invocation.py
@@ -8,7 +8,14 @@ from dagster.core.errors import (
     DagsterTypeCheckDidNotPass,
 )
 
-from .events import AssetMaterialization, DynamicOutput, ExpectationResult, Materialization, Output
+from .events import (
+    AssetMaterialization,
+    AssetObservation,
+    DynamicOutput,
+    ExpectationResult,
+    Materialization,
+    Output,
+)
 from .output import DynamicOutputDefinition
 
 if TYPE_CHECKING:
@@ -198,7 +205,10 @@ def _type_check_output_wrapper(
             outputs_seen = set()
 
             async for event in async_gen:
-                if isinstance(event, (AssetMaterialization, Materialization, ExpectationResult)):
+                if isinstance(
+                    event,
+                    (AssetMaterialization, AssetObservation, Materialization, ExpectationResult),
+                ):
                     yield event
                 else:
                     if not isinstance(event, (Output, DynamicOutput)):
@@ -239,7 +249,10 @@ def _type_check_output_wrapper(
         def type_check_gen(gen):
             outputs_seen = set()
             for event in gen:
-                if isinstance(event, (AssetMaterialization, Materialization, ExpectationResult)):
+                if isinstance(
+                    event,
+                    (AssetMaterialization, AssetObservation, Materialization, ExpectationResult),
+                ):
                     yield event
                 else:
                     if not isinstance(event, (Output, DynamicOutput)):
@@ -274,7 +287,9 @@ def _type_check_function_output(
 ) -> Any:
     """Unpacks valid outputs from solid function."""
 
-    if isinstance(result, (AssetMaterialization, Materialization, ExpectationResult)):
+    if isinstance(
+        result, (AssetMaterialization, AssetObservation, Materialization, ExpectationResult)
+    ):
         raise DagsterInvariantViolationError(
             (
                 f"Error in {solid_def.node_type_str} '{solid_def.name}'': If you are returning an AssetMaterialization "

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -26,6 +26,7 @@ from .errors import (
     DagsterDbtRpcUnexpectedPollOutputError,
 )
 from .ops import (
+    dbt_build_op,
     dbt_compile_op,
     dbt_docs_generate_op,
     dbt_ls_op,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -6,10 +6,13 @@ from typing import AbstractSet, Any, Callable, Dict, Mapping, Optional, Sequence
 
 from dagster_dbt.cli.types import DbtCliOutput
 from dagster_dbt.cli.utils import execute_cli
-from dagster_dbt.utils import generate_materializations
+from dagster_dbt.errors import DagsterDbtCliHandledRuntimeError
+from dagster_dbt.types import DbtOutput
+from dagster_dbt.utils import generate_events
 
 from dagster import (
     AssetKey,
+    AssetMaterialization,
     MetadataValue,
     Out,
     Output,
@@ -69,6 +72,7 @@ def _dbt_nodes_to_assets(
     ] = None,
     io_manager_key: Optional[str] = None,
     node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey] = _get_node_asset_key,
+    use_build: bool = False,
 ) -> AssetsDefinition:
     outs: Dict[str, Out] = {}
     sources: Set[AssetKey] = set()
@@ -123,22 +127,44 @@ def _dbt_nodes_to_assets(
         internal_asset_deps=internal_asset_deps,
     )
     def _dbt_project_multi_assset(context):
-        dbt_output = context.resources.dbt.run(select=select)
-        # yield an Output for each materialization generated in the run
-        for materialization in generate_materializations(dbt_output):
-            output_name = materialization.asset_key.path[-1]
-            if runtime_metadata_fn:
-                yield Output(
-                    value=None,
-                    output_name=output_name,
-                    metadata=runtime_metadata_fn(context, out_name_to_node_info[output_name]),
-                )
+        dbt_output = None
+        try:
+            if use_build:
+                dbt_output = context.resources.dbt.build(select=select)
             else:
-                yield Output(
-                    value=None,
-                    output_name=output_name,
-                    metadata_entries=materialization.metadata_entries,
-                )
+                dbt_output = context.resources.dbt.run(select=select)
+        finally:
+            # in the case that the project only partially runs successfully, still attempt to generate
+            # events for the parts that were successful
+            if dbt_output is None:
+                dbt_output = DbtOutput(result=context.resources.dbt.get_run_results_json())
+
+            # yield an Output for each materialization generated in the run
+            for event in generate_events(
+                dbt_output,
+                node_info_to_asset_key=node_info_to_asset_key,
+                manifest_json=context.resources.dbt.get_manifest_json(),
+            ):
+                # convert AssetMaterializations to outputs
+                if isinstance(event, AssetMaterialization):
+                    output_name = event.asset_key.path[-1]
+                    if runtime_metadata_fn:
+                        yield Output(
+                            value=None,
+                            output_name=output_name,
+                            metadata=runtime_metadata_fn(
+                                context, out_name_to_node_info[output_name]
+                            ),
+                        )
+                    else:
+                        yield Output(
+                            value=None,
+                            output_name=output_name,
+                            metadata_entries=event.metadata_entries,
+                        )
+                # yield AssetObservations normally
+                else:
+                    yield event
 
     return _dbt_project_multi_assset
 
@@ -174,6 +200,7 @@ def load_assets_from_dbt_project(
     ] = None,
     io_manager_key: Optional[str] = None,
     node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey] = _get_node_asset_key,
+    use_build: bool = False,
 ) -> Sequence[AssetsDefinition]:
     """
     Loads a set of DBT models from a DBT project into Dagster assets.
@@ -198,6 +225,9 @@ def load_assets_from_dbt_project(
         node_info_to_asset_key: (Mapping[str, Any] -> AssetKey): A function that takes a dictionary
             of dbt node info and returns the AssetKey that you want to represent that node. By
             default, the asset key will simply be the name of the dbt model.
+        use_build: (bool): Flag indicating if you want to use `dbt build` as the core computation
+            for this asset, rather than `dbt run`.
+
     """
     check.str_param(project_dir, "project_dir")
     profiles_dir = check.opt_str_param(
@@ -221,6 +251,7 @@ def load_assets_from_dbt_project(
             runtime_metadata_fn=runtime_metadata_fn,
             io_manager_key=io_manager_key,
             node_info_to_asset_key=node_info_to_asset_key,
+            use_build=use_build,
         ),
     ]
 
@@ -233,6 +264,7 @@ def load_assets_from_dbt_manifest(
     io_manager_key: Optional[str] = None,
     selected_unique_ids: Optional[AbstractSet[str]] = None,
     node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey] = _get_node_asset_key,
+    use_build: bool = False,
 ) -> Sequence[AssetsDefinition]:
     """
     Loads a set of dbt models, described in a manifest.json, into Dagster assets.
@@ -254,6 +286,8 @@ def load_assets_from_dbt_manifest(
         node_info_to_asset_key: (Mapping[str, Any] -> AssetKey): A function that takes a dictionary
             of dbt node info and returns the AssetKey that you want to represent that node. By
             default, the asset key will simply be the name of the dbt model.
+        use_build: (bool): Flag indicating if you want to use `dbt build` as the core computation
+            for this asset, rather than `dbt run`.
     """
     check.dict_param(manifest_json, "manifest_json", key_type=str)
     dbt_nodes = {**manifest_json["nodes"], **manifest_json["sources"]}
@@ -280,5 +314,6 @@ def load_assets_from_dbt_manifest(
             select=select,
             selected_unique_ids=selected_unique_ids,
             node_info_to_asset_key=node_info_to_asset_key,
+            use_build=use_build,
         )
     ]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -6,7 +6,6 @@ from typing import AbstractSet, Any, Callable, Dict, Mapping, Optional, Sequence
 
 from dagster_dbt.cli.types import DbtCliOutput
 from dagster_dbt.cli.utils import execute_cli
-from dagster_dbt.errors import DagsterDbtCliHandledRuntimeError
 from dagster_dbt.types import DbtOutput
 from dagster_dbt.utils import generate_events
 
@@ -72,7 +71,7 @@ def _dbt_nodes_to_assets(
     ] = None,
     io_manager_key: Optional[str] = None,
     node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey] = _get_node_asset_key,
-    use_build: bool = False,
+    use_build_command: bool = False,
 ) -> AssetsDefinition:
     outs: Dict[str, Out] = {}
     sources: Set[AssetKey] = set()
@@ -129,7 +128,7 @@ def _dbt_nodes_to_assets(
     def _dbt_project_multi_assset(context):
         dbt_output = None
         try:
-            if use_build:
+            if use_build_command:
                 dbt_output = context.resources.dbt.build(select=select)
             else:
                 dbt_output = context.resources.dbt.run(select=select)
@@ -200,7 +199,7 @@ def load_assets_from_dbt_project(
     ] = None,
     io_manager_key: Optional[str] = None,
     node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey] = _get_node_asset_key,
-    use_build: bool = False,
+    use_build_command: bool = False,
 ) -> Sequence[AssetsDefinition]:
     """
     Loads a set of DBT models from a DBT project into Dagster assets.
@@ -225,7 +224,7 @@ def load_assets_from_dbt_project(
         node_info_to_asset_key: (Mapping[str, Any] -> AssetKey): A function that takes a dictionary
             of dbt node info and returns the AssetKey that you want to represent that node. By
             default, the asset key will simply be the name of the dbt model.
-        use_build: (bool): Flag indicating if you want to use `dbt build` as the core computation
+        use_build_command: (bool): Flag indicating if you want to use `dbt build` as the core computation
             for this asset, rather than `dbt run`.
 
     """
@@ -251,7 +250,7 @@ def load_assets_from_dbt_project(
             runtime_metadata_fn=runtime_metadata_fn,
             io_manager_key=io_manager_key,
             node_info_to_asset_key=node_info_to_asset_key,
-            use_build=use_build,
+            use_build_command=use_build_command,
         ),
     ]
 
@@ -264,7 +263,7 @@ def load_assets_from_dbt_manifest(
     io_manager_key: Optional[str] = None,
     selected_unique_ids: Optional[AbstractSet[str]] = None,
     node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey] = _get_node_asset_key,
-    use_build: bool = False,
+    use_build_command: bool = False,
 ) -> Sequence[AssetsDefinition]:
     """
     Loads a set of dbt models, described in a manifest.json, into Dagster assets.
@@ -286,7 +285,7 @@ def load_assets_from_dbt_manifest(
         node_info_to_asset_key: (Mapping[str, Any] -> AssetKey): A function that takes a dictionary
             of dbt node info and returns the AssetKey that you want to represent that node. By
             default, the asset key will simply be the name of the dbt model.
-        use_build: (bool): Flag indicating if you want to use `dbt build` as the core computation
+        use_build_command: (bool): Flag indicating if you want to use `dbt build` as the core computation
             for this asset, rather than `dbt run`.
     """
     check.dict_param(manifest_json, "manifest_json", key_type=str)
@@ -314,6 +313,6 @@ def load_assets_from_dbt_manifest(
             select=select,
             selected_unique_ids=selected_unique_ids,
             node_info_to_asset_key=node_info_to_asset_key,
-            use_build=use_build,
+            use_build_command=use_build_command,
         )
     ]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
@@ -125,10 +125,10 @@ def parse_run_results(path: str, target_path: str = DEFAULT_DBT_TARGET_PATH) -> 
 
 
 def parse_manifest(path: str, target_path: str = DEFAULT_DBT_TARGET_PATH) -> Dict[str, Any]:
-    """Parses the `target/run_results.json` artifact that is produced by a dbt process."""
-    run_results_path = os.path.join(path, target_path, "manifest.json")
+    """Parses the `target/manifest.json` artifact that is produced by a dbt process."""
+    manifest_path = os.path.join(path, target_path, "manifest.json")
     try:
-        with open(run_results_path, encoding="utf8") as file:
+        with open(manifest_path, encoding="utf8") as file:
             return json.load(file)
     except FileNotFoundError:
         raise DagsterDbtCliOutputsNotFoundError(path=run_results_path)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
@@ -131,4 +131,4 @@ def parse_manifest(path: str, target_path: str = DEFAULT_DBT_TARGET_PATH) -> Dic
         with open(manifest_path, encoding="utf8") as file:
             return json.load(file)
     except FileNotFoundError:
-        raise DagsterDbtCliOutputsNotFoundError(path=run_results_path)
+        raise DagsterDbtCliOutputsNotFoundError(path=manifest_path)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
@@ -122,3 +122,13 @@ def parse_run_results(path: str, target_path: str = DEFAULT_DBT_TARGET_PATH) -> 
             return json.load(file)
     except FileNotFoundError:
         raise DagsterDbtCliOutputsNotFoundError(path=run_results_path)
+
+
+def parse_manifest(path: str, target_path: str = DEFAULT_DBT_TARGET_PATH) -> Dict[str, Any]:
+    """Parses the `target/run_results.json` artifact that is produced by a dbt process."""
+    run_results_path = os.path.join(path, target_path, "manifest.json")
+    try:
+        with open(run_results_path, encoding="utf8") as file:
+            return json.load(file)
+    except FileNotFoundError:
+        raise DagsterDbtCliOutputsNotFoundError(path=run_results_path)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_resource.py
@@ -160,6 +160,18 @@ class DbtResource:
         """
 
     @abstractmethod
+    def build(self, select: Optional[List[str]] = None, **kwargs) -> DbtOutput:
+        """
+        Run the ``build`` command on a dbt project. kwargs are passed in as additional parameters.
+
+        Args:
+            select (List[str], optional): the models/resources to include in the run.
+
+        Returns:
+            DbtOutput: object containing parsed output from dbt
+        """
+
+    @abstractmethod
     def generate_docs(self, compile_project: bool = False, **kwargs) -> DbtOutput:
         """
         Run the ``docs generate`` command on a dbt project. kwargs are passed in as additional parameters.
@@ -185,3 +197,23 @@ class DbtResource:
         Returns:
             DbtOutput: object containing parsed output from dbt
         """
+
+    def get_run_results_json(self, **kwargs) -> Optional[Dict[str, Any]]:
+        """
+        Get a parsed version of the run_results.json file for the relevant dbt project.
+
+        Returns:
+            Dict[str, Any]: dictionary containing the parsed contents of the run_results json file
+                for this dbt project.
+        """
+        return None
+
+    def get_manifest_json(self, **kwargs) -> Optional[Dict[str, Any]]:
+        """
+        Get a parsed version of the manifest.json file for the relevant dbt project.
+
+        Returns:
+            Dict[str, Any]: dictionary containing the parsed contents of the manifest json file
+                for this dbt project.
+        """
+        return None

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_resource.py
@@ -170,6 +170,7 @@ class DbtResource:
         Returns:
             DbtOutput: object containing parsed output from dbt
         """
+        raise NotImplementedError()
 
     @abstractmethod
     def generate_docs(self, compile_project: bool = False, **kwargs) -> DbtOutput:
@@ -198,6 +199,7 @@ class DbtResource:
             DbtOutput: object containing parsed output from dbt
         """
 
+    @abstractmethod
     def get_run_results_json(self, **kwargs) -> Optional[Dict[str, Any]]:
         """
         Get a parsed version of the run_results.json file for the relevant dbt project.
@@ -206,8 +208,8 @@ class DbtResource:
             Dict[str, Any]: dictionary containing the parsed contents of the run_results json file
                 for this dbt project.
         """
-        return None
 
+    @abstractmethod
     def get_manifest_json(self, **kwargs) -> Optional[Dict[str, Any]]:
         """
         Get a parsed version of the manifest.json file for the relevant dbt project.
@@ -216,4 +218,3 @@ class DbtResource:
             Dict[str, Any]: dictionary containing the parsed contents of the manifest json file
                 for this dbt project.
         """
-        return None

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
@@ -457,6 +457,41 @@ class DbtRpcResource(DbtResource):
 
         return self._get_result(data=json.dumps(data))
 
+    def build(self, select: Optional[List[str]] = None, **kwargs) -> DbtRpcOutput:
+        """
+        Run the ``build`` command on a dbt project. kwargs are passed in as additional parameters.
+
+        Args:
+            select (List[str], optional): the models/resources to include in the run.
+
+        Returns:
+            DbtOutput: object containing parsed output from dbt
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+        raise NotImplementedError()
+
+    def get_run_results_json(self, **kwargs) -> Optional[Dict[str, Any]]:
+        """
+        Get a parsed version of the run_results.json file for the relevant dbt project.
+
+        Returns:
+            Dict[str, Any]: dictionary containing the parsed contents of the run_results json file
+                for this dbt project.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+        raise NotImplementedError()
+
+    def get_manifest_json(self, **kwargs) -> Optional[Dict[str, Any]]:
+        """
+        Get a parsed version of the manifest.json file for the relevant dbt project.
+
+        Returns:
+            Dict[str, Any]: dictionary containing the parsed contents of the manifest json file
+                for this dbt project.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+        raise NotImplementedError()
+
 
 class DbtRpcSyncResource(DbtRpcResource):
     def __init__(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -1,12 +1,16 @@
-from typing import Any, Dict, Iterator, List, Mapping, Optional
+from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional, Union
 
 import dateutil
 
-from dagster import AssetMaterialization, AssetObservation, MetadataValue
+from dagster import AssetKey, AssetMaterialization, AssetObservation, MetadataValue
 from dagster import _check as check
 from dagster.core.definitions.metadata import RawMetadataValue
 
 from .types import DbtOutput
+
+
+def default_node_info_to_asset_key(node_info: Dict[str, Any]) -> AssetKey:
+    return AssetKey(node_info["unique_id"].split("."))
 
 
 def _node_type(unique_id: str) -> str:
@@ -47,31 +51,38 @@ def _timing_to_metadata(timings: List[Dict[str, Any]]) -> Mapping[str, RawMetada
     return metadata
 
 
-def result_to_materialization(
+def result_to_events(
     result: Dict[str, Any],
-    asset_key_prefix: Optional[List[str]] = None,
     docs_url: Optional[str] = None,
-) -> Optional[AssetMaterialization]:
+    node_info_to_asset_key: Optional[Callable[[Dict[str, Any]], AssetKey]] = None,
+    manifest_json: Optional[Dict[str, Any]] = None,
+) -> Optional[Iterator[Union[AssetMaterialization, AssetObservation]]]:
     """
     This is a hacky solution that attempts to consolidate parsing many of the potential formats
     that dbt can provide its results in. This is known to work for CLI Outputs for dbt versions 0.18+,
     as well as RPC responses for a similar time period, but as the RPC response schema is not documented
     nor enforced, this can become out of date easily.
     """
-
-    asset_key_prefix = check.opt_list_param(asset_key_prefix, "asset_key_prefix", of_type=str)
+    node_info_to_asset_key = check.opt_callable_param(
+        node_info_to_asset_key, "node_info_to_asset_key", default=default_node_info_to_asset_key
+    )
 
     # status comes from set of fields rather than "status"
     if "fail" in result:
-        success = not result.get("fail") and not result.get("skip") and not result.get("error")
+        status = (
+            "fail"
+            if result.get("fail")
+            else "skip"
+            if result.get("skip")
+            else "error"
+            if result.get("error")
+            else "success"
+        )
     else:
-        success = result["status"] == "success"
-
-    if not success:
-        return None
+        status = result["status"]
 
     # all versions represent timing the same way
-    metadata = {"Execution Time (seconds)": result["execution_time"]}
+    metadata = {"Status": status, "Execution Time (seconds)": result["execution_time"]}
     metadata.update(_timing_to_metadata(result["timing"]))
 
     # working with a response that contains the node block (RPC and CLI 0.18.x)
@@ -82,34 +93,59 @@ def result_to_materialization(
     else:
         unique_id = result["unique_id"]
 
-    if
-
-    id_prefix = unique_id.split(".")
-
-    # only generate materializations for models
-    if id_prefix[0] != "model":
-        return None
-
     if docs_url:
         metadata["docs_url"] = MetadataValue.url(f"{docs_url}#!/model/{unique_id}")
 
-    return AssetMaterialization(
-        description=f"dbt node: {unique_id}",
-        metadata=metadata,
-        asset_key=asset_key_prefix + id_prefix,
-    )
+    node_type = _node_type(unique_id)
+
+    # if you have a manifest available, get the full node info, otherwise just populate unique_id
+    node_info = manifest_json["nodes"][unique_id] if manifest_json else {"unique_id": unique_id}
+
+    if node_type == "model" and status == "success":
+        yield AssetMaterialization(
+            asset_key=node_info_to_asset_key(node_info),
+            description=f"dbt node: {unique_id}",
+            metadata=metadata,
+        )
+    # can only associate tests with assets if we have manifest_json available
+    elif node_type == "test" and manifest_json:
+        upstream_unique_ids = manifest_json["nodes"][unique_id]["depends_on"]["nodes"]
+        # tests can apply to multiple asset keys
+        for upstream_id in upstream_unique_ids:
+            node_info = manifest_json["nodes"][upstream_id]
+            upstream_asset_key = node_info_to_asset_key(node_info)
+            yield AssetObservation(asset_key=upstream_asset_key, metadata=metadata)
 
 
 def generate_events(
     dbt_output: DbtOutput,
-    node_info_to_asset_key: Optional[Callable[Dict[str, Any], AssetKey]] = lambda info: AssetKey(
-        info["unique_id"].split(".")
-    ),
+    node_info_to_asset_key: Optional[Callable[[Dict[str, Any]], AssetKey]] = None,
+    manifest_json: Optional[Dict[str, Any]] = None,
 ) -> Iterator[Union[AssetMaterialization, AssetObservation]]:
 
     """
     This function yields :py:class:`dagster.AssetMaterialization` events for each model updated by
     a dbt command, and :py:class:`dagster.AssetObservation` events for each test run.
+
+    Information parsed from a :py:class:`~DbtOutput` object.
+    """
+
+    for result in dbt_output.result["results"]:
+        yield from result_to_events(
+            result,
+            docs_url=dbt_output.docs_url,
+            node_info_to_asset_key=node_info_to_asset_key,
+            manifest_json=manifest_json,
+        )
+
+
+def generate_materializations(
+    dbt_output: DbtOutput,
+    asset_key_prefix: Optional[List[str]] = None,
+) -> Iterator[AssetMaterialization]:
+    """
+    This function yields :py:class:`dagster.AssetMaterialization` events for each model updated by
+    a dbt command.
 
     Information parsed from a :py:class:`~DbtOutput` object.
 
@@ -141,18 +177,12 @@ def generate_events(
         def my_dbt_rpc_job():
             my_custom_dbt_run()
     """
-
     asset_key_prefix = check.opt_list_param(asset_key_prefix, "asset_key_prefix", of_type=str)
 
-    for result in dbt_output.result["results"]:
-        schema_version = dbt_output.result.get("metadata", {}).get("dbt_schema_version")
-        # we can only generate
-        observation_compatible = isinstance(dbt_output, DbtCliOutput) and schema_version is not None
-        event = result_to_event(
-            result,
-            node_info_to_asset_key,
-            docs_url=dbt_output.docs_url,
-            schema_version=,
-        )
-        if materialization is not None:
-            yield materialization
+    for event in generate_events(
+        dbt_output,
+        node_info_to_asset_key=lambda info: AssetKey(
+            asset_key_prefix + info["unique_id"].split(".")
+        ),
+    ):
+        yield check.inst(event, AssetMaterialization)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources.py
@@ -52,7 +52,7 @@ def test_ls(conn_string, test_project_dir, dbt_config_dir):  # pylint: disable=u
 
     context = get_dbt_solid_context(test_project_dir, dbt_config_dir)
     dbt_result = my_dbt_solid(context)
-    assert len(dbt_result.raw_output.split("\n\n")) == 22
+    assert len(dbt_result.raw_output.split("\n\n")) == 24
 
 
 def test_ls_resource_type(
@@ -77,7 +77,7 @@ def test_test(
 
     context = get_dbt_solid_context(test_project_dir, dbt_config_dir)
     dbt_result = my_dbt_solid(context)
-    assert len(dbt_result.result["results"]) == 15
+    assert len(dbt_result.result["results"]) == 17
 
 
 def test_basic_run(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_test_project/tests/failing_test.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_test_project/tests/failing_test.sql
@@ -1,0 +1,2 @@
+select * from {{ref("sort_by_calories")}}
+where {{var("fail_test", "false")}}

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_test_project/tests/test2.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_test_project/tests/test2.sql
@@ -1,0 +1,2 @@
+select * from {{ref("sort_cold_cereals_by_calories")}}
+where false

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -26,6 +26,8 @@ def test_load_from_manifest_json():
 
     dbt = MagicMock()
     dbt.run.return_value = DbtOutput(run_results_json)
+    dbt.build.return_value = DbtOutput(run_results_json)
+    dbt.get_manifest_json.return_value = manifest_json
     assets_job = build_assets_job(
         "assets_job",
         dbt_assets,
@@ -53,6 +55,8 @@ def test_runtime_metadata_fn():
 
     dbt = MagicMock()
     dbt.run.return_value = DbtOutput(run_results_json)
+    dbt.build.return_value = DbtOutput(run_results_json)
+    dbt.get_manifest_json.return_value = manifest_json
     assets_job = build_assets_job(
         "assets_job",
         dbt_assets,
@@ -100,11 +104,12 @@ def assert_assets_match_project(dbt_assets):
     assert not dbt_assets[0].asset_deps[AssetKey(["test-schema", "sort_by_calories"])]
 
 
+@pytest.mark.parametrize("use_build, fail_test", [(True, False), (True, True), (False, False)])
 def test_basic(
-    dbt_seed, conn_string, test_project_dir, dbt_config_dir
+    dbt_seed, conn_string, test_project_dir, dbt_config_dir, use_build, fail_test
 ):  # pylint: disable=unused-argument
 
-    dbt_assets = load_assets_from_dbt_project(test_project_dir, dbt_config_dir)
+    dbt_assets = load_assets_from_dbt_project(test_project_dir, dbt_config_dir, use_build=use_build)
 
     assert dbt_assets[0].op.name == "run_dbt_dagster_dbt_test_project"
 
@@ -113,26 +118,48 @@ def test_basic(
         dbt_assets,
         resource_defs={
             "dbt": dbt_cli_resource.configured(
-                {"project_dir": test_project_dir, "profiles_dir": dbt_config_dir}
+                {
+                    "project_dir": test_project_dir,
+                    "profiles_dir": dbt_config_dir,
+                    "vars": {"fail_test": fail_test},
+                }
             )
         },
-    ).execute_in_process()
+    ).execute_in_process(raise_on_error=False)
 
-    assert result.success
+    assert result.success == (not fail_test)
     materializations = [
         event.event_specific_data.materialization
         for event in result.events_for_node(dbt_assets[0].op.name)
         if event.event_type_value == "ASSET_MATERIALIZATION"
     ]
-    assert len(materializations) == 4
+    if fail_test:
+        # the test will fail after the first model is completed, so others will not be emitted
+        assert len(materializations) == 1
+        assert materializations[0].asset_key == AssetKey(["test-schema", "sort_by_calories"])
+    else:
+        assert len(materializations) == 4
+    observations = [
+        event.event_specific_data.asset_observation
+        for event in result.events_for_node(dbt_assets[0].op.name)
+        if event.event_type_value == "ASSET_OBSERVATION"
+    ]
+    if use_build:
+        assert len(observations) == 17
+    else:
+        assert len(observations) == 0
 
 
+@pytest.mark.parametrize("use_build", [True, False])
 def test_select_from_project(
-    dbt_seed, conn_string, test_project_dir, dbt_config_dir
+    dbt_seed, conn_string, test_project_dir, dbt_config_dir, use_build
 ):  # pylint: disable=unused-argument
 
     dbt_assets = load_assets_from_dbt_project(
-        test_project_dir, dbt_config_dir, select="sort_by_calories subdir.least_caloric"
+        test_project_dir,
+        dbt_config_dir,
+        select="sort_by_calories subdir.least_caloric",
+        use_build=use_build,
     )
 
     assert dbt_assets[0].op.name == "run_dbt_dagster_dbt_test_project_e4753"
@@ -154,6 +181,15 @@ def test_select_from_project(
         if event.event_type_value == "ASSET_MATERIALIZATION"
     ]
     assert len(materializations) == 2
+    observations = [
+        event.event_specific_data.asset_observation
+        for event in result.events_for_node(dbt_assets[0].op.name)
+        if event.event_type_value == "ASSET_OBSERVATION"
+    ]
+    if use_build:
+        assert len(observations) == 16
+    else:
+        assert len(observations) == 0
 
 
 def test_multiple_select_from_project(
@@ -183,8 +219,9 @@ def test_dbt_ls_fail_fast():
         load_assets_from_dbt_project("bad_project_dir", "bad_config_dir")
 
 
+@pytest.mark.parametrize("use_build", [True, False])
 def test_select_from_manifest(
-    dbt_seed, conn_string, test_project_dir, dbt_config_dir
+    dbt_seed, conn_string, test_project_dir, dbt_config_dir, use_build
 ):  # pylint: disable=unused-argument
 
     manifest_path = file_relative_path(__file__, "sample_manifest.json")
@@ -196,6 +233,7 @@ def test_select_from_manifest(
             "model.dagster_dbt_test_project.sort_by_calories",
             "model.dagster_dbt_test_project.least_caloric",
         },
+        use_build=use_build,
     )
 
     result = build_assets_job(
@@ -215,15 +253,26 @@ def test_select_from_manifest(
         if event.event_type_value == "ASSET_MATERIALIZATION"
     ]
     assert len(materializations) == 2
+    observations = [
+        event.event_specific_data.asset_observation
+        for event in result.events_for_node(dbt_assets[0].op.name)
+        if event.event_type_value == "ASSET_OBSERVATION"
+    ]
+    if use_build:
+        assert len(observations) == 16
+    else:
+        assert len(observations) == 0
 
 
+@pytest.mark.parametrize("use_build", [True, False])
 def test_node_info_to_asset_key(
-    dbt_seed, conn_string, test_project_dir, dbt_config_dir
+    dbt_seed, conn_string, test_project_dir, dbt_config_dir, use_build
 ):  # pylint: disable=unused-argument
     dbt_assets = load_assets_from_dbt_project(
         test_project_dir,
         dbt_config_dir,
         node_info_to_asset_key=lambda node_info: AssetKey(["foo", node_info["name"]]),
+        use_build=use_build,
     )
 
     result = build_assets_job(
@@ -244,3 +293,12 @@ def test_node_info_to_asset_key(
     ]
     assert len(materializations) == 4
     assert materializations[0].asset_key == AssetKey(["foo", "sort_by_calories"])
+    observations = [
+        event.event_specific_data.asset_observation
+        for event in result.events_for_node(dbt_assets[0].op.name)
+        if event.event_type_value == "ASSET_OBSERVATION"
+    ]
+    if use_build:
+        assert len(observations) == 17
+    else:
+        assert len(observations) == 0

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -109,7 +109,9 @@ def test_basic(
     dbt_seed, conn_string, test_project_dir, dbt_config_dir, use_build, fail_test
 ):  # pylint: disable=unused-argument
 
-    dbt_assets = load_assets_from_dbt_project(test_project_dir, dbt_config_dir, use_build=use_build)
+    dbt_assets = load_assets_from_dbt_project(
+        test_project_dir, dbt_config_dir, use_build_command=use_build
+    )
 
     assert dbt_assets[0].op.name == "run_dbt_dagster_dbt_test_project"
 
@@ -159,7 +161,7 @@ def test_select_from_project(
         test_project_dir,
         dbt_config_dir,
         select="sort_by_calories subdir.least_caloric",
-        use_build=use_build,
+        use_build_command=use_build,
     )
 
     assert dbt_assets[0].op.name == "run_dbt_dagster_dbt_test_project_e4753"
@@ -233,7 +235,7 @@ def test_select_from_manifest(
             "model.dagster_dbt_test_project.sort_by_calories",
             "model.dagster_dbt_test_project.least_caloric",
         },
-        use_build=use_build,
+        use_build_command=use_build,
     )
 
     result = build_assets_job(
@@ -272,7 +274,7 @@ def test_node_info_to_asset_key(
         test_project_dir,
         dbt_config_dir,
         node_info_to_asset_key=lambda node_info: AssetKey(["foo", node_info["name"]]),
-        use_build=use_build,
+        use_build_command=use_build,
     )
 
     result = build_assets_job(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_ops.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_ops.py
@@ -1,5 +1,5 @@
 import pytest
-from dagster_dbt import dbt_cli_resource, dbt_run_op, dbt_seed_op, dbt_test_op, dbt_build_op
+from dagster_dbt import dbt_build_op, dbt_cli_resource, dbt_run_op, dbt_seed_op, dbt_test_op
 
 from dagster import build_op_context, job
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_ops.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_ops.py
@@ -1,4 +1,5 @@
-from dagster_dbt import dbt_cli_resource, dbt_run_op, dbt_seed_op, dbt_test_op
+import pytest
+from dagster_dbt import dbt_cli_resource, dbt_run_op, dbt_seed_op, dbt_test_op, dbt_build_op
 
 from dagster import build_op_context, job
 
@@ -10,6 +11,29 @@ def test_seed_op(conn_string, test_project_dir, dbt_config_dir):  # pylint: disa
     )
     dbt_result = dbt_seed_op(build_op_context(resources={"dbt": dbt_resource}))
     assert len(dbt_result.result["results"]) == 1
+
+
+@pytest.mark.parametrize("yield_asset_events", [True, False])
+def test_build_op(
+    dbt_seed, conn_string, test_project_dir, dbt_config_dir, yield_asset_events
+):  # pylint: disable=unused-argument
+
+    dbt_resource = dbt_cli_resource.configured(
+        {"project_dir": test_project_dir, "profiles_dir": dbt_config_dir}
+    )
+    if not yield_asset_events:
+        test_op = dbt_build_op.configured({"yield_asset_events": False}, name="foo")
+    else:
+        test_op = dbt_build_op
+    dbt_results = list(test_op(build_op_context(resources={"dbt": dbt_resource})))
+
+    if yield_asset_events:
+        # includes asset materializations and observations
+        assert len(dbt_results) == 1 + 4 + 17
+    else:
+        assert len(dbt_results) == 1
+
+    assert len(dbt_results[-1].value.result["results"]) == 1 + 4 + 17
 
 
 def test_run_op(
@@ -45,4 +69,4 @@ def test_run_test_job(
     dbt_test_result = dbt_result.output_for_node("dbt_test_op")
 
     assert len(dbt_run_result.result["results"]) == 4
-    assert len(dbt_test_result.result["results"]) == 15
+    assert len(dbt_test_result.result["results"]) == 17


### PR DESCRIPTION
### Summary & Motivation

`dbt build` runs a dbt project in dag order, including any tests (so if you have model1 -> model2, and model1 has tests, it'll update model1, then run tests on that model, and if they fail, it will skip model2). This is pretty neat, and we should make it easier for users to take advantage of it.

These tests also give information about a particular asset (the dbt model), and so they can pretty transparently be modeled as AssetObservations.

Finally, in the case that a dbt project partially runs, we still would like to record the fact that some of the assets were materialized (this was actually a problem in the existing implementation as well). To handle this, we wrap our computation in a try block, and if we don't get a dbt_output from our normal computation, we piece one together as best we can.

### How I Tested These Changes

unit testzz
