### PR TITLE
Add toposort pin

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
             "typing_compat",
             "typing_extensions>=3.10",
             "sqlalchemy>=1.0",
-            "toposort>=1.0",
+            "toposort>=1.7",
             "watchdog>=0.8.3",
             'psutil >= 1.0; platform_system=="Windows"',
             # https://github.com/mhammond/pywin32/issues/1439


### PR DESCRIPTION
Summary:
With topsort 1.6 or earlier installed, pipeline execution fails with this error: https://gist.github.com/gibsondan/5c064215f08ab29ed6c961942cfc0a45

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
