### PR TITLE
toposort frozenset workaround

### DIFF
--- a/python_modules/dagster/dagster/core/utils.py
+++ b/python_modules/dagster/dagster/core/utils.py
@@ -50,7 +50,7 @@ def coerce_valid_log_level(log_level: Union[str, int]) -> int:
 
 def toposort(data):
     # Workaround a bug in older versions of toposort that choke on frozenset
-    data = { k: set(v) if isinstance(v, frozenset) else v for k, v in data.items() }
+    data = {k: set(v) if isinstance(v, frozenset) else v for k, v in data.items()}
     return [sorted(list(level)) for level in toposort_.toposort(data)]
 
 

--- a/python_modules/dagster/dagster/core/utils.py
+++ b/python_modules/dagster/dagster/core/utils.py
@@ -49,6 +49,8 @@ def coerce_valid_log_level(log_level: Union[str, int]) -> int:
 
 
 def toposort(data):
+    # Workaround a bug in older versions of toposort that choke on frozenset
+    data = { k: set(v) if isinstance(v, frozenset) else v for k, v in data.items() }
     return [sorted(list(level)) for level in toposort_.toposort(data)]
 
 


### PR DESCRIPTION
### Summary & Motivation

A user ran into a problem with an older version of `toposort` choking on frozenset, this workaround ensures that toposort is never passed a frozenset.

### How I Tested These Changes

Manually:

```
$ pip install toposort==1.6
$ dagit -d examples/bollinger -m bollinger
# click materialize all -- it passes (fails on master)
```