### PR TITLE
[1/n] Subsetting Stack: use subset_selector for AssetGoup.build_job

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/asset_group.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_group.py
@@ -1,12 +1,12 @@
 import inspect
 import os
 import pkgutil
-import re
 import warnings
 from collections import defaultdict
 from importlib import import_module
 from types import ModuleType
 from typing import (
+    AbstractSet,
     Any,
     Dict,
     Generator,
@@ -16,6 +16,7 @@ from typing import (
     Optional,
     Sequence,
     Set,
+    Tuple,
     Union,
     cast,
 )
@@ -32,7 +33,6 @@ from dagster.utils.backcompat import ExperimentalWarning
 
 from ..definitions.executor_definition import ExecutorDefinition
 from ..definitions.job_definition import JobDefinition
-from ..definitions.op_definition import OpDefinition
 from ..definitions.partition import PartitionsDefinition
 from ..definitions.resource_definition import ResourceDefinition
 from ..errors import DagsterInvalidDefinitionError
@@ -201,12 +201,14 @@ class AssetGroup:
                 job_with_multiple_selections = the_asset_group.build_job(selection=["*some_asset", "other_asset++"])
         """
 
-        from dagster.core.selector.subset_selector import parse_op_selection
+        from dagster.core.selector.subset_selector import parse_asset_selection
 
         check.str_param(name, "name")
 
         if not isinstance(selection, str):
             selection = check.opt_list_param(selection, "selection", of_type=str)
+        else:
+            selection = [selection]
         executor_def = check.opt_inst_param(
             executor_def, "executor_def", ExecutorDefinition, self.executor_def
         )
@@ -216,34 +218,9 @@ class AssetGroup:
             **{"root_manager": build_root_manager(build_source_assets_by_key(self.source_assets))},
         }
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=ExperimentalWarning)
-            mega_job_def = build_assets_job(
-                name=name,
-                assets=self.assets,
-                source_assets=self.source_assets,
-                resource_defs=resource_defs,
-                executor_def=executor_def,
-            )
-
         if selection:
-            op_selection = self._parse_asset_selection(selection, job_name=name)
-            # We currently re-use the logic from op selection to parse the
-            # asset key selection, but this has disadvantages. Eventually we
-            # will want to decouple these implementations.
-            # https://github.com/dagster-io/dagster/issues/6647.
-            resolved_op_selection_dict = parse_op_selection(mega_job_def, op_selection)
-
-            included_assets = []
-            excluded_assets: List[Union[AssetsDefinition, SourceAsset]] = list(self.source_assets)
-
-            op_names = set(list(resolved_op_selection_dict.keys()))
-
-            for asset in self.assets:
-                if asset.op.name in op_names:
-                    included_assets.append(asset)
-                else:
-                    excluded_assets.append(asset)
+            selected_asset_keys = parse_asset_selection(self.assets, selection)
+            included_assets, excluded_assets = self._subset_assets_defs(selected_asset_keys)
         else:
             included_assets = cast(List[AssetsDefinition], self.assets)
             # Call to list(...) serves as a copy constructor, so that we don't
@@ -263,94 +240,33 @@ class AssetGroup:
             )
         return asset_job
 
-    def _parse_asset_selection(self, selection: Union[str, List[str]], job_name: str) -> List[str]:
-        """Convert selection over asset keys to selection over ops"""
-
-        asset_keys_to_ops: Dict[str, List[OpDefinition]] = {}
-        op_names_to_asset_keys: Dict[str, Set[str]] = {}
-        seen_asset_keys: Set[str] = set()
-
-        if isinstance(selection, str):
-            selection = [selection]
-
-        if len(selection) == 1 and selection[0] == "*":
-            return selection
-
-        source_asset_keys = set()
+    def _subset_assets_defs(
+        self, selected_asset_keys: AbstractSet[AssetKey]
+    ) -> Tuple[Sequence[AssetsDefinition], Sequence[AssetsDefinition]]:
+        """Given a list of asset key selection queries, generate a set of AssetsDefinition objects
+        representing the included/excluded definitions.
+        """
+        included_assets: Set[AssetsDefinition] = set()
+        excluded_assets: Set[AssetsDefinition] = set()
 
         for asset in self.assets:
-            if asset.op.name not in op_names_to_asset_keys:
-                op_names_to_asset_keys[asset.op.name] = set()
-            for asset_key in asset.asset_keys:
-                asset_key_as_str = ">".join([piece for piece in asset_key.path])
-                op_names_to_asset_keys[asset.op.name].add(asset_key_as_str)
-                if not asset_key_as_str in asset_keys_to_ops:
-                    asset_keys_to_ops[asset_key_as_str] = []
-                asset_keys_to_ops[asset_key_as_str].append(asset.op)
-
-        for asset in self.source_assets:
-            asset_key_as_str = ">".join([piece for piece in asset.key.path])
-            source_asset_keys.add(asset_key_as_str)
-
-        op_selection = []
-
-        for clause in selection:
-            token_matching = re.compile(r"^(\*?\+*)?([>.\w\d\[\]?_-]+)(\+*\*?)?$").search(
-                clause.strip()
-            )
-            parts = token_matching.groups() if token_matching is not None else None
-            if parts is None:
+            # intersection
+            selected_subset = selected_asset_keys & asset.asset_keys
+            # all assets in this def are selected
+            if selected_subset == asset.asset_keys:
+                included_assets.add(asset)
+            # no assets in this def are selected
+            elif len(selected_subset) == 0:
+                excluded_assets.add(asset)
+            else:
                 raise DagsterInvalidDefinitionError(
-                    f"When attempting to create job '{job_name}', the clause "
-                    f"{clause} within the asset key selection was invalid. Please "
-                    "review the selection syntax here: "
-                    "https://docs.dagster.io/concepts/ops-jobs-graphs/job-execution#op-selection-syntax."
+                    f"When building job, the AssetsDefinition '{asset.node_def.name}' "
+                    f"contains asset keys {sorted(list(asset.asset_keys))}, but "
+                    f"attempted to select only {sorted(list(selected_subset))}. "
+                    "This AssetsDefinition does not support subsetting. Please select all "
+                    "asset keys produced by this asset."
                 )
-            upstream_part, key_str, downstream_part = parts
-
-            # Error if you express a clause in terms of a source asset key.
-            # Eventually we will want to support selection over source asset
-            # keys as a means of running downstream ops.
-            # https://github.com/dagster-io/dagster/issues/6647
-            if key_str in source_asset_keys:
-                raise DagsterInvalidDefinitionError(
-                    f"When attempting to create job '{job_name}', the clause '"
-                    f"{clause}' selects asset_key '{key_str}', which comes from "
-                    "a source asset. Source assets can't be materialized, and "
-                    "therefore can't be subsetted into a job. Please choose a "
-                    "subset on asset keys that are materializable - that is, "
-                    f"included on assets within the group. Valid assets: {list(asset_keys_to_ops.keys())}"
-                )
-            if key_str not in asset_keys_to_ops:
-                raise DagsterInvalidDefinitionError(
-                    f"When attempting to create job '{job_name}', the clause "
-                    f"'{clause}' within the asset key selection did not match "
-                    f"any asset keys. Present asset keys: {list(asset_keys_to_ops.keys())}"
-                )
-
-            seen_asset_keys.add(key_str)
-
-            for op in asset_keys_to_ops[key_str]:
-
-                op_clause = f"{upstream_part}{op.name}{downstream_part}"
-                op_selection.append(op_clause)
-
-        # Verify that for each selected asset key, the corresponding op had all
-        # asset keys selected. Eventually, we will want to have specific syntax
-        # that allows for selecting all asset keys for a given multi-asset
-        # https://github.com/dagster-io/dagster/issues/6647.
-        for op_name, asset_key_set in op_names_to_asset_keys.items():
-            are_keys_in_set = [key in seen_asset_keys for key in asset_key_set]
-            if any(are_keys_in_set) and not all(are_keys_in_set):
-                raise DagsterInvalidDefinitionError(
-                    f"When building job '{job_name}', the asset '{op_name}' "
-                    f"contains asset keys {sorted(list(asset_key_set))}, but "
-                    f"attempted to select only {sorted(list(asset_key_set.intersection(seen_asset_keys)))}. "
-                    "Selecting only some of the asset keys for a particular "
-                    "asset is not yet supported behavior. Please select all "
-                    "asset keys produced by a given asset when subsetting."
-                )
-        return op_selection
+        return list(included_assets), list(excluded_assets)
 
     def to_source_assets(self) -> Sequence[SourceAsset]:
         """
@@ -744,7 +660,8 @@ def _validate_resource_reqs_for_asset_group(
         missing_resource_keys = list(set(resource_keys) - present_resource_keys)
         if missing_resource_keys:
             raise DagsterInvalidDefinitionError(
-                f"AssetGroup is missing required resource keys for asset '{asset_def.op.name}'. Missing resource keys: {missing_resource_keys}"
+                f"AssetGroup is missing required resource keys for asset '{asset_def.node_def.name}'. "
+                f"Missing resource keys: {missing_resource_keys}"
             )
 
         for output_name, asset_key in asset_def.asset_keys_by_output_name.items():

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -20,7 +20,7 @@ class AssetsDefinition:
         partitions_def: Optional[PartitionsDefinition] = None,
         partition_mappings: Optional[Mapping[AssetKey, PartitionMapping]] = None,
         asset_deps: Optional[Mapping[AssetKey, AbstractSet[AssetKey]]] = None,
-        # if adding new fields, make sure to handle them in the with_replaced_asset_keys method
+        # if adding new fields, make sure to handle them in both with_replaced_asset_keys
     ):
         self._node_def = node_def
         self._asset_keys_by_input_name = check.dict_param(
@@ -190,6 +190,16 @@ class AssetsDefinition:
                 node_def=self.node_def,
                 partitions_def=self.partitions_def,
                 partition_mappings=self._partition_mappings,
+                asset_deps={
+                    output_asset_key_replacements.get(key, key): {
+                        input_asset_key_replacements.get(
+                            upstream_key,
+                            output_asset_key_replacements.get(upstream_key, upstream_key),
+                        )
+                        for upstream_key in value
+                    }
+                    for key, value in self.asset_deps.items()
+                },
             )
 
     def to_source_assets(self) -> Sequence[SourceAsset]:

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -121,6 +121,16 @@ class AssetKey(NamedTuple("_AssetKey", [("path", List[str])])):
             return ASSET_KEY_STRUCTURED_DELIMITER.join(self.path)
         return seven.json.dumps(self.path)
 
+    def to_user_string(self) -> str:
+        """
+        E.g. "first_component>second_component"
+        """
+        return ">".join(self.path)
+
+    @staticmethod
+    def from_user_string(asset_key_string: str) -> "AssetKey":
+        return AssetKey(asset_key_string.split(">"))
+
     @staticmethod
     def from_db_string(asset_key_string: Optional[str]) -> Optional["AssetKey"]:
         if not asset_key_string:


### PR DESCRIPTION
### Summary & Motivation

Part 1 of a stack designed to allow ops that produce multiple assets to have their computation
sliced to produce subsets of the original set of assets.

This diff is focused purely on translating an asset selection into a set of assets definitions
in a more granular way than the existing short-term solution does. Prior to this diff, we
attempted to translate an asset selection string into an op selection string. In this diff,
we use the full-fidelity asset dependency graph to translate these selection strings.


### How I Tested These Changes

This diff is designed not to have many user-facing changes, but in the course of running existing
unit tests against this diff, I noticed that some of the tests didn't map to my expectations.

As an example, the existing test_up_start job in test_asset_group_build_subset_job() specifies
the selection "*follows_o2". If we're purely in asset-land, this selection corresponds to the
assets: [follows_o2, o2, start_asset]. o2 is produced in the same computation as o1 (middle_asset),
but is not part of this selection, so this is actually not a valid selection if middle_asset
cannot be subset.

I replaced this test with a (potentially over-complicated but more thorough) test that goes
through a bunch of different selctions with a mix of normal and multi assets, and verifies the
base selection, output values, and planned asset materializations.
