### PR TITLE
[2/n] Subsetting Stack: AssetsDefinition subsetting!

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/asset_group.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_group.py
@@ -258,6 +258,12 @@ class AssetGroup:
             # no assets in this def are selected
             elif len(selected_subset) == 0:
                 excluded_assets.add(asset)
+            elif asset.can_subset:
+                # subset of the asset that we want
+                subset_asset = asset.subset_for(selected_asset_keys)
+                included_assets.add(subset_asset)
+                # subset of the asset that we don't want
+                excluded_assets.add(asset.subset_for(asset.asset_keys - subset_asset.asset_keys))
             else:
                 raise DagsterInvalidDefinitionError(
                     f"When building job, the AssetsDefinition '{asset.node_def.name}' "

--- a/python_modules/dagster/dagster/core/asset_defs/assets_job.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets_job.py
@@ -294,7 +294,9 @@ def build_root_manager(
         @root_input_manager(required_resource_keys=source_asset_io_manager_keys)
         def _root_manager(input_context: InputContext) -> Any:
             source_asset_key = cast(AssetKey, input_context.asset_key)
-            source_asset = source_assets_by_key[source_asset_key]
+            source_asset = source_assets_by_key.get(source_asset_key)
+            if not source_asset:
+                return None
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=ExperimentalWarning)
 

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -245,43 +245,49 @@ def multi_asset(
     partitions_def: Optional[PartitionsDefinition] = None,
     partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
     op_tags: Optional[Dict[str, Any]] = None,
+    can_subset: bool = False,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a combined definition of multiple assets that are computed using the same op and same
-    upstream assets.
+        upstream assets.
 
-    Each argument to the decorated function references an upstream asset that this asset depends on.
-    The name of the argument designates the name of the upstream asset.
+        Each argument to the decorated function references an upstream asset that this asset depends on.
+        The name of the argument designates the name of the upstream asset.
 
-    Args:
-        name (Optional[str]): The name of the op.
-        outs: (Optional[Dict[str, Out]]): The Outs representing the produced assets.
-        ins (Optional[Mapping[str, AssetIn]]): A dictionary that maps input names to their metadata
-            and namespaces.
-        non_argument_deps (Optional[Set[AssetKey]]): Set of asset keys that are upstream dependencies,
-            but do not pass an input to the multi_asset.
-        required_resource_keys (Optional[Set[str]]): Set of resource handles required by the op.
-        io_manager_key (Optional[str]): The resource key of the IOManager used for storing the
-            output of the op as an asset, and for loading it in downstream ops
-            (default: "io_manager").
-        compute_kind (Optional[str]): A string to represent the kind of computation that produces
-            the asset, e.g. "dbt" or "spark". It will be displayed in Dagit as a badge on the asset.
-        internal_asset_deps (Optional[Mapping[str, Set[AssetKey]]]): By default, it is assumed
-            that all assets produced by a multi_asset depend on all assets that are consumed by that
-            multi asset. If this default is not correct, you pass in a map of output names to a
-            corrected set of AssetKeys that they depend on. Any AssetKeys in this list must be either
-            used as input to the asset or produced within the op.
-        partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
-            compose the assets.
-        partition_mappings (Optional[Mapping[str, PartitionMapping]]): Defines how to map partition
-            keys for this asset to partition keys of upstream assets. Each key in the dictionary
-            correponds to one of the input assets, and each value is a PartitionMapping.
-            If no entry is provided for a particular asset dependency, the partition mapping defaults
-            to the default partition mapping for the partitions definition, which is typically maps
-            partition keys to the same partition keys in upstream assets.
-        op_tags (Optional[Dict[str, Any]]): A dictionary of tags for the op that computes the asset.
-            Frameworks may expect and require certain metadata to be attached to a op. Values that
-            are not strings will be json encoded and must meet the criteria that
-            `json.loads(json.dumps(value)) == value`.
+        Args:
+            name (Optional[str]): The name of the op.
+            outs: (Optional[Dict[str, Out]]): The Outs representing the produced assets.
+            ins (Optional[Mapping[str, AssetIn]]): A dictionary that maps input names to their metadata
+                and namespaces.
+            non_argument_deps (Optional[Set[AssetKey]]): Set of asset keys that are upstream dependencies,
+                but do not pass an input to the multi_asset.
+            required_resource_keys (Optional[Set[str]]): Set of resource handles required by the op.
+            io_manager_key (Optional[str]): The resource key of the IOManager used for storing the
+                output of the op as an asset, and for loading it in downstream ops
+                (default: "io_manager").
+            compute_kind (Optional[str]): A string to represent the kind of computation that produces
+                the asset, e.g. "dbt" or "spark". It will be displayed in Dagit as a badge on the asset.
+            internal_asset_deps (Optional[Mapping[str, Set[AssetKey]]]): By default, it is assumed
+                that all assets produced by a multi_asset depend on all assets that are consumed by that
+                multi asset. If this default is not correct, you pass in a map of output names to a
+                corrected set of AssetKeys that they depend on. Any AssetKeys in this list must be either
+                used as input to the asset or produced within the op.
+    <<<<<<< HEAD
+            partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
+                compose the assets.
+            partition_mappings (Optional[Mapping[str, PartitionMapping]]): Defines how to map partition
+                keys for this asset to partition keys of upstream assets. Each key in the dictionary
+                correponds to one of the input assets, and each value is a PartitionMapping.
+                If no entry is provided for a particular asset dependency, the partition mapping defaults
+                to the default partition mapping for the partitions definition, which is typically maps
+                partition keys to the same partition keys in upstream assets.
+            op_tags (Optional[Dict[str, Any]]): A dictionary of tags for the op that computes the asset.
+                Frameworks may expect and require certain metadata to be attached to a op. Values that
+                are not strings will be json encoded and must meet the criteria that
+                `json.loads(json.dumps(value)) == value`.
+    =======
+            can_subset (bool): If this asset's computation can emit a subset of the asset
+                keys based on the context.selected_assets argument. Defaults to False.
+    >>>>>>> [2/n] Subsetting Stack: AssetsDefinition subsetting!
     """
 
     check.invariant(
@@ -354,6 +360,7 @@ def multi_asset(
             }
             if partition_mappings
             else None,
+            can_subset=can_subset,
         )
 
     return inner

--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -1,9 +1,10 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterator, List, Mapping, Optional, cast
+from typing import AbstractSet, Any, Dict, Iterator, List, Mapping, Optional, cast
 
 import dagster._check as check
 from dagster.core.definitions.dependency import Node, NodeHandle
 from dagster.core.definitions.events import (
+    AssetKey,
     AssetMaterialization,
     AssetObservation,
     ExpectationResult,
@@ -293,6 +294,22 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
         definition is not a TimeWindowPartitionsDefinition.
         """
         return self._step_execution_context.partition_time_window
+
+    def selected_asset_keys(self) -> AbstractSet[AssetKey]:
+        return self.job_def.asset_layer.asset_keys_for_node(self.solid_handle)
+
+    @property
+    def selected_output_names(self) -> AbstractSet[str]:
+        # map selected asset keys to the output names they correspond to
+        selected_asset_keys = self.selected_asset_keys
+        selected_outputs = set()
+        for output_name in self.op.output_dict.keys():
+            asset_info = self.job_def.asset_layer.asset_info_for_output(
+                self.solid_handle, output_name
+            )
+            if asset_info and asset_info.key in selected_asset_keys:
+                selected_outputs.add(output_name)
+        return selected_outputs
 
     def output_asset_partition_key(self, output_name: str = "result") -> str:
         """Returns the asset partition key for the given output. Defaults to "result", which is the

--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -295,6 +295,7 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
         """
         return self._step_execution_context.partition_time_window
 
+    @property
     def selected_asset_keys(self) -> AbstractSet[AssetKey]:
         return self.job_def.asset_layer.asset_keys_for_node(self.solid_handle)
 

--- a/python_modules/dagster/dagster/core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute.py
@@ -62,7 +62,7 @@ def create_step_outputs(
                     is_dynamic=output_def.is_dynamic,
                     is_asset=asset_info is not None,
                     should_materialize=output_def.name in config_output_names,
-                    asset_key=asset_info.key if asset_info else None,
+                    asset_key=asset_info.key if asset_info and asset_info.is_required else None,
                 ),
             )
         )

--- a/python_modules/dagster/dagster/core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_step.py
@@ -443,6 +443,8 @@ def _asset_key_and_partitions_for_output(
                 "means that you should use an IOManager that does not specify an AssetKey in its "
                 "get_output_asset_key() function for this output."
             )
+        if not output_asset_info.is_required:
+            output_context.log.warn(f"Materializing unexpected asset key: {output_asset_info.key}.")
         return (
             output_asset_info.key,
             output_asset_info.partitions_fn(output_context) or set(),

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
@@ -1,4 +1,7 @@
+import pytest
+
 from dagster import AssetKey, Out, Output
+from dagster.check import CheckError
 from dagster.core.asset_defs import AssetIn, SourceAsset, asset, multi_asset
 
 
@@ -28,6 +31,127 @@ def test_with_replaced_asset_keys():
     assert replaced.asset_keys_by_input_name["input2"] == AssetKey(["apple", "banana"])
 
     assert replaced.asset_keys_by_output_name["result"] == AssetKey(["prefix1", "asset1_changed"])
+
+
+@pytest.mark.parametrize(
+    "subset,expected_keys,expected_inputs,expected_outputs",
+    [
+        ("foo,bar,baz,in1,in2,in3,a,b,c,foo2,bar2,baz2", "a,b,c", 3, 3),
+        ("foo,bar,baz", None, 0, 0),
+        ("in1,a,b,c", "a,b,c", 3, 3),
+        ("foo,in1,a,b,c,bar", "a,b,c", 3, 3),
+        ("foo,in1,in2,in3,a,bar", "a", 2, 1),
+        ("foo,in1,in2,a,b,bar", "a,b", 2, 2),
+        ("in1,in2,in3,b", "b", 0, 1),
+    ],
+)
+def test_subset_for(subset, expected_keys, expected_inputs, expected_outputs):
+    @multi_asset(
+        outs={"a": Out(), "b": Out(), "c": Out()},
+        internal_asset_deps={
+            "a": {AssetKey("in1"), AssetKey("in2")},
+            "b": set(),
+            "c": {AssetKey("a"), AssetKey("b"), AssetKey("in2"), AssetKey("in3")},
+        },
+        can_subset=True,
+    )
+    def abc_(context, in1, in2, in3):  # pylint: disable=unused-argument
+        pass
+
+    subbed = abc_.subset_for({AssetKey(key) for key in subset.split(",")})
+
+    assert subbed.asset_keys == (
+        {AssetKey(key) for key in expected_keys.split(",")} if expected_keys else set()
+    )
+
+    assert len(subbed.asset_keys_by_input_name) == expected_inputs
+    assert len(subbed.asset_keys_by_output_name) == expected_outputs
+
+    # the asset dependency structure should stay the same
+    assert subbed.asset_deps == abc_.asset_deps
+
+
+def test_chain_replace_and_subset_for():
+    @multi_asset(
+        outs={"a": Out(), "b": Out(), "c": Out()},
+        internal_asset_deps={
+            "a": {AssetKey("in1"), AssetKey("in2")},
+            "b": set(),
+            "c": {AssetKey("a"), AssetKey("b"), AssetKey("in2"), AssetKey("in3")},
+        },
+        can_subset=True,
+    )
+    def abc_(context, in1, in2, in3):  # pylint: disable=unused-argument
+        pass
+
+    replaced_1 = abc_.with_replaced_asset_keys(
+        output_asset_key_replacements={AssetKey(["a"]): AssetKey(["foo", "foo_a"])},
+        input_asset_key_replacements={AssetKey(["in1"]): AssetKey(["foo", "bar_in1"])},
+    )
+
+    assert replaced_1.asset_keys == {AssetKey(["foo", "foo_a"]), AssetKey("b"), AssetKey("c")}
+    assert replaced_1.asset_deps == {
+        AssetKey(["foo", "foo_a"]): {AssetKey(["foo", "bar_in1"]), AssetKey("in2")},
+        AssetKey("b"): set(),
+        AssetKey("c"): {
+            AssetKey(["foo", "foo_a"]),
+            AssetKey("b"),
+            AssetKey("in2"),
+            AssetKey("in3"),
+        },
+    }
+
+    subbed_1 = replaced_1.subset_for(
+        {AssetKey(["foo", "bar_in1"]), AssetKey("in3"), AssetKey(["foo", "foo_a"]), AssetKey("b")}
+    )
+    assert subbed_1.asset_keys == {AssetKey(["foo", "foo_a"]), AssetKey("b")}
+
+    replaced_2 = subbed_1.with_replaced_asset_keys(
+        output_asset_key_replacements={
+            AssetKey(["foo", "foo_a"]): AssetKey(["again", "foo", "foo_a"]),
+            AssetKey(["b"]): AssetKey(["something", "bar_b"]),
+        },
+        input_asset_key_replacements={
+            AssetKey(["foo", "bar_in1"]): AssetKey(["again", "foo", "bar_in1"]),
+            AssetKey(["in2"]): AssetKey(["foo", "in2"]),
+            AssetKey(["in3"]): AssetKey(["foo", "in3"]),
+        },
+    )
+    assert replaced_2.asset_keys == {
+        AssetKey(["again", "foo", "foo_a"]),
+        AssetKey(["something", "bar_b"]),
+    }
+    assert replaced_2.asset_deps == {
+        AssetKey(["again", "foo", "foo_a"]): {
+            AssetKey(["again", "foo", "bar_in1"]),
+            AssetKey(["foo", "in2"]),
+        },
+        AssetKey(["something", "bar_b"]): set(),
+        AssetKey("c"): {
+            AssetKey(["again", "foo", "foo_a"]),
+            AssetKey(["something", "bar_b"]),
+            AssetKey(["foo", "in2"]),
+            AssetKey(["foo", "in3"]),
+        },
+    }
+
+    subbed_2 = replaced_2.subset_for(
+        {
+            AssetKey(["again", "foo", "bar_in1"]),
+            AssetKey(["again", "foo", "foo_a"]),
+            AssetKey(["c"]),
+        }
+    )
+    assert subbed_2.asset_keys == {AssetKey(["again", "foo", "foo_a"])}
+
+
+def test_fail_on_subset_for_nonsubsettable():
+    @multi_asset(outs={"a": Out(), "b": Out(), "c": Out()})
+    def abc_(context, start):  # pylint: disable=unused-argument
+        pass
+
+    with pytest.raises(CheckError, match="can_subset=False"):
+        abc_.subset_for({AssetKey("start"), AssetKey("a")})
 
 
 def test_to_source_assets():

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dagster import AssetKey, Out, Output
-from dagster.check import CheckError
+from dagster._check import CheckError
 from dagster.core.asset_defs import AssetIn, SourceAsset, asset, multi_asset
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -665,7 +665,7 @@ def test_asset_def_from_graph_inputs():
 
     @graph(ins={"x": GraphIn(), "y": GraphIn()})
     def my_graph(x, y):
-        my_op(x, y)
+        return my_op(x, y)
 
     assets_def = AssetsDefinition.from_graph(
         graph_def=my_graph,

--- a/python_modules/dagster/dagster_tests/core_tests/test_asset_events.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_asset_events.py
@@ -53,13 +53,10 @@ def test_non_assets_job_no_register_event():
         my_op()
 
     with instance_for_test() as instance:
-        result = my_job.execute_in_process(instance=instance)
-        events = result.all_events
-        intent_to_materialize_events = [
-            event
-            for event in events
-            if event.event_type == DagsterEventType.ASSET_MATERIALIZATION_PLANNED
-        ]
+        my_job.execute_in_process(instance=instance)
+        intent_to_materialize_events = instance.get_event_records(
+            EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION_PLANNED)
+        )
 
         assert intent_to_materialize_events == []
 


### PR DESCRIPTION
### Summary & Motivation

Here, we make it possible to create AssetsDefinition objects which can optionally produce
a subset of their available assets.

There are two parts of this, the definition-time subsetting (making a Definition that
declares that it will produce a subset of the original assets), and the runtime subsetting
(when you're actually running this op, how do you inform it that it should do something
different than usual.

One edge case that I wante to make sure to handle was the case where you had an AssetsDefinition
that was capable of producing [A, B, C], but subsetted it to declare that it would only produce
[A]. If you ran this, and actually did yield and output for [B, C] as well as the declared [A],
we should still produce AssetMaterialization events for these outputs (because they did indeed
get materialized, even if we didn't expect it).

To handle this, when we're building the job from our AssetsDefinitions, we keep track of the
mapping from output to asset key for ALL outputs in the underlying NodeDefinition, even if the
corresponding key has been subsetted out.


### How I Tested These Changes

Unit tests!
