### PR TITLE
pin xmltodict to fix aws test failures, until moto 3.1.9

### DIFF
--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
         extras_require={
             "redshift": ["psycopg2-binary"],
             "pyspark": ["dagster-pyspark"],
-            "test": ["moto>=2.2.8", "requests-mock"],
+            "test": ["moto>=2.2.8", "requests-mock", "xmltodict==0.12.0"],
         },
         zip_safe=False,
     )

--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -42,7 +42,11 @@ if __name__ == "__main__":
         extras_require={
             "redshift": ["psycopg2-binary"],
             "pyspark": ["dagster-pyspark"],
-            "test": ["moto>=2.2.8", "requests-mock", "xmltodict==0.12.0"],
+            "test": [
+                "moto>=2.2.8",
+                "requests-mock",
+                "xmltodict==0.12.0",  # pinned until moto>=3.1.9 (https://github.com/spulec/moto/issues/5112)
+            ],
         },
         zip_safe=False,
     )


### PR DESCRIPTION
### Summary & Motivation
`xmltodict` pushed `0.13.0`, which changed the type from ordereddict to regular dict.

See https://github.com/spulec/moto/issues/5112

We should temporarily pin until `moto` releases `3.1.9`

### How I Tested These Changes
tox
