### PR TITLE
Change the fake repo that simulates an import error while loading dagster code

### DIFF
--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/grpc_repo_with_error.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/grpc_repo_with_error.py
@@ -1,1 +1,4 @@
-from made_up_module import made_up_function  # pylint:disable=import-error,unused-import
+from dagster import ScheduleDefinition
+
+# Definition that will fire an error when it is imported
+ScheduleDefinition(cron_schedule="* * * * * * * * * *", pipeline_name="foo")

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -284,7 +284,7 @@ def test_load_with_error(capfd):
         process.wait()
 
         _, err = capfd.readouterr()
-        assert "No module named" in err
+        assert "Dagster recognizes standard cron expressions" in err
     finally:
         if process.poll() is None:
             process.terminate()
@@ -469,7 +469,7 @@ def test_lazy_load_with_error():
             DagsterGrpcClient(port=port).list_repositories()
         )
         assert isinstance(list_repositories_response, SerializableErrorInfo)
-        assert "No module named" in list_repositories_response.message
+        assert "Dagster recognizes standard cron expressions" in list_repositories_response.message
     finally:
         process.terminate()
 
@@ -502,7 +502,9 @@ def test_lazy_load_via_env_var():
                 DagsterGrpcClient(port=port).list_repositories()
             )
             assert isinstance(list_repositories_response, SerializableErrorInfo)
-            assert "No module named" in list_repositories_response.message
+            assert (
+                "Dagster recognizes standard cron expressions" in list_repositories_response.message
+            )
         finally:
             process.terminate()
 


### PR DESCRIPTION
Summary:
Something about importing a made up module seems to cause transient segfaults. Let's try a simpler failure that just raises a Dagster exception instead.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
