### PR TITLE
filter all views for repo tags

### DIFF
--- a/js_modules/dagit/packages/core/src/pipelines/PipelineRunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineRunsRoot.tsx
@@ -19,6 +19,7 @@ import {
 } from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {RunTable, RUN_TABLE_RUN_FRAGMENT} from '../runs/RunTable';
+import {DagsterTag} from '../runs/RunTag';
 import {RunsQueryRefetchContext} from '../runs/RunUtils';
 import {
   RunFilterTokenType,
@@ -65,7 +66,11 @@ export const PipelineRunsRoot: React.FC<Props> = (props) => {
     ].filter(Boolean) as TokenizingFieldValue[];
   }, [isJob, pipelineName, snapshotId]);
 
-  const allTokens = [...filterTokens, ...permanentTokens];
+  const repoToken = {
+    token: 'tag',
+    value: `${DagsterTag.RepositoryLabelTag}=${repoAddress?.name}@${repoAddress?.location}`,
+  };
+  const allTokens = [...filterTokens, ...permanentTokens, repoToken];
 
   const {queryResult, paginationProps} = useCursorPaginatedQuery<
     PipelineRunsRootQuery,

--- a/js_modules/dagit/packages/core/src/runs/RunTag.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTag.tsx
@@ -15,6 +15,7 @@ export enum DagsterTag {
   RootRunId = 'dagster/root_run_id',
   ScheduleName = 'dagster/schedule_name',
   SensorName = 'dagster/sensor_name',
+  RepositoryLabelTag = '.dagster/repository',
 }
 
 export type TagType = {

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -7,7 +7,13 @@ from dagster._core.host_representation import (
     RepositorySelector,
 )
 from dagster._core.storage.pipeline_run import RunsFilter
-from dagster._core.storage.tags import PARTITION_NAME_TAG, PARTITION_SET_TAG, TagType, get_tag_type
+from dagster._core.storage.tags import (
+    PARTITION_NAME_TAG,
+    PARTITION_SET_TAG,
+    REPOSITORY_LABEL_TAG,
+    TagType,
+    get_tag_type,
+)
 from dagster._utils.yaml_utils import dump_run_config_yaml
 
 from .utils import capture_error
@@ -179,6 +185,7 @@ def get_partition_set_partition_statuses(
     run_partition_data = graphene_info.context.instance.run_storage.get_run_partition_data(
         runs_filter=RunsFilter(
             pipeline_name=job_name,
+            tags={REPOSITORY_LABEL_TAG: repository_handle.get_external_origin().get_label()},
         )
     )
     names_result = graphene_info.context.get_external_partition_names(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -15,7 +15,7 @@ from dagster._core.host_representation.external_data import (
 )
 from dagster._core.scheduler.instigation import InstigatorType
 from dagster._core.storage.pipeline_run import JobBucket, RunRecord, RunsFilter, TagBucket
-from dagster._core.storage.tags import SCHEDULE_NAME_TAG, SENSOR_NAME_TAG
+from dagster._core.storage.tags import REPOSITORY_LABEL_TAG, SCHEDULE_NAME_TAG, SENSOR_NAME_TAG
 from dagster._core.workspace.context import WorkspaceRequestContext
 
 
@@ -69,6 +69,11 @@ class RepositoryScopedBatchLoader:
             job_names = [x.name for x in self._repository.get_all_external_pipelines()]
             if self._instance.supports_bucket_queries:
                 records = self._instance.get_run_records(
+                    filters=RunsFilter(
+                        tags={
+                            REPOSITORY_LABEL_TAG: self._repository.get_external_origin().get_label(),
+                        },
+                    ),
                     bucket_by=JobBucket(bucket_limit=limit, job_names=job_names),
                 )
             else:
@@ -77,7 +82,13 @@ class RepositoryScopedBatchLoader:
                     records.extend(
                         list(
                             self._instance.get_run_records(
-                                filters=RunsFilter(pipeline_name=job_name), limit=limit
+                                filters=RunsFilter(
+                                    pipeline_name=job_name,
+                                    tags={
+                                        REPOSITORY_LABEL_TAG: self._repository.get_external_origin().get_label(),
+                                    },
+                                ),
+                                limit=limit,
                             )
                         )
                     )
@@ -90,6 +101,11 @@ class RepositoryScopedBatchLoader:
             ]
             if self._instance.supports_bucket_queries:
                 records = self._instance.get_run_records(
+                    filters=RunsFilter(
+                        tags={
+                            REPOSITORY_LABEL_TAG: self._repository.get_external_origin().get_label(),
+                        }
+                    ),
                     bucket_by=TagBucket(
                         tag_key=SCHEDULE_NAME_TAG,
                         bucket_limit=limit,
@@ -102,7 +118,12 @@ class RepositoryScopedBatchLoader:
                     records.extend(
                         list(
                             self._instance.get_run_records(
-                                filters=RunsFilter(tags={SCHEDULE_NAME_TAG: schedule_name}),
+                                filters=RunsFilter(
+                                    tags={
+                                        SCHEDULE_NAME_TAG: schedule_name,
+                                        REPOSITORY_LABEL_TAG: self._repository.get_external_origin().get_label(),
+                                    }
+                                ),
                                 limit=limit,
                             )
                         )
@@ -114,6 +135,11 @@ class RepositoryScopedBatchLoader:
             sensor_names = [sensor.name for sensor in self._repository.get_external_sensors()]
             if self._instance.supports_bucket_queries:
                 records = self._instance.get_run_records(
+                    filters=RunsFilter(
+                        tags={
+                            REPOSITORY_LABEL_TAG: self._repository.get_external_origin().get_label(),
+                        }
+                    ),
                     bucket_by=TagBucket(
                         tag_key=SENSOR_NAME_TAG,
                         bucket_limit=limit,
@@ -126,7 +152,12 @@ class RepositoryScopedBatchLoader:
                     records.extend(
                         list(
                             self._instance.get_run_records(
-                                filters=RunsFilter(tags={SENSOR_NAME_TAG: sensor_name}),
+                                filters=RunsFilter(
+                                    tags={
+                                        SENSOR_NAME_TAG: sensor_name,
+                                        REPOSITORY_LABEL_TAG: self._repository.get_external_origin().get_label(),
+                                    }
+                                ),
                                 limit=limit,
                             )
                         )


### PR DESCRIPTION
### Summary & Motivation
For runs that are loaded off of a repository object (job, schedule, sensor), we should apply the (new) repository label tag.

### How I Tested These Changes
BK, loaded historic runs.
