### PR TITLE
Allow passing posargs to tox commands

### DIFF
--- a/examples/airflow_ingest/tox.ini
+++ b/examples/airflow_ingest/tox.ini
@@ -23,4 +23,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/airflow_ingest/tox.ini
+++ b/examples/airflow_ingest/tox.ini
@@ -19,7 +19,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml airflow_ingest
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} airflow_ingest
 
 [testenv:mypy]
 commands =

--- a/examples/basic_pyspark/tox.ini
+++ b/examples/basic_pyspark/tox.ini
@@ -24,4 +24,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/basic_pyspark/tox.ini
+++ b/examples/basic_pyspark/tox.ini
@@ -20,7 +20,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml .
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} .
 
 [testenv:mypy]
 commands =

--- a/examples/bollinger/tox.ini
+++ b/examples/bollinger/tox.ini
@@ -22,4 +22,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/bollinger/tox.ini
+++ b/examples/bollinger/tox.ini
@@ -18,7 +18,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml bollinger bollinger_tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} bollinger bollinger_tests
 
 [testenv:mypy]
 commands =

--- a/examples/dbt_example/tox.ini
+++ b/examples/dbt_example/tox.ini
@@ -26,7 +26,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml dbt_example dbt_example_tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} dbt_example dbt_example_tests
 
 [testenv:mypy]
 commands =

--- a/examples/dbt_example/tox.ini
+++ b/examples/dbt_example/tox.ini
@@ -30,4 +30,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/deploy_docker/tox.ini
+++ b/examples/deploy_docker/tox.ini
@@ -22,4 +22,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/deploy_docker/tox.ini
+++ b/examples/deploy_docker/tox.ini
@@ -18,7 +18,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml .
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} .
 
 [testenv:mypy]
 commands =

--- a/examples/deploy_ecs/tox.ini
+++ b/examples/deploy_ecs/tox.ini
@@ -23,4 +23,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/deploy_ecs/tox.ini
+++ b/examples/deploy_ecs/tox.ini
@@ -19,7 +19,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml .
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} .
 
 [testenv:mypy]
 commands =

--- a/examples/deploy_k8s/tox.ini
+++ b/examples/deploy_k8s/tox.ini
@@ -27,4 +27,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/deploy_k8s/tox.ini
+++ b/examples/deploy_k8s/tox.ini
@@ -23,7 +23,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml example_project tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} example_project tests
 
 [testenv:mypy]
 commands =

--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -32,7 +32,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml docs_snippets docs_snippets_tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} docs_snippets docs_snippets_tests
 
 [testenv:mypy]
 commands =

--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -36,4 +36,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/emr_pyspark/tox.ini
+++ b/examples/emr_pyspark/tox.ini
@@ -25,4 +25,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/emr_pyspark/tox.ini
+++ b/examples/emr_pyspark/tox.ini
@@ -21,7 +21,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml .
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} .
 
 [testenv:mypy]
 commands =

--- a/examples/ge_example/tox.ini
+++ b/examples/ge_example/tox.ini
@@ -23,7 +23,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml ge_example ge_example_tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} ge_example ge_example_tests
 
 [testenv:mypy]
 commands =

--- a/examples/ge_example/tox.ini
+++ b/examples/ge_example/tox.ini
@@ -27,4 +27,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/hacker_news/tox.ini
+++ b/examples/hacker_news/tox.ini
@@ -27,7 +27,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml hacker_news hacker_news_tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} hacker_news hacker_news_tests
 
 [testenv:mypy]
 commands =

--- a/examples/hacker_news/tox.ini
+++ b/examples/hacker_news/tox.ini
@@ -31,4 +31,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/hacker_news_assets/tox.ini
+++ b/examples/hacker_news_assets/tox.ini
@@ -26,7 +26,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml hacker_news_assets hacker_news_assets_tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} hacker_news_assets hacker_news_assets_tests
 
 [testenv:mypy]
 commands =

--- a/examples/hacker_news_assets/tox.ini
+++ b/examples/hacker_news_assets/tox.ini
@@ -30,4 +30,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/memoized_development/tox.ini
+++ b/examples/memoized_development/tox.ini
@@ -25,4 +25,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/memoized_development/tox.ini
+++ b/examples/memoized_development/tox.ini
@@ -21,7 +21,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml memoized_development tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} memoized_development tests
 
 [testenv:mypy]
 commands =

--- a/examples/modern_data_stack_assets/tox.ini
+++ b/examples/modern_data_stack_assets/tox.ini
@@ -23,7 +23,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml modern_data_stack_assets modern_data_stack_assets_tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} modern_data_stack_assets modern_data_stack_assets_tests
 
 [testenv:mypy]
 commands =

--- a/examples/modern_data_stack_assets/tox.ini
+++ b/examples/modern_data_stack_assets/tox.ini
@@ -27,4 +27,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/nyt-feed/tox.ini
+++ b/examples/nyt-feed/tox.ini
@@ -19,7 +19,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml nyt_feed nyt_feed_tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} nyt_feed nyt_feed_tests
 
 [testenv:mypy]
 commands =

--- a/examples/nyt-feed/tox.ini
+++ b/examples/nyt-feed/tox.ini
@@ -23,4 +23,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/run_attribution_example/tox.ini
+++ b/examples/run_attribution_example/tox.ini
@@ -25,4 +25,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/run_attribution_example/tox.ini
+++ b/examples/run_attribution_example/tox.ini
@@ -21,7 +21,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml run_attribution_example run_attribution_example_tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} run_attribution_example run_attribution_example_tests
 
 [testenv:mypy]
 commands =

--- a/examples/software_defined_assets/tox.ini
+++ b/examples/software_defined_assets/tox.ini
@@ -25,4 +25,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/software_defined_assets/tox.ini
+++ b/examples/software_defined_assets/tox.ini
@@ -21,7 +21,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml software_defined_assets software_defined_assets_tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} software_defined_assets software_defined_assets_tests
 
 [testenv:mypy]
 commands =

--- a/examples/user_in_loop/tox.ini
+++ b/examples/user_in_loop/tox.ini
@@ -23,4 +23,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/examples/user_in_loop/tox.ini
+++ b/examples/user_in_loop/tox.ini
@@ -19,7 +19,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml user_in_loop tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} user_in_loop tests
 
 [testenv:mypy]
 commands =

--- a/helm/dagster/schema/tox.ini
+++ b/helm/dagster/schema/tox.ini
@@ -26,4 +26,4 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml schema_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} schema_tests

--- a/integration_tests/python_modules/dagster-k8s-test-infra/tox.ini
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/tox.ini
@@ -32,4 +32,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/integration_tests/test_suites/backcompat-test-suite/tox.ini
+++ b/integration_tests/test_suites/backcompat-test-suite/tox.ini
@@ -26,7 +26,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagit_service/repo.py tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagit_service/repo.py tests
 
 [testenv:mypy]
 commands =

--- a/integration_tests/test_suites/backcompat-test-suite/tox.ini
+++ b/integration_tests/test_suites/backcompat-test-suite/tox.ini
@@ -30,4 +30,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/integration_tests/test_suites/celery-k8s-integration-test-suite/tox.ini
+++ b/integration_tests/test_suites/celery-k8s-integration-test-suite/tox.ini
@@ -39,7 +39,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml conftest marks tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} conftest marks tests
 
 [testenv:mypy]
 commands =

--- a/integration_tests/test_suites/celery-k8s-integration-test-suite/tox.ini
+++ b/integration_tests/test_suites/celery-k8s-integration-test-suite/tox.ini
@@ -43,4 +43,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/integration_tests/test_suites/daemon-test-suite/tox.ini
+++ b/integration_tests/test_suites/daemon-test-suite/tox.ini
@@ -35,4 +35,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/integration_tests/test_suites/daemon-test-suite/tox.ini
+++ b/integration_tests/test_suites/daemon-test-suite/tox.ini
@@ -31,7 +31,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml conftest repo utils monitoring_daemon_tests test_daemon.py test_memory.py test_queued.py
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} conftest repo utils monitoring_daemon_tests test_daemon.py test_memory.py test_queued.py
 
 [testenv:mypy]
 commands =

--- a/integration_tests/test_suites/k8s-integration-test-suite/tox.ini
+++ b/integration_tests/test_suites/k8s-integration-test-suite/tox.ini
@@ -37,7 +37,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml conftest tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} conftest tests
 
 [testenv:mypy]
 commands =

--- a/integration_tests/test_suites/k8s-integration-test-suite/tox.ini
+++ b/integration_tests/test_suites/k8s-integration-test-suite/tox.ini
@@ -41,4 +41,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/automation/automation/scaffold/assets/dagster-example-tmpl/tox.ini.tmpl
+++ b/python_modules/automation/automation/scaffold/assets/dagster-example-tmpl/tox.ini.tmpl
@@ -18,4 +18,8 @@ commands =
 
 [testenv:pylint]
 commands =
-  /bin/bash -c 'cd .. && pylint -j0 --rcfile=../pyproject.toml {{EXAMPLE_NAME}}/'
+  pylint -j0 --rcfile=../pyproject.toml {posargs} {{EXAMPLE_NAME}}
+
+[testenv:mypy]
+commands =
+  mypy --config=../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/automation/automation/scaffold/assets/dagster-library-tmpl/tox.ini.tmpl
+++ b/python_modules/automation/automation/scaffold/assets/dagster-library-tmpl/tox.ini.tmpl
@@ -23,4 +23,8 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint: pylint -j0 --rcfile=../../../pyproject.toml dagster_{{LIBRARY_NAME}} dagster_{{LIBRARY_NAME}}_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_{{LIBRARY_NAME}} dagster_{{LIBRARY_NAME}}_tests
+
+[testenv:mypy]
+commands =
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -23,7 +23,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml automation automation_tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} automation automation_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -27,4 +27,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/dagit/tox.ini
+++ b/python_modules/dagit/tox.ini
@@ -28,7 +28,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml dagit dagit_tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} dagit dagit_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/dagit/tox.ini
+++ b/python_modules/dagit/tox.ini
@@ -32,4 +32,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/dagster-graphql/tox.ini
+++ b/python_modules/dagster-graphql/tox.ini
@@ -28,7 +28,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml dagster_graphql dagster_graphql_tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} dagster_graphql dagster_graphql_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/dagster-graphql/tox.ini
+++ b/python_modules/dagster-graphql/tox.ini
@@ -32,4 +32,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/dagster-test/tox.ini
+++ b/python_modules/dagster-test/tox.ini
@@ -34,7 +34,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml dagster_test dagster_test_tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} dagster_test dagster_test_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/dagster-test/tox.ini
+++ b/python_modules/dagster-test/tox.ini
@@ -38,4 +38,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -46,4 +46,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../pyproject.toml --non-interactive .
+  mypy --config=../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -42,7 +42,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml dagster dagster_tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} dagster dagster_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-airbyte/tox.ini
+++ b/python_modules/libraries/dagster-airbyte/tox.ini
@@ -20,7 +20,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_airbyte dagster_airbyte_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_airbyte dagster_airbyte_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-airbyte/tox.ini
+++ b/python_modules/libraries/dagster-airbyte/tox.ini
@@ -24,4 +24,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-airflow/tox.ini
+++ b/python_modules/libraries/dagster-airflow/tox.ini
@@ -33,7 +33,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_airflow dagster_airflow_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_airflow dagster_airflow_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-airflow/tox.ini
+++ b/python_modules/libraries/dagster-airflow/tox.ini
@@ -37,4 +37,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-aws/tox.ini
+++ b/python_modules/libraries/dagster-aws/tox.ini
@@ -31,4 +31,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-aws/tox.ini
+++ b/python_modules/libraries/dagster-aws/tox.ini
@@ -27,7 +27,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_aws dagster_aws_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_aws dagster_aws_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-azure/tox.ini
+++ b/python_modules/libraries/dagster-azure/tox.ini
@@ -28,4 +28,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-azure/tox.ini
+++ b/python_modules/libraries/dagster-azure/tox.ini
@@ -24,7 +24,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_azure dagster_azure_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_azure dagster_azure_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-celery-docker/tox.ini
+++ b/python_modules/libraries/dagster-celery-docker/tox.ini
@@ -33,4 +33,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-celery-k8s/tox.ini
+++ b/python_modules/libraries/dagster-celery-k8s/tox.ini
@@ -38,4 +38,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-celery/tox.ini
+++ b/python_modules/libraries/dagster-celery/tox.ini
@@ -35,4 +35,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-celery/tox.ini
+++ b/python_modules/libraries/dagster-celery/tox.ini
@@ -31,7 +31,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_celery dagster_celery_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_celery dagster_celery_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-census/tox.ini
+++ b/python_modules/libraries/dagster-census/tox.ini
@@ -28,4 +28,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-dask/tox.ini
+++ b/python_modules/libraries/dagster-dask/tox.ini
@@ -30,7 +30,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_dask dagster_dask_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_dask dagster_dask_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-dask/tox.ini
+++ b/python_modules/libraries/dagster-dask/tox.ini
@@ -34,4 +34,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-databricks/tox.ini
+++ b/python_modules/libraries/dagster-databricks/tox.ini
@@ -26,7 +26,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_databricks dagster_databricks_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_databricks dagster_databricks_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-databricks/tox.ini
+++ b/python_modules/libraries/dagster-databricks/tox.ini
@@ -30,4 +30,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-datadog/tox.ini
+++ b/python_modules/libraries/dagster-datadog/tox.ini
@@ -22,7 +22,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_datadog dagster_datadog_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_datadog dagster_datadog_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-datadog/tox.ini
+++ b/python_modules/libraries/dagster-datadog/tox.ini
@@ -26,4 +26,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -26,7 +26,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_dbt dagster_dbt_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_dbt dagster_dbt_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -30,4 +30,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-docker/tox.ini
+++ b/python_modules/libraries/dagster-docker/tox.ini
@@ -36,4 +36,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-fivetran/tox.ini
+++ b/python_modules/libraries/dagster-fivetran/tox.ini
@@ -20,7 +20,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_fivetran dagster_fivetran_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_fivetran dagster_fivetran_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-fivetran/tox.ini
+++ b/python_modules/libraries/dagster-fivetran/tox.ini
@@ -24,4 +24,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-gcp/tox.ini
+++ b/python_modules/libraries/dagster-gcp/tox.ini
@@ -25,7 +25,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_gcp dagster_gcp_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_gcp dagster_gcp_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-gcp/tox.ini
+++ b/python_modules/libraries/dagster-gcp/tox.ini
@@ -29,4 +29,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-ge/tox.ini
+++ b/python_modules/libraries/dagster-ge/tox.ini
@@ -25,7 +25,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_ge dagster_ge_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_ge dagster_ge_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-ge/tox.ini
+++ b/python_modules/libraries/dagster-ge/tox.ini
@@ -29,4 +29,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-github/tox.ini
+++ b/python_modules/libraries/dagster-github/tox.ini
@@ -22,7 +22,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_github dagster_github_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_github dagster_github_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-github/tox.ini
+++ b/python_modules/libraries/dagster-github/tox.ini
@@ -26,4 +26,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-k8s/tox.ini
+++ b/python_modules/libraries/dagster-k8s/tox.ini
@@ -31,7 +31,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_k8s dagster_k8s_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_k8s dagster_k8s_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-k8s/tox.ini
+++ b/python_modules/libraries/dagster-k8s/tox.ini
@@ -35,4 +35,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-mlflow/tox.ini
+++ b/python_modules/libraries/dagster-mlflow/tox.ini
@@ -22,7 +22,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_mlflow dagster_mlflow_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_mlflow dagster_mlflow_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-mlflow/tox.ini
+++ b/python_modules/libraries/dagster-mlflow/tox.ini
@@ -26,4 +26,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-msteams/tox.ini
+++ b/python_modules/libraries/dagster-msteams/tox.ini
@@ -22,7 +22,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_msteams dagster_msteams_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_msteams dagster_msteams_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-msteams/tox.ini
+++ b/python_modules/libraries/dagster-msteams/tox.ini
@@ -26,4 +26,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-mysql/tox.ini
+++ b/python_modules/libraries/dagster-mysql/tox.ini
@@ -22,7 +22,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_mysql dagster_mysql_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_mysql dagster_mysql_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-mysql/tox.ini
+++ b/python_modules/libraries/dagster-mysql/tox.ini
@@ -26,4 +26,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-pagerduty/tox.ini
+++ b/python_modules/libraries/dagster-pagerduty/tox.ini
@@ -22,7 +22,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_pagerduty dagster_pagerduty_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_pagerduty dagster_pagerduty_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-pagerduty/tox.ini
+++ b/python_modules/libraries/dagster-pagerduty/tox.ini
@@ -26,4 +26,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-pandas/tox.ini
+++ b/python_modules/libraries/dagster-pandas/tox.ini
@@ -28,4 +28,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-pandas/tox.ini
+++ b/python_modules/libraries/dagster-pandas/tox.ini
@@ -24,7 +24,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_pandas dagster_pandas_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_pandas dagster_pandas_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-pandera/tox.ini
+++ b/python_modules/libraries/dagster-pandera/tox.ini
@@ -27,4 +27,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-pandera/tox.ini
+++ b/python_modules/libraries/dagster-pandera/tox.ini
@@ -23,7 +23,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_pandera dagster_pandera_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_pandera dagster_pandera_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-papertrail/tox.ini
+++ b/python_modules/libraries/dagster-papertrail/tox.ini
@@ -22,7 +22,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_papertrail dagster_papertrail_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_papertrail dagster_papertrail_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-papertrail/tox.ini
+++ b/python_modules/libraries/dagster-papertrail/tox.ini
@@ -26,4 +26,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-postgres/tox.ini
+++ b/python_modules/libraries/dagster-postgres/tox.ini
@@ -26,4 +26,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-postgres/tox.ini
+++ b/python_modules/libraries/dagster-postgres/tox.ini
@@ -22,7 +22,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_postgres dagster_postgres_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_postgres dagster_postgres_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-prometheus/tox.ini
+++ b/python_modules/libraries/dagster-prometheus/tox.ini
@@ -22,7 +22,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_prometheus dagster_prometheus_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_prometheus dagster_prometheus_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-prometheus/tox.ini
+++ b/python_modules/libraries/dagster-prometheus/tox.ini
@@ -26,4 +26,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-pyspark/tox.ini
@@ -28,4 +28,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-pyspark/tox.ini
@@ -24,7 +24,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_pyspark dagster_pyspark_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_pyspark dagster_pyspark_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-shell/tox.ini
+++ b/python_modules/libraries/dagster-shell/tox.ini
@@ -28,4 +28,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-shell/tox.ini
+++ b/python_modules/libraries/dagster-shell/tox.ini
@@ -24,7 +24,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_shell dagster_shell_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_shell dagster_shell_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-slack/tox.ini
+++ b/python_modules/libraries/dagster-slack/tox.ini
@@ -22,7 +22,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_slack dagster_slack_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_slack dagster_slack_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-slack/tox.ini
+++ b/python_modules/libraries/dagster-slack/tox.ini
@@ -26,4 +26,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-snowflake-pandas/tox.ini
+++ b/python_modules/libraries/dagster-snowflake-pandas/tox.ini
@@ -25,4 +25,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-snowflake-pandas/tox.ini
+++ b/python_modules/libraries/dagster-snowflake-pandas/tox.ini
@@ -21,7 +21,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_snowflake_pandas dagster_snowflake_pandas_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_snowflake_pandas dagster_snowflake_pandas_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-snowflake/tox.ini
+++ b/python_modules/libraries/dagster-snowflake/tox.ini
@@ -23,7 +23,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_snowflake dagster_snowflake_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_snowflake dagster_snowflake_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-snowflake/tox.ini
+++ b/python_modules/libraries/dagster-snowflake/tox.ini
@@ -27,4 +27,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-spark/tox.ini
+++ b/python_modules/libraries/dagster-spark/tox.ini
@@ -26,4 +26,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-spark/tox.ini
+++ b/python_modules/libraries/dagster-spark/tox.ini
@@ -22,7 +22,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_spark dagster_spark_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_spark dagster_spark_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-ssh/tox.ini
+++ b/python_modules/libraries/dagster-ssh/tox.ini
@@ -28,4 +28,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-ssh/tox.ini
+++ b/python_modules/libraries/dagster-ssh/tox.ini
@@ -24,7 +24,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_ssh dagster_ssh_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_ssh dagster_ssh_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-twilio/tox.ini
+++ b/python_modules/libraries/dagster-twilio/tox.ini
@@ -26,4 +26,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .

--- a/python_modules/libraries/dagster-twilio/tox.ini
+++ b/python_modules/libraries/dagster-twilio/tox.ini
@@ -22,7 +22,7 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../../pyproject.toml dagster_twilio dagster_twilio_tests
+  pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_twilio dagster_twilio_tests
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagstermill/tox.ini
+++ b/python_modules/libraries/dagstermill/tox.ini
@@ -39,4 +39,4 @@ commands =
 
 [testenv:mypy]
 commands =
-  mypy --config=../../../pyproject.toml --non-interactive .
+  mypy --config=../../../pyproject.toml --non-interactive {posargs} .


### PR DESCRIPTION
### Summary & Motivation

Tweak to toxfiles that allows passing additional positional args to tox commands envs (mypy/pylint)-- useful when invoking these envs locally.

### How I Tested These Changes

Existing BK suite.
