### PR TITLE
[dagit] Fix global search for repeated item keys

### DIFF
--- a/js_modules/dagit/packages/core/src/search/SearchResults.tsx
+++ b/js_modules/dagit/packages/core/src/search/SearchResults.tsx
@@ -85,7 +85,7 @@ export const SearchResults = (props: Props) => {
     <List hasResults={!!results.length}>
       {results.map((result, ii) => (
         <SearchResultItem
-          key={result.item.key}
+          key={result.item.href}
           isHighlight={highlight === ii}
           result={result}
           onClickResult={onClickResult}


### PR DESCRIPTION
### Summary & Motivation

There is currently a bug where users who have jobs/sensors/schedules that share the same name end up with a broken global search experience because keys are repeated.

To repair this, use `href`, which should be guaranteed unique for various objects, even if they have the same name.

### How I Tested These Changes

View Dagit as a user with repeated object names for jobs/sensors. Open global search, verify that rendering and behavior (typing, key navigation) is correct when searching for a name that would have previously collided.
