### PR TITLE
[dagit] Remove search item key

### DIFF
--- a/js_modules/dagit/packages/core/src/search/types.ts
+++ b/js_modules/dagit/packages/core/src/search/types.ts
@@ -11,7 +11,6 @@ export enum SearchResultType {
 }
 
 export type SearchResult = {
-  key: string;
   label: string;
   description: string;
   href: string;

--- a/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
+++ b/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
@@ -50,7 +50,6 @@ const bootstrapDataToSearchResults = (data?: SearchBootstrapQuery) => {
             return [
               ...flat,
               {
-                key: `${repoPath}-${name}`,
                 label: name,
                 description: manyRepos
                   ? `${isJob ? 'Job' : 'Pipeline'} in ${repoPath}`
@@ -68,7 +67,6 @@ const bootstrapDataToSearchResults = (data?: SearchBootstrapQuery) => {
           }, [] as SearchResult[]);
 
         const allSchedules: SearchResult[] = schedules.map((schedule) => ({
-          key: `${repoPath}-${schedule.name}`,
           label: schedule.name,
           description: manyRepos ? `Schedule in ${repoPath}` : 'Schedule',
           href: workspacePath(repoName, locationName, `/schedules/${schedule.name}`),
@@ -76,7 +74,6 @@ const bootstrapDataToSearchResults = (data?: SearchBootstrapQuery) => {
         }));
 
         const allSensors: SearchResult[] = sensors.map((sensor) => ({
-          key: `${repoPath}-${sensor.name}`,
           label: sensor.name,
           description: manyRepos ? `Sensor in ${repoPath}` : 'Sensor',
           href: workspacePath(repoName, locationName, `/sensors/${sensor.name}`),
@@ -86,7 +83,6 @@ const bootstrapDataToSearchResults = (data?: SearchBootstrapQuery) => {
         const allPartitionSets: SearchResult[] = partitionSets
           .filter((item) => !isAssetGroup(item.pipelineName))
           .map((partitionSet) => ({
-            key: `${repoPath}-${partitionSet.name}`,
             label: partitionSet.name,
             description: manyRepos ? `Partition set in ${repoPath}` : 'Partition set',
             href: workspacePath(
@@ -119,7 +115,6 @@ const secondaryDataToSearchResults = (data?: SearchSecondaryQuery) => {
   const {nodes} = data.assetsOrError;
   const allEntries = nodes.map(({key}) => {
     return {
-      key: displayNameForAssetKey(key),
       label: displayNameForAssetKey(key),
       segments: key.path,
       description: 'Asset',


### PR DESCRIPTION
### Summary & Motivation

Since we'll now key search results on `href` (which should be unique per object), we don't need the `key` key on the result objects anymore.

### How I Tested These Changes

yarn ts
