### PR TITLE
[dagit] Make schedule/sensor tags more prominent in RunTags

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTag.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTag.tsx
@@ -36,32 +36,55 @@ export const RunTag = ({tag, actions}: IRunTagProps) => {
   const {key, value} = tag;
   const isDagsterTag = key.startsWith(DagsterTag.Namespace);
 
-  const displayedTag = React.useMemo(
-    () => (isDagsterTag ? {key: key.slice(DagsterTag.Namespace.length), value} : {key, value}),
-    [isDagsterTag, key, value],
-  );
+  const displayedKey = React.useMemo(() => {
+    if (isDagsterTag) {
+      switch (key) {
+        case DagsterTag.Backfill:
+          return 'Backfill';
+        case DagsterTag.ScheduleName:
+        case DagsterTag.SensorName:
+          return null;
+        default:
+          return key.slice(DagsterTag.Namespace.length);
+      }
+    }
+    return key;
+  }, [isDagsterTag, key]);
 
-  const button = (
-    <Tag intent={isDagsterTag ? 'none' : 'primary'} interactive>
-      {`${displayedTag.key}: ${displayedTag.value}`}
+  const icon = React.useMemo(() => {
+    switch (key) {
+      case DagsterTag.ScheduleName:
+        return 'schedule';
+      case DagsterTag.SensorName:
+        return 'sensors';
+      case DagsterTag.Backfill:
+        return 'settings_backup_restore';
+      default:
+        return null;
+    }
+  }, [key]);
+
+  const tagElement = (
+    <Tag intent={isDagsterTag ? 'none' : 'primary'} interactive icon={icon || undefined}>
+      {displayedKey ? `${displayedKey}: ${value}` : value}
     </Tag>
   );
 
   if (actions?.length) {
     return (
       <Popover
-        content={<TagActions actions={actions} tag={displayedTag} />}
+        content={<TagActions actions={actions} tag={tag} />}
         hoverOpenDelay={100}
         hoverCloseDelay={100}
         placement="top"
         interactionKind="hover"
       >
-        {button}
+        {tagElement}
       </Popover>
     );
   }
 
-  return button;
+  return tagElement;
 };
 
 const TagActions = ({tag, actions}: {tag: TagType; actions: TagAction[]}) => (
@@ -82,7 +105,7 @@ const ActionContainer = styled(Box)`
 const TagButton = styled.button`
   border: none;
   background: ${Colors.Dark};
-  color: ${Colors.Gray200};
+  color: ${Colors.Gray100};
   cursor: pointer;
   padding: 8px 12px;
   text-align: left;

--- a/js_modules/dagit/packages/core/src/runs/RunTags.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTags.tsx
@@ -4,8 +4,15 @@ import * as React from 'react';
 import {SharedToaster} from '../app/DomUtils';
 import {useCopyToClipboard} from '../app/browser';
 
-import {RunTag, TagType} from './RunTag';
+import {DagsterTag, RunTag, TagType} from './RunTag';
 import {RunFilterToken} from './RunsFilterInput';
+
+// Sort these tags to the start of the list.
+export const priorityTagSet = new Set([
+  DagsterTag.ScheduleName as string,
+  DagsterTag.SensorName as string,
+  DagsterTag.Backfill as string,
+]);
 
 export const RunTags: React.FC<{
   tags: TagType[];
@@ -37,6 +44,19 @@ export const RunTags: React.FC<{
     return list;
   }, [copy, onSetFilter]);
 
+  const sortedTags = React.useMemo(() => {
+    const priority = [];
+    const others = [];
+    for (const tag of tags) {
+      if (priorityTagSet.has(tag.key)) {
+        priority.push(tag);
+      } else {
+        others.push(tag);
+      }
+    }
+    return [...priority, ...others];
+  }, [tags]);
+
   if (!tags.length) {
     return null;
   }
@@ -44,7 +64,7 @@ export const RunTags: React.FC<{
   return (
     <Box flex={{direction: 'row', wrap: 'wrap', gap: 4}}>
       {mode ? <RunTag tag={{key: 'mode', value: mode}} /> : null}
-      {tags.map((tag, idx) => (
+      {sortedTags.map((tag, idx) => (
         <RunTag tag={tag} key={idx} actions={actions} />
       ))}
     </Box>


### PR DESCRIPTION
### Summary & Motivation

Resolves #7829.

Show schedule/sensor information more prominently on the Runs table.

- Sort schedule/sensor tags to the front of the tag list
- Show a schedule/sensor icon on the tag
- Just show the name of the schedule/sensor in the tag

Copying or adding the tag to the filter will still use the full tag text.

<img width="1043" alt="Screen Shot 2022-05-10 at 5 06 31 PM" src="https://user-images.githubusercontent.com/2823852/167730412-3e38f02b-1ffa-4c1c-ba81-2a54a472f9a0.png">


### How I Tested These Changes

View Runs page, verify rendering and hover/copy/filter behavior.
