### PR TITLE
warn for instance.get_event_records calls without an event type filter

### DIFF
--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1317,7 +1317,7 @@ class DagsterInstance:
     @traced
     def get_event_records(
         self,
-        event_records_filter: Optional["EventRecordsFilter"] = None,
+        event_records_filter: "EventRecordsFilter",
         limit: Optional[int] = None,
         ascending: bool = False,
     ) -> Iterable["EventLogRecord"]:

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1317,7 +1317,7 @@ class DagsterInstance:
     @traced
     def get_event_records(
         self,
-        event_records_filter: "EventRecordsFilter",
+        event_records_filter: Optional["EventRecordsFilter"] = None,
         limit: Optional[int] = None,
         ascending: bool = False,
     ) -> Iterable["EventLogRecord"]:

--- a/python_modules/dagster/dagster/core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/base.py
@@ -87,7 +87,7 @@ class EventRecordsFilter(
     NamedTuple(
         "_EventRecordsFilter",
         [
-            ("event_type", DagsterEventType),
+            ("event_type", Optional[DagsterEventType]),
             ("asset_key", Optional[AssetKey]),
             ("asset_partitions", Optional[List[str]]),
             ("after_cursor", Optional[Union[int, RunShardedEventsCursor]]),
@@ -122,7 +122,7 @@ class EventRecordsFilter(
 
     def __new__(
         cls,
-        event_type: DagsterEventType,
+        event_type: Optional[DagsterEventType] = None,
         asset_key: Optional[AssetKey] = None,
         asset_partitions: Optional[List[str]] = None,
         after_cursor: Optional[Union[int, RunShardedEventsCursor]] = None,
@@ -131,9 +131,16 @@ class EventRecordsFilter(
         before_timestamp: Optional[float] = None,
     ):
         check.opt_list_param(asset_partitions, "asset_partitions", of_type=str)
+        event_type = check.opt_inst_param(event_type, "event_type", DagsterEventType)
+        if not event_type:
+            warnings.warn(
+                "The use of `EventRecordsFilter` without an event type is deprecated and will "
+                "begin erroring starting in 0.15.0"
+            )
+
         return super(EventRecordsFilter, cls).__new__(
             cls,
-            event_type=check.inst_param(event_type, "event_type", DagsterEventType),
+            event_type=event_type,
             asset_key=check.opt_inst_param(asset_key, "asset_key", AssetKey),
             asset_partitions=asset_partitions,
             after_cursor=check.opt_inst_param(
@@ -244,7 +251,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
     @abstractmethod
     def get_event_records(
         self,
-        event_records_filter: EventRecordsFilter,
+        event_records_filter: Optional[EventRecordsFilter] = None,
         limit: Optional[int] = None,
         ascending: bool = False,
     ) -> Iterable[EventLogRecord]:

--- a/python_modules/dagster/dagster/core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/base.py
@@ -87,7 +87,7 @@ class EventRecordsFilter(
     NamedTuple(
         "_EventRecordsFilter",
         [
-            ("event_type", Optional[DagsterEventType]),
+            ("event_type", DagsterEventType),
             ("asset_key", Optional[AssetKey]),
             ("asset_partitions", Optional[List[str]]),
             ("after_cursor", Optional[Union[int, RunShardedEventsCursor]]),
@@ -122,7 +122,7 @@ class EventRecordsFilter(
 
     def __new__(
         cls,
-        event_type: Optional[DagsterEventType] = None,
+        event_type: DagsterEventType,
         asset_key: Optional[AssetKey] = None,
         asset_partitions: Optional[List[str]] = None,
         after_cursor: Optional[Union[int, RunShardedEventsCursor]] = None,
@@ -133,7 +133,7 @@ class EventRecordsFilter(
         check.opt_list_param(asset_partitions, "asset_partitions", of_type=str)
         return super(EventRecordsFilter, cls).__new__(
             cls,
-            event_type=check.opt_inst_param(event_type, "event_type", DagsterEventType),
+            event_type=check.inst_param(event_type, "event_type", DagsterEventType),
             asset_key=check.opt_inst_param(asset_key, "asset_key", AssetKey),
             asset_partitions=asset_partitions,
             after_cursor=check.opt_inst_param(
@@ -244,7 +244,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
     @abstractmethod
     def get_event_records(
         self,
-        event_records_filter: Optional[EventRecordsFilter] = None,
+        event_records_filter: EventRecordsFilter,
         limit: Optional[int] = None,
         ascending: bool = False,
     ) -> Iterable[EventLogRecord]:

--- a/python_modules/dagster/dagster/core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/in_memory.py
@@ -352,6 +352,7 @@ class InMemoryEventLogStorage(EventLogStorage, ConfigurableClass):
         )
         event_records = self.get_event_records(
             EventRecordsFilter(
+                event_type=DagsterEventType.ASSET_MATERIALIZATION,
                 asset_key=asset_key,
                 asset_partitions=partitions,
                 before_cursor=before_cursor,

--- a/python_modules/dagster/dagster/core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/in_memory.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import warnings
 from collections import OrderedDict, defaultdict
 from typing import Dict, Iterable, Mapping, Optional, Sequence
 
@@ -173,6 +174,12 @@ class InMemoryEventLogStorage(EventLogStorage, ConfigurableClass):
         limit: Optional[int] = None,
         ascending: bool = False,
     ) -> Iterable[EventLogRecord]:
+        if not event_records_filter:
+            warnings.warn(
+                "The use of `get_event_records` without an `EventRecordsFilter` is deprecated and "
+                "will begin erroring starting in 0.15.0"
+            )
+
         after_id = (
             (
                 event_records_filter.after_cursor.id

--- a/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from abc import abstractmethod
 from collections import OrderedDict
 from datetime import datetime
@@ -673,6 +674,12 @@ class SqlEventLogStorage(EventLogStorage):
         check.opt_inst_param(event_records_filter, "event_records_filter", EventRecordsFilter)
         check.opt_int_param(limit, "limit")
         check.bool_param(ascending, "ascending")
+
+        if not event_records_filter:
+            warnings.warn(
+                "The use of `get_event_records` without an `EventRecordsFilter` is deprecated and "
+                "will begin erroring starting in 0.15.0"
+            )
 
         query = db.select([SqlEventLogStorageTable.c.id, SqlEventLogStorageTable.c.event])
         if event_records_filter and event_records_filter.asset_key:

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -1272,17 +1272,7 @@ class TestEventLogStorage:
             run_records = instance.get_run_records()
             assert len(run_records) == 1
 
-            # all logs returned in descending order
-            all_event_records = storage.get_event_records()
-            assert _event_types([all_event_records[0].event_log_entry]) == [
-                DagsterEventType.PIPELINE_SUCCESS
-            ]
-            assert _event_types([all_event_records[-1].event_log_entry]) == [
-                DagsterEventType.PIPELINE_START
-            ]
-
             # second run
-            events = []
             execute_run(
                 InMemoryPipeline(a_pipe),
                 instance.create_run_for_pipeline(
@@ -1292,11 +1282,8 @@ class TestEventLogStorage:
             )
             run_records = instance.get_run_records()
             assert len(run_records) == 2
-            for event in events:
-                storage.store_event(event)
 
             # third run
-            events = []
             execute_run(
                 InMemoryPipeline(a_pipe),
                 instance.create_run_for_pipeline(
@@ -1306,8 +1293,6 @@ class TestEventLogStorage:
             )
             run_records = instance.get_run_records()
             assert len(run_records) == 3
-            for event in events:
-                storage.store_event(event)
 
             update_timestamp = run_records[-1].update_timestamp
             tzaware_dt = pendulum.from_timestamp(datetime_as_float(update_timestamp), tz="UTC")

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -1151,7 +1151,7 @@ class TestEventLogStorage:
     @pytest.mark.parametrize(
         "cursor_dt", cursor_datetime_args()
     )  # test both tz-aware and naive datetimes
-    def test_get_event_records(self, storage, cursor_dt, test_run_id):
+    def test_get_event_records(self, storage, cursor_dt):
         if isinstance(storage, SqliteEventLogStorage):
             # test sqlite in test_get_event_records_sqlite
             pytest.skip()
@@ -1178,7 +1178,6 @@ class TestEventLogStorage:
             events, _ = _synthesize_events(_solids, run_id=run_id)
             for event in events:
                 storage.store_event(event)
-                print(event)
 
         # store events for three runs
         [run_id_1, run_id_2, run_id_3] = [make_new_run_id(), make_new_run_id(), make_new_run_id()]

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -899,7 +899,10 @@ class TestEventLogStorage:
                 event.dagster_event.event_type_value == DagsterEventType.ASSET_MATERIALIZATION.value
             )
 
-            records = storage.get_event_records(EventRecordsFilter(asset_key=asset_key))
+            records = storage.get_event_records(EventRecordsFilter(
+                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                asset_key=asset_key
+            ))
             assert len(records) == 1
             record = records[0]
             assert isinstance(record, EventLogRecord)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/emr_tests/test_pyspark.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/emr_tests/test_pyspark.py
@@ -116,10 +116,10 @@ def test_local():
 @mock.patch("dagster_aws.emr.emr.EmrJobRunner.is_emr_step_complete")
 def test_pyspark_emr(mock_is_emr_step_complete, mock_read_events, mock_s3_bucket):
     with instance_for_test() as instance:
-        execute_pipeline(reconstructable(define_do_nothing_pipe), mode="local", instance=instance)
-        mock_read_events.return_value = [
-            record.event_log_entry for record in instance.get_event_records()
-        ]
+        result = execute_pipeline(
+            reconstructable(define_do_nothing_pipe), mode="local", instance=instance
+        )
+        mock_read_events.return_value = instance.all_logs(result.run_id)
 
     run_job_flow_args = dict(
         Instances={

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
@@ -175,13 +175,13 @@ def test_pyspark_databricks(
     mock_get_run_state.side_effect = [running_state] * 5 + [final_state]
 
     with instance_for_test() as instance:
-        execute_pipeline(
+        result = execute_pipeline(
             pipeline=reconstructable(define_do_nothing_pipe), mode="local", instance=instance
         )
         mock_get_step_events.return_value = [
-            record.event_log_entry
-            for record in instance.get_event_records()
-            if record.event_log_entry.step_key == "do_nothing_solid"
+            event
+            for event in instance.all_logs(result.run_id)
+            if event.step_key == "do_nothing_solid"
         ]
     config = BASE_DATABRICKS_PYSPARK_STEP_LAUNCHER_CONFIG.copy()
     config.pop("local_pipeline_package_path")


### PR DESCRIPTION
### Summary & Motivation
Need to limit unfettered cross-run reads to the event log so that we can create summary tables (per event type) to service these queries performantly.

### How I Tested These Changes
BK