### PR TITLE
[dagit] add log-level flag

### DIFF
--- a/python_modules/dagit/dagit/cli.py
+++ b/python_modules/dagit/dagit/cli.py
@@ -97,8 +97,26 @@ DEFAULT_DB_STATEMENT_TIMEOUT = 15000  # 15 sec
     help="Filter all warnings when hosting Dagit.",
     is_flag=True,
 )
+@click.option(
+    "--log-level",
+    help="Set the log level for the uvicorn web server.",
+    show_default=True,
+    default="warning",
+    type=click.Choice(
+        ["critical", "error", "warning", "info", "debug", "trace"], case_sensitive=False
+    ),
+)
 @click.version_option(version=__version__, prog_name="dagit")
-def dagit(host, port, path_prefix, db_statement_timeout, read_only, suppress_warnings, **kwargs):
+def dagit(
+    host,
+    port,
+    path_prefix,
+    db_statement_timeout,
+    read_only,
+    suppress_warnings,
+    log_level,
+    **kwargs,
+):
     if suppress_warnings:
         os.environ["PYTHONWARNINGS"] = "ignore"
 
@@ -117,6 +135,7 @@ def dagit(host, port, path_prefix, db_statement_timeout, read_only, suppress_war
                 host,
                 port,
                 path_prefix,
+                log_level,
             )
 
 
@@ -125,6 +144,7 @@ def host_dagit_ui_with_workspace_process_context(
     host: Optional[str],
     port: int,
     path_prefix: str,
+    log_level: str,
 ):
     check.inst_param(
         workspace_process_context, "workspace_process_context", WorkspaceProcessContext
@@ -149,8 +169,7 @@ def host_dagit_ui_with_workspace_process_context(
             app,
             host=host,
             port=port,
-            access_log=False,
-            log_level="warning",
+            log_level=log_level,
         )
 
 

--- a/python_modules/dagit/dagit_tests/test_app.py
+++ b/python_modules/dagit/dagit_tests/test_app.py
@@ -139,6 +139,7 @@ def test_successful_host_dagit_ui_from_workspace():
                 host=None,
                 port=2343,
                 path_prefix="",
+                log_level="warning",
             )
 
 
@@ -158,6 +159,7 @@ def test_successful_host_dagit_ui_from_multiple_workspace_files():
                 host=None,
                 port=2343,
                 path_prefix="",
+                log_level="warning",
             )
 
 
@@ -172,6 +174,7 @@ def test_successful_host_dagit_ui_from_legacy_repository():
                 host=None,
                 port=2343,
                 path_prefix="",
+                log_level="warning",
             )
 
 
@@ -188,6 +191,7 @@ def test_invalid_path_prefix():
                     host=None,
                     port=2343,
                     path_prefix="no-leading-slash",
+                    log_level="warning",
                 )
             assert "path prefix should begin with a leading" in str(exc_info.value)
 
@@ -197,6 +201,7 @@ def test_invalid_path_prefix():
                     host=None,
                     port=2343,
                     path_prefix="/extra-trailing-slash/",
+                    log_level="warning",
                 )
             assert "path prefix should not include a trailing" in str(exc_info.value)
 
@@ -213,6 +218,7 @@ def test_valid_path_prefix():
                 host=None,
                 port=2343,
                 path_prefix="/dagster-path",
+                log_level="warning",
             )
 
 


### PR DESCRIPTION
### Summary & Motivation

make the hard coded uvicorn args configurable via cli

### How I Tested These Changes

```
dagit --log-level info
2022-05-12 09:15:21 -0500 - dagit - INFO - Serving dagit on http://127.0.0.1:3000 in process 27231
INFO:     Started server process [27231]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:3000 (Press CTRL+C to quit)
INFO:     127.0.0.1:49316 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49316 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49316 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49317 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49318 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49317 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49318 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49319 - "POST /graphql HTTP/1.1" 200 OK
INFO:     ('127.0.0.1', 49320) - "WebSocket /graphql" [accepted]
INFO:     ('127.0.0.1', 49322) - "WebSocket /graphql" [accepted]
INFO:     ('127.0.0.1', 49323) - "WebSocket /graphql" [accepted]
INFO:     127.0.0.1:49324 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49324 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49324 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49324 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49325 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49327 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49328 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49329 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49325 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49329 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49326 - "POST /graphql HTTP/1.1" 200 OK
INFO:     127.0.0.1:49327 - "POST /graphql HTTP/1.1" 200 OK
^C
Aborted!
INFO:     Shutting down
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete.
INFO:     Finished server process [27231]
```
`dagit --log-level INFO`
`dagit --log-level InFo`