### PR TITLE
migrate from deprecated sqlalchemy methods

### DIFF
--- a/python_modules/dagster/dagster/core/storage/alembic/versions/001_initial_1.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/001_initial_1.py
@@ -11,8 +11,7 @@ Create Date: 2019-11-21 09:59:57.028730
 
 import sqlalchemy as sa
 from alembic import context, op
-from sqlalchemy import Column
-from sqlalchemy.engine import reflection
+from sqlalchemy import Column, inspect
 
 from dagster.core.storage.event_log import SqlEventLogStorageTable
 
@@ -27,9 +26,7 @@ def upgrade():
     # This is our root migration, and we don't have a common base. Before this revision, sqlite- and
     # postgres-based event logs had different schemas. The conditionality below is to deal with dev
     # databases that might not have been stamped by Alembic.
-    bind = op.get_context().bind
-
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
 
     if "event_log" not in has_tables:

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/002_cascade_run_deletion_postgres.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/002_cascade_run_deletion_postgres.py
@@ -6,7 +6,7 @@ Create Date: 2020-02-10 12:52:49.540462
 
 """
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # pylint: disable=no-member
 # alembic dynamically populates the alembic.context module
@@ -19,8 +19,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
 
     if "runs" in has_tables and "run_tags" in has_tables:
@@ -36,8 +35,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
 
     if "runs" in has_tables and "run_tags" in has_tables:

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/002_cascade_run_deletion_sqlite.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/002_cascade_run_deletion_sqlite.py
@@ -6,7 +6,7 @@ Create Date: 2020-02-10 18:13:58.993653
 
 """
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # pylint: disable=no-member
 
@@ -18,8 +18,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
 
     if "runs" in has_tables and "run_tags" in has_tables:

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/003_add_step_key_pipeline_name_postgres.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/003_add_step_key_pipeline_name_postgres.py
@@ -7,7 +7,7 @@ Create Date: 2020-03-31 11:21:26.811734
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # pylint: disable=no-member
 
@@ -19,8 +19,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "event_logs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("event_logs")]
@@ -29,8 +28,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "event_logs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("event_logs")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/003_add_step_key_pipeline_name_sqlite.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/003_add_step_key_pipeline_name_sqlite.py
@@ -7,7 +7,7 @@ Create Date: 2020-03-31 11:01:42.609069
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # pylint: disable=no-member
 
@@ -19,8 +19,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "event_logs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("event_logs")]
@@ -29,8 +28,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "event_logs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("event_logs")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/004_add_snapshots_to_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/004_add_snapshots_to_run_storage.py
@@ -7,7 +7,7 @@ Create Date: 2020-04-09 05:57:20.639458
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 from dagster.core.storage.migration.utils import has_column, has_table
 
@@ -22,8 +22,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
 
     if not has_table("runs"):
         return
@@ -50,7 +49,8 @@ def upgrade():
                         "snapshot_id",
                         sa.String(255),
                         sa.ForeignKey(
-                            "snapshots.snapshot_id", name="fk_runs_snapshot_id_snapshots_snapshot_id"
+                            "snapshots.snapshot_id",
+                            name="fk_runs_snapshot_id_snapshots_snapshot_id",
                         ),
                     ),
                 )
@@ -63,8 +63,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
 
     if not has_table("runs"):
         return

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/005_add_asset_key_postgres.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/005_add_asset_key_postgres.py
@@ -7,7 +7,7 @@ Create Date: 2020-04-28 09:17:33.253185
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # pylint: disable=no-member
 
@@ -19,8 +19,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "event_logs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("event_logs")]
@@ -33,8 +32,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "event_logs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("event_logs")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/005_add_asset_key_sqlite.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/005_add_asset_key_sqlite.py
@@ -7,7 +7,7 @@ Create Date: 2020-04-28 09:35:54.768791
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # pylint: disable=no-member
 
@@ -19,8 +19,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "event_logs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("event_logs")]
@@ -33,8 +32,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "event_logs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("event_logs")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/006_scheduler_update_postgres.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/006_scheduler_update_postgres.py
@@ -6,7 +6,7 @@ Create Date: 2020-06-10 10:00:57.793622
 
 """
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 from dagster.core.storage.migration.utils import get_currently_upgrading_instance, has_table
 
@@ -22,8 +22,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
 
     if "postgresql" not in inspector.dialect.dialect_description:
         return

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/007_create_run_id_idx_postgres.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/007_create_run_id_idx_postgres.py
@@ -6,7 +6,7 @@ Create Date: 2020-06-11 09:27:11.922143
 
 """
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # pylint: disable=no-member
 
@@ -18,8 +18,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "event_logs" in has_tables:
         indices = [x.get("name") for x in inspector.get_indexes("event_logs")]
@@ -28,8 +27,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "event_logs" in has_tables:
         indices = [x.get("name") for x in inspector.get_indexes("event_logs")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/007_create_run_id_idx_sqlite.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/007_create_run_id_idx_sqlite.py
@@ -6,7 +6,7 @@ Create Date: 2020-06-11 10:40:25.216776
 
 """
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # pylint: disable=no-member
 
@@ -18,8 +18,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "event_logs" in has_tables:
         indices = [x.get("name") for x in inspector.get_indexes("event_logs")]
@@ -28,8 +27,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "event_logs" in has_tables:
         indices = [x.get("name") for x in inspector.get_indexes("event_logs")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/008_add_run_tags_index_postgres.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/008_add_run_tags_index_postgres.py
@@ -6,7 +6,7 @@ Create Date: 2020-12-01 12:19:34.460760
 
 """
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # pylint: disable=no-member
 
@@ -18,8 +18,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "run_tags" in has_tables:
         indices = [x.get("name") for x in inspector.get_indexes("run_tags")]
@@ -28,8 +27,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "run_tags" in has_tables:
         indices = [x.get("name") for x in inspector.get_indexes("run_tags")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/008_add_run_tags_index_sqlite.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/008_add_run_tags_index_sqlite.py
@@ -6,7 +6,7 @@ Create Date: 2020-12-01 12:10:23.650381
 
 """
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # pylint: disable=no-member
 
@@ -18,8 +18,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "run_tags" in has_tables:
         indices = [x.get("name") for x in inspector.get_indexes("run_tags")]
@@ -28,8 +27,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "run_tags" in has_tables:
         indices = [x.get("name") for x in inspector.get_indexes("run_tags")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/009_add_partition_column_postgres.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/009_add_partition_column_postgres.py
@@ -7,7 +7,7 @@ Create Date: 2020-12-21 10:13:54.430623
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # pylint: disable=no-member
 
@@ -19,8 +19,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "event_logs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("event_logs")]
@@ -32,8 +31,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "event_logs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("event_logs")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/009_add_partition_column_sqlite.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/009_add_partition_column_sqlite.py
@@ -7,7 +7,7 @@ Create Date: 2020-12-21 10:07:10.099687
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # pylint: disable=no-member
 
@@ -19,8 +19,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "event_logs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("event_logs")]
@@ -32,8 +31,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "event_logs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("event_logs")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/010_add_run_partition_columns_postgres.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/010_add_run_partition_columns_postgres.py
@@ -7,7 +7,7 @@ Create Date: 2021-01-05 15:21:52.820686
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # pylint: disable=no-member
 
@@ -20,8 +20,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "runs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("runs")]
@@ -38,8 +37,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "runs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("runs")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/010_add_run_partition_columns_sqlite.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/010_add_run_partition_columns_sqlite.py
@@ -7,7 +7,7 @@ Create Date: 2021-01-05 14:39:50.395455
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # pylint: disable=no-member
 
@@ -19,8 +19,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "runs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("runs")]
@@ -37,8 +36,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "runs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("runs")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/011_wipe_schedules_table_for_0_10_0_postgres.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/011_wipe_schedules_table_for_0_10_0_postgres.py
@@ -6,7 +6,7 @@ Create Date: 2021-01-11 22:20:01.253271
 
 """
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 from dagster.core.storage.migration.utils import get_currently_upgrading_instance, has_table
 
@@ -22,9 +22,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
 
     if "postgresql" not in inspector.dialect.dialect_description:
         return

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/011_wipe_schedules_table_for_0_10_0_sqlite_1.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/011_wipe_schedules_table_for_0_10_0_sqlite_1.py
@@ -6,7 +6,7 @@ Create Date: 2020-06-10 09:05:47.963960
 
 """
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 from dagster.core.storage.migration.utils import get_currently_upgrading_instance, has_table
 
@@ -22,9 +22,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
 
     if "sqlite" not in inspector.dialect.dialect_description:
         return

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/011_wipe_schedules_table_for_0_10_0_sqlite_2.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/011_wipe_schedules_table_for_0_10_0_sqlite_2.py
@@ -6,7 +6,7 @@ Create Date: 2021-01-11 22:16:50.896040
 
 """
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 from dagster.core.storage.migration.utils import get_currently_upgrading_instance, has_table
 
@@ -22,9 +22,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
 
     if "sqlite" not in inspector.dialect.dialect_description:
         return

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/017_add_run_status_index_postgres.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/017_add_run_status_index_postgres.py
@@ -6,7 +6,7 @@ Create Date: 2021-02-23 16:00:45.689578
 
 """
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # pylint: disable=no-member
 
@@ -18,8 +18,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "runs" in has_tables:
         indices = [x.get("name") for x in inspector.get_indexes("runs")]
@@ -28,8 +27,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "runs" in has_tables:
         indices = [x.get("name") for x in inspector.get_indexes("runs")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/017_add_run_status_index_sqlite.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/017_add_run_status_index_sqlite.py
@@ -6,7 +6,7 @@ Create Date: 2021-02-23 15:55:33.837945
 
 """
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # pylint: disable=no-member
 
@@ -18,8 +18,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "runs" in has_tables:
         indices = [x.get("name") for x in inspector.get_indexes("runs")]
@@ -28,8 +27,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "runs" in has_tables:
         indices = [x.get("name") for x in inspector.get_indexes("runs")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/021_add_column_mode_mysql.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/021_add_column_mode_mysql.py
@@ -7,7 +7,7 @@ Create Date: 2021-07-06 14:04:04.808944
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.
 revision = "45fa602c43dc"
@@ -19,8 +19,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
 
     if "runs" in has_tables:
@@ -31,8 +30,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "runs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("runs")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/021_add_column_mode_postgres.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/021_add_column_mode_postgres.py
@@ -7,7 +7,7 @@ Create Date: 2021-07-06 13:56:08.987201
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.
 revision = "ddcc6d7244c6"
@@ -19,8 +19,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
 
     if "runs" in has_tables:
@@ -31,8 +30,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "runs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("runs")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/021_add_column_mode_sqlite.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/021_add_column_mode_sqlite.py
@@ -7,7 +7,7 @@ Create Date: 2021-07-06 13:49:53.668345
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.
 revision = "7f2b1a4ca7a5"
@@ -19,8 +19,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
 
     if "runs" in has_tables:
@@ -31,8 +30,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "runs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("runs")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/024_add_columns_start_time_and_end_time_postgres.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/024_add_columns_start_time_and_end_time_postgres.py
@@ -7,7 +7,7 @@ Create Date: 2021-12-20 13:41:14.924529
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.
 revision = "42add02bf976"
@@ -20,8 +20,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
 
     if "runs" in has_tables:
@@ -34,8 +33,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "runs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("runs")]

--- a/python_modules/dagster/dagster/core/storage/alembic/versions/024_add_columns_start_time_and_end_time_sqlite.py
+++ b/python_modules/dagster/dagster/core/storage/alembic/versions/024_add_columns_start_time_and_end_time_sqlite.py
@@ -7,7 +7,7 @@ Create Date: 2021-12-20 13:18:31.122983
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.
 revision = "f4eed4c26e2c"
@@ -19,8 +19,7 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
 
     if "runs" in has_tables:
@@ -33,8 +32,7 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
+    inspector = inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "runs" in has_tables:
         columns = [x.get("name") for x in inspector.get_columns("runs")]

--- a/python_modules/dagster/dagster/core/storage/migration/utils.py
+++ b/python_modules/dagster/dagster/core/storage/migration/utils.py
@@ -2,16 +2,14 @@ from contextlib import contextmanager
 
 import sqlalchemy as db
 from alembic import op
-from sqlalchemy.engine import reflection
+from sqlalchemy import inspect
 
 import dagster._check as check
 from dagster.core.storage.sql import get_current_timestamp
 
 
 def get_inspector():
-    # pylint: disable=no-member
-    bind = op.get_context().bind
-    return reflection.Inspector.from_engine(bind)
+    return inspect(op.get_bind())
 
 
 def get_table_names():


### PR DESCRIPTION
### Summary & Motivation
noticed this in a BK run
```
[2022-05-12T18:55:29Z]   /workdir/python_modules/dagster/dagster/core/storage/alembic/versions/002_cascade_run_deletion_postgres.py:23: SADeprecationWarning: The from_engine() method on Inspector is deprecated and will be removed in a future release.  Please use the sqlalchemy.inspect() function on an Engine or Connection in order to acquire an Inspector. (deprecated since: 1.4)
[2022-05-12T18:55:29Z]     inspector = reflection.Inspector.from_engine(bind)
```

migrate to the recommended methods

### How I Tested These Changes

bk