### PR TITLE
[bk] set env var on trigger builds

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
@@ -45,6 +45,7 @@ def dagster():
                     "DAGSTER_BRANCH": branch_name,
                     "DAGSTER_COMMIT_HASH": os.getenv("BUILDKITE_COMMIT"),
                     "DAGIT_ONLY_OSS_CHANGE": "1" if dagit_only else "",
+                    "OSS_TRIGGERED_BUILD": "true",
                 },
             ),
         ]


### PR DESCRIPTION
to be used by internal CI to distinguish oss triggered builds


