### PR TITLE
enable @asset-decorated functions to accept kwargs

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -345,3 +345,14 @@ def test_op_tags():
         ...
 
     assert my_asset.op.tags == tags_stringified
+
+
+def test_kwargs():
+    @asset(ins={"upstream": AssetIn()})
+    def my_asset(**kwargs):
+        del kwargs
+
+    assert isinstance(my_asset, AssetsDefinition)
+    assert len(my_asset.op.output_defs) == 1
+    assert len(my_asset.op.input_defs) == 1
+    assert AssetKey("upstream") in my_asset.asset_keys_by_input_name.values()


### PR DESCRIPTION
### Summary & Motivation

We already accept these for ops, so we might as well accept them for assets as well.

Motivated by this user request: https://dagster.slack.com/archives/C02NA9CUPU0/p1652130480781049

### How I Tested These Changes

Added a test.
