### PR TITLE
docs: fix vercel build

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -712,5 +712,29 @@
         "path": "/community/public-apis"
       }
     ]
+  },
+  {
+    "title": "Changelog",
+    "icon": "Change",
+    "path": "/changelog",
+    "isUnversioned": true,
+    "children": [
+      {
+        "title": "Changelog",
+        "path": "/changelog",
+        "isUnversioned": true
+      },
+      {
+        "title": "Migration Guides",
+        "path": "/migration",
+        "isUnversioned": true
+      }
+    ]
+  },
+  {
+    "title": "Dagster Cloud Docs",
+    "icon": "Cloud",
+    "path": "https://docs.dagster.cloud/",
+    "isExternalLink": true
   }
 ]

--- a/docs/next/.versioned_content/_versioned_navigation.json
+++ b/docs/next/.versioned_content/_versioned_navigation.json
@@ -29586,6 +29586,30 @@
       "icon": "Users",
       "path": "/community",
       "title": "Community"
+    },
+    {
+      "children": [
+        {
+          "isUnversioned": true,
+          "path": "/changelog",
+          "title": "Changelog"
+        },
+        {
+          "isUnversioned": true,
+          "path": "/migration",
+          "title": "Migration Guides"
+        }
+      ],
+      "icon": "Change",
+      "isUnversioned": true,
+      "path": "/changelog",
+      "title": "Changelog"
+    },
+    {
+      "icon": "Cloud",
+      "isExternalLink": true,
+      "path": "https://docs.dagster.cloud/",
+      "title": "Dagster Cloud Docs"
     }
   ],
   "0.14.2": [

--- a/docs/next/pages/[...page].tsx
+++ b/docs/next/pages/[...page].tsx
@@ -15,7 +15,7 @@ import { versionFromPage } from "../util/useVersion";
 import axios from "axios";
 import { GetStaticProps } from "next";
 import { MdxRemote } from "next-mdx-remote/types";
-import { latestAllPaths } from "util/useNavigation";
+import { latestAllVersionedPaths } from "util/useNavigation";
 import { promises as fs } from "fs";
 import generateToc from "mdast-util-toc";
 import matter from "gray-matter";
@@ -251,7 +251,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
 export function getStaticPaths({}) {
   return {
-    paths: latestAllPaths(), // only generate pages of latest version at build time
+    paths: latestAllVersionedPaths(), // only generate pages of latest version at build time
     fallback: true,
   };
 }

--- a/docs/next/util/useNavigation.ts
+++ b/docs/next/util/useNavigation.ts
@@ -2,6 +2,14 @@ import masterNavigation from "../../content/_navigation.json";
 import { useVersion, latestVersion } from "./useVersion";
 import versionedNavigation from "../.versioned_content/_versioned_navigation.json";
 
+type NavEntry = {
+  title: string;
+  path: string;
+  children?: NavEntry[];
+  icon?: string;
+  isUnversioned?: boolean;
+  isExternalLink?: boolean;
+};
 export function flatten(yx: any) {
   const xs = JSON.parse(JSON.stringify(yx));
 
@@ -29,6 +37,20 @@ export const latestAllPaths = () => {
   // latest version
   return flatten(versionedNavigation[latestVersion])
     .filter((n: { path: any }) => n.path)
+    .map(({ path }) => path.split("/").splice(1))
+    .map((page: string[]) => {
+      return {
+        params: {
+          page: page,
+        },
+      };
+    });
+};
+
+export const latestAllVersionedPaths = () => {
+  // latest version, excluding paths that are
+  return flatten(versionedNavigation[latestVersion])
+    .filter((n: NavEntry) => n.path && !n.isExternalLink && !n.isUnversioned)
     .map(({ path }) => path.split("/").splice(1))
     .map((page: string[]) => {
       return {


### PR DESCRIPTION
### Summary & Motivation
- Revert the stopgap https://github.com/dagster-io/dagster/pull/7873
- Fix the root cause: 
  * Error: 
  ```
  error - Conflicting paths returned from getStaticPaths, paths must be unique per page.
  path: "/changelog" from page: "/[...page]" conflicts with path: "/changelog"
  path: "/migration" from page: "/[...page]" conflicts with path: "/migration"
  ```
  * What happened? we did have duplicate paths: `/changelog` (the file path) vs "/changelog" entry in the nav (which dynamically generates all the paths vercel needs to build statically).
    * Why this only happened during the release? It's because we only do static generation for "latest" version, which means when we released the new navigation (more specifically, when we said now 0.14.15 is the latest so "go statically generate all paths that are in the 0.14.15 nav"), it had duplicate paths.
  * Fix: ignore entries in the navigation that's marked unversioned.

### How I Tested These Changes
First vercel should fail: https://vercel.com/elementl/dagster/5nQrRKCtHEUuGSWJrzr4p6vJghDU
Second should succeed: https://vercel.com/elementl/dagster/2KnvXKAXurR3EiWeY28MfdkxA2YS