### PR TITLE
Don't call it a 'framework error' when a run worker unexpectedly restarts

### DIFF
--- a/python_modules/dagster/dagster_tests/execution_tests/test_api_iterators.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_api_iterators.py
@@ -123,14 +123,16 @@ def test_execute_run_iterator():
             mode="default",
         ).with_status(PipelineRunStatus.SUCCESS)
 
-        with pytest.raises(
-            Exception,
-            match=r"basic_resource_pipeline \({}\) started a new "
-            r"run while the run was already in state DagsterRunStatus.SUCCESS.".format(
-                pipeline_run.run_id
-            ),
-        ):
+        events = list(
             execute_run_iterator(InMemoryPipeline(pipeline_def), pipeline_run, instance=instance)
+        )
+
+        assert any(
+            [
+                "Ignoring a run worker that started after the run had already finished." in event
+                for event in events
+            ]
+        )
 
         with instance_for_test(
             overrides={
@@ -177,6 +179,72 @@ def test_execute_run_iterator():
         assert (
             events[0].message
             == "Not starting execution since the run was canceled before execution could start"
+        )
+
+
+def test_restart_running_run_worker():
+    def event_callback(_record):
+        pass
+
+    with instance_for_test() as instance:
+        pipeline_def = PipelineDefinition(
+            name="basic_resource_pipeline",
+            solid_defs=[resource_solid],
+            mode_defs=[
+                ModeDefinition(
+                    resource_defs={"a": resource_a, "b": resource_b},
+                    logger_defs={"callback": construct_event_logger(event_callback)},
+                )
+            ],
+        )
+        pipeline_run = instance.create_run_for_pipeline(
+            pipeline_def=pipeline_def,
+            run_config={"loggers": {"callback": {}}},
+            mode="default",
+        ).with_status(PipelineRunStatus.STARTED)
+
+        events = list(
+            execute_run_iterator(InMemoryPipeline(pipeline_def), pipeline_run, instance=instance)
+        )
+
+        assert any(
+            [
+                f"{pipeline_run.pipeline_name} ({pipeline_run.run_id}) started a new run worker while the run was already in state DagsterRunStatus.STARTED. "
+                in event.message
+                for event in events
+            ]
+        )
+
+        assert instance.get_run_by_id(pipeline_run.run_id).status == PipelineRunStatus.FAILURE
+
+
+def test_start_run_worker_after_run_failure():
+    def event_callback(_record):
+        pass
+
+    with instance_for_test() as instance:
+        pipeline_def = PipelineDefinition(
+            name="basic_resource_pipeline",
+            solid_defs=[resource_solid],
+            mode_defs=[
+                ModeDefinition(
+                    resource_defs={"a": resource_a, "b": resource_b},
+                    logger_defs={"callback": construct_event_logger(event_callback)},
+                )
+            ],
+        )
+        pipeline_run = instance.create_run_for_pipeline(
+            pipeline_def=pipeline_def,
+            run_config={"loggers": {"callback": {}}},
+            mode="default",
+        ).with_status(PipelineRunStatus.FAILURE)
+
+        event = next(
+            execute_run_iterator(InMemoryPipeline(pipeline_def), pipeline_run, instance=instance)
+        )
+        assert (
+            "Ignoring a run worker that started after the run had already finished."
+            in event.message
         )
 
 


### PR DESCRIPTION
Summary:
A user pointed out that it's confusing if Dagster times out a run because it took too long to start, then it eventually starts up, then Dagster confusingly claims it was a framework error. Change that specific case to be more of an FYI instead of a framework error.

There's also a good case to be made I think that we shouldn't treat the existing case when this happens when the run was already started as a 'framework error' either (although we should certainly still fail the run if the cluster interrupts a run and then tries to start it up again from the beginning)

Test Plan: Bk

### Summary & Motivation

### How I Tested These Changes
