### PR TITLE
[dagster-airbyte] don't cancel completed syncs

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -56,7 +56,6 @@ def test_assets(schema_prefix):
         json=get_sample_job_json(schema_prefix=schema_prefix),
         status=200,
     )
-    responses.add(responses.POST, f"{ab_resource.api_base_url}/jobs/cancel", status=204)
 
     ab_job = build_assets_job(
         "ab_job",

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_ops.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_ops.py
@@ -40,7 +40,6 @@ def test_airbyte_sync_op():
         rsps.add(rsps.POST, f"{ab_url}/connections/sync", json={"job": {"id": 1}})
         rsps.add(rsps.POST, f"{ab_url}/jobs/get", json={"job": {"id": 1, "status": "running"}})
         rsps.add(rsps.POST, f"{ab_url}/jobs/get", json={"job": {"id": 1, "status": "succeeded"}})
-        rsps.add(rsps.POST, f"{ab_url}/jobs/cancel", status=204)
 
         result = airbyte_sync_job.execute_in_process()
         assert result.output_for_node("airbyte_sync_op") == AirbyteOutput(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
@@ -70,7 +70,8 @@ def test_sync_and_poll(state):
         json={"job": {"id": 1, "status": state}},
         status=200,
     )
-    responses.add(responses.POST, f"{ab_resource.api_base_url}/jobs/cancel", status=204)
+    if state == "unrecognized":
+        responses.add(responses.POST, f"{ab_resource.api_base_url}/jobs/cancel", status=204)
 
     if state == AirbyteState.ERROR:
         with pytest.raises(Failure, match="Job failed"):


### PR DESCRIPTION
### Summary & Motivation

Turns out my original comment was not correct (🤦 ), and cancelling a job that has completed will trigger alerts. This update makes it so we will only fire a cancellation request if the job is in a state which indicates it is still running.

### How I Tested These Changes


