### PR TITLE
[cloud dagit] Add optional nav tabs parameter for settings root page

### DIFF
--- a/js_modules/dagit/packages/core/src/app/ContentRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/ContentRoot.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {Route, Switch} from 'react-router-dom';
 
 const InstanceRoot = React.lazy(() => import('../instance/InstanceRoot'));
-const SettingsRoot = React.lazy(() => import('../app/SettingsRoot'));
+const UserSettingsRoot = React.lazy(() => import('./UserSettingsRoot'));
 const WorkspaceRoot = React.lazy(() => import('../workspace/WorkspaceRoot'));
 const FallthroughRoot = React.lazy(() => import('./FallthroughRoot'));
 
@@ -20,7 +20,7 @@ export const ContentRoot = React.memo(() => (
     </Route>
     <Route path="/settings">
       <React.Suspense fallback={<div />}>
-        <SettingsRoot />
+        <UserSettingsRoot />
       </React.Suspense>
     </Route>
     <Route path="*">

--- a/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
@@ -21,7 +21,7 @@ import {automaticLabel} from './time/browserTimezone';
 export interface SettingsRootProps {
   tabs?: React.ReactNode;
 }
-const UserSettingsRoot: React.FC<SettingsRootProps> = React.memo(({tabs}) => {
+const UserSettingsRoot: React.FC<SettingsRootProps> = ({tabs}) => {
   useDocumentTitle('User settings');
 
   const [flags, setFlags] = React.useState<FeatureFlag[]>(() => getFeatureFlags());
@@ -149,7 +149,7 @@ const UserSettingsRoot: React.FC<SettingsRootProps> = React.memo(({tabs}) => {
       </Box>
     </div>
   );
-});
+};
 
 // Imported via React.lazy, which requires a default export.
 // eslint-disable-next-line import/no-default-export

--- a/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
@@ -3,9 +3,9 @@ import {
   ButtonLink,
   Checkbox,
   Colors,
+  Heading,
   MetadataTable,
   PageHeader,
-  Heading,
   Subheading,
 } from '@dagster-io/ui';
 import * as React from 'react';
@@ -18,7 +18,10 @@ import {SHORTCUTS_STORAGE_KEY} from './ShortcutHandler';
 import {TimezoneSelect} from './time/TimezoneSelect';
 import {automaticLabel} from './time/browserTimezone';
 
-const SettingsRoot = () => {
+export interface SettingsRootProps {
+  tabs?: React.ReactNode;
+}
+const UserSettingsRoot: React.FC<SettingsRootProps> = React.memo(({tabs}) => {
   useDocumentTitle('User settings');
 
   const [flags, setFlags] = React.useState<FeatureFlag[]>(() => getFeatureFlags());
@@ -54,7 +57,7 @@ const SettingsRoot = () => {
 
   return (
     <div style={{height: '100vh', overflowY: 'auto'}}>
-      <PageHeader title={<Heading>User settings</Heading>} />
+      <PageHeader title={<Heading>User settings</Heading>} tabs={tabs} />
       <Box padding={{vertical: 16, horizontal: 24}}>
         <Box padding={{bottom: 8}}>
           <Subheading>Preferences</Subheading>
@@ -146,8 +149,8 @@ const SettingsRoot = () => {
       </Box>
     </div>
   );
-};
+});
 
 // Imported via React.lazy, which requires a default export.
 // eslint-disable-next-line import/no-default-export
-export default SettingsRoot;
+export default UserSettingsRoot;


### PR DESCRIPTION
## Summary

Allows tabs to be injected into the user settings page, for Cloud.
Also renames to `UserSettingsRoot` for clarity.

## Test Plan

Tested locally.