### PR TITLE
remove markupsafe pin

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -61,7 +61,6 @@ if __name__ == "__main__":
             "coloredlogs>=6.1, <=14.0",
             "contextvars; python_version < '3.7'",
             "Jinja2",
-            "markupsafe<=2.0.1",
             "PyYAML>=5.1",
             # core (not explicitly expressed atm)
             # alembic 1.6.3 broke our migrations: https://github.com/sqlalchemy/alembic/issues/848

--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -54,6 +54,9 @@ if __name__ == "__main__":
                 "kubernetes==10.0.1",
                 # New WTForms release breaks the version of airflow used by tests
                 "WTForms<3.0.0",
+                # pinned based on certain incompatible versions of Jinja2, which is itself pinned
+                # by apache-airflow==1.10.10
+                "markupsafe<=2.0.1",
             ],
         },
         entry_points={"console_scripts": ["dagster-airflow = dagster_airflow.cli:main"]},

--- a/python_modules/libraries/dagstermill/tox.ini
+++ b/python_modules/libraries/dagstermill/tox.ini
@@ -14,6 +14,7 @@ deps =
   papermill1: nbconvert<6.0.0
   papermill1: nbformat<=5.1.3
   papermill1: Jinja2<3.0
+  papermill1: markupsafe<=2.0.1
   -e ../../dagster[mypy,test]
   -e ../dagster-pandas
 allowlist_externals =


### PR DESCRIPTION
### Summary & Motivation

This removes the pin on `markupsafe`, hoping that the `jinja2` a user/dependency pulls will work correctly. This potentially should have occurred relative to https://github.com/dagster-io/dagster/issues/4167

It might not be possible to describe a set of `markupsafe` and `jinja2` pins that can handle a proper pre-`jiinja2<3` and post-`jinja2=>3`. Removing the markupsafe pin altogether allows the dependency to float such that users can specify their own depending on the requirements of their related packages.

### How I Tested These Changes

No direct tests, though have encountered [issues with dagster-airflow](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=506180&view=logs&j=d0d954b5-f111-5dc4-4d76-03b6c9d0cf7e&t=841356e0-85bb-57d8-dbbc-852e683d1642&l=5290) with this downstream on [conda-forge](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=506180&view=logs&j=d0d954b5-f111-5dc4-4d76-03b6c9d0cf7e&t=841356e0-85bb-57d8-dbbc-852e683d1642&l=5290), where even importing with an improper version throws errors.