### PR TITLE
make docker_compose_cm a contextmanager rather than a fixture

### DIFF
--- a/python_modules/dagster-test/dagster_test/fixtures/__init__.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/__init__.py
@@ -1,2 +1,7 @@
-from .docker_compose import docker_compose, docker_compose_cm
+from .docker_compose import (
+    default_docker_compose_yml,
+    docker_compose,
+    docker_compose_cm,
+    docker_compose_cm_fixture,
+)
 from .utils import retrying_requests, test_directory, test_id


### PR DESCRIPTION
Summary:
I would like to use this in a session-scoped fixture, but i can't, because its a module-scoped fixture. Instead, make the cm a contextmanager, and docker_compose() the fixture.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
