### PR TITLE
RFC: allow reexecuting generator step and any of its downstream together

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -29,7 +29,6 @@ def compute_step_keys_to_execute(graphene_info, execution_params):
         if execution_params.execution_metadata.parent_run_id and execution_params.step_keys:
             known_state = KnownExecutionState.for_reexecution(
                 instance.all_logs(execution_params.execution_metadata.parent_run_id),
-                execution_params.step_keys,
             )
 
         return execution_params.step_keys, known_state

--- a/python_modules/dagster/dagster/core/execution/api.py
+++ b/python_modules/dagster/dagster/core/execution/api.py
@@ -1025,7 +1025,7 @@ def _resolve_reexecute_step_selection(
         run_config,
         mode,
         step_keys_to_execute=list(step_keys_to_execute),
-        known_state=KnownExecutionState.for_reexecution(parent_logs, step_keys_to_execute),
+        known_state=KnownExecutionState.for_reexecution(parent_logs),
         tags=parent_pipeline_run.tags,
     )
     return execution_plan

--- a/python_modules/dagster/dagster/core/execution/backfill.py
+++ b/python_modules/dagster/dagster/core/execution/backfill.py
@@ -249,7 +249,6 @@ def create_backfill_run(
         if last_run and last_run.status == PipelineRunStatus.SUCCESS:
             known_state = KnownExecutionState.for_reexecution(
                 instance.all_logs(parent_run_id),
-                step_keys_to_execute,
             )
         else:
             known_state = None

--- a/python_modules/dagster/dagster/core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/plan.py
@@ -758,31 +758,18 @@ class ExecutionPlan(
         step_output_versions = check.opt_dict_param(
             step_output_versions, "step_output_versions", key_type=StepOutputHandle, value_type=str
         )
-        step_handles_to_execute_set = set()
+        step_handles_to_execute = [StepHandle.parse_from_key(key) for key in step_keys_to_execute]
+
         bad_keys = []
-
-        for key in step_keys_to_execute:
-            handle = StepHandle.parse_from_key(key)
-
+        for handle in step_handles_to_execute:
             if handle not in self.step_dict:
-                if isinstance(handle, ResolvedFromDynamicStepHandle):
-                    unresolved_handle = UnresolvedStepHandle(solid_handle=handle.solid_handle)
-                    if unresolved_handle in self.step_dict: # ok if the unresolved version is present
-                        step_handles_to_execute_set.add(unresolved_handle)
-                        continue
-
                 bad_keys.append(handle.to_key())
-
-            step_handles_to_execute_set.add(handle)
-
 
         if bad_keys:
             raise DagsterExecutionStepNotFoundError(
                 f"Can not build subset plan from unknown step{'s' if len(bad_keys)> 1 else ''}: {', '.join(bad_keys)}",
                 step_keys=bad_keys,
             )
-
-        step_handles_to_execute = list(step_handles_to_execute_set) if step_handles_to_execute_set else []
 
         executable_map, resolvable_map = _compute_step_maps(
             self.step_dict,

--- a/python_modules/dagster/dagster/core/execution/plan/resume_retry.py
+++ b/python_modules/dagster/dagster/core/execution/plan/resume_retry.py
@@ -140,4 +140,4 @@ def get_retry_steps_from_parent_run(
         step_handle.to_key() for step_set in to_retry.values() for step_handle in step_set
     ]
 
-    return steps_to_retry, KnownExecutionState.for_reexecution(parent_run_logs, steps_to_retry)
+    return steps_to_retry, KnownExecutionState.for_reexecution(parent_run_logs)

--- a/python_modules/dagster/dagster/core/execution/plan/state.py
+++ b/python_modules/dagster/dagster/core/execution/plan/state.py
@@ -108,17 +108,9 @@ class KnownExecutionState(
         )
 
     @staticmethod
-    def for_reexecution(
-        parent_run_logs: List[EventLogEntry], step_keys_to_execute: List[str]
-    ) -> "KnownExecutionState":
+    def for_reexecution(parent_run_logs: List[EventLogEntry]) -> "KnownExecutionState":
         """
-        Copy over dynamic mappings from previous run, but drop any for steps that we intend to re-execute
+        Copy over dynamic mappings from previous run
         """
         parent_state = KnownExecutionState.derive_from_logs(parent_run_logs)
-        dynamic_mappings_to_use = {
-            step_key: parent_state.dynamic_mappings[step_key]
-            for step_key in parent_state.dynamic_mappings.keys()
-            if step_key not in step_keys_to_execute
-        }
-        # return KnownExecutionState({}, dynamic_mappings_to_use)
         return KnownExecutionState({}, parent_state.dynamic_mappings)

--- a/python_modules/dagster/dagster/core/execution/plan/state.py
+++ b/python_modules/dagster/dagster/core/execution/plan/state.py
@@ -120,4 +120,5 @@ class KnownExecutionState(
             for step_key in parent_state.dynamic_mappings.keys()
             if step_key not in step_keys_to_execute
         }
-        return KnownExecutionState({}, dynamic_mappings_to_use)
+        # return KnownExecutionState({}, dynamic_mappings_to_use)
+        return KnownExecutionState({}, parent_state.dynamic_mappings)

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_dynamic_execution.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_dynamic_execution.py
@@ -1,6 +1,8 @@
+from dagster.core.events import DagsterEventType
 import pytest
 
 from dagster import (
+    DynamicOut,
     DynamicOutput,
     DynamicOutputDefinition,
     Field,
@@ -9,6 +11,8 @@ from dagster import (
     OutputDefinition,
     composite_solid,
     execute_pipeline,
+    job,
+    op,
     pipeline,
     reconstructable,
     solid,
@@ -283,6 +287,91 @@ def test_fan_out_in_out_in(run_config):
         assert empty_result.result_for_solid("sum_numbers").output_value() == 0
 
 
+def define_real_dynamic_job():
+    @op(config_schema=list, out=DynamicOut(int))
+    def generate_subtasks(context):
+        for num in context.op_config:
+            yield DynamicOutput(num, mapping_key=str(num))
+
+    @op
+    def subtask(input_number: int):
+        print(f"Found {input_number} cereals")
+        return input_number
+
+    @job
+    def real_dynamic_job():
+        generate_subtasks().map(subtask)
+
+    return real_dynamic_job
+
+
+def test_select_dynamic_step_with_non_static_mapping():
+    with instance_for_test() as instance:
+        result_0 = execute_pipeline(
+            reconstructable(define_real_dynamic_job),
+            instance=instance,
+            run_config={"ops": {"generate_subtasks": {"config": [0, 2, 4]}}},
+        )
+        assert result_0.success
+
+        result_1 = reexecute_pipeline(
+            reconstructable(define_real_dynamic_job),
+            parent_run_id=result_0.run_id,
+            instance=instance,
+            step_selection=["generate_subtasks", "subtask[4]"],
+            run_config={"ops": {"generate_subtasks": {"config": [0, 2, 4]}}},
+        )
+        assert result_1.success
+        keys_1 = result_1.events_by_step_key.keys()
+        assert "generate_subtasks" in keys_1
+        assert "subtask[4]" in keys_1
+        assert "subtask[0]" not in keys_1
+        assert "subtask[2]" not in keys_1
+
+        result_2 = reexecute_pipeline(
+            reconstructable(define_real_dynamic_job),
+            parent_run_id=result_0.run_id,
+            instance=instance,
+            step_selection=["generate_subtasks", "subtask[4]"],
+            run_config={"ops": {"generate_subtasks": {"config": [1, 3, 5]}}},
+        )
+        # subtask[4] is skipped - bc generate_subtasks doesn't yield "4"
+        # subtask[1], subtask[3], subtask[5] have been generated but not selected to execute
+        assert result_2.success
+        keys_2 = result_2.events_by_step_key.keys()
+        assert "generate_subtasks" in keys_2
+        assert "subtask[4]" in keys_2
+        assert (
+            result_2.events_by_step_key["subtask[4]"][0].event_type == DagsterEventType.STEP_SKIPPED
+        )
+        assert "subtask[1]" not in keys_2
+        assert "subtask[3]" not in keys_2
+        assert "subtask[5]" not in keys_2
+
+        result_3 = reexecute_pipeline(
+            reconstructable(define_real_dynamic_job),
+            parent_run_id=result_0.run_id,
+            instance=instance,
+            step_selection=["generate_subtasks", "subtask[4]"],
+            run_config={"ops": {"generate_subtasks": {"config": [1, 2, 3, 4, 5]}}},
+        )
+        # subtask[4] is executed
+        # subtask[0], subtask[1], subtask[2], subtask[3], subtask[5] have been generated but not
+        # selected to execute
+        assert result_3.success
+        keys_3 = result_3.events_by_step_key.keys()
+        assert "generate_subtasks" in keys_3
+        assert "subtask[4]" in keys_3
+        assert DagsterEventType.STEP_SUCCESS in [
+            e.event_type for e in result_3.events_by_step_key["subtask[4]"]
+        ]
+        assert "subtask[0]" not in keys_3
+        assert "subtask[1]" not in keys_3
+        assert "subtask[2]" not in keys_3
+        assert "subtask[3]" not in keys_3
+        assert "subtask[5]" not in keys_3
+
+
 def test_select_dynamic_step_and_downstream():
     with instance_for_test() as instance:
         result_1 = execute_pipeline(dynamic_pipeline, instance=instance)
@@ -319,44 +408,19 @@ def test_select_dynamic_step_and_downstream():
         assert "multiply_inputs[2]" in keys_3
         assert "multiply_by_two[0]" not in keys_3
 
-
         result_4 = reexecute_pipeline(
             dynamic_pipeline,
             parent_run_id=result_1.run_id,
             instance=instance,
-            step_selection=["emit", "emit_ten", "multiply_inputs[1]"],
+            step_selection=["emit_ten", "multiply_inputs[1]", "multiply_by_two[1]"],
         )
 
         keys_4 = result_4.events_by_step_key.keys()
+        assert "emit_ten" in keys_4
         assert "multiply_inputs[1]" in keys_4
+        assert "multiply_by_two[1]" in keys_4
+        assert "emit" not in keys_4
         assert "multiply_inputs[0]" not in keys_4
-
-        result_5 = reexecute_pipeline(
-            dynamic_pipeline,
-            parent_run_id=result_1.run_id,
-            instance=instance,
-            step_selection=["emit", "emit_ten", "multiply_inputs[1]", "multiply_by_two[1]"],
-        )
-
-        keys_5 = result_5.events_by_step_key.keys()
-        assert "multiply_inputs[1]" in keys_5
-        assert "multiply_by_two[1]" in keys_5
-        assert "multiply_inputs[0]" not in keys_5
-
-def test_bad_step_selection():
-    with instance_for_test() as instance:
-        result_1 = execute_pipeline(dynamic_pipeline, instance=instance)
-        assert result_1.success
-
-        # this exact error could be improved, but it should fail if you try to select
-        # both the dynamic outputting step key and something resolved by it in the previous run
-        with pytest.raises(DagsterExecutionStepNotFoundError):
-            reexecute_pipeline(
-                dynamic_pipeline,
-                parent_run_id=result_1.run_id,
-                instance=instance,
-                step_selection=["emit", "multiply_by_two[1]"],
-            )
 
 
 @pytest.mark.parametrize(

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_dynamic_execution.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_dynamic_execution.py
@@ -1,4 +1,3 @@
-from dagster.core.events import DagsterEventType
 import pytest
 
 from dagster import (
@@ -18,6 +17,7 @@ from dagster import (
     solid,
 )
 from dagster.core.errors import DagsterExecutionStepNotFoundError
+from dagster.core.events import DagsterEventType
 from dagster.core.execution.api import create_execution_plan, reexecute_pipeline
 from dagster.core.execution.plan.state import KnownExecutionState
 from dagster.core.test_utils import default_mode_def_for_test, instance_for_test


### PR DESCRIPTION
### Summary & Motivation

This proposal is going to result in a user-facing behavioral change - it allows additional possible cases (see test case `test_select_dynamic_step_with_non_static_mapping`) and doesn't affect existing patterns, which could resolve https://github.com/dagster-io/dagster/issues/6044

The fix here is to allow re-executing the step that generates dynamic outs (aka `generate_subtasks`) and any downstream dynamic steps that were resolved from those dynamic outs (e.g. `subtask[4]`), which would impose the following logics:
![image](https://user-images.githubusercontent.com/4531914/169149454-58d703ac-2d03-4fba-a818-966a429718eb.png)
- When `generate_subtasks` aren't always generating the same dynamic outs in each re-execution, the execution engine would use the execution plan that's constructed in **the same run** but only execute the selected steps. It means if a selected step is not being constructed in `generate_subtasks`, it will skip because its upstream output doesn't exist.


Alternative is ... TODO


### How I Tested These Changes
- Repro locally: all cases mentioned on the issue work now
```
# didn't work and now work
+hello_dynamic
generate_subtasks*
generate_subtasks+
generate_subtasks, hello_dynamic
# did work and still work
hello_dynamic
hello_dynamic*
hello_dynamic[subtask_1]
```
<img width="300" alt="image" src="https://user-images.githubusercontent.com/4531914/168673709-33bae900-b3e8-4be5-a10a-3243b13ef4f9.png">

- Added more unit tests for edge cases