### PR TITLE
[asset-resources 1/n] Resource defs on assets

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/asset_group.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_group.py
@@ -664,10 +664,13 @@ def _validate_resource_reqs_for_asset_group(
 ):
     present_resource_keys = set(resource_defs.keys())
     for asset_def in asset_list:
-        resource_keys: Set[str] = set()
+        provided_resource_keys = set(asset_def.resource_defs.keys())
+        present_resource_keys = present_resource_keys.union(provided_resource_keys)
+
+        required_resource_keys: Set[str] = set()
         for op_def in asset_def.node_def.iterate_solid_defs():
-            resource_keys.update(set(op_def.required_resource_keys or {}))
-        missing_resource_keys = list(set(resource_keys) - present_resource_keys)
+            required_resource_keys.update(set(op_def.required_resource_keys or {}))
+        missing_resource_keys = list(set(required_resource_keys) - present_resource_keys)
         if missing_resource_keys:
             raise DagsterInvalidDefinitionError(
                 f"AssetGroup is missing required resource keys for asset '{asset_def.node_def.name}'. "


### PR DESCRIPTION
Adds a resource_defs arg to assets. This introduces the possibility for resource conflicts for a given resource key. Errors around these conflicts are caught at job creation time (and transitively, since the assetgroup is converted to a mega job at repo construction time, at repo construction time).