### PR TITLE
InputContext.upstream_output is missing asset key when root input

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/assets_job.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets_job.py
@@ -322,6 +322,7 @@ def build_root_manager(
                 metadata=cast(Dict[str, Any], source_asset.metadata),
                 resource_config=resource_config,
                 resources=cast(NamedTuple, resources)._asdict(),
+                asset_key=source_asset_key,
             )
             input_context_with_upstream = build_input_context(
                 name=input_context.name,

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -236,6 +236,8 @@ def test_source_asset():
             assert context.resource_config["a"] == 7
             assert context.resources.subresource == 9
             assert context.upstream_output.resources.subresource == 9
+            assert context.upstream_output.asset_key == AssetKey("source1")
+            assert context.asset_key == AssetKey("source1")
             return 5
 
     @io_manager(config_schema={"a": int}, required_resource_keys={"subresource"})


### PR DESCRIPTION
I caused this bug with a recent change.
