### PR TITLE
[asset-resources 2/n][rfc] io manager defs directly on asset defs

### DIFF
--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -867,10 +867,6 @@ def is_list(
 # ########################
 
 
-def is_mapping_param(obj: object) -> bool:
-    return isinstance(obj, collections.abc.Mapping)
-
-
 def mapping_param(
     obj: Mapping[T, U],
     param_name: str,

--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -867,6 +867,10 @@ def is_list(
 # ########################
 
 
+def is_mapping_param(obj: object) -> bool:
+    return isinstance(obj, collections.abc.Mapping)
+
+
 def mapping_param(
     obj: Mapping[T, U],
     param_name: str,

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -53,7 +53,7 @@ def asset(
     description: Optional[str] = ...,
     required_resource_keys: Optional[Set[str]] = ...,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = ...,
-    io_manager_def: Optional[Union[Mapping[str, IOManagerDefinition], IOManagerDefinition]] = ...,
+    io_manager_def: Optional[IOManagerDefinition] = ...,
     io_manager_key: Optional[str] = ...,
     compute_kind: Optional[str] = ...,
     dagster_type: Optional[DagsterType] = ...,

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
@@ -256,22 +256,6 @@ def test_multiple_assets_io_manager_defs():
     assert io_manager_inst.values[other_asset_key] == 6
 
 
-def test_asset_with_io_manager_key_and_def():
-    io_manager_inst = InMemoryIOManager()
-
-    @io_manager
-    def the_io_manager():
-        return io_manager_inst
-
-    @asset(io_manager_def={"the_key": the_io_manager})
-    def the_asset():
-        return 5
-
-    AssetGroup([the_asset]).materialize()
-
-    assert list(io_manager_inst.values.values())[0] == 5
-
-
 def test_asset_with_io_manager_key_only():
     io_manager_inst = InMemoryIOManager()
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dagster import AssetKey, Out, Output, io_manager, IOManager
+from dagster import AssetKey, IOManager, Out, Output, io_manager
 from dagster._check import CheckError
 from dagster.core.asset_defs import AssetGroup, AssetIn, SourceAsset, asset, multi_asset
 from dagster.core.storage.mem_io_manager import InMemoryIOManager
@@ -231,7 +231,7 @@ def test_asset_with_io_manager_def():
 
     result = AssetGroup([the_asset]).materialize()
     assert result.success
-    assert outputs == ["entered for the_asset"]
+    assert events == ["entered for the_asset"]
 
 
 def test_multiple_assets_io_manager_defs():

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
@@ -1,8 +1,9 @@
 import pytest
 
-from dagster import AssetKey, Out, Output
+from dagster import AssetKey, Out, Output, io_manager
 from dagster._check import CheckError
-from dagster.core.asset_defs import AssetIn, SourceAsset, asset, multi_asset
+from dagster.core.asset_defs import AssetGroup, AssetIn, SourceAsset, asset, multi_asset
+from dagster.core.storage.mem_io_manager import InMemoryIOManager
 
 
 def test_with_replaced_asset_keys():
@@ -208,3 +209,80 @@ def test_coerced_asset_keys():
     @asset(ins={"input1": AssetIn(asset_key=["Asset", "1"])})
     def asset1(input1):
         assert input1
+
+
+def test_asset_with_io_manager_def():
+    io_manager_inst = InMemoryIOManager()
+
+    @io_manager
+    def the_io_manager():
+        return io_manager_inst
+
+    @asset(io_manager=the_io_manager)
+    def the_asset():
+        return 5
+
+    AssetGroup([the_asset]).materialize()
+
+    assert list(io_manager_inst.values.values())[0] == 5
+
+
+def test_multiple_assets_io_manager_defs():
+    io_manager_inst = InMemoryIOManager()
+    num_times = [0]
+
+    @io_manager
+    def the_io_manager():
+        num_times[0] += 1
+        return io_manager_inst
+
+    # These will produce different instances of the io manager.
+    @asset(io_manager=the_io_manager)
+    def the_asset():
+        return 5
+
+    @asset(io_manager=the_io_manager)
+    def other_asset():
+        return 6
+
+    AssetGroup([the_asset, other_asset]).materialize()
+
+    assert num_times[0] == 2
+
+    the_asset_key = [key for key in io_manager_inst.values.keys() if key[1] == "the_asset"][0]
+    assert io_manager_inst.values[the_asset_key] == 5
+
+    other_asset_key = [key for key in io_manager_inst.values.keys() if key[1] == "other_asset"][0]
+    assert io_manager_inst.values[other_asset_key] == 6
+
+
+def test_asset_with_io_manager_key_and_def():
+    io_manager_inst = InMemoryIOManager()
+
+    @io_manager
+    def the_io_manager():
+        return io_manager_inst
+
+    @asset(io_manager={"the_key": the_io_manager})
+    def the_asset():
+        return 5
+
+    AssetGroup([the_asset]).materialize()
+
+    assert list(io_manager_inst.values.values())[0] == 5
+
+
+def test_asset_with_io_manager_key_only():
+    io_manager_inst = InMemoryIOManager()
+
+    @io_manager
+    def the_io_manager():
+        return io_manager_inst
+
+    @asset(io_manager="the_key")
+    def the_asset():
+        return 5
+
+    AssetGroup([the_asset], resource_defs={"the_key": the_io_manager}).materialize()
+
+    assert list(io_manager_inst.values.values())[0] == 5

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
@@ -218,7 +218,7 @@ def test_asset_with_io_manager_def():
     def the_io_manager():
         return io_manager_inst
 
-    @asset(io_manager=the_io_manager)
+    @asset(io_manager_def=the_io_manager)
     def the_asset():
         return 5
 
@@ -237,11 +237,11 @@ def test_multiple_assets_io_manager_defs():
         return io_manager_inst
 
     # These will produce different instances of the io manager.
-    @asset(io_manager=the_io_manager)
+    @asset(io_manager_def=the_io_manager)
     def the_asset():
         return 5
 
-    @asset(io_manager=the_io_manager)
+    @asset(io_manager_def=the_io_manager)
     def other_asset():
         return 6
 
@@ -263,7 +263,7 @@ def test_asset_with_io_manager_key_and_def():
     def the_io_manager():
         return io_manager_inst
 
-    @asset(io_manager={"the_key": the_io_manager})
+    @asset(io_manager_def={"the_key": the_io_manager})
     def the_asset():
         return 5
 
@@ -279,10 +279,26 @@ def test_asset_with_io_manager_key_only():
     def the_io_manager():
         return io_manager_inst
 
-    @asset(io_manager="the_key")
+    @asset(io_manager_key="the_key")
     def the_asset():
         return 5
 
     AssetGroup([the_asset], resource_defs={"the_key": the_io_manager}).materialize()
 
     assert list(io_manager_inst.values.values())[0] == 5
+
+
+def test_asset_both_io_manager_args_provided():
+    @io_manager
+    def the_io_manager():
+        pass
+
+    with pytest.raises(
+        CheckError,
+        match="Both io_manager_key and io_manager_def were provided to `@asset` "
+        "decorator. Please provide one or the other.",
+    ):
+
+        @asset(io_manager_key="the_key", io_manager_def=the_io_manager)
+        def the_asset():
+            pass


### PR DESCRIPTION
Allows io managers to be placed directly on assets definitions. `io_manager_key` becomes a backcompat argument, and there are 3 different ways that the argument can be specified: as a string key, as a dictionary mapping a key to a definition, or as a definition object only.