### PR TITLE
chore(helm): remove local from compute log manager options

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/compute_log_manager.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/compute_log_manager.py
@@ -9,7 +9,6 @@ from .config import StringSource
 
 class ComputeLogManagerType(str, Enum):
     NOOP = "NoOpComputeLogManager"
-    LOCAL = "LocalComputeLogManager"  # deprecated in favor of noop
     AZURE = "AzureBlobComputeLogManager"
     GCS = "GCSComputeLogManager"
     S3 = "S3ComputeLogManager"

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -414,16 +414,9 @@ def test_custom_run_coordinator_config(template: HelmTemplate):
     assert instance["run_coordinator"]["config"] == config
 
 
-@pytest.mark.parametrize(
-    "compute_log_manager_type",
-    [ComputeLogManagerType.NOOP, ComputeLogManagerType.LOCAL],
-    ids=["noop", "local compute log manager becomes noop"],
-)
-def test_noop_compute_log_manager(
-    template: HelmTemplate, compute_log_manager_type: ComputeLogManagerType
-):
+def test_noop_compute_log_manager(template: HelmTemplate):
     helm_values = DagsterHelmValues.construct(
-        computeLogManager=ComputeLogManager.construct(type=compute_log_manager_type)
+        computeLogManager=ComputeLogManager.construct(type=ComputeLogManagerType.NOOP)
     )
 
     configmaps = template.render(helm_values)

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -80,7 +80,7 @@ data:
 
     {{- $computeLogManagerType := .Values.computeLogManager.type }}
     compute_logs:
-      {{- if has $computeLogManagerType (list "NoOpComputeLogManager" "LocalComputeLogManager") -}}
+      {{- if eq $computeLogManagerType "NoOpComputeLogManager" -}}
         {{- include "dagsterYaml.computeLogManager.noop" . | indent 6 -}}
       {{- else if eq $computeLogManagerType "AzureBlobComputeLogManager" }}
         {{- include "dagsterYaml.computeLogManager.azure" . | indent 6 -}}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1044,7 +1044,6 @@
             "description": "An enumeration.",
             "enum": [
                 "NoOpComputeLogManager",
-                "LocalComputeLogManager",
                 "AzureBlobComputeLogManager",
                 "GCSComputeLogManager",
                 "S3ComputeLogManager",

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -160,7 +160,6 @@ dagit:
 computeLogManager:
   # Type can be one of [
   #   NoOpComputeLogManager,
-  #   LocalComputeLogManager (deprecated - if set, NoOpComputeLogManager will be used instead),
   #   AzureBlobComputeLogManager,
   #   GCSComputeLogManager,
   #   S3ComputeLogManager,


### PR DESCRIPTION
### Summary & Motivation
This has been marked for deprecation since July 2021. Remove it as an option.

### How I Tested These Changes
bk
