### PR TITLE
Better error handling when an ExternalRepository grpc call fails

### DIFF
--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -396,6 +396,17 @@ class ExternalSensorData(
 
 
 @whitelist_for_serdes
+class ExternalRepositoryErrorData(
+    NamedTuple("_ExternalRepositoryErrorData", [("error", Optional[SerializableErrorInfo])])
+):
+    def __new__(cls, error: Optional[SerializableErrorInfo]):
+        return super(ExternalRepositoryErrorData, cls).__new__(
+            cls,
+            error=check.opt_inst_param(error, "error", SerializableErrorInfo),
+        )
+
+
+@whitelist_for_serdes
 class ExternalSensorExecutionErrorData(
     NamedTuple("_ExternalSensorExecutionErrorData", [("error", Optional[SerializableErrorInfo])])
 ):


### PR DESCRIPTION
Summary:
I can't come up with a case where this *should* happen - to the point where I'm having trouble finding a good test to write for this (an error getting raised not when the repo is first loaded, but when we go to fetch the external repository), but at least one user-submitted issue suggests that it *does* happen: https://github.com/dagster-io/dagster/issues/7927. Add better error handling like the other gRPC methods for this where we will surface a nice stack trace when it does.

This is technically a minor breaking change, in that errors on older versions that used to fail with one gross exception (DagsterUserCodeUnreachableError with an inscrutable stack trace) will now fail with a different gross exception until you upgrade (failed to find ExternalRepositoryErrorData to deserialize it). If we wanted to be really sneaky we could repurpose a class like  ExternalSensorExecutionErrorData, which has the same arguments, to avoid that.

### How I Tested These Changes
Working on an automated test - having trouble finding a good repro