### PR TITLE
provide job_timeout_in_seconds in dataproc resource config

### DIFF
--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/ops.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/ops.py
@@ -1,9 +1,18 @@
-from dagster import Bool, Field, op, solid
+from dagster import Bool, Field, Int, op, solid
 from dagster.seven import json
 
 from .configs import define_dataproc_submit_job_config
+from .resources import TWENTY_MINUTES
 
 DATAPROC_CONFIG_SCHEMA = {
+    "job_timeout_in_seconds": Field(
+        Int,
+        description="""Optional. Maximum time in seconds to wait for the job being
+                    completed. Default is set to 1200 seconds (20 minutes).
+                    """,
+        is_required=False,
+        default_value=TWENTY_MINUTES,
+    ),
     "job_config": define_dataproc_submit_job_config(),
     "job_scoped_cluster": Field(
         Bool,
@@ -16,8 +25,12 @@ DATAPROC_CONFIG_SCHEMA = {
 
 def _dataproc_compute(context):
     job_config = context.solid_config["job_config"]
+    job_timeout = context.solid_config["job_timeout_in_seconds"]
 
-    context.log.info("submitting job with config: %s" % str(json.dumps(job_config)))
+    context.log.info(
+        "submitting job with config: %s and timeout of: %d seconds"
+        % (str(json.dumps(job_config)), job_timeout)
+    )
 
     if context.solid_config["job_scoped_cluster"]:
         # Cluster context manager, creates and then deletes cluster
@@ -27,7 +40,8 @@ def _dataproc_compute(context):
 
             job_id = result["reference"]["jobId"]
             context.log.info("Submitted job ID {}".format(job_id))
-            cluster.wait_for_job(job_id)
+            cluster.wait_for_job(job_id, wait_timeout=job_timeout)
+
     else:
         # Submit to an existing cluster
         # Submit the job specified by this solid to the cluster defined by the associated resource
@@ -35,7 +49,7 @@ def _dataproc_compute(context):
 
         job_id = result["reference"]["jobId"]
         context.log.info("Submitted job ID {}".format(job_id))
-        context.resources.dataproc.wait_for_job(job_id)
+        context.resources.dataproc.wait_for_job(job_id, wait_timeout=job_timeout)
 
 
 @solid(required_resource_keys={"dataproc"}, config_schema=DATAPROC_CONFIG_SCHEMA)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
@@ -98,7 +98,7 @@ class DataprocResource:
             projectId=self.project_id, region=self.region, jobId=job_id
         ).execute()
 
-    def wait_for_job(self, job_id):
+    def wait_for_job(self, job_id, wait_timeout=TWENTY_MINUTES):
         """This method polls job status every 5 seconds"""
         # TODO: Add logging here print('Waiting for job ID {} to finish...'.format(job_id))
         def iter_fn():
@@ -114,7 +114,7 @@ class DataprocResource:
 
             return False
 
-        done = DataprocResource._iter_and_sleep_until_ready(iter_fn)
+        done = DataprocResource._iter_and_sleep_until_ready(iter_fn, max_wait_time_sec=wait_timeout)
         if not done:
             job = self.get_job(job_id)
             raise DataprocError("Job run timed out: %s" % str(job["status"]))

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/dataproc_tests/test_resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/dataproc_tests/test_resources.py
@@ -128,8 +128,7 @@ def test_dataproc_resource():
 
 
 def test_wait_for_job_with_timeout():
-    """Test submitting a job with timeout of 0 second so that it always fails.
-    """
+    """Test submitting a job with timeout of 0 second so that it always fails."""
     with mock.patch("httplib2.Http", new=HttpSnooper):
 
         @job(resource_defs={"dataproc": dataproc_resource})
@@ -137,7 +136,7 @@ def test_wait_for_job_with_timeout():
             dataproc_op()
 
         try:
-            result = test_dataproc.execute_in_process(
+            test_dataproc.execute_in_process(
                 run_config={
                     "ops": {
                         "dataproc_op": {


### PR DESCRIPTION
### Summary & Motivation
Currently dataproc_op always has a unmodifiable timeout of 20 minutes. That does not allow long running job to be submitted by dagster. This PR extends a resource param so that user can decide how long the job should take.

### How I Tested These Changes
Mock submitting a job with 0 seconds as timeout so that it always fails.