### PR TITLE
[dagit] Do not display the partition_set, step_selection tags on asset group runs

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetNodeList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeList.tsx
@@ -37,7 +37,7 @@ export const AssetNodeList: React.FC<{
 };
 
 const Container = styled(Box)`
-  height: 112px;
+  height: 124px;
   overflow-x: auto;
   width: 100%;
   white-space: nowrap;

--- a/js_modules/dagit/packages/core/src/runs/RunTags.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTags.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import {SharedToaster} from '../app/DomUtils';
 import {useCopyToClipboard} from '../app/browser';
+import {__ASSET_GROUP_PREFIX} from '../asset-graph/Utils';
 
 import {DagsterTag, RunTag, TagType} from './RunTag';
 import {RunFilterToken} from './RunsFilterInput';
@@ -44,11 +45,16 @@ export const RunTags: React.FC<{
     return list;
   }, [copy, onSetFilter]);
 
-  const sortedTags = React.useMemo(() => {
+  const displayedTags = React.useMemo(() => {
     const priority = [];
     const others = [];
     for (const tag of tags) {
-      if (priorityTagSet.has(tag.key)) {
+      if (
+        tag.value.startsWith(__ASSET_GROUP_PREFIX) &&
+        (tag.key === DagsterTag.PartitionSet || tag.key === DagsterTag.StepSelection)
+      ) {
+        continue;
+      } else if (priorityTagSet.has(tag.key)) {
         priority.push(tag);
       } else {
         others.push(tag);
@@ -64,7 +70,7 @@ export const RunTags: React.FC<{
   return (
     <Box flex={{direction: 'row', wrap: 'wrap', gap: 4}}>
       {mode ? <RunTag tag={{key: 'mode', value: mode}} /> : null}
-      {sortedTags.map((tag, idx) => (
+      {displayedTags.map((tag, idx) => (
         <RunTag tag={tag} key={idx} actions={actions} />
       ))}
     </Box>


### PR DESCRIPTION
### Summary & Motivation

If you materialize assets in an asset group that are partitioned, the run is launched with a `dagster/partition_set` tag and a `dagster/partition` tag. The partition_set tag reveals the auto-generated partition set name and thus provides no real value.  It also takes up space.

This filters out the tag so that only `dagster/partition` is shown. This same component is used within the "Run Details > Show Tags and Config" modal and applies there as well.

Before:
<img width="1149" alt="image" src="https://user-images.githubusercontent.com/1037212/168952845-91981466-b0a3-4a02-9a6c-d082f204b29b.png">

After:
<img width="1005" alt="image" src="https://user-images.githubusercontent.com/1037212/168952828-a80b03d5-f54c-4832-88d5-f65b106c30a6.png">


### How I Tested These Changes
