### PR TITLE
Set default hour of day and minute of hour in build_schedule_from_partitioned_job based on the offsets of the parittioned job

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/partitioned_schedule.py
+++ b/python_modules/dagster/dagster/core/definitions/partitioned_schedule.py
@@ -50,12 +50,17 @@ def build_schedule_from_partitioned_job(
     check.inst(partitioned_config.partitions_def, TimeWindowPartitionsDefinition)
     partitions_def = cast(TimeWindowPartitionsDefinition, partitioned_config.partitions_def)
 
-    minute_of_hour = cast(int, check.opt_int_param(minute_of_hour, "minute_of_hour", default=0))
+    minute_of_hour = cast(
+        int,
+        check.opt_int_param(minute_of_hour, "minute_of_hour", default=partitions_def.minute_offset),
+    )
 
     if partitions_def.schedule_type == ScheduleType.HOURLY:
         check.invariant(hour_of_day is None, "Cannot set hour parameter with hourly partitions.")
 
-    hour_of_day = cast(int, check.opt_int_param(hour_of_day, "hour_of_day", default=0))
+    hour_of_day = cast(
+        int, check.opt_int_param(hour_of_day, "hour_of_day", default=partitions_def.hour_offset)
+    )
     execution_time = time(minute=minute_of_hour, hour=hour_of_day)
 
     if partitions_def.schedule_type == ScheduleType.DAILY:

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_partitioned_schedule.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_partitioned_schedule.py
@@ -94,6 +94,9 @@ def test_daily_schedule_with_offsets():
         "end": "2021-05-06T02:15:00+00:00",
     }
 
+    my_schedule_default = schedule_for_partitioned_config(my_partitioned_config)
+    assert my_schedule_default.cron_schedule == "15 2 * * *"
+
     my_schedule = schedule_for_partitioned_config(
         my_partitioned_config, hour_of_day=9, minute_of_hour=30
     )
@@ -127,6 +130,9 @@ def test_hourly_schedule():
         "start": "2021-05-05T00:00:00+00:00",
         "end": "2021-05-05T01:00:00+00:00",
     }
+
+    my_schedule_default = schedule_for_partitioned_config(my_partitioned_config)
+    assert my_schedule_default.cron_schedule == "0 * * * *"
 
     my_schedule = schedule_for_partitioned_config(my_partitioned_config, minute_of_hour=30)
     assert my_schedule.cron_schedule == "30 * * * *"


### PR DESCRIPTION
Summary:
User pointed out that they created partitioned config with hour_offset=3 and it didn't affect the time at which their schedules run. This appears to be an oversight to me, since we are using the day offset below?

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
