### PR TITLE
Fix issue where azure IO manager was sometimes failing on recursive deletes

### DIFF
--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -46,8 +46,7 @@ class PickledObjectADLS2IOManager(IOManager):
 
         file_client = self.file_system_client.get_file_client(key)
         with self._acquire_lease(file_client, is_rm=True) as lease:
-            # This operates recursively already so is nice and simple.
-            file_client.delete_file(lease=lease)
+            file_client.delete_file(lease=lease, recursive=True)
 
     def _has_object(self, key):
         check.str_param(key, "key")


### PR DESCRIPTION
Summary:
I'm still a little unclear on when an IO manager would actually be expected to delete a folder rather than a file (as evidenced by my janky test which was the best way I could find to make it try), but this uses an undocumented(!) recursive argument to the Azure delete_file function to ensure that it can delete folders.

Test Plan: New test case passes, failed before

### Summary & Motivation

### How I Tested These Changes
