### PR TITLE
Make asset input def order deterministic

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/assets_job.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets_job.py
@@ -265,7 +265,9 @@ def build_deps(
             node_key = node_name
         deps[node_key] = {}
         assets_defs_by_node_handle[NodeHandle(alias, parent=None)] = assets_def
-        for input_name, asset_key in assets_def.asset_keys_by_input_name.items():
+        for input_name, asset_key in sorted(
+            assets_def.asset_keys_by_input_name.items(), key=lambda input: input[0]
+        ):  # sort so that input definition order is deterministic
             if asset_key in node_outputs_by_asset:
                 node_def, output_name = node_outputs_by_asset[asset_key]
                 deps[node_key][input_name] = DependencyDefinition(node_def.name, output_name)


### PR DESCRIPTION
https://github.com/dagster-io/dagster/pull/7835 attempts to add a test with 2 assets upstream of another asset. Because input definitions in asset jobs are not created deterministically, snapshot tests sporadically fail. This PR updates input definitions to be created in sorted order to resolve this issue.