### PR TITLE
[RFC] Drop step_context from upstream_output

### DIFF
--- a/python_modules/dagster/dagster/core/execution/context/system.py
+++ b/python_modules/dagster/dagster/core/execution/context/system.py
@@ -494,6 +494,16 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
     ) -> InputContext:
         upstream_output: Optional[OutputContext] = None
         if source_handle is not None:
+            asset_partition_key_range: Optional[PartitionKeyRange] = None
+            if self.has_asset_partitions_for_input(name):
+                asset_partition_key_range = self.asset_partition_key_range_for_input(name)
+
+            asset_partitions_time_window: Optional[TimeWindow] = None
+            try:
+                asset_partitions_time_window = self.asset_partitions_time_window_for_input(name)
+            except ValueError:
+                pass
+
             upstream_output = get_output_context(
                 self.execution_plan,
                 self.pipeline_def,
@@ -504,6 +514,8 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
                 step_context=None,
                 resources=None,
                 version=self.execution_plan.get_version_for_step_output_handle(source_handle),
+                asset_partition_key_range=asset_partition_key_range,
+                asset_partitions_time_window=asset_partitions_time_window,
             )
 
         return InputContext(

--- a/python_modules/dagster/dagster/core/execution/context/system.py
+++ b/python_modules/dagster/dagster/core/execution/context/system.py
@@ -492,13 +492,27 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         resource_config: Any = None,
         resources: Optional["Resources"] = None,
     ) -> InputContext:
+        upstream_output: Optional[OutputContext] = None
+        if source_handle is not None:
+            upstream_output = get_output_context(
+                self.execution_plan,
+                self.pipeline_def,
+                self.resolved_run_config,
+                source_handle,
+                self._get_source_run_id(source_handle),
+                log_manager=self.log,
+                step_context=None,
+                resources=None,
+                version=self.execution_plan.get_version_for_step_output_handle(source_handle),
+            )
+
         return InputContext(
             pipeline_name=self.pipeline_def.name,
             name=name,
             solid_def=self.solid_def,
             config=config,
             metadata=metadata,
-            upstream_output=self.get_output_context(source_handle) if source_handle else None,
+            upstream_output=upstream_output,
             dagster_type=dagster_type,
             log_manager=self.log,
             step_context=self,

--- a/python_modules/dagster/dagster/core/execution/context/system.py
+++ b/python_modules/dagster/dagster/core/execution/context/system.py
@@ -62,6 +62,14 @@ if TYPE_CHECKING:
     from .hook import HookContext
 
 
+def is_iterable(obj: Any) -> bool:
+    try:
+        iter(obj)
+    except:
+        return False
+    return True
+
+
 class IPlanContext(ABC):
     """Context interface to represent run information that does not require access to user code.
 
@@ -702,7 +710,8 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
     def has_asset_partitions_for_input(self, input_name: str) -> bool:
         op_config = self.op_config
-        if op_config is not None and "assets" in op_config:
+
+        if is_iterable(op_config) and "assets" in op_config:
             all_input_asset_partitions = op_config["assets"].get("input_partitions")
             if all_input_asset_partitions is not None:
                 this_input_asset_partitions = all_input_asset_partitions.get(input_name)
@@ -713,7 +722,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
     def asset_partition_key_range_for_input(self, input_name: str) -> PartitionKeyRange:
         op_config = self.op_config
-        if op_config is not None and "assets" in op_config:
+        if is_iterable(op_config) and "assets" in op_config:
             all_input_asset_partitions = op_config["assets"].get("input_partitions")
             if all_input_asset_partitions is not None:
                 this_input_asset_partitions = all_input_asset_partitions.get(input_name)
@@ -736,7 +745,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
     def has_asset_partitions_for_output(self, output_name: str) -> bool:
         op_config = self.op_config
-        if op_config is not None and "assets" in op_config:
+        if is_iterable(op_config) and "assets" in op_config:
             all_output_asset_partitions = op_config["assets"].get("output_partitions")
             if all_output_asset_partitions is not None:
                 this_output_asset_partitions = all_output_asset_partitions.get(output_name)
@@ -747,7 +756,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
     def asset_partition_key_range_for_output(self, output_name: str) -> PartitionKeyRange:
         op_config = self.op_config
-        if op_config is not None and "assets" in op_config:
+        if is_iterable(op_config) and "assets" in op_config:
             all_output_asset_partitions = op_config["assets"].get("output_partitions")
             if all_output_asset_partitions is not None:
                 this_output_asset_partitions = all_output_asset_partitions.get(output_name)


### PR DESCRIPTION
### Summary & Motivation

This is a proposal to address #7900. This still requires more work:

* Add tests covering the cases we are trying to fix
* address `OutputContext.has_partition_key` and `OutputContext.partition_key`, that still use step_context.
* I think it can be cleaned up a bit more.

I may be able to work on this over the weekend, otherwise I'm ok if someone else takes over.

### How I Tested These Changes

* Checked that existing core_tests pass,
* black & pylint are happy
* The following code runs without error

```
import dagster

partitions = dagster.StaticPartitionsDefinition(["A"])

@dagster.multi_asset(
    partitions_def=partitions,
    outs={
        "out_1": dagster.Out(asset_key=dagster.AssetKey("upstream_asset_1")),
        "out_2": dagster.Out(asset_key=dagster.AssetKey("upstream_asset_2"))
    }
)
def upstream_asset():
    return (
        dagster.Output(1, output_name="out_1"),
        dagster.Output(2, output_name="out_2")
    )

@dagster.asset(
    partitions_def=partitions,
)
def downstream_asset(upstream_asset_1: int) -> int:
    return 2

group = dagster.AssetGroup(
        [upstream_asset, downstream_asset],
         resource_defs={
             "io_manager": dagster.fs_asset_io_manager.configured({"base_dir": "."})
         }
)

job = group.build_job(name="TheJob")

job.execute_in_process(partition_key="A")
```