### PR TITLE
Still make cursor editable if it is not set

### DIFF
--- a/js_modules/dagit/packages/core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorDetails.tsx
@@ -168,24 +168,24 @@ export const SensorDetails: React.FC<{
               </td>
             </tr>
           ) : null}
-          {cursor ? (
-            <tr>
-              <td>Cursor</td>
-              <td>
-                {isCursorEditing ? (
-                  <EditCursorDialog
-                    sensorSelector={sensorSelector}
-                    cursor={cursor}
-                    onClose={() => setCursorEditing(false)}
-                  />
-                ) : null}
-                <Box flex={{direction: 'row', alignItems: 'center'}}>
-                  <Box style={{fontFamily: FontFamily.monospace, marginRight: 10}}>{cursor}</Box>
-                  <Button onClick={() => setCursorEditing(true)}>Edit</Button>
+          <tr>
+            <td>Cursor</td>
+            <td>
+              {isCursorEditing ? (
+                <EditCursorDialog
+                  sensorSelector={sensorSelector}
+                  cursor={cursor ? cursor : ''}
+                  onClose={() => setCursorEditing(false)}
+                />
+              ) : null}
+              <Box flex={{direction: 'row', alignItems: 'center'}}>
+                <Box style={{fontFamily: FontFamily.monospace, marginRight: 10}}>
+                  {cursor ? cursor : 'None'}
                 </Box>
-              </td>
-            </tr>
-          ) : null}
+                <Button onClick={() => setCursorEditing(true)}>Edit</Button>
+              </Box>
+            </td>
+          </tr>
           <tr>
             <td>Frequency</td>
             <td>{humanizeSensorInterval(sensor.minIntervalSeconds)}</td>


### PR DESCRIPTION
Summary:
You still might want to manually set the cursor even if it is empty (e.g. when testing a sensor locally)

Test Plan: View sensor page with and without a cursor set

### Summary & Motivation

### How I Tested These Changes
