### PR TITLE
create get_records_for_run for event log storage, using an opaque string cursor

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -392,7 +392,7 @@ type Run implements PipelineRun {
   parentRunId: String
   canTerminate: Boolean!
   assets: [Asset!]!
-  events(after: Cursor): [DagsterRunEvent!]!
+  eventConnection(cursor: String): GrapheneEventConnection!
   assetSelection: [AssetKey!]
   resolvedOpSelection: [String!]
   assetMaterializations: [MaterializationEvent!]!
@@ -428,7 +428,7 @@ interface PipelineRun {
   parentRunId: String
   canTerminate: Boolean!
   assets: [Asset!]!
-  events(after: Cursor): [DagsterRunEvent!]!
+  eventConnection(cursor: String): GrapheneEventConnection!
 }
 
 type RepositoryOrigin {
@@ -653,6 +653,12 @@ type ObservationEvent implements MessageEvent & StepEvent & DisplayableEvent {
   runOrError: RunOrError!
   stepStats: RunStepStats!
   partition: String
+}
+
+type GrapheneEventConnection {
+  events: [DagsterRunEvent!]!
+  cursor: String!
+  hasMore: Boolean!
 }
 
 union DagsterRunEvent =
@@ -1080,8 +1086,6 @@ type AssetMaterializationPlannedEvent implements MessageEvent & RunEvent {
   assetKey: AssetKey
   runOrError: RunOrError!
 }
-
-scalar Cursor
 
 type RunNotFoundError implements PipelineRunNotFoundError & Error {
   runId: String!
@@ -2390,7 +2394,7 @@ type LogTelemetrySuccess {
 }
 
 type DagitSubscription {
-  pipelineRunLogs(runId: ID!, after: Cursor): PipelineRunLogsSubscriptionPayload!
+  pipelineRunLogs(runId: ID!, cursor: String): PipelineRunLogsSubscriptionPayload!
   computeLogs(runId: ID!, stepKey: String!, ioType: ComputeIOType!, cursor: String): ComputeLogFile!
   locationStateChangeEvents: LocationStateChangeSubscription!
 }
@@ -2403,6 +2407,7 @@ type PipelineRunLogsSubscriptionSuccess {
   run: Run!
   messages: [DagsterRunEvent!]!
   hasMorePastEvents: Boolean!
+  cursor: String!
 }
 
 type PipelineRunLogsSubscriptionFailure {
@@ -3004,6 +3009,8 @@ type AssetMetadataEntry implements MetadataEntry {
   description: String
   assetKey: AssetKey!
 }
+
+scalar Cursor
 
 type RunGroups {
   results: [RunGroup!]!

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -392,7 +392,7 @@ type Run implements PipelineRun {
   parentRunId: String
   canTerminate: Boolean!
   assets: [Asset!]!
-  eventConnection(cursor: String): GrapheneEventConnection!
+  eventConnection(afterCursor: String): GrapheneEventConnection!
   assetSelection: [AssetKey!]
   resolvedOpSelection: [String!]
   assetMaterializations: [MaterializationEvent!]!
@@ -428,7 +428,7 @@ interface PipelineRun {
   parentRunId: String
   canTerminate: Boolean!
   assets: [Asset!]!
-  eventConnection(cursor: String): GrapheneEventConnection!
+  eventConnection(afterCursor: String): GrapheneEventConnection!
 }
 
 type RepositoryOrigin {

--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -63,13 +63,12 @@ const BATCH_INTERVAL = 100;
 
 type State = {
   nodes: Nodes;
-  cursor: number;
+  cursor: string | null;
   loading: boolean;
 };
 
 type Action =
-  | {type: 'append'; queued: RunDagsterRunEventFragment[]; hasMore: boolean}
-  | {type: 'set-cursor'}
+  | {type: 'append'; queued: RunDagsterRunEventFragment[]; hasMore: boolean; cursor: string}
   | {type: 'reset'};
 
 const reducer = (state: State, action: Action) => {
@@ -79,11 +78,9 @@ const reducer = (state: State, action: Action) => {
         ...m,
         clientsideKey: `csk${idx}`,
       }));
-      return {...state, nodes, loading: action.hasMore};
-    case 'set-cursor':
-      return {...state, cursor: state.nodes.length - 1};
+      return {...state, nodes, loading: action.hasMore, cursor: action.cursor};
     case 'reset':
-      return {nodes: [], cursor: -1, loading: true};
+      return {nodes: [], cursor: null, loading: true};
     default:
       return state;
   }
@@ -91,13 +88,12 @@ const reducer = (state: State, action: Action) => {
 
 const initialState = {
   nodes: [],
-  cursor: -1,
+  cursor: null,
   loading: true,
 };
 
 const useLogsProviderWithSubscription = (runId: string) => {
   const client = useApolloClient();
-  const {websocketClient} = React.useContext(WebSocketContext);
   const queue = React.useRef<RunDagsterRunEventFragment[]>([]);
   const [state, dispatch] = React.useReducer(reducer, initialState);
 
@@ -132,13 +128,6 @@ const useLogsProviderWithSubscription = (runId: string) => {
     [client, runId],
   );
 
-  // If the WebSocket disconnects, move the cursor to the end to ensure that we don't
-  // incorrectly refetch logs that we already have.
-  React.useEffect(() => {
-    const unlisten = websocketClient?.onDisconnected(() => dispatch({type: 'set-cursor'}));
-    return () => unlisten && unlisten();
-  }, [websocketClient]);
-
   React.useEffect(() => {
     queue.current = [];
     dispatch({type: 'reset'});
@@ -147,10 +136,10 @@ const useLogsProviderWithSubscription = (runId: string) => {
   // Batch the nodes together so they don't overwhelm the animation of the Gantt,
   // which depends on a bit of a timing delay to maintain smoothness.
   const throttledSetNodes = React.useMemo(() => {
-    return throttle((hasMore: boolean) => {
+    return throttle((hasMore: boolean, cursor: string) => {
       const queued = [...queue.current];
       queue.current = [];
-      dispatch({type: 'append', queued, hasMore});
+      dispatch({type: 'append', queued, hasMore, cursor});
     }, BATCH_INTERVAL);
   }, []);
 
@@ -160,14 +149,14 @@ const useLogsProviderWithSubscription = (runId: string) => {
     PIPELINE_RUN_LOGS_SUBSCRIPTION,
     {
       fetchPolicy: 'no-cache',
-      variables: {runId, after: cursor},
+      variables: {runId, cursor},
       onSubscriptionData: ({subscriptionData}) => {
         const logs = subscriptionData.data?.pipelineRunLogs;
         if (!logs || logs.__typename === 'PipelineRunLogsSubscriptionFailure') {
           return;
         }
 
-        const {messages, hasMorePastEvents} = logs;
+        const {messages, hasMorePastEvents, cursor} = logs;
         const nextPipelineStatus = pipelineStatusFromMessages(messages);
 
         // If we're still loading past events, don't sync to the cache -- event chunks could
@@ -178,7 +167,7 @@ const useLogsProviderWithSubscription = (runId: string) => {
 
         // Maintain a queue of messages as they arrive, and call the throttled setter.
         queue.current = [...queue.current, ...messages];
-        throttledSetNodes(hasMorePastEvents);
+        throttledSetNodes(hasMorePastEvents, cursor);
       },
     },
   );
@@ -209,13 +198,13 @@ const POLL_INTERVAL = 5000;
 const LogsProviderWithQuery = (props: LogsProviderWithQueryProps) => {
   const {children, runId} = props;
   const [nodes, setNodes] = React.useState<LogNode[]>(() => []);
-  const [after, setAfter] = React.useState<number>(-1);
+  const [cursor, setCursor] = React.useState<string | null>(null);
 
   const {stopPolling, startPolling} = useQuery<RunLogsQuery, RunLogsQueryVariables>(
     RUN_LOGS_QUERY,
     {
       notifyOnNetworkStatusChange: true,
-      variables: {runId, after},
+      variables: {runId, cursor},
       pollInterval: POLL_INTERVAL,
       onCompleted: (data: RunLogsQuery) => {
         // We have to stop polling in order to update the `after` value.
@@ -224,7 +213,7 @@ const LogsProviderWithQuery = (props: LogsProviderWithQueryProps) => {
         const slice = () => {
           const count = nodes.length;
           if (data?.pipelineRunOrError.__typename === 'Run') {
-            return data?.pipelineRunOrError.events.map((event, ii) => ({
+            return data?.pipelineRunOrError.eventConnection.events.map((event, ii) => ({
               ...event,
               clientsideKey: `csk${count + ii}`,
             }));
@@ -234,7 +223,9 @@ const LogsProviderWithQuery = (props: LogsProviderWithQueryProps) => {
 
         const newSlice = slice();
         setNodes((current) => [...current, ...newSlice]);
-        setAfter((current) => current + newSlice.length);
+        if (data?.pipelineRunOrError.__typename === 'Run') {
+          setCursor(data.pipelineRunOrError.eventConnection.cursor);
+        }
 
         const status =
           data?.pipelineRunOrError.__typename === 'Run' ? data?.pipelineRunOrError.status : null;
@@ -279,8 +270,8 @@ export const LogsProvider: React.FC<LogsProviderProps> = (props) => {
 };
 
 const PIPELINE_RUN_LOGS_SUBSCRIPTION = gql`
-  subscription PipelineRunLogsSubscription($runId: ID!, $after: Cursor) {
-    pipelineRunLogs(runId: $runId, after: $after) {
+  subscription PipelineRunLogsSubscription($runId: ID!, $cursor: String) {
+    pipelineRunLogs(runId: $runId, cursor: $cursor) {
       __typename
       ... on PipelineRunLogsSubscriptionSuccess {
         messages {
@@ -290,6 +281,7 @@ const PIPELINE_RUN_LOGS_SUBSCRIPTION = gql`
           ...RunDagsterRunEventFragment
         }
         hasMorePastEvents
+        cursor
       }
       ... on PipelineRunLogsSubscriptionFailure {
         missingRunId
@@ -311,19 +303,22 @@ const PIPELINE_RUN_LOGS_SUBSCRIPTION_STATUS_FRAGMENT = gql`
 `;
 
 const RUN_LOGS_QUERY = gql`
-  query RunLogsQuery($runId: ID!, $after: Cursor) {
+  query RunLogsQuery($runId: ID!, $cursor: String) {
     pipelineRunOrError(runId: $runId) {
       ... on Run {
         id
         runId
         status
         canTerminate
-        events(after: $after) {
-          ... on MessageEvent {
-            runId
+        eventConnection(cursor: $cursor) {
+          events {
+            __typename
+            ... on MessageEvent {
+              runId
+            }
+            ...RunDagsterRunEventFragment
           }
-          ...RunDagsterRunEventFragment
-          __typename
+          cursor
         }
       }
     }

--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -310,7 +310,7 @@ const RUN_LOGS_QUERY = gql`
         runId
         status
         canTerminate
-        eventConnection(cursor: $cursor) {
+        eventConnection(afterCursor: $cursor) {
           events {
             __typename
             ... on MessageEvent {

--- a/js_modules/dagit/packages/core/src/runs/types/PipelineRunLogsSubscription.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/PipelineRunLogsSubscription.ts
@@ -2049,6 +2049,7 @@ export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubs
   __typename: "PipelineRunLogsSubscriptionSuccess";
   messages: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages[];
   hasMorePastEvents: boolean;
+  cursor: string;
 }
 
 export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionFailure {
@@ -2065,5 +2066,5 @@ export interface PipelineRunLogsSubscription {
 
 export interface PipelineRunLogsSubscriptionVariables {
   runId: string;
-  after?: any | null;
+  cursor?: string | null;
 }

--- a/js_modules/dagit/packages/core/src/runs/types/RunLogsQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunLogsQuery.ts
@@ -13,7 +13,7 @@ export interface RunLogsQuery_pipelineRunOrError_RunNotFoundError {
   __typename: "RunNotFoundError" | "PythonError";
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepSkippedEvent {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepSkippedEvent {
   __typename: "ExecutionStepSkippedEvent" | "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "ExecutionStepRestartEvent" | "LogMessageEvent" | "RunStartEvent" | "RunEnqueuedEvent" | "RunDequeuedEvent" | "RunStartingEvent" | "RunCancelingEvent" | "RunCanceledEvent" | "RunSuccessEvent" | "HookCompletedEvent" | "HookSkippedEvent" | "AlertStartEvent" | "AlertSuccessEvent" | "AlertFailureEvent" | "AssetMaterializationPlannedEvent";
   runId: string;
   message: string;
@@ -23,47 +23,47 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepSkipped
   eventType: DagsterEventType | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_assetKey {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_assetKey {
   __typename: "AssetKey";
   path: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_PathMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_PathMetadataEntry {
   __typename: "PathMetadataEntry";
   label: string;
   description: string | null;
   path: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_JsonMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_JsonMetadataEntry {
   __typename: "JsonMetadataEntry";
   label: string;
   description: string | null;
   jsonString: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_UrlMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_UrlMetadataEntry {
   __typename: "UrlMetadataEntry";
   label: string;
   description: string | null;
   url: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TextMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TextMetadataEntry {
   __typename: "TextMetadataEntry";
   label: string;
   description: string | null;
   text: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_MarkdownMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_MarkdownMetadataEntry {
   __typename: "MarkdownMetadataEntry";
   label: string;
   description: string | null;
   mdStr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_PythonArtifactMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_PythonArtifactMetadataEntry {
   __typename: "PythonArtifactMetadataEntry";
   label: string;
   description: string | null;
@@ -71,14 +71,14 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent
   name: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_FloatMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_FloatMetadataEntry {
   __typename: "FloatMetadataEntry";
   label: string;
   description: string | null;
   floatValue: number | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_IntMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_IntMetadataEntry {
   __typename: "IntMetadataEntry";
   label: string;
   description: string | null;
@@ -86,107 +86,107 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent
   intRepr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_BoolMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_BoolMetadataEntry {
   __typename: "BoolMetadataEntry";
   label: string;
   description: string | null;
   boolValue: boolean | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_PipelineRunMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_PipelineRunMetadataEntry {
   __typename: "PipelineRunMetadataEntry";
   label: string;
   description: string | null;
   runId: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_AssetMetadataEntry_assetKey {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_AssetMetadataEntry_assetKey {
   __typename: "AssetKey";
   path: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_AssetMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_AssetMetadataEntry {
   __typename: "AssetMetadataEntry";
   label: string;
   description: string | null;
-  assetKey: RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_AssetMetadataEntry_assetKey;
+  assetKey: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_AssetMetadataEntry_assetKey;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table {
   __typename: "Table";
   records: string[];
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table_schema;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableMetadataEntry {
   __typename: "TableMetadataEntry";
   label: string;
   description: string | null;
-  table: RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table;
+  table: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableMetadataEntry_table;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry {
   __typename: "TableSchemaMetadataEntry";
   label: string;
   description: string | null;
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry_schema;
 }
 
-export type RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry;
+export type RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry;
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent {
   __typename: "MaterializationEvent";
   runId: string;
   message: string;
@@ -194,53 +194,53 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  assetKey: RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_assetKey | null;
+  assetKey: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_assetKey | null;
   label: string;
   description: string | null;
-  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent_metadataEntries[];
+  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent_metadataEntries[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_assetKey {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_assetKey {
   __typename: "AssetKey";
   path: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_PathMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_PathMetadataEntry {
   __typename: "PathMetadataEntry";
   label: string;
   description: string | null;
   path: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_JsonMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_JsonMetadataEntry {
   __typename: "JsonMetadataEntry";
   label: string;
   description: string | null;
   jsonString: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_UrlMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_UrlMetadataEntry {
   __typename: "UrlMetadataEntry";
   label: string;
   description: string | null;
   url: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TextMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TextMetadataEntry {
   __typename: "TextMetadataEntry";
   label: string;
   description: string | null;
   text: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_MarkdownMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_MarkdownMetadataEntry {
   __typename: "MarkdownMetadataEntry";
   label: string;
   description: string | null;
   mdStr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_PythonArtifactMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_PythonArtifactMetadataEntry {
   __typename: "PythonArtifactMetadataEntry";
   label: string;
   description: string | null;
@@ -248,14 +248,14 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_met
   name: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_FloatMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_FloatMetadataEntry {
   __typename: "FloatMetadataEntry";
   label: string;
   description: string | null;
   floatValue: number | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_IntMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_IntMetadataEntry {
   __typename: "IntMetadataEntry";
   label: string;
   description: string | null;
@@ -263,107 +263,107 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_met
   intRepr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_BoolMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_BoolMetadataEntry {
   __typename: "BoolMetadataEntry";
   label: string;
   description: string | null;
   boolValue: boolean | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_PipelineRunMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_PipelineRunMetadataEntry {
   __typename: "PipelineRunMetadataEntry";
   label: string;
   description: string | null;
   runId: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_AssetMetadataEntry_assetKey {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_AssetMetadataEntry_assetKey {
   __typename: "AssetKey";
   path: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_AssetMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_AssetMetadataEntry {
   __typename: "AssetMetadataEntry";
   label: string;
   description: string | null;
-  assetKey: RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_AssetMetadataEntry_assetKey;
+  assetKey: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_AssetMetadataEntry_assetKey;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableMetadataEntry_table_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableMetadataEntry_table_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableMetadataEntry_table {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableMetadataEntry_table {
   __typename: "Table";
   records: string[];
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableMetadataEntry_table_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableMetadataEntry_table_schema;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableMetadataEntry {
   __typename: "TableMetadataEntry";
   label: string;
   description: string | null;
-  table: RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableMetadataEntry_table;
+  table: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableMetadataEntry_table;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry {
   __typename: "TableSchemaMetadataEntry";
   label: string;
   description: string | null;
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry_schema;
 }
 
-export type RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry;
+export type RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry;
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent {
   __typename: "ObservationEvent";
   runId: string;
   message: string;
@@ -371,26 +371,26 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent {
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  assetKey: RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_assetKey | null;
+  assetKey: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_assetKey | null;
   label: string;
   description: string | null;
-  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent_metadataEntries[];
+  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent_metadataEntries[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_RunFailureEvent_pipelineFailureError_cause {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_RunFailureEvent_pipelineFailureError_cause {
   __typename: "PythonError";
   message: string;
   stack: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_RunFailureEvent_pipelineFailureError {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_RunFailureEvent_pipelineFailureError {
   __typename: "PythonError";
   message: string;
   stack: string[];
-  cause: RunLogsQuery_pipelineRunOrError_Run_events_RunFailureEvent_pipelineFailureError_cause | null;
+  cause: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_RunFailureEvent_pipelineFailureError_cause | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_RunFailureEvent {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_RunFailureEvent {
   __typename: "RunFailureEvent";
   runId: string;
   message: string;
@@ -398,58 +398,58 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_RunFailureEvent {
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  pipelineFailureError: RunLogsQuery_pipelineRunOrError_Run_events_RunFailureEvent_pipelineFailureError | null;
+  pipelineFailureError: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_RunFailureEvent_pipelineFailureError | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_error_cause {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_error_cause {
   __typename: "PythonError";
   message: string;
   stack: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_error {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_error {
   __typename: "PythonError";
   message: string;
   stack: string[];
-  cause: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_error_cause | null;
+  cause: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_error_cause | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_PathMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_PathMetadataEntry {
   __typename: "PathMetadataEntry";
   label: string;
   description: string | null;
   path: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_JsonMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_JsonMetadataEntry {
   __typename: "JsonMetadataEntry";
   label: string;
   description: string | null;
   jsonString: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_UrlMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_UrlMetadataEntry {
   __typename: "UrlMetadataEntry";
   label: string;
   description: string | null;
   url: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TextMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TextMetadataEntry {
   __typename: "TextMetadataEntry";
   label: string;
   description: string | null;
   text: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_MarkdownMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_MarkdownMetadataEntry {
   __typename: "MarkdownMetadataEntry";
   label: string;
   description: string | null;
   mdStr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_PythonArtifactMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_PythonArtifactMetadataEntry {
   __typename: "PythonArtifactMetadataEntry";
   label: string;
   description: string | null;
@@ -457,14 +457,14 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailure
   name: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_FloatMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_FloatMetadataEntry {
   __typename: "FloatMetadataEntry";
   label: string;
   description: string | null;
   floatValue: number | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_IntMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_IntMetadataEntry {
   __typename: "IntMetadataEntry";
   label: string;
   description: string | null;
@@ -472,112 +472,112 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailure
   intRepr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_BoolMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_BoolMetadataEntry {
   __typename: "BoolMetadataEntry";
   label: string;
   description: string | null;
   boolValue: boolean | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_PipelineRunMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_PipelineRunMetadataEntry {
   __typename: "PipelineRunMetadataEntry";
   label: string;
   description: string | null;
   runId: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_AssetMetadataEntry_assetKey {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_AssetMetadataEntry_assetKey {
   __typename: "AssetKey";
   path: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_AssetMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_AssetMetadataEntry {
   __typename: "AssetMetadataEntry";
   label: string;
   description: string | null;
-  assetKey: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_AssetMetadataEntry_assetKey;
+  assetKey: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_AssetMetadataEntry_assetKey;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table {
   __typename: "Table";
   records: string[];
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table_schema;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry {
   __typename: "TableMetadataEntry";
   label: string;
   description: string | null;
-  table: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table;
+  table: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry_table;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry {
   __typename: "TableSchemaMetadataEntry";
   label: string;
   description: string | null;
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry_schema;
 }
 
-export type RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry;
+export type RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries_TableSchemaMetadataEntry;
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata {
   __typename: "FailureMetadata";
-  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries[];
+  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata_metadataEntries[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent {
   __typename: "ExecutionStepFailureEvent";
   runId: string;
   message: string;
@@ -585,25 +585,25 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailure
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  error: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_error | null;
+  error: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_error | null;
   errorSource: ErrorSource | null;
-  failureMetadata: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent_failureMetadata | null;
+  failureMetadata: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent_failureMetadata | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepUpForRetryEvent_error_cause {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepUpForRetryEvent_error_cause {
   __typename: "PythonError";
   message: string;
   stack: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepUpForRetryEvent_error {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepUpForRetryEvent_error {
   __typename: "PythonError";
   message: string;
   stack: string[];
-  cause: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepUpForRetryEvent_error_cause | null;
+  cause: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepUpForRetryEvent_error_cause | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepUpForRetryEvent {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepUpForRetryEvent {
   __typename: "ExecutionStepUpForRetryEvent";
   runId: string;
   message: string;
@@ -611,45 +611,45 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepUpForRe
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  error: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepUpForRetryEvent_error | null;
+  error: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepUpForRetryEvent_error | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_PathMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_PathMetadataEntry {
   __typename: "PathMetadataEntry";
   label: string;
   description: string | null;
   path: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_JsonMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_JsonMetadataEntry {
   __typename: "JsonMetadataEntry";
   label: string;
   description: string | null;
   jsonString: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_UrlMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_UrlMetadataEntry {
   __typename: "UrlMetadataEntry";
   label: string;
   description: string | null;
   url: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TextMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TextMetadataEntry {
   __typename: "TextMetadataEntry";
   label: string;
   description: string | null;
   text: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry {
   __typename: "MarkdownMetadataEntry";
   label: string;
   description: string | null;
   mdStr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry {
   __typename: "PythonArtifactMetadataEntry";
   label: string;
   description: string | null;
@@ -657,14 +657,14 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEv
   name: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_FloatMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_FloatMetadataEntry {
   __typename: "FloatMetadataEntry";
   label: string;
   description: string | null;
   floatValue: number | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_IntMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_IntMetadataEntry {
   __typename: "IntMetadataEntry";
   label: string;
   description: string | null;
@@ -672,115 +672,115 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEv
   intRepr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_BoolMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_BoolMetadataEntry {
   __typename: "BoolMetadataEntry";
   label: string;
   description: string | null;
   boolValue: boolean | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry {
   __typename: "PipelineRunMetadataEntry";
   label: string;
   description: string | null;
   runId: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey {
   __typename: "AssetKey";
   path: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_AssetMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_AssetMetadataEntry {
   __typename: "AssetMetadataEntry";
   label: string;
   description: string | null;
-  assetKey: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey;
+  assetKey: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table {
   __typename: "Table";
   records: string[];
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry {
   __typename: "TableMetadataEntry";
   label: string;
   description: string | null;
-  table: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table;
+  table: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry_table;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry {
   __typename: "TableSchemaMetadataEntry";
   label: string;
   description: string | null;
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema;
 }
 
-export type RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry;
+export type RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry;
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck {
   __typename: "TypeCheck";
   label: string;
   description: string | null;
   success: boolean;
-  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck_metadataEntries[];
+  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent {
   __typename: "ExecutionStepInputEvent";
   runId: string;
   message: string;
@@ -789,45 +789,45 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEv
   stepKey: string | null;
   eventType: DagsterEventType | null;
   inputName: string;
-  typeCheck: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent_typeCheck;
+  typeCheck: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent_typeCheck;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry {
   __typename: "PathMetadataEntry";
   label: string;
   description: string | null;
   path: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry {
   __typename: "JsonMetadataEntry";
   label: string;
   description: string | null;
   jsonString: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry {
   __typename: "UrlMetadataEntry";
   label: string;
   description: string | null;
   url: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry {
   __typename: "TextMetadataEntry";
   label: string;
   description: string | null;
   text: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry {
   __typename: "MarkdownMetadataEntry";
   label: string;
   description: string | null;
   mdStr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry {
   __typename: "PythonArtifactMetadataEntry";
   label: string;
   description: string | null;
@@ -835,14 +835,14 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputE
   name: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry {
   __typename: "FloatMetadataEntry";
   label: string;
   description: string | null;
   floatValue: number | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry {
   __typename: "IntMetadataEntry";
   label: string;
   description: string | null;
@@ -850,150 +850,150 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputE
   intRepr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry {
   __typename: "BoolMetadataEntry";
   label: string;
   description: string | null;
   boolValue: boolean | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry {
   __typename: "PipelineRunMetadataEntry";
   label: string;
   description: string | null;
   runId: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey {
   __typename: "AssetKey";
   path: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry {
   __typename: "AssetMetadataEntry";
   label: string;
   description: string | null;
-  assetKey: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey;
+  assetKey: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table {
   __typename: "Table";
   records: string[];
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry {
   __typename: "TableMetadataEntry";
   label: string;
   description: string | null;
-  table: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table;
+  table: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry {
   __typename: "TableSchemaMetadataEntry";
   label: string;
   description: string | null;
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema;
 }
 
-export type RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry;
+export type RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry;
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck {
   __typename: "TypeCheck";
   label: string;
   description: string | null;
   success: boolean;
-  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck_metadataEntries[];
+  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry {
   __typename: "PathMetadataEntry";
   label: string;
   description: string | null;
   path: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry {
   __typename: "JsonMetadataEntry";
   label: string;
   description: string | null;
   jsonString: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry {
   __typename: "UrlMetadataEntry";
   label: string;
   description: string | null;
   url: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry {
   __typename: "TextMetadataEntry";
   label: string;
   description: string | null;
   text: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry {
   __typename: "MarkdownMetadataEntry";
   label: string;
   description: string | null;
   mdStr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
   __typename: "PythonArtifactMetadataEntry";
   label: string;
   description: string | null;
@@ -1001,14 +1001,14 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputE
   name: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry {
   __typename: "FloatMetadataEntry";
   label: string;
   description: string | null;
   floatValue: number | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry {
   __typename: "IntMetadataEntry";
   label: string;
   description: string | null;
@@ -1016,107 +1016,107 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputE
   intRepr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry {
   __typename: "BoolMetadataEntry";
   label: string;
   description: string | null;
   boolValue: boolean | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry {
   __typename: "PipelineRunMetadataEntry";
   label: string;
   description: string | null;
   runId: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
   __typename: "AssetKey";
   path: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry {
   __typename: "AssetMetadataEntry";
   label: string;
   description: string | null;
-  assetKey: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+  assetKey: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table {
   __typename: "Table";
   records: string[];
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry {
   __typename: "TableMetadataEntry";
   label: string;
   description: string | null;
-  table: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table;
+  table: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry {
   __typename: "TableSchemaMetadataEntry";
   label: string;
   description: string | null;
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
 }
 
-export type RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry;
+export type RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry;
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent {
   __typename: "ExecutionStepOutputEvent";
   runId: string;
   message: string;
@@ -1125,46 +1125,46 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputE
   stepKey: string | null;
   eventType: DagsterEventType | null;
   outputName: string;
-  typeCheck: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_typeCheck;
-  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent_metadataEntries[];
+  typeCheck: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_typeCheck;
+  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent_metadataEntries[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_PathMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_PathMetadataEntry {
   __typename: "PathMetadataEntry";
   label: string;
   description: string | null;
   path: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_JsonMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_JsonMetadataEntry {
   __typename: "JsonMetadataEntry";
   label: string;
   description: string | null;
   jsonString: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_UrlMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_UrlMetadataEntry {
   __typename: "UrlMetadataEntry";
   label: string;
   description: string | null;
   url: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TextMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TextMetadataEntry {
   __typename: "TextMetadataEntry";
   label: string;
   description: string | null;
   text: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_MarkdownMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_MarkdownMetadataEntry {
   __typename: "MarkdownMetadataEntry";
   label: string;
   description: string | null;
   mdStr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_PythonArtifactMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_PythonArtifactMetadataEntry {
   __typename: "PythonArtifactMetadataEntry";
   label: string;
   description: string | null;
@@ -1172,14 +1172,14 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResul
   name: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_FloatMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_FloatMetadataEntry {
   __typename: "FloatMetadataEntry";
   label: string;
   description: string | null;
   floatValue: number | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_IntMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_IntMetadataEntry {
   __typename: "IntMetadataEntry";
   label: string;
   description: string | null;
@@ -1187,115 +1187,115 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResul
   intRepr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_BoolMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_BoolMetadataEntry {
   __typename: "BoolMetadataEntry";
   label: string;
   description: string | null;
   boolValue: boolean | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_PipelineRunMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_PipelineRunMetadataEntry {
   __typename: "PipelineRunMetadataEntry";
   label: string;
   description: string | null;
   runId: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_AssetMetadataEntry_assetKey {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_AssetMetadataEntry_assetKey {
   __typename: "AssetKey";
   path: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_AssetMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_AssetMetadataEntry {
   __typename: "AssetMetadataEntry";
   label: string;
   description: string | null;
-  assetKey: RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_AssetMetadataEntry_assetKey;
+  assetKey: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_AssetMetadataEntry_assetKey;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table {
   __typename: "Table";
   records: string[];
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table_schema;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry {
   __typename: "TableMetadataEntry";
   label: string;
   description: string | null;
-  table: RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table;
+  table: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry_table;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry {
   __typename: "TableSchemaMetadataEntry";
   label: string;
   description: string | null;
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry_schema;
 }
 
-export type RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry;
+export type RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_TableSchemaMetadataEntry;
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult {
   __typename: "ExpectationResult";
   success: boolean;
   label: string;
   description: string | null;
-  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult_metadataEntries[];
+  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent {
   __typename: "StepExpectationResultEvent";
   runId: string;
   message: string;
@@ -1303,45 +1303,45 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResul
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  expectationResult: RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent_expectationResult;
+  expectationResult: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent_expectationResult;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_PathMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_PathMetadataEntry {
   __typename: "PathMetadataEntry";
   label: string;
   description: string | null;
   path: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_JsonMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_JsonMetadataEntry {
   __typename: "JsonMetadataEntry";
   label: string;
   description: string | null;
   jsonString: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_UrlMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_UrlMetadataEntry {
   __typename: "UrlMetadataEntry";
   label: string;
   description: string | null;
   url: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TextMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TextMetadataEntry {
   __typename: "TextMetadataEntry";
   label: string;
   description: string | null;
   text: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_MarkdownMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_MarkdownMetadataEntry {
   __typename: "MarkdownMetadataEntry";
   label: string;
   description: string | null;
   mdStr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_PythonArtifactMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_PythonArtifactMetadataEntry {
   __typename: "PythonArtifactMetadataEntry";
   label: string;
   description: string | null;
@@ -1349,14 +1349,14 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperation
   name: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_FloatMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_FloatMetadataEntry {
   __typename: "FloatMetadataEntry";
   label: string;
   description: string | null;
   floatValue: number | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_IntMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_IntMetadataEntry {
   __typename: "IntMetadataEntry";
   label: string;
   description: string | null;
@@ -1364,113 +1364,113 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperation
   intRepr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_BoolMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_BoolMetadataEntry {
   __typename: "BoolMetadataEntry";
   label: string;
   description: string | null;
   boolValue: boolean | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_PipelineRunMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_PipelineRunMetadataEntry {
   __typename: "PipelineRunMetadataEntry";
   label: string;
   description: string | null;
   runId: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_AssetMetadataEntry_assetKey {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_AssetMetadataEntry_assetKey {
   __typename: "AssetKey";
   path: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_AssetMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_AssetMetadataEntry {
   __typename: "AssetMetadataEntry";
   label: string;
   description: string | null;
-  assetKey: RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_AssetMetadataEntry_assetKey;
+  assetKey: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_AssetMetadataEntry_assetKey;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table {
   __typename: "Table";
   records: string[];
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table_schema;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry {
   __typename: "TableMetadataEntry";
   label: string;
   description: string | null;
-  table: RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table;
+  table: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry_table;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry {
   __typename: "TableSchemaMetadataEntry";
   label: string;
   description: string | null;
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry_schema;
 }
 
-export type RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry;
+export type RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries_TableSchemaMetadataEntry;
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult {
   __typename: "ObjectStoreOperationResult";
   op: ObjectStoreOperationType;
-  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult_metadataEntries[];
+  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult_metadataEntries[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent {
   __typename: "ObjectStoreOperationEvent";
   runId: string;
   message: string;
@@ -1478,45 +1478,45 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperation
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  operationResult: RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent_operationResult;
+  operationResult: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent_operationResult;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_PathMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_PathMetadataEntry {
   __typename: "PathMetadataEntry";
   label: string;
   description: string | null;
   path: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_JsonMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_JsonMetadataEntry {
   __typename: "JsonMetadataEntry";
   label: string;
   description: string | null;
   jsonString: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_UrlMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_UrlMetadataEntry {
   __typename: "UrlMetadataEntry";
   label: string;
   description: string | null;
   url: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TextMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TextMetadataEntry {
   __typename: "TextMetadataEntry";
   label: string;
   description: string | null;
   text: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry {
   __typename: "MarkdownMetadataEntry";
   label: string;
   description: string | null;
   mdStr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
   __typename: "PythonArtifactMetadataEntry";
   label: string;
   description: string | null;
@@ -1524,14 +1524,14 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_m
   name: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_FloatMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_FloatMetadataEntry {
   __typename: "FloatMetadataEntry";
   label: string;
   description: string | null;
   floatValue: number | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_IntMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_IntMetadataEntry {
   __typename: "IntMetadataEntry";
   label: string;
   description: string | null;
@@ -1539,107 +1539,107 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_m
   intRepr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_BoolMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_BoolMetadataEntry {
   __typename: "BoolMetadataEntry";
   label: string;
   description: string | null;
   boolValue: boolean | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry {
   __typename: "PipelineRunMetadataEntry";
   label: string;
   description: string | null;
   runId: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
   __typename: "AssetKey";
   path: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_AssetMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_AssetMetadataEntry {
   __typename: "AssetMetadataEntry";
   label: string;
   description: string | null;
-  assetKey: RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+  assetKey: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table {
   __typename: "Table";
   records: string[];
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry {
   __typename: "TableMetadataEntry";
   label: string;
   description: string | null;
-  table: RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table;
+  table: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry {
   __typename: "TableSchemaMetadataEntry";
   label: string;
   description: string | null;
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
 }
 
-export type RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry;
+export type RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry;
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent {
   __typename: "HandledOutputEvent";
   runId: string;
   message: string;
@@ -1649,45 +1649,45 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent {
   eventType: DagsterEventType | null;
   outputName: string;
   managerKey: string;
-  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent_metadataEntries[];
+  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent_metadataEntries[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_PathMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_PathMetadataEntry {
   __typename: "PathMetadataEntry";
   label: string;
   description: string | null;
   path: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_JsonMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_JsonMetadataEntry {
   __typename: "JsonMetadataEntry";
   label: string;
   description: string | null;
   jsonString: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_UrlMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_UrlMetadataEntry {
   __typename: "UrlMetadataEntry";
   label: string;
   description: string | null;
   url: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TextMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TextMetadataEntry {
   __typename: "TextMetadataEntry";
   label: string;
   description: string | null;
   text: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry {
   __typename: "MarkdownMetadataEntry";
   label: string;
   description: string | null;
   mdStr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry {
   __typename: "PythonArtifactMetadataEntry";
   label: string;
   description: string | null;
@@ -1695,14 +1695,14 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_met
   name: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_FloatMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_FloatMetadataEntry {
   __typename: "FloatMetadataEntry";
   label: string;
   description: string | null;
   floatValue: number | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_IntMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_IntMetadataEntry {
   __typename: "IntMetadataEntry";
   label: string;
   description: string | null;
@@ -1710,107 +1710,107 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_met
   intRepr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_BoolMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_BoolMetadataEntry {
   __typename: "BoolMetadataEntry";
   label: string;
   description: string | null;
   boolValue: boolean | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry {
   __typename: "PipelineRunMetadataEntry";
   label: string;
   description: string | null;
   runId: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey {
   __typename: "AssetKey";
   path: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_AssetMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_AssetMetadataEntry {
   __typename: "AssetMetadataEntry";
   label: string;
   description: string | null;
-  assetKey: RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+  assetKey: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table {
   __typename: "Table";
   records: string[];
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry {
   __typename: "TableMetadataEntry";
   label: string;
   description: string | null;
-  table: RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table;
+  table: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry {
   __typename: "TableSchemaMetadataEntry";
   label: string;
   description: string | null;
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
 }
 
-export type RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry;
+export type RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry;
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent {
   __typename: "LoadedInputEvent";
   runId: string;
   message: string;
@@ -1822,45 +1822,45 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent {
   managerKey: string;
   upstreamOutputName: string | null;
   upstreamStepKey: string | null;
-  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent_metadataEntries[];
+  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent_metadataEntries[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_PathMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_PathMetadataEntry {
   __typename: "PathMetadataEntry";
   label: string;
   description: string | null;
   path: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_JsonMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_JsonMetadataEntry {
   __typename: "JsonMetadataEntry";
   label: string;
   description: string | null;
   jsonString: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_UrlMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_UrlMetadataEntry {
   __typename: "UrlMetadataEntry";
   label: string;
   description: string | null;
   url: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TextMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TextMetadataEntry {
   __typename: "TextMetadataEntry";
   label: string;
   description: string | null;
   text: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_MarkdownMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_MarkdownMetadataEntry {
   __typename: "MarkdownMetadataEntry";
   label: string;
   description: string | null;
   mdStr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_PythonArtifactMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_PythonArtifactMetadataEntry {
   __typename: "PythonArtifactMetadataEntry";
   label: string;
   description: string | null;
@@ -1868,14 +1868,14 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadata
   name: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_FloatMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_FloatMetadataEntry {
   __typename: "FloatMetadataEntry";
   label: string;
   description: string | null;
   floatValue: number | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_IntMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_IntMetadataEntry {
   __typename: "IntMetadataEntry";
   label: string;
   description: string | null;
@@ -1883,120 +1883,120 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadata
   intRepr: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_BoolMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_BoolMetadataEntry {
   __typename: "BoolMetadataEntry";
   label: string;
   description: string | null;
   boolValue: boolean | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_PipelineRunMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_PipelineRunMetadataEntry {
   __typename: "PipelineRunMetadataEntry";
   label: string;
   description: string | null;
   runId: string;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey {
   __typename: "AssetKey";
   path: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_AssetMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_AssetMetadataEntry {
   __typename: "AssetMetadataEntry";
   label: string;
   description: string | null;
-  assetKey: RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey;
+  assetKey: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableMetadataEntry_table {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table {
   __typename: "Table";
   records: string[];
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry {
   __typename: "TableMetadataEntry";
   label: string;
   description: string | null;
-  table: RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableMetadataEntry_table;
+  table: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
   __typename: "TableColumnConstraints";
   nullable: boolean;
   unique: boolean;
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
   __typename: "TableColumn";
   name: string;
   description: string | null;
   type: string;
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
   __typename: "TableConstraints";
   other: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema {
   __typename: "TableSchema";
-  columns: RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+  columns: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry {
   __typename: "TableSchemaMetadataEntry";
   label: string;
   description: string | null;
-  schema: RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+  schema: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema;
 }
 
-export type RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry;
+export type RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries = RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry;
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_engineError_cause {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_engineError_cause {
   __typename: "PythonError";
   message: string;
   stack: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_engineError {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_engineError {
   __typename: "PythonError";
   message: string;
   stack: string[];
-  cause: RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_engineError_cause | null;
+  cause: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_engineError_cause | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent {
   __typename: "EngineEvent";
   runId: string;
   message: string;
@@ -2004,26 +2004,26 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent {
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_metadataEntries[];
-  engineError: RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent_engineError | null;
+  metadataEntries: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_metadataEntries[];
+  engineError: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent_engineError | null;
   markerStart: string | null;
   markerEnd: string | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HookErroredEvent_error_cause {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HookErroredEvent_error_cause {
   __typename: "PythonError";
   message: string;
   stack: string[];
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HookErroredEvent_error {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HookErroredEvent_error {
   __typename: "PythonError";
   message: string;
   stack: string[];
-  cause: RunLogsQuery_pipelineRunOrError_Run_events_HookErroredEvent_error_cause | null;
+  cause: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HookErroredEvent_error_cause | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_HookErroredEvent {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HookErroredEvent {
   __typename: "HookErroredEvent";
   runId: string;
   message: string;
@@ -2031,10 +2031,10 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_HookErroredEvent {
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  error: RunLogsQuery_pipelineRunOrError_Run_events_HookErroredEvent_error | null;
+  error: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HookErroredEvent_error | null;
 }
 
-export interface RunLogsQuery_pipelineRunOrError_Run_events_LogsCapturedEvent {
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LogsCapturedEvent {
   __typename: "LogsCapturedEvent";
   runId: string;
   message: string;
@@ -2047,7 +2047,13 @@ export interface RunLogsQuery_pipelineRunOrError_Run_events_LogsCapturedEvent {
   pid: number | null;
 }
 
-export type RunLogsQuery_pipelineRunOrError_Run_events = RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepSkippedEvent | RunLogsQuery_pipelineRunOrError_Run_events_MaterializationEvent | RunLogsQuery_pipelineRunOrError_Run_events_ObservationEvent | RunLogsQuery_pipelineRunOrError_Run_events_RunFailureEvent | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepFailureEvent | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepUpForRetryEvent | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepInputEvent | RunLogsQuery_pipelineRunOrError_Run_events_ExecutionStepOutputEvent | RunLogsQuery_pipelineRunOrError_Run_events_StepExpectationResultEvent | RunLogsQuery_pipelineRunOrError_Run_events_ObjectStoreOperationEvent | RunLogsQuery_pipelineRunOrError_Run_events_HandledOutputEvent | RunLogsQuery_pipelineRunOrError_Run_events_LoadedInputEvent | RunLogsQuery_pipelineRunOrError_Run_events_EngineEvent | RunLogsQuery_pipelineRunOrError_Run_events_HookErroredEvent | RunLogsQuery_pipelineRunOrError_Run_events_LogsCapturedEvent;
+export type RunLogsQuery_pipelineRunOrError_Run_eventConnection_events = RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepSkippedEvent | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_MaterializationEvent | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObservationEvent | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_RunFailureEvent | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepFailureEvent | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepUpForRetryEvent | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepInputEvent | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ExecutionStepOutputEvent | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_StepExpectationResultEvent | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_ObjectStoreOperationEvent | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HandledOutputEvent | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LoadedInputEvent | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_EngineEvent | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_HookErroredEvent | RunLogsQuery_pipelineRunOrError_Run_eventConnection_events_LogsCapturedEvent;
+
+export interface RunLogsQuery_pipelineRunOrError_Run_eventConnection {
+  __typename: "GrapheneEventConnection";
+  events: RunLogsQuery_pipelineRunOrError_Run_eventConnection_events[];
+  cursor: string;
+}
 
 export interface RunLogsQuery_pipelineRunOrError_Run {
   __typename: "Run";
@@ -2055,7 +2061,7 @@ export interface RunLogsQuery_pipelineRunOrError_Run {
   runId: string;
   status: RunStatus;
   canTerminate: boolean;
-  events: RunLogsQuery_pipelineRunOrError_Run_events[];
+  eventConnection: RunLogsQuery_pipelineRunOrError_Run_eventConnection;
 }
 
 export type RunLogsQuery_pipelineRunOrError = RunLogsQuery_pipelineRunOrError_RunNotFoundError | RunLogsQuery_pipelineRunOrError_Run;
@@ -2066,5 +2072,5 @@ export interface RunLogsQuery {
 
 export interface RunLogsQueryVariables {
   runId: string;
-  after?: any | null;
+  cursor?: string | null;
 }

--- a/python_modules/dagster-graphql/dagster_graphql/client/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/query.py
@@ -248,7 +248,7 @@ query pipelineRunEvents($runId: ID!, $cursor: String) {
   pipelineRunOrError(runId: $runId) {
     __typename
     ... on PipelineRun {
-      eventConnection(cursor: $cursor) {
+      eventConnection(afterCursor: $cursor) {
         events {
           ...messageEventFragment
         }

--- a/python_modules/dagster-graphql/dagster_graphql/client/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/query.py
@@ -244,12 +244,15 @@ subscription subscribeTest($runId: ID!) {
 RUN_EVENTS_QUERY = (
     MESSAGE_EVENT_FRAGMENTS
     + """
-query pipelineRunEvents($runId: ID!, $after: Cursor) {
+query pipelineRunEvents($runId: ID!, $cursor: String) {
   pipelineRunOrError(runId: $runId) {
     __typename
     ... on PipelineRun {
-      events(after: $after) {
-        ...messageEventFragment
+      eventConnection(cursor: $cursor) {
+        events {
+          ...messageEventFragment
+        }
+        cursor
       }
     }
   }

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -7,6 +7,7 @@ import dagster._check as check
 from dagster.core.events import DagsterEventType, EngineEventData
 from dagster.core.instance import DagsterInstance
 from dagster.core.storage.compute_log_manager import ComputeIOType
+from dagster.core.storage.event_log.base import EventLogCursor
 from dagster.core.storage.pipeline_run import PipelineRunStatus, RunsFilter
 from dagster.serdes import serialize_dagster_namedtuple
 from dagster.utils.error import serializable_error_info_from_exc_info
@@ -158,8 +159,11 @@ def get_pipeline_run_observable(graphene_info, run_id, after=None):
             hasMorePastEvents=loading_past,
         )
 
+    # need to translate after into an offset cursor
+    cursor = str(EventLogCursor.from_offset(after)) if after is not None else None
+
     # pylint: disable=E1101
-    return Observable.create(PipelineRunObservableSubscribe(instance, run_id, cursor=after)).map(
+    return Observable.create(PipelineRunObservableSubscribe(instance, run_id, cursor=cursor)).map(
         _handle_events
     )
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -159,9 +159,9 @@ def get_pipeline_run_observable(graphene_info, run_id, after=None):
         )
 
     # pylint: disable=E1101
-    return Observable.create(
-        PipelineRunObservableSubscribe(instance, run_id, after_cursor=after)
-    ).map(_handle_events)
+    return Observable.create(PipelineRunObservableSubscribe(instance, run_id, cursor=after)).map(
+        _handle_events
+    )
 
 
 def get_compute_log_observable(graphene_info, run_id, step_key, io_type, cursor=None):

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -152,7 +152,7 @@ def get_pipeline_run_observable(graphene_info, run_id, after=None):
     run = record.pipeline_run
 
     def _handle_events(payload):
-        events, loading_past = payload
+        events, loading_past, _cursor = payload
         return GraphenePipelineRunLogsSubscriptionSuccess(
             run=GrapheneRun(record),
             messages=[from_event_record(event, run.pipeline_name) for event in events],

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/pipeline_run_storage.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/pipeline_run_storage.py
@@ -20,30 +20,30 @@ def get_chunk_size() -> int:
 
 
 class PipelineRunObservableSubscribe:
-    def __init__(self, instance, run_id, after_cursor=None):
+    def __init__(self, instance, run_id, cursor=None):
         self.instance = instance
         self.run_id = run_id
         self.observer = None
         self.state = State.NULL
         self.stopping = None
         self.stopped = None
-        self.after_cursor = after_cursor if after_cursor is not None else -1
+        self.cursor = cursor
 
     def __call__(self, observer):
         self.observer = observer
         check.invariant(self.state is State.NULL, f"unexpected state {self.state}")
         chunk_size = get_chunk_size()
-        events = self.instance.logs_after(self.run_id, self.after_cursor, limit=chunk_size)
-        done_loading = len(events) < chunk_size
+        connection = self.instance.get_records_for_run(self.run_id, self.cursor, limit=chunk_size)
 
-        if events:
-            self.observer.on_next((events, not done_loading))
-            self.after_cursor = len(events) + int(self.after_cursor)
+        if connection and connection.records:
+            events = [record.event_log_entry for record in connection.records]
+            self.observer.on_next((events, connection.has_more))
+            self.cursor = connection.cursor
 
-        if done_loading:
-            self.watch_events()
-        else:
+        if connection.has_more:
             self.load_events()
+        else:
+            self.watch_events()
 
         return self
 
@@ -62,22 +62,23 @@ class PipelineRunObservableSubscribe:
 
     def watch_events(self):
         self.state = State.WATCHING
-        self.instance.watch_event_logs(self.run_id, self.after_cursor, self.handle_new_event)
+        self.instance.watch_event_logs(self.run_id, self.cursor, self.handle_new_event)
 
     def background_event_loading(self, sleep_fn):
         chunk_size = get_chunk_size()
 
         while not self.stopping.is_set():
-            events = self.instance.logs_after(self.run_id, self.after_cursor, limit=chunk_size)
+            connection = self.instance.get_records_for_run(
+                self.run_id, self.cursor, limit=chunk_size
+            )
             if self.observer is None:
                 break
 
-            done_loading = len(events) < chunk_size
+            events = [record.event_log_entry for record in connection.records]
+            self.observer.on_next((events, connection.has_more))
+            self.cursor = connection.cursor
 
-            self.observer.on_next((events, not done_loading))
-            self.after_cursor = len(events) + int(self.after_cursor)
-
-            if done_loading:
+            if not connection.has_more:
                 break
 
             sleep_fn(0)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/pipeline_run_storage.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/pipeline_run_storage.py
@@ -35,7 +35,7 @@ class PipelineRunObservableSubscribe:
         chunk_size = get_chunk_size()
         connection = self.instance.get_records_for_run(self.run_id, self.cursor, limit=chunk_size)
         events = [record.event_log_entry for record in connection.records]
-        self.observer.on_next((events, connection.has_more))
+        self.observer.on_next((events, connection.has_more, connection.cursor))
         self.cursor = connection.cursor
 
         if connection.has_more:
@@ -73,7 +73,7 @@ class PipelineRunObservableSubscribe:
                 break
 
             events = [record.event_log_entry for record in connection.records]
-            self.observer.on_next((events, connection.has_more))
+            self.observer.on_next((events, connection.has_more, connection.cursor))
             self.cursor = connection.cursor
 
             if not connection.has_more:
@@ -98,6 +98,6 @@ class PipelineRunObservableSubscribe:
         elif self.state is State.LOADING:
             self.stopping.set()
 
-    def handle_new_event(self, new_event):
+    def handle_new_event(self, new_event, cursor):
         if self.observer:
-            self.observer.on_next(([new_event], False))
+            self.observer.on_next(([new_event], False, cursor))

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/pipeline_run_storage.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/pipeline_run_storage.py
@@ -34,11 +34,9 @@ class PipelineRunObservableSubscribe:
         check.invariant(self.state is State.NULL, f"unexpected state {self.state}")
         chunk_size = get_chunk_size()
         connection = self.instance.get_records_for_run(self.run_id, self.cursor, limit=chunk_size)
-
-        if connection and connection.records:
-            events = [record.event_log_entry for record in connection.records]
-            self.observer.on_next((events, connection.has_more))
-            self.cursor = connection.cursor
+        events = [record.event_log_entry for record in connection.records]
+        self.observer.on_next((events, connection.has_more))
+        self.cursor = connection.cursor
 
         if connection.has_more:
             self.load_events()

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -29,7 +29,6 @@ from ..logs.events import (
     GrapheneObservationEvent,
     GrapheneRunStepStats,
 )
-from ..paging import GrapheneCursor
 from ..repository_origin import GrapheneRepositoryOrigin
 from ..runs import GrapheneRunConfigData
 from ..schedules.schedules import GrapheneSchedule
@@ -382,8 +381,6 @@ class GrapheneRun(graphene.ObjectType):
         ]
 
     def resolve_eventConnection(self, graphene_info, cursor=None):
-        if after is not None:
-            cursor = EventLogCursor.from_offset(after)
         conn = graphene_info.context.instance.get_records_for_run(self.run_id, cursor=cursor)
         return GrapheneEventConnection(
             events=[

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -205,7 +205,7 @@ class GraphenePipelineRun(graphene.Interface):
     assets = non_null_list(GrapheneAsset)
     eventConnection = graphene.Field(
         graphene.NonNull(GrapheneEventConnection),
-        cursor=graphene.Argument(graphene.String),
+        afterCursor=graphene.Argument(graphene.String),
     )
 
     class Meta:
@@ -247,7 +247,7 @@ class GrapheneRun(graphene.ObjectType):
     assets = non_null_list(GrapheneAsset)
     eventConnection = graphene.Field(
         graphene.NonNull(GrapheneEventConnection),
-        cursor=graphene.Argument(graphene.String),
+        afterCursor=graphene.Argument(graphene.String),
     )
     startTime = graphene.Float()
     endTime = graphene.Float()
@@ -380,8 +380,8 @@ class GrapheneRun(graphene.ObjectType):
             )
         ]
 
-    def resolve_eventConnection(self, graphene_info, cursor=None):
-        conn = graphene_info.context.instance.get_records_for_run(self.run_id, cursor=cursor)
+    def resolve_eventConnection(self, graphene_info, afterCursor=None):
+        conn = graphene_info.context.instance.get_records_for_run(self.run_id, cursor=afterCursor)
         return GrapheneEventConnection(
             events=[
                 from_event_record(record.event_log_entry, self._pipeline_run.pipeline_name)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/subscription.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/subscription.py
@@ -10,6 +10,7 @@ class GraphenePipelineRunLogsSubscriptionSuccess(graphene.ObjectType):
     run = graphene.NonNull(GrapheneRun)
     messages = non_null_list(GrapheneDagsterRunEvent)
     hasMorePastEvents = graphene.NonNull(graphene.Boolean)
+    cursor = graphene.NonNull(graphene.String)
 
     class Meta:
         name = "PipelineRunLogsSubscriptionSuccess"

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/subscription.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/subscription.py
@@ -7,7 +7,6 @@ from dagster.core.storage.compute_log_manager import ComputeIOType
 from ...implementation.execution import get_compute_log_observable, get_pipeline_run_observable
 from ..external import GrapheneLocationStateChangeSubscription, get_location_state_change_observable
 from ..logs.compute_logs import GrapheneComputeIOType, GrapheneComputeLogFile
-from ..paging import GrapheneCursor
 from ..pipelines.subscription import GraphenePipelineRunLogsSubscriptionPayload
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/subscription.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/subscription.py
@@ -18,7 +18,7 @@ class GrapheneDagitSubscription(graphene.ObjectType):
     pipelineRunLogs = graphene.Field(
         graphene.NonNull(GraphenePipelineRunLogsSubscriptionPayload),
         runId=graphene.Argument(graphene.NonNull(graphene.ID)),
-        after=graphene.Argument(GrapheneCursor),
+        cursor=graphene.Argument(graphene.String),
     )
 
     computeLogs = graphene.Field(
@@ -33,8 +33,8 @@ class GrapheneDagitSubscription(graphene.ObjectType):
         graphene.NonNull(GrapheneLocationStateChangeSubscription)
     )
 
-    def resolve_pipelineRunLogs(self, graphene_info, runId, after=None):
-        return get_pipeline_run_observable(graphene_info, runId, after)
+    def resolve_pipelineRunLogs(self, graphene_info, runId, cursor=None):
+        return get_pipeline_run_observable(graphene_info, runId, cursor)
 
     def resolve_computeLogs(self, graphene_info, runId, stepKey, ioType, cursor=None):
         check.str_param(ioType, "ioType")  # need to resolve to enum

--- a/python_modules/dagster-graphql/dagster_graphql_tests/test_pipeline_run_observable_subscribe_with_polling.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/test_pipeline_run_observable_subscribe_with_polling.py
@@ -71,9 +71,9 @@ MAX_NUM_EVENTS_AFTER_WATCH = 2
 @pytest.mark.parametrize(
     "before_watch_config",
     [
-        NumEventsAndCursor(num_events_before_watch, after_cursor)
+        NumEventsAndCursor(num_events_before_watch, cursor)
         for num_events_before_watch in range(0, MAX_NUM_EVENTS_BEFORE_WATCH + 1)
-        for after_cursor in [
+        for cursor in [
             None,
             *map(
                 lambda storage_id: str(EventLogCursor.from_storage_id(storage_id)),
@@ -100,7 +100,12 @@ def test_using_instance(before_watch_config: NumEventsAndCursor, num_events_afte
         call_args = observable_subscribe.observer.on_next.call_args_list
 
         # wait until all events have been captured
-        most_recent_event_processed = lambda: int(call_args[-1][0][0][0][-1].user_message)
+        def most_recent_event_processed():
+            events = call_args[-1][0][0][0]
+            if not events:
+                return 0
+            return int(events[-1].user_message)
+
         attempts = 10
         while (
             len(call_args) == 0 or most_recent_event_processed() < total_num_events

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1322,7 +1322,7 @@ class DagsterInstance:
     def get_records_for_run(
         self,
         run_id: str,
-        cursor: Optional[Union[str, int]] = None,
+        cursor: Optional[str] = None,
         of_type: Optional[Union["DagsterEventType", Set["DagsterEventType"]]] = None,
         limit: Optional[int] = None,
     ):

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1318,6 +1318,16 @@ class DagsterInstance:
     ):
         return self._event_storage.get_logs_for_run(run_id, of_type=of_type)
 
+    @traced
+    def get_records_for_run(
+        self,
+        run_id: str,
+        cursor: Optional[Union[str, int]] = None,
+        of_type: Optional[Union["DagsterEventType", Set["DagsterEventType"]]] = None,
+        limit: Optional[int] = None,
+    ):
+        return self._event_storage.get_records_for_run(run_id, cursor, of_type, limit)
+
     def watch_event_logs(self, run_id, cursor, cb):
         return self._event_storage.watch(run_id, cursor, cb)
 

--- a/python_modules/dagster/dagster/core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/base.py
@@ -246,7 +246,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
     def get_records_for_run(
         self,
         run_id: str,
-        cursor: Optional[Union[str, int]] = None,
+        cursor: Optional[str] = None,
         of_type: Optional[Union[DagsterEventType, Set[DagsterEventType]]] = None,
         limit: Optional[int] = None,
     ) -> EventLogConnection:
@@ -254,8 +254,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
 
         Args:
             run_id (str): The id of the run for which to fetch logs.
-            cursor (Optional[Union[str, int]]): Cursor value to track paginated queries.  Legacy
-                support for integer offset cursors.
+            cursor (Optional[str]): Cursor value to track paginated queries.
             of_type (Optional[DagsterEventType]): the dagster event type to filter the logs.
             limit (Optional[int]): Max number of records to return.
         """

--- a/python_modules/dagster/dagster/core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/base.py
@@ -48,6 +48,12 @@ class EventLogRecord(NamedTuple):
     event_log_entry: EventLogEntry
 
 
+class EventLogConnection(NamedTuple):
+    records: List[EventLogRecord]
+    cursor: Optional[str]
+    has_more: bool
+
+
 class AssetEntry(
     NamedTuple(
         "_AssetEntry",
@@ -166,11 +172,10 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
     should be done by setting values in that file.
     """
 
-    @abstractmethod
     def get_logs_for_run(
         self,
         run_id: str,
-        cursor: Optional[int] = -1,
+        cursor: Optional[Union[str, int]] = None,
         of_type: Optional[Union[DagsterEventType, Set[DagsterEventType]]] = None,
         limit: Optional[int] = None,
     ) -> Iterable[EventLogEntry]:
@@ -178,9 +183,30 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
 
         Args:
             run_id (str): The id of the run for which to fetch logs.
-            cursor (Optional[int]): Zero-indexed logs will be returned starting from cursor + 1,
-                i.e., if cursor is -1, all logs will be returned. (default: -1)
+            cursor (Optional[Union[str, int]]): Cursor value to track paginated queries.  Legacy
+                support for integer offset cursors.
             of_type (Optional[DagsterEventType]): the dagster event type to filter the logs.
+            limit (Optional[int]): Max number of records to return.
+        """
+        records = self.get_records_for_run(run_id, cursor, of_type, limit).records
+        return [record.event_log_entry for record in records]
+
+    @abstractmethod
+    def get_records_for_run(
+        self,
+        run_id: str,
+        cursor: Optional[Union[str, int]] = None,
+        of_type: Optional[Union[DagsterEventType, Set[DagsterEventType]]] = None,
+        limit: Optional[int] = None,
+    ) -> EventLogConnection:
+        """Get all of the event log records corresponding to a run.
+
+        Args:
+            run_id (str): The id of the run for which to fetch logs.
+            cursor (Optional[Union[str, int]]): Cursor value to track paginated queries.  Legacy
+                support for integer offset cursors.
+            of_type (Optional[DagsterEventType]): the dagster event type to filter the logs.
+            limit (Optional[int]): Max number of records to return.
         """
 
     def get_stats_for_run(self, run_id: str) -> PipelineRunStatsSnapshot:
@@ -230,7 +256,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
         """Clear the log storage."""
 
     @abstractmethod
-    def watch(self, run_id: str, start_cursor: int, callback: Callable):
+    def watch(self, run_id: str, cursor: str, callback: Callable):
         """Call this method to start watching."""
 
     @abstractmethod

--- a/python_modules/dagster/dagster/core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/in_memory.py
@@ -120,7 +120,7 @@ class InMemoryEventLogStorage(EventLogStorage, ConfigurableClass):
         check.inst_param(event, "event", EventLogEntry)
         run_id = event.run_id
         self._logs[run_id].append(event)
-        offset = len(self._log[run_id])
+        offset = len(self._logs[run_id])
 
         if (
             event.is_dagster_event

--- a/python_modules/dagster/dagster/core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/in_memory.py
@@ -120,6 +120,7 @@ class InMemoryEventLogStorage(EventLogStorage, ConfigurableClass):
         check.inst_param(event, "event", EventLogEntry)
         run_id = event.run_id
         self._logs[run_id].append(event)
+        offset = len(self._log[run_id])
 
         if (
             event.is_dagster_event
@@ -137,7 +138,7 @@ class InMemoryEventLogStorage(EventLogStorage, ConfigurableClass):
 
         for handler in handlers:
             try:
-                handler(event)
+                handler(event, str(EventLogCursor.from_offset(offset)))
             except Exception:
                 logging.exception("Exception in callback for event watch on run %s.", run_id)
 

--- a/python_modules/dagster/dagster/core/storage/event_log/migration.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/migration.py
@@ -30,9 +30,8 @@ def migrate_event_log_data(instance=None):
         return
 
     for run in instance.get_runs():
-        event_records_by_id = event_log_storage.get_logs_for_run_by_log_id(run.run_id)
-        for record_id, event in event_records_by_id.items():
-            event_log_storage.update_event_log_record(record_id, event)
+        for record in event_log_storage.get_records_for_run(run.run_id).records:
+            event_log_storage.update_event_log_record(record.storage_id, record.event_log_entry)
 
 
 def migrate_asset_key_data(event_log_storage, print_fn=None):

--- a/python_modules/dagster/dagster/core/storage/event_log/polling_event_watcher.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/polling_event_watcher.py
@@ -1,5 +1,5 @@
 import threading
-from typing import Callable, List, MutableMapping, NamedTuple
+from typing import Callable, List, MutableMapping, NamedTuple, Optional
 
 import dagster._check as check
 from dagster.core.events.log import EventLogEntry
@@ -12,13 +12,12 @@ POLLING_CADENCE = 0.1  # 100 ms
 class CallbackAfterCursor(NamedTuple):
     """Callback passed from Observer class in event polling
 
-    start_cursor (int): Only process EventLogEntrys with an id >= start_cursor
-        (earlier ones have presumably already been processed)
+    cursor (str): Only process EventLogEntrys after the given cursor
     callback (Callable[[EventLogEntry], None]): callback passed from Observer
         to call on new EventLogEntrys
     """
 
-    start_cursor: int
+    cursor: Optional[str]
     callback: Callable[[EventLogEntry], None]
 
 
@@ -48,9 +47,11 @@ class SqlPollingEventWatcher:
             _has_run_id = run_id in self._run_id_to_watcher_dict
         return _has_run_id
 
-    def watch_run(self, run_id: str, start_cursor: int, callback: Callable[[EventLogEntry], None]):
+    def watch_run(
+        self, run_id: str, cursor: Optional[str], callback: Callable[[EventLogEntry], None]
+    ):
         run_id = check.str_param(run_id, "run_id")
-        start_cursor = check.int_param(start_cursor, "start_cursor")
+        cursor = check.opt_str_param(cursor, "cursor")
         callback = check.callable_param(callback, "callback")
         with self._dict_lock:
             if run_id not in self._run_id_to_watcher_dict:
@@ -59,7 +60,7 @@ class SqlPollingEventWatcher:
                 )
                 self._run_id_to_watcher_dict[run_id].daemon = True
                 self._run_id_to_watcher_dict[run_id].start()
-            self._run_id_to_watcher_dict[run_id].add_callback(start_cursor, callback)
+            self._run_id_to_watcher_dict[run_id].add_callback(cursor, callback)
 
     def unwatch_run(self, run_id: str, handler: Callable[[EventLogEntry], None]):
         run_id = check.str_param(run_id, "run_id")
@@ -90,7 +91,7 @@ class SqlPollingRunIdEventWatcherThread(threading.Thread):
 
     Holds a list of callbacks (_callback_fn_list) each passed in by an `Observer`. Note that
         the callbacks have a cursor associated; this means that the callbacks should be
-        only executed on EventLogEntrys with an associated id >= callback.start_cursor
+        only executed on EventLogEntrys with an associated id >= callback.cursor
     Exits when `self.should_thread_exit` is set.
 
     LOCKING INFO:
@@ -113,18 +114,18 @@ class SqlPollingRunIdEventWatcherThread(threading.Thread):
     def should_thread_exit(self) -> threading.Event:
         return self._should_thread_exit
 
-    def add_callback(self, start_cursor: int, callback: Callable[[EventLogEntry], None]):
+    def add_callback(self, cursor: Optional[str], callback: Callable[[EventLogEntry], None]):
         """Observer has started watching this run.
-            Add a callback to execute on new EventLogEntrys st. id >= start_cursor
+            Add a callback to execute on new EventLogEntrys after the given cursor
 
         Args:
-            start_cursor (int): minimum event_id for the callback to execute
+            cursor (Optional[str]): minimum event_id for the callback to execute
             callback (Callable[[EventLogEntry], None]): callback to update the Dagster UI
         """
-        start_cursor = check.int_param(start_cursor, "start_cursor")
+        cursor = check.opt_str_param(cursor, "cursor")
         callback = check.callable_param(callback, "callback")
         with self._callback_fn_list_lock:
-            self._callback_fn_list.append(CallbackAfterCursor(start_cursor, callback))
+            self._callback_fn_list.append(CallbackAfterCursor(cursor, callback))
 
     def remove_callback(self, callback: Callable[[EventLogEntry], None]):
         """Observer has stopped watching this run;
@@ -152,12 +153,21 @@ class SqlPollingRunIdEventWatcherThread(threading.Thread):
             2. fires each callback (taking into account the callback.cursor) on the new EventLogEntrys
         Uses max_index_so_far as a cursor in the DB to make sure that only new records are retrieved
         """
-        cursor = -1
+        cursor = None
         while not self._should_thread_exit.wait(POLLING_CADENCE):
-            events = self._event_log_storage.get_logs_for_run(self._run_id, cursor=cursor)
-            for event_record in events:
-                cursor += 1
+            conn = self._event_log_storage.get_records_for_run(self._run_id, cursor=cursor)
+            cursor = conn.cursor if conn.cursor else cursor
+            for event_record in conn.records:
                 with self._callback_fn_list_lock:
                     for callback_with_cursor in self._callback_fn_list:
-                        if callback_with_cursor.start_cursor < cursor:
-                            callback_with_cursor.callback(event_record)
+                        should_callback = False
+                        try:
+                            should_callback = (
+                                callback_with_cursor.cursor is None
+                                or int(callback_with_cursor.cursor) < event_record.storage_id
+                            )
+                        except ValueError:
+                            pass
+
+                        if should_callback:
+                            callback_with_cursor.callback(event_record.event_log_entry)

--- a/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
@@ -16,7 +16,11 @@ from dagster.core.errors import DagsterEventLogInvalidForRun
 from dagster.core.events import DagsterEventType
 from dagster.core.events.log import EventLogEntry
 from dagster.core.execution.stats import build_run_step_stats_from_events
-from dagster.serdes import deserialize_json_to_dagster_namedtuple, serialize_dagster_namedtuple
+from dagster.serdes import (
+    deserialize_as,
+    deserialize_json_to_dagster_namedtuple,
+    serialize_dagster_namedtuple,
+)
 from dagster.serdes.errors import DeserializationError
 from dagster.utils import datetime_as_float, utc_datetime_from_naive, utc_datetime_from_timestamp
 
@@ -295,9 +299,7 @@ class SqlEventLogStorage(EventLogStorage):
                 records.append(
                     EventLogRecord(
                         storage_id=record_id,
-                        event_log_entry=cast(
-                            EventLogEntry, deserialize_json_to_dagster_namedtuple(json_str)
-                        ),
+                        event_log_entry=deserialize_as(json_str, EventLogEntry),
                     )
                 )
                 last_record_id = record_id

--- a/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
@@ -309,6 +309,7 @@ class SqlEventLogStorage(EventLogStorage):
         if last_record_id is not None:
             next_cursor = EventLogCursor.from_storage_id(last_record_id).to_string()
         elif cursor:
+            # record fetch returned no new logs, return the same cursor
             next_cursor = cursor
         else:
             # rely on the fact that all storage ids will be positive integers

--- a/python_modules/dagster/dagster/core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
@@ -9,6 +9,7 @@ from watchdog.observers import Observer
 
 import dagster._check as check
 from dagster.config.source import StringSource
+from dagster.core.storage.event_log.base import EventLogCursor
 from dagster.core.storage.pipeline_run import PipelineRunStatus
 from dagster.core.storage.sql import (
     check_alembic_revision,
@@ -156,7 +157,10 @@ class ConsolidatedSqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             for record in connection.records:
                 status = None
                 try:
-                    status = callback(record.event_log_entry)
+                    status = callback(
+                        record.event_log_entry,
+                        str(EventLogCursor.from_storage_id(record.storage_id)),
+                    )
                 except Exception:
                     logging.exception("Exception in callback for event watch on run %s.", run_id)
 

--- a/python_modules/dagster/dagster/core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sqlite/sqlite_event_log.py
@@ -19,7 +19,7 @@ import dagster.seven as seven
 from dagster.config.source import StringSource
 from dagster.core.events import DagsterEventType
 from dagster.core.events.log import EventLogEntry
-from dagster.core.storage.event_log.base import EventLogRecord, EventRecordsFilter
+from dagster.core.storage.event_log.base import EventLogCursor, EventLogRecord, EventRecordsFilter
 from dagster.core.storage.pipeline_run import PipelineRunStatus, RunsFilter
 from dagster.core.storage.sql import (
     check_alembic_revision,
@@ -428,7 +428,9 @@ class SqliteEventLogStorageWatchdog(PatternMatchingEventHandler):
         for record in connection.records:
             status = None
             try:
-                status = self._cb(record.event_log_entry)
+                status = self._cb(
+                    record.event_log_entry, str(EventLogCursor.from_storage_id(record.storage_id))
+                )
             except Exception:
                 logging.exception("Exception in callback for event watch on run %s.", self._run_id)
 

--- a/python_modules/dagster/dagster/core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sqlite/sqlite_event_log.py
@@ -382,12 +382,12 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         super(SqliteEventLogStorage, self).wipe_asset(asset_key)
         self._delete_mirrored_events_for_asset_key(asset_key)
 
-    def watch(self, run_id, start_cursor, callback):
+    def watch(self, run_id, cursor, callback):
         if not self._obs:
             self._obs = Observer()
             self._obs.start()
 
-        watchdog = SqliteEventLogStorageWatchdog(self, run_id, callback, start_cursor)
+        watchdog = SqliteEventLogStorageWatchdog(self, run_id, callback, cursor)
         self._watchers[run_id][callback] = (
             watchdog,
             self._obs.schedule(watchdog, self._base_dir, True),
@@ -411,23 +411,24 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
 
 class SqliteEventLogStorageWatchdog(PatternMatchingEventHandler):
-    def __init__(self, event_log_storage, run_id, callback, start_cursor, **kwargs):
+    def __init__(self, event_log_storage, run_id, callback, cursor, **kwargs):
         self._event_log_storage = check.inst_param(
             event_log_storage, "event_log_storage", SqliteEventLogStorage
         )
         self._run_id = check.str_param(run_id, "run_id")
         self._cb = check.callable_param(callback, "callback")
         self._log_path = event_log_storage.path_for_shard(run_id)
-        self._cursor = start_cursor if start_cursor is not None else -1
+        self._cursor = cursor
         super(SqliteEventLogStorageWatchdog, self).__init__(patterns=[self._log_path], **kwargs)
 
     def _process_log(self):
-        events = self._event_log_storage.get_logs_for_run(self._run_id, self._cursor)
-        self._cursor += len(events)
-        for event in events:
+        connection = self._event_log_storage.get_records_for_run(self._run_id, self._cursor)
+        if connection.cursor:
+            self._cursor = connection.cursor
+        for record in connection.records:
             status = None
             try:
-                status = self._cb(event)
+                status = self._cb(record.event_log_entry)
             except Exception:
                 logging.exception("Exception in callback for event watch on run %s.", self._run_id)
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_event_log.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_event_log.py
@@ -84,7 +84,7 @@ class TestSqliteEventLogStorage(TestEventLogStorage):
     def cmd(self, exceptions, tmpdir_path):
         storage = SqliteEventLogStorage(tmpdir_path)
         try:
-            storage.get_logs_for_run_by_log_id("foo")
+            storage.get_logs_for_run("foo")
         except Exception as exc:
             exceptions.put(exc)
             exc_info = sys.exc_info()

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_polling_event_watcher.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_polling_event_watcher.py
@@ -7,6 +7,7 @@ import dagster._check as check
 from dagster.core.events import DagsterEvent, DagsterEventType, EngineEventData
 from dagster.core.events.log import EventLogEntry
 from dagster.core.storage.event_log import SqlPollingEventWatcher, SqliteEventLogStorage
+from dagster.core.storage.event_log.base import EventLogCursor
 
 
 class SqlitePollingEventLogStorage(SqliteEventLogStorage):
@@ -83,12 +84,12 @@ def test_using_logstorage():
         assert len(storage.get_logs_for_run(RUN_ID)) == 1
         assert len(watched_1) == 0
 
-        storage.watch(RUN_ID, str(1), watched_1.append)
+        storage.watch(RUN_ID, str(EventLogCursor.from_storage_id(1)), watched_1.append)
 
         storage.store_event(create_event(2))
         storage.store_event(create_event(3))
 
-        storage.watch(RUN_ID, str(3), watched_2.append)
+        storage.watch(RUN_ID, str(EventLogCursor.from_storage_id(3)), watched_2.append)
         storage.store_event(create_event(4))
 
         attempts = 10

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -416,7 +416,9 @@ class TestEventLogStorage:
         assert len(storage.get_logs_for_run(test_run_id)) == 1
         assert len(watched) == 0
 
-        storage.watch(test_run_id, str(1), watcher)
+        conn = storage.get_records_for_run(test_run_id)
+        assert len(conn.records) == 1
+        storage.watch(test_run_id, conn.cursor, watcher)
 
         storage.store_event(create_test_event_log_record(str(2), test_run_id))
         storage.store_event(create_test_event_log_record(str(3), test_run_id))

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -416,7 +416,7 @@ class TestEventLogStorage:
         assert len(storage.get_logs_for_run(test_run_id)) == 1
         assert len(watched) == 0
 
-        storage.watch(test_run_id, 0, watcher)
+        storage.watch(test_run_id, str(1), watcher)
 
         storage.store_event(create_test_event_log_record(str(2), test_run_id))
         storage.store_event(create_test_event_log_record(str(3), test_run_id))
@@ -757,7 +757,7 @@ class TestEventLogStorage:
 
         event_list = []
 
-        storage.watch(test_run_id, -1, lambda x: event_list.append(x))
+        storage.watch(test_run_id, None, lambda x: event_list.append(x))
 
         events, _ = _synthesize_events(return_one_solid_func, run_id=test_run_id)
         for event in events:
@@ -780,7 +780,7 @@ class TestEventLogStorage:
         with create_and_delete_test_runs(instance, [run_id_one, run_id_two]):
             # only watch one of the runs
             event_list = []
-            storage.watch(run_id_two, -1, lambda x: event_list.append(x))
+            storage.watch(run_id_two, None, lambda x: event_list.append(x))
 
             events_one, _result_one = _synthesize_events(return_one_solid_func, run_id=run_id_one)
             for event in events_one:
@@ -809,8 +809,8 @@ class TestEventLogStorage:
 
         with create_and_delete_test_runs(instance, [run_id_one, run_id_two]):
 
-            storage.watch(run_id_one, -1, lambda x: event_list_one.append(x))
-            storage.watch(run_id_two, -1, lambda x: event_list_two.append(x))
+            storage.watch(run_id_one, None, lambda x: event_list_one.append(x))
+            storage.watch(run_id_two, None, lambda x: event_list_two.append(x))
 
             events_one, _result_one = _synthesize_events(return_one_solid_func, run_id=run_id_one)
             for event in events_one:
@@ -1370,8 +1370,8 @@ class TestEventLogStorage:
 
         event_list = []
 
-        storage.watch(err_run_id, -1, _throw)
-        storage.watch(safe_run_id, -1, lambda x: event_list.append(x))
+        storage.watch(err_run_id, None, _throw)
+        storage.watch(safe_run_id, None, lambda x: event_list.append(x))
 
         for event in err_events:
             storage.store_event(event)
@@ -1409,10 +1409,10 @@ class TestEventLogStorage:
 
         # Direct end_watch emulates behavior of clean up on exception downstream
         # of the subscription in the dagit webserver.
-        storage.watch(err_run_id, -1, _unsub)
+        storage.watch(err_run_id, None, _unsub)
 
         # Other active watches should proceed correctly.
-        storage.watch(safe_run_id, -1, lambda x: event_list.append(x))
+        storage.watch(safe_run_id, None, lambda x: event_list.append(x))
 
         for event in err_events:
             storage.store_event(event)

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -408,7 +408,7 @@ class TestEventLogStorage:
             pytest.skip("storage cannot watch runs")
 
         watched = []
-        watcher = lambda x: watched.append(x)  # pylint: disable=unnecessary-lambda
+        watcher = lambda x, y: watched.append(x)  # pylint: disable=unnecessary-lambda
 
         assert len(storage.get_logs_for_run(test_run_id)) == 0
 
@@ -759,7 +759,7 @@ class TestEventLogStorage:
 
         event_list = []
 
-        storage.watch(test_run_id, None, lambda x: event_list.append(x))
+        storage.watch(test_run_id, None, lambda x, _y: event_list.append(x))
 
         events, _ = _synthesize_events(return_one_solid_func, run_id=test_run_id)
         for event in events:
@@ -782,7 +782,7 @@ class TestEventLogStorage:
         with create_and_delete_test_runs(instance, [run_id_one, run_id_two]):
             # only watch one of the runs
             event_list = []
-            storage.watch(run_id_two, None, lambda x: event_list.append(x))
+            storage.watch(run_id_two, None, lambda x, _y: event_list.append(x))
 
             events_one, _result_one = _synthesize_events(return_one_solid_func, run_id=run_id_one)
             for event in events_one:
@@ -811,8 +811,8 @@ class TestEventLogStorage:
 
         with create_and_delete_test_runs(instance, [run_id_one, run_id_two]):
 
-            storage.watch(run_id_one, None, lambda x: event_list_one.append(x))
-            storage.watch(run_id_two, None, lambda x: event_list_two.append(x))
+            storage.watch(run_id_one, None, lambda x, _y: event_list_one.append(x))
+            storage.watch(run_id_two, None, lambda x, _y: event_list_two.append(x))
 
             events_one, _result_one = _synthesize_events(return_one_solid_func, run_id=run_id_one)
             for event in events_one:
@@ -1364,7 +1364,7 @@ class TestEventLogStorage:
         class CBException(Exception):
             pass
 
-        def _throw(_):
+        def _throw(_x, _y):
             raise CBException("problem in watch callback")
 
         err_events, _ = _synthesize_events(return_one_solid_func, run_id=err_run_id)
@@ -1373,7 +1373,7 @@ class TestEventLogStorage:
         event_list = []
 
         storage.watch(err_run_id, None, _throw)
-        storage.watch(safe_run_id, None, lambda x: event_list.append(x))
+        storage.watch(safe_run_id, None, lambda x, _y: event_list.append(x))
 
         for event in err_events:
             storage.store_event(event)
@@ -1401,7 +1401,7 @@ class TestEventLogStorage:
         err_run_id = make_new_run_id()
         safe_run_id = make_new_run_id()
 
-        def _unsub(_):
+        def _unsub(_x, _y):
             storage.end_watch(err_run_id, _unsub)
 
         err_events, _ = _synthesize_events(return_one_solid_func, run_id=err_run_id)
@@ -1414,7 +1414,7 @@ class TestEventLogStorage:
         storage.watch(err_run_id, None, _unsub)
 
         # Other active watches should proceed correctly.
-        storage.watch(safe_run_id, None, lambda x: event_list.append(x))
+        storage.watch(safe_run_id, None, lambda x, _y: event_list.append(x))
 
         for event in err_events:
             storage.store_event(event)

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -83,15 +83,15 @@ def test_event_log_step_key_migration():
         run_ids = instance._event_storage.get_all_run_ids()
         assert run_ids == ["6405c4a0-3ccc-4600-af81-b5ee197f8528"]
         assert isinstance(instance._event_storage, SqlEventLogStorage)
-        events_by_id = instance._event_storage.get_logs_for_run_by_log_id(
+        records = instance._event_storage.get_records_for_run(
             "6405c4a0-3ccc-4600-af81-b5ee197f8528"
-        )
-        assert len(events_by_id) == 40
+        ).records
+        assert len(records) == 40
 
         step_key_records = []
-        for record_id, _event in events_by_id.items():
+        for record in records:
             row_data = instance._event_storage.get_event_log_table_data(
-                "6405c4a0-3ccc-4600-af81-b5ee197f8528", record_id
+                "6405c4a0-3ccc-4600-af81-b5ee197f8528", record.storage_id
             )
             if row_data.step_key is not None:
                 step_key_records.append(row_data)
@@ -101,9 +101,9 @@ def test_event_log_step_key_migration():
         migrate_event_log_data(instance=instance)
 
         step_key_records = []
-        for record_id, _event in events_by_id.items():
+        for record in records:
             row_data = instance._event_storage.get_event_log_table_data(
-                "6405c4a0-3ccc-4600-af81-b5ee197f8528", record_id
+                "6405c4a0-3ccc-4600-af81-b5ee197f8528", record.storage_id
             )
             if row_data.step_key is not None:
                 step_key_records.append(row_data)

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -168,8 +168,8 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         if name in self._secondary_index_cache:
             del self._secondary_index_cache[name]
 
-    def watch(self, run_id, start_cursor, callback):
-        self._event_watcher.watch_run(run_id, start_cursor, callback)
+    def watch(self, run_id, cursor, callback):
+        self._event_watcher.watch_run(run_id, cursor, callback)
 
     def end_watch(self, run_id, handler):
         self._event_watcher.unwatch_run(run_id, handler)

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -7,6 +7,7 @@ from dagster.core.storage.event_log import (
     SqlEventLogStorageMetadata,
     SqlPollingEventWatcher,
 )
+from dagster.core.storage.event_log.base import EventLogCursor
 from dagster.core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster.core.storage.sql import (
     check_alembic_revision,
@@ -169,6 +170,8 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             del self._secondary_index_cache[name]
 
     def watch(self, run_id, cursor, callback):
+        if cursor and EventLogCursor.parse(cursor).is_offset_cursor():
+            check.failed("Cannot call `watch` with an offset cursor")
         self._event_watcher.watch_run(run_id, cursor, callback)
 
     def end_watch(self, run_id, handler):

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_event_log.py
@@ -8,6 +8,7 @@ from dagster_tests.core_tests.storage_tests.utils.event_log_storage import (
     create_test_event_log_record,
 )
 
+from dagster.core.storage.event_log.base import EventLogCursor
 from dagster.core.test_utils import instance_for_test
 
 
@@ -34,12 +35,12 @@ class TestMySQLEventLogStorage(TestEventLogStorage):
         assert len(storage.get_logs_for_run(run_id)) == 1
         assert len(watched_1) == 0
 
-        storage.watch(run_id, str(1), watched_1.append)
+        storage.watch(run_id, str(EventLogCursor.from_storage_id(1)), watched_1.append)
 
         storage.store_event(create_test_event_log_record(str(2), run_id=run_id))
         storage.store_event(create_test_event_log_record(str(3), run_id=run_id))
 
-        storage.watch(run_id, str(3), watched_2.append)
+        storage.watch(run_id, str(EventLogCursor.from_storage_id(3)), watched_2.append)
         storage.store_event(create_test_event_log_record(str(4), run_id=run_id))
 
         attempts = 10

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_event_log.py
@@ -29,18 +29,24 @@ class TestMySQLEventLogStorage(TestEventLogStorage):
         watched_1 = []
         watched_2 = []
 
+        def watch_one(event, _cursor):
+            watched_1.append(event)
+
+        def watch_two(event, _cursor):
+            watched_2.append(event)
+
         assert len(storage.get_logs_for_run(run_id)) == 0
 
         storage.store_event(create_test_event_log_record(str(1), run_id=run_id))
         assert len(storage.get_logs_for_run(run_id)) == 1
         assert len(watched_1) == 0
 
-        storage.watch(run_id, str(EventLogCursor.from_storage_id(1)), watched_1.append)
+        storage.watch(run_id, str(EventLogCursor.from_storage_id(1)), watch_one)
 
         storage.store_event(create_test_event_log_record(str(2), run_id=run_id))
         storage.store_event(create_test_event_log_record(str(3), run_id=run_id))
 
-        storage.watch(run_id, str(EventLogCursor.from_storage_id(3)), watched_2.append)
+        storage.watch(run_id, str(EventLogCursor.from_storage_id(3)), watch_two)
         storage.store_event(create_test_event_log_record(str(4), run_id=run_id))
 
         attempts = 10
@@ -52,7 +58,7 @@ class TestMySQLEventLogStorage(TestEventLogStorage):
         assert len(watched_1) == 3
         assert len(watched_2) == 1
 
-        storage.end_watch(run_id, watched_1.append)
+        storage.end_watch(run_id, watch_one)
         time.sleep(0.3)  # this value scientifically selected from a range of attractive values
         storage.store_event(create_test_event_log_record(str(5), run_id=run_id))
 
@@ -60,7 +66,7 @@ class TestMySQLEventLogStorage(TestEventLogStorage):
         while len(watched_2) < 2 and attempts > 0:
             time.sleep(0.1)
             attempts -= 1
-        storage.end_watch(run_id, watched_2.append)
+        storage.end_watch(run_id, watch_two)
 
         assert len(storage.get_logs_for_run(run_id)) == 5
         assert len(watched_1) == 3

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_event_log.py
@@ -34,12 +34,12 @@ class TestMySQLEventLogStorage(TestEventLogStorage):
         assert len(storage.get_logs_for_run(run_id)) == 1
         assert len(watched_1) == 0
 
-        storage.watch(run_id, 0, watched_1.append)
+        storage.watch(run_id, str(1), watched_1.append)
 
         storage.store_event(create_test_event_log_record(str(2), run_id=run_id))
         storage.store_event(create_test_event_log_record(str(3), run_id=run_id))
 
-        storage.watch(run_id, 2, watched_2.append)
+        storage.watch(run_id, str(3), watched_2.append)
         storage.store_event(create_test_event_log_record(str(4), run_id=run_id))
 
         attempts = 10

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
@@ -34,12 +34,12 @@ class TestPostgresEventLogStorage(TestEventLogStorage):
         assert len(storage.get_logs_for_run(run_id)) == 1
         assert len(watched_1) == 0
 
-        storage.watch(run_id, 0, watched_1.append)
+        storage.watch(run_id, str(1), watched_1.append)
 
         storage.store_event(create_test_event_log_record(str(2), run_id=run_id))
         storage.store_event(create_test_event_log_record(str(3), run_id=run_id))
 
-        storage.watch(run_id, 2, watched_2.append)
+        storage.watch(run_id, str(3), watched_2.append)
         storage.store_event(create_test_event_log_record(str(4), run_id=run_id))
 
         attempts = 10

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
@@ -8,6 +8,7 @@ from dagster_tests.core_tests.storage_tests.utils.event_log_storage import (
     create_test_event_log_record,
 )
 
+from dagster.core.storage.event_log.base import EventLogCursor
 from dagster.core.test_utils import instance_for_test
 
 
@@ -34,12 +35,12 @@ class TestPostgresEventLogStorage(TestEventLogStorage):
         assert len(storage.get_logs_for_run(run_id)) == 1
         assert len(watched_1) == 0
 
-        storage.watch(run_id, str(1), watched_1.append)
+        storage.watch(run_id, str(EventLogCursor.from_storage_id(1)), watched_1.append)
 
         storage.store_event(create_test_event_log_record(str(2), run_id=run_id))
         storage.store_event(create_test_event_log_record(str(3), run_id=run_id))
 
-        storage.watch(run_id, str(3), watched_2.append)
+        storage.watch(run_id, str(EventLogCursor.from_storage_id(3)), watched_2.append)
         storage.store_event(create_test_event_log_record(str(4), run_id=run_id))
 
         attempts = 10

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_event_callback.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_event_callback.py
@@ -24,7 +24,7 @@ def test_event_callback_logging():
     with instance_for_test() as instance:
         pipeline_run = instance.create_run_for_pipeline(pipeline_def)
 
-        instance.watch_event_logs(pipeline_run.run_id, -1, _event_callback)
+        instance.watch_event_logs(pipeline_run.run_id, None, _event_callback)
 
         res = execute_run(
             pipeline,

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_event_callback.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_event_callback.py
@@ -11,7 +11,7 @@ from dagster.core.test_utils import instance_for_test
 def test_event_callback_logging():
     events = defaultdict(list)
 
-    def _event_callback(record):
+    def _event_callback(record, _cursor):
         assert isinstance(record, EventLogEntry)
         if record.is_dagster_event:
             events[record.dagster_event.event_type].append(record)


### PR DESCRIPTION
### Summary & Motivation
This PR creates a method on the event log storage which uses opaque string cursor instead of an int offset or integer id (we would basically switch off which one we would use depending on the context).

This method returns a connection object, which returns the records, a string cursor, and a `has_more` flag.

We keeps around support for integer cursors to power legacy calls to `get_logs_for_run` that might rely on the integer offset logic, but we can probably drop this after we deprecate calls to `get_logs_for_run`.

Also, this switches all the `watch` calls to use this new connection method (along with string cursors).

Naming alternative suggestions welcome...

### How I Tested These Changes
BK
