### PR TITLE
Remove can_terminate from run launchers and run coordinators, use a status check instead in graphql

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -354,11 +354,14 @@ class GrapheneRun(graphene.ObjectType):
     def run_id(self):
         return self.runId
 
-    def resolve_canTerminate(self, graphene_info):
+    def resolve_canTerminate(self, _graphene_info):
         # short circuit if the pipeline run is in a terminal state
         if self._pipeline_run.is_finished:
             return False
-        return graphene_info.context.instance.run_coordinator.can_cancel_run(self.run_id)
+        return (
+            self._pipeline_run.status == PipelineRunStatus.QUEUED
+            or self._pipeline_run.status == PipelineRunStatus.STARTED
+        )
 
     def resolve_assets(self, graphene_info):
         return get_assets_for_run_id(graphene_info, self.run_id)

--- a/python_modules/dagster/dagster/core/launcher/base.py
+++ b/python_modules/dagster/dagster/core/launcher/base.py
@@ -75,12 +75,6 @@ class RunLauncher(ABC, MayHaveInstanceWeakref):
         """
 
     @abstractmethod
-    def can_terminate(self, run_id):
-        """
-        Can this run_id be terminated by this run launcher.
-        """
-
-    @abstractmethod
     def terminate(self, run_id):
         """
         Terminates a process.

--- a/python_modules/dagster/dagster/core/launcher/default_run_launcher.py
+++ b/python_modules/dagster/dagster/core/launcher/default_run_launcher.py
@@ -4,22 +4,13 @@ from typing import cast
 import dagster.seven as seven
 from dagster import Bool, Field
 from dagster import _check as check
-from dagster.core.errors import (
-    DagsterInvariantViolationError,
-    DagsterLaunchFailedError,
-    DagsterUserCodeUnreachableError,
-)
+from dagster.core.errors import DagsterInvariantViolationError, DagsterLaunchFailedError
 from dagster.core.host_representation.grpc_server_registry import ProcessGrpcServerRegistry
 from dagster.core.host_representation.repository_location import GrpcServerRepositoryLocation
 from dagster.core.storage.pipeline_run import PipelineRun
 from dagster.core.storage.tags import GRPC_INFO_TAG
 from dagster.grpc.client import DagsterGrpcClient
-from dagster.grpc.types import (
-    CanCancelExecutionRequest,
-    CancelExecutionRequest,
-    ExecuteExternalPipelineArgs,
-    StartRunResult,
-)
+from dagster.grpc.types import CancelExecutionRequest, ExecuteExternalPipelineArgs, StartRunResult
 from dagster.serdes import ConfigurableClass, deserialize_as, deserialize_json_to_dagster_namedtuple
 from dagster.utils import merge_dicts
 
@@ -145,23 +136,6 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
             host=grpc_info.get("host"),
             use_ssl=bool(grpc_info.get("use_ssl", False)),
         )
-
-    def can_terminate(self, run_id):
-        check.str_param(run_id, "run_id")
-
-        client = self._get_grpc_client_for_termination(run_id)
-        if not client:
-            return False
-
-        try:
-            res = deserialize_json_to_dagster_namedtuple(
-                client.can_cancel_execution(CanCancelExecutionRequest(run_id=run_id), timeout=5)
-            )
-        except DagsterUserCodeUnreachableError:
-            # Server that created the run may no longer exist
-            return False
-
-        return res.can_cancel
 
     def terminate(self, run_id):
         check.str_param(run_id, "run_id")

--- a/python_modules/dagster/dagster/core/launcher/sync_in_memory_run_launcher.py
+++ b/python_modules/dagster/dagster/core/launcher/sync_in_memory_run_launcher.py
@@ -34,8 +34,5 @@ class SyncInMemoryRunLauncher(RunLauncher, ConfigurableClass):
         recon_pipeline = recon_pipeline_from_origin(context.pipeline_code_origin)  # type: ignore
         execute_run(recon_pipeline, context.pipeline_run, self._instance)
 
-    def can_terminate(self, run_id):
-        return False
-
     def terminate(self, run_id):
         check.not_implemented("Termination not supported.")

--- a/python_modules/dagster/dagster/core/run_coordinator/base.py
+++ b/python_modules/dagster/dagster/core/run_coordinator/base.py
@@ -43,12 +43,6 @@ class RunCoordinator(ABC, MayHaveInstanceWeakref):
         """
 
     @abstractmethod
-    def can_cancel_run(self, run_id):
-        """
-        Can this run_id be canceled
-        """
-
-    @abstractmethod
     def cancel_run(self, run_id):
         """
         Cancels a run. The run may be queued in the coordinator, or it may have been launched.

--- a/python_modules/dagster/dagster/core/run_coordinator/default_run_coordinator.py
+++ b/python_modules/dagster/dagster/core/run_coordinator/default_run_coordinator.py
@@ -35,8 +35,5 @@ class DefaultRunCoordinator(RunCoordinator, ConfigurableClass):
             check.failed(f"Failed to reload run {pipeline_run.run_id}")
         return run
 
-    def can_cancel_run(self, run_id):
-        return self._instance.run_launcher.can_terminate(run_id)
-
     def cancel_run(self, run_id):
         return self._instance.run_launcher.terminate(run_id)

--- a/python_modules/dagster/dagster/core/run_coordinator/queued_run_coordinator.py
+++ b/python_modules/dagster/dagster/core/run_coordinator/queued_run_coordinator.py
@@ -145,15 +145,6 @@ class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
             check.failed(f"Failed to reload run {pipeline_run.run_id}")
         return run
 
-    def can_cancel_run(self, run_id):
-        run = self._instance.get_run_by_id(run_id)
-        if not run:
-            return False
-        if run.status == PipelineRunStatus.QUEUED:
-            return True
-        else:
-            return self._instance.run_launcher.can_terminate(run_id)
-
     def cancel_run(self, run_id):
         run = self._instance.get_run_by_id(run_id)
         if not run:

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -310,9 +310,6 @@ class ExplodingRunLauncher(RunLauncher, ConfigurableClass):
     def join(self, timeout=30):
         """Nothing to join on since all executions are synchronous."""
 
-    def can_terminate(self, run_id):
-        return False
-
     def terminate(self, run_id):
         check.not_implemented("Termination not supported")
 
@@ -356,9 +353,6 @@ class MockedRunLauncher(RunLauncher, ConfigurableClass):
     def inst_data(self):
         return self._inst_data
 
-    def can_terminate(self, run_id):
-        return False
-
     def terminate(self, run_id):
         check.not_implemented("Termintation not supported")
 
@@ -392,9 +386,6 @@ class MockedRunCoordinator(RunCoordinator, ConfigurableClass):
     @property
     def inst_data(self):
         return self._inst_data
-
-    def can_cancel_run(self, run_id):
-        check.not_implemented("Cancellation not supported")
 
     def cancel_run(self, run_id):
         check.not_implemented("Cancellation not supported")

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -193,9 +193,6 @@ class TestNonResumeRunLauncher(RunLauncher, ConfigurableClass):
     def join(self, timeout=30):
         raise NotImplementedError()
 
-    def can_terminate(self, run_id):
-        raise NotImplementedError()
-
     def terminate(self, run_id):
         raise NotImplementedError()
 
@@ -421,9 +418,6 @@ def test_instance_subclass():
 
 # class that doesn't implement needed methods on ConfigurableClass
 class InvalidRunLauncher(RunLauncher, ConfigurableClass):
-    def can_terminate(self, run_id):
-        return False
-
     def launch_run(self, context: LaunchRunContext) -> None:
         pass
 

--- a/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_default_run_launcher.py
@@ -424,7 +424,6 @@ def test_terminated_run(get_workspace, run_config):  # pylint: disable=redefined
             poll_for_step_start(instance, run_id)
 
             launcher = instance.run_launcher
-            assert launcher.can_terminate(run_id)
             assert launcher.terminate(run_id)
 
             terminated_pipeline_run = poll_for_finished_run(instance, run_id, timeout=30)
@@ -740,5 +739,4 @@ def test_not_initialized():  # pylint: disable=redefined-outer-name
     run_id = "dummy"
 
     assert run_launcher.join() is None
-    assert run_launcher.can_terminate(run_id) is False
     assert run_launcher.terminate(run_id) is False

--- a/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_persistent_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_persistent_grpc_run_launcher.py
@@ -133,7 +133,6 @@ def test_terminate_after_shutdown():
             launcher = instance.run_launcher
 
             # Can terminate the run even after the shutdown event has been received
-            assert launcher.can_terminate(pipeline_run.run_id)
             assert launcher.terminate(pipeline_run.run_id)
 
 
@@ -179,7 +178,6 @@ def test_server_down():
                 poll_for_step_start(instance, pipeline_run.run_id)
 
                 launcher = instance.run_launcher
-                assert launcher.can_terminate(pipeline_run.run_id)
 
                 original_run_tags = instance.get_run_by_id(pipeline_run.run_id).tags[GRPC_INFO_TAG]
 
@@ -192,8 +190,6 @@ def test_server_down():
                         )
                     },
                 )
-
-                assert not launcher.can_terminate(pipeline_run.run_id)
 
                 instance.add_run_tags(
                     pipeline_run.run_id,

--- a/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_queued_run_coordinator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_queued_run_coordinator.py
@@ -162,12 +162,9 @@ class TestQueuedRunCoordinator:
         run = self.create_run(
             instance, external_pipeline, run_id="foo-1", status=PipelineRunStatus.NOT_STARTED
         )
-        assert not coordinator.can_cancel_run(run.run_id)
 
         coordinator.submit_run(SubmitRunContext(run, workspace))
-        assert coordinator.can_cancel_run(run.run_id)
 
         coordinator.cancel_run(run.run_id)
         stored_run = instance.get_run_by_id("foo-1")
         assert stored_run.status == PipelineRunStatus.CANCELED
-        assert not coordinator.can_cancel_run(run.run_id)

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
@@ -50,9 +50,6 @@ class TestRunLauncher(RunLauncher, ConfigurableClass):
     def join(self, timeout=30):
         pass
 
-    def can_terminate(self, run_id):
-        raise NotImplementedError()
-
     def terminate(self, run_id):
         raise NotImplementedError()
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -268,22 +268,6 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
             cls=self.__class__,
         )
 
-    def can_terminate(self, run_id):
-        tags = self._get_run_tags(run_id)
-
-        if not (tags.arn and tags.cluster):
-            return False
-
-        tasks = self.ecs.describe_tasks(tasks=[tags.arn], cluster=tags.cluster).get("tasks")
-        if not tasks:
-            return False
-
-        status = tasks[0].get("lastStatus")
-        if status and status != "STOPPED":
-            return True
-
-        return False
-
     def terminate(self, run_id):
         tags = self._get_run_tags(run_id)
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_termination.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_termination.py
@@ -1,11 +1,7 @@
 def test_termination(instance, workspace, run):
-    assert not instance.run_launcher.can_terminate(run.run_id)
-
     instance.launch_run(run.run_id, workspace)
 
-    assert instance.run_launcher.can_terminate(run.run_id)
     assert instance.run_launcher.terminate(run.run_id)
-    assert not instance.run_launcher.can_terminate(run.run_id)
     assert not instance.run_launcher.terminate(run.run_id)
 
 
@@ -18,12 +14,6 @@ def test_missing_run(instance, workspace, run, monkeypatch):
     original = instance.get_run_by_id
 
     monkeypatch.setattr(instance, "get_run_by_id", missing_run)
-    assert not instance.run_launcher.can_terminate(run.run_id)
-
-    monkeypatch.setattr(instance, "get_run_by_id", original)
-    assert instance.run_launcher.can_terminate(run.run_id)
-
-    monkeypatch.setattr(instance, "get_run_by_id", missing_run)
     assert not instance.run_launcher.terminate(run.run_id)
 
     monkeypatch.setattr(instance, "get_run_by_id", original)
@@ -33,16 +23,6 @@ def test_missing_run(instance, workspace, run, monkeypatch):
 def test_missing_tag(instance, workspace, run):
     instance.launch_run(run.run_id, workspace)
     original = instance.get_run_by_id(run.run_id).tags
-
-    instance.add_run_tags(run.run_id, {"ecs/task_arn": ""})
-    assert not instance.run_launcher.can_terminate(run.run_id)
-
-    instance.add_run_tags(run.run_id, original)
-    instance.add_run_tags(run.run_id, {"ecs/cluster": ""})
-    assert not instance.run_launcher.can_terminate(run.run_id)
-
-    instance.add_run_tags(run.run_id, original)
-    assert instance.run_launcher.can_terminate(run.run_id)
 
     instance.add_run_tags(run.run_id, {"ecs/task_arn": ""})
     assert not instance.run_launcher.terminate(run.run_id)
@@ -62,12 +42,6 @@ def test_eventual_consistency(instance, workspace, run, monkeypatch):
         return {"tasks": []}
 
     original = instance.run_launcher.ecs.describe_tasks
-
-    monkeypatch.setattr(instance.run_launcher.ecs, "describe_tasks", empty)
-    assert not instance.run_launcher.can_terminate(run.run_id)
-
-    monkeypatch.setattr(instance.run_launcher.ecs, "describe_tasks", original)
-    assert instance.run_launcher.can_terminate(run.run_id)
 
     monkeypatch.setattr(instance.run_launcher.ecs, "describe_tasks", empty)
     assert not instance.run_launcher.terminate(run.run_id)

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -184,10 +184,6 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
         except Exception:
             return None
 
-    def can_terminate(self, run_id):
-        run = self._instance.get_run_by_id(run_id)
-        return self._get_container(run) != None
-
     def terminate(self, run_id):
         run = self._instance.get_run_by_id(run_id)
         container = self._get_container(run)

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
@@ -236,7 +236,6 @@ def test_terminate_launched_docker_run():
 
             poll_for_step_start(instance, run_id)
 
-            assert instance.run_launcher.can_terminate(run_id)
             assert instance.run_launcher.terminate(run_id)
 
             terminated_pipeline_run = poll_for_finished_run(instance, run_id, timeout=30)
@@ -469,7 +468,6 @@ def _test_launch(
                             raise Exception("Timed out waiting for run to start")
 
                 launcher = instance.run_launcher
-                assert launcher.can_terminate(run.run_id)
                 assert launcher.terminate(run.run_id)
 
                 poll_for_finished_run(instance, run.run_id, timeout=60)

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_terminate.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_terminate.py
@@ -91,7 +91,6 @@ def test_terminate_kills_subproc():
             time.sleep(0.5)
 
             launcher = instance.run_launcher
-            assert launcher.can_terminate(run_id)
             assert launcher.terminate(run_id)
 
             terminated_pipeline_run = poll_for_finished_run(instance, run_id, timeout=30)


### PR DESCRIPTION
Summary:
The default implementation of this when the run is running involves a DB query for each run that you call it on (and in the backfill UI we might call it on lots of running runs). I claim that this method is no longer needed and in the vast majority of cases a status check is sufficient. It also brings open source dagster in line with Dagster Cloud, which just uses a status check for termination.

Test Plan: BK, terminate a run from dagit

### Summary & Motivation

### How I Tested These Changes
