### PR TITLE
Don't fetch every run in the InstanceBackfillsQuery

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1405,7 +1405,9 @@ type PartitionRun {
 type PartitionBackfill {
   backfillId: String!
   status: BulkActionStatus!
+  backfillStatus: BackfillStatus!
   partitionNames: [String!]!
+  numPartitions: Int!
   numRequested: Int!
   fromFailure: Boolean!
   reexecutionSteps: [String!]!
@@ -1413,7 +1415,9 @@ type PartitionBackfill {
   timestamp: Float!
   partitionSet: PartitionSet
   runs(limit: Int): [Run!]!
+  unfinishedRuns(limit: Int): [Run!]!
   error: PythonError
+  partitionRunStats: BackfillRunStats!
 }
 
 enum BulkActionStatus {
@@ -1421,6 +1425,24 @@ enum BulkActionStatus {
   COMPLETED
   FAILED
   CANCELED
+}
+
+enum BackfillStatus {
+  REQUESTED
+  FAILED
+  CANCELED
+  IN_PROGRESS
+  COMPLETED
+  INCOMPLETE
+}
+
+type BackfillRunStats {
+  numQueued: Int!
+  numInProgress: Int!
+  numSucceeded: Int!
+  numFailed: Int!
+  numPartitionsWithRuns: Int!
+  numTotalRuns: Int!
 }
 
 type FutureInstigationTicks {

--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
@@ -119,13 +119,9 @@ export const BackfillTable = ({
     }
   };
 
-  const cancelableRuns = cancelRunBackfill?.runs.filter(
-    (run) => !doneStatuses.has(run?.status) && run.canTerminate,
-  );
+  const unfinishedRuns = cancelRunBackfill?.unfinishedRuns;
   const unfinishedMap =
-    cancelRunBackfill?.runs
-      .filter((run) => !doneStatuses.has(run?.status))
-      .reduce((accum, run) => ({...accum, [run.id]: run.canTerminate}), {}) || {};
+    unfinishedRuns?.reduce((accum, run) => ({...accum, [run.id]: run.canTerminate}), {}) || {};
 
   return (
     <>
@@ -170,7 +166,7 @@ export const BackfillTable = ({
         onComplete={() => refetch()}
       />
       <TerminationDialog
-        isOpen={!!cancelableRuns?.length}
+        isOpen={!!unfinishedRuns?.length}
         onClose={() => setCancelRunBackfill(undefined)}
         onComplete={() => refetch()}
         selectedRuns={unfinishedMap}
@@ -523,8 +519,18 @@ export const BACKFILL_TABLE_FRAGMENT = gql`
   fragment BackfillTableFragment on PartitionBackfill {
     backfillId
     status
+    backfillStatus
     numRequested
     partitionNames
+    numPartitions
+    partitionRunStats {
+      numQueued
+      numInProgress
+      numSucceeded
+      numFailed
+      numPartitionsWithRuns
+      numTotalRuns
+    }
     runs {
       id
       canTerminate
@@ -533,6 +539,10 @@ export const BACKFILL_TABLE_FRAGMENT = gql`
         key
         value
       }
+    }
+    unfinishedRuns {
+      id
+      canTerminate
     }
     timestamp
     partitionSetName

--- a/js_modules/dagit/packages/core/src/instance/types/BackfillTableFragment.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/BackfillTableFragment.ts
@@ -3,11 +3,21 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { BulkActionStatus, RunStatus } from "./../../types/globalTypes";
+import { BulkActionStatus, BackfillStatus, RunStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: BackfillTableFragment
 // ====================================================
+
+export interface BackfillTableFragment_partitionRunStats {
+  __typename: "BackfillRunStats";
+  numQueued: number;
+  numInProgress: number;
+  numSucceeded: number;
+  numFailed: number;
+  numPartitionsWithRuns: number;
+  numTotalRuns: number;
+}
 
 export interface BackfillTableFragment_runs_tags {
   __typename: "PipelineTag";
@@ -21,6 +31,12 @@ export interface BackfillTableFragment_runs {
   canTerminate: boolean;
   status: RunStatus;
   tags: BackfillTableFragment_runs_tags[];
+}
+
+export interface BackfillTableFragment_unfinishedRuns {
+  __typename: "Run";
+  id: string;
+  canTerminate: boolean;
 }
 
 export interface BackfillTableFragment_partitionSet_repositoryOrigin {
@@ -56,9 +72,13 @@ export interface BackfillTableFragment {
   __typename: "PartitionBackfill";
   backfillId: string;
   status: BulkActionStatus;
+  backfillStatus: BackfillStatus;
   numRequested: number;
   partitionNames: string[];
+  numPartitions: number;
+  partitionRunStats: BackfillTableFragment_partitionRunStats;
   runs: BackfillTableFragment_runs[];
+  unfinishedRuns: BackfillTableFragment_unfinishedRuns[];
   timestamp: number;
   partitionSetName: string;
   partitionSet: BackfillTableFragment_partitionSet | null;

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceBackfillsQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceBackfillsQuery.ts
@@ -3,24 +3,26 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { BulkActionStatus, RunStatus } from "./../../types/globalTypes";
+import { BulkActionStatus, BackfillStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: InstanceBackfillsQuery
 // ====================================================
 
-export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_runs_tags {
-  __typename: "PipelineTag";
-  key: string;
-  value: string;
+export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionRunStats {
+  __typename: "BackfillRunStats";
+  numQueued: number;
+  numInProgress: number;
+  numSucceeded: number;
+  numFailed: number;
+  numPartitionsWithRuns: number;
+  numTotalRuns: number;
 }
 
-export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_runs {
+export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_unfinishedRuns {
   __typename: "Run";
   id: string;
   canTerminate: boolean;
-  status: RunStatus;
-  tags: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_runs_tags[];
 }
 
 export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionSet_repositoryOrigin {
@@ -56,9 +58,11 @@ export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackf
   __typename: "PartitionBackfill";
   backfillId: string;
   status: BulkActionStatus;
+  backfillStatus: BackfillStatus;
   numRequested: number;
-  partitionNames: string[];
-  runs: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_runs[];
+  numPartitions: number;
+  partitionRunStats: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionRunStats;
+  unfinishedRuns: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_unfinishedRuns[];
   timestamp: number;
   partitionSetName: string;
   partitionSet: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionSet | null;

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceBackfillsQueryNew.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceBackfillsQueryNew.ts
@@ -3,24 +3,26 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { BulkActionStatus, RunStatus } from "./../../types/globalTypes";
+import { BulkActionStatus, BackfillStatus, RunStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: InstanceBackfillsQueryNew
 // ====================================================
 
-export interface InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results_runs_tags {
-  __typename: "PipelineTag";
-  key: string;
-  value: string;
+export interface InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results_partitionRunStats {
+  __typename: "BackfillRunStats";
+  numQueued: number;
+  numInProgress: number;
+  numSucceeded: number;
+  numFailed: number;
+  numPartitionsWithRuns: number;
+  numTotalRuns: number;
 }
 
-export interface InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results_runs {
+export interface InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results_unfinishedRuns {
   __typename: "Run";
   id: string;
   canTerminate: boolean;
-  status: RunStatus;
-  tags: InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results_runs_tags[];
 }
 
 export interface InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results_partitionSet_repositoryOrigin {
@@ -52,17 +54,35 @@ export interface InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBa
   cause: InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results_error_cause | null;
 }
 
+export interface InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results_runs_tags {
+  __typename: "PipelineTag";
+  key: string;
+  value: string;
+}
+
+export interface InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results_runs {
+  __typename: "Run";
+  id: string;
+  canTerminate: boolean;
+  status: RunStatus;
+  tags: InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results_runs_tags[];
+}
+
 export interface InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results {
   __typename: "PartitionBackfill";
   backfillId: string;
   status: BulkActionStatus;
+  backfillStatus: BackfillStatus;
   numRequested: number;
   partitionNames: string[];
-  runs: InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results_runs[];
+  numPartitions: number;
+  partitionRunStats: InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results_partitionRunStats;
+  unfinishedRuns: InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results_unfinishedRuns[];
   timestamp: number;
   partitionSetName: string;
   partitionSet: InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results_partitionSet | null;
   error: InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results_error | null;
+  runs: InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills_results_runs[];
 }
 
 export interface InstanceBackfillsQueryNew_partitionBackfillsOrError_PartitionBackfills {

--- a/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsQuery.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsQuery.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { RepositorySelector, BulkActionStatus, RunStatus } from "./../../types/globalTypes";
+import { RepositorySelector, BulkActionStatus, BackfillStatus, RunStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: JobBackfillsQuery
@@ -11,6 +11,16 @@ import { RepositorySelector, BulkActionStatus, RunStatus } from "./../../types/g
 
 export interface JobBackfillsQuery_partitionSetOrError_PartitionSetNotFoundError {
   __typename: "PartitionSetNotFoundError" | "PythonError";
+}
+
+export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionRunStats {
+  __typename: "BackfillRunStats";
+  numQueued: number;
+  numInProgress: number;
+  numSucceeded: number;
+  numFailed: number;
+  numPartitionsWithRuns: number;
+  numTotalRuns: number;
 }
 
 export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_runs_tags {
@@ -25,6 +35,12 @@ export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_ru
   canTerminate: boolean;
   status: RunStatus;
   tags: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_runs_tags[];
+}
+
+export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_unfinishedRuns {
+  __typename: "Run";
+  id: string;
+  canTerminate: boolean;
 }
 
 export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionSet_repositoryOrigin {
@@ -60,9 +76,13 @@ export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills {
   __typename: "PartitionBackfill";
   backfillId: string;
   status: BulkActionStatus;
+  backfillStatus: BackfillStatus;
   numRequested: number;
   partitionNames: string[];
+  numPartitions: number;
+  partitionRunStats: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionRunStats;
   runs: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_runs[];
+  unfinishedRuns: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_unfinishedRuns[];
   timestamp: number;
   partitionSetName: string;
   partitionSet: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionSet | null;

--- a/js_modules/dagit/packages/core/src/partitions/types/PartitionProgressQuery.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/PartitionProgressQuery.ts
@@ -3,24 +3,26 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { BulkActionStatus, RunStatus } from "./../../types/globalTypes";
+import { BulkActionStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: PartitionProgressQuery
 // ====================================================
 
-export interface PartitionProgressQuery_partitionBackfillOrError_PartitionBackfill_runs_tags {
-  __typename: "PipelineTag";
-  key: string;
-  value: string;
+export interface PartitionProgressQuery_partitionBackfillOrError_PartitionBackfill_partitionRunStats {
+  __typename: "BackfillRunStats";
+  numQueued: number;
+  numInProgress: number;
+  numSucceeded: number;
+  numFailed: number;
+  numPartitionsWithRuns: number;
+  numTotalRuns: number;
 }
 
-export interface PartitionProgressQuery_partitionBackfillOrError_PartitionBackfill_runs {
+export interface PartitionProgressQuery_partitionBackfillOrError_PartitionBackfill_unfinishedRuns {
   __typename: "Run";
   id: string;
   canTerminate: boolean;
-  status: RunStatus;
-  tags: PartitionProgressQuery_partitionBackfillOrError_PartitionBackfill_runs_tags[];
 }
 
 export interface PartitionProgressQuery_partitionBackfillOrError_PartitionBackfill {
@@ -29,7 +31,9 @@ export interface PartitionProgressQuery_partitionBackfillOrError_PartitionBackfi
   status: BulkActionStatus;
   numRequested: number;
   partitionNames: string[];
-  runs: PartitionProgressQuery_partitionBackfillOrError_PartitionBackfill_runs[];
+  numPartitions: number;
+  partitionRunStats: PartitionProgressQuery_partitionBackfillOrError_PartitionBackfill_partitionRunStats;
+  unfinishedRuns: PartitionProgressQuery_partitionBackfillOrError_PartitionBackfill_unfinishedRuns[];
 }
 
 export interface PartitionProgressQuery_partitionBackfillOrError_PythonError_cause {
@@ -53,5 +57,4 @@ export interface PartitionProgressQuery {
 
 export interface PartitionProgressQueryVariables {
   backfillId: string;
-  limit?: number | null;
 }

--- a/js_modules/dagit/packages/core/src/types/globalTypes.ts
+++ b/js_modules/dagit/packages/core/src/types/globalTypes.ts
@@ -7,6 +7,15 @@
 // START Enums and Input Objects
 //==============================================================
 
+export enum BackfillStatus {
+  CANCELED = "CANCELED",
+  COMPLETED = "COMPLETED",
+  FAILED = "FAILED",
+  INCOMPLETE = "INCOMPLETE",
+  IN_PROGRESS = "IN_PROGRESS",
+  REQUESTED = "REQUESTED",
+}
+
 export enum BulkActionStatus {
   CANCELED = "CANCELED",
   COMPLETED = "COMPLETED",

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -3,7 +3,8 @@ import graphene
 
 import dagster._check as check
 from dagster.core.execution.backfill import BulkActionStatus, PartitionBackfill
-from dagster.core.storage.pipeline_run import RunsFilter
+from dagster.core.storage.pipeline_run import PipelineRunStatus, RunsFilter
+from dagster.core.storage.tags import PARTITION_NAME_TAG
 
 from .errors import (
     GrapheneInvalidOutputError,
@@ -82,13 +83,39 @@ class GrapheneBulkActionStatus(graphene.Enum):
         name = "BulkActionStatus"
 
 
+class GrapheneBackfillStatus(graphene.Enum):
+    REQUESTED = "REQUESTED"
+    FAILED = "FAILED"
+    CANCELED = "CANCELED"
+    IN_PROGRESS = "IN_PROGRESS"
+    COMPLETED = "COMPLETED"
+    INCOMPLETE = "INCOMPLETE"
+
+    class Meta:
+        name = "BackfillStatus"
+
+
+class GrapheneBackfillRunStats(graphene.ObjectType):
+    class Meta:
+        name = "BackfillRunStats"
+
+    numQueued = graphene.NonNull(graphene.Int)
+    numInProgress = graphene.NonNull(graphene.Int)
+    numSucceeded = graphene.NonNull(graphene.Int)
+    numFailed = graphene.NonNull(graphene.Int)
+    numPartitionsWithRuns = graphene.NonNull(graphene.Int)
+    numTotalRuns = graphene.NonNull(graphene.Int)
+
+
 class GraphenePartitionBackfill(graphene.ObjectType):
     class Meta:
         name = "PartitionBackfill"
 
     backfillId = graphene.NonNull(graphene.String)
     status = graphene.NonNull(GrapheneBulkActionStatus)
+    backfillStatus = graphene.NonNull(GrapheneBackfillStatus)
     partitionNames = non_null_list(graphene.String)
+    numPartitions = graphene.NonNull(graphene.Int)
     numRequested = graphene.NonNull(graphene.Int)
     fromFailure = graphene.NonNull(graphene.Boolean)
     reexecutionSteps = non_null_list(graphene.String)
@@ -99,10 +126,17 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         non_null_list("dagster_graphql.schema.pipelines.pipeline.GrapheneRun"),
         limit=graphene.Int(),
     )
+    unfinishedRuns = graphene.Field(
+        non_null_list("dagster_graphql.schema.pipelines.pipeline.GrapheneRun"),
+        limit=graphene.Int(),
+    )
     error = graphene.Field(GraphenePythonError)
+    partitionRunStats = graphene.NonNull(GrapheneBackfillRunStats)
 
     def __init__(self, backfill_job):
         self._backfill_job = check.opt_inst_param(backfill_job, "backfill_job", PartitionBackfill)
+
+        self._records = None
 
         super().__init__(
             backfillId=backfill_job.backfill_id,
@@ -114,24 +148,99 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             timestamp=backfill_job.backfill_timestamp,
         )
 
-    def resolve_runs(self, graphene_info, **kwargs):
+    def _get_records(self, graphene_info):
+        if self._records == None:
+            filters = RunsFilter.for_backfill(self._backfill_job.backfill_id)
+            self._records = graphene_info.context.instance.get_run_records(
+                filters=filters,
+            )
+        return self._records
+
+    def resolve_unfinishedRuns(self, graphene_info):
         from .pipelines.pipeline import GrapheneRun
 
-        filters = RunsFilter.for_backfill(self._backfill_job.backfill_id)
-        return [
-            GrapheneRun(record)
-            for record in graphene_info.context.instance.get_run_records(
-                filters=filters,
-                limit=kwargs.get("limit"),
-            )
-        ]
+        records = self._get_records(graphene_info)
+        return [GrapheneRun(record) for record in records if not record.pipeline_run.is_finished]
+
+    def resolve_backfillStatus(self, graphene_info):
+        if self._backfill_job.status == BulkActionStatus.REQUESTED:
+            return GrapheneBackfillStatus.REQUESTED
+        if self._backfill_job.status == BulkActionStatus.CANCELED:
+            return GrapheneBackfillStatus.CANCELED
+        if self._backfill_job.status == BulkActionStatus.FAILED:
+            return GrapheneBackfillStatus.FAILED
+        if self._backfill_job.status == BulkActionStatus.COMPLETED:
+            records = self._get_records(graphene_info)
+
+            is_done = all(record.pipeline_run.is_finished for record in records)
+            if not is_done:
+                return GrapheneBackfillStatus.IN_PROGRESS
+            else:
+                num_success = len(
+                    [
+                        record
+                        for record in records
+                        if record.pipeline_run.status == PipelineRunStatus.SUCCESS
+                    ]
+                )
+                if num_success == len(self._backfill_job.partition_names):
+                    return GrapheneBackfillStatus.COMPLETED
+                else:
+                    return GrapheneBackfillStatus.INCOMPLETE
+
+    def resolve_partitionRunStats(self, graphene_info):
+        records = self._get_records(graphene_info)
+
+        by_partition_records = {}
+
+        for record in records:
+            partition = record.pipeline_run.tags.get(PARTITION_NAME_TAG)
+            if partition and partition not in by_partition_records:  # get latest for each partition
+                by_partition_records[partition] = record
+
+        num_queued = 0
+        num_in_progress = 0
+        num_succeeded = 0
+        num_failed = 0
+
+        for _partition, record in by_partition_records.items():
+            status = record.pipeline_run.status
+            if status == PipelineRunStatus.QUEUED:
+                num_queued = num_queued + 1
+            elif not record.pipeline_run.is_finished:
+                num_in_progress = num_in_progress + 1
+            elif status == PipelineRunStatus.SUCCESS:
+                num_succeeded = num_succeeded + 1
+            elif status in {PipelineRunStatus.FAILURE, PipelineRunStatus.CANCELED}:
+                num_failed = num_failed + 1
+            else:
+                check.invariant(False, f"Unexpected PipelineRunStatus {status}")
+
+        return GrapheneBackfillRunStats(
+            numQueued=num_queued,
+            numInProgress=num_in_progress,
+            numSucceeded=num_succeeded,
+            numFailed=num_failed,
+            numPartitionsWithRuns=len(by_partition_records),
+            numTotalRuns=len(records),
+        )
+
+    def resolve_runs(self, graphene_info):
+        from .pipelines.pipeline import GrapheneRun
+
+        records = self._get_records(graphene_info)
+        return [GrapheneRun(record) for record in records]
+
+    def resolve_numPartitions(self, _graphene_info):
+        return len(self._backfill_job.partition_names)
 
     def resolve_numRequested(self, graphene_info):
-        filters = RunsFilter.for_backfill(self._backfill_job.backfill_id)
-        run_count = graphene_info.context.instance.get_runs_count(filters)
         if self._backfill_job.status == BulkActionStatus.COMPLETED:
             return len(self._backfill_job.partition_names)
 
+        records = self._get_records(graphene_info)
+
+        run_count = len(records)
         checkpoint = self._backfill_job.last_submitted_partition_name
         return max(
             run_count,


### PR DESCRIPTION
Summary:
This elminates places where the (old) backfill ui loads every single run in every backfill. The problem doesn't appear to be the fact that we need to fetch all the runs, but rather the gigantic graphql response when we return 10s of thousands of runs to the client.

I did leave a 'cancelableRuns' field that I would love to remove as well - that appears to mainly exist so that Dagit can do buik termination from the client. Instead we should write a 'terminate every run in backfill X' bulk action and not need to send thousands of run IDs to dagit, but that is future work after this PR.

For now i just took the new backill UI out of the existing path to test this out. I won't land that - prha has graciously volunteered to split the two UIs a bit more before we land this.

I also still need to add tests for the new fields I added.

However, this drops a large backfill page with ~16k runs load time from about 4 minutes to about 15 seconds.

### Summary & Motivation

### How I Tested These Changes
