### PR TITLE
Generate buildkite headers inside dagster-buildkite

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -216,7 +216,8 @@ class PackageSpec(
                         build_tox_step(
                             self.directory,
                             tox_env,
-                            base_label=f":pytest: {base_name}",
+                            base_label=base_name,
+                            command_type="pytest",
                             python_version=py_version,
                             env_vars=self.env_vars,
                             extra_commands_pre=extra_commands_pre,
@@ -234,7 +235,8 @@ class PackageSpec(
                 build_tox_step(
                     self.directory,
                     "mypy",
-                    base_label=f":mypy: {base_name}",
+                    base_label=base_name,
+                    command_type="mypy",
                     python_version=supported_python_versions[-1],
                 )
             )
@@ -244,7 +246,8 @@ class PackageSpec(
                 build_tox_step(
                     self.directory,
                     "pylint",
-                    base_label=f":lint-roller: {base_name}",
+                    base_label=base_name,
+                    command_type="pylint",
                     python_version=supported_python_versions[-1],
                 )
             )

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
@@ -46,9 +46,9 @@ def build_docs_steps() -> List[GroupStep]:
         .on_integration_image(AvailablePythonVersion.V3_8)
         .build(),
         # mypy for build scripts
-        build_tox_step("docs", "mypy", base_label=":mypy: docs"),
+        build_tox_step("docs", "mypy", command_type="mypy"),
         # pylint for build scripts
-        build_tox_step("docs", "pylint", base_label=":lint-roller: docs"),
+        build_tox_step("docs", "pylint", command_type="pylint"),
     ]
     return [
         GroupStep(

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -133,3 +133,15 @@ def is_feature_branch(branch_name: str) -> bool:
 
 def is_release_branch(branch_name: str) -> bool:
     return branch_name.startswith("release-")
+
+
+# Preceding a line of BK output with "---" turns it into a section header.
+# The characters surrounding the `message` are ANSI escope sequences used to colorize the output.
+# Note that "\" is doubled below to insert a single literal backslash in the string.
+#
+# \033[0;32m : initiate green coloring
+# \033[0m : end coloring
+#
+# Green is hardcoded, but can easily be parameterized if needed.
+def make_buildkite_section_header(message: str) -> str:
+    return f"--- \\033[0;32m{message}\\033[0m"

--- a/examples/airflow_ingest/tox.ini
+++ b/examples/airflow_ingest/tox.ini
@@ -11,10 +11,8 @@ deps =
   -e ../../python_modules/libraries/dagster-airflow[test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/basic_pyspark/tox.ini
+++ b/examples/basic_pyspark/tox.ini
@@ -12,10 +12,8 @@ deps =
   -e ../../python_modules/libraries/dagster-pyspark
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/bollinger/tox.ini
+++ b/examples/bollinger/tox.ini
@@ -11,7 +11,6 @@ deps =
   -e ../../python_modules/libraries/dagster-pandera/
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv

--- a/examples/dbt_example/tox.ini
+++ b/examples/dbt_example/tox.ini
@@ -18,10 +18,8 @@ deps =
   -e ../../python_modules/libraries/dagster-dbt[test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/deploy_docker/tox.ini
+++ b/examples/deploy_docker/tox.ini
@@ -10,10 +10,8 @@ deps =
   -e ../../python_modules/dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/deploy_ecs/tox.ini
+++ b/examples/deploy_ecs/tox.ini
@@ -11,10 +11,8 @@ deps =
   -e ../../python_modules/dagster-test
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -s -vv {posargs}
 
 [testenv:mypy]

--- a/examples/deploy_k8s/tox.ini
+++ b/examples/deploy_k8s/tox.ini
@@ -15,10 +15,8 @@ deps =
   -e ../../python_modules/libraries/dagster-celery-k8s
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -24,10 +24,8 @@ deps =
   -e ../../python_modules/dagit
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/emr_pyspark/tox.ini
+++ b/examples/emr_pyspark/tox.ini
@@ -13,10 +13,8 @@ deps =
   -e ../../python_modules/libraries/dagster-pyspark
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/ge_example/tox.ini
+++ b/examples/ge_example/tox.ini
@@ -15,10 +15,8 @@ deps =
   -e ../../python_modules/libraries/dagster-ge
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/hacker_news/tox.ini
+++ b/examples/hacker_news/tox.ini
@@ -19,10 +19,8 @@ deps =
   -e ../../python_modules/libraries/dagstermill/
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv
 
 [testenv:mypy]

--- a/examples/hacker_news_assets/tox.ini
+++ b/examples/hacker_news_assets/tox.ini
@@ -18,10 +18,8 @@ deps =
   -e ../../python_modules/libraries/dagster-postgres/
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv
 
 [testenv:mypy]

--- a/examples/memoized_development/tox.ini
+++ b/examples/memoized_development/tox.ini
@@ -13,10 +13,8 @@ deps =
   -e ../../python_modules/dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/modern_data_stack_assets/tox.ini
+++ b/examples/modern_data_stack_assets/tox.ini
@@ -15,10 +15,8 @@ deps =
   -e ../../python_modules/libraries/dagster-pandas/
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv
 
 [testenv:mypy]

--- a/examples/nyt-feed/tox.ini
+++ b/examples/nyt-feed/tox.ini
@@ -11,10 +11,8 @@ deps =
   -e ../../python_modules/dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/run_attribution_example/tox.ini
+++ b/examples/run_attribution_example/tox.ini
@@ -13,10 +13,8 @@ deps =
   -e ../../python_modules/dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/software_defined_assets/tox.ini
+++ b/examples/software_defined_assets/tox.ini
@@ -13,10 +13,8 @@ deps =
   -e .[test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/user_in_loop/tox.ini
+++ b/examples/user_in_loop/tox.ini
@@ -11,10 +11,8 @@ deps =
   -e ../../python_modules/dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/helm/dagster/schema/tox.ini
+++ b/helm/dagster/schema/tox.ini
@@ -19,10 +19,8 @@ extras =
   test
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest --reruns 2 -vv {posargs}
 
 [testenv:mypy]

--- a/integration_tests/python_modules/dagster-k8s-test-infra/tox.ini
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/tox.ini
@@ -16,11 +16,9 @@ deps =
 usedevelop = true
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_k8s_test_infra --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/integration_tests/test_suites/backcompat-test-suite/tox.ini
+++ b/integration_tests/test_suites/backcompat-test-suite/tox.ini
@@ -15,10 +15,8 @@ deps =
 
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   dagit-latest-release: pytest -m "dagit-latest-release" -vv -s {posargs}
   dagit-earliest-release: pytest -m "dagit-earliest-release" -vv -s {posargs}
   user-code-latest-release: pytest -m "user-code-latest-release" -vv -s {posargs}

--- a/integration_tests/test_suites/celery-k8s-test-suite/tox.ini
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tox.ini
@@ -23,11 +23,9 @@ deps =
   -e ../../python_modules/dagster-k8s-test-infra
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   default: pytest --log-cli-level=INFO -m "not mark_user_code_deployment_subchart and not mark_daemon and mark_rabbitmq and not mark_monitoring" -s -vv --junitxml=test_results.xml --cov=../../../python_modules/libraries/dagster-celery-k8s --cov-append --cov-report= {posargs}
   markredis: pytest --log-cli-level=INFO -m "not mark_user_code_deployment_subchart and not mark_daemon and mark_redis and not mark_monitoring" -s -vv --junitxml=test_results.xml --cov=../../../python_modules/libraries/dagster-celery-k8s --cov-append --cov-report= {posargs}
   markusercodedeploymentsubchart: pytest --log-cli-level=INFO -m mark_user_code_deployment_subchart -s -vv --junitxml=test_results.xml --cov=../../../python_modules/libraries/dagster-celery-k8s --cov-append --cov-report= {posargs}

--- a/integration_tests/test_suites/daemon-test-suite/tox.ini
+++ b/integration_tests/test_suites/daemon-test-suite/tox.ini
@@ -22,11 +22,9 @@ deps =
   -e ../../../python_modules/libraries/dagster-docker
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest  -s -vv --junitxml=test_results.xml {posargs}
 
 [testenv:mypy]

--- a/integration_tests/test_suites/k8s-test-suite/tox.ini
+++ b/integration_tests/test_suites/k8s-test-suite/tox.ini
@@ -24,11 +24,9 @@ deps =
   pyparsing<3.0.0
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   default: pytest --log-cli-level=INFO -m "default" --junitxml=test_results.xml --cov=../../../python_modules/libraries/dagster-k8s --cov-append --cov-report= {posargs}
   subchart: pytest --log-cli-level=INFO -m "subchart" --junitxml=test_results.xml --cov=../../../python_modules/libraries/dagster-k8s --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/js_modules/dagit/tox.ini
+++ b/js_modules/dagit/tox.ini
@@ -15,13 +15,11 @@ deps =
 usedevelop = False
 allowlist_externals =
   /bin/bash
-  echo
   git
   yarn
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:Running dagit webapp tests\033[0m"
   yarn install
   yarn workspace @dagster-io/dagit-core generate-graphql
   yarn workspace @dagster-io/dagit-core generate-perms

--- a/python_modules/automation/automation/scaffold/assets/dagster-example-tmpl/tox.ini.tmpl
+++ b/python_modules/automation/automation/scaffold/assets/dagster-example-tmpl/tox.ini.tmpl
@@ -10,10 +10,8 @@ deps =
   -e ../../python_modules/dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/python_modules/automation/automation/scaffold/assets/dagster-library-tmpl/tox.ini.tmpl
+++ b/python_modules/automation/automation/scaffold/assets/dagster-library-tmpl/tox.ini.tmpl
@@ -11,11 +11,9 @@ deps =
 usedevelop = true
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_{{LIBRARY_NAME}} --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -11,11 +11,9 @@ deps =
 usedevelop = true
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=automation --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/dagit/tox.ini
+++ b/python_modules/dagit/tox.ini
@@ -16,11 +16,9 @@ deps =
 
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -n 2 -v --junitxml=dagit_test_results.xml --cov=dagit --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/dagster-graphql/tox.ini
+++ b/python_modules/dagster-graphql/tox.ini
@@ -14,11 +14,9 @@ deps =
   postgres: -e ../libraries/dagster-postgres
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   not_graphql_context_test_suite: pytest -m "not graphql_context_test_suite and not graphql_context_variants and not python_client_test_suite" -vv --junitxml=dagster_graphql_test_results.xml --cov=dagster_graphql --cov-append --cov-report= {posargs}
   in_memory_instance_multi_location: pytest -m "graphql_context_test_suite and in_memory_instance and multi_location" -vv --junitxml=dagster_graphql_test_results.xml --cov=dagster_graphql --cov-append --cov-report= {posargs}
   in_memory_instance_managed_grpc_env: pytest -m "graphql_context_test_suite and in_memory_instance and managed_grpc_env" -vv --junitxml=dagster_graphql_test_results.xml --cov=dagster_graphql --cov-append --cov-report= {posargs}

--- a/python_modules/dagster-test/tox.ini
+++ b/python_modules/dagster-test/tox.ini
@@ -22,11 +22,9 @@ deps =
   -e ../libraries/dagstermill
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv -s -p dagster_test.fixtures --junitxml=test_results.xml --cov=dagster_test --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -18,12 +18,10 @@ deps =
   -e ../dagster-test
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   flake8 . --count --exclude=./.*,dagster/seven/__init__.py --select=E9,F63,F7,F82 --show-source --statistics
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
 
   api_tests: pytest -vv ./dagster_tests/api_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
   cli_tests: pytest -vv ./dagster_tests/cli_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}

--- a/python_modules/libraries/dagster-airbyte/tox.ini
+++ b/python_modules/libraries/dagster-airbyte/tox.ini
@@ -8,11 +8,9 @@ deps =
   -e ../../dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_airbyte --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-airflow/tox.ini
+++ b/python_modules/libraries/dagster-airflow/tox.ini
@@ -20,11 +20,9 @@ deps =
 
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   requiresairflowdb: airflow initdb
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   !requiresairflowdb: pytest -m "not requires_airflow_db" -vv --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report= {posargs}
   requiresairflowdb: pytest -m requires_airflow_db -vv --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-aws/tox.ini
+++ b/python_modules/libraries/dagster-aws/tox.ini
@@ -15,11 +15,9 @@ deps =
   -e ../dagster-pyspark
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_aws --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-azure/tox.ini
+++ b/python_modules/libraries/dagster-azure/tox.ini
@@ -12,11 +12,9 @@ deps =
   -e ../dagster-pyspark
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_azure --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-celery-docker/tox.ini
+++ b/python_modules/libraries/dagster-celery-docker/tox.ini
@@ -17,11 +17,9 @@ deps =
   -e ../dagster-postgres
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_celery_docker --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-celery-k8s/tox.ini
+++ b/python_modules/libraries/dagster-celery-k8s/tox.ini
@@ -22,11 +22,9 @@ deps =
   -e ../dagster-gcp
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_celery_k8s --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-celery/tox.ini
+++ b/python_modules/libraries/dagster-celery/tox.ini
@@ -19,11 +19,9 @@ deps =
   -e ../dagster-celery-docker
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_celery --cov-append --cov-report= {posargs} -s
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-census/tox.ini
+++ b/python_modules/libraries/dagster-census/tox.ini
@@ -9,11 +9,9 @@ deps =
 usedevelop = true
 whitelist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_census --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-dask/tox.ini
+++ b/python_modules/libraries/dagster-dask/tox.ini
@@ -18,11 +18,9 @@ deps =
   -e ../dagster-pandas
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_dask --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-databricks/tox.ini
+++ b/python_modules/libraries/dagster-databricks/tox.ini
@@ -14,11 +14,9 @@ deps =
   -e ../dagster-pyspark
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_databricks --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-datadog/tox.ini
+++ b/python_modules/libraries/dagster-datadog/tox.ini
@@ -10,11 +10,9 @@ deps =
   -e ../../dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_datadog --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -14,11 +14,9 @@ deps =
   -e ../dagster-postgres
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_dbt --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-docker/tox.ini
+++ b/python_modules/libraries/dagster-docker/tox.ini
@@ -20,11 +20,9 @@ deps =
   -e ../dagster-postgres
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_docker --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-fivetran/tox.ini
+++ b/python_modules/libraries/dagster-fivetran/tox.ini
@@ -8,11 +8,9 @@ deps =
   -e ../../dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_fivetran --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-gcp/tox.ini
+++ b/python_modules/libraries/dagster-gcp/tox.ini
@@ -13,11 +13,9 @@ deps =
   -e ../dagster-pandas
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest {posargs} -vv --junitxml=test_results.xml --cov=dagster_gcp --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-ge/tox.ini
+++ b/python_modules/libraries/dagster-ge/tox.ini
@@ -13,11 +13,9 @@ deps =
   -e ../dagster-pyspark
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_ge --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-github/tox.ini
+++ b/python_modules/libraries/dagster-github/tox.ini
@@ -10,11 +10,9 @@ deps =
   -e ../../dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_github --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-k8s/tox.ini
+++ b/python_modules/libraries/dagster-k8s/tox.ini
@@ -19,11 +19,9 @@ deps =
   -e ../../libraries/dagster-celery-docker
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest --log-cli-level=INFO -vv --junitxml=test_results.xml --cov=dagster_k8s --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-mlflow/tox.ini
+++ b/python_modules/libraries/dagster-mlflow/tox.ini
@@ -10,11 +10,9 @@ deps =
   -e ../../dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_mlflow --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-msteams/tox.ini
+++ b/python_modules/libraries/dagster-msteams/tox.ini
@@ -10,11 +10,9 @@ deps =
   -e ../../dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_msteams --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-mysql/tox.ini
+++ b/python_modules/libraries/dagster-mysql/tox.ini
@@ -10,11 +10,9 @@ deps =
   -e ../../dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_mysql --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-pagerduty/tox.ini
+++ b/python_modules/libraries/dagster-pagerduty/tox.ini
@@ -10,11 +10,9 @@ deps =
   -e ../../dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_pagerduty --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-pandas/tox.ini
+++ b/python_modules/libraries/dagster-pandas/tox.ini
@@ -12,11 +12,9 @@ deps =
 
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   ipython kernel install --name "dagster" --user
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -v --cov=dagster_pandas --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tgox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-pandera/tox.ini
+++ b/python_modules/libraries/dagster-pandera/tox.ini
@@ -11,11 +11,9 @@ deps =
 
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   ipython kernel install --name "dagster" --user
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -v --cov=dagster_pandera --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tgox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-papertrail/tox.ini
+++ b/python_modules/libraries/dagster-papertrail/tox.ini
@@ -10,11 +10,9 @@ deps =
   -e ../../dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_papertrail --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-postgres/tox.ini
+++ b/python_modules/libraries/dagster-postgres/tox.ini
@@ -10,11 +10,9 @@ deps =
   -e ../../dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_postgres --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-prometheus/tox.ini
+++ b/python_modules/libraries/dagster-prometheus/tox.ini
@@ -10,11 +10,9 @@ deps =
   -e ../../dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_prometheus --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-pyspark/tox.ini
@@ -12,11 +12,9 @@ deps =
   -e ../../libraries/dagster-aws
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_pyspark --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-shell/tox.ini
+++ b/python_modules/libraries/dagster-shell/tox.ini
@@ -12,11 +12,9 @@ deps =
   -e ../../dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_shell --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-slack/tox.ini
+++ b/python_modules/libraries/dagster-slack/tox.ini
@@ -10,11 +10,9 @@ deps =
   -e ../../dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_slack --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-snowflake-pandas/tox.ini
+++ b/python_modules/libraries/dagster-snowflake-pandas/tox.ini
@@ -9,11 +9,9 @@ deps =
   -e ../dagster-snowflake
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_snowflake_pandas --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-snowflake/tox.ini
+++ b/python_modules/libraries/dagster-snowflake/tox.ini
@@ -11,11 +11,9 @@ deps =
   -e ../dagster-pandas
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_snowflake --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-spark/tox.ini
+++ b/python_modules/libraries/dagster-spark/tox.ini
@@ -10,11 +10,9 @@ deps =
   -e ../../dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_spark --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-ssh/tox.ini
+++ b/python_modules/libraries/dagster-ssh/tox.ini
@@ -12,11 +12,9 @@ deps =
   -e ../../dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_ssh --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-twilio/tox.ini
+++ b/python_modules/libraries/dagster-twilio/tox.ini
@@ -10,11 +10,9 @@ deps =
   -e ../../dagster[mypy,test]
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -vv --junitxml=test_results.xml --cov=dagster_twilio --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagstermill/tox.ini
+++ b/python_modules/libraries/dagstermill/tox.ini
@@ -19,11 +19,9 @@ deps =
   -e ../dagster-pandas
 allowlist_externals =
   /bin/bash
-  echo
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   ipython kernel install --name "dagster" --user
-  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
   pytest -v -vv {posargs} --cov=dagstermill --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tgox/*,**/test_*.py'


### PR DESCRIPTION
### Summary & Motivation

This PR builds on top of #7813 to generate buildkite headers for all tox steps. This allows us to simplify our tox files by removing the echo commands that generate these headers (which may not render properly anyway when running tox manually).

### How I Tested These Changes

Examined BK step logs.
