### PR TITLE
tox: remove check for non-editable installs of dagster/dagit

### DIFF
--- a/examples/airflow_ingest/tox.ini
+++ b/examples/airflow_ingest/tox.ini
@@ -9,10 +9,7 @@ passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[mypy,test]
   -e ../../python_modules/libraries/dagster-airflow[test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/basic_pyspark/tox.ini
+++ b/examples/basic_pyspark/tox.ini
@@ -10,10 +10,7 @@ deps =
   -e ../../python_modules/dagster[mypy,test]
   -e ../../python_modules/libraries/dagster-spark
   -e ../../python_modules/libraries/dagster-pyspark
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/bollinger/tox.ini
+++ b/examples/bollinger/tox.ini
@@ -9,10 +9,7 @@ passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE SNOWFLAKE_ACCOUNT SNOWFLAKE_USER S
 deps =
   -e ../../python_modules/dagster[mypy,test]
   -e ../../python_modules/libraries/dagster-pandera/
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv
 
 [testenv:mypy]

--- a/examples/dbt_example/tox.ini
+++ b/examples/dbt_example/tox.ini
@@ -16,10 +16,7 @@ deps =
   -e ../../python_modules/libraries/dagster-slack
   -e ../../python_modules/libraries/dagstermill
   -e ../../python_modules/libraries/dagster-dbt[test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/deploy_docker/tox.ini
+++ b/examples/deploy_docker/tox.ini
@@ -8,10 +8,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE DEPLOY_DOCKER_DAGIT_HOST
 deps =
   -e ../../python_modules/dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/deploy_ecs/tox.ini
+++ b/examples/deploy_ecs/tox.ini
@@ -9,10 +9,7 @@ passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE DEPLOY_DOCKER_DAGIT_HOST
 deps =
   -e ../../python_modules/dagster[mypy,test]
   -e ../../python_modules/dagster-test
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -s -vv {posargs}
 
 [testenv:mypy]

--- a/examples/deploy_k8s/tox.ini
+++ b/examples/deploy_k8s/tox.ini
@@ -13,10 +13,7 @@ deps =
   -e ../../python_modules/libraries/dagster-celery
   -e ../../python_modules/libraries/dagster-k8s
   -e ../../python_modules/libraries/dagster-celery-k8s
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -22,10 +22,7 @@ deps =
   -e ../../python_modules/libraries/dagster-dbt
   -e ../../python_modules/libraries/dagster-k8s
   -e ../../python_modules/dagit
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/emr_pyspark/tox.ini
+++ b/examples/emr_pyspark/tox.ini
@@ -11,10 +11,7 @@ deps =
   -e ../../python_modules/libraries/dagster-aws[test]
   -e ../../python_modules/libraries/dagster-spark
   -e ../../python_modules/libraries/dagster-pyspark
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/ge_example/tox.ini
+++ b/examples/ge_example/tox.ini
@@ -13,10 +13,7 @@ deps =
   -e ../../python_modules/dagit
   -e ../../python_modules/libraries/dagster-pandas
   -e ../../python_modules/libraries/dagster-ge
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/hacker_news/tox.ini
+++ b/examples/hacker_news/tox.ini
@@ -17,10 +17,7 @@ deps =
   -e ../../python_modules/libraries/dagster-gcp/
   -e ../../python_modules/libraries/dagster-postgres/
   -e ../../python_modules/libraries/dagstermill/
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv
 
 [testenv:mypy]

--- a/examples/hacker_news_assets/tox.ini
+++ b/examples/hacker_news_assets/tox.ini
@@ -16,10 +16,7 @@ deps =
   -e ../../python_modules/libraries/dagster-aws/
   -e ../../python_modules/libraries/dagster-gcp/
   -e ../../python_modules/libraries/dagster-postgres/
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv
 
 [testenv:mypy]

--- a/examples/memoized_development/tox.ini
+++ b/examples/memoized_development/tox.ini
@@ -11,10 +11,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/modern_data_stack_assets/tox.ini
+++ b/examples/modern_data_stack_assets/tox.ini
@@ -13,10 +13,7 @@ deps =
   -e ../../python_modules/libraries/dagster-airbyte/
   -e ../../python_modules/libraries/dagster-postgres/
   -e ../../python_modules/libraries/dagster-pandas/
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv
 
 [testenv:mypy]

--- a/examples/nyt-feed/tox.ini
+++ b/examples/nyt-feed/tox.ini
@@ -9,10 +9,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/run_attribution_example/tox.ini
+++ b/examples/run_attribution_example/tox.ini
@@ -11,10 +11,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/software_defined_assets/tox.ini
+++ b/examples/software_defined_assets/tox.ini
@@ -11,10 +11,7 @@ deps =
   -e ../../python_modules/libraries/dagster-spark
   -e ../../python_modules/libraries/dagster-pyspark
   -e .[test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/examples/user_in_loop/tox.ini
+++ b/examples/user_in_loop/tox.ini
@@ -9,10 +9,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/helm/dagster/schema/tox.ini
+++ b/helm/dagster/schema/tox.ini
@@ -17,10 +17,7 @@ deps =
 usedevelop = true
 extras =
   test
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest --reruns 2 -vv {posargs}
 
 [testenv:mypy]

--- a/integration_tests/python_modules/dagster-k8s-test-infra/tox.ini
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/tox.ini
@@ -14,10 +14,7 @@ deps =
   -e ../../../python_modules/libraries/dagster-celery-k8s
   -e ../../../python_modules/libraries/dagster-postgres
 usedevelop = true
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_k8s_test_infra --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/integration_tests/test_suites/backcompat-test-suite/tox.ini
+++ b/integration_tests/test_suites/backcompat-test-suite/tox.ini
@@ -13,10 +13,7 @@ deps =
   -e ../../../python_modules/dagster-test
   -e ../../../python_modules/libraries/dagster-postgres
 
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   dagit-latest-release: pytest -m "dagit-latest-release" -vv -s {posargs}
   dagit-earliest-release: pytest -m "dagit-earliest-release" -vv -s {posargs}
   user-code-latest-release: pytest -m "user-code-latest-release" -vv -s {posargs}

--- a/integration_tests/test_suites/celery-k8s-test-suite/tox.ini
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tox.ini
@@ -21,10 +21,7 @@ deps =
   -e ../../../python_modules/libraries/dagster-aws
   -e ../../../python_modules/libraries/dagster-gcp
   -e ../../python_modules/dagster-k8s-test-infra
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   default: pytest --log-cli-level=INFO -m "not mark_user_code_deployment_subchart and not mark_daemon and mark_rabbitmq and not mark_monitoring" -s -vv --junitxml=test_results.xml --cov=../../../python_modules/libraries/dagster-celery-k8s --cov-append --cov-report= {posargs}
   markredis: pytest --log-cli-level=INFO -m "not mark_user_code_deployment_subchart and not mark_daemon and mark_redis and not mark_monitoring" -s -vv --junitxml=test_results.xml --cov=../../../python_modules/libraries/dagster-celery-k8s --cov-append --cov-report= {posargs}

--- a/integration_tests/test_suites/daemon-test-suite/tox.ini
+++ b/integration_tests/test_suites/daemon-test-suite/tox.ini
@@ -20,10 +20,7 @@ deps =
   -e ../../../python_modules/libraries/dagster-celery-k8s
   -e ../../../python_modules/libraries/dagster-postgres
   -e ../../../python_modules/libraries/dagster-docker
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest  -s -vv --junitxml=test_results.xml {posargs}
 

--- a/integration_tests/test_suites/k8s-test-suite/tox.ini
+++ b/integration_tests/test_suites/k8s-test-suite/tox.ini
@@ -22,10 +22,7 @@ deps =
   -e ../../../python_modules/libraries/dagster-gcp
   -e ../../python_modules/dagster-k8s-test-infra
   pyparsing<3.0.0
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   default: pytest --log-cli-level=INFO -m "default" --junitxml=test_results.xml --cov=../../../python_modules/libraries/dagster-k8s --cov-append --cov-report= {posargs}
   subchart: pytest --log-cli-level=INFO -m "subchart" --junitxml=test_results.xml --cov=../../../python_modules/libraries/dagster-k8s --cov-append --cov-report= {posargs}

--- a/js_modules/dagit/tox.ini
+++ b/js_modules/dagit/tox.ini
@@ -18,7 +18,6 @@ allowlist_externals =
   git
   yarn
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   yarn install
   yarn workspace @dagster-io/dagit-core generate-graphql

--- a/python_modules/automation/automation/scaffold/assets/dagster-example-tmpl/tox.ini.tmpl
+++ b/python_modules/automation/automation/scaffold/assets/dagster-example-tmpl/tox.ini.tmpl
@@ -8,10 +8,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   pytest -vv {posargs}
 
 [testenv:mypy]

--- a/python_modules/automation/automation/scaffold/assets/dagster-library-tmpl/tox.ini.tmpl
+++ b/python_modules/automation/automation/scaffold/assets/dagster-library-tmpl/tox.ini.tmpl
@@ -9,10 +9,7 @@ deps =
   -e ../../dagster[mypy,test]
   -e .[test]
 usedevelop = true
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_{{LIBRARY_NAME}} --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -9,10 +9,7 @@ deps =
   -e ../dagster[mypy,test]
   -e ../dagster-graphql
 usedevelop = true
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=automation --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/dagit/tox.ini
+++ b/python_modules/dagit/tox.ini
@@ -14,10 +14,7 @@ deps =
   -e ../dagster-graphql
   -e .[starlette]
 
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -n 2 -v --junitxml=dagit_test_results.xml --cov=dagit --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/dagster-graphql/tox.ini
+++ b/python_modules/dagster-graphql/tox.ini
@@ -12,10 +12,7 @@ passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE POSTGRES_TEST_DB_HOST
 deps =
   -e ../dagster[mypy,test]
   postgres: -e ../libraries/dagster-postgres
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   not_graphql_context_test_suite: pytest -m "not graphql_context_test_suite and not graphql_context_variants and not python_client_test_suite" -vv --junitxml=dagster_graphql_test_results.xml --cov=dagster_graphql --cov-append --cov-report= {posargs}
   in_memory_instance_multi_location: pytest -m "graphql_context_test_suite and in_memory_instance and multi_location" -vv --junitxml=dagster_graphql_test_results.xml --cov=dagster_graphql --cov-append --cov-report= {posargs}

--- a/python_modules/dagster-test/tox.ini
+++ b/python_modules/dagster-test/tox.ini
@@ -20,10 +20,7 @@ deps =
   -e ../libraries/dagster-celery-k8s
   -e ../libraries/dagster-celery-docker
   -e ../libraries/dagstermill
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv -s -p dagster_test.fixtures --junitxml=test_results.xml --cov=dagster_test --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -16,10 +16,7 @@ deps =
   definitions_tests_old_pendulum: pendulum==1.4.4
   core_tests_old_sqlalchemy: sqlalchemy==1.3.24
   -e ../dagster-test
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   flake8 . --count --exclude=./.*,dagster/seven/__init__.py --select=E9,F63,F7,F82 --show-source --statistics
 

--- a/python_modules/libraries/dagster-airbyte/tox.ini
+++ b/python_modules/libraries/dagster-airbyte/tox.ini
@@ -6,10 +6,7 @@ usedevelop = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_airbyte --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-airflow/tox.ini
+++ b/python_modules/libraries/dagster-airflow/tox.ini
@@ -18,10 +18,7 @@ deps =
   -e ../dagster-postgres
   -e ../../dagster-test
 
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   requiresairflowdb: airflow initdb
   !requiresairflowdb: pytest -m "not requires_airflow_db" -vv --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report= {posargs}
   requiresairflowdb: pytest -m requires_airflow_db -vv --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report= {posargs}

--- a/python_modules/libraries/dagster-aws/tox.ini
+++ b/python_modules/libraries/dagster-aws/tox.ini
@@ -13,10 +13,7 @@ deps =
   -e ../../dagster[mypy,test]
   -e ../dagster-spark
   -e ../dagster-pyspark
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_aws --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-azure/tox.ini
+++ b/python_modules/libraries/dagster-azure/tox.ini
@@ -10,10 +10,7 @@ deps =
   -e ../../dagster[mypy,test]
   -e ../dagster-spark
   -e ../dagster-pyspark
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_azure --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-celery-docker/tox.ini
+++ b/python_modules/libraries/dagster-celery-docker/tox.ini
@@ -15,10 +15,7 @@ deps =
   -e ../dagster-gcp
   -e ../dagster-celery
   -e ../dagster-postgres
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_celery_docker --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-celery-k8s/tox.ini
+++ b/python_modules/libraries/dagster-celery-k8s/tox.ini
@@ -20,10 +20,7 @@ deps =
   -e ../dagster-airflow
   -e ../dagster-aws
   -e ../dagster-gcp
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_celery_k8s --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-celery/tox.ini
+++ b/python_modules/libraries/dagster-celery/tox.ini
@@ -17,10 +17,7 @@ deps =
   -e ../dagster-gcp
   -e ../dagster-celery-k8s
   -e ../dagster-celery-docker
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_celery --cov-append --cov-report= {posargs} -s
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-census/tox.ini
+++ b/python_modules/libraries/dagster-census/tox.ini
@@ -10,7 +10,6 @@ usedevelop = true
 whitelist_externals =
   /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_census --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-dask/tox.ini
+++ b/python_modules/libraries/dagster-dask/tox.ini
@@ -16,10 +16,7 @@ deps =
   -e ../../dagster-graphql
   -e ../dagster-aws
   -e ../dagster-pandas
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_dask --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-databricks/tox.ini
+++ b/python_modules/libraries/dagster-databricks/tox.ini
@@ -12,10 +12,7 @@ deps =
   -e ../dagster-azure
   -e ../dagster-spark
   -e ../dagster-pyspark
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_databricks --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-datadog/tox.ini
+++ b/python_modules/libraries/dagster-datadog/tox.ini
@@ -8,10 +8,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_datadog --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -12,10 +12,7 @@ deps =
   -e ../../dagster[mypy,test]
   -e ../dagster-pandas
   -e ../dagster-postgres
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_dbt --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-docker/tox.ini
+++ b/python_modules/libraries/dagster-docker/tox.ini
@@ -18,10 +18,7 @@ deps =
   -e ../dagster-k8s
   -e ../dagster-celery-k8s
   -e ../dagster-postgres
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_docker --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-fivetran/tox.ini
+++ b/python_modules/libraries/dagster-fivetran/tox.ini
@@ -6,10 +6,7 @@ usedevelop = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_fivetran --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-gcp/tox.ini
+++ b/python_modules/libraries/dagster-gcp/tox.ini
@@ -11,10 +11,7 @@ passenv = CI_* COVERALLS_REPO_TOKEN GOOGLE_APPLICATION_CREDENTIALS GCP_PROJECT_I
 deps =
   -e ../../dagster[mypy,test]
   -e ../dagster-pandas
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest {posargs} -vv --junitxml=test_results.xml --cov=dagster_gcp --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-ge/tox.ini
+++ b/python_modules/libraries/dagster-ge/tox.ini
@@ -11,10 +11,7 @@ deps =
   -e ../dagster-pandas
   -e ../dagster-spark
   -e ../dagster-pyspark
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_ge --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-github/tox.ini
+++ b/python_modules/libraries/dagster-github/tox.ini
@@ -8,10 +8,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_github --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-k8s/tox.ini
+++ b/python_modules/libraries/dagster-k8s/tox.ini
@@ -17,10 +17,7 @@ deps =
   -e ../../libraries/dagster-postgres
   -e ../../libraries/dagster-celery-k8s
   -e ../../libraries/dagster-celery-docker
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest --log-cli-level=INFO -vv --junitxml=test_results.xml --cov=dagster_k8s --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-mlflow/tox.ini
+++ b/python_modules/libraries/dagster-mlflow/tox.ini
@@ -8,10 +8,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_mlflow --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-msteams/tox.ini
+++ b/python_modules/libraries/dagster-msteams/tox.ini
@@ -8,10 +8,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_msteams --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-mysql/tox.ini
+++ b/python_modules/libraries/dagster-mysql/tox.ini
@@ -8,10 +8,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN MYSQL_TEST_* BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_mysql --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-pagerduty/tox.ini
+++ b/python_modules/libraries/dagster-pagerduty/tox.ini
@@ -8,10 +8,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_pagerduty --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-pandas/tox.ini
+++ b/python_modules/libraries/dagster-pandas/tox.ini
@@ -10,10 +10,7 @@ deps =
   -e ../../dagster[mypy,test]
   -e ../dagstermill[test]
 
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   ipython kernel install --name "dagster" --user
   pytest -v --cov=dagster_pandas --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-pandera/tox.ini
+++ b/python_modules/libraries/dagster-pandera/tox.ini
@@ -9,10 +9,7 @@ passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
 
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   ipython kernel install --name "dagster" --user
   pytest -v --cov=dagster_pandera --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-papertrail/tox.ini
+++ b/python_modules/libraries/dagster-papertrail/tox.ini
@@ -8,10 +8,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_papertrail --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-postgres/tox.ini
+++ b/python_modules/libraries/dagster-postgres/tox.ini
@@ -8,10 +8,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN POSTGRES_TEST_* BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_postgres --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-prometheus/tox.ini
+++ b/python_modules/libraries/dagster-prometheus/tox.ini
@@ -8,10 +8,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_prometheus --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-pyspark/tox.ini
@@ -10,10 +10,7 @@ deps =
   -e ../../dagster[mypy,test]
   -e ../../libraries/dagster-spark
   -e ../../libraries/dagster-aws
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_pyspark --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-shell/tox.ini
+++ b/python_modules/libraries/dagster-shell/tox.ini
@@ -10,10 +10,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_shell --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-slack/tox.ini
+++ b/python_modules/libraries/dagster-slack/tox.ini
@@ -8,10 +8,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_slack --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-snowflake-pandas/tox.ini
+++ b/python_modules/libraries/dagster-snowflake-pandas/tox.ini
@@ -7,10 +7,7 @@ passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
   -e ../dagster-snowflake
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_snowflake_pandas --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-snowflake/tox.ini
+++ b/python_modules/libraries/dagster-snowflake/tox.ini
@@ -9,10 +9,7 @@ passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUIL
 deps =
   -e ../../dagster[mypy,test]
   -e ../dagster-pandas
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_snowflake --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-spark/tox.ini
+++ b/python_modules/libraries/dagster-spark/tox.ini
@@ -8,10 +8,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_spark --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-ssh/tox.ini
+++ b/python_modules/libraries/dagster-ssh/tox.ini
@@ -10,10 +10,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_ssh --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagster-twilio/tox.ini
+++ b/python_modules/libraries/dagster-twilio/tox.ini
@@ -8,10 +8,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN TWILIO_*
 deps =
   -e ../../dagster[mypy,test]
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   pytest -vv --junitxml=test_results.xml --cov=dagster_twilio --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered

--- a/python_modules/libraries/dagstermill/tox.ini
+++ b/python_modules/libraries/dagstermill/tox.ini
@@ -17,10 +17,7 @@ deps =
   papermill1: markupsafe<=2.0.1
   -e ../../dagster[mypy,test]
   -e ../dagster-pandas
-allowlist_externals =
-  /bin/bash
 commands =
-  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   ipython kernel install --name "dagster" --user
   pytest -v -vv {posargs} --cov=dagstermill --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered


### PR DESCRIPTION
### Summary & Motivation

Many of our toxfiles contain this command:

```
!windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
```

I'm not entirely sure, but I think it's intended to make sure the installed dagster and dagit are editable installs before running tests.

I have never seen this catch anything, and I'm not sure how it would given that we specify editable in the `deps`. I'm guessing it's a historical artifact that was just never removed?

In any case IMO it clutters and makes the toxfiles more intimidating. If anyone has a case for retaining this happy to close this PR, but thought I would throw it up to solicit any explanation.

### How I Tested These Changes

BK
