### PR TITLE
Fix relative path for pytest fixture in backcompat tests

### DIFF
--- a/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
+++ b/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
@@ -112,7 +112,7 @@ def graphql_client(release_test_map, retrying_requests):
     user_code_version = release_test_map["user_code"]
 
     with docker_service_up(
-        file_relative_path(__file__, "./dagit_service/docker-compose.yml"),
+        os.path.join(os.getcwd(), "dagit_service", "docker-compose.yml"),
         build_args=[dagit_version, user_code_version],
     ):
         result = retrying_requests.get(f"http://{dagit_host}:3000/dagit_info")


### PR DESCRIPTION
Unsure why this wasn't caught before, but use of `file_relative_path` is incorrect here, and results in failures on local.