### PR TITLE
fetch partition status instead of runs

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1676,6 +1676,7 @@ type PartitionStatuses {
 type PartitionStatus {
   id: String!
   partitionName: String!
+  runId: String
   runStatus: RunStatus
   runDuration: Float
 }
@@ -1702,6 +1703,7 @@ type PartitionBackfill {
   unfinishedRuns(limit: Int): [Run!]!
   error: PythonError
   partitionRunStats: BackfillRunStats!
+  partitionStatuses: PartitionStatuses!
 }
 
 enum BulkActionStatus {

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1699,7 +1699,6 @@ type PartitionBackfill {
   partitionSetName: String!
   timestamp: Float!
   partitionSet: PartitionSet
-  runs(limit: Int): [Run!]!
   unfinishedRuns(limit: Int): [Run!]!
   error: PythonError
   partitionRunStats: BackfillRunStats!

--- a/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
@@ -6,13 +6,11 @@ import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {TerminationDialog} from '../runs/TerminationDialog';
 import {BulkActionStatus} from '../types/globalTypes';
 
+import {BackfillTableFragment} from './types/BackfillTableFragment';
 import {CancelBackfill, CancelBackfillVariables} from './types/CancelBackfill';
-import {InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results} from './types/InstanceBackfillsQuery';
-
-type Backfill = InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results;
 
 interface Props {
-  backfill?: Backfill;
+  backfill?: BackfillTableFragment;
   onClose: () => void;
   onComplete: () => void;
 }

--- a/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
@@ -3,6 +3,7 @@ import {Button, DialogBody, DialogFooter, Dialog} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {cancelableStatuses} from '../runs/RunStatuses';
 import {TerminationDialog} from '../runs/TerminationDialog';
 import {BulkActionStatus} from '../types/globalTypes';
 
@@ -23,20 +24,26 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
   if (!backfill) {
     return null;
   }
+
   const numUnscheduled = (backfill.numPartitions || 0) - (backfill.numRequested || 0);
-  const unfinishedRuns = backfill.unfinishedRuns;
-
-  const unfinishedMap = unfinishedRuns?.reduce(
-    (accum, run) => ({...accum, [run.id]: run.canTerminate}),
-    {},
-  );
-
   const cancel = async () => {
     setIsSubmitting(true);
     await cancelBackfill({variables: {backfillId: backfill.backfillId}});
     onComplete();
     setIsSubmitting(false);
+    onClose();
   };
+
+  const unfinishedPartitions = backfill.partitionStatuses.results.filter(
+    (partition) =>
+      partition.runStatus && partition.runId && partition.runStatus in cancelableStatuses,
+  );
+  const unfinishedMap =
+    unfinishedPartitions?.reduce(
+      (accum, partition) =>
+        partition && partition.runId ? {...accum, [partition.runId]: true} : accum,
+      {},
+    ) || {};
 
   return (
     <>
@@ -68,7 +75,7 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
         isOpen={
           !!backfill &&
           (!numUnscheduled || backfill.status !== 'REQUESTED') &&
-          !!unfinishedRuns.length
+          !!unfinishedPartitions.length
         }
         onClose={onClose}
         onComplete={onComplete}

--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -77,7 +77,6 @@ export const InstanceBackfills = () => {
             .filter((daemon) => daemon.daemonType === 'BACKFILL')
             .map((daemon) => daemon.required && daemon.healthy);
           const isBackfillHealthy = backfillHealths.length && backfillHealths.every((x) => x);
-
           return (
             <div>
               {isBackfillHealthy ? null : (
@@ -137,7 +136,6 @@ const BACKFILLS_QUERY = gql`
           status
           backfillStatus
           numRequested
-          partitionNames
           numPartitions
           partitionRunStats {
             numQueued
@@ -175,6 +173,6 @@ const BACKFILLS_QUERY = gql`
     }
   }
 
-  ${PYTHON_ERROR_FRAGMENT}
   ${BACKFILL_TABLE_FRAGMENT}
+  ${PYTHON_ERROR_FRAGMENT}
 `;

--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -137,18 +137,6 @@ const BACKFILLS_QUERY = gql`
           backfillStatus
           numRequested
           numPartitions
-          partitionRunStats {
-            numQueued
-            numInProgress
-            numSucceeded
-            numFailed
-            numPartitionsWithRuns
-            numTotalRuns
-          }
-          unfinishedRuns {
-            id
-            canTerminate
-          }
           timestamp
           partitionSetName
           partitionSet {

--- a/js_modules/dagit/packages/core/src/instance/types/BackfillTableFragment.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/BackfillTableFragment.ts
@@ -9,12 +9,6 @@ import { BulkActionStatus, RunStatus } from "./../../types/globalTypes";
 // GraphQL fragment: BackfillTableFragment
 // ====================================================
 
-export interface BackfillTableFragment_unfinishedRuns {
-  __typename: "Run";
-  id: string;
-  canTerminate: boolean;
-}
-
 export interface BackfillTableFragment_partitionSet_repositoryOrigin {
   __typename: "RepositoryOrigin";
   id: string;
@@ -64,7 +58,6 @@ export interface BackfillTableFragment {
   numRequested: number;
   partitionNames: string[];
   numPartitions: number;
-  unfinishedRuns: BackfillTableFragment_unfinishedRuns[];
   timestamp: number;
   partitionSetName: string;
   partitionSet: BackfillTableFragment_partitionSet | null;

--- a/js_modules/dagit/packages/core/src/instance/types/BackfillTableFragment.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/BackfillTableFragment.ts
@@ -3,35 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { BulkActionStatus, BackfillStatus, RunStatus } from "./../../types/globalTypes";
+import { BulkActionStatus, RunStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: BackfillTableFragment
 // ====================================================
-
-export interface BackfillTableFragment_partitionRunStats {
-  __typename: "BackfillRunStats";
-  numQueued: number;
-  numInProgress: number;
-  numSucceeded: number;
-  numFailed: number;
-  numPartitionsWithRuns: number;
-  numTotalRuns: number;
-}
-
-export interface BackfillTableFragment_runs_tags {
-  __typename: "PipelineTag";
-  key: string;
-  value: string;
-}
-
-export interface BackfillTableFragment_runs {
-  __typename: "Run";
-  id: string;
-  canTerminate: boolean;
-  status: RunStatus;
-  tags: BackfillTableFragment_runs_tags[];
-}
 
 export interface BackfillTableFragment_unfinishedRuns {
   __typename: "Run";
@@ -55,6 +31,19 @@ export interface BackfillTableFragment_partitionSet {
   repositoryOrigin: BackfillTableFragment_partitionSet_repositoryOrigin;
 }
 
+export interface BackfillTableFragment_partitionStatuses_results {
+  __typename: "PartitionStatus";
+  id: string;
+  partitionName: string;
+  runId: string | null;
+  runStatus: RunStatus | null;
+}
+
+export interface BackfillTableFragment_partitionStatuses {
+  __typename: "PartitionStatuses";
+  results: BackfillTableFragment_partitionStatuses_results[];
+}
+
 export interface BackfillTableFragment_error_cause {
   __typename: "PythonError";
   message: string;
@@ -72,15 +61,13 @@ export interface BackfillTableFragment {
   __typename: "PartitionBackfill";
   backfillId: string;
   status: BulkActionStatus;
-  backfillStatus: BackfillStatus;
   numRequested: number;
   partitionNames: string[];
   numPartitions: number;
-  partitionRunStats: BackfillTableFragment_partitionRunStats;
-  runs: BackfillTableFragment_runs[];
   unfinishedRuns: BackfillTableFragment_unfinishedRuns[];
   timestamp: number;
   partitionSetName: string;
   partitionSet: BackfillTableFragment_partitionSet | null;
+  partitionStatuses: BackfillTableFragment_partitionStatuses;
   error: BackfillTableFragment_error | null;
 }

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceBackfillsQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceBackfillsQuery.ts
@@ -41,6 +41,19 @@ export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackf
   repositoryOrigin: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionSet_repositoryOrigin;
 }
 
+export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionStatuses_results {
+  __typename: "PartitionStatus";
+  id: string;
+  partitionName: string;
+  runId: string | null;
+  runStatus: RunStatus | null;
+}
+
+export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionStatuses {
+  __typename: "PartitionStatuses";
+  results: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionStatuses_results[];
+}
+
 export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_error_cause {
   __typename: "PythonError";
   message: string;
@@ -81,6 +94,8 @@ export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackf
   timestamp: number;
   partitionSetName: string;
   partitionSet: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionSet | null;
+  partitionNames: string[];
+  partitionStatuses: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionStatuses;
   error: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_error | null;
   runs: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_runs[];
 }

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceBackfillsQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceBackfillsQuery.ts
@@ -9,22 +9,6 @@ import { BulkActionStatus, BackfillStatus, RunStatus } from "./../../types/globa
 // GraphQL query operation: InstanceBackfillsQuery
 // ====================================================
 
-export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionRunStats {
-  __typename: "BackfillRunStats";
-  numQueued: number;
-  numInProgress: number;
-  numSucceeded: number;
-  numFailed: number;
-  numPartitionsWithRuns: number;
-  numTotalRuns: number;
-}
-
-export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_unfinishedRuns {
-  __typename: "Run";
-  id: string;
-  canTerminate: boolean;
-}
-
 export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionSet_repositoryOrigin {
   __typename: "RepositoryOrigin";
   id: string;
@@ -41,19 +25,6 @@ export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackf
   repositoryOrigin: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionSet_repositoryOrigin;
 }
 
-export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionStatuses_results {
-  __typename: "PartitionStatus";
-  id: string;
-  partitionName: string;
-  runId: string | null;
-  runStatus: RunStatus | null;
-}
-
-export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionStatuses {
-  __typename: "PartitionStatuses";
-  results: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionStatuses_results[];
-}
-
 export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_error_cause {
   __typename: "PythonError";
   message: string;
@@ -67,18 +38,17 @@ export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackf
   cause: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_error_cause | null;
 }
 
-export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_runs_tags {
-  __typename: "PipelineTag";
-  key: string;
-  value: string;
+export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionStatuses_results {
+  __typename: "PartitionStatus";
+  id: string;
+  partitionName: string;
+  runId: string | null;
+  runStatus: RunStatus | null;
 }
 
-export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_runs {
-  __typename: "Run";
-  id: string;
-  canTerminate: boolean;
-  status: RunStatus;
-  tags: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_runs_tags[];
+export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionStatuses {
+  __typename: "PartitionStatuses";
+  results: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionStatuses_results[];
 }
 
 export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results {
@@ -87,17 +57,13 @@ export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackf
   status: BulkActionStatus;
   backfillStatus: BackfillStatus;
   numRequested: number;
-  partitionNames: string[];
   numPartitions: number;
-  partitionRunStats: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionRunStats;
-  unfinishedRuns: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_unfinishedRuns[];
   timestamp: number;
   partitionSetName: string;
   partitionSet: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionSet | null;
+  error: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_error | null;
   partitionNames: string[];
   partitionStatuses: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionStatuses;
-  error: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_error | null;
-  runs: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_runs[];
 }
 
 export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills {

--- a/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsQuery.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsQuery.ts
@@ -13,12 +13,6 @@ export interface JobBackfillsQuery_partitionSetOrError_PartitionSetNotFoundError
   __typename: "PartitionSetNotFoundError" | "PythonError";
 }
 
-export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_unfinishedRuns {
-  __typename: "Run";
-  id: string;
-  canTerminate: boolean;
-}
-
 export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionSet_repositoryOrigin {
   __typename: "RepositoryOrigin";
   id: string;
@@ -68,7 +62,6 @@ export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills {
   numRequested: number;
   partitionNames: string[];
   numPartitions: number;
-  unfinishedRuns: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_unfinishedRuns[];
   timestamp: number;
   partitionSetName: string;
   partitionSet: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionSet | null;

--- a/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsQuery.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsQuery.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { RepositorySelector, BulkActionStatus, BackfillStatus, RunStatus } from "./../../types/globalTypes";
+import { RepositorySelector, BulkActionStatus, RunStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: JobBackfillsQuery
@@ -11,30 +11,6 @@ import { RepositorySelector, BulkActionStatus, BackfillStatus, RunStatus } from 
 
 export interface JobBackfillsQuery_partitionSetOrError_PartitionSetNotFoundError {
   __typename: "PartitionSetNotFoundError" | "PythonError";
-}
-
-export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionRunStats {
-  __typename: "BackfillRunStats";
-  numQueued: number;
-  numInProgress: number;
-  numSucceeded: number;
-  numFailed: number;
-  numPartitionsWithRuns: number;
-  numTotalRuns: number;
-}
-
-export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_runs_tags {
-  __typename: "PipelineTag";
-  key: string;
-  value: string;
-}
-
-export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_runs {
-  __typename: "Run";
-  id: string;
-  canTerminate: boolean;
-  status: RunStatus;
-  tags: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_runs_tags[];
 }
 
 export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_unfinishedRuns {
@@ -59,6 +35,19 @@ export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_pa
   repositoryOrigin: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionSet_repositoryOrigin;
 }
 
+export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionStatuses_results {
+  __typename: "PartitionStatus";
+  id: string;
+  partitionName: string;
+  runId: string | null;
+  runStatus: RunStatus | null;
+}
+
+export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionStatuses {
+  __typename: "PartitionStatuses";
+  results: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionStatuses_results[];
+}
+
 export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_error_cause {
   __typename: "PythonError";
   message: string;
@@ -76,16 +65,14 @@ export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills {
   __typename: "PartitionBackfill";
   backfillId: string;
   status: BulkActionStatus;
-  backfillStatus: BackfillStatus;
   numRequested: number;
   partitionNames: string[];
   numPartitions: number;
-  partitionRunStats: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionRunStats;
-  runs: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_runs[];
   unfinishedRuns: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_unfinishedRuns[];
   timestamp: number;
   partitionSetName: string;
   partitionSet: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionSet | null;
+  partitionStatuses: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionStatuses;
   error: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_error | null;
 }
 

--- a/js_modules/dagit/packages/core/src/runs/RunStatuses.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStatuses.tsx
@@ -13,3 +13,5 @@ export const failedStatuses = new Set([RunStatus.FAILURE, RunStatus.CANCELED]);
 export const canceledStatuses = new Set([RunStatus.CANCELING, RunStatus.CANCELED]);
 
 export const doneStatuses = new Set([RunStatus.FAILURE, RunStatus.SUCCESS, RunStatus.CANCELED]);
+
+export const cancelableStatuses = new Set([RunStatus.QUEUED, RunStatus.STARTED]);

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -176,10 +176,12 @@ def get_partition_set_partition_statuses(
 
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
     check.str_param(partition_set_name, "partition_set_name")
+    check.str_param(job_name, "job_name")
+
     partition_data_by_name = {
         partition_data.partition: partition_data
         for partition_data in graphene_info.context.instance.run_storage.get_run_partition_data(
-            partition_set_name, job_name, repository_handle.get_external_origin().get_id()
+            partition_set_name, job_name, repository_handle.get_external_origin().get_label()
         )
     }
     names_result = graphene_info.context.get_external_partition_names(
@@ -201,6 +203,7 @@ def get_partition_set_partition_statuses(
             GraphenePartitionStatus(
                 id=f"{partition_set_name}:{name}",
                 partitionName=name,
+                runId=partition_data.run_id,
                 runStatus=partition_data.status,
                 runDuration=partition_data.end_time - partition_data.start_time
                 if partition_data.end_time and partition_data.start_time

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -172,26 +172,38 @@ def _apply_cursor_limit_reverse(items, cursor, limit, reverse):
 def get_partition_set_partition_statuses(
     graphene_info, repository_handle, partition_set_name, job_name
 ):
-    from ..schema.partition_sets import GraphenePartitionStatus, GraphenePartitionStatuses
-
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
     check.str_param(partition_set_name, "partition_set_name")
     check.str_param(job_name, "job_name")
 
-    partition_data_by_name = {
-        partition_data.partition: partition_data
-        for partition_data in graphene_info.context.instance.run_storage.get_run_partition_data(
-            partition_set_name, job_name, repository_handle.get_external_origin().get_label()
+    run_partition_data = graphene_info.context.instance.run_storage.get_run_partition_data(
+        runs_filter=RunsFilter(
+            pipeline_name=job_name,
+            tags={PARTITION_SET_TAG: partition_set_name},
         )
-    }
+    )
     names_result = graphene_info.context.get_external_partition_names(
         repository_handle, partition_set_name
     )
-    status_results = []
 
-    for name in names_result.partition_names:
+    return partition_statuses_from_run_partition_data(
+        partition_set_name, run_partition_data, names_result.partition_names
+    )
+
+
+def partition_statuses_from_run_partition_data(
+    partition_set_name, run_partition_data, partition_names
+):
+    from ..schema.partition_sets import GraphenePartitionStatus, GraphenePartitionStatuses
+
+    partition_data_by_name = {
+        partition_data.partition: partition_data for partition_data in run_partition_data
+    }
+
+    results = []
+    for name in partition_names:
         if not partition_data_by_name.get(name):
-            status_results.append(
+            results.append(
                 GraphenePartitionStatus(
                     id=f"{partition_set_name}:{name}",
                     partitionName=name,
@@ -199,7 +211,7 @@ def get_partition_set_partition_statuses(
             )
             continue
         partition_data = partition_data_by_name[name]
-        status_results.append(
+        results.append(
             GraphenePartitionStatus(
                 id=f"{partition_set_name}:{name}",
                 partitionName=name,
@@ -211,7 +223,7 @@ def get_partition_set_partition_statuses(
             )
         )
 
-    return GraphenePartitionStatuses(results=status_results)
+    return GraphenePartitionStatuses(results=results)
 
 
 def get_partition_set_partition_runs(graphene_info, partition_set):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -52,6 +52,7 @@ class GraphenePartitionRunConfigOrError(graphene.Union):
 class GraphenePartitionStatus(graphene.ObjectType):
     id = graphene.NonNull(graphene.String)
     partitionName = graphene.NonNull(graphene.String)
+    runId = graphene.Field(graphene.String)
     runStatus = graphene.Field(GrapheneRunStatus)
     runDuration = graphene.Field(graphene.Float)
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -35,7 +35,6 @@ PARTITION_PROGRESS_QUERY = """
           numSucceeded
           numFailed
           numPartitionsWithRuns
-          numTotalRuns
         }
         unfinishedRuns {
           id
@@ -358,7 +357,6 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
             "numInProgress": 1,  # "5"
             "numSucceeded": 1,  # "4"
             "numFailed": 2,  # "2,3"
-            "numTotalRuns": 8,
         }
 
         assert len(result.data["partitionBackfillOrError"]["unfinishedRuns"]) == 4
@@ -425,7 +423,6 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
             "numInProgress": 0,
             "numSucceeded": 4,
             "numFailed": 0,
-            "numTotalRuns": 4,
         }
 
         assert result.data["partitionBackfillOrError"]["backfillStatus"] == "COMPLETED"
@@ -481,7 +478,6 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
             "numInProgress": 0,
             "numSucceeded": 3,
             "numFailed": 1,
-            "numTotalRuns": 4,
         }
 
         assert result.data["partitionBackfillOrError"]["backfillStatus"] == "INCOMPLETE"

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1314,13 +1314,9 @@ class DagsterInstance:
         return self._run_storage.supports_bucket_queries
 
     @traced
-    def get_run_partition_data(
-        self, partition_set_name: str, job_name: str, repository_label: str
-    ) -> List[RunPartitionData]:
+    def get_run_partition_data(self, runs_filter: RunsFilter) -> List[RunPartitionData]:
         """Get run partition data for a given partitioned job."""
-        return self._run_storage.get_run_partition_data(
-            partition_set_name, job_name, repository_label
-        )
+        return self._run_storage.get_run_partition_data(runs_filter)
 
     def wipe(self):
         self._run_storage.wipe()

--- a/python_modules/dagster/dagster/core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/core/storage/pipeline_run.py
@@ -113,6 +113,12 @@ NON_IN_PROGRESS_RUN_STATUSES = [
     PipelineRunStatus.CANCELED,
 ]
 
+FINISHED_STATUSES = [
+    PipelineRunStatus.SUCCESS,
+    PipelineRunStatus.FAILURE,
+    PipelineRunStatus.CANCELED,
+]
+
 
 @whitelist_for_serdes
 class PipelineRunStatsSnapshot(
@@ -455,11 +461,7 @@ class PipelineRun(
 
     @property
     def is_finished(self):
-        return (
-            self.status == PipelineRunStatus.SUCCESS
-            or self.status == PipelineRunStatus.FAILURE
-            or self.status == PipelineRunStatus.CANCELED
-        )
+        return self.status in FINISHED_STATUSES
 
     @property
     def is_success(self):

--- a/python_modules/dagster/dagster/core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/core/storage/runs/base.py
@@ -324,12 +324,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
         return True
 
     @abstractmethod
-    def get_run_partition_data(
-        self,
-        partition_set_name: str,
-        job_name: str,
-        repository_label: str,
-    ) -> List[RunPartitionData]:
+    def get_run_partition_data(self, runs_filter: RunsFilter) -> List[RunPartitionData]:
         """Get run partition data for a given partitioned job."""
 
     def migrate(self, print_fn: Optional[Callable] = None, force_rebuild_all: bool = False):

--- a/python_modules/dagster/dagster/core/storage/runs/in_memory.py
+++ b/python_modules/dagster/dagster/core/storage/runs/in_memory.py
@@ -15,7 +15,7 @@ from dagster.core.snap import (
     create_execution_plan_snapshot_id,
     create_pipeline_snapshot_id,
 )
-from dagster.core.storage.tags import PARTITION_NAME_TAG, PARTITION_SET_TAG
+from dagster.core.storage.tags import PARTITION_NAME_TAG
 from dagster.daemon.types import DaemonHeartbeat
 from dagster.utils import EPOCH, frozendict, merge_dicts
 
@@ -339,16 +339,9 @@ class InMemoryRunStorage(RunStorage):
             for root_run_id, run_group in root_run_id_to_group.items()
         }
 
-    def get_run_partition_data(
-        self, partition_set_name: str, job_name: str, repository_label: str
-    ) -> List[RunPartitionData]:
+    def get_run_partition_data(self, runs_filter: RunsFilter) -> List[RunPartitionData]:
         """Get run partition data for a given partitioned job."""
-        check.str_param(partition_set_name, "partition_set_name")
-        check.str_param(job_name, "job_name")
-
-        run_filter = build_run_filter(
-            RunsFilter(pipeline_name=job_name, tags={PARTITION_SET_TAG: partition_set_name})
-        )
+        run_filter = build_run_filter(runs_filter)
         matching_runs = list(filter(run_filter, list(self._runs.values())[::-1]))
         _partition_data_by_partition = {}
         for run in matching_runs:

--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -815,17 +815,10 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
         return defensively_unpack_pipeline_snapshot_query(logging, row) if row else None
 
-    def get_run_partition_data(
-        self, partition_set_name: str, job_name: str, repository_label: str
-    ) -> List[RunPartitionData]:
+    def get_run_partition_data(self, runs_filter: RunsFilter) -> List[RunPartitionData]:
         if self.has_built_index(RUN_PARTITIONS) and self.has_run_stats_index_cols():
             query = self._runs_query(
-                filters=RunsFilter(
-                    pipeline_name=job_name,
-                    tags={
-                        PARTITION_SET_TAG: partition_set_name,
-                    },
-                ),
+                filters=runs_filter,
                 columns=["run_id", "status", "start_time", "end_time", "partition"],
             )
             rows = self.fetchall(query)
@@ -846,14 +839,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
             return list(_partition_data_by_partition.values())
         else:
-            query = self._runs_query(
-                filters=RunsFilter(
-                    pipeline_name=job_name,
-                    tags={
-                        PARTITION_SET_TAG: partition_set_name,
-                    },
-                ),
-            )
+            query = self._runs_query(filters=runs_filter)
             rows = self.fetchall(query)
             _partition_data_by_partition = {}
             for row in rows:

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
@@ -1126,7 +1126,12 @@ class TestRunStorage:
             },
         )
         storage.add_run(three)
-        partition_data = storage.get_run_partition_data("foo_set", "foo_pipeline", "fake@fake")
+        partition_data = storage.get_run_partition_data(
+            runs_filter=RunsFilter(
+                pipeline_name="foo_pipeline",
+                tags={PARTITION_SET_TAG: "foo_set"},
+            )
+        )
         assert len(partition_data) == 3
         assert {_.partition for _ in partition_data} == {"one", "two", "three"}
         assert {_.run_id for _ in partition_data} == {one.run_id, two_retried.run_id, three.run_id}


### PR DESCRIPTION
### Summary & Motivation
This PR takes advantage of the changes in #7985 to not ship down the full set of runs in the old partitions page.

It recombines the old/new partitions page to share a common query, changing the new partitions page to request status by partition instead of the full set of historical runs.

Similar to the run stats change, but by accumulating status by partition instead of just counts.

### How I Tested These Changes
BK