### PR TITLE
Coerce asset_key on AssetIn

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/asset_in.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_in.py
@@ -1,7 +1,7 @@
 from typing import Any, Mapping, NamedTuple, Optional, Sequence
 
 import dagster._check as check
-from dagster.core.definitions.events import AssetKey
+from dagster.core.definitions.events import AssetKey, CoerceableToAssetKey
 
 
 class AssetIn(
@@ -16,7 +16,7 @@ class AssetIn(
 ):
     def __new__(
         cls,
-        asset_key: Optional[AssetKey] = None,
+        asset_key: Optional[CoerceableToAssetKey] = None,
         metadata: Optional[Mapping[str, Any]] = None,
         namespace: Optional[Sequence[str]] = None,
     ):
@@ -30,7 +30,7 @@ class AssetIn(
 
         return super(AssetIn, cls).__new__(
             cls,
-            asset_key=check.opt_inst_param(asset_key, "asset_key", AssetKey),
+            asset_key=AssetKey.from_coerceable(asset_key) if asset_key is not None else None,
             metadata=check.opt_inst_param(metadata, "metadata", Mapping),
             namespace=check.opt_list_param(namespace, "namespace", str),
         )

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
@@ -202,3 +202,9 @@ def test_to_source_assets():
             description="ablablabl",
         ),
     ]
+
+
+def test_coerced_asset_keys():
+    @asset(ins={"input1": AssetIn(asset_key=["Asset", "1"])})
+    def asset1(input1):
+        assert input1


### PR DESCRIPTION
### Summary & Motivation

Allow `AssetIn` constructor argument be coerceable to `AssetKey`. This allows for a minor improvement in user experience: `dagster.AssetIn("Asset1")` instead of `dagser.AssetIn(dagster.AssetKey("Asset1"))`

### How I Tested These Changes
Added a test making of coercion, ran all core_tests and checked pylint and black.