### PR TITLE
Add a __main__.py to dagster/daemon

### DIFF
--- a/python_modules/dagster/dagster/daemon/__main__.py
+++ b/python_modules/dagster/dagster/daemon/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+main()


### PR DESCRIPTION
Summary:
This lets you run "python -m dagster.daemon run" and have it launch the daemon - right now the only way to do that is to make use of the click entry point

Test Plan: Run the command above locally

### Summary & Motivation

### How I Tested These Changes
