### PR TITLE
KnownState.ready_outputs

### DIFF
--- a/python_modules/dagster/dagster/core/execution/context/system.py
+++ b/python_modules/dagster/dagster/core/execution/context/system.py
@@ -15,7 +15,6 @@ from typing import (
     Mapping,
     NamedTuple,
     Optional,
-    Sequence,
     Set,
     Union,
     cast,
@@ -60,6 +59,7 @@ if TYPE_CHECKING:
     from dagster.core.definitions.resource_definition import Resources
     from dagster.core.events import DagsterEvent
     from dagster.core.execution.plan.plan import ExecutionPlan
+    from dagster.core.execution.plan.state import KnownExecutionState
     from dagster.core.instance import DagsterInstance
 
     from .hook import HookContext
@@ -295,7 +295,11 @@ class PlanExecutionContext(IPlanContext):
     def output_capture(self) -> Optional[Dict[StepOutputHandle, Any]]:
         return self._output_capture
 
-    def for_step(self, step: ExecutionStep, previous_attempt_count: int = 0) -> IStepContext:
+    def for_step(
+        self,
+        step: ExecutionStep,
+        known_state: Optional["KnownExecutionState"] = None,
+    ) -> IStepContext:
 
         return StepExecutionContext(
             plan_data=self.plan_data,
@@ -303,7 +307,7 @@ class PlanExecutionContext(IPlanContext):
             log_manager=self._log_manager.with_tags(**step.logging_tags),
             step=step,
             output_capture=self.output_capture,
-            previous_attempt_count=previous_attempt_count,
+            known_state=known_state,
         )
 
     @property
@@ -372,7 +376,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         log_manager: DagsterLogManager,
         step: ExecutionStep,
         output_capture: Optional[Dict[StepOutputHandle, Any]],
-        previous_attempt_count: int,
+        known_state: Optional["KnownExecutionState"],
     ):
         from dagster.core.execution.resources_init import get_required_resource_keys_for_step
 
@@ -391,7 +395,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         self._resources = execution_data.scoped_resources_builder.build(
             self._required_resource_keys
         )
-        self._previous_attempt_count = previous_attempt_count
+        self._known_state = known_state
         self._input_lineage: List[AssetLineageInfo] = []
 
         resources_iter = cast(Iterable, self._resources)
@@ -522,19 +526,20 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
         return HookContext(self, hook_def)
 
+    def get_known_state(self) -> "KnownExecutionState":
+        if not self._known_state:
+            check.failed(
+                "Attempted to access KnownExecutionState but it was not provided at context creation"
+            )
+        return self._known_state
+
     def can_load(
         self,
         step_output_handle: StepOutputHandle,
-        step_output_events: Sequence["DagsterEvent"],
     ) -> bool:
-        # Whether IO Manager can load the source
-        # FIXME https://github.com/dagster-io/dagster/issues/3511
-        # This is a stopgap which asks the instance to check the event logs to find out step skipping
-
         # can load from upstream in the same run
-        for event in step_output_events:
-            if step_output_handle == event.step_output_data.step_output_handle:
-                return True
+        if step_output_handle in self.get_known_state().ready_outputs:
+            return True
 
         if (
             self._should_load_from_previous_runs(step_output_handle)
@@ -690,7 +695,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
     @property
     def previous_attempt_count(self) -> int:
-        return self._previous_attempt_count
+        return self.get_known_state().get_retry_state().get_attempt_count(self._step.key)
 
     @property
     def op_config(self) -> Any:

--- a/python_modules/dagster/dagster/core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/core/execution/plan/active.py
@@ -9,8 +9,8 @@ from dagster.core.errors import (
 )
 from dagster.core.events import DagsterEvent
 from dagster.core.execution.context.system import PlanOrchestrationContext
-from dagster.core.execution.plan.state import KnownExecutionState, StepOutputVersionData
-from dagster.core.execution.retries import RetryMode, RetryState
+from dagster.core.execution.plan.state import KnownExecutionState
+from dagster.core.execution.retries import RetryMode
 from dagster.core.storage.tags import PRIORITY_TAG
 from dagster.utils.interrupts import pop_captured_interrupt
 
@@ -30,15 +30,13 @@ class ActiveExecution:
         self,
         execution_plan: ExecutionPlan,
         retry_mode: RetryMode,
-        retry_state: RetryState,
         sort_key_fn: Optional[Callable[[ExecutionStep], float]] = None,
-        step_output_versions: Optional[List[StepOutputVersionData]] = None,
     ):
         self._plan: ExecutionPlan = check.inst_param(
             execution_plan, "execution_plan", ExecutionPlan
         )
         self._retry_mode = check.inst_param(retry_mode, "retry_mode", RetryMode)
-        self._retry_state = check.inst_param(retry_state, "retry_state", RetryState)
+        self._retry_state = self._plan.known_state.get_retry_state()
 
         self._sort_key_fn: Callable[[ExecutionStep], float] = (
             check.opt_callable_param(
@@ -48,14 +46,10 @@ class ActiveExecution:
             or _default_sort_key
         )
 
-        self._step_output_versions = check.opt_list_param(
-            step_output_versions, "step_output_versions", of_type=StepOutputVersionData
-        )
-
         self._context_guard: bool = False  # Prevent accidental direct use
 
         # We decide what steps to skip based on what outputs are yielded by upstream steps
-        self._step_outputs: Set[StepOutputHandle] = set()
+        self._step_outputs: Set[StepOutputHandle] = set(self._plan.known_state.ready_outputs)
 
         # All steps to be executed start out here in _pending
         self._pending: Dict[str, Set[str]] = self._plan.get_executable_step_deps()
@@ -467,7 +461,8 @@ class ActiveExecution:
         return KnownExecutionState(
             previous_retry_attempts=self._retry_state.snapshot_attempts(),
             dynamic_mappings=dict(self._successful_dynamic_outputs),
-            step_output_versions=self._step_output_versions,
+            ready_outputs=self._step_outputs,
+            step_output_versions=self._plan.known_state.step_output_versions,
         )
 
     def _prep_for_dynamic_outputs(self, step: ExecutionStep):

--- a/python_modules/dagster/dagster/core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_plan.py
@@ -40,9 +40,7 @@ def inner_plan_execution_iterator(
             step = active_execution.get_next_step()
             step_context = cast(
                 StepExecutionContext,
-                pipeline_context.for_step(
-                    step, active_execution.retry_state.get_attempt_count(step.key)
-                ),
+                pipeline_context.for_step(step, active_execution.get_known_state()),
             )
             step_event_list = []
 

--- a/python_modules/dagster/dagster/core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/core/execution/plan/inputs.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
     from dagster.core.execution.context.input import InputContext
     from dagster.core.execution.context.system import StepExecutionContext
     from dagster.core.storage.input_manager import InputManager
-    from dagster.core.types.dagster_type import DagsterType
 
 
 def _get_asset_lineage_from_fns(
@@ -635,22 +634,14 @@ class FromMultipleSources(
         step_context: "StepExecutionContext",
         input_def: InputDefinition,
     ):
-        from dagster.core.events import DagsterEvent, DagsterEventType
+        from dagster.core.events import DagsterEvent
 
         values = []
-
-        # https://github.com/dagster-io/dagster/issues/3511
-        step_output_events = [
-            record.dagster_event
-            for record in step_context.instance.all_logs(
-                step_context.run_id, of_type=DagsterEventType.STEP_OUTPUT
-            )
-        ]
 
         # some upstream steps may have skipped and we allow fan-in to continue in their absence
         source_handles_to_skip = list(
             filter(
-                lambda x: not step_context.can_load(x, step_output_events),
+                lambda x: not step_context.can_load(x),
                 self.step_output_handle_dependencies,
             )
         )

--- a/python_modules/dagster/dagster/core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/plan.py
@@ -38,7 +38,7 @@ from dagster.core.execution.plan.handle import (
     StepHandle,
     UnresolvedStepHandle,
 )
-from dagster.core.execution.retries import RetryMode, RetryState
+from dagster.core.execution.retries import RetryMode
 from dagster.core.instance import DagsterInstance, InstanceRef
 from dagster.core.storage.mem_io_manager import mem_io_manager
 from dagster.core.system_config.objects import ResolvedRunConfig
@@ -73,7 +73,10 @@ from .step import (
 )
 
 if TYPE_CHECKING:
+    from dagster.core.snap.execution_plan_snapshot import ExecutionPlanSnapshot
+
     from .active import ActiveExecution
+
 
 StepHandleTypes = (StepHandle, UnresolvedStepHandle, ResolvedFromDynamicStepHandle)
 StepHandleUnion = Union[StepHandle, UnresolvedStepHandle, ResolvedFromDynamicStepHandle]
@@ -98,7 +101,7 @@ class _PlanBuilder:
         pipeline: IPipeline,
         resolved_run_config: ResolvedRunConfig,
         step_keys_to_execute: Optional[List[str]],
-        known_state,
+        known_state: KnownExecutionState,
         instance_ref: Optional[InstanceRef],
         tags: Dict[str, str],
     ):
@@ -117,7 +120,7 @@ class _PlanBuilder:
         self.step_output_map: Dict[
             SolidOutputHandle, Union[StepOutputHandle, UnresolvedStepOutputHandle]
         ] = dict()
-        self.known_state = known_state
+        self.known_state = check.inst_param(known_state, "known_state", KnownExecutionState)
         self._instance_ref = instance_ref
         self._seen_handles: Set[StepHandleUnion] = set()
         self._tags = check.dict_param(tags, "tags", key_type=str, value_type=str)
@@ -604,14 +607,14 @@ class ExecutionPlan(
 ):
     def __new__(
         cls,
-        step_dict,
-        executable_map,
-        resolvable_map,
-        step_handles_to_execute,
-        known_state=None,
-        artifacts_persisted=False,
-        step_dict_by_key=None,
-        executor_name=None,
+        step_dict: Dict[StepHandleUnion, IExecutionStep],
+        executable_map: Dict[str, Union[StepHandle, ResolvedFromDynamicStepHandle]],
+        resolvable_map: Dict[FrozenSet[str], List[UnresolvedStepHandle]],
+        step_handles_to_execute: List[StepHandleUnion],
+        known_state: KnownExecutionState,
+        artifacts_persisted: bool = False,
+        step_dict_by_key: Optional[Dict[str, IExecutionStep]] = None,
+        executor_name: Optional[str] = None,
     ):
         return super(ExecutionPlan, cls).__new__(
             cls,
@@ -632,7 +635,7 @@ class ExecutionPlan(
                 "step_handles_to_execute",
                 of_type=(StepHandle, UnresolvedStepHandle, ResolvedFromDynamicStepHandle),
             ),
-            known_state=check.opt_inst_param(known_state, "known_state", KnownExecutionState),
+            known_state=check.inst_param(known_state, "known_state", KnownExecutionState),
             artifacts_persisted=check.bool_param(artifacts_persisted, "artifacts_persisted"),
             step_dict_by_key={step.key: step for step in step_dict.values()}
             if step_dict_by_key is None
@@ -809,16 +812,11 @@ class ExecutionPlan(
         # If step output versions were provided when constructing the subset plan, add them to the
         # known state.
         if len(step_output_versions) > 0:
-
-            known_state = KnownExecutionState(
-                previous_retry_attempts=self.known_state.previous_retry_attempts
-                if self.known_state
-                else {},
-                dynamic_mappings=self.known_state.dynamic_mappings if self.known_state else {},
-                step_output_versions=StepOutputVersionData.get_version_list_from_dict(
-                    step_output_versions
-                ),
-            )
+            versions = StepOutputVersionData.get_version_list_from_dict(step_output_versions)
+            if self.known_state:
+                known_state = self.known_state._replace(step_output_versions=versions)
+            else:
+                known_state = KnownExecutionState(step_output_versions=versions)
         else:
             known_state = self.known_state
 
@@ -953,9 +951,7 @@ class ExecutionPlan(
         return ActiveExecution(
             self,
             retry_mode,
-            self.known_state.get_retry_state() if self.known_state else RetryState(),
             sort_key_fn,
-            self.known_state.step_output_versions if self.known_state else [],
         )
 
     def step_handle_for_single_step_plans(
@@ -981,9 +977,9 @@ class ExecutionPlan(
         pipeline: IPipeline,
         resolved_run_config: ResolvedRunConfig,
         step_keys_to_execute: Optional[List[str]] = None,
-        known_state=None,
-        instance_ref=None,
-        tags=None,
+        known_state: Optional[KnownExecutionState] = None,
+        instance_ref: Optional[InstanceRef] = None,
+        tags: Optional[Dict[str, str]] = None,
     ) -> "ExecutionPlan":
         """Here we build a new ExecutionPlan from a pipeline definition and the resolved run config.
 
@@ -996,7 +992,13 @@ class ExecutionPlan(
         check.inst_param(pipeline, "pipeline", IPipeline)
         check.inst_param(resolved_run_config, "resolved_run_config", ResolvedRunConfig)
         check.opt_nullable_list_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
-        check.opt_inst_param(known_state, "known_state", KnownExecutionState)
+        known_state = check.opt_inst_param(
+            known_state,
+            "known_state",
+            KnownExecutionState,
+            # may be good to force call sites to specify instead of defaulting to unknown
+            default=KnownExecutionState(),
+        )
         tags = check.opt_dict_param(tags, "tags", key_type=str, value_type=str)
 
         plan_builder = _PlanBuilder(
@@ -1043,7 +1045,10 @@ class ExecutionPlan(
             )
 
     @staticmethod
-    def rebuild_from_snapshot(pipeline_name, execution_plan_snapshot):
+    def rebuild_from_snapshot(
+        pipeline_name: str,
+        execution_plan_snapshot: "ExecutionPlanSnapshot",
+    ):
         if not execution_plan_snapshot.can_reconstruct_plan:
             raise DagsterInvariantViolationError(
                 "Tried to reconstruct an old ExecutionPlanSnapshot that was created before snapshots "
@@ -1063,17 +1068,23 @@ class ExecutionPlan(
 
             step_outputs = [
                 StepOutput(
-                    step_output_snap.solid_handle,
+                    check.not_none(step_output_snap.solid_handle),
                     step_output_snap.name,
                     step_output_snap.dagster_type_key,
-                    step_output_snap.properties,
+                    check.not_none(step_output_snap.properties),
                 )
                 for step_output_snap in output_snaps
             ]
 
             if step_snap.kind == StepKind.COMPUTE:
-                step = ExecutionStep(
-                    step_snap.step_handle,
+                step: IExecutionStep = ExecutionStep(
+                    check.inst(
+                        cast(
+                            Union[StepHandle, ResolvedFromDynamicStepHandle],
+                            step_snap.step_handle,
+                        ),
+                        ttype=(StepHandle, ResolvedFromDynamicStepHandle),
+                    ),
                     pipeline_name,
                     step_inputs,
                     step_outputs,
@@ -1081,7 +1092,10 @@ class ExecutionPlan(
                 )
             elif step_snap.kind == StepKind.UNRESOLVED_MAPPED:
                 step = UnresolvedMappedExecutionStep(
-                    step_snap.step_handle,
+                    check.inst(
+                        cast(UnresolvedStepHandle, step_snap.step_handle),
+                        ttype=UnresolvedStepHandle,
+                    ),
                     pipeline_name,
                     step_inputs,
                     step_outputs,
@@ -1089,7 +1103,7 @@ class ExecutionPlan(
                 )
             elif step_snap.kind == StepKind.UNRESOLVED_COLLECT:
                 step = UnresolvedCollectExecutionStep(
-                    step_snap.step_handle,
+                    check.inst(cast(StepHandle, step_snap.step_handle), ttype=StepHandle),
                     pipeline_name,
                     step_inputs,
                     step_outputs,
@@ -1117,7 +1131,8 @@ class ExecutionPlan(
             executable_map,
             resolvable_map,
             step_handles_to_execute,
-            execution_plan_snapshot.initial_known_state,
+            # default to empty known execution state if initial was not persisted
+            execution_plan_snapshot.initial_known_state or KnownExecutionState(),
             execution_plan_snapshot.artifacts_persisted,
             executor_name=execution_plan_snapshot.executor_name,
         )

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_execution_plan.py
@@ -10,7 +10,15 @@ snapshots['test_create_execution_plan_with_dep 1'] = '''{
   "__class__": "ExecutionPlanSnapshot",
   "artifacts_persisted": true,
   "executor_name": "in_process",
-  "initial_known_state": null,
+  "initial_known_state": {
+    "__class__": "KnownExecutionState",
+    "dynamic_mappings": {},
+    "previous_retry_attempts": {},
+    "ready_outputs": {
+      "__frozenset__": []
+    },
+    "step_output_versions": []
+  },
   "pipeline_snapshot_id": "330e31c23c3edacaa7a9224039b53a703f011788",
   "snapshot_version": 1,
   "step_keys_to_execute": [
@@ -135,7 +143,15 @@ snapshots['test_create_noop_execution_plan 1'] = '''{
   "__class__": "ExecutionPlanSnapshot",
   "artifacts_persisted": true,
   "executor_name": "in_process",
-  "initial_known_state": null,
+  "initial_known_state": {
+    "__class__": "KnownExecutionState",
+    "dynamic_mappings": {},
+    "previous_retry_attempts": {},
+    "ready_outputs": {
+      "__frozenset__": []
+    },
+    "step_output_versions": []
+  },
   "pipeline_snapshot_id": "7ffd65ba8633d4c172a7b15dfee5927bed301724",
   "snapshot_version": 1,
   "step_keys_to_execute": [
@@ -189,7 +205,15 @@ snapshots['test_create_noop_execution_plan_with_tags 1'] = '''{
   "__class__": "ExecutionPlanSnapshot",
   "artifacts_persisted": true,
   "executor_name": "in_process",
-  "initial_known_state": null,
+  "initial_known_state": {
+    "__class__": "KnownExecutionState",
+    "dynamic_mappings": {},
+    "previous_retry_attempts": {},
+    "ready_outputs": {
+      "__frozenset__": []
+    },
+    "step_output_versions": []
+  },
   "pipeline_snapshot_id": "b96bfd4d61336a6ed2016679d1467c3e1daa3285",
   "snapshot_version": 1,
   "step_keys_to_execute": [
@@ -257,7 +281,15 @@ snapshots['test_create_with_composite 1'] = '''{
   "__class__": "ExecutionPlanSnapshot",
   "artifacts_persisted": true,
   "executor_name": "in_process",
-  "initial_known_state": null,
+  "initial_known_state": {
+    "__class__": "KnownExecutionState",
+    "dynamic_mappings": {},
+    "previous_retry_attempts": {},
+    "ready_outputs": {
+      "__frozenset__": []
+    },
+    "step_output_versions": []
+  },
   "pipeline_snapshot_id": "7bb46b4373672e250386288663f7eca81f0a0a02",
   "snapshot_version": 1,
   "step_keys_to_execute": [

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
@@ -38,6 +38,7 @@ from dagster.core.execution.plan.external_step import (
     step_context_to_step_run_ref,
     step_run_ref_to_step_context,
 )
+from dagster.core.execution.plan.state import KnownExecutionState
 from dagster.core.execution.retries import RetryMode
 from dagster.core.instance import DagsterInstance
 from dagster.core.storage.pipeline_run import PipelineRun
@@ -311,7 +312,10 @@ def initialize_step_context(scratch_dir, instance):
         pass
     pipeline_context = initialization_manager.get_context()
 
-    step_context = pipeline_context.for_step(plan.get_step_by_key("return_two"))
+    step_context = pipeline_context.for_step(
+        plan.get_step_by_key("return_two"),
+        KnownExecutionState(),
+    )
     return step_context
 
 


### PR DESCRIPTION
### Summary & Motivation

Adds the set of already produced `StepOutputHandle` to the `KnownState` so that things like "which entries of this fan-in dependency should can i load" can be calculated from that.

Will address parent run loading in next PR

### How I Tested These Changes

BK, existing tests
