### PR TITLE
[dagit] Sectioned left nav

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Flags.tsx
+++ b/js_modules/dagit/packages/core/src/app/Flags.tsx
@@ -11,6 +11,7 @@ export enum FeatureFlag {
   flagAlwaysCollapseNavigation = 'flagAlwaysCollapseNavigation',
   flagDisableWebsockets = 'flagDisableWebsockets',
   flagNewPartitionsView = 'flagNewPartitionsView',
+  flagSectionedLeftNav = 'flagSectionedLeftNav',
 }
 
 export const getFeatureFlags: () => FeatureFlag[] = memoize(

--- a/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
@@ -144,6 +144,16 @@ const UserSettingsRoot: React.FC<SettingsRootProps> = ({tabs}) => {
                 />
               ),
             },
+            {
+              key: 'Sectioned left nav (experimental)',
+              value: (
+                <Checkbox
+                  format="switch"
+                  checked={flags.includes(FeatureFlag.flagSectionedLeftNav)}
+                  onChange={() => toggleFlag(FeatureFlag.flagSectionedLeftNav)}
+                />
+              ),
+            },
           ]}
         />
       </Box>

--- a/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
@@ -3,7 +3,9 @@ import * as React from 'react';
 import {useLocation} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
+import {useFeatureFlags} from '../app/Flags';
 import {explorerPathFromString} from '../pipelines/PipelinePathUtils';
+import {SectionedLeftNav} from '../ui/SectionedLeftNav';
 import {DagsterRepoOption, WorkspaceContext} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
 
@@ -17,6 +19,8 @@ const LoadedRepositorySection: React.FC<{
   toggleVisible: (repoAddresses: RepoAddress[]) => void;
 }> = ({allRepos, visibleRepos, toggleVisible}) => {
   const location = useLocation();
+  const {flagSectionedLeftNav} = useFeatureFlags();
+
   const workspacePath = location.pathname.split('/workspace/').pop();
   const [, repoPath, type, item, tab] =
     workspacePath?.match(
@@ -30,19 +34,31 @@ const LoadedRepositorySection: React.FC<{
       ? explorerPathFromString(item).pipelineName
       : item;
 
+  const listContent = () => {
+    if (visibleRepos.length) {
+      if (flagSectionedLeftNav) {
+        return <SectionedLeftNav />;
+      }
+
+      return (
+        <FlatContentList repoPath={repoPath} selector={selector} repos={visibleRepos} tab={tab} />
+      );
+    }
+
+    if (allRepos.length > 0) {
+      return <EmptyState>Select a repository to see a list of jobs.</EmptyState>;
+    }
+
+    return (
+      <EmptyState>
+        There are no repositories in this workspace. Add a repository to see a list of jobs.
+      </EmptyState>
+    );
+  };
+
   return (
     <Container>
-      <ListContainer>
-        {visibleRepos.length ? (
-          <FlatContentList repoPath={repoPath} selector={selector} repos={visibleRepos} tab={tab} />
-        ) : allRepos.length > 0 ? (
-          <EmptyState>Select a repository to see a list of jobs.</EmptyState>
-        ) : (
-          <EmptyState>
-            There are no repositories in this workspace. Add a repository to see a list of jobs.
-          </EmptyState>
-        )}
-      </ListContainer>
+      <ListContainer>{listContent()}</ListContainer>
       <RepositoryLocationStateObserver />
       <RepoNavItem allRepos={allRepos} selected={visibleRepos} onToggle={toggleVisible} />
     </Container>

--- a/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.stories.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.stories.tsx
@@ -1,0 +1,35 @@
+import {Meta} from '@storybook/react/types-6-0';
+import * as React from 'react';
+
+import {LEFT_NAV_WIDTH} from '../nav/LeftNav';
+import {StorybookProvider} from '../testing/StorybookProvider';
+import {defaultMocks} from '../testing/defaultMocks';
+
+import {SectionedLeftNav} from './SectionedLeftNav';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'SectionedLeftNav',
+  component: SectionedLeftNav,
+} as Meta;
+
+const mocks = {
+  Repository: () => ({
+    ...defaultMocks.Repository(),
+    pipelines: () => [...new Array(15)],
+  }),
+  Workspace: () => ({
+    ...defaultMocks.Workspace(),
+    locationEntries: () => [...new Array(2)],
+  }),
+};
+
+export const Default = () => {
+  return (
+    <StorybookProvider apolloProps={{mocks}}>
+      <div style={{position: 'absolute', left: 0, top: 0, height: '100%', width: LEFT_NAV_WIDTH}}>
+        <SectionedLeftNav />
+      </div>
+    </StorybookProvider>
+  );
+};

--- a/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
@@ -1,0 +1,267 @@
+import {BaseTag, Box, Colors, Icon, IconWrapper, StyledTag} from '@dagster-io/ui';
+import * as React from 'react';
+import styled from 'styled-components/macro';
+
+import {AppContext} from '../app/AppContext';
+import {isAssetGroup} from '../asset-graph/Utils';
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
+import {getJobItemsForOption, JobItem} from '../nav/FlatContentList';
+import {DagsterRepoOption, WorkspaceContext} from '../workspace/WorkspaceContext';
+import {buildRepoAddress} from '../workspace/buildRepoAddress';
+import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {RepoAddress} from '../workspace/types';
+
+const validateExpandedKeys = (parsed: unknown) => (Array.isArray(parsed) ? parsed : []);
+const EXPANDED_REPO_KEYS = 'dagit.expanded-repo-keys';
+
+export const SectionedLeftNav = () => {
+  const {loading, visibleRepos} = React.useContext(WorkspaceContext);
+  const {basePath} = React.useContext(AppContext);
+
+  const [expandedKeys, setExpandedKeys] = useStateWithStorage<string[]>(
+    basePath + ':' + EXPANDED_REPO_KEYS,
+    validateExpandedKeys,
+  );
+
+  const onToggle = React.useCallback(
+    (repoAddress: RepoAddress) => {
+      const key = repoAddressAsString(repoAddress);
+      setExpandedKeys((current) => {
+        let nextExpandedKeys = [...(current || [])];
+        if (nextExpandedKeys.includes(key)) {
+          nextExpandedKeys = nextExpandedKeys.filter((k) => k !== key);
+        } else {
+          nextExpandedKeys = [...nextExpandedKeys, key];
+        }
+        return nextExpandedKeys;
+      });
+    },
+    [setExpandedKeys],
+  );
+
+  const duplicateRepoNames = React.useMemo(() => {
+    const uniques = new Set<string>();
+    const duplicates = new Set<string>();
+    visibleRepos.forEach((repo) => {
+      const repoName = repo.repository.name;
+      if (uniques.has(repoName)) {
+        duplicates.add(repoName);
+      } else {
+        uniques.add(repoName);
+      }
+    });
+    return duplicates;
+  }, [visibleRepos]);
+
+  // Sort repositories alphabetically, then move empty repos to the bottom.
+  const sortedRepos = React.useMemo(() => {
+    const alphaSorted = [...visibleRepos].sort((a, b) =>
+      a.repository.name.toLocaleLowerCase().localeCompare(b.repository.name.toLocaleLowerCase()),
+    );
+    const reposWithJobs = [];
+    const reposWithoutJobs = [];
+    for (const repo of alphaSorted) {
+      const jobs = repo.repository.pipelines;
+      if (jobs.length > 0 && jobs.some((job) => !isAssetGroup(job.name))) {
+        reposWithJobs.push(repo);
+      } else {
+        reposWithoutJobs.push(repo);
+      }
+    }
+    return [...reposWithJobs, ...reposWithoutJobs];
+  }, [visibleRepos]);
+
+  if (loading) {
+    return <div style={{flex: 1}} />;
+  }
+
+  return (
+    <>
+      <Box
+        flex={{direction: 'row', alignItems: 'center', gap: 8}}
+        padding={{horizontal: 24, bottom: 12}}
+        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+      >
+        <Icon name="job" />
+        <span style={{fontSize: '16px', fontWeight: 600}}>Jobs</span>
+      </Box>
+      <Container>
+        {sortedRepos.map((repo) => {
+          const repoName = repo.repository.name;
+          const repoAddress = buildRepoAddress(repoName, repo.repositoryLocation.name);
+          const addressAsString = repoAddressAsString(repoAddress);
+          return (
+            <Section
+              key={addressAsString}
+              onToggle={onToggle}
+              option={repo}
+              expanded={expandedKeys.includes(addressAsString)}
+              showRepoLocation={duplicateRepoNames.has(repoName)}
+            />
+          );
+        })}
+      </Container>
+    </>
+  );
+};
+
+const HEADER_HEIGHT = 48;
+const HEADER_HEIGHT_WITH_LOCATION = 64;
+
+interface SectionProps {
+  expanded: boolean;
+  onToggle: (repoAddress: RepoAddress) => void;
+  option: DagsterRepoOption;
+  showRepoLocation: boolean;
+}
+
+export const Section: React.FC<SectionProps> = (props) => {
+  const {expanded, onToggle, option, showRepoLocation} = props;
+  const repoAddress = buildRepoAddress(option.repository.name, option.repositoryLocation.name);
+  const jobItems = React.useMemo(() => getJobItemsForOption(option), [option]);
+  const anyJobs = jobItems.length > 0;
+  const showJobs = expanded && anyJobs;
+
+  return (
+    <Box background={Colors.Gray100}>
+      <SectionHeader
+        $open={showJobs}
+        $showRepoLocation={showRepoLocation}
+        disabled={!anyJobs}
+        onClick={() => onToggle(repoAddress)}
+      >
+        <Box flex={{direction: 'row', alignItems: 'flex-start', gap: 8}}>
+          <Box margin={{top: 2}}>
+            <Icon name="folder_open" size={16} />
+          </Box>
+          <RepoNameContainer>
+            <div style={{minWidth: 0}}>
+              <RepoName style={{fontWeight: 500}} data-tooltip={option.repository.name}>
+                {option.repository.name}
+              </RepoName>
+              {showRepoLocation ? (
+                <RepoLocation
+                  data-tooltip={`@${option.repositoryLocation.name}`}
+                  $disabled={!anyJobs}
+                >
+                  @{option.repositoryLocation.name}
+                </RepoLocation>
+              ) : null}
+            </div>
+            {/* Wrapper div to prevent tag from stretching vertically */}
+            <div>
+              <BaseTag
+                fillColor={Colors.Gray10}
+                textColor={Colors.Dark}
+                label={jobItems.length.toLocaleString()}
+              />
+            </div>
+          </RepoNameContainer>
+          <Box margin={{top: 2}}>
+            <Icon name="arrow_drop_down" />
+          </Box>
+        </Box>
+      </SectionHeader>
+      {showJobs ? (
+        <Box
+          padding={{vertical: 8, horizontal: 12}}
+          border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        >
+          {jobItems.map((jobItem) => (
+            <JobItem job={jobItem} key={jobItem.path} />
+          ))}
+        </Box>
+      ) : null}
+    </Box>
+  );
+};
+
+const Container = styled.div`
+  background-color: ${Colors.Gray100};
+  overflow-y: auto;
+  overflow-x: hidden;
+`;
+
+const SectionHeader = styled.button<{$open: boolean; $showRepoLocation: boolean}>`
+  background: ${Colors.Gray100};
+  border: 0;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 12px 0 24px;
+  text-align: left;
+  white-space: nowrap;
+
+  height: ${({$showRepoLocation}) =>
+    $showRepoLocation ? HEADER_HEIGHT_WITH_LOCATION : HEADER_HEIGHT}px;
+  width: 100%;
+  margin: 0;
+
+  box-shadow: inset 0px -1px 0 ${Colors.KeylineGray};
+
+  :disabled {
+    cursor: default;
+  }
+
+  :hover,
+  :active {
+    background-color: ${Colors.Gray50};
+  }
+
+  :disabled:hover,
+  :disabled:active {
+    background-color: ${Colors.Gray100};
+  }
+
+  :focus,
+  :active {
+    outline: none;
+  }
+
+  ${IconWrapper}[aria-label="arrow_drop_down"] {
+    transition: transform 100ms linear;
+    ${({$open}) => ($open ? null : `transform: rotate(90deg);`)}
+  }
+
+  :disabled ${IconWrapper} {
+    background-color: ${Colors.Gray300};
+  }
+
+  ${StyledTag} {
+    margin-top: -3px;
+    margin-left: 6px;
+  }
+
+  :not(:disabled) ${StyledTag} {
+    cursor: pointer;
+  }
+
+  :disabled ${StyledTag} {
+    color: ${Colors.Gray400};
+  }
+}`;
+
+const RepoNameContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-top: 2px;
+  width: 244px;
+`;
+
+const RepoName = styled.div`
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const RepoLocation = styled.div<{$disabled: boolean}>`
+  color: ${({$disabled}) => ($disabled ? Colors.Gray400 : Colors.Gray700)};
+  font-size: 12px;
+  margin-top: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;


### PR DESCRIPTION
### Summary & Motivation

Split the left nav into expandable repository sections, with the list of the repo's jobs rendered below it.

- Show the name of the repo and a tag with the number of (non-asset-group) jobs in that repo
- Make the repo name/count clickable to expand/collapse the list of jobs below it
- Show empty repositories, but make them disabled and gray them out
- Surface repositories *with* jobs to the top of the list
- For repository names that are repeated in multiple repo locations, additionally display the repo location under the repo name

This is behind a feature flag, settable at User Settings.

Will follow with a Jest test once we're settled on the layout and interactions.

### How I Tested These Changes

View Dagit and Storybook example. Verify correct rendering, disabled state, expandability, collapsibility, job count, scrollability.
