### PR TITLE
[dagit] Disable unloadables if no permissions

### DIFF
--- a/js_modules/dagit/packages/core/src/instigation/Unloadable.test.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/Unloadable.test.tsx
@@ -1,0 +1,252 @@
+import {gql, useQuery} from '@apollo/client';
+import {act, render, screen} from '@testing-library/react';
+import * as React from 'react';
+
+import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {TestProvider} from '../testing/TestProvider';
+import {InstigationStatus} from '../types/globalTypes';
+
+import {INSTIGATION_STATE_FRAGMENT} from './InstigationUtils';
+import {UnloadableSchedules, UnloadableSensors} from './Unloadable';
+import {UnloadableInstigationStatesQuery} from './types/UnloadableInstigationStatesQuery';
+
+describe('Unloadables', () => {
+  const UNLOADABLE_INSTIGATION_STATES_QUERY = gql`
+    query UnloadableInstigationStatesQuery {
+      unloadableInstigationStatesOrError {
+        ... on InstigationStates {
+          results {
+            id
+            ...InstigationStateFragment
+          }
+        }
+        ...PythonErrorFragment
+      }
+    }
+
+    ${PYTHON_ERROR_FRAGMENT}
+    ${INSTIGATION_STATE_FRAGMENT}
+  `;
+
+  const defaultMocks = {
+    InstigationStates: () => ({
+      results: () => [...new Array(1)],
+    }),
+  };
+
+  describe('Sensors', () => {
+    const Test = () => {
+      const {data, loading} = useQuery<UnloadableInstigationStatesQuery>(
+        UNLOADABLE_INSTIGATION_STATES_QUERY,
+      );
+      if (loading) {
+        return <div>Loading…</div>;
+      }
+      const states = data?.unloadableInstigationStatesOrError;
+      if (states && states.__typename === 'InstigationStates') {
+        return <UnloadableSensors sensorStates={states.results} />;
+      }
+      return <div>Error!</div>;
+    };
+
+    it('shows enabled ON switch if running and viewer has permission to edit sensors', async () => {
+      const mocks = {
+        InstigationState: () => ({
+          status: () => InstigationStatus.RUNNING,
+        }),
+      };
+
+      await act(async () => {
+        render(
+          <TestProvider
+            apolloProps={{mocks: [defaultMocks, mocks]}}
+            permissionOverrides={{edit_sensor: true}}
+          >
+            <Test />
+          </TestProvider>,
+        );
+      });
+
+      const switchElem: HTMLInputElement = screen.getByRole('checkbox');
+      expect(switchElem.checked).toBe(true);
+      expect(switchElem.disabled).toBe(false);
+    });
+
+    it('shows disabled OFF switch if stopped, even if viewer has permission to edit sensors', async () => {
+      const mocks = {
+        InstigationState: () => ({
+          status: () => InstigationStatus.STOPPED,
+        }),
+      };
+
+      await act(async () => {
+        render(
+          <TestProvider
+            apolloProps={{mocks: [defaultMocks, mocks]}}
+            permissionOverrides={{edit_sensor: true}}
+          >
+            <Test />
+          </TestProvider>,
+        );
+      });
+
+      const switchElem: HTMLInputElement = screen.getByRole('checkbox');
+      expect(switchElem.checked).toBe(false);
+      expect(switchElem.disabled).toBe(true);
+    });
+
+    it('shows disabled ON switch if running and no permission to edit sensors', async () => {
+      const mocks = {
+        InstigationState: () => ({
+          status: () => InstigationStatus.RUNNING,
+        }),
+      };
+
+      await act(async () => {
+        render(
+          <TestProvider
+            apolloProps={{mocks: [defaultMocks, mocks]}}
+            permissionOverrides={{edit_sensor: false}}
+          >
+            <Test />
+          </TestProvider>,
+        );
+      });
+
+      const switchElem: HTMLInputElement = screen.getByRole('checkbox');
+      expect(switchElem.checked).toBe(true);
+      expect(switchElem.disabled).toBe(true);
+    });
+
+    it('shows disabled OFF switch if stopped and no permission to edit sensors', async () => {
+      const mocks = {
+        InstigationState: () => ({
+          status: () => InstigationStatus.STOPPED,
+        }),
+      };
+
+      await act(async () => {
+        render(
+          <TestProvider
+            apolloProps={{mocks: [defaultMocks, mocks]}}
+            permissionOverrides={{edit_sensor: false}}
+          >
+            <Test />
+          </TestProvider>,
+        );
+      });
+
+      const switchElem: HTMLInputElement = screen.getByRole('checkbox');
+      expect(switchElem.checked).toBe(false);
+      expect(switchElem.disabled).toBe(true);
+    });
+  });
+
+  describe('Schedules', () => {
+    const Test = () => {
+      const {data, loading} = useQuery<UnloadableInstigationStatesQuery>(
+        UNLOADABLE_INSTIGATION_STATES_QUERY,
+      );
+      if (loading) {
+        return <div>Loading…</div>;
+      }
+      const states = data?.unloadableInstigationStatesOrError;
+      if (states && states.__typename === 'InstigationStates') {
+        return <UnloadableSchedules scheduleStates={states.results} />;
+      }
+      return <div>Error!</div>;
+    };
+
+    it('shows enabled ON switch if running and viewer has permission to stop schedules', async () => {
+      const mocks = {
+        InstigationState: () => ({
+          status: () => InstigationStatus.RUNNING,
+        }),
+      };
+
+      await act(async () => {
+        render(
+          <TestProvider
+            apolloProps={{mocks: [defaultMocks, mocks]}}
+            permissionOverrides={{stop_running_schedule: true}}
+          >
+            <Test />
+          </TestProvider>,
+        );
+      });
+
+      const switchElem: HTMLInputElement = screen.getByRole('checkbox');
+      expect(switchElem.checked).toBe(true);
+      expect(switchElem.disabled).toBe(false);
+    });
+
+    it('shows disabled OFF switch if stopped, even if viewer has permission to start schedule', async () => {
+      const mocks = {
+        InstigationState: () => ({
+          status: () => InstigationStatus.STOPPED,
+        }),
+      };
+
+      await act(async () => {
+        render(
+          <TestProvider
+            apolloProps={{mocks: [defaultMocks, mocks]}}
+            permissionOverrides={{start_schedule: true}}
+          >
+            <Test />
+          </TestProvider>,
+        );
+      });
+
+      const switchElem: HTMLInputElement = screen.getByRole('checkbox');
+      expect(switchElem.checked).toBe(false);
+      expect(switchElem.disabled).toBe(true);
+    });
+
+    it('shows disabled ON switch if running and no permission to stop schedules', async () => {
+      const mocks = {
+        InstigationState: () => ({
+          status: () => InstigationStatus.RUNNING,
+        }),
+      };
+
+      await act(async () => {
+        render(
+          <TestProvider
+            apolloProps={{mocks: [defaultMocks, mocks]}}
+            permissionOverrides={{stop_running_schedule: false}}
+          >
+            <Test />
+          </TestProvider>,
+        );
+      });
+
+      const switchElem: HTMLInputElement = screen.getByRole('checkbox');
+      expect(switchElem.checked).toBe(true);
+      expect(switchElem.disabled).toBe(true);
+    });
+
+    it('shows disabled OFF switch if stopped and no permission to start schedule', async () => {
+      const mocks = {
+        InstigationState: () => ({
+          status: () => InstigationStatus.STOPPED,
+        }),
+      };
+
+      await act(async () => {
+        render(
+          <TestProvider
+            apolloProps={{mocks: [defaultMocks, mocks]}}
+            permissionOverrides={{start_schedule: false}}
+          >
+            <Test />
+          </TestProvider>,
+        );
+      });
+
+      const switchElem: HTMLInputElement = screen.getByRole('checkbox');
+      expect(switchElem.checked).toBe(false);
+      expect(switchElem.disabled).toBe(true);
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/instigation/types/UnloadableInstigationStatesQuery.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/UnloadableInstigationStatesQuery.ts
@@ -1,0 +1,94 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { InstigationType, InstigationStatus, RunStatus, InstigationTickStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: UnloadableInstigationStatesQuery
+// ====================================================
+
+export interface UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData_SensorData {
+  __typename: "SensorData";
+  lastRunKey: string | null;
+  lastCursor: string | null;
+}
+
+export interface UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData_ScheduleData {
+  __typename: "ScheduleData";
+  cronSchedule: string;
+}
+
+export type UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData = UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData_SensorData | UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData_ScheduleData;
+
+export interface UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results_runs {
+  __typename: "Run";
+  id: string;
+  runId: string;
+  status: RunStatus;
+}
+
+export interface UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error_cause {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  cause: UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error_cause | null;
+}
+
+export interface UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks {
+  __typename: "InstigationTick";
+  id: string;
+  cursor: string | null;
+  status: InstigationTickStatus;
+  timestamp: number;
+  skipReason: string | null;
+  runIds: string[];
+  runKeys: string[];
+  error: UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error | null;
+}
+
+export interface UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results {
+  __typename: "InstigationState";
+  id: string;
+  selectorId: string;
+  name: string;
+  instigationType: InstigationType;
+  status: InstigationStatus;
+  repositoryName: string;
+  repositoryLocationName: string;
+  typeSpecificData: UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData | null;
+  runs: UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results_runs[];
+  ticks: UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks[];
+  runningCount: number;
+}
+
+export interface UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates {
+  __typename: "InstigationStates";
+  results: UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results[];
+}
+
+export interface UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_PythonError_cause {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  cause: UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_PythonError_cause | null;
+}
+
+export type UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError = UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates | UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_PythonError;
+
+export interface UnloadableInstigationStatesQuery {
+  unloadableInstigationStatesOrError: UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError;
+}

--- a/js_modules/dagit/packages/core/src/testing/defaultMocks.ts
+++ b/js_modules/dagit/packages/core/src/testing/defaultMocks.ts
@@ -181,4 +181,7 @@ export const defaultMocks = {
   ConfigTypeOrError: () => ({
     __typename: 'EnumConfigType',
   }),
+  InstigationStatesOrError: () => ({
+    __typename: 'InstigationStates',
+  }),
 };


### PR DESCRIPTION
### Summary & Motivation

Disallow sensor/schedule toggling on unloadable sensors/schedules for viewers who don't have permissions.

### How I Tested These Changes

`yarn jest Unloadable`
