### PR TITLE
KnownState parent run info

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -1,9 +1,11 @@
 from graphql.execution.base import ResolveInfo
 
 import dagster._check as check
+from dagster.core.errors import DagsterRunNotFoundError
 from dagster.core.execution.plan.resume_retry import get_retry_steps_from_parent_run
 from dagster.core.execution.plan.state import KnownExecutionState
-from dagster.core.storage.pipeline_run import PipelineRunStatus
+from dagster.core.instance import DagsterInstance
+from dagster.core.storage.pipeline_run import DagsterRun, PipelineRunStatus
 from dagster.core.storage.tags import RESUME_RETRY_TAG
 from dagster.core.utils import make_new_run_id
 from dagster.utils import merge_dicts
@@ -13,24 +15,34 @@ from ..external import ensure_valid_config, get_external_execution_plan_or_raise
 from ..utils import ExecutionParams, UserFacingGraphQLError
 
 
+def _get_run(instance: DagsterInstance, run_id: str) -> DagsterRun:
+    run = instance.get_run_by_id(run_id)
+    if not run:
+        raise DagsterRunNotFoundError(invalid_run_id=run_id)
+    return run
+
+
 def compute_step_keys_to_execute(graphene_info, execution_params):
     check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(execution_params, "execution_params", ExecutionParams)
 
-    instance = graphene_info.context.instance
+    instance: DagsterInstance = graphene_info.context.instance
 
     if not execution_params.step_keys and is_resume_retry(execution_params):
         # Get step keys from parent_run_id if it's a resume/retry
+        parent_run = _get_run(instance, execution_params.execution_metadata.parent_run_id)
         return get_retry_steps_from_parent_run(
-            instance, execution_params.execution_metadata.parent_run_id
+            instance,
+            parent_run,
         )
     else:
         known_state = None
         if execution_params.execution_metadata.parent_run_id and execution_params.step_keys:
-            known_state = KnownExecutionState.for_reexecution(
-                instance.all_logs(execution_params.execution_metadata.parent_run_id),
-                execution_params.step_keys,
-            )
+            parent_run = _get_run(instance, execution_params.execution_metadata.parent_run_id)
+            known_state = KnownExecutionState.build_for_reexecution(
+                instance,
+                parent_run,
+            ).update_for_step_selection(execution_params.step_keys)
 
         return execution_params.step_keys, known_state
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
@@ -414,9 +414,9 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
     def test_pipeline_reexecution_invalid_step_in_subset(self, graphql_context):
         run_id = make_new_run_id()
         selector = infer_pipeline_selector(graphql_context, "csv_hello_world")
-        execute_dagster_graphql_and_finish_runs(
+        result_one = execute_dagster_graphql_and_finish_runs(
             graphql_context,
-            LAUNCH_PIPELINE_REEXECUTION_MUTATION,
+            LAUNCH_PIPELINE_EXECUTION_MUTATION,
             variables={
                 "executionParams": {
                     "selector": selector,
@@ -426,6 +426,7 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
                 }
             },
         )
+        assert result_one.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
 
         # retry
         new_run_id = make_new_run_id()

--- a/python_modules/dagster/dagster/core/definitions/step_launcher.py
+++ b/python_modules/dagster/dagster/core/definitions/step_launcher.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Dict, Mapping, NamedTuple, Optional, Sequence
+from typing import TYPE_CHECKING, Dict, Mapping, NamedTuple, Optional
 
 import dagster._check as check
 from dagster.core.definitions.reconstruct import ReconstructablePipeline
@@ -23,8 +23,6 @@ class StepRunRef(
             ("recon_pipeline", ReconstructablePipeline),
             ("prior_attempts_count", int),
             ("known_state", Optional["KnownExecutionState"]),
-            ("run_group", Sequence[PipelineRun]),
-            ("upstream_output_events", Sequence["EventLogEntry"]),
         ],
     )
 ):
@@ -43,11 +41,8 @@ class StepRunRef(
         recon_pipeline: ReconstructablePipeline,
         prior_attempts_count: int,
         known_state: Optional["KnownExecutionState"],
-        run_group: Optional[Sequence[PipelineRun]],
-        upstream_output_events: Optional[Sequence["EventLogEntry"]],
     ):
         from dagster.core.execution.plan.state import KnownExecutionState
-        from dagster.core.storage.event_log import EventLogEntry
 
         return super(StepRunRef, cls).__new__(
             cls,
@@ -59,10 +54,6 @@ class StepRunRef(
             check.inst_param(recon_pipeline, "recon_pipeline", ReconstructablePipeline),
             check.int_param(prior_attempts_count, "prior_attempts_count"),
             check.opt_inst_param(known_state, "known_state", KnownExecutionState),
-            check.opt_list_param(run_group, "run_group", of_type=PipelineRun),
-            check.opt_list_param(
-                upstream_output_events, "upstream_output_events", of_type=EventLogEntry
-            ),
         )
 
 

--- a/python_modules/dagster/dagster/core/execution/backfill.py
+++ b/python_modules/dagster/dagster/core/execution/backfill.py
@@ -247,10 +247,10 @@ def create_backfill_run(
             )
         step_keys_to_execute = backfill_job.reexecution_steps
         if last_run and last_run.status == PipelineRunStatus.SUCCESS:
-            known_state = KnownExecutionState.for_reexecution(
-                instance.all_logs(parent_run_id),
-                step_keys_to_execute,
-            )
+            known_state = KnownExecutionState.build_for_reexecution(
+                instance,
+                last_run,
+            ).update_for_step_selection(step_keys_to_execute)
         else:
             known_state = None
 

--- a/python_modules/dagster/dagster/core/execution/memoization.py
+++ b/python_modules/dagster/dagster/core/execution/memoization.py
@@ -1,5 +1,5 @@
 import dagster._check as check
-from dagster.core.errors import DagsterInvariantViolationError, DagsterRunNotFoundError
+from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.execution.context.system import IPlanContext
 from dagster.core.execution.plan.plan import ExecutionPlan
 
@@ -13,12 +13,6 @@ def validate_reexecution_memoization(
 
     if parent_run_id is None:
         return
-
-    if not plan_context.instance.has_run(parent_run_id):
-        raise DagsterRunNotFoundError(
-            "Run id {} set as parent run id was not found in instance".format(parent_run_id),
-            invalid_run_id=parent_run_id,
-        )
 
     # exclude full pipeline re-execution
     if len(execution_plan.step_keys_to_execute) == len(execution_plan.steps):

--- a/python_modules/dagster/dagster/core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/core/execution/plan/active.py
@@ -463,6 +463,7 @@ class ActiveExecution:
             dynamic_mappings=dict(self._successful_dynamic_outputs),
             ready_outputs=self._step_outputs,
             step_output_versions=self._plan.known_state.step_output_versions,
+            parent_state=self._plan.known_state.parent_state,
         )
 
     def _prep_for_dynamic_outputs(self, step: ExecutionStep):

--- a/python_modules/dagster/dagster/core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/external_step.py
@@ -13,7 +13,7 @@ from dagster.core.definitions.reconstruct import ReconstructablePipeline, Recons
 from dagster.core.definitions.resource_definition import resource
 from dagster.core.definitions.step_launcher import StepLauncher, StepRunRef
 from dagster.core.errors import raise_execution_interrupts
-from dagster.core.events import DagsterEvent, DagsterEventType
+from dagster.core.events import DagsterEvent
 from dagster.core.execution.api import create_execution_plan
 from dagster.core.execution.context.system import StepExecutionContext
 from dagster.core.execution.context_creation_pipeline import PlanExecutionContextManager
@@ -106,44 +106,6 @@ def _module_in_package_dir(file_path: str, package_dir: str) -> str:
     return ".".join(without_extension.split(os.sep))
 
 
-def _upstream_events_and_runs(step_context: StepExecutionContext):
-    "Grabs the minimal set of output events and runs to inform a remote instance of how to load each output."
-    step_inputs = step_context.step.step_inputs
-    upstream_output_handles = set().union(
-        *(step_input.source.step_output_handle_dependencies for step_input in step_inputs)
-    )
-    current_run = step_context.pipeline_run
-    events = []
-    runs = []
-    while True:
-        runs.append(current_run)
-        # note: this would cost N db calls where N = number of parent runs
-        step_output_records = step_context.instance.all_logs(
-            current_run.run_id, of_type=DagsterEventType.STEP_OUTPUT
-        )
-        # if the parent run has yielded an StepOutput event for the given step output,
-        # we find the source run id
-        for r in step_output_records:
-            output_handle = r.dagster_event.step_output_data.step_output_handle
-            # if this output matches one of the required step outputs, add it to the list of
-            # required events
-            if output_handle in upstream_output_handles:
-                events.append(r)
-                upstream_output_handles.remove(output_handle)
-
-        if current_run.parent_run_id is None:
-            if upstream_output_handles:
-                step_context.log.warn(
-                    f"Could not find outputs in the logs for output handles: {upstream_output_handles}"
-                )
-            break
-
-        # else, keep looking backwards
-        current_run = step_context.instance.get_run_by_id(current_run.parent_run_id)
-
-    return events, runs
-
-
 def step_context_to_step_run_ref(
     step_context: StepExecutionContext,
     prior_attempts_count: int,
@@ -192,7 +154,6 @@ def step_context_to_step_run_ref(
                 solids_to_execute=recon_pipeline.solids_to_execute,
             )
 
-    upstream_output_events, run_group = _upstream_events_and_runs(step_context)
     return StepRunRef(
         run_config=step_context.run_config,
         pipeline_run=step_context.pipeline_run,
@@ -202,8 +163,6 @@ def step_context_to_step_run_ref(
         recon_pipeline=recon_pipeline,  # type: ignore
         prior_attempts_count=prior_attempts_count,
         known_state=step_context.get_known_state(),
-        run_group=run_group,
-        upstream_output_events=upstream_output_events,
     )
 
 
@@ -223,14 +182,6 @@ def external_instance_from_step_run_ref(
         DagsterInstance: A DagsterInstance that can be used to execute an external step.
     """
     instance = DagsterInstance.ephemeral()
-    # re-execution expects the parent run(s) to be available on the instance, so add these
-    for run in step_run_ref.run_group:
-        # remove the pipeline_snapshot_id, as this instance doesn't have any snapshots
-        instance.add_run(run._replace(pipeline_snapshot_id=None))
-    # the can_load() function on the step context currently depends on reading output events
-    # from the instance, so we make sure the remote instance has the relevant events
-    for entry in step_run_ref.upstream_output_events:
-        instance.handle_new_event(entry)
     if event_listener_fn:
         instance.add_event_listener(step_run_ref.run_id, event_listener_fn)
     return instance

--- a/python_modules/dagster/dagster/core/execution/plan/state.py
+++ b/python_modules/dagster/dagster/core/execution/plan/state.py
@@ -2,9 +2,11 @@ from collections import defaultdict
 from typing import Dict, List, NamedTuple, Optional, Set, cast
 
 import dagster._check as check
-from dagster.core.events.log import EventLogEntry
+from dagster.core.events import DagsterEventType
 from dagster.core.execution.plan.outputs import StepOutputHandle
 from dagster.core.execution.retries import RetryState
+from dagster.core.instance import DagsterInstance
+from dagster.core.storage.pipeline_run import DagsterRun
 from dagster.serdes import whitelist_for_serdes
 
 
@@ -30,6 +32,40 @@ class StepOutputVersionData(NamedTuple):
 
 
 @whitelist_for_serdes
+class PastExecutionState(
+    NamedTuple(
+        "_PastExecutionState",
+        [
+            ("run_id", str),
+            ("produced_outputs", Set[StepOutputHandle]),
+            # PastExecutionState, but no cycles allowed in NT
+            ("parent_state", Optional[object]),
+        ],
+    )
+):
+    """
+    Information relevant to execution about the parent run, notably which outputs
+    were produced by which run ids, allowing for the proper ones to be loaded.
+    """
+
+    def __new__(
+        cls,
+        run_id: str,
+        produced_outputs: Set[StepOutputHandle],
+        parent_state: Optional["PastExecutionState"],
+    ):
+        return super().__new__(
+            cls,
+            check.str_param(run_id, "run_id"),
+            check.set_param(produced_outputs, "produced_outputs", StepOutputHandle),
+            check.opt_inst_param(parent_state, "parent_state", PastExecutionState),
+        )
+
+    def get_parent_state(self) -> Optional["PastExecutionState"]:
+        return cast(Optional[PastExecutionState], self.parent_state)
+
+
+@whitelist_for_serdes
 class KnownExecutionState(
     NamedTuple(
         "_KnownExecutionState",
@@ -41,6 +77,7 @@ class KnownExecutionState(
             # step_output_handle -> version
             ("step_output_versions", List[StepOutputVersionData]),
             ("ready_outputs", Set[StepOutputHandle]),
+            ("parent_state", Optional[PastExecutionState]),
         ],
     )
 ):
@@ -56,78 +93,87 @@ class KnownExecutionState(
         dynamic_mappings: Optional[Dict[str, Dict[str, List[str]]]] = None,
         step_output_versions: Optional[List[StepOutputVersionData]] = None,
         ready_outputs: Optional[Set[StepOutputHandle]] = None,
+        parent_state: Optional[PastExecutionState] = None,
     ):
 
         return super(KnownExecutionState, cls).__new__(
             cls,
             check.opt_dict_param(
-                previous_retry_attempts, "previous_retry_attempts", key_type=str, value_type=int
+                previous_retry_attempts,
+                "previous_retry_attempts",
+                key_type=str,
+                value_type=int,
             ),
             check.opt_dict_param(
-                dynamic_mappings, "dynamic_mappings", key_type=str, value_type=dict
+                dynamic_mappings,
+                "dynamic_mappings",
+                key_type=str,
+                value_type=dict,
             ),
             check.opt_list_param(
                 step_output_versions, "step_output_versions", of_type=StepOutputVersionData
             ),
             check.opt_set_param(ready_outputs, "ready_outputs", StepOutputHandle),
+            check.opt_inst_param(parent_state, "parent_state", PastExecutionState),
         )
 
     def get_retry_state(self):
         return RetryState(self.previous_retry_attempts)
 
-    @staticmethod
-    def derive_from_logs(logs: List[EventLogEntry]) -> "KnownExecutionState":
-        """
-        Derive the known state from iterating over the event logs
-        """
-
-        previous_retry_attempts: Dict[str, int] = defaultdict(int)
-        dynamic_outputs: Dict[str, Dict[str, List[str]]] = defaultdict(lambda: defaultdict(list))
-        successful_dynamic_mappings: Dict[str, Dict[str, List[str]]] = {}
-
-        for log in logs:
-            if not log.is_dagster_event:
-                continue
-            event = log.get_dagster_event()
-
-            step_key = cast(str, event.step_key)
-
-            # record dynamic outputs
-            if event.is_successful_output and event.step_output_data.mapping_key:
-                dynamic_outputs[step_key][event.step_output_data.output_name].append(
-                    event.step_output_data.mapping_key
-                )
-
-            # on a retry
-            if event.is_step_up_for_retry:
-                # tally up retry attempt
-                previous_retry_attempts[step_key] += 1
-
-                # clear any existing tracked mapping keys
-                if event.step_key in dynamic_outputs:
-                    for mapping_list in dynamic_outputs[step_key].values():
-                        mapping_list.clear()
-
-            # commit the set of dynamic outputs once the step is successful
-            if event.is_step_success and step_key in dynamic_outputs:
-                successful_dynamic_mappings[step_key] = dict(dynamic_outputs[step_key])
-
-        return KnownExecutionState(
-            dict(previous_retry_attempts),
-            successful_dynamic_mappings,
+    def update_for_step_selection(self, step_keys_to_execute) -> "KnownExecutionState":
+        dynamic_mappings_to_use = {
+            step_key: self.dynamic_mappings[step_key]
+            for step_key in self.dynamic_mappings.keys()
+            if step_key not in step_keys_to_execute
+        }
+        return self._replace(
+            dynamic_mappings=dynamic_mappings_to_use,
         )
 
     @staticmethod
-    def for_reexecution(
-        parent_run_logs: List[EventLogEntry], step_keys_to_execute: List[str]
+    def build_for_reexecution(
+        instance: DagsterInstance,
+        parent_run: DagsterRun,
     ) -> "KnownExecutionState":
-        """
-        Copy over dynamic mappings from previous run, but drop any for steps that we intend to re-execute
-        """
-        parent_state = KnownExecutionState.derive_from_logs(parent_run_logs)
-        dynamic_mappings_to_use = {
-            step_key: parent_state.dynamic_mappings[step_key]
-            for step_key in parent_state.dynamic_mappings.keys()
-            if step_key not in step_keys_to_execute
-        }
-        return KnownExecutionState({}, dynamic_mappings_to_use)
+
+        # recursively build parent state chain
+
+        def _create_parent_state(target_run):
+            output_set = set()
+            dynamic_outputs = defaultdict(lambda: defaultdict(list))
+            for output_record in instance.all_logs(
+                target_run.run_id, of_type=DagsterEventType.STEP_OUTPUT
+            ):
+                output_data = output_record.get_dagster_event().step_output_data
+                dynamic_outputs[output_record.step_key][output_data.output_name].append(
+                    output_data.mapping_key
+                )
+                output_set.add(output_data.step_output_handle)
+
+            parent_parent_run = None
+            if target_run.parent_run_id:
+                run = instance.get_run_by_id(target_run.parent_run_id)
+                if not run:
+                    check.failed(
+                        f"Could not load ancestor run {target_run.parent_run_id} for re-execution"
+                    )
+                parent_parent_run, _ = _create_parent_state(run)
+
+            return (
+                PastExecutionState(
+                    target_run.run_id,
+                    output_set,
+                    parent_parent_run,
+                ),
+                dynamic_outputs,
+            )
+
+        parent_state, dynamic_mappings = _create_parent_state(parent_run)
+
+        return KnownExecutionState(
+            previous_retry_attempts={},  # no need to calculate these for re-execution
+            dynamic_mappings=dynamic_mappings,
+            step_output_versions=None,
+            ready_outputs=None,
+            parent_state=parent_state,
+        )

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1051,7 +1051,7 @@ class DagsterInstance:
 
     def create_reexecuted_run(
         self,
-        parent_run: PipelineRun,
+        parent_run: DagsterRun,
         repo_location: "RepositoryLocation",
         external_pipeline: "ExternalPipeline",
         strategy: "ReexecutionStrategy",
@@ -1059,14 +1059,14 @@ class DagsterInstance:
         run_config: Optional[Dict[str, Any]] = None,
         mode: Optional[str] = None,
         use_parent_run_tags: bool = False,
-    ) -> PipelineRun:
+    ) -> DagsterRun:
         from dagster.core.execution.plan.resume_retry import (
             ReexecutionStrategy,
             get_retry_steps_from_parent_run,
         )
         from dagster.core.host_representation import ExternalPipeline, RepositoryLocation
 
-        check.inst_param(parent_run, "parent_run", PipelineRun)
+        check.inst_param(parent_run, "parent_run", DagsterRun)
         check.inst_param(repo_location, "repo_location", RepositoryLocation)
         check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
         check.inst_param(strategy, "strategy", ReexecutionStrategy)
@@ -1100,7 +1100,8 @@ class DagsterInstance:
             )
 
             step_keys_to_execute, known_state = get_retry_steps_from_parent_run(
-                self, parent_run=parent_run
+                self,
+                parent_run=parent_run,
             )
             tags[RESUME_RETRY_TAG] = "true"
         elif strategy == ReexecutionStrategy.ALL_STEPS:

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_execution_plan.py
@@ -13,6 +13,7 @@ snapshots['test_create_execution_plan_with_dep 1'] = '''{
   "initial_known_state": {
     "__class__": "KnownExecutionState",
     "dynamic_mappings": {},
+    "parent_state": null,
     "previous_retry_attempts": {},
     "ready_outputs": {
       "__frozenset__": []
@@ -146,6 +147,7 @@ snapshots['test_create_noop_execution_plan 1'] = '''{
   "initial_known_state": {
     "__class__": "KnownExecutionState",
     "dynamic_mappings": {},
+    "parent_state": null,
     "previous_retry_attempts": {},
     "ready_outputs": {
       "__frozenset__": []
@@ -208,6 +210,7 @@ snapshots['test_create_noop_execution_plan_with_tags 1'] = '''{
   "initial_known_state": {
     "__class__": "KnownExecutionState",
     "dynamic_mappings": {},
+    "parent_state": null,
     "previous_retry_attempts": {},
     "ready_outputs": {
       "__frozenset__": []
@@ -284,6 +287,7 @@ snapshots['test_create_with_composite 1'] = '''{
   "initial_known_state": {
     "__class__": "KnownExecutionState",
     "dynamic_mappings": {},
+    "parent_state": null,
     "previous_retry_attempts": {},
     "ready_outputs": {
       "__frozenset__": []

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_reexecute.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_reexecute.py
@@ -171,10 +171,13 @@ def dynamic_with_optional_output_job():
     def dynamic_optional_output_op(context):
         for i in range(10):
             if (
+                # re-execution run skipped odd numbers
                 context.pipeline_run.parent_run_id
-                and i % 2 == 0  # re-execution run skipped odd numbers
-                or not context.pipeline_run.parent_run_id
-                and i % 2 == 1  # root run skipped even numbers
+                and i % 2 == 0
+            ) or (
+                # root run skipped even numbers
+                not context.pipeline_run.parent_run_id
+                and i % 2 == 1
             ):
                 yield DynamicOutput(value=i, mapping_key=str(i))
 


### PR DESCRIPTION
### Summary & Motivation

To be able to load outputs during re-execution, we need to know the run id lineage and which outputs were produced in which runs.

This adds a recursive structure to `KnownExecutionState` that holds a `run_id` and `Set[StepOutputHandle]` to allow for this. This is more information that is strictly needed, but opted for simplicity. Open to feedback on this call. 
 

### How I Tested These Changes

Existing tests from when the hacks this removes were added. 