### PR TITLE
add example Python incompatibilities on Py 3.6

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -106,7 +106,8 @@ class PackageSpec(
             Defaults to None.
         tox_file (str, optional): The tox file to use. Defaults to {directory}/tox.ini.
         retries (int, optional): Whether to retry these tests on failure
-        upload_coverage (bool, optional): Whether to copy coverage artifacts. Enabled by default.
+        upload_coverage (bool, optional): Whether to copy coverage artifacts. By default, enabled
+            for packages of type "core" or "library", disabled for other packages.
         timeout_in_minutes (int, optional): Fail after this many minutes.
         queue (BuildkiteQueue, optional): Schedule steps to this queue.
         run_pytest (bool, optional): Whether to run pytest. Enabled by default.
@@ -128,18 +129,19 @@ class PackageSpec(
         env_vars: Optional[List[str]] = None,
         tox_file: Optional[str] = None,
         retries: Optional[int] = None,
-        upload_coverage: bool = True,
+        upload_coverage: Optional[bool] = None,
         timeout_in_minutes: Optional[int] = None,
         queue: Optional[BuildkiteQueue] = None,
         run_pytest: bool = True,
         run_mypy: bool = True,
         run_pylint: bool = True,
     ):
+        package_type = package_type or _infer_package_type(directory)
         return super(PackageSpec, cls).__new__(
             cls,
             directory,
             name or os.path.basename(directory),
-            package_type or _infer_package_type(directory),
+            package_type,
             unsupported_python_versions or [],
             pytest_extra_cmds,
             pytest_step_dependencies,
@@ -147,7 +149,7 @@ class PackageSpec(
             env_vars or [],
             tox_file,
             retries,
-            upload_coverage,
+            upload_coverage if upload_coverage is not None else package_type in ("core", "library"),
             timeout_in_minutes,
             queue,
             run_pytest,

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -303,33 +303,29 @@ PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     PackageSpec(
         "examples/airflow_ingest",
         unsupported_python_versions=[AvailablePythonVersion.V3_9],
-        upload_coverage=False,
     ),
     PackageSpec(
         "examples/bollinger",
         unsupported_python_versions=[
             # dependency on dagster-pandera
             AvailablePythonVersion.V3_6,
-        ]
+        ],
     ),
     PackageSpec(
         "examples/dbt_example",
         pytest_extra_cmds=dbt_example_extra_cmds,
-        upload_coverage=False,
         unsupported_python_versions=[
             # dependency on dagster-dbt
             AvailablePythonVersion.V3_6,
-        ]
+        ],
     ),
     PackageSpec(
         "examples/deploy_docker",
         pytest_extra_cmds=deploy_docker_example_extra_cmds,
-        upload_coverage=False,
     ),
     PackageSpec(
         "examples/docs_snippets",
         pytest_extra_cmds=docs_snippets_extra_cmds,
-        upload_coverage=False,
         run_mypy=False,
     ),
     PackageSpec(
@@ -342,7 +338,6 @@ PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     PackageSpec(
         "examples/hacker_news",
         env_vars=["SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER", "SNOWFLAKE_PASSWORD"],
-        upload_coverage=False,
         unsupported_python_versions=[
             # dependency on dagster-dbt
             AvailablePythonVersion.V3_6,
@@ -351,7 +346,6 @@ PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     PackageSpec(
         "examples/hacker_news_assets",
         env_vars=["SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER", "SNOWFLAKE_PASSWORD"],
-        upload_coverage=False,
         unsupported_python_versions=[
             # dependency on dagster-dbt
             AvailablePythonVersion.V3_6,

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -329,7 +329,7 @@ PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         run_mypy=False,
     ),
     PackageSpec(
-        "examples/ge-example",
+        "examples/ge_example",
         unsupported_python_versions=[
             # dependency on dagster-ge
             AvailablePythonVersion.V3_6,

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -306,9 +306,20 @@ PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         upload_coverage=False,
     ),
     PackageSpec(
+        "examples/bollinger",
+        unsupported_python_versions=[
+            # dependency on dagster-pandera
+            AvailablePythonVersion.V3_6,
+        ]
+    ),
+    PackageSpec(
         "examples/dbt_example",
         pytest_extra_cmds=dbt_example_extra_cmds,
         upload_coverage=False,
+        unsupported_python_versions=[
+            # dependency on dagster-dbt
+            AvailablePythonVersion.V3_6,
+        ]
     ),
     PackageSpec(
         "examples/deploy_docker",
@@ -322,17 +333,32 @@ PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         run_mypy=False,
     ),
     PackageSpec(
-        "examples/hacker_news_assets",
-        env_vars=["SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER", "SNOWFLAKE_PASSWORD"],
-        upload_coverage=False,
+        "examples/ge-example",
+        unsupported_python_versions=[
+            # dependency on dagster-ge
+            AvailablePythonVersion.V3_6,
+        ],
     ),
     PackageSpec(
         "examples/hacker_news",
         env_vars=["SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER", "SNOWFLAKE_PASSWORD"],
         upload_coverage=False,
+        unsupported_python_versions=[
+            # dependency on dagster-dbt
+            AvailablePythonVersion.V3_6,
+        ],
     ),
-    PackageSpec("python_modules/dagit", pytest_extra_cmds=dagit_extra_cmds),
+    PackageSpec(
+        "examples/hacker_news_assets",
+        env_vars=["SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER", "SNOWFLAKE_PASSWORD"],
+        upload_coverage=False,
+        unsupported_python_versions=[
+            # dependency on dagster-dbt
+            AvailablePythonVersion.V3_6,
+        ],
+    ),
     PackageSpec("python_modules/automation"),
+    PackageSpec("python_modules/dagit", pytest_extra_cmds=dagit_extra_cmds),
     PackageSpec(
         "python_modules/dagster",
         pytest_extra_cmds=dagster_extra_cmds,


### PR DESCRIPTION
### Summary & Motivation

Fixes ongoing BK issues on master. Previously examples were only tested on 3.8 on master, now they're tested on all versions, so 3.6 tests were failing if they used a 3.6-incompatibile dependency.

### How I Tested These Changes

BK