### PR TITLE
Load all code artifacts on grpc server startup, not just pipelines/jobs

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/repository_definition.py
@@ -405,6 +405,15 @@ class RepositoryData(ABC):
     def get_source_assets_by_key(self) -> Mapping[AssetKey, SourceAsset]:
         return {}
 
+    def load_all_definitions(self):
+        # force load of all lazy constructed code artifacts
+        self.get_all_pipelines()
+        self.get_all_jobs()
+        self.get_all_partition_sets()
+        self.get_all_schedules()
+        self.get_all_sensors()
+        self.get_source_assets_by_key()
+
 
 T = TypeVar("T")
 Resolvable = Callable[[], T]
@@ -1051,6 +1060,10 @@ class RepositoryDefinition:
     @property
     def description(self) -> Optional[str]:
         return self._description
+
+    def load_all_definitions(self):
+        # force load of all lazy constructed code artifacts
+        self._repository_data.load_all_definitions()
 
     @property
     def pipeline_names(self) -> List[str]:

--- a/python_modules/dagster/dagster/grpc/server.py
+++ b/python_modules/dagster/dagster/grpc/server.py
@@ -111,8 +111,10 @@ class LoadedRepositories:
                 entry_point=entry_point,
             )
             repo_def = recon_repo.get_definition()
-            # force load of all lazy constructed jobs/pipelines
-            repo_def.get_all_pipelines()
+            # force load of all lazy constructed code artifacts to prevent
+            # any thread-safety issues loading them later on when serving
+            # definitions from multiple threads
+            repo_def.load_all_definitions()
 
             self._code_pointers_by_repo_name[repo_def.name] = pointer
             self._recon_repos_by_name[repo_def.name] = recon_repo

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
@@ -82,13 +82,14 @@ def test_repository_data_can_reload_without_restarting(workspace_process_context
     request_context = workspace_process_context.create_request_context()
     repo_location = request_context.get_repository_location("test")
     repo = repo_location.get_repository("bar_repo")
-    # get_all_pipelines called on server init then on repository load, so starts at 2
+    # get_all_pipelines called on server init twice, then on repository load, so starts at 3
     # this is a janky test
-    assert repo.has_pipeline("foo_2")
+    assert repo.has_pipeline("foo_3")
     assert not repo.has_pipeline("foo_1")
+    assert not repo.has_pipeline("foo_2")
 
-    external_pipeline = repo.get_full_external_pipeline("foo_2")
-    assert external_pipeline.has_solid_invocation("do_something_2")
+    external_pipeline = repo.get_full_external_pipeline("foo_3")
+    assert external_pipeline.has_solid_invocation("do_something_3")
 
     # Reloading the location changes the pipeline without needing
     # to restart the server process
@@ -96,11 +97,11 @@ def test_repository_data_can_reload_without_restarting(workspace_process_context
     request_context = workspace_process_context.create_request_context()
     repo_location = request_context.get_repository_location("test")
     repo = repo_location.get_repository("bar_repo")
-    assert repo.has_pipeline("foo_3")
-    assert not repo.has_pipeline("foo_2")
+    assert repo.has_pipeline("foo_4")
+    assert not repo.has_pipeline("foo_3")
 
-    external_pipeline = repo.get_full_external_pipeline("foo_3")
-    assert external_pipeline.has_solid_invocation("do_something_3")
+    external_pipeline = repo.get_full_external_pipeline("foo_4")
+    assert external_pipeline.has_solid_invocation("do_something_4")
 
 
 def test_custom_repo_select_only_job():


### PR DESCRIPTION
Summary:
User reported a race condition with partition set loading - we have logic in place to prevent this for jobs/pipelines, but not for the other code artifacts. Fix that by adding a new method that pulls in any lazy code artifacts at grpc server startup time.

Test Plan:
Add log outputs to validate that partition sets are loaded as soon as the grpc server is started up

### Summary & Motivation

### How I Tested These Changes
