### PR TITLE
Raise error upon incomplete graph-backed asset subset

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_all_snapshot_ids.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_all_snapshot_ids.py
@@ -21825,7 +21825,7 @@ snapshots['test_all_snapshot_ids 29'] = '''{
       }
     ]
   },
-  "description": null,
+  "description": "",
   "graph_def_name": "foo_job",
   "lineage_snapshot": null,
   "mode_def_snaps": [
@@ -23175,7 +23175,7 @@ snapshots['test_all_snapshot_ids 3'] = '''{
   "tags": {}
 }'''
 
-snapshots['test_all_snapshot_ids 30'] = '046bc61b12af12c19ec9f2f0e9bbf886b727a1ea'
+snapshots['test_all_snapshot_ids 30'] = '8d28524540c0b45084583be03e12091ad9ab1b5a'
 
 snapshots['test_all_snapshot_ids 31'] = '''{
   "__class__": "PipelineSnapshot",
@@ -24478,7 +24478,7 @@ snapshots['test_all_snapshot_ids 31'] = '''{
       }
     ]
   },
-  "description": null,
+  "description": "",
   "graph_def_name": "hanging_graph_asset_job",
   "lineage_snapshot": null,
   "mode_def_snaps": [
@@ -24773,7 +24773,7 @@ snapshots['test_all_snapshot_ids 31'] = '''{
   "tags": {}
 }'''
 
-snapshots['test_all_snapshot_ids 32'] = 'af958a0fa4e0ec4c58474480fd769f01d9706833'
+snapshots['test_all_snapshot_ids 32'] = '049a7c852520e5ba22784c40172825640d0b2ef2'
 
 snapshots['test_all_snapshot_ids 33'] = '''{
   "__class__": "PipelineSnapshot",

--- a/python_modules/dagster/dagster/core/asset_defs/asset_group.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_group.py
@@ -162,7 +162,7 @@ class AssetGroup:
     def build_job(
         self,
         name: str,
-        selection: Optional[Union[str, List[str], FrozenSet[AssetKey]]] = None,
+        selection: Optional[Union[str, List[str]]] = None,
         executor_def: Optional[ExecutorDefinition] = None,
         tags: Optional[Dict[str, Any]] = None,
         description: Optional[str] = None,
@@ -209,7 +209,8 @@ class AssetGroup:
 
         check.str_param(name, "name")
         check.opt_inst_param(_asset_selection_data, "_asset_selection_data", AssetSelectionData)
-        selected_asset_keys = {}
+
+        selected_asset_keys: FrozenSet[AssetKey] = frozenset()
         if isinstance(selection, str):
             selected_asset_keys = parse_asset_selection(self.assets, [selection])
         elif isinstance(selection, list):
@@ -222,7 +223,8 @@ class AssetGroup:
         executor_def = check.opt_inst_param(
             executor_def, "executor_def", ExecutorDefinition, self.executor_def
         )
-        description = check.opt_str_param(description, "description")
+        description = check.opt_str_param(description, "description", "")
+        tags = check.opt_dict_param(tags, "tags", key_type=str)
 
         return build_asset_selection_job(
             name=name,

--- a/python_modules/dagster/dagster/core/asset_defs/asset_group.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_group.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from importlib import import_module
 from types import ModuleType
 from typing import (
-    AbstractSet,
     Any,
     Dict,
     FrozenSet,
@@ -17,9 +16,7 @@ from typing import (
     Optional,
     Sequence,
     Set,
-    Tuple,
     Union,
-    cast,
 )
 
 import dagster._check as check

--- a/python_modules/dagster/dagster/core/asset_defs/assets_job.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets_job.py
@@ -1,6 +1,7 @@
 import itertools
 import warnings
 from typing import (
+    TYPE_CHECKING,
     AbstractSet,
     Any,
     Dict,
@@ -45,6 +46,9 @@ from dagster.utils.merger import merge_dicts
 from .asset_partitions import get_upstream_partitions_for_partition_range
 from .assets import AssetsDefinition
 from .source_asset import SourceAsset
+
+if TYPE_CHECKING:
+    from dagster.core.asset_defs import AssetGroup
 
 
 @experimental
@@ -92,6 +96,8 @@ def build_assets_job(
     Returns:
         JobDefinition: A job that materializes the given assets.
     """
+    from dagster.core.asset_defs import AssetGroup
+
     check.str_param(name, "name")
     check.sequence_param(assets, "assets", of_type=AssetsDefinition)
     check.opt_sequence_param(

--- a/python_modules/dagster/dagster/core/asset_defs/assets_job.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets_job.py
@@ -1,7 +1,6 @@
 import itertools
 import warnings
 from typing import (
-    TYPE_CHECKING,
     AbstractSet,
     Any,
     Dict,
@@ -46,9 +45,6 @@ from dagster.utils.merger import merge_dicts
 from .asset_partitions import get_upstream_partitions_for_partition_range
 from .assets import AssetsDefinition
 from .source_asset import SourceAsset
-
-if TYPE_CHECKING:
-    from dagster.core.asset_defs import AssetGroup
 
 
 @experimental
@@ -96,7 +92,6 @@ def build_assets_job(
     Returns:
         JobDefinition: A job that materializes the given assets.
     """
-    from dagster.core.asset_defs import AssetGroup
 
     check.str_param(name, "name")
     check.sequence_param(assets, "assets", of_type=AssetsDefinition)

--- a/python_modules/dagster/dagster/core/asset_defs/assets_job.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets_job.py
@@ -136,8 +136,7 @@ def build_assets_job(
         tags=tags,
         executor_def=executor_def,
         asset_layer=AssetLayer.from_graph_and_assets_node_mapping(
-            graph,
-            assets_defs_by_node_handle,
+            graph, assets_defs_by_node_handle, source_assets
         ),
         _asset_selection_data=_asset_selection_data,
     )

--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -1,7 +1,9 @@
+import warnings
 from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
+    Any,
     Callable,
     Dict,
     FrozenSet,
@@ -14,16 +16,20 @@ from typing import (
     Set,
     Tuple,
     Union,
+    cast,
 )
 
 import dagster._check as check
 from dagster.core.definitions.events import AssetKey
 from dagster.core.selector.subset_selector import AssetSelectionData
+from dagster.utils.backcompat import ExperimentalWarning
 
-from ..errors import DagsterInvalidSubsetError
+from ..errors import DagsterInvalidDefinitionError, DagsterInvalidSubsetError
 from .dependency import NodeHandle, NodeInputHandle, NodeOutputHandle
+from .executor_definition import ExecutorDefinition
 from .graph_definition import GraphDefinition
 from .node_definition import NodeDefinition
+from .resource_definition import ResourceDefinition
 
 if TYPE_CHECKING:
     from dagster.core.asset_defs import AssetGroup, AssetsDefinition, SourceAsset
@@ -492,45 +498,89 @@ class AssetLayer:
 
 
 def build_asset_selection_job(
-    job_to_subselect: "JobDefinition",
-    asset_selection: FrozenSet[AssetKey],
-    asset_layer: AssetLayer,
-    asset_selection_data: AssetSelectionData,
-) -> "JobDefinition":
-    from ..asset_defs.asset_group import build_resource_defs
-    from ..asset_defs.assets_job import build_assets_job
+    name: str,
+    assets: Sequence["AssetsDefinition"],
+    source_assets: Sequence[Union["AssetsDefinition", "SourceAsset"]],
+    executor_def: ExecutorDefinition,
+    resource_defs: Dict[str, ResourceDefinition],
+    description: str,
+    tags: Dict[str, Any],
+    asset_selection: Optional[FrozenSet[AssetKey]],
+    asset_selection_data: Optional[AssetSelectionData] = None,
+):
+    from dagster.core.asset_defs import build_assets_job
 
-    check.invariant(
-        asset_layer._assets_defs != None,  # pylint:disable=protected-access
-        "Asset layer must have _asset_defs argument defined",
-    )
+    if asset_selection:
+        included_assets, excluded_assets = _subset_assets_defs(
+            assets, source_assets, asset_selection
+        )
+        resource_defs = _build_resource_defs(resource_defs, excluded_assets)
+    else:
+        included_assets = cast(List["AssetsDefinition"], assets)
+        # Call to list(...) serves as a copy constructor, so that we don't
+        # accidentally add to the original list
+        excluded_assets = list(source_assets)
 
-    included_assets: List["AssetsDefinition"] = []
-    excluded_assets: List["AssetsDefinition"] = []
-    for assets_def in asset_layer._assets_defs:  # pylint:disable=protected-access
-        if any([asset_key in asset_selection for asset_key in assets_def.asset_keys]):
-            # For now, the asset selection provided must select all assets in each
-            # AssetsDefinition (i.e. all assets outputted from a graph-backed asset).
-            # Subsetting a graph-backed asset is a future feature.
-            if not all(
-                [asset_key in asset_selection for asset_key in assets_def.asset_keys],
-            ):
-                raise DagsterInvalidSubsetError(
-                    f"Asset selection provided must contain all assets outputted from {assets_def.node_def.name}"
-                )
-            included_assets.append(assets_def)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=ExperimentalWarning)
+        asset_job = build_assets_job(
+            name=name,
+            assets=included_assets,
+            source_assets=excluded_assets,
+            resource_defs=resource_defs,
+            executor_def=executor_def,
+            description=description,
+            tags=tags,
+            _asset_selection_data=asset_selection_data,
+        )
+
+    return asset_job
+
+
+def _subset_assets_defs(
+    assets: Sequence["AssetsDefinition"],
+    source_assets: Sequence[Union["AssetsDefinition", "SourceAsset"]],
+    selected_asset_keys: AbstractSet[AssetKey],
+) -> Tuple[Sequence["AssetsDefinition"], Sequence["AssetsDefinition"]]:
+    """Given a list of asset key selection queries, generate a set of AssetsDefinition objects
+    representing the included/excluded definitions.
+    """
+    included_assets: Set[AssetsDefinition] = set()
+    excluded_assets: Set[AssetsDefinition] = set()
+
+    for asset in assets:
+        # intersection
+        selected_subset = selected_asset_keys & asset.asset_keys
+        # all assets in this def are selected
+        if selected_subset == asset.asset_keys:
+            included_assets.add(asset)
+        # no assets in this def are selected
+        elif len(selected_subset) == 0:
+            excluded_assets.add(asset)
+        elif asset.can_subset:
+            # subset of the asset that we want
+            subset_asset = asset.subset_for(selected_asset_keys)
+            included_assets.add(subset_asset)
+            # subset of the asset that we don't want
+            excluded_assets.add(asset.subset_for(asset.asset_keys - subset_asset.asset_keys))
         else:
-            excluded_assets.append(assets_def)
+            raise DagsterInvalidDefinitionError(
+                f"When building job, the AssetsDefinition '{asset.node_def.name}' "
+                f"contains asset keys {sorted(list(asset.asset_keys))}, but "
+                f"attempted to select only {sorted(list(selected_subset))}. "
+                "This AssetsDefinition does not support subsetting. Please select all "
+                "asset keys produced by this asset."
+            )
 
-    excluded_assets += asset_layer._source_asset_defs  # pylint:disable=protected-access
+    all_excluded_assets = list(excluded_assets) + source_assets
 
-    return build_assets_job(
-        name=job_to_subselect.name,
-        assets=included_assets,
-        source_assets=excluded_assets,
-        resource_defs=build_resource_defs(job_to_subselect.resource_defs, excluded_assets),
-        executor_def=job_to_subselect.executor_def,
-        description=job_to_subselect.description,
-        tags=job_to_subselect.tags,
-        _asset_selection_data=asset_selection_data,
-    )
+    return list(included_assets), all_excluded_assets
+
+
+def _build_resource_defs(resource_defs, source_assets):
+    from dagster.core.asset_defs.assets_job import build_root_manager, build_source_assets_by_key
+
+    return {
+        **resource_defs,
+        **{"root_manager": build_root_manager(build_source_assets_by_key(source_assets))},
+    }

--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -26,7 +26,7 @@ from .graph_definition import GraphDefinition
 from .node_definition import NodeDefinition
 
 if TYPE_CHECKING:
-    from dagster.core.asset_defs import AssetGroup, AssetsDefinition
+    from dagster.core.asset_defs import AssetGroup, AssetsDefinition, SourceAsset
     from dagster.core.execution.context.output import OutputContext
 
     from .job_definition import JobDefinition
@@ -352,7 +352,10 @@ class AssetLayer:
         asset_deps: Optional[Mapping[AssetKey, AbstractSet[AssetKey]]] = None,
         dependency_node_handles_by_asset_key: Optional[Mapping[AssetKey, Set[NodeHandle]]] = None,
         assets_defs: Optional[List["AssetsDefinition"]] = None,
+        source_asset_defs: Optional[Sequence[Union["SourceAsset", "AssetsDefinition"]]] = None,
     ):
+        from dagster.core.asset_defs import AssetsDefinition, SourceAsset
+
         self._asset_keys_by_node_input_handle = check.opt_dict_param(
             asset_keys_by_node_input_handle,
             "asset_keys_by_node_input_handle",
@@ -375,6 +378,9 @@ class AssetLayer:
             value_type=Set,
         )
         self._assets_defs = check.opt_list_param(assets_defs, "assets_defs")
+        self._source_asset_defs = check.opt_list_param(
+            source_asset_defs, "source_assets", of_type=(SourceAsset, AssetsDefinition)
+        )
 
         # keep an index from node handle to all keys expected to be generated in that node
         self._asset_keys_by_node_handle: Dict[NodeHandle, Set[AssetKey]] = defaultdict(set)
@@ -397,6 +403,7 @@ class AssetLayer:
     def from_graph_and_assets_node_mapping(
         graph_def: GraphDefinition,
         assets_defs_by_node_handle: Mapping[NodeHandle, "AssetsDefinition"],
+        source_assets: Optional[Sequence[Union["SourceAsset", "AssetsDefinition"]]] = None,
     ) -> "AssetLayer":
         """
         Generate asset info from a GraphDefinition and a mapping from nodes in that graph to the
@@ -448,6 +455,7 @@ class AssetLayer:
                 graph_def, assets_defs_by_node_handle
             ),
             assets_defs=[assets_def for assets_def in assets_defs_by_node_handle.values()],
+            source_asset_defs=source_assets,
         )
 
     @property
@@ -513,6 +521,8 @@ def build_asset_selection_job(
             included_assets.append(assets_def)
         else:
             excluded_assets.append(assets_def)
+
+    excluded_assets += asset_layer._source_asset_defs  # pylint:disable=protected-access
 
     return build_assets_job(
         name=job_to_subselect.name,

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -326,10 +326,21 @@ class JobDefinition(PipelineDefinition):
             asset_selection=asset_selection,
             parent_job_def=self,
         )
+
+        check.invariant(
+            self.asset_layer._assets_defs != None,  # pylint:disable=protected-access
+            "Asset layer must have _asset_defs argument defined",
+        )
+
         new_job = build_asset_selection_job(
-            job_to_subselect=self,
+            name=self.name,
+            assets=self.asset_layer._assets_defs,
+            source_assets=self.asset_layer._source_asset_defs,
+            executor_def=self.executor_def,
+            resource_defs=self.resource_defs,
+            description=self.description,
+            tags=self.tags,
             asset_selection=asset_selection,
-            asset_layer=self.asset_layer,
             asset_selection_data=asset_selection_data,
         )
         return new_job

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -334,8 +334,8 @@ class JobDefinition(PipelineDefinition):
 
         new_job = build_asset_selection_job(
             name=self.name,
-            assets=self.asset_layer._assets_defs,
-            source_assets=self.asset_layer._source_asset_defs,
+            assets=self.asset_layer._assets_defs,  # pylint:disable=protected-access
+            source_assets=self.asset_layer._source_asset_defs,  # pylint:disable=protected-access
             executor_def=self.executor_def,
             resource_defs=self.resource_defs,
             description=self.description,

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -1171,7 +1171,7 @@ def test_raise_error_on_incomplete_graph_asset_subset():
     ).build_job("job")
 
     with instance_for_test() as instance:
-        with pytest.raises(DagsterInvalidSubsetError, match="complicated_graph"):
+        with pytest.raises(DagsterInvalidDefinitionError, match="complicated_graph"):
             job.execute_in_process(instance=instance, asset_selection=[AssetKey("comments_table")])
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -1173,3 +1173,31 @@ def test_raise_error_on_incomplete_graph_asset_subset():
     with instance_for_test() as instance:
         with pytest.raises(DagsterInvalidSubsetError, match="complicated_graph"):
             job.execute_in_process(instance=instance, asset_selection=[AssetKey("comments_table")])
+
+
+def test_subset_with_source_asset():
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            pass
+
+        def load_input(self, context):
+            return 5
+
+    @io_manager
+    def the_manager():
+        return MyIOManager()
+
+    my_source_asset = SourceAsset(key=AssetKey("my_source_asset"), io_manager_key="the_manager")
+
+    @asset
+    def my_derived_asset(my_source_asset):
+        return my_source_asset + 4
+
+    source_asset_job = AssetGroup(
+        assets=[my_derived_asset],
+        source_assets=[my_source_asset],
+        resource_defs={"the_manager": the_manager},
+    ).build_job("source_asset_job")
+
+    result = source_asset_job.execute_in_process(asset_selection=[AssetKey("my_derived_asset")])
+    assert result.success


### PR DESCRIPTION
For 0.15.0, asset selections provided in Dagit and `execute_in_process` must subselect all assets from the `AssetsDefinition` instance if any of its assets are selected.

E.g., a graph-backed asset that outputs 2 assets will raise an error if only 1 of the assets is selected for materialization in Dagit.

This PR raises an error when an invalid subset is provided and confirms that an appropriate error is raised in terminal and Dagit.

<img width="1324" alt="image" src="https://user-images.githubusercontent.com/29110579/170115661-ecf3f4e1-0720-47d6-9aff-90ba7daac1ef.png">
