### PR TITLE
[dagit] Use dialog for multiple schedules/sensors in left nav

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/ScheduleAndSensorDialog.tsx
+++ b/js_modules/dagit/packages/core/src/nav/ScheduleAndSensorDialog.tsx
@@ -1,0 +1,128 @@
+import {Box, Button, Dialog, DialogFooter, Subheading, Table} from '@dagster-io/ui';
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+
+import {ScheduleSwitch} from '../schedules/ScheduleSwitch';
+import {humanCronString} from '../schedules/humanCronString';
+import {ScheduleSwitchFragment} from '../schedules/types/ScheduleSwitchFragment';
+import {SensorSwitch} from '../sensors/SensorSwitch';
+import {SensorSwitchFragment} from '../sensors/types/SensorSwitchFragment';
+import {RepoAddress} from '../workspace/types';
+import {workspacePathFromAddress} from '../workspace/workspacePath';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  repoAddress: RepoAddress;
+  schedules: ScheduleSwitchFragment[];
+  sensors: SensorSwitchFragment[];
+  showSwitch?: boolean;
+}
+
+export const ScheduleAndSensorDialog = ({
+  isOpen,
+  onClose,
+  repoAddress,
+  schedules,
+  sensors,
+  showSwitch,
+}: Props) => {
+  const scheduleCount = schedules.length;
+  const sensorCount = sensors.length;
+
+  const dialogTitle =
+    scheduleCount && sensorCount
+      ? 'Schedules and sensors'
+      : scheduleCount
+      ? 'Schedules'
+      : 'Sensors';
+
+  return (
+    <Dialog
+      title={dialogTitle}
+      canOutsideClickClose
+      canEscapeKeyClose
+      isOpen={isOpen}
+      style={{width: '50vw', minWidth: '600px', maxWidth: '800px'}}
+      onClose={onClose}
+    >
+      <Box padding={{bottom: 12}}>
+        {scheduleCount ? (
+          <>
+            {sensorCount ? (
+              <Box padding={{vertical: 16, horizontal: 24}}>
+                <Subheading>Schedules ({scheduleCount})</Subheading>
+              </Box>
+            ) : null}
+            <Table>
+              <thead>
+                <tr>
+                  {showSwitch ? <th style={{width: '80px'}} /> : null}
+                  <th>Schedule name</th>
+                  <th>Schedule</th>
+                </tr>
+              </thead>
+              <tbody>
+                {schedules.map((schedule) => (
+                  <tr key={schedule.name}>
+                    {showSwitch ? (
+                      <td>
+                        <ScheduleSwitch repoAddress={repoAddress} schedule={schedule} />
+                      </td>
+                    ) : null}
+                    <td>
+                      <Link
+                        to={workspacePathFromAddress(repoAddress, `/schedules/${schedule.name}`)}
+                      >
+                        {schedule.name}
+                      </Link>
+                    </td>
+                    <td>{humanCronString(schedule.cronSchedule)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </>
+        ) : null}
+        {sensorCount ? (
+          <>
+            {scheduleCount ? (
+              <Box padding={{vertical: 16, horizontal: 24}}>
+                <Subheading>Sensors ({sensorCount})</Subheading>
+              </Box>
+            ) : null}
+            <Table>
+              <thead>
+                <tr>
+                  {showSwitch ? <th style={{width: '80px'}} /> : null}
+                  <th>Sensor name</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sensors.map((sensor) => (
+                  <tr key={sensor.name}>
+                    {showSwitch ? (
+                      <td>
+                        <SensorSwitch repoAddress={repoAddress} sensor={sensor} />
+                      </td>
+                    ) : null}
+                    <td>
+                      <Link to={workspacePathFromAddress(repoAddress, `/sensors/${sensor.name}`)}>
+                        {sensor.name}
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </>
+        ) : null}
+      </Box>
+      <DialogFooter>
+        <Button intent="primary" onClick={onClose}>
+          OK
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  );
+};

--- a/js_modules/dagit/packages/core/src/nav/ScheduleOrSensorTag.tsx
+++ b/js_modules/dagit/packages/core/src/nav/ScheduleOrSensorTag.tsx
@@ -1,16 +1,4 @@
-import {
-  Box,
-  Button,
-  ButtonLink,
-  Colors,
-  DialogFooter,
-  Dialog,
-  Table,
-  Tag,
-  Subheading,
-  Tooltip,
-  FontFamily,
-} from '@dagster-io/ui';
+import {Box, ButtonLink, Colors, Tag, Tooltip, FontFamily} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
@@ -21,6 +9,8 @@ import {SensorSwitch} from '../sensors/SensorSwitch';
 import {SensorSwitchFragment} from '../sensors/types/SensorSwitchFragment';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
+
+import {ScheduleAndSensorDialog} from './ScheduleAndSensorDialog';
 
 export const ScheduleOrSensorTag: React.FC<{
   schedules: ScheduleSwitchFragment[];
@@ -41,13 +31,6 @@ export const ScheduleOrSensorTag: React.FC<{
         ? `View ${scheduleCount} schedules`
         : `View ${sensorCount} sensors`;
 
-    const dialogTitle =
-      scheduleCount && sensorCount
-        ? 'Schedules and sensors'
-        : scheduleCount
-        ? 'Schedules'
-        : 'Sensors';
-
     const icon = scheduleCount > 1 ? 'schedule' : 'sensors';
 
     return (
@@ -57,97 +40,14 @@ export const ScheduleOrSensorTag: React.FC<{
             {buttonText}
           </ButtonLink>
         </Tag>
-        <Dialog
-          title={dialogTitle}
-          canOutsideClickClose
-          canEscapeKeyClose
+        <ScheduleAndSensorDialog
           isOpen={open}
-          style={{width: '50vw', minWidth: '600px', maxWidth: '800px'}}
           onClose={() => setOpen(false)}
-        >
-          <Box padding={{bottom: 12}}>
-            {schedules.length ? (
-              <>
-                {sensors.length ? (
-                  <Box padding={{vertical: 16, horizontal: 24}}>
-                    <Subheading>Schedules ({schedules.length})</Subheading>
-                  </Box>
-                ) : null}
-                <Table>
-                  <thead>
-                    <tr>
-                      {showSwitch ? <th style={{width: '80px'}} /> : null}
-                      <th>Schedule name</th>
-                      <th>Schedule</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {schedules.map((schedule) => (
-                      <tr key={schedule.name}>
-                        {showSwitch ? (
-                          <td>
-                            <ScheduleSwitch repoAddress={repoAddress} schedule={schedule} />
-                          </td>
-                        ) : null}
-                        <td>
-                          <Link
-                            to={workspacePathFromAddress(
-                              repoAddress,
-                              `/schedules/${schedule.name}`,
-                            )}
-                          >
-                            {schedule.name}
-                          </Link>
-                        </td>
-                        <td>{humanCronString(schedule.cronSchedule)}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </Table>
-              </>
-            ) : null}
-            {sensors.length ? (
-              <>
-                {schedules.length ? (
-                  <Box padding={{vertical: 16, horizontal: 24}}>
-                    <Subheading>Sensors ({sensors.length})</Subheading>
-                  </Box>
-                ) : null}
-                <Table>
-                  <thead>
-                    <tr>
-                      {showSwitch ? <th style={{width: '80px'}} /> : null}
-                      <th>Sensor name</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sensors.map((sensor) => (
-                      <tr key={sensor.name}>
-                        {showSwitch ? (
-                          <td>
-                            <SensorSwitch repoAddress={repoAddress} sensor={sensor} />
-                          </td>
-                        ) : null}
-                        <td>
-                          <Link
-                            to={workspacePathFromAddress(repoAddress, `/sensors/${sensor.name}`)}
-                          >
-                            {sensor.name}
-                          </Link>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </Table>
-              </>
-            ) : null}
-          </Box>
-          <DialogFooter>
-            <Button intent="primary" onClick={() => setOpen(false)}>
-              OK
-            </Button>
-          </DialogFooter>
-        </Dialog>
+          repoAddress={repoAddress}
+          schedules={schedules}
+          sensors={sensors}
+          showSwitch={showSwitch}
+        />
       </>
     );
   }

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
@@ -88,16 +88,19 @@ const ROOT_WORKSPACE_QUERY = gql`
                 }
                 schedules {
                   id
+                  cronSchedule
                   mode
                   name
                   pipelineName
                   scheduleState {
                     id
+                    selectorId
                     status
                   }
                 }
                 sensors {
                   id
+                  jobOriginId
                   name
                   targets {
                     mode
@@ -105,6 +108,7 @@ const ROOT_WORKSPACE_QUERY = gql`
                   }
                   sensorState {
                     id
+                    selectorId
                     status
                   }
                 }

--- a/js_modules/dagit/packages/core/src/workspace/types/RootWorkspaceQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/RootWorkspaceQuery.ts
@@ -34,12 +34,14 @@ export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_l
 export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_scheduleState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   status: InstigationStatus;
 }
 
 export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules {
   __typename: "Schedule";
   id: string;
+  cronSchedule: string;
   mode: string;
   name: string;
   pipelineName: string;
@@ -55,12 +57,14 @@ export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_l
 export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors_sensorState {
   __typename: "InstigationState";
   id: string;
+  selectorId: string;
   status: InstigationStatus;
 }
 
 export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors {
   __typename: "Sensor";
   id: string;
+  jobOriginId: string;
   name: string;
   targets: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors_targets[] | null;
   sensorState: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors_sensorState;


### PR DESCRIPTION
### Summary & Motivation

Make some changes to Schedule/Sensor display in the left nav. This applies to both the flat list and the sectioned list.

- For single schedules, show the human cron string instead of the schedule name, as we do on the job page.

<img width="217" alt="Screen Shot 2022-05-25 at 10 13 58 AM" src="https://user-images.githubusercontent.com/2823852/170302689-c78dad6d-bcf3-45b5-a891-2fe4bb602a51.png">

- If a job has multiple schedules, multiple sensors, or at least one of both, use a `Dialog` to show the list of sensors/schedules when clicking the icon in the nav. This is the same behavior as the equivalent on a job page.
- Render a switch in the dialog list, allowing users to enable/disable schedules/sensors from this UI.

### How I Tested These Changes

- Verify that individual schedules now show a human cron string in the tooltip
- Verify that individual sensors are unaffected
- Force "needs dialog" to be true. Click on a schedule icon, verify that it opens the Dialog and renders the list of schedules.
- Use the switch in the dialog, verify that it enables/disables the schedule, and that the left nav icon updates accordingly.
