### PR TITLE
Disallow empty AssetKey

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -87,6 +87,9 @@ class AssetKey(NamedTuple("_AssetKey", [("path", List[str])])):
         else:
             path = list(check.sequence_param(path, "path", of_type=str))
 
+        check.invariant(
+            all(len(seg) > 0 for seg in path), "Asset key segments must be non-empty strings."
+        )
         return super(AssetKey, cls).__new__(cls, path=path)
 
     def __str__(self):

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_assets.py
@@ -1,10 +1,20 @@
+import pytest
+
 from dagster import AssetKey, AssetMaterialization, Output, job, op
+from dagster._check import CheckError
 from dagster.core.definitions.events import parse_asset_key_string
 from dagster.core.events.log import EventLogEntry
 from dagster.core.instance import DagsterInstance, InstanceRef
 from dagster.core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster.utils import file_relative_path
 from dagster.utils.test import copy_directory
+
+
+def test_invalid_asset_key():
+    with pytest.raises(CheckError):
+        AssetKey("")
+    with pytest.raises(CheckError):
+        AssetKey(["foo", "", "bar"])
 
 
 def test_structured_asset_key():


### PR DESCRIPTION
### Summary & Motivation

AssetKeys that are empty strings are currently not blocked by Dagster but cause crashes. This PR disallows them.

### How I Tested These Changes

Added some unit tests.
