### PR TITLE
Pass in engine rather than connection in SnowflakePandasTypeHandler

### DIFF
--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -49,7 +49,7 @@ class SnowflakePandasTypeHandler(DbTypeHandler[DataFrame]):
             with_uppercase_cols = obj.rename(str.upper, copy=False, axis="columns")
             with_uppercase_cols.to_sql(
                 table_slice.table,
-                con=con,
+                con=con.engine,
                 if_exists="append",
                 index=False,
                 method=pd_writer,

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -86,6 +86,7 @@ def emit_pandas_df(_):
 @op
 def read_pandas_df(df: pandas.DataFrame):
     assert set(df.columns) == {"foo", "quux"}
+    assert len(df.index) == 2
 
 
 snowflake_io_manager = build_snowflake_io_manager([SnowflakePandasTypeHandler()])


### PR DESCRIPTION
Summary:
A user reported that without this, the IO manager doesn't actually insert rows into the table, and that making this change fixes it. I can't reproduce that specific issue, but to_sql does appear to prefer an engine rather than a connection.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
