### PR TITLE
Remove unnecessary queries from Asset Details page

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
@@ -364,10 +364,6 @@ const ASSET_EVENTS_QUERY = gql`
     runId
     timestamp
     stepKey
-    stepStats {
-      endTime
-      startTime
-    }
     label
     description
     metadataEntries {

--- a/js_modules/dagit/packages/core/src/assets/types/AssetEventsQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetEventsQuery.ts
@@ -42,12 +42,6 @@ export interface AssetEventsQuery_assetOrError_Asset_assetObservations_runOrErro
 
 export type AssetEventsQuery_assetOrError_Asset_assetObservations_runOrError = AssetEventsQuery_assetOrError_Asset_assetObservations_runOrError_RunNotFoundError | AssetEventsQuery_assetOrError_Asset_assetObservations_runOrError_Run;
 
-export interface AssetEventsQuery_assetOrError_Asset_assetObservations_stepStats {
-  __typename: "RunStepStats";
-  endTime: number | null;
-  startTime: number | null;
-}
-
 export interface AssetEventsQuery_assetOrError_Asset_assetObservations_metadataEntries_PathMetadataEntry {
   __typename: "PathMetadataEntry";
   label: string;
@@ -213,7 +207,6 @@ export interface AssetEventsQuery_assetOrError_Asset_assetObservations {
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  stepStats: AssetEventsQuery_assetOrError_Asset_assetObservations_stepStats;
   label: string;
   description: string | null;
   metadataEntries: AssetEventsQuery_assetOrError_Asset_assetObservations_metadataEntries[];

--- a/js_modules/dagit/packages/core/src/assets/types/AssetObservationFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetObservationFragment.ts
@@ -33,12 +33,6 @@ export interface AssetObservationFragment_runOrError_Run {
 
 export type AssetObservationFragment_runOrError = AssetObservationFragment_runOrError_RunNotFoundError | AssetObservationFragment_runOrError_Run;
 
-export interface AssetObservationFragment_stepStats {
-  __typename: "RunStepStats";
-  endTime: number | null;
-  startTime: number | null;
-}
-
 export interface AssetObservationFragment_metadataEntries_PathMetadataEntry {
   __typename: "PathMetadataEntry";
   label: string;
@@ -204,7 +198,6 @@ export interface AssetObservationFragment {
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  stepStats: AssetObservationFragment_stepStats;
   label: string;
   description: string | null;
   metadataEntries: AssetObservationFragment_metadataEntries[];


### PR DESCRIPTION
Rolls a couple changes to limit expensive queries upon asset details page load:
- Asset events query was still fetching `stepStats` which was unused. This PR removes this field.
- The asset details page displays live information (e.g. in progress runs) about the asset. This information only exists if the asset is defined in code. Previously, we were doing fetches for this information for non-SDA assets. This PR now updates this information to only query and display for SDA assets.