### PR TITLE
Remove step stats query from AssetObservation

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
@@ -364,10 +364,6 @@ const ASSET_EVENTS_QUERY = gql`
     runId
     timestamp
     stepKey
-    stepStats {
-      endTime
-      startTime
-    }
     label
     description
     metadataEntries {

--- a/js_modules/dagit/packages/core/src/assets/types/AssetEventsQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetEventsQuery.ts
@@ -42,12 +42,6 @@ export interface AssetEventsQuery_assetOrError_Asset_assetObservations_runOrErro
 
 export type AssetEventsQuery_assetOrError_Asset_assetObservations_runOrError = AssetEventsQuery_assetOrError_Asset_assetObservations_runOrError_RunNotFoundError | AssetEventsQuery_assetOrError_Asset_assetObservations_runOrError_Run;
 
-export interface AssetEventsQuery_assetOrError_Asset_assetObservations_stepStats {
-  __typename: "RunStepStats";
-  endTime: number | null;
-  startTime: number | null;
-}
-
 export interface AssetEventsQuery_assetOrError_Asset_assetObservations_metadataEntries_PathMetadataEntry {
   __typename: "PathMetadataEntry";
   label: string;
@@ -213,7 +207,6 @@ export interface AssetEventsQuery_assetOrError_Asset_assetObservations {
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  stepStats: AssetEventsQuery_assetOrError_Asset_assetObservations_stepStats;
   label: string;
   description: string | null;
   metadataEntries: AssetEventsQuery_assetOrError_Asset_assetObservations_metadataEntries[];

--- a/js_modules/dagit/packages/core/src/assets/types/AssetObservationFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetObservationFragment.ts
@@ -33,12 +33,6 @@ export interface AssetObservationFragment_runOrError_Run {
 
 export type AssetObservationFragment_runOrError = AssetObservationFragment_runOrError_RunNotFoundError | AssetObservationFragment_runOrError_Run;
 
-export interface AssetObservationFragment_stepStats {
-  __typename: "RunStepStats";
-  endTime: number | null;
-  startTime: number | null;
-}
-
 export interface AssetObservationFragment_metadataEntries_PathMetadataEntry {
   __typename: "PathMetadataEntry";
   label: string;
@@ -204,7 +198,6 @@ export interface AssetObservationFragment {
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  stepStats: AssetObservationFragment_stepStats;
   label: string;
   description: string | null;
   metadataEntries: AssetObservationFragment_metadataEntries[];


### PR DESCRIPTION
This PR removes the expensive stepStats query from AssetObservations. This field is unused (was already previously removed for AssetMaterializations).