### PR TITLE
GCP:GCS:GCSFileManager Adds optional write keys

### DIFF
--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/file_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/file_manager.py
@@ -92,7 +92,8 @@ class GCSFileManager(FileManager):
         check.inst_param(data, "data", bytes)
         return self.write(io.BytesIO(data), mode="wb", key=key, ext=ext)
 
-    def write(self, file_obj, mode="wb", key: Optional[str] = str(uuid.uuid4()), ext=None):
+    def write(self, file_obj, mode="wb", key: Optional[str] = None, ext=None):
+        key = check.opt_str_param(key, "key", default=str(uuid.uuid4()))
         check_file_like_obj(file_obj)
         gcs_key = self.get_full_key(key + (("." + ext) if ext is not None else ""))
         bucket_obj = self._client.bucket(self._gcs_bucket)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/file_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/file_manager.py
@@ -87,7 +87,8 @@ class GCSFileManager(FileManager):
         with self.read(file_handle, mode="rb") as file_obj:
             return file_obj.read()
 
-    def write_data(self, data, key: Optional[str] = str(uuid.uuid4()), ext=None):
+    def write_data(self, data, key: Optional[str] = None, ext=None):
+        key = check.opt_str_param(key, "key", default=str(uuid.uuid4()))
         check.inst_param(data, "data", bytes)
         return self.write(io.BytesIO(data), mode="wb", key=key, ext=ext)
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/file_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/file_manager.py
@@ -87,12 +87,12 @@ class GCSFileManager(FileManager):
         with self.read(file_handle, mode="rb") as file_obj:
             return file_obj.read()
 
-    def write_data(self, data, key: Optional[str] = None, ext=None):
+    def write_data(self, data, ext=None, key: Optional[str] = None):
         key = check.opt_str_param(key, "key", default=str(uuid.uuid4()))
         check.inst_param(data, "data", bytes)
         return self.write(io.BytesIO(data), mode="wb", key=key, ext=ext)
 
-    def write(self, file_obj, mode="wb", key: Optional[str] = None, ext=None):
+    def write(self, file_obj, mode="wb", ext=None, key: Optional[str] = None):
         key = check.opt_str_param(key, "key", default=str(uuid.uuid4()))
         check_file_like_obj(file_obj)
         gcs_key = self.get_full_key(key + (("." + ext) if ext is not None else ""))

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/file_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/file_manager.py
@@ -1,6 +1,7 @@
 import io
 import uuid
 from contextlib import contextmanager
+from typing import Optional
 
 from google.cloud import storage  # type: ignore
 
@@ -86,13 +87,13 @@ class GCSFileManager(FileManager):
         with self.read(file_handle, mode="rb") as file_obj:
             return file_obj.read()
 
-    def write_data(self, data, ext=None):
+    def write_data(self, data, key: Optional[str] = str(uuid.uuid4()), ext=None):
         check.inst_param(data, "data", bytes)
-        return self.write(io.BytesIO(data), mode="wb", ext=ext)
+        return self.write(io.BytesIO(data), mode="wb", key=key, ext=ext)
 
-    def write(self, file_obj, mode="wb", ext=None):
+    def write(self, file_obj, mode="wb", key: Optional[str] = str(uuid.uuid4()), ext=None):
         check_file_like_obj(file_obj)
-        gcs_key = self.get_full_key(str(uuid.uuid4()) + (("." + ext) if ext is not None else ""))
+        gcs_key = self.get_full_key(key + (("." + ext) if ext is not None else ""))
         bucket_obj = self._client.bucket(self._gcs_bucket)
         bucket_obj.blob(gcs_key).upload_from_file(file_obj)
         return GCSFileHandle(self._gcs_bucket, gcs_key)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_gcs_file_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_gcs_file_manager.py
@@ -23,7 +23,7 @@ def test_gcs_file_manager_write():
 
     assert gcs_mock.bucket().blob().upload_from_file.call_count == 1
 
-    file_handle = file_manager.write_data(foo_bytes, key="test", ext="foo")
+    file_handle = file_manager.write_data(foo_bytes, ext="foo", key="test")
 
     assert isinstance(file_handle, GCSFileHandle)
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_gcs_file_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_gcs_file_manager.py
@@ -23,12 +23,13 @@ def test_gcs_file_manager_write():
 
     assert gcs_mock.bucket().blob().upload_from_file.call_count == 1
 
-    file_handle = file_manager.write_data(foo_bytes, ext="foo")
+    file_handle = file_manager.write_data(foo_bytes, key="test", ext="foo")
 
     assert isinstance(file_handle, GCSFileHandle)
 
     assert file_handle.gcs_bucket == "some-bucket"
     assert file_handle.gcs_key.startswith("some-key/")
+    assert file_handle.gcs_key.find("test") != -1
     assert file_handle.gcs_key[-4:] == ".foo"
 
     assert gcs_mock.bucket().blob().upload_from_file.call_count == 2


### PR DESCRIPTION
### Summary & Motivation

- This PR adds an optional `key` arg to `GCSFileManager.write` and `GCSFileManager.write_data` which, if provided, will be set as the GCS blob key.
- I was not satisfied with non-deterministic UUID4s as the only option for keys naming.

### How I Tested These Changes

- Added a true positive case to `dagster_gcp_tests` and tests pass.
