### PR TITLE
[dagit] Break apart LaunchpadSessionContainer

### DIFF
--- a/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
 import {getJSONForKey, useStateWithStorage} from '../hooks/useStateWithStorage';
+import {LaunchpadSessionContainerPartitionSetsFragment} from '../launchpad/types/LaunchpadSessionContainerPartitionSetsFragment';
+import {LaunchpadSessionContainerPipelineFragment} from '../launchpad/types/LaunchpadSessionContainerPipelineFragment';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
 
@@ -79,6 +81,24 @@ export function applyChangesToSession(
   };
 }
 
+export const createSingleSession = (initial: IExecutionSessionChanges = {}, key?: string) => {
+  return {
+    name: 'New Run',
+    runConfigYaml: '',
+    mode: null,
+    base: null,
+    needsRefresh: false,
+    solidSelection: null,
+    solidSelectionQuery: '*',
+    flattenGraphs: false,
+    tags: null,
+    runId: undefined,
+    ...initial,
+    configChangedSinceRun: false,
+    key: key || `s${Date.now()}`,
+  };
+};
+
 export function applyCreateSession(
   data: IStorageData,
   initial: IExecutionSessionChanges = {},
@@ -89,21 +109,7 @@ export function applyCreateSession(
     current: key,
     sessions: {
       ...data.sessions,
-      [key]: {
-        name: 'New Run',
-        runConfigYaml: '',
-        mode: null,
-        base: null,
-        needsRefresh: false,
-        solidSelection: null,
-        solidSelectionQuery: '*',
-        flattenGraphs: false,
-        tags: null,
-        runId: undefined,
-        ...initial,
-        configChangedSinceRun: false,
-        key,
-      },
+      [key]: createSingleSession(initial, key),
     },
     selectedExecutionType: data.selectedExecutionType,
   };
@@ -214,4 +220,31 @@ export const useInvalidateConfigsForRepo = () => {
   );
 
   return onSave;
+};
+
+export const useInitialDataForMode = (
+  pipeline: LaunchpadSessionContainerPipelineFragment,
+  partitionSets: LaunchpadSessionContainerPartitionSetsFragment,
+) => {
+  const {isJob, presets} = pipeline;
+  const partitionSetsForMode = partitionSets.results;
+
+  return React.useMemo(() => {
+    const presetsForMode = isJob ? (presets.length ? [presets[0]] : []) : presets;
+
+    if (presetsForMode.length === 1 && partitionSetsForMode.length === 0) {
+      return {
+        base: {presetName: presetsForMode[0].name, tags: null},
+        runConfigYaml: presetsForMode[0].runConfigYaml,
+      };
+    }
+
+    if (!presetsForMode.length && partitionSetsForMode.length === 1) {
+      return {
+        base: {partitionsSetName: partitionSetsForMode[0].name, partitionName: null, tags: null},
+      };
+    }
+
+    return {};
+  }, [isJob, partitionSetsForMode, presets]);
 };

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadManySessionsContainer.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadManySessionsContainer.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+import {
+  applyChangesToSession,
+  applyCreateSession,
+  IExecutionSessionChanges,
+  useExecutionSessionStorage,
+  useInitialDataForMode,
+} from '../app/ExecutionSessionStorage';
+import {RepoAddress} from '../workspace/types';
+
+import LaunchpadSessionContainer from './LaunchpadSessionContainer';
+import {LaunchpadTabs} from './LaunchpadTabs';
+import {LaunchpadSessionContainerPartitionSetsFragment} from './types/LaunchpadSessionContainerPartitionSetsFragment';
+import {LaunchpadSessionContainerPipelineFragment} from './types/LaunchpadSessionContainerPipelineFragment';
+
+interface Props {
+  pipeline: LaunchpadSessionContainerPipelineFragment;
+  partitionSets: LaunchpadSessionContainerPartitionSetsFragment;
+  repoAddress: RepoAddress;
+}
+
+export const LaunchpadManySessionsContainer = (props: Props) => {
+  const {pipeline, partitionSets, repoAddress} = props;
+
+  const initialDataForMode = useInitialDataForMode(pipeline, partitionSets);
+  const [data, onSave] = useExecutionSessionStorage(repoAddress, pipeline.name, initialDataForMode);
+
+  const onCreateSession = () => {
+    onSave(applyCreateSession(data, initialDataForMode));
+  };
+
+  const onSaveSession = (changes: IExecutionSessionChanges) => {
+    onSave(applyChangesToSession(data, data.current, changes));
+  };
+
+  const currentSession = data.sessions[data.current];
+
+  return (
+    <>
+      <LaunchpadTabs data={data} onCreate={onCreateSession} onSave={onSave} />
+      <LaunchpadSessionContainer
+        session={currentSession}
+        onSave={onSaveSession}
+        pipeline={pipeline}
+        partitionSets={partitionSets}
+        repoAddress={repoAddress}
+      />
+    </>
+  );
+};
+
+// eslint-disable-next-line import/no-default-export
+export default LaunchpadManySessionsContainer;

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
@@ -17,7 +17,7 @@ import {LaunchpadSessionError} from './LaunchpadSessionError';
 import {LaunchpadSessionLoading} from './LaunchpadSessionLoading';
 import {LaunchpadRootQuery, LaunchpadRootQueryVariables} from './types/LaunchpadRootQuery';
 
-const LaunchpadSessionContainer = React.lazy(() => import('./LaunchpadSessionContainer'));
+const LaunchpadManySessionsContainer = React.lazy(() => import('./LaunchpadManySessionsContainer'));
 
 export const LaunchpadRoot: React.FC<{repoAddress: RepoAddress}> = (props) => {
   const {repoAddress} = props;
@@ -114,7 +114,7 @@ const LaunchpadAllowedRoot: React.FC<Props> = (props) => {
 
   return (
     <React.Suspense fallback={<div />}>
-      <LaunchpadSessionContainer
+      <LaunchpadManySessionsContainer
         pipeline={pipelineOrError}
         partitionSets={partitionSetsOrError}
         repoAddress={repoAddress}

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSingleSessionContainer.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSingleSessionContainer.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+
+import {
+  createSingleSession,
+  IExecutionSessionChanges,
+  useInitialDataForMode,
+} from '../app/ExecutionSessionStorage';
+import {RepoAddress} from '../workspace/types';
+
+import LaunchpadSessionContainer from './LaunchpadSessionContainer';
+import {LaunchpadSessionContainerPartitionSetsFragment} from './types/LaunchpadSessionContainerPartitionSetsFragment';
+import {LaunchpadSessionContainerPipelineFragment} from './types/LaunchpadSessionContainerPipelineFragment';
+
+interface Props {
+  pipeline: LaunchpadSessionContainerPipelineFragment;
+  partitionSets: LaunchpadSessionContainerPartitionSetsFragment;
+  repoAddress: RepoAddress;
+}
+
+export const LaunchpadSingleSessionContainer = (props: Props) => {
+  const {pipeline, partitionSets, repoAddress} = props;
+
+  const initialDataForMode = useInitialDataForMode(pipeline, partitionSets);
+
+  const [session, saveSession] = React.useState(() => createSingleSession(initialDataForMode));
+  const onSaveSession = React.useCallback((changes: IExecutionSessionChanges) => {
+    saveSession((current) => ({...current, ...changes}));
+  }, []);
+
+  return (
+    <LaunchpadSessionContainer
+      session={session}
+      onSave={onSaveSession}
+      pipeline={pipeline}
+      partitionSets={partitionSets}
+      repoAddress={repoAddress}
+    />
+  );
+};


### PR DESCRIPTION
### Summary & Motivation

Break `LaunchpadSessionContainer` into two pieces:

- `LaunchpadManySessionsContainer`, which renders the launchpad tabs and tracks all session state in LocalStorage, as with the existing launchpad
- `LaunchpadSessionContainer`, which receives a session object and renders everything else

The new `LaunchpadSessionContainer` now knows nothing at all about LocalStorage, and can be used for one-off launchpads that can track session state locally to the component tree.

As an example, I have included `LaunchpadSingleSessionContainer`. I believe this may be directly usable by @smackesey for asset config.

### How I Tested These Changes

View Dagit with routing still using the many-session container. Verify that I can make changes to the editor, select ops, create and remove tabs, scaffold and remove config. Verify that tab state is maintained even after reloading the page.

Replace existing route with `LaunchpadSingleSessionContainer`. Verify that it renders properly, and that config changes are tracked correctly. Use scaffold/remove actions, verify behavior. Launch a run, verify that it is successful.
