### PR TITLE
[asset-resources] io manager defs on source assets

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_subset.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_subset.py
@@ -71,7 +71,4 @@ class TestSolidSelections(NonLaunchableGraphQLContextTestMatrix):
         error_msg = result.data["runConfigSchemaOrError"]["message"]
 
         assert "DagsterInvalidSubsetError" in error_msg
-        assert (
-            "Input 'some_input' of solid 'fail_subset' has no upstream output, no default value, and no dagster type loader."
-            in error_msg
-        )
+        assert "Input 'some_input' of solid 'fail_subset' has no way of being resolved" in error_msg

--- a/python_modules/dagster/dagster/core/asset_defs/assets_job.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets_job.py
@@ -100,6 +100,18 @@ def build_assets_job(
         config=None,
     )
 
+    # turn any AssetsDefinitions into SourceAssets
+    resolved_source_assets: List[SourceAsset] = []
+    for asset in source_assets or []:
+        if isinstance(asset, AssetsDefinition):
+            resolved_source_assets += asset.to_source_assets()
+        elif isinstance(asset, SourceAsset):
+            resolved_source_assets.append(asset)
+
+    asset_layer = AssetLayer.from_graph_and_assets_node_mapping(
+        graph, assets_defs_by_node_handle, resolved_source_assets
+    )
+
     all_resource_defs = dict(resource_defs)
     for asset_def in assets:
         for resource_key, resource_def in asset_def.resource_defs.items():
@@ -112,22 +124,25 @@ def build_assets_job(
                 )
             all_resource_defs[resource_key] = resource_def
 
-    # turn any AssetsDefinitions into SourceAssets
-    resolved_source_assets: List[SourceAsset] = []
-    for asset in source_assets or []:
-        if isinstance(asset, AssetsDefinition):
-            resolved_source_assets += asset.to_source_assets()
-        elif isinstance(asset, SourceAsset):
-            resolved_source_assets.append(asset)
+    required_io_manager_keys = set()
+    for source_asset in resolved_source_assets:
+        if not source_asset.io_manager_def:
+            required_io_manager_keys.add(source_asset.get_io_manager_key())
+        else:
+            all_resource_defs[source_asset.get_io_manager_key()] = source_asset.io_manager_def
+
+    for required_key in sorted(list(required_io_manager_keys)):
+        if required_key not in all_resource_defs:
+            raise DagsterInvalidDefinitionError(
+                f"Error when attempting to build job '{name}': source asset with key '{source_asset.key}' requires IO Manager for key '{source_asset.get_io_manager_key()}', but none was provided."
+            )
 
     return graph.to_job(
         resource_defs=merge_dicts({"io_manager": fs_asset_io_manager}, all_resource_defs),
         config=config or partitioned_config,
         tags=tags,
         executor_def=executor_def,
-        asset_layer=AssetLayer.from_graph_and_assets_node_mapping(
-            graph, assets_defs_by_node_handle, resolved_source_assets
-        ),
+        asset_layer=asset_layer,
         _asset_selection_data=_asset_selection_data,
     )
 

--- a/python_modules/dagster/dagster/core/asset_defs/source_asset.py
+++ b/python_modules/dagster/dagster/core/asset_defs/source_asset.py
@@ -10,6 +10,7 @@ from dagster.core.definitions.metadata import (
     normalize_metadata,
 )
 from dagster.core.definitions.partition import PartitionsDefinition
+from dagster.core.storage.io_manager import IOManagerDefinition
 
 
 class SourceAsset(
@@ -18,7 +19,8 @@ class SourceAsset(
         [
             ("key", AssetKey),
             ("metadata_entries", Sequence[Union[MetadataEntry, PartitionMetadataEntry]]),
-            ("io_manager_key", str),
+            ("io_manager_key", Optional[str]),
+            ("io_manager_def", Optional[IOManagerDefinition]),
             ("description", Optional[str]),
             ("partitions_def", Optional[PartitionsDefinition]),
         ],
@@ -29,7 +31,9 @@ class SourceAsset(
     Attributes:
         key (Union[AssetKey, Sequence[str], str]): The key of the asset.
         metadata_entries (List[MetadataEntry]): Metadata associated with the asset.
-        io_manager_key (str): The key for the IOManager that will be used to load the contents of
+        io_manager_key (Optional[str]): The key for the IOManager that will be used to load the contents of
+            the asset when it's used as an input to other assets inside a job.
+        io_manager_def (Optional[IOManagerDefinition]): The definition of the IOManager that will be used to load the contents of
             the asset when it's used as an input to other assets inside a job.
         description (Optional[str]): The description of the asset.
         partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
@@ -40,18 +44,23 @@ class SourceAsset(
         cls,
         key: CoerceableToAssetKey,
         metadata: Optional[MetadataUserInput] = None,
-        io_manager_key: str = "io_manager",
+        io_manager_key: Optional[str] = None,
+        io_manager_def: Optional[IOManagerDefinition] = None,
         description: Optional[str] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
     ):
 
+        key = AssetKey.from_coerceable(key)
         metadata = check.opt_dict_param(metadata, "metadata", key_type=str)
         metadata_entries = normalize_metadata(metadata, [], allow_invalid=True)
         return super().__new__(
             cls,
-            key=AssetKey.from_coerceable(key),
+            key=key,
             metadata_entries=metadata_entries,
-            io_manager_key=check.str_param(io_manager_key, "io_manager_key"),
+            io_manager_key=check.opt_str_param(io_manager_key, "io_manager_key"),
+            io_manager_def=check.opt_inst_param(
+                io_manager_def, "io_manager_def", IOManagerDefinition
+            ),
             description=check.opt_str_param(description, "description"),
             partitions_def=check.opt_inst_param(
                 partitions_def, "partitions_def", PartitionsDefinition
@@ -62,3 +71,9 @@ class SourceAsset(
     def metadata(self) -> MetadataMapping:
         # PartitionMetadataEntry (unstable API) case is unhandled
         return {entry.label: entry.entry_data for entry in self.metadata_entries}  # type: ignore
+
+    def get_io_manager_key(self) -> str:
+        if not self.io_manager_key and not self.io_manager_def:
+            return "io_manager"
+        source_asset_path = "__".join(self.key.path)
+        return self.io_manager_key or f"{source_asset_path}__io_manager"

--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -452,7 +452,7 @@ class AssetLayer:
         asset_info_by_output: Dict[NodeOutputHandle, AssetOutputInfo] = {}
         asset_deps: Dict[AssetKey, AbstractSet[AssetKey]] = {}
         io_manager_by_asset: Dict[AssetKey, str] = {
-            source_asset.key: source_asset.io_manager_key for source_asset in source_assets
+            source_asset.key: source_asset.get_io_manager_key() for source_asset in source_assets
         }
         for node_handle, assets_def in assets_defs_by_node_handle.items():
             asset_deps.update(assets_def.asset_deps)

--- a/python_modules/dagster/dagster/core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/core/definitions/dependency.py
@@ -33,6 +33,7 @@ from .output import OutputDefinition
 from .utils import DEFAULT_OUTPUT, struct_to_string, validate_tags
 
 if TYPE_CHECKING:
+    from .asset_layer import AssetLayer
     from .composition import MappedInputPlaceholder
     from .graph_definition import GraphDefinition
     from .node_definition import NodeDefinition
@@ -247,6 +248,7 @@ class Node:
         self,
         parent_handle: Optional["NodeHandle"] = None,
         outer_container: Optional["GraphDefinition"] = None,
+        asset_layer: Optional["AssetLayer"] = None,
     ) -> Iterator["ResourceRequirement"]:
         from .resource_requirement import InputManagerRequirement
 
@@ -254,7 +256,7 @@ class Node:
 
         if not self.is_graph:
             solid_def = self.definition.ensure_solid_def()
-            for requirement in solid_def.get_resource_requirements(cur_node_handle):
+            for requirement in solid_def.get_resource_requirements((cur_node_handle, asset_layer)):
                 # If requirement is a root input manager requirement, but the corresponding node has an upstream output, then ignore the requirement.
                 if (
                     isinstance(requirement, InputManagerRequirement)
@@ -270,7 +272,7 @@ class Node:
         else:
             graph_def = self.definition.ensure_graph_def()
             for node in graph_def.node_dict.values():
-                yield from node.get_resource_requirements(cur_node_handle, graph_def)
+                yield from node.get_resource_requirements(cur_node_handle, graph_def, asset_layer)
 
 
 class NodeHandleSerializer(DefaultNamedTupleSerializer):

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -738,9 +738,11 @@ class GraphDefinition(NodeDefinition):
     def is_subselected(self) -> bool:
         return False
 
-    def get_resource_requirements(self) -> Iterator[ResourceRequirement]:
+    def get_resource_requirements(
+        self, asset_layer: Optional["AssetLayer"] = None
+    ) -> Iterator[ResourceRequirement]:
         for node in self.node_dict.values():
-            yield from node.get_resource_requirements(outer_container=self)
+            yield from node.get_resource_requirements(outer_container=self, asset_layer=asset_layer)
 
         for dagster_type in self.all_dagster_types():
             yield from dagster_type.get_resource_requirements()

--- a/python_modules/dagster/dagster/core/definitions/hook_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/hook_invocation.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, List, Optional
 import dagster._check as check
 
 from ..execution.context.hook import BoundHookContext, UnboundHookContext
+from .resource_requirement import ensure_requirements_satisfied
 
 if TYPE_CHECKING:
     from ..events import DagsterEvent
@@ -21,8 +22,9 @@ def hook_invocation_result(
 
     # Validate that all required resources are provided in the context
     # pylint: disable=protected-access
-    for requirement in hook_def.get_resource_requirements():
-        requirement.requirement_satisfied(hook_context._resource_defs)
+    ensure_requirements_satisfied(
+        hook_context._resource_defs, list(hook_def.get_resource_requirements())
+    )
 
     bound_context = BoundHookContext(
         hook_def=hook_def,

--- a/python_modules/dagster/dagster/core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/node_definition.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import TYPE_CHECKING, List, Mapping, Sequence
+from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence
 
 import dagster._check as check
 from dagster.core.definitions.configurable import NamedConfigurableDefinition
@@ -10,6 +10,8 @@ from .hook_definition import HookDefinition
 from .utils import check_valid_name, validate_tags
 
 if TYPE_CHECKING:
+    from .asset_layer import AssetLayer
+    from .dependency import NodeHandle
     from .graph_definition import GraphDefinition
     from .input import InputDefinition
     from .output import OutputDefinition
@@ -147,10 +149,6 @@ class NodeDefinition(NamedConfigurableDefinition):
     def input_supports_dynamic_output_dep(self, input_name):
         raise NotImplementedError()
 
-    @abstractmethod
-    def get_inputs_must_be_resolved_top_level(self) -> List["InputDefinition"]:
-        raise NotImplementedError()
-
     def all_input_output_types(self):
         for input_def in self._input_defs:
             yield input_def.dagster_type
@@ -234,3 +232,9 @@ class NodeDefinition(NamedConfigurableDefinition):
             return self
 
         check.failed(f"{self.name} is not a SolidDefinition")
+
+    @abstractmethod
+    def get_inputs_must_be_resolved_top_level(
+        self, asset_layer: "AssetLayer", handle: Optional["NodeHandle"] = None
+    ) -> List["InputDefinition"]:
+        raise NotImplementedError()

--- a/python_modules/dagster/dagster/core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/node_definition.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Mapping, Sequence
+from typing import TYPE_CHECKING, List, Mapping, Sequence
 
 import dagster._check as check
 from dagster.core.definitions.configurable import NamedConfigurableDefinition
@@ -145,6 +145,10 @@ class NodeDefinition(NamedConfigurableDefinition):
 
     @abstractmethod
     def input_supports_dynamic_output_dep(self, input_name):
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_inputs_must_be_resolved_top_level(self) -> List["InputDefinition"]:
         raise NotImplementedError()
 
     def all_input_output_types(self):

--- a/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
@@ -265,6 +265,8 @@ class PipelineDefinition:
         if self.version_strategy is not None:
             experimental_class_warning("VersionStrategy")
 
+        self._graph_def.get_inputs_must_be_resolved_top_level(self._asset_layer)
+
     def _get_resource_requirements_for_mode(self, mode_def: ModeDefinition) -> Set[str]:
         from ..execution.resources_init import get_dependencies, resolve_resource_dependencies
 

--- a/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
@@ -239,6 +239,10 @@ class PipelineDefinition:
                 )
             self._preset_dict[preset.name] = preset
 
+        self._asset_layer = check.opt_inst_param(
+            asset_layer, "asset_layer", AssetLayer, default=AssetLayer.from_graph(self.graph)
+        )
+
         resource_requirements = {}
         for mode_def in self._mode_definitions:
             resource_requirements[mode_def.name] = self._get_resource_requirements_for_mode(
@@ -261,14 +265,10 @@ class PipelineDefinition:
         if self.version_strategy is not None:
             experimental_class_warning("VersionStrategy")
 
-        self._asset_layer = check.opt_inst_param(
-            asset_layer, "asset_layer", AssetLayer, default=AssetLayer.from_graph(self.graph)
-        )
-
     def _get_resource_requirements_for_mode(self, mode_def: ModeDefinition) -> Set[str]:
         from ..execution.resources_init import get_dependencies, resolve_resource_dependencies
 
-        requirements = list(self._graph_def.get_resource_requirements())
+        requirements = list(self._graph_def.get_resource_requirements(self.asset_layer))
         for hook_def in self._hook_defs:
             requirements += list(
                 hook_def.get_resource_requirements(

--- a/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
@@ -9,6 +9,7 @@ from typing import (
     List,
     Optional,
     Set,
+    Tuple,
     Union,
 )
 
@@ -21,14 +22,7 @@ from dagster.core.errors import (
     DagsterInvalidSubsetError,
     DagsterInvariantViolationError,
 )
-from dagster.core.storage.io_manager import IOManagerDefinition
-from dagster.core.storage.output_manager import IOutputManagerDefinition
-from dagster.core.storage.root_input_manager import (
-    IInputManagerDefinition,
-    RootInputManagerDefinition,
-)
 from dagster.core.storage.tags import MEMOIZED_RUN_TAG
-from dagster.core.types.dagster_type import DagsterType, DagsterTypeKind
 from dagster.core.utils import str_format_set
 from dagster.utils import frozentags, merge_dicts
 from dagster.utils.backcompat import experimental_class_warning
@@ -36,20 +30,19 @@ from dagster.utils.backcompat import experimental_class_warning
 from .asset_layer import AssetLayer
 from .dependency import (
     DependencyDefinition,
-    DependencyStructure,
     DynamicCollectDependencyDefinition,
     IDependencyDefinition,
     MultiDependencyDefinition,
     Node,
     NodeHandle,
     NodeInvocation,
-    SolidInputHandle,
 )
 from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .hook_definition import HookDefinition
 from .mode import ModeDefinition
 from .node_definition import NodeDefinition
 from .preset import PresetDefinition
+from .resource_requirement import ResourceRequirement
 from .utils import validate_tags
 from .version_strategy import VersionStrategy
 
@@ -246,23 +239,18 @@ class PipelineDefinition:
                 )
             self._preset_dict[preset.name] = preset
 
-        self._asset_layer = check.opt_inst_param(
-            asset_layer, "asset_layer", AssetLayer, default=AssetLayer.from_graph(self.graph)
-        )
-
-        self._resource_requirements = {
-            mode_def.name: _checked_resource_reqs_for_mode(
-                self._graph_def,
-                mode_def,
-                self._current_level_node_defs,
-                self._graph_def._dagster_type_dict,
-                self._graph_def.node_dict,
-                self._hook_defs,
-                self._graph_def._dependency_structure,
-                self._asset_layer,
-            )
-            for mode_def in self._mode_definitions
-        }
+        resource_requirements = {}
+        for mode_def in self._mode_definitions:
+            required_keys = set()
+            for requirement in self._get_resource_requirements_for_mode(mode_def):
+                requirement.requirement_satisfied(
+                    resource_defs=mode_def.resource_defs,
+                    mode_name=mode_def.name,
+                    error_if_unsatisfied=True,
+                )
+                required_keys.add(requirement.key)
+            resource_requirements[mode_def.name] = required_keys
+        self._resource_requirements = resource_requirements
 
         # Recursively explore all nodes in the this pipeline
         self._all_node_defs = _build_all_node_defs(self._current_level_node_defs)
@@ -278,6 +266,42 @@ class PipelineDefinition:
 
         if self.version_strategy is not None:
             experimental_class_warning("VersionStrategy")
+
+        self._asset_layer = check.opt_inst_param(
+            asset_layer, "asset_layer", AssetLayer, default=AssetLayer.from_graph(self.graph)
+        )
+
+    def _get_resource_requirements_for_mode(
+        self, mode_def: ModeDefinition
+    ) -> List[ResourceRequirement]:
+        from ..execution.resources_init import get_dependencies, resolve_resource_dependencies
+
+        requirements = list(self._graph_def.get_resource_requirements())
+        for hook_def in self._hook_defs:
+            requirements += list(
+                hook_def.get_resource_requirements(
+                    outer_context=f"{self.target_type} '{self._name}'"
+                )
+            )
+        for requirement in requirements:
+            requirement.requirement_satisfied(mode_def.resource_defs)
+        required_keys = sorted([requirement.key for requirement in requirements])
+        resource_dependencies = resolve_resource_dependencies(mode_def.resource_defs)
+        seen = set()
+        while required_keys:
+            required_key = required_keys.pop()
+            if required_key in seen:
+                continue
+            seen.add(required_key)
+            for requirement in mode_def.resource_defs[required_key].get_resource_requirements(
+                outer_context=required_key
+            ):
+                requirement.requirement_satisfied(mode_def.resource_defs)
+                requirements.append(requirement)
+
+            required_keys += get_dependencies(required_key, resource_dependencies)
+
+        return requirements
 
     @property
     def name(self):
@@ -727,375 +751,6 @@ def _iterate_all_nodes(root_node_dict: Dict[str, Node]) -> Iterator[Node]:
             yield from _iterate_all_nodes(node.definition.ensure_graph_def().node_dict)
 
 
-def _checked_resource_reqs_for_mode(
-    top_level_graph_def: GraphDefinition,
-    mode_def: ModeDefinition,
-    node_defs: List[NodeDefinition],
-    dagster_type_dict: Dict[str, DagsterType],
-    root_node_dict: Dict[str, Node],
-    pipeline_hook_defs: AbstractSet[HookDefinition],
-    dependency_structure: DependencyStructure,
-    asset_layer: AssetLayer,
-) -> Set[str]:
-    """
-    Calculate the resource requirements for the pipeline in this mode and ensure they are
-    provided by the mode.
-
-    We combine these operations in to one traversal to allow for raising excpetions that provide
-    as much context as possible about where the unsatisfied resource requirement came from.
-    """
-    resource_reqs: Set[str] = set()
-    mode_output_managers = set(
-        key
-        for key, resource_def in mode_def.resource_defs.items()
-        if isinstance(resource_def, IOutputManagerDefinition)
-    )
-    mode_resources = set(mode_def.resource_defs.keys())
-    for node_def in node_defs:
-        for solid_def in node_def.iterate_solid_defs():
-            for required_resource in solid_def.required_resource_keys:
-                resource_reqs.add(required_resource)
-                if required_resource not in mode_resources:
-                    error_msg = _get_missing_resource_error_msg(
-                        resource_type="resource",
-                        resource_key=required_resource,
-                        descriptor=solid_def.describe_node(),
-                        mode_def=mode_def,
-                        resource_defs_of_type=mode_resources,
-                    )
-                    raise DagsterInvalidDefinitionError(error_msg)
-
-            for output_def in solid_def.output_defs:
-                resource_reqs.add(output_def.io_manager_key)
-                if output_def.io_manager_key not in mode_resources:
-                    error_msg = _get_missing_resource_error_msg(
-                        resource_type="IO manager",
-                        resource_key=output_def.io_manager_key,
-                        descriptor=f"output '{output_def.name}' of {solid_def.describe_node()}",
-                        mode_def=mode_def,
-                        resource_defs_of_type=mode_output_managers,
-                    )
-                    raise DagsterInvalidDefinitionError(error_msg)
-
-    resource_reqs.update(
-        _checked_type_resource_reqs_for_mode(
-            mode_def,
-            dagster_type_dict,
-        )
-    )
-
-    # Validate unsatisfied inputs can be materialized from config
-    resource_reqs.update(
-        _checked_input_resource_reqs_for_mode(
-            top_level_graph_def, dependency_structure, root_node_dict, mode_def, asset_layer
-        )
-    )
-
-    for node in _iterate_all_nodes(root_node_dict):
-        for hook_def in node.hook_defs:
-            for required_resource in hook_def.required_resource_keys:
-                resource_reqs.add(required_resource)
-                if required_resource not in mode_resources:
-                    error_msg = _get_missing_resource_error_msg(
-                        resource_type="resource",
-                        resource_key=required_resource,
-                        descriptor=f"hook '{hook_def.name}'",
-                        mode_def=mode_def,
-                        resource_defs_of_type=mode_resources,
-                    )
-                    raise DagsterInvalidDefinitionError(error_msg)
-
-    for hook_def in pipeline_hook_defs:
-        for required_resource in hook_def.required_resource_keys:
-            resource_reqs.add(required_resource)
-            if required_resource not in mode_resources:
-                error_msg = _get_missing_resource_error_msg(
-                    resource_type="resource",
-                    resource_key=required_resource,
-                    descriptor=f"hook '{hook_def.name}'",
-                    mode_def=mode_def,
-                    resource_defs_of_type=mode_resources,
-                )
-                raise DagsterInvalidDefinitionError(error_msg)
-
-    for resource_key, resource in mode_def.resource_defs.items():
-        for required_resource in resource.required_resource_keys:
-            if required_resource not in mode_resources:
-                error_msg = _get_missing_resource_error_msg(
-                    resource_type="resource",
-                    resource_key=required_resource,
-                    descriptor=f"resource at key '{resource_key}'",
-                    mode_def=mode_def,
-                    resource_defs_of_type=mode_resources,
-                )
-                raise DagsterInvalidDefinitionError(error_msg)
-
-    # Finally, recursively add any resources that the set of required resources require
-    while True:
-        new_resources: Set[str] = set()
-        for resource_key in resource_reqs:
-            resource = mode_def.resource_defs[resource_key]
-            new_resources.update(resource.required_resource_keys - resource_reqs)
-
-        if not len(new_resources):
-            break
-
-        resource_reqs.update(new_resources)
-
-    return resource_reqs
-
-
-def _checked_type_resource_reqs_for_mode(
-    mode_def: ModeDefinition,
-    dagster_type_dict: Dict[str, DagsterType],
-) -> Set[str]:
-    """
-    Calculate all the resource requirements related to DagsterTypes for this mode and ensure the
-    mode provides those resources.
-    """
-
-    resource_reqs = set()
-    mode_resources = set(mode_def.resource_defs.keys())
-    for dagster_type in dagster_type_dict.values():
-        for required_resource in dagster_type.required_resource_keys:
-            resource_reqs.add(required_resource)
-            if required_resource not in mode_resources:
-                error_msg = _get_missing_resource_error_msg(
-                    resource_type="resource",
-                    resource_key=required_resource,
-                    descriptor=f"type '{dagster_type.display_name}'",
-                    mode_def=mode_def,
-                    resource_defs_of_type=mode_resources,
-                )
-                raise DagsterInvalidDefinitionError(error_msg)
-        if dagster_type.loader:
-            for required_resource in dagster_type.loader.required_resource_keys():
-                resource_reqs.add(required_resource)
-                if required_resource not in mode_resources:
-                    error_msg = _get_missing_resource_error_msg(
-                        resource_type="resource",
-                        resource_key=required_resource,
-                        descriptor=f"the loader on type '{dagster_type.display_name}'",
-                        mode_def=mode_def,
-                        resource_defs_of_type=mode_resources,
-                    )
-                    raise DagsterInvalidDefinitionError(error_msg)
-        if dagster_type.materializer:
-            for required_resource in dagster_type.materializer.required_resource_keys():
-                resource_reqs.add(required_resource)
-                if required_resource not in mode_resources:
-                    error_msg = _get_missing_resource_error_msg(
-                        resource_type="resource",
-                        resource_key=required_resource,
-                        descriptor=f"the materializer on type '{dagster_type.display_name}'",
-                        mode_def=mode_def,
-                        resource_defs_of_type=mode_resources,
-                    )
-                    raise DagsterInvalidDefinitionError(error_msg)
-
-    return resource_reqs
-
-
-def _checked_input_resource_reqs_for_mode(
-    top_level_graph_def: GraphDefinition,
-    dependency_structure: DependencyStructure,
-    node_dict: Dict[str, Node],
-    mode_def: ModeDefinition,
-    asset_layer: AssetLayer,
-    outer_dependency_structures: Optional[List[DependencyStructure]] = None,
-    outer_solids: Optional[List[Node]] = None,
-    parent_node_handle: Optional[NodeHandle] = None,
-) -> Set[str]:
-    outer_dependency_structures = check.opt_list_param(
-        outer_dependency_structures, "outer_dependency_structures", DependencyStructure
-    )
-    outer_solids = check.opt_list_param(outer_solids, "outer_solids", Node)
-
-    resource_reqs = set()
-    mode_root_input_managers = set(
-        key
-        for key, resource_def in mode_def.resource_defs.items()
-        if isinstance(resource_def, RootInputManagerDefinition)
-    )
-    mode_io_managers = set(
-        key
-        for key, resource_def in mode_def.resource_defs.items()
-        if isinstance(resource_def, IOManagerDefinition)
-    )
-
-    for node in node_dict.values():
-        node_handle = NodeHandle(name=node.name, parent=parent_node_handle)
-        if node.is_graph:
-            graph_def = node.definition.ensure_graph_def()
-            # check inner solids
-            resource_reqs.update(
-                _checked_input_resource_reqs_for_mode(
-                    top_level_graph_def=top_level_graph_def,
-                    dependency_structure=graph_def.dependency_structure,
-                    node_dict=graph_def.node_dict,
-                    mode_def=mode_def,
-                    asset_layer=asset_layer,
-                    outer_dependency_structures=outer_dependency_structures
-                    + [dependency_structure],
-                    outer_solids=outer_solids + [node],
-                    parent_node_handle=node_handle,
-                )
-            )
-        for handle in node.input_handles():
-            source_output_handles = None
-            if dependency_structure.has_deps(handle):
-                # input is connected to outputs from the same dependency structure
-                source_output_handles = dependency_structure.get_deps_list(handle)
-            else:
-                # input is connected to outputs from outer dependency structure, e.g. first solids
-                # in a composite
-                curr_node = node
-                curr_handle = handle
-                curr_index = len(outer_solids) - 1
-
-                # Checks to see if input is mapped to an outer dependency structure
-                while curr_index >= 0 and curr_node.container_maps_input(curr_handle.input_name):
-                    curr_handle = SolidInputHandle(
-                        solid=outer_solids[curr_index],
-                        input_def=curr_node.container_mapped_input(
-                            curr_handle.input_name
-                        ).definition,
-                    )
-
-                    if outer_dependency_structures[curr_index].has_deps(curr_handle):
-                        source_output_handles = outer_dependency_structures[
-                            curr_index
-                        ].get_deps_list(curr_handle)
-                        break
-
-                    curr_node = outer_solids[curr_index]
-                    curr_index -= 1
-
-            if source_output_handles:
-                # input is connected to source output handles within the graph
-                for source_output_handle in source_output_handles:
-                    output_manager_key = source_output_handle.output_def.io_manager_key
-                    output_manager_def = mode_def.resource_defs[output_manager_key]
-                    if not isinstance(output_manager_def, IInputManagerDefinition):
-                        raise DagsterInvalidDefinitionError(
-                            f'Input "{handle.input_def.name}" of {node.describe_node()} is '
-                            f'connected to output "{source_output_handle.output_def.name}" '
-                            f"of {source_output_handle.solid.describe_node()}. That output does not "
-                            "have an output "
-                            f"manager that knows how to load inputs, so we don't know how "
-                            f"to load the input. To address this, assign an IOManager to "
-                            f"the upstream output."
-                        )
-            else:
-                # input is not connected to upstream output
-                input_def = handle.input_def
-                input_asset_key = asset_layer.asset_key_for_input(node_handle, input_def.name)
-
-                # Input is not nothing, not resolvable by config, and isn't
-                # mapped from a top-level output.
-                if not _is_input_resolvable(
-                    top_level_graph_def, input_def, node, outer_solids, input_asset_key
-                ):
-                    raise DagsterInvalidDefinitionError(
-                        f"Input '{input_def.name}' of {node.describe_node()} "
-                        "has no upstream output, no default value, and no "
-                        "dagster type loader. Must provide a value to this "
-                        "input via either a direct input value mapped from the "
-                        "top-level graph, or a root input manager key. To "
-                        "learn more, see the docs for unconnected inputs: "
-                        "https://docs.dagster.io/concepts/io-management/unconnected-inputs#unconnected-inputs."
-                    )
-
-                # If a root manager is provided, it's always used. I.e. it has priority over
-                # the other ways of loading unsatisfied inputs - dagster type loaders and
-                # default values.
-                if input_def.root_manager_key:
-                    resource_reqs.add(input_def.root_manager_key)
-                    if input_def.root_manager_key not in mode_def.resource_defs:
-                        error_msg = _get_missing_resource_error_msg(
-                            resource_type="root input manager",
-                            resource_key=input_def.root_manager_key,
-                            descriptor=f"unsatisfied input '{input_def.name}' of {node.describe_node()}",
-                            mode_def=mode_def,
-                            resource_defs_of_type=mode_root_input_managers,
-                        )
-                        raise DagsterInvalidDefinitionError(error_msg)
-                # If a root manager is not provided, but the input is associated with an asset, we
-                # can load the input using the io_manager for that asset
-                elif input_asset_key:
-                    io_manager_key = asset_layer.io_manager_key_for_asset(input_asset_key)
-                    resource_reqs.add(io_manager_key)
-                    if io_manager_key not in mode_def.resource_defs:
-                        error_msg = _get_missing_resource_error_msg(
-                            resource_type="io_manager",
-                            resource_key=io_manager_key,
-                            descriptor=f"unsatisfied input '{input_def.name}' of {node.describe_node()} with asset key {input_asset_key}",
-                            mode_def=mode_def,
-                            resource_defs_of_type=mode_io_managers,
-                        )
-                        raise DagsterInvalidDefinitionError(error_msg)
-
-    return resource_reqs
-
-
-def _is_input_resolvable(graph_def, input_def, node, upstream_nodes, input_asset_key):
-    # If input is not loadable via config, check if loadable via top-level input (meaning it is mapped all the way up the graph composition).
-    if (
-        not input_def.dagster_type.loader
-        and not input_def.dagster_type.kind == DagsterTypeKind.NOTHING
-        and not input_def.root_manager_key
-        and not input_def.has_default_value
-        and not input_asset_key
-    ):
-        return _is_input_resolved_from_top_level(graph_def, input_def, node, upstream_nodes)
-    else:
-        return True
-
-
-def _is_input_resolved_from_top_level(graph_def, input_def, node, upstream_nodes):
-    from dagster.core.definitions.input import InputPointer
-
-    input_name = input_def.name
-    node_name = node.name
-
-    # Upstream nodes are in order of composition, with the top-level graph
-    # being first.
-    upstream_nodes = upstream_nodes[::-1]
-    for upstream_node in upstream_nodes:
-        input_mapping = upstream_node.definition.input_mapping_for_pointer(
-            InputPointer(solid_name=node_name, input_name=input_name)
-        )
-        if not input_mapping:
-            return False
-        else:
-            input_name = input_mapping.definition.name
-            node_name = upstream_node.name
-
-    top_level_mapping = graph_def.input_mapping_for_pointer(
-        InputPointer(solid_name=node_name, input_name=input_name)
-    )
-    return bool(top_level_mapping)
-
-
-def _get_missing_resource_error_msg(
-    resource_type, resource_key, descriptor, mode_def, resource_defs_of_type
-):
-    if mode_def.name == "default":
-        return (
-            f"{resource_type} key '{resource_key}' is required by "
-            f"{descriptor}, but is not provided. Provide a {resource_type} for key '{resource_key}',  "
-            f"or change '{resource_key}' to one of the provided {resource_type} keys: "
-            f"{sorted(resource_defs_of_type)}."
-        )
-    else:
-        return (
-            f"{resource_type} key '{resource_key}' is required by "
-            f"{descriptor}, but is not provided by mode '{mode_def.name}'. "
-            f"In mode '{mode_def.name}', provide a {resource_type} for key '{resource_key}', "
-            f"or change '{resource_key}' to one of the provided root input managers keys: {sorted(resource_defs_of_type)}."
-        )
-
-
 def _build_all_node_defs(node_defs: List[NodeDefinition]) -> Dict[str, NodeDefinition]:
     all_defs: Dict[str, NodeDefinition] = {}
     for current_level_node_def in node_defs:
@@ -1178,3 +833,14 @@ def _create_run_config_schema(
         config_type_dict_by_key=config_type_dict_by_key,
         config_mapping=mode_definition.config_mapping,
     )
+
+
+def _add_resource_req(
+    resource_reqs: Dict[str, Tuple[str, Set[str]]],
+    resource_key: str,
+    resource_type: str,
+    requiree_descriptor: str,
+) -> None:
+    if resource_key not in resource_reqs:
+        resource_reqs[resource_key] = (resource_type, set())
+    resource_reqs[resource_key][1].add(requiree_descriptor)

--- a/python_modules/dagster/dagster/core/definitions/resource_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_invocation.py
@@ -57,7 +57,8 @@ def _check_invocation_requirements(
 
     if init_context is not None and resource_def.required_resource_keys:
         ensure_requirements_satisfied(
-            init_context._resource_defs, list(resource_def.get_resource_requirements())
+            init_context._resource_defs,  # pylint: disable=protected-access
+            list(resource_def.get_resource_requirements()),
         )
 
     # Check config requirements

--- a/python_modules/dagster/dagster/core/definitions/resource_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_invocation.py
@@ -7,6 +7,7 @@ from dagster.core.errors import DagsterInvalidConfigError, DagsterInvalidInvocat
 
 from ...config import Shape
 from ..decorator_utils import get_function_params
+from .resource_requirement import ensure_requirements_satisfied
 
 if TYPE_CHECKING:
     from dagster.core.definitions.resource_definition import ResourceDefinition
@@ -55,10 +56,9 @@ def _check_invocation_requirements(
         )
 
     if init_context is not None and resource_def.required_resource_keys:
-        for requirement in resource_def.get_resource_requirements():
-            requirement.requirement_satisfied(
-                init_context._resource_defs  # pylint: disable=protected-access
-            )
+        ensure_requirements_satisfied(
+            init_context._resource_defs, list(resource_def.get_resource_requirements())
+        )
 
     # Check config requirements
     if not init_context and resource_def.config_schema.as_field().is_required:

--- a/python_modules/dagster/dagster/core/definitions/resource_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_invocation.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 def resource_invocation_result(
-    resource_def: "ResourceDefinition", init_context: Optional["InitResourceContext"]
+    resource_def: "ResourceDefinition", init_context: Optional["UnboundInitResourceContext"]
 ) -> Any:
     from .resource_definition import is_context_provided
 
@@ -43,7 +43,7 @@ def resource_invocation_result(
 
 
 def _check_invocation_requirements(
-    resource_def: "ResourceDefinition", init_context: Optional["InitResourceContext"]
+    resource_def: "ResourceDefinition", init_context: Optional["UnboundInitResourceContext"]
 ) -> "InitResourceContext":
     from dagster.core.execution.context.init import InitResourceContext, build_init_resource_context
 
@@ -55,17 +55,10 @@ def _check_invocation_requirements(
         )
 
     if init_context is not None and resource_def.required_resource_keys:
-        resources_dict = cast(
-            "InitResourceContext",
-            init_context,
-        ).resources._asdict()  # type: ignore[attr-defined]
-
-        for resource_key in resource_def.required_resource_keys:
-            if resource_key not in resources_dict:
-                raise DagsterInvalidInvocationError(
-                    f'Resource requires resource "{resource_key}", but no resource '
-                    "with that key was found on the context."
-                )
+        for requirement in resource_def.get_resource_requirements():
+            requirement.requirement_satisfied(
+                init_context._resource_defs  # pylint: disable=protected-access
+            )
 
     # Check config requirements
     if not init_context and resource_def.config_schema.as_field().is_required:

--- a/python_modules/dagster/dagster/core/definitions/resource_requirement.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_requirement.py
@@ -1,0 +1,170 @@
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, AbstractSet, Iterator, List, Mapping, NamedTuple, Optional, Type
+
+from ..errors import DagsterInvalidDefinitionError
+
+if TYPE_CHECKING:
+    from ..types.dagster_type import DagsterType
+    from .dependency import Node, NodeHandle
+    from .pipeline_definition import PipelineDefinition
+    from .resource_definition import ResourceDefinition
+    from .solid_definition import SolidDefinition
+
+
+class ResourceRequirement(ABC):
+    @property
+    @abstractmethod
+    def key(self) -> str:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def describe_requirement(self) -> str:
+        raise NotImplementedError()
+
+    @property
+    def expected_type(self) -> Type:
+        from .resource_definition import ResourceDefinition
+
+        return ResourceDefinition
+
+    @property
+    def is_io_manager_requirement(self) -> bool:
+        from ..storage.io_manager import IInputManagerDefinition, IOManagerDefinition
+
+        return (
+            self.expected_type == IOManagerDefinition
+            or self.expected_type == IInputManagerDefinition
+        )
+
+    def keys_of_expected_type(self, resource_defs: Mapping[str, "ResourceDefinition"]) -> List[str]:
+        return [
+            resource_key
+            for resource_key, resource_def in resource_defs.items()
+            if isinstance(resource_def, self.expected_type)
+        ]
+
+    def requirement_satisfied(
+        self,
+        resource_defs: Mapping[str, "ResourceDefinition"],
+        mode_name: Optional[str] = None,
+        error_if_unsatisfied: bool = True,
+    ) -> bool:
+        # Always error if resource type mismatches
+        if self.key in resource_defs and not isinstance(
+            resource_defs[self.key], self.expected_type
+        ):
+            raise DagsterInvalidDefinitionError(
+                f"{self.describe_requirement()}, but received {type(resource_defs[self.key])}."
+            )
+
+        # Conditionally error if resource defs don't provide the correct resource key
+        if self.key not in resource_defs:
+            if error_if_unsatisfied:
+                mode_descriptor = (
+                    f" by mode '{mode_name}'" if mode_name and mode_name != "default" else ""
+                )
+                raise DagsterInvalidDefinitionError(
+                    f"{self.describe_requirement()} was not provided{mode_descriptor}. Please provide a {str(self.expected_type)} to key '{self.key}', or change the required key to one of the following keys which points to an {str(self.expected_type)}: {self.keys_of_expected_type(resource_defs)}"
+                )
+            return False
+        return True
+
+
+class SolidDefinitionResourceRequirement(
+    NamedTuple("_SolidDefinitionResourceRequirement", [("key", str), ("node_description", str)]),
+    ResourceRequirement,
+):
+    def describe_requirement(self) -> str:
+        return f"resource with key '{self.key}' required by {self.node_description}"
+
+
+class InputManagerRequirement(
+    NamedTuple(
+        "_InputManagerRequirement", [("key", str), ("node_description", str), ("input_name", str)]
+    ),
+    ResourceRequirement,
+):
+    @property
+    def expected_type(self) -> Type:
+        from ..storage.io_manager import IInputManagerDefinition
+
+        return IInputManagerDefinition
+
+    def describe_requirement(self) -> str:
+        return f"input manager with key '{self.key}' required by input '{self.input_name}' of {self.node_description}"
+
+
+class OutputManagerRequirement(
+    NamedTuple(
+        "_OutputManagerRequirement", [("key", str), ("node_description", str), ("output_name", str)]
+    ),
+    ResourceRequirement,
+):
+    @property
+    def expected_type(self) -> Type:
+        from ..storage.io_manager import IOManagerDefinition
+
+        return IOManagerDefinition
+
+    def describe_requirement(self) -> str:
+        return f"io manager with key '{self.key}' required by output '{self.output_name}' of {self.node_description}'"
+
+
+class HookResourceRequirement(
+    NamedTuple(
+        "_HookResourceRequirement",
+        [("key", str), ("attached_to", Optional[str]), ("hook_name", str)],
+    ),
+    ResourceRequirement,
+):
+    def describe_requirement(self) -> str:
+        attached_to_desc = f"attached to {self.attached_to}" if self.attached_to else ""
+        return (
+            f"resource with key '{self.key}' required by hook '{self.hook_name}' {attached_to_desc}"
+        )
+
+
+class TypeResourceRequirement(
+    NamedTuple("_TypeResourceRequirement", [("key", str), ("type_display_name", str)]),
+    ResourceRequirement,
+):
+    def describe_requirement(self) -> str:
+        return f"resource with key '{self.key}' required by type '{self.type_display_name}'"
+
+
+class TypeLoaderResourceRequirement(
+    NamedTuple("_TypeLoaderResourceRequirement", [("key", str), ("type_display_name", str)]),
+    ResourceRequirement,
+):
+    def describe_requirement(self) -> str:
+        return f"resource with key '{self.key}' required by the loader on type '{self.type_display_name}'"
+
+
+class TypeMaterializerResourceRequirement(
+    NamedTuple("_TypeMaterializerResourceRequirement", [("key", str), ("type_display_name", str)]),
+    ResourceRequirement,
+):
+    def describe_requirement(self) -> str:
+        return f"resource with key '{self.key}' required by the materializer on type '{self.type_display_name}'"
+
+
+class ResourceDependencyRequirement(
+    NamedTuple("_ResourceDependencyRequirement", [("key", str), ("source_key", Optional[str])]),
+    ResourceRequirement,
+):
+    def describe_requirement(self) -> str:
+        source_descriptor = f" by resource with key '{self.source_key}'" if self.source_key else ""
+        return f"resource with key '{self.key}' required{source_descriptor}"
+
+
+class RequiresResources(ABC):
+    @property
+    @abstractmethod
+    def required_resource_keys(self) -> AbstractSet[str]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_resource_requirements(
+        self, outer_context: Optional[object] = None
+    ) -> Iterator[ResourceRequirement]:
+        raise NotImplementedError()

--- a/python_modules/dagster/dagster/core/definitions/solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_definition.py
@@ -239,7 +239,10 @@ class SolidDefinition(NodeDefinition, RequiresResources):
     ) -> Tuple[OutputDefinition, NodeHandle]:
         return self.output_def_named(output_name), handle
 
-    def get_inputs_must_be_resolved_top_level(self) -> List[InputDefinition]:
+    def get_inputs_must_be_resolved_top_level(
+        self, asset_layer: "AssetLayer", handle: Optional[NodeHandle] = None
+    ) -> List[InputDefinition]:
+        handle = cast(NodeHandle, check.inst_param(handle, "handle", NodeHandle))
         unresolveable_input_defs = []
         for input_def in self.input_defs:
             if (
@@ -248,6 +251,12 @@ class SolidDefinition(NodeDefinition, RequiresResources):
                 and not input_def.root_manager_key
                 and not input_def.has_default_value
             ):
+                input_asset_key = asset_layer.asset_key_for_input(handle, input_def.name)
+                # If input_asset_key is present, this input can be resolved
+                # by a source asset, so input does not need to be resolved
+                # at the top level.
+                if input_asset_key:
+                    continue
                 unresolveable_input_defs.append(input_def)
         return unresolveable_input_defs
 

--- a/python_modules/dagster/dagster/core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/core/execution/context/hook.py
@@ -197,7 +197,7 @@ class UnboundHookContext(HookContext):
         job_name: Optional[str],
         op_exception: Optional[Exception],
     ):  # pylint: disable=super-init-not-called
-        from ..build_resources import build_resources
+        from ..build_resources import build_resources, wrap_resources_for_execution
         from ..context_creation_pipeline import initialize_console_manager
 
         self._mode_def = mode_def
@@ -212,7 +212,8 @@ class UnboundHookContext(HookContext):
             self._op = temp_graph.solids[0]
 
         # Open resource context manager
-        self._resources_cm = build_resources(resources)
+        self._resource_defs = wrap_resources_for_execution(resources)
+        self._resources_cm = build_resources(self._resource_defs)
         self._resources = self._resources_cm.__enter__()  # pylint: disable=no-member
         self._resources_contain_cm = isinstance(self._resources, IContainsGenerator)
 

--- a/python_modules/dagster/dagster/core/execution/context/init.py
+++ b/python_modules/dagster/dagster/core/execution/context/init.py
@@ -129,7 +129,10 @@ class UnboundInitResourceContext(InitResourceContext):
         instance: Optional[DagsterInstance],
     ):
         from dagster.core.execution.api import ephemeral_instance_if_missing
-        from dagster.core.execution.build_resources import build_resources
+        from dagster.core.execution.build_resources import (
+            build_resources,
+            wrap_resources_for_execution,
+        )
         from dagster.core.execution.context_creation_pipeline import initialize_console_manager
 
         self._instance_provided = (
@@ -141,15 +144,15 @@ class UnboundInitResourceContext(InitResourceContext):
         # so ignore lint error
         instance = self._instance_cm.__enter__()  # pylint: disable=no-member
 
-        # If we are provided with a Resources instance, then we do not need to initialize
-        if isinstance(resources, Resources):
-            self._resources_cm = None
-        else:
-            self._resources_cm = build_resources(
-                check.opt_dict_param(resources, "resources", key_type=str), instance=instance
-            )
-            resources = self._resources_cm.__enter__()  # pylint: disable=no-member
-            self._resources_contain_cm = isinstance(resources, IContainsGenerator)
+        # Shouldn't actually ever have a resources object directly from this initialization
+
+        self._resource_defs = wrap_resources_for_execution(
+            check.opt_dict_param(resources, "resources")
+        )
+
+        self._resources_cm = build_resources(self._resource_defs, instance=instance)
+        resources = self._resources_cm.__enter__()  # pylint: disable=no-member
+        self._resources_contain_cm = isinstance(resources, IContainsGenerator)
 
         self._cm_scope_entered = False
         super(UnboundInitResourceContext, self).__init__(
@@ -167,8 +170,7 @@ class UnboundInitResourceContext(InitResourceContext):
         return self
 
     def __exit__(self, *exc):
-        if self._resources_cm:
-            self._resources_cm.__exit__(*exc)  # pylint: disable=no-member
+        self._resources_cm.__exit__(*exc)  # pylint: disable=no-member
         if self._instance_provided:
             self._instance_cm.__exit__(*exc)  # pylint: disable=no-member
 

--- a/python_modules/dagster/dagster/core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/core/execution/context/invocation.py
@@ -22,6 +22,7 @@ from dagster.core.definitions.resource_definition import (
     Resources,
     ScopedResourcesBuilder,
 )
+from dagster.core.definitions.resource_requirement import ensure_requirements_satisfied
 from dagster.core.definitions.solid_definition import SolidDefinition
 from dagster.core.definitions.step_launcher import StepLauncher
 from dagster.core.errors import (
@@ -303,7 +304,7 @@ def _validate_resource_requirements(
 
     for requirement in solid_def.get_resource_requirements():
         if not requirement.is_io_manager_requirement:
-            requirement.requirement_satisfied(resource_defs)
+            ensure_requirements_satisfied(resource_defs, [requirement])
 
 
 def _resolve_bound_config(solid_config: Any, solid_def: SolidDefinition) -> Any:

--- a/python_modules/dagster/dagster/core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/core/execution/context/invocation.py
@@ -18,6 +18,7 @@ from dagster.core.definitions.op_definition import OpDefinition
 from dagster.core.definitions.pipeline_definition import PipelineDefinition
 from dagster.core.definitions.resource_definition import (
     IContainsGenerator,
+    ResourceDefinition,
     Resources,
     ScopedResourcesBuilder,
 )
@@ -29,7 +30,7 @@ from dagster.core.errors import (
     DagsterInvalidPropertyError,
     DagsterInvariantViolationError,
 )
-from dagster.core.execution.build_resources import build_resources
+from dagster.core.execution.build_resources import build_resources, wrap_resources_for_execution
 from dagster.core.instance import DagsterInstance
 from dagster.core.log_manager import DagsterLogManager
 from dagster.core.storage.pipeline_run import PipelineRun
@@ -55,7 +56,7 @@ class UnboundSolidExecutionContext(OpExecutionContext):
     def __init__(
         self,
         solid_config: Any,
-        resources_dict: Optional[Dict[str, Any]],
+        resources_dict: Dict[str, Any],
         resources_config: Dict[str, Any],
         instance: Optional[DagsterInstance],
         partition_key: Optional[str],
@@ -79,8 +80,9 @@ class UnboundSolidExecutionContext(OpExecutionContext):
         self._resources_config = resources_config
         # Open resource context manager
         self._resources_contain_cm = False
+        self._resource_defs = wrap_resources_for_execution(resources_dict)
         self._resources_cm = build_resources(
-            resources=check.opt_dict_param(resources_dict, "resources_dict", key_type=str),
+            resources=self._resource_defs,
             instance=instance,
             resource_config=resources_config,
         )
@@ -221,7 +223,7 @@ class UnboundSolidExecutionContext(OpExecutionContext):
             else solid_def_or_invocation.node_def.ensure_solid_def()
         )
 
-        _validate_resource_requirements(self.resources, solid_def)
+        _validate_resource_requirements(self._resource_defs, solid_def)
 
         solid_config = _resolve_bound_config(self.solid_config, solid_def)
 
@@ -294,18 +296,14 @@ class UnboundSolidExecutionContext(OpExecutionContext):
         return self._mapping_key
 
 
-def _validate_resource_requirements(resources: "Resources", solid_def: SolidDefinition) -> None:
+def _validate_resource_requirements(
+    resource_defs: Dict[str, ResourceDefinition], solid_def: SolidDefinition
+) -> None:
     """Validate correctness of resources against required resource keys"""
 
-    resources_dict = resources._asdict()  # type: ignore[attr-defined]
-
-    required_resource_keys: AbstractSet[str] = solid_def.required_resource_keys or set()
-    for resource_key in required_resource_keys:
-        if resource_key not in resources_dict:
-            raise DagsterInvalidInvocationError(
-                f'{solid_def.node_type_str} "{solid_def.name}" requires resource "{resource_key}", but no resource '
-                "with that key was found on the context."
-            )
+    for requirement in solid_def.get_resource_requirements():
+        if not requirement.is_io_manager_requirement:
+            requirement.requirement_satisfied(resource_defs)
 
 
 def _resolve_bound_config(solid_config: Any, solid_def: SolidDefinition) -> Any:

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_pipeline.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_pipeline.py
@@ -71,6 +71,6 @@ def test_pipeline_with_invalid_definition_snapshot_api_grpc(instance):
         except DagsterUserCodeProcessError:
             error_info = serializable_error_info_from_exc_info(sys.exc_info())
             assert (
-                "Input 'some_input' of solid 'fail_subset' has no upstream output, no default value, and no dagster type loader."
+                "Input 'some_input' of solid 'fail_subset' has no way of being resolved"
                 in error_info.cause.message
             )

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -268,7 +268,8 @@ def test_missing_io_manager():
         return source1
 
     with pytest.raises(
-        Exception, match="'special_io_manager' is required by unsatisfied input 'source1'"
+        DagsterInvalidDefinitionError,
+        match="input manager with key 'special_io_manager' required by input 'source1' of op 'asset1' was not provided",
     ):
         build_assets_job(
             "a",

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -269,7 +269,7 @@ def test_missing_io_manager():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="input manager with key 'special_io_manager' required by input 'source1' of op 'asset1' was not provided",
+        match="requires IO Manager for key 'special_io_manager', but none was provided.",
     ):
         build_assets_job(
             "a",
@@ -1249,3 +1249,89 @@ def test_subset_with_source_asset():
 
     result = source_asset_job.execute_in_process(asset_selection=[AssetKey("my_derived_asset")])
     assert result.success
+
+
+def test_source_asset_io_manager_def():
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            pass
+
+        def load_input(self, context):
+            return 5
+
+    @io_manager
+    def the_manager():
+        return MyIOManager()
+
+    my_source_asset = SourceAsset(key=AssetKey("my_source_asset"), io_manager_def=the_manager)
+
+    @asset
+    def my_derived_asset(my_source_asset):
+        return my_source_asset + 4
+
+    source_asset_job = AssetGroup(
+        assets=[my_derived_asset],
+        source_assets=[my_source_asset],
+    ).build_job("source_asset_job")
+
+    result = source_asset_job.execute_in_process(asset_selection=[AssetKey("my_derived_asset")])
+    assert result.success
+    assert result.output_for_node("my_derived_asset") == 9
+
+
+def test_source_asset_io_manager_not_provided():
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            pass
+
+        def load_input(self, context):
+            return 5
+
+    @io_manager
+    def the_manager():
+        return MyIOManager()
+
+    my_source_asset = SourceAsset(key=AssetKey("my_source_asset"))
+
+    @asset
+    def my_derived_asset(my_source_asset):
+        return my_source_asset + 4
+
+    source_asset_job = AssetGroup(
+        assets=[my_derived_asset],
+        source_assets=[my_source_asset],
+        resource_defs={"io_manager": the_manager},
+    ).build_job("source_asset_job")
+
+    result = source_asset_job.execute_in_process(asset_selection=[AssetKey("my_derived_asset")])
+    assert result.success
+    assert result.output_for_node("my_derived_asset") == 9
+
+
+def test_source_asset_io_manager_key_provided():
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            pass
+
+        def load_input(self, context):
+            return 5
+
+    @io_manager
+    def the_manager():
+        return MyIOManager()
+
+    my_source_asset = SourceAsset(key=AssetKey("my_source_asset"), io_manager_key="some_key")
+
+    @asset
+    def my_derived_asset(my_source_asset):
+        return my_source_asset + 4
+
+    source_asset_job = AssetGroup(
+        assets=[my_derived_asset],
+        source_assets=[my_source_asset],
+        resource_defs={"some_key": the_manager},
+    ).build_job("source_asset_job")
+
+    result = source_asset_job.execute_in_process(asset_selection=[AssetKey("my_derived_asset")])
+    assert result.success
+    assert result.output_for_node("my_derived_asset") == 9

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_pipeline.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_pipeline.py
@@ -179,11 +179,9 @@ def test_unconfigurable_inputs_pipeline():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="Input '_' of solid 'noop' has no upstream output, no default "
-        "value, and no dagster type loader. Must provide a value to this input "
-        "via either a direct input value mapped from the top-level graph, or a "
-        "root input manager key. To learn more, see the docs for unconnected "
-        "inputs: https://docs.dagster.io/concepts/io-management/unconnected-inputs#unconnected-inputs.",
+        match="Input '_' of solid 'noop' has no way of being resolved. Must "
+        "provide a resolution to this input via another op/graph, or via a "
+        "direct input value mapped from the top-level graph.",
     ):
 
         @pipeline

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -1168,11 +1168,12 @@ def test_ounsatisfied_input_nested():
     def the_graph(x):
         ingest(x)
 
+    @graph
+    def the_top_level_graph():
+        the_graph()
+
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match="Input 'x' of graph 'the_graph' has no way of being resolved.",
     ):
-
-        @graph
-        def the_top_level_graph():
-            the_graph()
+        the_top_level_graph.to_job()

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -1168,12 +1168,11 @@ def test_ounsatisfied_input_nested():
     def the_graph(x):
         ingest(x)
 
-    @graph
-    def the_top_level_graph():
-        the_graph()
-
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="Input 'x' of op 'ingest' has no upstream output, no default value, and no dagster type loader.",
+        match="Input 'x' of graph 'the_graph' has no way of being resolved.",
     ):
-        the_top_level_graph.to_job()
+
+        @graph
+        def the_top_level_graph():
+            the_graph()

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
@@ -150,7 +150,7 @@ def test_hook_resource_error():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="resource key 'resource_b' is required by hook 'a_hook'",
+        match="resource with key 'resource_b' required by hook 'a_hook' attached to solid 'a_solid_with_hook' was not provided",
     ):
         PipelineDefinition(
             solid_defs=[a_solid],

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_invocation.py
@@ -5,7 +5,11 @@ import pytest
 
 from dagster import HookContext, build_hook_context, failure_hook, resource, solid, success_hook
 from dagster.core.definitions.decorators.hook_decorator import event_list_hook
-from dagster.core.errors import DagsterInvalidInvocationError, DagsterInvariantViolationError
+from dagster.core.errors import (
+    DagsterInvalidDefinitionError,
+    DagsterInvalidInvocationError,
+    DagsterInvariantViolationError,
+)
 
 
 def test_event_list_hook_invocation():
@@ -134,9 +138,8 @@ def test_success_hook_with_resources(hook_decorator, is_event_list_hook):
         hook(build_hook_context(resources={"foo": "foo", "bar": bar_resource}))
 
     with pytest.raises(
-        DagsterInvariantViolationError,
-        match=r"The hook 'my_hook_reqs_resources' requires resource '\w+', "
-        r"which was not provided by the context.",
+        DagsterInvalidDefinitionError,
+        match="resource with key 'bar' required by hook 'my_hook_reqs_resources'  was not provided",
     ):
         if is_event_list_hook:
             hook(None, None)

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_run.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_run.py
@@ -576,7 +576,8 @@ def test_hook_resource_mismatch():
         pass
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match="resource key 'b' is required by hook 'a_hook'"
+        DagsterInvalidDefinitionError,
+        match="resource with key 'b' required by hook 'a_hook' attached to pipeline '_' was not provided",
     ):
 
         @a_hook
@@ -585,7 +586,8 @@ def test_hook_resource_mismatch():
             a_solid()
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match="resource key 'b' is required by hook 'a_hook'"
+        DagsterInvalidDefinitionError,
+        match="resource with key 'b' required by hook 'a_hook' attached to solid 'a_solid' was not provided",
     ):
 
         @pipeline(mode_defs=[ModeDefinition(resource_defs={"a": resource_a})])

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
@@ -782,7 +782,7 @@ def test_root_input_manager_missing_fails():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match=r"'missing_root_input_manager' is required by unsatisfied input 'root_input' of solid 'requires_missing_root_input_manager'",
+        match="input manager with key 'missing_root_input_manager' required by input 'root_input' of solid 'requires_missing_root_input_manager' was not provided",
     ):
 
         @pipeline
@@ -797,7 +797,7 @@ def test_io_manager_missing_fails():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match=r"'missing_io_manager' is required by output 'result' of solid 'requires_missing_io_manager'",
+        match="io manager with key 'missing_io_manager' required by output 'result' of solid 'requires_missing_io_manager'' was not provided",
     ):
 
         @pipeline

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
@@ -154,21 +154,19 @@ def test_resource_cyclic_dependencies():
         called["dep_solid"] = True
         assert context.resources.bar_resource == "foobar"
 
-    pipeline_def = PipelineDefinition(
-        name="with_dep_resource",
-        solid_defs=[dep_solid],
-        mode_defs=[
-            ModeDefinition(
-                resource_defs={"foo_resource": foo_resource, "bar_resource": bar_resource}
-            )
-        ],
-    )
-
     with pytest.raises(
         DagsterInvariantViolationError,
         match='Resource key "(foo_resource|bar_resource)" transitively depends on itself.',
     ):
-        execute_pipeline(pipeline_def)
+        PipelineDefinition(
+            name="with_dep_resource",
+            solid_defs=[dep_solid],
+            mode_defs=[
+                ModeDefinition(
+                    resource_defs={"foo_resource": foo_resource, "bar_resource": bar_resource}
+                )
+            ],
+        )
 
 
 def test_yield_resource():
@@ -1142,13 +1140,20 @@ def test_resource_needs_resource():
     def foo_resource(init_context):
         return init_context.resources.bar_resource + "foo"
 
-    with pytest.raises(DagsterInvalidDefinitionError, match="is required by resource"):
+    @op(required_resource_keys={"foo_resource"})
+    def op_requires_foo():
+        pass
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="resource with key 'bar_resource' required by resource with key 'foo_resource' was not provided",
+    ):
 
         @pipeline(
             mode_defs=[ModeDefinition(resource_defs={"foo_resource": foo_resource})],
         )
         def _fail():
-            pass
+            op_requires_foo()
 
 
 def test_resource_op_subset():

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_invocation.py
@@ -3,7 +3,11 @@ from contextlib import contextmanager
 import pytest
 
 from dagster import Field, Noneable, Selector, build_init_resource_context, resource
-from dagster.core.errors import DagsterInvalidConfigError, DagsterInvalidInvocationError
+from dagster.core.errors import (
+    DagsterInvalidConfigError,
+    DagsterInvalidDefinitionError,
+    DagsterInvalidInvocationError,
+)
 
 
 def test_resource_invocation_no_arg():
@@ -58,9 +62,8 @@ def test_resource_invocation_with_resources():
     context = build_init_resource_context()
 
     with pytest.raises(
-        DagsterInvalidInvocationError,
-        match='Resource requires resource "foo", but no resource '
-        "with that key was found on the context.",
+        DagsterInvalidDefinitionError,
+        match="resource with key 'foo' required was not provided.",
     ):
         resource_reqs_resources(context)
 

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_dict.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_dict.py
@@ -200,8 +200,7 @@ def test_dict_type_loader_typing_fail():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="Input 'dict_input' of solid 'emit_dict' has no upstream output, "
-        "no default value, and no dagster type loader.",
+        match="Input 'dict_input' of solid 'emit_dict' has no way of being resolved.",
     ):
         execute_solid(
             emit_dict,

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_input_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_input_manager.py
@@ -322,17 +322,14 @@ def test_resource_not_input_manager():
     def solid_requires_manager(_, _input):
         pass
 
-    @pipeline(mode_defs=[ModeDefinition(resource_defs={"not_manager": resource_not_manager})])
-    def basic():
-        solid_requires_manager()
-
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="Input '_input' for solid 'solid_requires_manager' requires root_manager_key "
-        "'not_manager', but the resource definition provided is not an "
-        "IInputManagerDefinition",
+        match="input manager with key 'not_manager' required by input '_input' of solid 'solid_requires_manager', but received <class 'dagster.core.definitions.resource_definition.ResourceDefinition'>",
     ):
-        execute_pipeline(basic)
+
+        @pipeline(mode_defs=[ModeDefinition(resource_defs={"not_manager": resource_not_manager})])
+        def basic():
+            solid_requires_manager()
 
 
 def test_mode_missing_input_manager():

--- a/python_modules/dagster/dagster_tests/core_tests/test_mode_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_mode_definitions.py
@@ -187,7 +187,8 @@ def test_mode_with_resource_deps():
     assert called["count"] == 1
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match=r"'a' is required by solid 'requires_a'"
+        DagsterInvalidDefinitionError,
+        match="resource with key 'a' required by solid 'requires_a' was not provided",
     ):
         PipelineDefinition(
             name="mode_with_bad_deps",

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
@@ -169,9 +169,8 @@ def test_solid_invocation_with_resources():
     # resource.
     context = build_solid_context()
     with pytest.raises(
-        DagsterInvalidInvocationError,
-        match='solid "solid_requires_resources" requires resource "foo", but no resource '
-        "with that key was found on the context.",
+        DagsterInvalidDefinitionError,
+        match="resource with key 'foo' required by solid 'solid_requires_resources' was not provided",
     ):
         solid_requires_resources(context)
 


### PR DESCRIPTION
Allows io manager defs to be specified directly on source assets. This is necessary for a world in which resources cant be specified directly on jobs or asset groups.