### PR TITLE
docs(helm): add doc hint for dagster-user-deployments.imagePullSecrets

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
@@ -36,4 +36,5 @@ class UserDeployment(BaseModel):
 class UserDeployments(BaseModel):
     enabled: bool
     enableSubchart: bool
+    imagePullSecrets: List[kubernetes.SecretRef]
     deployments: List[UserDeployment]

--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -74,7 +74,7 @@ def test_daemon_command_with_user_deployments(template: HelmTemplate):
         dagsterDaemon=Daemon.construct(
             image=kubernetes.Image.construct(repository=repository, tag=tag)
         ),
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=True,
             enableSubchart=True,
             deployments=[create_simple_user_deployment("simple-deployment-one")],
@@ -99,7 +99,7 @@ def test_daemon_command_without_user_deployments(template: HelmTemplate):
         dagsterDaemon=Daemon.construct(
             image=kubernetes.Image.construct(repository=repository, tag=tag)
         ),
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=False,
             enableSubchart=False,
             deployments=[],

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -146,7 +146,7 @@ def test_deployments_enabled_subchart_disabled(template: HelmTemplate, capfd):
     with pytest.raises(subprocess.CalledProcessError):
         template.render(
             DagsterHelmValues.construct(
-                dagsterUserDeployments=UserDeployments(
+                dagsterUserDeployments=UserDeployments.construct(
                     enabled=True,
                     enableSubchart=False,
                     deployments=[create_simple_user_deployment("simple-deployment-one")],
@@ -162,7 +162,7 @@ def test_deployments_disabled_subchart_enabled(template: HelmTemplate, capfd):
     with pytest.raises(subprocess.CalledProcessError):
         template.render(
             DagsterHelmValues.construct(
-                dagsterUserDeployments=UserDeployments(
+                dagsterUserDeployments=UserDeployments.construct(
                     enabled=False,
                     enableSubchart=True,
                     deployments=[create_simple_user_deployment("simple-deployment-one")],
@@ -181,7 +181,7 @@ def test_deployments_disabled_subchart_disabled(template: HelmTemplate, capfd):
     with pytest.raises(subprocess.CalledProcessError):
         template.render(
             DagsterHelmValues.construct(
-                dagsterUserDeployments=UserDeployments(
+                dagsterUserDeployments=UserDeployments.construct(
                     enabled=False,
                     enableSubchart=False,
                     deployments=[create_simple_user_deployment("simple-deployment-one")],
@@ -197,21 +197,21 @@ def test_deployments_disabled_subchart_disabled(template: HelmTemplate, capfd):
     "helm_values",
     [
         DagsterHelmValues.construct(
-            dagsterUserDeployments=UserDeployments(
+            dagsterUserDeployments=UserDeployments.construct(
                 enabled=True,
                 enableSubchart=True,
                 deployments=[create_simple_user_deployment("simple-deployment-one")],
             )
         ),
         DagsterHelmValues.construct(
-            dagsterUserDeployments=UserDeployments(
+            dagsterUserDeployments=UserDeployments.construct(
                 enabled=True,
                 enableSubchart=True,
                 deployments=[create_complex_user_deployment("complex-deployment-one")],
             )
         ),
         DagsterHelmValues.construct(
-            dagsterUserDeployments=UserDeployments(
+            dagsterUserDeployments=UserDeployments.construct(
                 enabled=True,
                 enableSubchart=True,
                 deployments=[
@@ -221,7 +221,7 @@ def test_deployments_disabled_subchart_disabled(template: HelmTemplate, capfd):
             )
         ),
         DagsterHelmValues.construct(
-            dagsterUserDeployments=UserDeployments(
+            dagsterUserDeployments=UserDeployments.construct(
                 enabled=True,
                 enableSubchart=True,
                 deployments=[
@@ -247,7 +247,7 @@ def test_deployments_render(helm_values: DagsterHelmValues, template: HelmTempla
 
 def test_chart_does_not_render(full_template: HelmTemplate, capfd):
     helm_values = DagsterHelmValues.construct(
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=False,
             enableSubchart=True,
             deployments=[create_simple_user_deployment("simple-deployment-one")],
@@ -268,7 +268,7 @@ def test_chart_does_not_render(full_template: HelmTemplate, capfd):
     "helm_values",
     [
         DagsterHelmValues.construct(
-            dagsterUserDeployments=UserDeployments(
+            dagsterUserDeployments=UserDeployments.construct(
                 enabled=True,
                 enableSubchart=False,
                 deployments=[
@@ -277,7 +277,7 @@ def test_chart_does_not_render(full_template: HelmTemplate, capfd):
             )
         ),
         DagsterHelmValues.construct(
-            dagsterUserDeployments=UserDeployments(
+            dagsterUserDeployments=UserDeployments.construct(
                 enabled=True,
                 enableSubchart=False,
                 deployments=[
@@ -303,7 +303,7 @@ def test_chart_does_render(helm_values: DagsterHelmValues, full_template: HelmTe
     "helm_values",
     [
         DagsterHelmValues.construct(
-            dagsterUserDeployments=UserDeployments(
+            dagsterUserDeployments=UserDeployments.construct(
                 enabled=True,
                 enableSubchart=True,
                 deployments=[
@@ -312,7 +312,7 @@ def test_chart_does_render(helm_values: DagsterHelmValues, full_template: HelmTe
             )
         ),
         DagsterHelmValues.construct(
-            dagsterUserDeployments=UserDeployments(
+            dagsterUserDeployments=UserDeployments.construct(
                 enabled=True,
                 enableSubchart=True,
                 deployments=[
@@ -348,7 +348,7 @@ def test_user_deployment_checksum_unchanged(helm_values: DagsterHelmValues, temp
 
 def test_user_deployment_checksum_changes(template: HelmTemplate):
     pre_upgrade_helm_values = DagsterHelmValues.construct(
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=True,
             enableSubchart=True,
             deployments=[
@@ -358,7 +358,7 @@ def test_user_deployment_checksum_changes(template: HelmTemplate):
         )
     )
     post_upgrade_helm_values = DagsterHelmValues.construct(
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=True,
             enableSubchart=True,
             deployments=[
@@ -510,7 +510,7 @@ def test_user_deployment_tag_can_be_numeric(template: HelmTemplate, tag: Union[s
     deployment.image.tag = tag
 
     helm_values = DagsterHelmValues.construct(
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=True,
             enableSubchart=True,
             deployments=[deployment],
@@ -536,7 +536,7 @@ def _assert_no_container_context(user_deployment):
 def test_user_deployment_image(template: HelmTemplate):
     deployment = create_simple_user_deployment("foo")
     helm_values = DagsterHelmValues.construct(
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=True,
             enableSubchart=True,
             deployments=[deployment],
@@ -559,7 +559,7 @@ def test_user_deployment_image(template: HelmTemplate):
 def test_user_deployment_include_config(template: HelmTemplate):
     deployment = create_simple_user_deployment("foo", include_config_in_launched_runs=True)
     helm_values = DagsterHelmValues.construct(
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=True,
             enableSubchart=True,
             deployments=[deployment],
@@ -614,7 +614,7 @@ def test_user_deployment_volumes(template: HelmTemplate, include_config_in_launc
     )
 
     helm_values = DagsterHelmValues.construct(
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=True,
             enableSubchart=True,
             deployments=[deployment],
@@ -692,7 +692,7 @@ def test_user_deployment_secrets_and_configmaps(
     )
 
     helm_values = DagsterHelmValues.construct(
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=True,
             enableSubchart=True,
             deployments=[deployment],
@@ -741,7 +741,7 @@ def test_user_deployment_labels(template: HelmTemplate, include_config_in_launch
     )
 
     helm_values = DagsterHelmValues.construct(
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=True,
             enableSubchart=True,
             deployments=[deployment],
@@ -789,7 +789,7 @@ def test_user_deployment_resources(template: HelmTemplate, include_config_in_lau
     )
 
     helm_values = DagsterHelmValues.construct(
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=True,
             enableSubchart=True,
             deployments=[deployment],

--- a/helm/dagster/schema/schema_tests/test_workspace.py
+++ b/helm/dagster/schema/schema_tests/test_workspace.py
@@ -24,7 +24,7 @@ def helm_template() -> HelmTemplate:
 
 def test_workspace_renders_fail(template: HelmTemplate, capfd):
     helm_values = DagsterHelmValues.construct(
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=False,
             enableSubchart=True,
             deployments=[],
@@ -43,7 +43,7 @@ def test_workspace_renders_fail(template: HelmTemplate, capfd):
 
 def test_workspace_does_not_render(template: HelmTemplate, capfd):
     helm_values = DagsterHelmValues.construct(
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=False,
             enableSubchart=False,
             deployments=[create_simple_user_deployment("deployment-one")],
@@ -63,7 +63,7 @@ def test_workspace_renders_from_helm_user_deployments(template: HelmTemplate):
         create_simple_user_deployment("deployment-two"),
     ]
     helm_values = DagsterHelmValues.construct(
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=True,
             enableSubchart=True,
             deployments=deployments,
@@ -95,7 +95,7 @@ def test_workspace_renders_from_helm_dagit(template: HelmTemplate):
     ]
     helm_values = DagsterHelmValues.construct(
         dagit=Dagit.construct(workspace=Workspace(enabled=True, servers=servers)),
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=True,
             enableSubchart=True,
             deployments=[
@@ -129,7 +129,7 @@ def test_workspace_server_location_name_renders_from_helm_dagit(template: HelmTe
     ]
     helm_values = DagsterHelmValues.construct(
         dagit=Dagit.construct(workspace=Workspace(enabled=True, servers=servers)),
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=True,
             enableSubchart=True,
             deployments=[
@@ -162,7 +162,7 @@ def test_workspace_renders_empty(template: HelmTemplate):
     servers: List[Server] = []
     helm_values = DagsterHelmValues.construct(
         dagit=Dagit.construct(workspace=Workspace(enabled=True, servers=servers)),
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=True,
             enableSubchart=True,
             deployments=[],
@@ -192,7 +192,7 @@ def test_workspace_external_configmap_fail(template: HelmTemplate, capfd):
                 externalConfigmap="test",
             )
         ),
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=True,
             enableSubchart=True,
             deployments=[create_simple_user_deployment("deployment-one")],
@@ -215,7 +215,7 @@ def test_workspace_external_configmap_not_present(template: HelmTemplate, capfd)
                 externalConfigmap="test",
             )
         ),
-        dagsterUserDeployments=UserDeployments(
+        dagsterUserDeployments=UserDeployments.construct(
             enabled=True,
             enableSubchart=False,
             deployments=[],

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -435,6 +435,12 @@
             ],
             "additionalProperties": false
         },
+        "SecretRef": {
+            "title": "SecretRef",
+            "type": "object",
+            "properties": {},
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+        },
         "UserDeploymentIncludeConfigInLaunchedRuns": {
             "title": "UserDeploymentIncludeConfigInLaunchedRuns",
             "type": "object",
@@ -577,6 +583,13 @@
                     "title": "Enablesubchart",
                     "type": "boolean"
                 },
+                "imagePullSecrets": {
+                    "title": "Imagepullsecrets",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SecretRef"
+                    }
+                },
                 "deployments": {
                     "title": "Deployments",
                     "type": "array",
@@ -588,6 +601,7 @@
             "required": [
                 "enabled",
                 "enableSubchart",
+                "imagePullSecrets",
                 "deployments"
             ]
         },
@@ -1037,12 +1051,6 @@
                 "readOnlyDagit",
                 "flower"
             ]
-        },
-        "SecretRef": {
-            "title": "SecretRef",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.LocalObjectReference"
         },
         "ComputeLogManagerType": {
             "title": "ComputeLogManagerType",

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -235,6 +235,10 @@ dagster-user-deployments:
   # If you plan on deploying user code in a separate Helm release, set this to false.
   enableSubchart: true
 
+  # Specify secrets to run user code server containers based on images in private registries. See:
+  # https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod
+  imagePullSecrets: []
+
   # List of unique deployments
   deployments:
     - name: "k8s-example-user-code-1"


### PR DESCRIPTION
### Summary & Motivation

Hint for users that want to use private container registry for User Code Deployments (which is normally the case).

### How I Tested These Changes

* Using my Kubernetes k3s cluster
* Using `--debug`