### PR TITLE
Fix typo in k8s executor config

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -35,7 +35,7 @@ from .utils import delete_job
         {
             "job_namespace": Field(StringSource, is_required=False),
             "retries": get_retries_config(),
-            "max_concurrency": Field(
+            "max_concurrent": Field(
                 IntSource,
                 is_required=False,
                 description="Limit on the number of pods that will run concurrently within the scope "


### PR DESCRIPTION
Closes https://github.com/dagster-io/dagster/issues/6580

Typo was able to slip in bc one test wraps it in a different executor: https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py#L209

and the other doesn't actually validate the schema: https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py#L121

What's the best way to validate the schema in the unit tests?