### PR TITLE
fix(helm): allow numeric quoted strings as image tags

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -32,7 +32,8 @@ If release name contains chart name it will be used as a full name.
   {{- $ := index . 0 }}
 
   {{- with index . 1 }}
-    {{- $tag := .tag | default $.Chart.Version | toYaml }}
+    # Filter the tag to parse strings, string integers, and string floats.
+    {{- $tag := .tag | default $.Chart.Version | toYaml | trimAll "\"" }}
     {{- printf "%s:%s" .repository $tag }}
   {{- end }}
 {{- end }}

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -504,7 +504,7 @@ def test_user_deployment_default_image_tag_is_chart_version(
     assert image_tag == chart_version
 
 
-@pytest.mark.parametrize("tag", [5176135, "abc1234"])
+@pytest.mark.parametrize("tag", [5176135, "abc1234", "20220531.1", "1234"])
 def test_user_deployment_tag_can_be_numeric(template: HelmTemplate, tag: Union[str, int]):
     deployment = create_simple_user_deployment("foo")
     deployment.image.tag = tag

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -33,7 +33,8 @@ If release name contains chart name it will be used as a full name.
   {{- $ := index . 0 }}
 
   {{- with index . 1 }}
-    {{- $tag := .tag | default $.Chart.Version | toYaml }}
+    # Filter the tag to parse strings, string integers, and string floats.
+    {{- $tag := .tag | default $.Chart.Version | toYaml | trimAll "\"" }}
     {{- printf "%s:%s" .repository $tag }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
### Summary & Motivation
A follow up to https://github.com/dagster-io/dagster/pull/7579. Although raw integers are supported, quoted integers and quoted floats are not. Fix that.

The root issue stems from https://github.com/helm/helm/issues/1707. We cannot parse raw floats effectively, as they will get converted to scientific notation. They must be passed in as strings. 

### How I Tested These Changes
pytest
