### PR TITLE
[dagster-io/eslint-config] v1.0.5

### DIFF
--- a/js_modules/dagit/packages/eslint-config/CHANGES.md
+++ b/js_modules/dagit/packages/eslint-config/CHANGES.md
@@ -1,3 +1,7 @@
+## 1.0.5 (June 2, 2022)
+
+- Add rule to require GraphQL query variables
+
 ## 1.0.4 (May 16, 2022)
 
 - Add recommended Jest lint configuration

--- a/js_modules/dagit/packages/eslint-config/package.json
+++ b/js_modules/dagit/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dagster-io/eslint-config",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Shared eslint configuration for @dagster-io",
   "license": "Apache-2.0",
   "main": "index.js",


### PR DESCRIPTION
### Summary & Motivation

Bump eslint-config to v1.0.5 so that we can get the new query variables rule in use in Cloud.

### How I Tested These Changes

Buildkite
