### PR TITLE
[dagit] Remove asset graph bundling based on path prefixes, experimental flag

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Flags.tsx
+++ b/js_modules/dagit/packages/core/src/app/Flags.tsx
@@ -6,7 +6,6 @@ import {getJSONForKey} from '../hooks/useStateWithStorage';
 export const DAGIT_FLAGS_KEY = 'DAGIT_FLAGS';
 
 export enum FeatureFlag {
-  flagExperimentalAssetDAG = 'flagExperimentalAssetDAG',
   flagDebugConsoleLogging = 'flagDebugConsoleLogging',
   flagAlwaysCollapseNavigation = 'flagAlwaysCollapseNavigation',
   flagDisableWebsockets = 'flagDisableWebsockets',

--- a/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
@@ -125,16 +125,6 @@ const UserSettingsRoot: React.FC<SettingsRootProps> = ({tabs}) => {
               ),
             },
             {
-              key: 'Experimental asset graph display',
-              value: (
-                <Checkbox
-                  format="switch"
-                  checked={flags.includes(FeatureFlag.flagExperimentalAssetDAG)}
-                  onChange={() => toggleFlag(FeatureFlag.flagExperimentalAssetDAG)}
-                />
-              ),
-            },
-            {
               key: 'New partitions view (experimental)',
               value: (
                 <Checkbox

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -1,15 +1,5 @@
-import {
-  Body,
-  Box,
-  Checkbox,
-  Colors,
-  Icon,
-  Mono,
-  NonIdealState,
-  SplitPanelContainer,
-} from '@dagster-io/ui';
+import {Box, Checkbox, Colors, NonIdealState, SplitPanelContainer} from '@dagster-io/ui';
 import flatMap from 'lodash/flatMap';
-import isEqual from 'lodash/isEqual';
 import pickBy from 'lodash/pickBy';
 import uniq from 'lodash/uniq';
 import uniqBy from 'lodash/uniqBy';
@@ -18,7 +8,6 @@ import React from 'react';
 import {useHistory} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import {useFeatureFlags} from '../app/Flags';
 import {GraphQueryItem} from '../app/GraphQueryImpl';
 import {
   FIFTEEN_SECONDS,
@@ -168,7 +157,6 @@ const AssetGraphExplorerWithData: React.FC<
 
   const history = useHistory();
   const findJobForAsset = useFindJobForAsset();
-  const {flagExperimentalAssetDAG: experiments} = useFeatureFlags();
 
   const [highlighted, setHighlighted] = React.useState<string | null>(null);
 
@@ -344,99 +332,6 @@ const AssetGraphExplorerWithData: React.FC<
                 <SVGContainer width={layout.width} height={layout.height}>
                   <AssetConnectedEdges highlighted={highlighted} edges={layout.edges} />
 
-                  {Object.values(layout.bundles)
-                    .sort((a, b) => a.id.length - b.id.length)
-                    .map(({id, bounds}) => {
-                      if (experiments && _scale < EXPERIMENTAL_MINI_SCALE) {
-                        const path = JSON.parse(id);
-                        return (
-                          <foreignObject
-                            x={bounds.x}
-                            y={bounds.y}
-                            width={bounds.width}
-                            height={bounds.height + 10}
-                            key={id}
-                            onDoubleClick={(e) => {
-                              viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
-                              e.stopPropagation();
-                            }}
-                          >
-                            <AssetNodeMinimal
-                              style={{
-                                border: `${2 / _scale}px solid ${Colors.Gray300}`,
-                                background: Colors.White,
-                              }}
-                              selected={selectedGraphNodes.some((g) =>
-                                hasPathPrefix(g.assetKey.path, path),
-                              )}
-                            >
-                              <NameMinimal
-                                style={{
-                                  fontSize: 18 / _scale,
-                                  display: 'flex',
-                                  flexDirection: 'column',
-                                  alignItems: 'center',
-                                }}
-                              >
-                                <div
-                                  style={{display: 'flex', gap: 3 / _scale, alignItems: 'center'}}
-                                >
-                                  <Icon
-                                    name="folder"
-                                    size={Math.round(16 / _scale) as any}
-                                    style={{marginTop: 4}}
-                                  />
-                                  {withMiddleTruncation(displayNameForAssetKey({path}), {
-                                    maxLength: 17,
-                                  })}
-                                </div>
-                                <Body style={{fontSize: 10 / _scale, color: Colors.Gray500}}>
-                                  {layout.bundleMapping[id].length} items
-                                </Body>
-                              </NameMinimal>
-                            </AssetNodeMinimal>
-                          </foreignObject>
-                        );
-                      }
-                      return (
-                        <foreignObject
-                          x={bounds.x}
-                          y={bounds.y}
-                          width={bounds.width}
-                          height={bounds.height + 10}
-                          style={{pointerEvents: 'none'}}
-                          key={id}
-                        >
-                          <Mono
-                            style={{
-                              opacity:
-                                _scale > EXPERIMENTAL_MINI_SCALE
-                                  ? (_scale - EXPERIMENTAL_MINI_SCALE) / 0.2
-                                  : 0,
-                              fontWeight: 600,
-                              display: 'flex',
-                              gap: 6,
-                            }}
-                          >
-                            <Icon name="folder" size={20} />
-                            {displayNameForAssetKey({path: JSON.parse(id)})}
-                          </Mono>
-                          <div
-                            style={{
-                              inset: 0,
-                              top: 24,
-                              position: 'absolute',
-                              borderRadius: 10,
-                              border: `${3 / _scale}px dashed ${Colors.Gray300}`,
-                              background: `rgba(223, 223, 223, ${
-                                0.4 - Math.max(0, _scale - EXPERIMENTAL_MINI_SCALE) * 0.3
-                              })`,
-                            }}
-                          />
-                        </foreignObject>
-                      );
-                    })}
-
                   {Object.values(layout.nodes).map(({id, bounds}, index) => {
                     const graphNode = assetGraphData.nodes[id];
                     const path = JSON.parse(id);
@@ -449,15 +344,6 @@ const AssetGraphExplorerWithData: React.FC<
                           y={bounds.y + bounds.height / 2}
                         />
                       ) : null;
-                    }
-
-                    if (experiments) {
-                      const isWithinBundle = Object.keys(layout.bundles).some((bundleId) =>
-                        hasPathPrefix(path, JSON.parse(bundleId)),
-                      );
-                      if (isWithinBundle && _scale < EXPERIMENTAL_MINI_SCALE) {
-                        return null;
-                      }
                     }
 
                     return (
@@ -475,7 +361,7 @@ const AssetGraphExplorerWithData: React.FC<
                       >
                         {!graphNode || !graphNode.definition.opNames.length ? (
                           <ForeignNode assetKey={{path}} />
-                        ) : experiments && _scale < EXPERIMENTAL_MINI_SCALE ? (
+                        ) : _scale < EXPERIMENTAL_MINI_SCALE ? (
                           <AssetNodeMinimal
                             style={{background: Colors.White}}
                             selected={selectedGraphNodes.includes(graphNode)}
@@ -594,10 +480,6 @@ const SVGContainer = styled.svg`
 `;
 
 // Helpers
-
-const hasPathPrefix = (path: string[], prefix: string[]) => {
-  return isEqual(prefix, path.slice(0, prefix.length));
-};
 
 const graphDirectionOf = ({
   graph,

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -28,110 +28,114 @@ export const AssetNode: React.FC<{
   liveData?: LiveDataForNode;
   computeStatus?: ComputeStatus;
   selected: boolean;
+  padded?: boolean;
   inAssetCatalog?: boolean;
-}> = React.memo(({definition, selected, liveData, inAssetCatalog, computeStatus}) => {
-  const firstOp = definition.opNames.length ? definition.opNames[0] : null;
-  const computeName = definition.graphName || definition.opNames[0] || null;
+}> = React.memo(
+  ({definition, selected, liveData, inAssetCatalog, computeStatus, padded = true}) => {
+    const firstOp = definition.opNames.length ? definition.opNames[0] : null;
+    const computeName = definition.graphName || definition.opNames[0] || null;
 
-  // Used for linking to the run with this step highlighted. We only support highlighting
-  // a single step, so just use the first one.
-  const stepKey = firstOp || '';
+    // Used for linking to the run with this step highlighted. We only support highlighting
+    // a single step, so just use the first one.
+    const stepKey = firstOp || '';
 
-  const displayName = withMiddleTruncation(displayNameForAssetKey(definition.assetKey), {
-    maxLength: ASSET_NODE_NAME_MAX_LENGTH,
-  });
+    const displayName = withMiddleTruncation(displayNameForAssetKey(definition.assetKey), {
+      maxLength: ASSET_NODE_NAME_MAX_LENGTH,
+    });
 
-  const {lastMaterialization} = liveData || MISSING_LIVE_DATA;
+    const {lastMaterialization} = liveData || MISSING_LIVE_DATA;
 
-  return (
-    <AssetNodeContainer $selected={selected}>
-      <AssetNodeBox $selected={selected}>
-        <Name>
-          <span style={{marginTop: 1}}>
-            <Icon name="asset" />
-          </span>
-          <div style={{overflow: 'hidden', textOverflow: 'ellipsis', marginTop: -1}}>
-            {displayName}
-          </div>
-          <div style={{flex: 1}} />
-          <div style={{maxWidth: ASSET_NODE_ANNOTATIONS_MAX_WIDTH}}>
-            {computeStatus === 'old' && (
-              <UpstreamNotice>
-                upstream
-                <br />
-                changed
-              </UpstreamNotice>
-            )}
-          </div>
-        </Name>
-        {definition.description && !inAssetCatalog && (
-          <Description>{markdownToPlaintext(definition.description).split('\n')[0]}</Description>
-        )}
-        {computeName && displayName !== computeName && (
-          <Description>
-            <Box
-              flex={{gap: 4, alignItems: 'flex-end'}}
-              style={{marginLeft: -2, overflow: 'hidden'}}
-            >
-              <Icon name={definition.graphName ? 'job' : 'op'} size={16} />
-              <div style={{minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis'}}>
-                {computeName}
-              </div>
-            </Box>
-          </Description>
-        )}
+    return (
+      <AssetNodeContainer $selected={selected} $padded={padded}>
+        <AssetNodeBox $selected={selected}>
+          <Name>
+            <span style={{marginTop: 1}}>
+              <Icon name="asset" />
+            </span>
+            <div style={{overflow: 'hidden', textOverflow: 'ellipsis', marginTop: -1}}>
+              {displayName}
+            </div>
+            <div style={{flex: 1}} />
+            <div style={{maxWidth: ASSET_NODE_ANNOTATIONS_MAX_WIDTH}}>
+              {computeStatus === 'old' && (
+                <UpstreamNotice>
+                  upstream
+                  <br />
+                  changed
+                </UpstreamNotice>
+              )}
+            </div>
+          </Name>
+          {definition.description && !inAssetCatalog && (
+            <Description>{markdownToPlaintext(definition.description).split('\n')[0]}</Description>
+          )}
+          {computeName && displayName !== computeName && (
+            <Description>
+              <Box
+                flex={{gap: 4, alignItems: 'flex-end'}}
+                style={{marginLeft: -2, overflow: 'hidden'}}
+              >
+                <Icon name={definition.graphName ? 'job' : 'op'} size={16} />
+                <div style={{minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis'}}>
+                  {computeName}
+                </div>
+              </Box>
+            </Description>
+          )}
 
-        <Stats>
-          {lastMaterialization ? (
-            <StatsRow>
-              <span>Materialized</span>
-              <CaptionMono>
-                <AssetRunLink
-                  runId={lastMaterialization.runId}
-                  event={{stepKey, timestamp: lastMaterialization.timestamp}}
-                >
-                  <TimestampDisplay
-                    timestamp={Number(lastMaterialization.timestamp) / 1000}
-                    timeFormat={{showSeconds: false, showTimezone: false}}
-                  />
-                </AssetRunLink>
-              </CaptionMono>
-            </StatsRow>
-          ) : (
-            <>
+          <Stats>
+            {lastMaterialization ? (
               <StatsRow>
                 <span>Materialized</span>
-                <span>–</span>
+                <CaptionMono>
+                  <AssetRunLink
+                    runId={lastMaterialization.runId}
+                    event={{stepKey, timestamp: lastMaterialization.timestamp}}
+                  >
+                    <TimestampDisplay
+                      timestamp={Number(lastMaterialization.timestamp) / 1000}
+                      timeFormat={{showSeconds: false, showTimezone: false}}
+                    />
+                  </AssetRunLink>
+                </CaptionMono>
               </StatsRow>
-            </>
-          )}
-          <StatsRow>
-            <span>Latest Run</span>
-            <CaptionMono>
-              <AssetLatestRunWithNotices liveData={liveData} stepKey={stepKey} />
-            </CaptionMono>
-          </StatsRow>
-        </Stats>
-        {definition.computeKind && (
-          <OpTags
-            minified={false}
-            style={{right: -2, paddingTop: 5}}
-            tags={[
-              {
-                label: definition.computeKind,
-                onClick: () => {
-                  window.requestAnimationFrame(() =>
-                    document.dispatchEvent(new Event('show-kind-info')),
-                  );
+            ) : (
+              <>
+                <StatsRow>
+                  <span>Materialized</span>
+                  <span>–</span>
+                </StatsRow>
+              </>
+            )}
+            <StatsRow>
+              <span>Latest Run</span>
+              <CaptionMono>
+                <AssetLatestRunWithNotices liveData={liveData} stepKey={stepKey} />
+              </CaptionMono>
+            </StatsRow>
+          </Stats>
+          {definition.computeKind && (
+            <OpTags
+              minified={false}
+              style={{right: -2, paddingTop: 5}}
+              tags={[
+                {
+                  label: definition.computeKind,
+                  onClick: () => {
+                    window.requestAnimationFrame(() =>
+                      document.dispatchEvent(new Event('show-kind-info')),
+                    );
+                  },
                 },
-              },
-            ]}
-          />
-        )}
-      </AssetNodeBox>
-    </AssetNodeContainer>
-  );
-}, isEqual);
+              ]}
+            />
+          )}
+        </AssetNodeBox>
+      </AssetNodeContainer>
+    );
+  },
+  isEqual,
+);
 
 export const AssetNodeMinimal: React.FC<{
   selected: boolean;
@@ -213,7 +217,7 @@ const BoxColors = {
   Stats: 'rgba(236, 236, 248, 1)',
 };
 
-const AssetNodeContainer = styled.div<{$selected: boolean}>`
+export const AssetNodeContainer = styled.div<{$selected: boolean; $padded?: boolean}>`
   outline: ${(p) => (p.$selected ? `2px dashed ${NodeHighlightColors.Border}` : 'none')};
   border-radius: 6px;
   outline-offset: -1px;

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -28,114 +28,110 @@ export const AssetNode: React.FC<{
   liveData?: LiveDataForNode;
   computeStatus?: ComputeStatus;
   selected: boolean;
-  padded?: boolean;
   inAssetCatalog?: boolean;
-}> = React.memo(
-  ({definition, selected, liveData, inAssetCatalog, computeStatus, padded = true}) => {
-    const firstOp = definition.opNames.length ? definition.opNames[0] : null;
-    const computeName = definition.graphName || definition.opNames[0] || null;
+}> = React.memo(({definition, selected, liveData, inAssetCatalog, computeStatus}) => {
+  const firstOp = definition.opNames.length ? definition.opNames[0] : null;
+  const computeName = definition.graphName || definition.opNames[0] || null;
 
-    // Used for linking to the run with this step highlighted. We only support highlighting
-    // a single step, so just use the first one.
-    const stepKey = firstOp || '';
+  // Used for linking to the run with this step highlighted. We only support highlighting
+  // a single step, so just use the first one.
+  const stepKey = firstOp || '';
 
-    const displayName = withMiddleTruncation(displayNameForAssetKey(definition.assetKey), {
-      maxLength: ASSET_NODE_NAME_MAX_LENGTH,
-    });
+  const displayName = withMiddleTruncation(displayNameForAssetKey(definition.assetKey), {
+    maxLength: ASSET_NODE_NAME_MAX_LENGTH,
+  });
 
-    const {lastMaterialization} = liveData || MISSING_LIVE_DATA;
+  const {lastMaterialization} = liveData || MISSING_LIVE_DATA;
 
-    return (
-      <AssetNodeContainer $selected={selected} $padded={padded}>
-        <AssetNodeBox $selected={selected}>
-          <Name>
-            <span style={{marginTop: 1}}>
-              <Icon name="asset" />
-            </span>
-            <div style={{overflow: 'hidden', textOverflow: 'ellipsis', marginTop: -1}}>
-              {displayName}
-            </div>
-            <div style={{flex: 1}} />
-            <div style={{maxWidth: ASSET_NODE_ANNOTATIONS_MAX_WIDTH}}>
-              {computeStatus === 'old' && (
-                <UpstreamNotice>
-                  upstream
-                  <br />
-                  changed
-                </UpstreamNotice>
-              )}
-            </div>
-          </Name>
-          {definition.description && !inAssetCatalog && (
-            <Description>{markdownToPlaintext(definition.description).split('\n')[0]}</Description>
-          )}
-          {computeName && displayName !== computeName && (
-            <Description>
-              <Box
-                flex={{gap: 4, alignItems: 'flex-end'}}
-                style={{marginLeft: -2, overflow: 'hidden'}}
-              >
-                <Icon name={definition.graphName ? 'job' : 'op'} size={16} />
-                <div style={{minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis'}}>
-                  {computeName}
-                </div>
-              </Box>
-            </Description>
-          )}
-
-          <Stats>
-            {lastMaterialization ? (
-              <StatsRow>
-                <span>Materialized</span>
-                <CaptionMono>
-                  <AssetRunLink
-                    runId={lastMaterialization.runId}
-                    event={{stepKey, timestamp: lastMaterialization.timestamp}}
-                  >
-                    <TimestampDisplay
-                      timestamp={Number(lastMaterialization.timestamp) / 1000}
-                      timeFormat={{showSeconds: false, showTimezone: false}}
-                    />
-                  </AssetRunLink>
-                </CaptionMono>
-              </StatsRow>
-            ) : (
-              <>
-                <StatsRow>
-                  <span>Materialized</span>
-                  <span>–</span>
-                </StatsRow>
-              </>
+  return (
+    <AssetNodeContainer $selected={selected}>
+      <AssetNodeBox $selected={selected}>
+        <Name>
+          <span style={{marginTop: 1}}>
+            <Icon name="asset" />
+          </span>
+          <div style={{overflow: 'hidden', textOverflow: 'ellipsis', marginTop: -1}}>
+            {displayName}
+          </div>
+          <div style={{flex: 1}} />
+          <div style={{maxWidth: ASSET_NODE_ANNOTATIONS_MAX_WIDTH}}>
+            {computeStatus === 'old' && (
+              <UpstreamNotice>
+                upstream
+                <br />
+                changed
+              </UpstreamNotice>
             )}
+          </div>
+        </Name>
+        {definition.description && !inAssetCatalog && (
+          <Description>{markdownToPlaintext(definition.description).split('\n')[0]}</Description>
+        )}
+        {computeName && displayName !== computeName && (
+          <Description>
+            <Box
+              flex={{gap: 4, alignItems: 'flex-end'}}
+              style={{marginLeft: -2, overflow: 'hidden'}}
+            >
+              <Icon name={definition.graphName ? 'job' : 'op'} size={16} />
+              <div style={{minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis'}}>
+                {computeName}
+              </div>
+            </Box>
+          </Description>
+        )}
+
+        <Stats>
+          {lastMaterialization ? (
             <StatsRow>
-              <span>Latest Run</span>
+              <span>Materialized</span>
               <CaptionMono>
-                <AssetLatestRunWithNotices liveData={liveData} stepKey={stepKey} />
+                <AssetRunLink
+                  runId={lastMaterialization.runId}
+                  event={{stepKey, timestamp: lastMaterialization.timestamp}}
+                >
+                  <TimestampDisplay
+                    timestamp={Number(lastMaterialization.timestamp) / 1000}
+                    timeFormat={{showSeconds: false, showTimezone: false}}
+                  />
+                </AssetRunLink>
               </CaptionMono>
             </StatsRow>
-          </Stats>
-          {definition.computeKind && (
-            <OpTags
-              minified={false}
-              style={{right: -2, paddingTop: 5}}
-              tags={[
-                {
-                  label: definition.computeKind,
-                  onClick: () => {
-                    window.requestAnimationFrame(() =>
-                      document.dispatchEvent(new Event('show-kind-info')),
-                    );
-                  },
-                },
-              ]}
-            />
+          ) : (
+            <>
+              <StatsRow>
+                <span>Materialized</span>
+                <span>–</span>
+              </StatsRow>
+            </>
           )}
-        </AssetNodeBox>
-      </AssetNodeContainer>
-    );
-  },
-  isEqual,
-);
+          <StatsRow>
+            <span>Latest Run</span>
+            <CaptionMono>
+              <AssetLatestRunWithNotices liveData={liveData} stepKey={stepKey} />
+            </CaptionMono>
+          </StatsRow>
+        </Stats>
+        {definition.computeKind && (
+          <OpTags
+            minified={false}
+            style={{right: -2, paddingTop: 5}}
+            tags={[
+              {
+                label: definition.computeKind,
+                onClick: () => {
+                  window.requestAnimationFrame(() =>
+                    document.dispatchEvent(new Event('show-kind-info')),
+                  );
+                },
+              },
+            ]}
+          />
+        )}
+      </AssetNodeBox>
+    </AssetNodeContainer>
+  );
+}, isEqual);
 
 export const AssetNodeMinimal: React.FC<{
   selected: boolean;
@@ -217,7 +213,7 @@ const BoxColors = {
   Stats: 'rgba(236, 236, 248, 1)',
 };
 
-export const AssetNodeContainer = styled.div<{$selected: boolean; $padded?: boolean}>`
+const AssetNodeContainer = styled.div<{$selected: boolean}>`
   outline: ${(p) => (p.$selected ? `2px dashed ${NodeHighlightColors.Border}` : 'none')};
   border-radius: 6px;
   outline-offset: -1px;

--- a/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
@@ -1,5 +1,4 @@
 import {pathVerticalDiagonal} from '@vx/shape';
-import uniq from 'lodash/uniq';
 
 import {AssetNodeDefinitionFragment} from '../assets/types/AssetNodeDefinitionFragment';
 
@@ -46,62 +45,6 @@ export interface GraphData {
 export const isSourceAsset = (node: {jobNames: string[]; opNames: string[]}) => {
   return node.jobNames.length === 0 && !node.opNames.length;
 };
-
-export function identifyBundles(assetIds: string[]) {
-  const pathPrefixes: {[prefixId: string]: string[]} = {};
-
-  for (const assetId of assetIds) {
-    const assetKeyPath = JSON.parse(assetId);
-
-    for (let ii = 1; ii < assetKeyPath.length; ii++) {
-      const prefix = assetKeyPath.slice(0, ii);
-      const key = JSON.stringify(prefix);
-      pathPrefixes[key] = pathPrefixes[key] || [];
-      pathPrefixes[key].push(assetId);
-    }
-  }
-
-  for (const key of Object.keys(pathPrefixes)) {
-    if (pathPrefixes[key].length <= 1) {
-      delete pathPrefixes[key];
-    }
-  }
-
-  const finalBundlePrefixes: {[prefixId: string]: string[]} = {};
-  const finalBundleIdForNodeId: {[id: string]: string} = {};
-
-  // Sort the prefix keys by length descending and iterate from the deepest folders first.
-  // Dedupe asset keys and replace asset keys we've already seen with the (deeper) folder
-  // they are within. This gets us "multi layer folders" of nodes.
-
-  // Turn this:
-  // {
-  //  "s3": [["s3", "collect"], ["s3", "prod", "a"], ["s3", "prod", "b"]],
-  //  "s3/prod": ["s3", "prod", "a"], ["s3", "prod", "b"]
-  // }
-
-  // Into this:
-  // {
-  //  "s3/prod": ["s3", "prod", "a"], ["s3", "prod", "b"]
-  //  "s3": [["s3", "collect"], ["s3", "prod"]],
-  // }
-
-  for (const prefixId of Object.keys(pathPrefixes).sort((a, b) => b.length - a.length)) {
-    const contents = uniq(
-      pathPrefixes[prefixId].map((p) =>
-        finalBundleIdForNodeId[p] ? finalBundleIdForNodeId[p] : p,
-      ),
-    );
-    if (contents.length === 1 && finalBundlePrefixes[contents[0]]) {
-      // If this bundle contains exactly one bundle, no need to show both outlines.
-      // Just show the inner one. eg: a > b > asset1, a > b > asset2, just show a > b.
-      continue;
-    }
-    finalBundlePrefixes[prefixId] = contents;
-    finalBundlePrefixes[prefixId].forEach((id) => (finalBundleIdForNodeId[id] = prefixId));
-  }
-  return finalBundlePrefixes;
-}
 
 export const buildGraphData = (assetNodes: AssetNode[]) => {
   const data: GraphData = {

--- a/js_modules/dagit/packages/core/src/asset-graph/layout.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/layout.ts
@@ -2,7 +2,7 @@ import * as dagre from 'dagre';
 
 import {IBounds, IPoint} from '../graph/common';
 
-import {GraphData, GraphNode, GraphId, displayNameForAssetKey, identifyBundles} from './Utils';
+import {GraphData, GraphNode, GraphId, displayNameForAssetKey} from './Utils';
 
 export interface AssetLayout {
   id: GraphId;
@@ -23,12 +23,6 @@ export type AssetGraphLayout = {
   height: number;
   edges: AssetLayoutEdge[];
   nodes: {[id: string]: AssetLayout};
-
-  bundles: {[id: string]: AssetLayout};
-  bundleEdges: AssetLayoutEdge[];
-  bundleMapping: {
-    [prefixId: string]: string[];
-  };
 };
 
 const opts: {margin: number; mini: boolean} = {
@@ -88,19 +82,6 @@ export const layoutAssetGraph = (graphData: GraphData): AssetGraphLayout => {
     g.setNode(id, getForeignNodeDimensions(id));
   });
 
-  // Create "parent" nodes for nodes with a shared ID (path) prefix (eg: s3>a, s3>b),
-  // and then place the children inside. Note that the bundles are identified in order
-  // and bundleMapping can reference bundles as children - this code can create multiple
-  // layers of parents!
-  const bundleMapping = identifyBundles(g.nodes());
-
-  for (const [parentId, nodeIds] of Object.entries(bundleMapping)) {
-    g.setNode(parentId, {});
-    for (const nodeId of nodeIds) {
-      g.setParent(nodeId, parentId);
-    }
-  }
-
   dagre.layout(g);
 
   const dagreNodesById: {[id: string]: dagre.Node} = {};
@@ -116,7 +97,6 @@ export const layoutAssetGraph = (graphData: GraphData): AssetGraphLayout => {
   let maxHeight = 0;
 
   const nodes: {[id: string]: AssetLayout} = {};
-  const bundles: {[id: string]: AssetLayout} = {};
 
   Object.keys(dagreNodesById).forEach((id) => {
     const dagreNode = dagreNodesById[id];
@@ -126,58 +106,27 @@ export const layoutAssetGraph = (graphData: GraphData): AssetGraphLayout => {
       width: dagreNode.width,
       height: dagreNode.height,
     };
-    if (bundleMapping[id]) {
-      return;
-    }
     nodes[id] = {id, bounds};
 
-    // If this node was inside one or more parent nodes, upsert the parent box
-    // into the bundles result set and expand it to include the child. Note:
-    // dagre does give us "parent" node dimensions, but sometimes they're randomly
-    // much larger than the contents.
-    let bundleId = g.parent(id);
-    while (bundleId) {
-      bundles[bundleId] = bundles[bundleId] || {id: bundleId, bounds};
-      bundles[bundleId].bounds = extendBounds(bundles[bundleId].bounds, {
-        x: bounds.x - opts.margin / 4,
-        y: bounds.y - opts.margin / 4,
-        width: bounds.width + opts.margin / 2,
-        height: bounds.height + opts.margin / 2,
-      });
-      bundleId = g.parent(bundleId);
-    }
     maxWidth = Math.max(maxWidth, dagreNode.x + dagreNode.width / 2);
     maxHeight = Math.max(maxHeight, dagreNode.y + dagreNode.height / 2);
   });
 
   const edges: AssetLayoutEdge[] = [];
-  const bundleEdges: AssetLayoutEdge[] = [];
 
   g.edges().forEach((e) => {
     const points = g.edge(e).points;
-    if (bundles[e.v] || bundles[e.w]) {
-      bundleEdges.push({
-        from: points[0],
-        fromId: e.v,
-        to: points[points.length - 1],
-        toId: e.w,
-      });
-    } else {
-      edges.push({
-        from: points[0],
-        fromId: e.v,
-        to: points[points.length - 1],
-        toId: e.w,
-      });
-    }
+    edges.push({
+      from: points[0],
+      fromId: e.v,
+      to: points[points.length - 1],
+      toId: e.w,
+    });
   });
 
   return {
     nodes,
     edges,
-    bundles,
-    bundleEdges,
-    bundleMapping,
     width: maxWidth + opts.margin,
     height: maxHeight + opts.margin,
   };

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -34,6 +34,7 @@ export const AssetNodeDefinition: React.FC<{
 }> = ({assetNode, liveDataByNode}) => {
   const partitionHealthData = usePartitionHealthData([assetNode.assetKey]);
   const {assetMetadata, assetType} = metadataForAssetNode(assetNode);
+
   const repoAddress = buildRepoAddress(
     assetNode.repository.name,
     assetNode.repository.location.name,


### PR DESCRIPTION
### Summary & Motivation

This PR removes the visual "bundling" of assets on the asset graph into folders. This behavior was primarily useful for the global graph which could display assets. Per discussion with Josh it's unlikely we'll still want this with asset groups, because 1) on asset group graphs, nodes in other asset groups will always be shown as links and 2) on the lineage graph, it's unlikely the bundling of a few upstream assets will make the rendering cleaner. (The graph will be small).  

We could potentially bring it back for #2 if we want to, but the code is fairly complex and I'd like to not have it lying around unused.

### How I Tested These Changes
