### PR TITLE
[dagit] Show more information for last run on Schedules/Sensors

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -8,7 +8,6 @@ import {
   PageHeader,
   Spinner,
   Table,
-  Tag,
   Body,
   Heading,
   TextInput,
@@ -22,7 +21,6 @@ import {isAssetGroup} from '../asset-graph/Utils';
 import {ScheduleOrSensorTag} from '../nav/ScheduleOrSensorTag';
 import {LegacyPipelineTag} from '../pipelines/LegacyPipelineTag';
 import {PipelineReference} from '../pipelines/PipelineReference';
-import {RunStatusIndicator} from '../runs/RunStatusDots';
 import {RunStatusPezList} from '../runs/RunStatusPez';
 import {
   failedStatuses,
@@ -31,12 +29,10 @@ import {
   successStatuses,
 } from '../runs/RunStatuses';
 import {RunTimelineContainer, TimelineJob, makeJobKey, HourWindow} from '../runs/RunTimeline';
-import {RunStateSummary, RunTime, RUN_TIME_FRAGMENT} from '../runs/RunUtils';
+import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {RunTimeFragment} from '../runs/types/RunTimeFragment';
 import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
 import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
-import {RunStatus} from '../types/globalTypes';
-import {AnchorButton} from '../ui/AnchorButton';
 import {REPOSITORY_INFO_FRAGMENT} from '../workspace/RepositoryInformation';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
@@ -46,9 +42,9 @@ import {workspacePipelinePath} from '../workspace/workspacePath';
 
 import {InstanceTabs} from './InstanceTabs';
 import {JobMenu} from './JobMenu';
+import {LastRunSummary} from './LastRunSummary';
 import {NextTick, SCHEDULE_FUTURE_TICKS_FRAGMENT} from './NextTick';
 import {RepoFilterButton} from './RepoFilterButton';
-import {StepSummaryForRun} from './StepSummaryForRun';
 import {
   InstanceOverviewInitialQuery,
   InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules as Schedule,
@@ -56,19 +52,6 @@ import {
 } from './types/InstanceOverviewInitialQuery';
 import {LastTenRunsPerJobQuery} from './types/LastTenRunsPerJobQuery';
 import {OverviewJobFragment} from './types/OverviewJobFragment';
-
-const intent = (status: RunStatus) => {
-  switch (status) {
-    case RunStatus.SUCCESS:
-      return 'success';
-    case RunStatus.CANCELED:
-    case RunStatus.CANCELING:
-    case RunStatus.FAILURE:
-      return 'danger';
-    default:
-      return 'none';
-  }
-};
 
 type JobItem = {
   job: OverviewJobFragment;
@@ -510,30 +493,7 @@ const JobSection = (props: JobSectionProps) => {
                   )}
                 </td>
                 <td>
-                  <Box
-                    flex={{
-                      direction: 'row',
-                      justifyContent: 'space-between',
-                      alignItems: 'flex-start',
-                    }}
-                  >
-                    <Box flex={{direction: 'column', alignItems: 'flex-start', gap: 8}}>
-                      <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
-                        <Tag intent={intent(job.runs[0].status)}>
-                          <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-                            <RunStatusIndicator status={job.runs[0].status} size={10} />
-                            <RunTime run={job.runs[0]} />
-                          </Box>
-                        </Tag>
-                        <RunStateSummary run={job.runs[0]} />
-                      </Box>
-                      {failedStatuses.has(job.runs[0].status) ||
-                      inProgressStatuses.has(job.runs[0].status) ? (
-                        <StepSummaryForRun runId={job.runs[0].id} />
-                      ) : undefined}
-                    </Box>
-                    <AnchorButton to={`/instance/runs/${job.runs[0].id}`}>View run</AnchorButton>
-                  </Box>
+                  <LastRunSummary run={job.runs[0]} />
                 </td>
                 <td>
                   <JobMenu job={job} repoAddress={repoAddress} />

--- a/js_modules/dagit/packages/core/src/instance/LastRunSummary.tsx
+++ b/js_modules/dagit/packages/core/src/instance/LastRunSummary.tsx
@@ -1,0 +1,55 @@
+import {Box, Tag} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {RunStatusIndicator} from '../runs/RunStatusDots';
+import {failedStatuses, inProgressStatuses} from '../runs/RunStatuses';
+import {RunStateSummary, RunTime} from '../runs/RunUtils';
+import {RunTimeFragment} from '../runs/types/RunTimeFragment';
+import {RunStatus} from '../types/globalTypes';
+import {AnchorButton} from '../ui/AnchorButton';
+
+import {StepSummaryForRun} from './StepSummaryForRun';
+
+export const LastRunSummary: React.FC<{run: RunTimeFragment}> = React.memo(({run}) => {
+  const {status} = run;
+
+  const intent = React.useMemo(() => {
+    switch (status) {
+      case RunStatus.SUCCESS:
+        return 'success';
+      case RunStatus.CANCELED:
+      case RunStatus.CANCELING:
+      case RunStatus.FAILURE:
+        return 'danger';
+      default:
+        return 'none';
+    }
+  }, [status]);
+
+  return (
+    <Box
+      flex={{
+        direction: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'flex-start',
+        gap: 16,
+      }}
+    >
+      <Box flex={{direction: 'column', alignItems: 'flex-start', gap: 8}}>
+        <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+          <Tag intent={intent}>
+            <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+              <RunStatusIndicator status={run.status} size={10} />
+              <RunTime run={run} />
+            </Box>
+          </Tag>
+          <RunStateSummary run={run} />
+        </Box>
+        {failedStatuses.has(run.status) || inProgressStatuses.has(run.status) ? (
+          <StepSummaryForRun runId={run.id} />
+        ) : undefined}
+      </Box>
+      <AnchorButton to={`/instance/runs/${run.id}`}>View run</AnchorButton>
+    </Box>
+  );
+});

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceSchedulesQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceSchedulesQuery.ts
@@ -80,6 +80,9 @@ export interface InstanceSchedulesQuery_repositoriesOrError_RepositoryConnection
   id: string;
   runId: string;
   status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface InstanceSchedulesQuery_repositoriesOrError_RepositoryConnection_nodes_schedules_scheduleState_ticks_error_cause {
@@ -194,6 +197,9 @@ export interface InstanceSchedulesQuery_unloadableInstigationStatesOrError_Insti
   id: string;
   runId: string;
   status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface InstanceSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error_cause {

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceSensorsQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceSensorsQuery.ts
@@ -79,6 +79,9 @@ export interface InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_n
   id: string;
   runId: string;
   status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_nodes_sensors_sensorState_ticks_error_cause {
@@ -198,6 +201,9 @@ export interface InstanceSensorsQuery_unloadableInstigationStatesOrError_Instiga
   id: string;
   runId: string;
   status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface InstanceSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error_cause {

--- a/js_modules/dagit/packages/core/src/instigation/InstigationUtils.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationUtils.tsx
@@ -5,8 +5,9 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {LastRunSummary} from '../instance/LastRunSummary';
 import {RunStatusIndicator} from '../runs/RunStatusDots';
-import {titleForRun} from '../runs/RunUtils';
+import {RUN_TIME_FRAGMENT, titleForRun} from '../runs/RunUtils';
 
 import {TICK_TAG_FRAGMENT} from './InstigationTick';
 import {InstigationStateFragment} from './types/InstigationStateFragment';
@@ -18,7 +19,7 @@ export const InstigatedRunStatus: React.FC<{
   if (!instigationState.runs.length) {
     return <span style={{color: Colors.Gray300}}>None</span>;
   }
-  return <RunStatusLink run={instigationState.runs[0]} />;
+  return <LastRunSummary run={instigationState.runs[0]} />;
 };
 
 export const RunStatusLink: React.FC<{run: RunStatusFragment}> = ({run}) => (
@@ -59,6 +60,7 @@ export const INSTIGATION_STATE_FRAGMENT = gql`
     runs(limit: 1) {
       id
       ...RunStatusFragment
+      ...RunTimeFragment
     }
     status
     ticks(limit: 1) {
@@ -71,6 +73,7 @@ export const INSTIGATION_STATE_FRAGMENT = gql`
   ${PYTHON_ERROR_FRAGMENT}
   ${TICK_TAG_FRAGMENT}
   ${RUN_STATUS_FRAGMENT}
+  ${RUN_TIME_FRAGMENT}
 `;
 
 export const StatusTable = styled.table`

--- a/js_modules/dagit/packages/core/src/instigation/types/InstigationStateFragment.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/InstigationStateFragment.ts
@@ -27,6 +27,9 @@ export interface InstigationStateFragment_runs {
   id: string;
   runId: string;
   status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface InstigationStateFragment_ticks_error_cause {

--- a/js_modules/dagit/packages/core/src/instigation/types/UnloadableInstigationStatesQuery.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/UnloadableInstigationStatesQuery.ts
@@ -27,6 +27,9 @@ export interface UnloadableInstigationStatesQuery_unloadableInstigationStatesOrE
   id: string;
   runId: string;
   status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface UnloadableInstigationStatesQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error_cause {

--- a/js_modules/dagit/packages/core/src/runs/types/SchedulerInfoQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/SchedulerInfoQuery.ts
@@ -74,6 +74,9 @@ export interface SchedulerInfoQuery_repositoriesOrError_RepositoryConnection_nod
   id: string;
   runId: string;
   status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface SchedulerInfoQuery_repositoriesOrError_RepositoryConnection_nodes_schedules_scheduleState_ticks_error_cause {

--- a/js_modules/dagit/packages/core/src/schedules/types/RepositorySchedulesFragment.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/RepositorySchedulesFragment.ts
@@ -39,6 +39,9 @@ export interface RepositorySchedulesFragment_schedules_scheduleState_runs {
   id: string;
   runId: string;
   status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface RepositorySchedulesFragment_schedules_scheduleState_ticks_error_cause {

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleFragment.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleFragment.ts
@@ -33,6 +33,9 @@ export interface ScheduleFragment_scheduleState_runs {
   id: string;
   runId: string;
   status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface ScheduleFragment_scheduleState_ticks_error_cause {

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleRootQuery.ts
@@ -33,6 +33,9 @@ export interface ScheduleRootQuery_scheduleOrError_Schedule_scheduleState_runs {
   id: string;
   runId: string;
   status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface ScheduleRootQuery_scheduleOrError_Schedule_scheduleState_ticks_error_cause {

--- a/js_modules/dagit/packages/core/src/schedules/types/SchedulesRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/SchedulesRootQuery.ts
@@ -43,6 +43,9 @@ export interface SchedulesRootQuery_repositoryOrError_Repository_schedules_sched
   id: string;
   runId: string;
   status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface SchedulesRootQuery_repositoryOrError_Repository_schedules_scheduleState_ticks_error_cause {
@@ -158,6 +161,9 @@ export interface SchedulesRootQuery_unloadableInstigationStatesOrError_Instigati
   id: string;
   runId: string;
   status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface SchedulesRootQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error_cause {

--- a/js_modules/dagit/packages/core/src/sensors/SensorsTable.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorsTable.tsx
@@ -29,7 +29,7 @@ export const SensorsTable: React.FC<{
           <th style={{width: '60px'}}></th>
           <th>Sensor Name</th>
           <th style={{width: '15%'}}>Frequency</th>
-          <th style={{width: '15%'}}>
+          <th style={{width: '10%'}}>
             <Box flex={{gap: 8, alignItems: 'end'}}>
               Last tick
               <Tooltip position="top" content={lastTick}>
@@ -37,7 +37,7 @@ export const SensorsTable: React.FC<{
               </Tooltip>
             </Box>
           </th>
-          <th style={{width: '20%'}}>
+          <th style={{width: '25%'}}>
             <Box flex={{gap: 8, alignItems: 'end'}}>
               Last Run
               <Tooltip position="top" content={lastRun}>

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.ts
@@ -32,6 +32,9 @@ export interface SensorFragment_sensorState_runs {
   id: string;
   runId: string;
   status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface SensorFragment_sensorState_ticks_error_cause {

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorRootQuery.ts
@@ -36,6 +36,9 @@ export interface SensorRootQuery_sensorOrError_Sensor_sensorState_runs {
   id: string;
   runId: string;
   status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface SensorRootQuery_sensorOrError_Sensor_sensorState_ticks_error_cause {

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorsRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorsRootQuery.ts
@@ -49,6 +49,9 @@ export interface SensorsRootQuery_sensorsOrError_Sensors_results_sensorState_run
   id: string;
   runId: string;
   status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface SensorsRootQuery_sensorsOrError_Sensors_results_sensorState_ticks_error_cause {
@@ -146,6 +149,9 @@ export interface SensorsRootQuery_unloadableInstigationStatesOrError_Instigation
   id: string;
   runId: string;
   status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface SensorsRootQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error_cause {


### PR DESCRIPTION
### Summary & Motivation

Use the run summary from Instance Overview in the Sensors and Schedules pages.

<img width="1522" alt="Screen Shot 2022-05-31 at 1 41 46 PM" src="https://user-images.githubusercontent.com/2823852/171265274-f1549b31-f85b-4eba-a828-587a850e5b6f.png">

### How I Tested These Changes

View Sensors and Schedules pages under Status, verify desired rendering.
