### PR TITLE
chore(helm): christen the code server service port name as grpc

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/service-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/service-user.yaml
@@ -20,7 +20,7 @@ spec:
   ports:
     - port: {{ $deployment.port }}
       protocol: TCP
-      name: http
+      name: grpc
   selector:
     {{- include "dagster.selectorLabels" $ | nindent 4 }}
     component: user-deployments


### PR DESCRIPTION
### Summary & Motivation

Istio derives the proxy sidecar protocol mode from service port names as documented here: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/

Due to the behavior documented in the link above, Dagit is unable to reach user-code deployments with Istio injection enabled on the Dagster deployment.

This PR changes the name of the user code deployment service port in the helm chart to signal to Istio that the service is a GRPC/HTTP2 server. This same naming convention may be used by other service meshes. I considered making this an optional value with a default, but it seems unlikely that anyone would have a compelling reason to name the service "http" instead of "grpc".

### How I Tested These Changes

I applied this Helm chart in my own cluster with and without Istio enabled and confirmed that it works in both cases.
