### PR TITLE
[dagit] Fix duplicate styled-components

### DIFF
--- a/js_modules/dagit/packages/app/package.json
+++ b/js_modules/dagit/packages/app/package.json
@@ -17,7 +17,6 @@
     "react-is": "^17.0.2",
     "react-router": "^5.2.1",
     "react-router-dom": "^5.3.0",
-    "styled-components": "^5.3.3",
     "web-vitals": "^2.1.3"
   },
   "devDependencies": {

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -5514,7 +5514,6 @@ __metadata:
     react-router: ^5.2.1
     react-router-dom: ^5.3.0
     source-map-explorer: ^2.5.0
-    styled-components: ^5.3.3
     typescript: ^4.6.4
     web-vitals: ^2.1.3
     webpack: ^5.0.0


### PR DESCRIPTION
### Summary & Motivation

We're getting a duplicate styled-components warning in the console in dev.

Removing the dep from `dagit-app` makes it go away. I'm not sure why this isn't being properly deduplicated by yarn, but I don't really want to sink time into it right now, and this fixes it for now.

### How I Tested These Changes

Load Dagit, verify that there are no duplicate styled-components warnings.
