### PR TITLE
[dagit] Add active state to left nav items

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/RepositoryContentList.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepositoryContentList.tsx
@@ -23,19 +23,21 @@ export const Items = styled.div`
   }
 `;
 
-export const Item = styled(Link)`
+export const Item = styled(Link)<{$active: boolean}>`
+  background-color: ${({$active}) => ($active ? Colors.Blue50 : 'transparent')};
   border-radius: 8px;
   font-size: 14px;
   text-overflow: ellipsis;
   overflow: hidden;
   padding: 6px 12px;
   display: block;
-  color: ${Colors.Gray900} !important;
+  color: ${({$active}) => ($active ? Colors.Blue700 : Colors.Dark)} !important;
   user-select: none;
+  transition: background 50ms linear, color 50ms linear;
 
   &:hover {
     text-decoration: none;
-    background-color: ${Colors.Gray10};
+    background-color: ${({$active}) => ($active ? Colors.Blue50 : Colors.Gray10)};
   }
 
   &:focus {
@@ -44,9 +46,5 @@ export const Item = styled(Link)`
 
   &.focused {
     border-left: 4px solid ${Colors.Gray400};
-  }
-
-  &.selected {
-    background: ${Colors.Gray200};
   }
 `;


### PR DESCRIPTION
### Summary & Motivation

Add an "active" state to the left nav, for the job that is currently being viewed. This is based on matching the active path in the URL.

If a job is active but its repo is collapsed, show the job item anyway. If the job item is scrolled out of view, scroll it into view.

<img width="566" alt="Screen Shot 2022-06-01 at 11 20 29 AM" src="https://user-images.githubusercontent.com/2823852/171452946-44119ddb-271c-439d-8f08-accafede7fc6.png">
<img width="601" alt="Screen Shot 2022-06-01 at 11 20 34 AM" src="https://user-images.githubusercontent.com/2823852/171452949-c9d55dd0-a88f-481f-98c8-8c4fd3c857d3.png">

### How I Tested These Changes

View Dagit, verify behavior described above.
