### PR TITLE
Avoid launching ECS runs with large overrides

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -206,11 +206,13 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         repository_origin = pipeline_origin.repository_origin
         # pylint: disable=protected-access
         stripped_repository_origin = repository_origin._replace(container_context={})
-        pipeline_origin = pipeline_origin._replace(repository_origin=stripped_repository_origin)
+        stripped_pipeline_origin = pipeline_origin._replace(
+            repository_origin=stripped_repository_origin
+        )
         # pylint: enable=protected-access
 
         args = ExecuteRunArgs(
-            pipeline_origin=pipeline_origin,
+            pipeline_origin=stripped_pipeline_origin,
             pipeline_run_id=run.run_id,
             instance_ref=self._instance.get_ref(),
         )

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -204,8 +204,10 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         # the container context off of our pipeline origin because we don't actually need
         # it to launch the run; we only needed it to create the task definition.
         repository_origin = pipeline_origin.repository_origin
+        # pylint: disable=protected-access
         stripped_repository_origin = repository_origin._replace(container_context={})
         pipeline_origin = pipeline_origin._replace(repository_origin=stripped_repository_origin)
+        # pylint: enable=protected-access
 
         args = ExecuteRunArgs(
             pipeline_origin=pipeline_origin,

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -197,6 +197,16 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
             "family"
         ]
 
+        # ECS limits overrides to 8192 characters including json formatting
+        # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html
+        # When container_context is serialized as part of the ExecuteRunArgs, we risk
+        # going over this limit (for example, if many secrets have been set). This strips
+        # the container context off of our pipeline origin because we don't actually need
+        # it to launch the run; we only needed it to create the task definition.
+        repository_origin = pipeline_origin.repository_origin
+        stripped_repository_origin = repository_origin._replace(container_context={})
+        pipeline_origin = pipeline_origin._replace(repository_origin=stripped_repository_origin)
+
         args = ExecuteRunArgs(
             pipeline_origin=pipeline_origin,
             pipeline_run_id=run.run_id,

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
@@ -342,6 +342,11 @@ class StubbedEcs:
                     raise StubbedEcsError
 
             overrides = kwargs.get("overrides", {})
+            # overrides is limited to 8192 characters including json formatting
+            # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html
+            if len(str(overrides)) > 8192:
+                self.stubber.add_client_error(method="run_task", expected_params={**kwargs})
+
             cpu = overrides.get("cpu") or task_definition.get("cpu")
             memory = overrides.get("memory") or task_definition.get("memory")
             if not self._valid_cpu_and_memory(cpu=cpu, memory=memory):

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_stubbed_ecs.py
@@ -371,6 +371,15 @@ def test_run_task(ecs, ec2, subnet):
     assert response["tasks"][0]["overrides"]["cpu"] == "512"
     assert response["tasks"][0]["overrides"]["memory"] == "1024"
 
+    # With very long overrides
+    with pytest.raises(Exception):
+        ecs.run_task(
+            taskDefinition="container",
+            # overrides is limited to 8192 characters including json formatting
+            # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html
+            overrides={"containerOverrides": ["boom" for i in range(10000)]},
+        )
+
 
 def test_stop_task(ecs):
     with pytest.raises(ClientError):


### PR DESCRIPTION
Per the AWS docs:

> A total of 8192 characters are allowed for overrides. This limit includes
> the JSON formatting characters of the override structure.

https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html

When users have very large container contexts (for example, if they set
many secrets), then we can run up against ECS's run task limits on
request size.

We don't actually need the container context to launch the run; only to
create its task definition. So this strips the container context out of
the command that gets passed to `dagster api execute_run` to keep our
override commands smaller.