### PR TITLE
add data migration to bulk actions table for backfill jobs

### DIFF
--- a/python_modules/dagster/dagster/core/execution/backfill.py
+++ b/python_modules/dagster/dagster/core/execution/backfill.py
@@ -31,6 +31,11 @@ from dagster.utils.error import SerializableErrorInfo
 
 
 @whitelist_for_serdes
+class BulkActionType(Enum):
+    BACKFILL = "BACKFILL"
+
+
+@whitelist_for_serdes
 class BulkActionStatus(Enum):
     REQUESTED = "REQUESTED"
     COMPLETED = "COMPLETED"
@@ -88,6 +93,10 @@ class PartitionBackfill(
             check.opt_str_param(last_submitted_partition_name, "last_submitted_partition_name"),
             check.opt_inst_param(error, "error", SerializableErrorInfo),
         )
+
+    @property
+    def selector_id(self):
+        return self.partition_set_origin.get_selector_id()
 
     def with_status(self, status):
         check.inst_param(status, "status", BulkActionStatus)

--- a/python_modules/dagster/dagster/core/execution/backfill.py
+++ b/python_modules/dagster/dagster/core/execution/backfill.py
@@ -31,11 +31,6 @@ from dagster.utils.error import SerializableErrorInfo
 
 
 @whitelist_for_serdes
-class BulkActionType(Enum):
-    BACKFILL = "BACKFILL"
-
-
-@whitelist_for_serdes
 class BulkActionStatus(Enum):
     REQUESTED = "REQUESTED"
     COMPLETED = "COMPLETED"

--- a/python_modules/dagster/dagster/core/execution/bulk_actions.py
+++ b/python_modules/dagster/dagster/core/execution/bulk_actions.py
@@ -1,0 +1,7 @@
+from enum import Enum
+from dagster.serdes import whitelist_for_serdes
+
+
+@whitelist_for_serdes
+class BulkActionType(Enum):
+    PARITION_BACKFILL = "PARTITION_BACKFILL"

--- a/python_modules/dagster/dagster/core/execution/bulk_actions.py
+++ b/python_modules/dagster/dagster/core/execution/bulk_actions.py
@@ -1,7 +1,8 @@
 from enum import Enum
+
 from dagster.serdes import whitelist_for_serdes
 
 
 @whitelist_for_serdes
 class BulkActionType(Enum):
-    PARITION_BACKFILL = "PARTITION_BACKFILL"
+    PARTITION_BACKFILL = "PARTITION_BACKFILL"

--- a/python_modules/dagster/dagster/core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/core/host_representation/origin.py
@@ -30,7 +30,7 @@ from dagster.serdes import (
 )
 from dagster.serdes.serdes import WhitelistMap, unpack_inner_value
 
-from .selector import RepositorySelector
+from .selector import PartitionSetSelector, RepositorySelector
 
 if TYPE_CHECKING:
     from dagster.core.host_representation.repository_location import (
@@ -529,3 +529,12 @@ class ExternalPartitionSetOrigin(
 
     def get_id(self) -> str:
         return create_snapshot_id(self)
+
+    def get_selector_id(self) -> str:
+        return create_snapshot_id(
+            PartitionSetSelector(
+                self.external_repository_origin.repository_location_origin.location_name,
+                self.external_repository_origin.repository_name,
+                self.partition_set_name,
+            )
+        )

--- a/python_modules/dagster/dagster/core/host_representation/selector.py
+++ b/python_modules/dagster/dagster/core/host_representation/selector.py
@@ -201,3 +201,30 @@ class GraphSelector(
             "repositoryName": self.repository_name,
             "graphName": self.graph_name,
         }
+
+
+@whitelist_for_serdes
+class PartitionSetSelector(
+    NamedTuple(
+        "_PartitionSetSelector",
+        [("location_name", str), ("repository_name", str), ("partition_set_name", str)],
+    )
+):
+    """
+    The information needed to resolve a partition set within a host process.
+    """
+
+    def __new__(cls, location_name: str, repository_name: str, partition_set_name: str):
+        return super(PartitionSetSelector, cls).__new__(
+            cls,
+            location_name=check.str_param(location_name, "location_name"),
+            repository_name=check.str_param(repository_name, "repository_name"),
+            partition_set_name=check.str_param(partition_set_name, "partition_set_name"),
+        )
+
+    def to_graphql_input(self):
+        return {
+            "repositoryLocationName": self.location_name,
+            "repositoryName": self.repository_name,
+            "partitionSetName": self.partition_set_name,
+        }

--- a/python_modules/dagster/dagster/core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/core/storage/runs/migration.py
@@ -6,7 +6,8 @@ from tqdm import tqdm
 import dagster._check as check
 from dagster.serdes import deserialize_as
 
-from ...execution.backfill import BulkActionType, PartitionBackfill
+from ...execution.backfill import PartitionBackfill
+from ...execution.bulk_actions import BulkActionType
 from ..pipeline_run import PipelineRun, PipelineRunStatus
 from ..runs.base import RunStorage
 from ..runs.schema import BulkActionsTable, RunTagsTable, RunsTable
@@ -246,7 +247,8 @@ def migrate_bulk_actions(run_storage: RunStorage, print_fn=None):
                 conn.execute(
                     BulkActionsTable.update()
                     .values(
-                        selector_id=backfill.selector_id, action_type=BulkActionType.BACKFILL.value
+                        selector_id=backfill.selector_id,
+                        action_type=BulkActionType.PARTITION_BACKFILL.value,
                     )
                     .where(BulkActionsTable.c.id == storage_id)
                 )

--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -18,7 +18,8 @@ from dagster.core.errors import (
     DagsterSnapshotDoesNotExist,
 )
 from dagster.core.events import EVENT_TYPE_TO_PIPELINE_RUN_STATUS, DagsterEvent, DagsterEventType
-from dagster.core.execution.backfill import BulkActionStatus, BulkActionType, PartitionBackfill
+from dagster.core.execution.backfill import BulkActionStatus, PartitionBackfill
+from dagster.core.execution.bulk_actions import BulkActionType
 from dagster.core.snap import (
     ExecutionPlanSnapshot,
     PipelineSnapshot,
@@ -1035,7 +1036,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
         if self.has_bulk_actions_selector_cols():
             values["selector_id"] = partition_backfill.selector_id
-            values["action_type"] = BulkActionType.BACKFILL.value
+            values["action_type"] = BulkActionType.PARTITION_BACKFILL.value
 
         with self.connect() as conn:
             conn.execute(


### PR DESCRIPTION
### Summary & Motivation
Prepping a data migration to accompany the schema migration associated with https://github.com/dagster-io/dagster/pull/7995

This will ensure that action type and selector_id will be non-null for backfills.

### How I Tested These Changes
Changed backcompat test to check data.
