### PR TITLE
[docs] Asset Job Schedules/Sensors [CON-28, CON-29]

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
@@ -197,7 +197,7 @@ def antarctica_schedule():
     yield request
 ```
 
-The [Schedules concept page](/concepts/partitions-schedules-sensors/schedules#a-schedule-from-a-partitioned-job) describes how construct both kinds of schedules in more detail.
+The [Schedules concept page](/concepts/partitions-schedules-sensors/schedules#schedules-from-partitioned-assets-and-jobs) describes how construct both kinds of schedules in more detail.
 
 ## Testing
 

--- a/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
@@ -197,7 +197,7 @@ def antarctica_schedule():
     yield request
 ```
 
-The [Schedules concept page](/concepts/partitions-schedules-sensors/schedules#schedules-from-partitioned-assets-and-jobs) describes how construct both kinds of schedules in more detail.
+Refer to the [Schedules documentation](/concepts/partitions-schedules-sensors/schedules#schedules-from-partitioned-assets-and-jobs) for more info about constructing both schedule types.
 
 ## Testing
 

--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -49,6 +49,14 @@ def my_job():
 basic_schedule = ScheduleDefinition(job=my_job, cron_schedule="0 0 * * *")
 ```
 
+In order to run schedules for assets, you can [build a job that materializes assets](/concepts/assets/software-defined-assets#building-jobs-that-materialize-assets) and construct a <PyObject object="ScheduleDefinition" /> similarly:
+
+```python file=concepts/partitions_schedules_sensors/schedules/schedules.py startafter=start_basic_asset_schedule endbefore=end_basic_asset_schedule
+asset_job = AssetGroup([...]).build_job("asset_job")
+
+basic_schedule = ScheduleDefinition(job=asset_job, cron_schedule="0 0 * * *")
+```
+
 ### A schedule that provides custom run config and tags
 
 If you want to vary the behavior of your job based on the time it's scheduled to run, you can use the <PyObject object="schedule" decorator /> decorator, which decorates a function that returns run config based on a provided <PyObject object="ScheduleEvaluationContext" />.
@@ -78,9 +86,9 @@ def configurable_job_schedule(context: ScheduleEvaluationContext):
 
 If you don't need access to the context parameter, you can omit it from the decorated function.
 
-### A schedule from a partitioned job
+### Schedules from partitioned assets and jobs
 
-#### Time partitioned job
+#### Time partitioned assets and jobs
 
 When you have a [partitioned job](/concepts/partitions-schedules-sensors/partitions) that's partitioned by time, you can use the <PyObject object="build_schedule_from_partitioned_job"/> function to construct a schedule for it whose interval matches the spacing of partitions in your job.
 
@@ -99,6 +107,19 @@ def do_stuff_partitioned():
 
 do_stuff_partitioned_schedule = build_schedule_from_partitioned_job(
     do_stuff_partitioned,
+)
+```
+
+The Partitioned Jobs concepts page also includes an [example of a date-partitioned asset](/concepts/partitions-schedules-sensors/partitions#partitioned-assets). You can define a schedule similarly using <PyObject object="build_schedule_from_partitioned_job"/>:
+
+```python file=/concepts/partitions_schedules_sensors/schedule_from_partitions.py startafter=start_partitioned_asset_schedule endbefore=end_partitioned_asset_schedule
+from dagster import build_schedule_from_partitioned_job, AssetGroup
+
+partitioned_asset_job = AssetGroup([...]).build_job("partitioned_job")
+
+
+asset_partitioned_schedule = build_schedule_from_partitioned_job(
+    partitioned_asset_job,
 )
 ```
 

--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -52,7 +52,7 @@ basic_schedule = ScheduleDefinition(job=my_job, cron_schedule="0 0 * * *")
 In order to run schedules for assets, you can [build a job that materializes assets](/concepts/assets/software-defined-assets#building-jobs-that-materialize-assets) and construct a <PyObject object="ScheduleDefinition" /> similarly:
 
 ```python file=concepts/partitions_schedules_sensors/schedules/schedules.py startafter=start_basic_asset_schedule endbefore=end_basic_asset_schedule
-asset_job = AssetGroup([...]).build_job("asset_job")
+asset_job = AssetGroup([my_asset]).build_job("asset_job")
 
 basic_schedule = ScheduleDefinition(job=asset_job, cron_schedule="0 0 * * *")
 ```
@@ -113,9 +113,9 @@ do_stuff_partitioned_schedule = build_schedule_from_partitioned_job(
 The Partitioned Jobs concepts page also includes an [example of a date-partitioned asset](/concepts/partitions-schedules-sensors/partitions#partitioned-assets). You can define a schedule similarly using <PyObject object="build_schedule_from_partitioned_job"/>:
 
 ```python file=/concepts/partitions_schedules_sensors/schedule_from_partitions.py startafter=start_partitioned_asset_schedule endbefore=end_partitioned_asset_schedule
-from dagster import build_schedule_from_partitioned_job, AssetGroup
+from dagster import AssetGroup
 
-partitioned_asset_job = AssetGroup([...]).build_job("partitioned_job")
+partitioned_asset_job = AssetGroup([partitioned_asset]).build_job("partitioned_job")
 
 
 asset_partitioned_schedule = build_schedule_from_partitioned_job(

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -83,7 +83,7 @@ def my_directory_sensor():
 
 This sensor iterates through all the files in `MY_DIRECTORY` and `yields` a <PyObject object="RunRequest"/> for each file. Note that despite the `yield` syntax, the function will run to completion before any runs are submitted.
 
-In order to write a sensor that materializes assets, you can [build a job that materializes assets](/concepts/assets/software-defined-assets#building-jobs-that-materialize-assets):
+To write a sensor that materializes assets, you can [build a job that materializes assets](/concepts/assets/software-defined-assets#building-jobs-that-materialize-assets):
 
 ```python file=concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_asset_job_sensor_marker endbefore=end_asset_job_sensor_marker
 asset_job = AssetGroup([my_asset]).build_job("asset_job")
@@ -112,7 +112,7 @@ A useful pattern is to create a sensor that checks for new <PyObject object="Ass
 
 One benefit of this pattern is that it enables cross-job and even cross-repository dependencies. Each job run instigated by an asset sensor is agnostic to the job that caused it.
 
-Dagster provides a special asset sensor definition format for sensors that fire a single RunRequest based on a single asset materialization. Here is an example of a sensor that generates a RunRequest for every materialization for the asset key `my_table`:
+Dagster provides a special asset sensor definition format for sensors that fire a single <PyObject object="RunRequest"/> based on a single asset materialization. Here is an example of a sensor that generates a <PyObject object="RunRequest"/> for every materialization for the asset key `my_table`:
 
 ```python file=/concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_asset_sensor_marker endbefore=end_asset_sensor_marker
 from dagster import AssetKey, asset_sensor

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -83,10 +83,21 @@ def my_directory_sensor():
 
 This sensor iterates through all the files in `MY_DIRECTORY` and `yields` a <PyObject object="RunRequest"/> for each file. Note that despite the `yield` syntax, the function will run to completion before any runs are submitted.
 
-Once `my_directory_sensor` is added to a <PyObject object="repository"/> with `log_file_job`, it can be started and will start creating runs. You can start or stop sensors in Dagit, or by setting the default status to `DefaultSensorStatus.RUNNING` in code:
+In order to write a sensor that materializes assets, you can [build a job that materializes assets](/concepts/assets/software-defined-assets#building-jobs-that-materialize-assets):
+
+```python file=concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_asset_job_sensor_marker endbefore=end_asset_job_sensor_marker
+asset_job = AssetGroup([...]).build_job("asset_job")
+
+
+@sensor(job=asset_job)
+def materializes_asset_sensor():
+    yield RunRequest(...)
+```
+
+Once a sensor is added to a <PyObject object="repository"/> with the job it yields a <PyObject object="RunRequest"/> for, it can be started and will start creating runs. You can start or stop sensors in Dagit, or by setting the default status to `DefaultSensorStatus.RUNNING` in code:
 
 ```python file=concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_running_in_code endbefore=end_running_in_code
-@sensor(job=log_file_job, default_status=DefaultSensorStatus.RUNNING)
+@sensor(job=asset_job, default_status=DefaultSensorStatus.RUNNING)
 def my_running_sensor():
     ...
 ```
@@ -94,6 +105,87 @@ def my_running_sensor():
 If you manually start or stop a sensor in Dagit, that will override any default status that is set in code.
 
 Once your sensor is started, if you're running the [dagster-daemon](/deployment/dagster-daemon) process as part of your deployment, the sensor will begin executing immediately, without needing to restart the dagster-daemon process.
+
+## Asset sensors
+
+A useful pattern is to create a sensor that checks for new <PyObject object="AssetMaterialization" /> events for a particular asset key. This can be used to kick off a job that computes downstream assets or notifies appropriate stakeholders.
+
+One benefit of this pattern is that it enables cross-job and even cross-repository dependencies. Each job run instigated by an asset sensor is agnostic to the job that caused it.
+
+Dagster provides a special asset sensor definition format for sensors that fire a single RunRequest based on a single asset materialization. Here is an example of a sensor that generates a RunRequest for every materialization for the asset key `my_table`:
+
+```python file=/concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_asset_sensor_marker endbefore=end_asset_sensor_marker
+from dagster import AssetKey, asset_sensor
+
+
+@asset_sensor(asset_key=AssetKey("my_table"), job=my_job)
+def my_asset_sensor(context, asset_event):
+    yield RunRequest(
+        run_key=context.cursor,
+        run_config={
+            "ops": {
+                "read_materialization": {
+                    "config": {
+                        "asset_key": asset_event.dagster_event.asset_key.path,
+                    }
+                }
+            }
+        },
+    )
+```
+
+### Multi-asset sensors
+
+Multi-asset sensors, which can trigger job executions based on some combination of states from multiple asset materialization event streams, can be handled using the base sensor definition and manual cursor management based on the asset event streams. These asset event streams can be queried using the `instance` attribute off of the <PyObject object="SensorEvaluationContext" /> object.
+
+```python file=/concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_multi_asset_sensor_marker endbefore=end_multi_asset_sensor_marker
+import json
+from dagster import EventRecordsFilter, DagsterEventType
+
+
+@sensor(job=my_job)
+def multi_asset_sensor(context):
+    cursor_dict = json.loads(context.cursor) if context.cursor else {}
+    a_cursor = cursor_dict.get("a")
+    b_cursor = cursor_dict.get("b")
+
+    a_event_records = context.instance.get_event_records(
+        EventRecordsFilter(
+            event_type=DagsterEventType.ASSET_MATERIALIZATION,
+            asset_key=AssetKey("table_a"),
+            after_cursor=a_cursor,
+        ),
+        ascending=False,
+        limit=1,
+    )
+    b_event_records = context.instance.get_event_records(
+        EventRecordsFilter(
+            event_type=DagsterEventType.ASSET_MATERIALIZATION,
+            asset_key=AssetKey("table_b"),
+            after_cursor=b_cursor,
+        ),
+        ascending=False,
+        limit=1,
+    )
+
+    if not a_event_records or not b_event_records:
+        return
+
+    # make sure we only generate events if both table_a and table_b have been materialized since
+    # the last evaluation.
+    yield RunRequest(run_key=None)
+
+    # update the sensor cursor by combining the individual event cursors from the two separate
+    # asset event streams
+    context.update_cursor(
+        json.dumps(
+            {
+                "a": a_event_records[0].storage_id,
+                "b": b_event_records[0].storage_id,
+            }
+        )
+    )
+```
 
 ## Idempotence and Cursors
 
@@ -289,87 +381,6 @@ src="/images/concepts/partitions-schedules-sensors/sensors/sensor-A.png"
 width={1982}
 height={1400}
 />
-
-## Asset sensors
-
-A useful pattern is to create a sensor that checks for new <PyObject object="AssetMaterialization" /> events for a particular asset key. This can be used to kick off a job that computes downstream assets or notifies appropriate stakeholders.
-
-One benefit of this pattern is that it enables cross-job and even cross-repository dependencies. Each job run instigated by an asset sensor is agnostic to the job that caused it.
-
-Dagster provides a special asset sensor definition format for sensors that fire a single RunRequest based on a single asset materialization. Here is an example of a sensor that generates a RunRequest for every materialization for the asset key `my_table`:
-
-```python file=/concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_asset_sensor_marker endbefore=end_asset_sensor_marker
-from dagster import AssetKey, asset_sensor
-
-
-@asset_sensor(asset_key=AssetKey("my_table"), job=my_job)
-def my_asset_sensor(context, asset_event):
-    yield RunRequest(
-        run_key=context.cursor,
-        run_config={
-            "ops": {
-                "read_materialization": {
-                    "config": {
-                        "asset_key": asset_event.dagster_event.asset_key.path,
-                    }
-                }
-            }
-        },
-    )
-```
-
-### Multi-asset sensors
-
-Multi-asset sensors, which can trigger job executions based on some combination of states from multiple asset materialization event streams, can be handled using the base sensor definition and manual cursor management based on the asset event streams. These asset event streams can be queried using the `instance` attribute off of the <PyObject object="SensorEvaluationContext" /> object.
-
-```python file=/concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_multi_asset_sensor_marker endbefore=end_multi_asset_sensor_marker
-import json
-from dagster import EventRecordsFilter, DagsterEventType
-
-
-@sensor(job=my_job)
-def multi_asset_sensor(context):
-    cursor_dict = json.loads(context.cursor) if context.cursor else {}
-    a_cursor = cursor_dict.get("a")
-    b_cursor = cursor_dict.get("b")
-
-    a_event_records = context.instance.get_event_records(
-        EventRecordsFilter(
-            event_type=DagsterEventType.ASSET_MATERIALIZATION,
-            asset_key=AssetKey("table_a"),
-            after_cursor=a_cursor,
-        ),
-        ascending=False,
-        limit=1,
-    )
-    b_event_records = context.instance.get_event_records(
-        EventRecordsFilter(
-            event_type=DagsterEventType.ASSET_MATERIALIZATION,
-            asset_key=AssetKey("table_b"),
-            after_cursor=b_cursor,
-        ),
-        ascending=False,
-        limit=1,
-    )
-
-    if not a_event_records or not b_event_records:
-        return
-
-    # make sure we only generate events if both table_a and table_b have been materialized since
-    # the last evaluation.
-    yield RunRequest(run_key=None)
-
-    # update the sensor cursor by combining the individual event cursors from the two separate
-    # asset event streams
-    context.update_cursor(
-        json.dumps(
-            {
-                "a": a_event_records[0].storage_id,
-                "b": b_event_records[0].storage_id,
-            }
-        )
-    )
-```
 
 ## Run status sensors
 

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -86,7 +86,7 @@ This sensor iterates through all the files in `MY_DIRECTORY` and `yields` a <PyO
 In order to write a sensor that materializes assets, you can [build a job that materializes assets](/concepts/assets/software-defined-assets#building-jobs-that-materialize-assets):
 
 ```python file=concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_asset_job_sensor_marker endbefore=end_asset_job_sensor_marker
-asset_job = AssetGroup([...]).build_job("asset_job")
+asset_job = AssetGroup([my_asset]).build_job("asset_job")
 
 
 @sensor(job=asset_job)

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedule_from_partitions.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedule_from_partitions.py
@@ -1,7 +1,7 @@
 # isort: skip_file
 
-from numpy import partition
 from .partitioned_job import my_partitioned_config
+from dagster import asset, HourlyPartitionsDefinition
 
 # start_marker
 from dagster import build_schedule_from_partitioned_job, job
@@ -18,10 +18,18 @@ do_stuff_partitioned_schedule = build_schedule_from_partitioned_job(
 
 # end_marker
 
-# start_partitioned_asset_schedule
-from dagster import build_schedule_from_partitioned_job, AssetGroup
 
-partitioned_asset_job = AssetGroup([...]).build_job("partitioned_job")
+@asset(
+    partitions_def=HourlyPartitionsDefinition(start_date="2022-05-31", fmt="%Y-%m-%d")
+)
+def partitioned_asset():
+    return 1
+
+
+# start_partitioned_asset_schedule
+from dagster import AssetGroup
+
+partitioned_asset_job = AssetGroup([partitioned_asset]).build_job("partitioned_job")
 
 
 asset_partitioned_schedule = build_schedule_from_partitioned_job(

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedule_from_partitions.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedule_from_partitions.py
@@ -1,5 +1,6 @@
 # isort: skip_file
 
+from numpy import partition
 from .partitioned_job import my_partitioned_config
 
 # start_marker
@@ -16,6 +17,19 @@ do_stuff_partitioned_schedule = build_schedule_from_partitioned_job(
 )
 
 # end_marker
+
+# start_partitioned_asset_schedule
+from dagster import build_schedule_from_partitioned_job, AssetGroup
+
+partitioned_asset_job = AssetGroup([...]).build_job("partitioned_job")
+
+
+asset_partitioned_schedule = build_schedule_from_partitioned_job(
+    partitioned_asset_job,
+)
+
+# end_partitioned_asset_schedule
+
 
 from .static_partitioned_job import continent_job, CONTINENTS
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
@@ -4,6 +4,7 @@ from dagster import (
     RunRequest,
     ScheduleDefinition,
     ScheduleEvaluationContext,
+    asset,
     job,
     op,
     schedule,
@@ -19,9 +20,15 @@ def my_job():
 basic_schedule = ScheduleDefinition(job=my_job, cron_schedule="0 0 * * *")
 # end_basic_schedule
 
+
+@asset
+def my_asset():
+    return 1
+
+
 # start_basic_asset_schedule
 
-asset_job = AssetGroup([...]).build_job("asset_job")
+asset_job = AssetGroup([my_asset]).build_job("asset_job")
 
 basic_schedule = ScheduleDefinition(job=asset_job, cron_schedule="0 0 * * *")
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
@@ -1,4 +1,5 @@
 from dagster import (
+    AssetGroup,
     DefaultScheduleStatus,
     RunRequest,
     ScheduleDefinition,
@@ -17,6 +18,14 @@ def my_job():
 
 basic_schedule = ScheduleDefinition(job=my_job, cron_schedule="0 0 * * *")
 # end_basic_schedule
+
+# start_basic_asset_schedule
+
+asset_job = AssetGroup([...]).build_job("asset_job")
+
+basic_schedule = ScheduleDefinition(job=asset_job, cron_schedule="0 0 * * *")
+
+# end_basic_asset_schedule
 
 # start_run_config_schedule
 @op(config_schema={"scheduled_date": str})

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -1,7 +1,7 @@
 # isort: skip_file
 # pylint: disable=unnecessary-ellipsis
 
-from dagster import repository, DefaultSensorStatus, SkipReason, AssetGroup
+from dagster import repository, DefaultSensorStatus, SkipReason, AssetGroup, asset
 
 
 # start_sensor_job_marker
@@ -43,8 +43,14 @@ def my_directory_sensor():
 
 # end_directory_sensor_marker
 
+
+@asset
+def my_asset():
+    return 1
+
+
 # start_asset_job_sensor_marker
-asset_job = AssetGroup([...]).build_job("asset_job")
+asset_job = AssetGroup([my_asset]).build_job("asset_job")
 
 
 @sensor(job=asset_job)

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -1,7 +1,7 @@
 # isort: skip_file
 # pylint: disable=unnecessary-ellipsis
 
-from dagster import repository, DefaultSensorStatus, SkipReason
+from dagster import repository, DefaultSensorStatus, SkipReason, AssetGroup
 
 
 # start_sensor_job_marker
@@ -43,8 +43,19 @@ def my_directory_sensor():
 
 # end_directory_sensor_marker
 
+# start_asset_job_sensor_marker
+asset_job = AssetGroup([...]).build_job("asset_job")
+
+
+@sensor(job=asset_job)
+def materializes_asset_sensor():
+    yield RunRequest(...)
+
+
+# end_asset_job_sensor_marker
+
 # start_running_in_code
-@sensor(job=log_file_job, default_status=DefaultSensorStatus.RUNNING)
+@sensor(job=asset_job, default_status=DefaultSensorStatus.RUNNING)
 def my_running_sensor():
     ...
 


### PR DESCRIPTION
This PR updates the schedules and sensors pages to contain examples of scheduling and triggering asset jobs.

Regular jobs and asset jobs are used to create schedules and sensors in exactly the same way (providing via an arg to `@schedule` or `@sensor`. The only difference is that in order to use assets with schedules and sensors, you have to build a job from the existing asset group.

I added some small examples to each page showing how assets can be used with schedules and sensors, and shifted the asset sensor description to be close to the top of the sensor page.

This PR is pending (will need to update the code examples if we remove asset groups), but wanted to get some preliminary thoughts on this.