### PR TITLE
Derive origin from pipeline run instead of the arg to ExecuteRunArgs

### DIFF
--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1154,6 +1154,7 @@ class DagsterInstance:
         execution_plan_snapshot,
         parent_pipeline_snapshot,
         solid_selection=None,
+        pipeline_code_origin=None,
     ):
         # The usage of this method is limited to dagster-airflow, specifically in Dagster
         # Operators that are executed in Airflow. Because a common workflow in Airflow is to
@@ -1181,6 +1182,7 @@ class DagsterInstance:
             pipeline_snapshot=pipeline_snapshot,
             execution_plan_snapshot=execution_plan_snapshot,
             parent_pipeline_snapshot=parent_pipeline_snapshot,
+            pipeline_code_origin=pipeline_code_origin,
         )
 
         def get_run():

--- a/python_modules/dagster/dagster/grpc/server.py
+++ b/python_modules/dagster/dagster/grpc/server.py
@@ -653,12 +653,14 @@ class DagsterApiServer(DagsterApiServicer):
             )
 
         try:
-            execute_run_args = check.inst(
+            execute_external_pipeline_args = check.inst(
                 deserialize_json_to_dagster_namedtuple(request.serialized_execute_run_args),
                 ExecuteExternalPipelineArgs,
             )
-            run_id = execute_run_args.pipeline_run_id
-            recon_pipeline = self._recon_pipeline_from_origin(execute_run_args.pipeline_origin)
+            run_id = execute_external_pipeline_args.pipeline_run_id
+            recon_pipeline = self._recon_pipeline_from_origin(
+                execute_external_pipeline_args.pipeline_origin
+            )
 
         except:
             return api_pb2.StartRunReply(
@@ -689,7 +691,7 @@ class DagsterApiServer(DagsterApiServicer):
             execution_process.start()
             self._executions[run_id] = (
                 execution_process,
-                execute_run_args.instance_ref,
+                execute_external_pipeline_args.instance_ref,
             )
             self._termination_events[run_id] = termination_event
 

--- a/python_modules/dagster/dagster/grpc/types.py
+++ b/python_modules/dagster/dagster/grpc/types.py
@@ -79,6 +79,7 @@ class ExecuteRunArgs(
     NamedTuple(
         "_ExecuteRunArgs",
         [
+            # Deprecated, only needed for back-compat since it can be pulled from the PipelineRun
             ("pipeline_origin", PipelinePythonOrigin),
             ("pipeline_run_id", str),
             ("instance_ref", Optional[InstanceRef]),
@@ -123,6 +124,7 @@ class ResumeRunArgs(
     NamedTuple(
         "_ResumeRunArgs",
         [
+            # Deprecated, only needed for back-compat since it can be pulled from the PipelineRun
             ("pipeline_origin", PipelinePythonOrigin),
             ("pipeline_run_id", str),
             ("instance_ref", Optional[InstanceRef]),
@@ -196,6 +198,7 @@ class ExecuteStepArgs(
     NamedTuple(
         "_ExecuteStepArgs",
         [
+            # Deprecated, only needed for back-compat since it can be pulled from the PipelineRun
             ("pipeline_origin", PipelinePythonOrigin),
             ("pipeline_run_id", str),
             ("step_keys_to_execute", Optional[List[str]]),

--- a/python_modules/dagster/dagster_tests/cli_tests/test_api_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_api_commands.py
@@ -47,7 +47,12 @@ def test_execute_run():
             runner = CliRunner()
 
             instance = DagsterInstance.get()
-            run = create_run_for_test(instance, pipeline_name="foo", run_id="new_run")
+            run = create_run_for_test(
+                instance,
+                pipeline_name="foo",
+                run_id="new_run",
+                pipeline_code_origin=pipeline_handle.get_python_origin(),
+            )
 
             input_json = serialize_dagster_namedtuple(
                 ExecuteRunArgs(
@@ -83,7 +88,12 @@ def test_execute_run_fail_pipeline():
             runner = CliRunner()
 
             instance = DagsterInstance.get()
-            run = create_run_for_test(instance, pipeline_name="foo", run_id="new_run")
+            run = create_run_for_test(
+                instance,
+                pipeline_name="foo",
+                run_id="new_run",
+                pipeline_code_origin=pipeline_handle.get_python_origin(),
+            )
 
             input_json = serialize_dagster_namedtuple(
                 ExecuteRunArgs(
@@ -102,7 +112,10 @@ def test_execute_run_fail_pipeline():
             assert "RUN_FAILURE" in result.stdout, "no match, result: {}".format(result)
 
             run = create_run_for_test(
-                instance, pipeline_name="foo", run_id="new_run_raise_on_error"
+                instance,
+                pipeline_name="foo",
+                run_id="new_run_raise_on_error",
+                pipeline_code_origin=pipeline_handle.get_python_origin(),
             )
 
             input_json_raise_on_failure = serialize_dagster_namedtuple(
@@ -208,7 +221,12 @@ def test_execute_step():
         with get_foo_pipeline_handle(instance) as pipeline_handle:
             runner = CliRunner()
 
-            run = create_run_for_test(instance, pipeline_name="foo", run_id="new_run")
+            run = create_run_for_test(
+                instance,
+                pipeline_name="foo",
+                run_id="new_run",
+                pipeline_code_origin=pipeline_handle.get_python_origin(),
+            )
 
             input_json = serialize_dagster_namedtuple(
                 ExecuteStepArgs(
@@ -240,7 +258,12 @@ def test_execute_step_1():
         with get_foo_pipeline_handle(instance) as pipeline_handle:
             runner = CliRunner()
 
-            run = create_run_for_test(instance, pipeline_name="foo", run_id="new_run")
+            run = create_run_for_test(
+                instance,
+                pipeline_name="foo",
+                run_id="new_run",
+                pipeline_code_origin=pipeline_handle.get_python_origin(),
+            )
 
             input_json = serialize_dagster_namedtuple(
                 ExecuteStepArgs(
@@ -275,6 +298,7 @@ def test_execute_step_verify_step():
                 instance,
                 pipeline_name="foo",
                 run_id="new_run",
+                pipeline_code_origin=pipeline_handle.get_python_origin(),
             )
 
             input_json = serialize_dagster_namedtuple(
@@ -338,6 +362,7 @@ def test_execute_step_verify_step_framework_error(mock_verify_step):
                 instance,
                 pipeline_name="foo",
                 run_id="new_run",
+                pipeline_code_origin=pipeline_handle.get_python_origin(),
             )
 
             input_json = serialize_dagster_namedtuple(

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_handler.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_handler.py
@@ -13,7 +13,7 @@ def foo_pipline():
 def test_step_handler_context():
     recon_pipeline = reconstructable(foo_pipline)
     with instance_for_test() as instance:
-        run = create_run_for_test(instance)
+        run = create_run_for_test(instance, pipeline_code_origin=recon_pipeline.get_python_origin())
 
         args = ExecuteStepArgs(
             pipeline_origin=recon_pipeline.get_python_origin(),

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/operators/docker_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/operators/docker_operator.py
@@ -229,6 +229,8 @@ class DagsterDockerOperator(DockerOperator):
         try:
             tags = {AIRFLOW_EXECUTION_DATE_STR: context.get("ts")} if "ts" in context else {}
 
+            recon_pipeline = self.recon_repo.get_reconstructable_pipeline(self.pipeline_name)
+
             pipeline_run = self.instance.register_managed_run(
                 pipeline_name=self.pipeline_name,
                 run_id=self.run_id,
@@ -242,6 +244,7 @@ class DagsterDockerOperator(DockerOperator):
                 pipeline_snapshot=self.pipeline_snapshot,
                 execution_plan_snapshot=self.execution_plan_snapshot,
                 parent_pipeline_snapshot=self.parent_pipeline_snapshot,
+                pipeline_code_origin=recon_pipeline.get_python_origin(),
             )
             if self._should_skip(pipeline_run):
                 raise AirflowSkipException(

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/operators/util.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/operators/util.py
@@ -84,6 +84,7 @@ def invoke_steps_within_python_operator(
     invocation_args, ts, dag_run, **kwargs
 ):  # pylint: disable=unused-argument
     mode = invocation_args.mode
+    recon_repo = invocation_args.recon_repo
     pipeline_name = invocation_args.pipeline_name
     step_keys = invocation_args.step_keys
     instance_ref = invocation_args.instance_ref
@@ -92,6 +93,8 @@ def invoke_steps_within_python_operator(
     pipeline_snapshot = invocation_args.pipeline_snapshot
     execution_plan_snapshot = invocation_args.execution_plan_snapshot
     parent_pipeline_snapshot = invocation_args.parent_pipeline_snapshot
+
+    recon_pipeline = recon_repo.get_reconstructable_pipeline(pipeline_name)
 
     run_id = dag_run.run_id
 
@@ -112,6 +115,7 @@ def invoke_steps_within_python_operator(
                 pipeline_snapshot=pipeline_snapshot,
                 execution_plan_snapshot=execution_plan_snapshot,
                 parent_pipeline_snapshot=parent_pipeline_snapshot,
+                pipeline_code_origin=recon_pipeline.get_python_origin(),
             )
 
             recon_pipeline = recon_repo.get_reconstructable_pipeline(

--- a/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/executor.py
+++ b/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/executor.py
@@ -237,7 +237,7 @@ def create_docker_task(celery_app, **task_kwargs):
         docker_image = (
             docker_config["image"]
             if docker_config.get("image")
-            else execute_step_args.pipeline_origin.repository_origin.container_image
+            else pipeline_run.pipeline_code_origin.repository_origin.container_image
         )
 
         if not docker_image:

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -369,7 +369,7 @@ def create_k8s_job_task(celery_app, **task_kwargs):
             pod_name,
             component="step_worker",
             labels={
-                "dagster/job": execute_step_args.pipeline_origin.pipeline_name,
+                "dagster/job": pipeline_run.pipeline_name,
                 "dagster/op": step_key,
                 "dagster/run-id": execute_step_args.pipeline_run_id,
             },

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, cast
 
 import docker
 from dagster_docker.utils import DOCKER_CONFIG_SCHEMA, validate_docker_config, validate_docker_image
@@ -13,6 +13,7 @@ from dagster.core.executor.base import Executor
 from dagster.core.executor.init import InitExecutorContext
 from dagster.core.executor.step_delegating import StepDelegatingExecutor
 from dagster.core.executor.step_delegating.step_handler.base import StepHandler, StepHandlerContext
+from dagster.core.origin import PipelinePythonOrigin
 from dagster.serdes.utils import hash_str
 from dagster.utils import merge_dicts
 from dagster.utils.backcompat import experimental
@@ -101,9 +102,9 @@ class DockerStepHandler(StepHandler):
     def _get_image(self, step_handler_context: StepHandlerContext):
         from . import DockerRunLauncher
 
-        image = (
-            step_handler_context.execute_step_args.pipeline_origin.repository_origin.container_image
-        )
+        image = cast(
+            PipelinePythonOrigin, step_handler_context.pipeline_run.pipeline_code_origin
+        ).repository_origin.container_image
         if not image:
             image = self._image
 
@@ -201,7 +202,7 @@ class DockerStepHandler(StepHandler):
         events = [
             DagsterEvent(
                 event_type_value=DagsterEventType.ENGINE_EVENT.value,
-                pipeline_name=step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                pipeline_name=step_handler_context.pipeline_run.pipeline_name,
                 step_key=step_key,
                 message="Launching step in Docker container",
                 event_specific_data=EngineEventData(
@@ -238,7 +239,7 @@ class DockerStepHandler(StepHandler):
             return [
                 DagsterEvent(
                     event_type_value=DagsterEventType.STEP_FAILURE.value,
-                    pipeline_name=step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                    pipeline_name=step_handler_context.pipeline_run.pipeline_name,
                     step_key=step_key,
                     message=f"Error when checking on step container health: {e}",
                     event_specific_data=StepFailureData(
@@ -257,7 +258,7 @@ class DockerStepHandler(StepHandler):
             return [
                 DagsterEvent(
                     event_type_value=DagsterEventType.STEP_FAILURE.value,
-                    pipeline_name=step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                    pipeline_name=step_handler_context.pipeline_run.pipeline_name,
                     step_key=step_key,
                     message=f"Container status is {container.status}. Hit exception attempting to get its return code: {e}",
                     event_specific_data=StepFailureData(
@@ -274,7 +275,7 @@ class DockerStepHandler(StepHandler):
         return [
             DagsterEvent(
                 event_type_value=DagsterEventType.STEP_FAILURE.value,
-                pipeline_name=step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                pipeline_name=step_handler_context.pipeline_run.pipeline_name,
                 step_key=step_key,
                 message=f"Container status is {container.status}. Return code is {str(ret_code)}.",
                 event_specific_data=StepFailureData(
@@ -296,7 +297,7 @@ class DockerStepHandler(StepHandler):
         events = [
             DagsterEvent(
                 event_type_value=DagsterEventType.ENGINE_EVENT.value,
-                pipeline_name=step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                pipeline_name=step_handler_context.pipeline_run.pipeline_name,
                 step_key=step_key,
                 message="Stopping Docker container for step",
                 event_specific_data=EngineEventData(),
@@ -317,7 +318,7 @@ class DockerStepHandler(StepHandler):
             events.append(
                 DagsterEvent(
                     event_type_value=DagsterEventType.ENGINE_EVENT.value,
-                    pipeline_name=step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                    pipeline_name=step_handler_context.pipeline_run.pipeline_name,
                     step_key=step_key,
                     message=f"Hit error while terminating Docker container:\n{e}",
                     event_specific_data=EngineEventData(),

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -214,7 +214,7 @@ class K8sStepHandler(StepHandler):
             component="step_worker",
             user_defined_k8s_config=user_defined_k8s_config,
             labels={
-                "dagster/job": step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                "dagster/job": step_handler_context.pipeline_run.pipeline_name,
                 "dagster/op": step_key,
                 "dagster/run-id": step_handler_context.execute_step_args.pipeline_run_id,
             },
@@ -223,7 +223,7 @@ class K8sStepHandler(StepHandler):
         events.append(
             DagsterEvent(
                 event_type_value=DagsterEventType.ENGINE_EVENT.value,
-                pipeline_name=step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                pipeline_name=step_handler_context.pipeline_run.pipeline_name,
                 step_key=step_key,
                 message=f"Executing step {step_key} in Kubernetes job {job_name}",
                 event_specific_data=EngineEventData(
@@ -257,7 +257,7 @@ class K8sStepHandler(StepHandler):
             return [
                 DagsterEvent(
                     event_type_value=DagsterEventType.STEP_FAILURE.value,
-                    pipeline_name=step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                    pipeline_name=step_handler_context.pipeline_run.pipeline_name,
                     step_key=step_key,
                     message=f"Discovered failed Kubernetes job {job_name} for step {step_key}",
                     event_specific_data=StepFailureData(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
@@ -87,6 +87,7 @@ def test_executor_init(k8s_run_launcher_instance):
     run = create_run_for_test(
         k8s_run_launcher_instance,
         pipeline_name="bar",
+        pipeline_code_origin=reconstructable(bar).get_python_origin(),
     )
 
     step_handler_context = StepHandlerContext(
@@ -193,6 +194,7 @@ def test_step_handler(kubeconfig_file, k8s_instance):
     run = create_run_for_test(
         k8s_instance,
         pipeline_name="bar",
+        pipeline_code_origin=reconstructable(bar).get_python_origin(),
     )
     handler.launch_step(
         StepHandlerContext(
@@ -243,6 +245,7 @@ def test_step_handler_user_defined_config(kubeconfig_file, k8s_instance):
         run = create_run_for_test(
             k8s_instance,
             pipeline_name="bar",
+            pipeline_code_origin=reconstructable(bar).get_python_origin(),
         )
         handler.launch_step(
             StepHandlerContext(
@@ -290,6 +293,7 @@ def test_step_handler_image_override(kubeconfig_file, k8s_instance):
     run = create_run_for_test(
         k8s_instance,
         pipeline_name="bar",
+        pipeline_code_origin=reconstructable(bar).get_python_origin(),
     )
     handler.launch_step(
         StepHandlerContext(


### PR DESCRIPTION
### Summary & Motivation
The origin has been available on the run for some time now, and we are running into size limits from passing it in as an arg to these CLI calls. Take the initial step on the road to removing it from the command line args.

### How I Tested These Changes
BK