### PR TITLE
[RFC][not landable] Hackernews using with_resources, and string indirection

### DIFF
--- a/examples/hacker_news_assets/hacker_news_assets/core/__init__.py
+++ b/examples/hacker_news_assets/hacker_news_assets/core/__init__.py
@@ -1,18 +1,9 @@
-from hacker_news_assets.resources import RESOURCES_LOCAL, RESOURCES_PROD, RESOURCES_STAGING
-
+from ..partitions import hourly_partitions
 from dagster import AssetGroup, schedule_from_partitions
 
 from . import assets
 
-core_assets_prod = AssetGroup.from_package_module(
-    package_module=assets, resource_defs=RESOURCES_PROD
-).prefixed("core")
-core_assets_staging = AssetGroup.from_package_module(
-    package_module=assets, resource_defs=RESOURCES_STAGING
-).prefixed("core")
-core_assets_local = AssetGroup.from_package_module(
-    package_module=assets, resource_defs=RESOURCES_LOCAL
-).prefixed("core")
+core_assets = load_assets_from_package({assets}, prefix="core")
 
 RUN_TAGS = {
     "dagster-k8s/config": {
@@ -24,19 +15,10 @@ RUN_TAGS = {
     }
 }
 
-core_assets_schedule_prod = schedule_from_partitions(
-    core_assets_prod.build_job(name="core_job", tags=RUN_TAGS)
+core_job_spec = JobSpec(
+    selection="core>id_range_for_time++", tags=RUN_TAGS
+)  # probably want to do better here
+
+core_assets_schedule = schedule_from_partitions(
+    job_name="core_job", partitions_def=hourly_partitions
 )
-
-core_assets_schedule_staging = schedule_from_partitions(
-    core_assets_staging.build_job(name="core_job", tags=RUN_TAGS)
-)
-
-core_assets_schedule_local = schedule_from_partitions(
-    core_assets_local.build_job(name="core_job", tags=RUN_TAGS)
-)
-
-
-core_definitions_prod = [core_assets_prod, core_assets_schedule_prod]
-core_definitions_staging = [core_assets_staging, core_assets_schedule_staging]
-core_definitions_local = [core_assets_local, core_assets_schedule_local]

--- a/examples/hacker_news_assets/hacker_news_assets/recommender/__init__.py
+++ b/examples/hacker_news_assets/hacker_news_assets/recommender/__init__.py
@@ -1,39 +1,13 @@
 from hacker_news_assets.core import core_assets_local, core_assets_prod, core_assets_staging
-from hacker_news_assets.resources import RESOURCES_LOCAL, RESOURCES_PROD, RESOURCES_STAGING
 from hacker_news_assets.sensors.hn_tables_updated_sensor import make_hn_tables_updated_sensor
 
 from dagster import AssetGroup
 
 from . import assets
 
-recommender_assets_prod = AssetGroup.from_package_module(
-    package_module=assets,
-    extra_source_assets=core_assets_prod.to_source_assets(),
-    resource_defs=RESOURCES_PROD,
-).prefixed("recommender")
+recommender_assets = load_assets_from_package({assets}, prefix="recommender")
 
-recommender_assets_staging = AssetGroup.from_package_module(
-    package_module=assets,
-    extra_source_assets=core_assets_staging.to_source_assets(),
-    resource_defs=RESOURCES_STAGING,
-).prefixed("recommender")
-
-recommender_assets_local = AssetGroup.from_package_module(
-    package_module=assets,
-    extra_source_assets=core_assets_local.to_source_assets(),
-    resource_defs=RESOURCES_LOCAL,
-).prefixed("recommender")
-
-recommender_assets_sensor_prod = make_hn_tables_updated_sensor(
-    recommender_assets_prod.build_job(name="story_recommender_job")
-)
-recommender_assets_sensor_staging = make_hn_tables_updated_sensor(
-    recommender_assets_staging.build_job(name="story_recommender_job")
-)
-recommender_assets_sensor_local = make_hn_tables_updated_sensor(
-    recommender_assets_local.build_job(name="story_recommender_job")
-)
-
-recommender_definitions_prod = [recommender_assets_prod, recommender_assets_sensor_prod]
-recommender_definitions_staging = [recommender_assets_staging, recommender_assets_sensor_staging]
-recommender_definitions_local = [recommender_assets_local, recommender_assets_sensor_local]
+recommender_job_spec = JobSpec(
+    selection="recommender>comment_stories*", name="story_recommender_job"
+)  # probably can do better here
+recommender_assets_sensor = make_hn_tables_updated_sensor(job_name=recommender_job_spec.name)

--- a/examples/hacker_news_assets/hacker_news_assets/sensors/hn_tables_updated_sensor.py
+++ b/examples/hacker_news_assets/hacker_news_assets/sensors/hn_tables_updated_sensor.py
@@ -11,13 +11,13 @@ from dagster import (
 )
 
 
-def make_hn_tables_updated_sensor(job: JobDefinition) -> SensorDefinition:
+def make_hn_tables_updated_sensor(job_name: str) -> SensorDefinition:
     """
     Returns a sensor that launches the given job when the HN "comments" and "stories" tables have
     both been updated.
     """
 
-    @sensor(name=f"{job.name}_on_hn_tables_updated", job=job)
+    @sensor(name=f"{job.name}_on_hn_tables_updated", pipeline_name=job_name)  # cringe
     def hn_tables_updated_sensor(context):
         cursor_dict = json.loads(context.cursor) if context.cursor else {}
         comments_cursor = cursor_dict.get("comments")


### PR DESCRIPTION
A modification of hacker news assets where we mass-apply resources using `with_resources`, and use string indirection for job and sensor targeting.

One annoying piece is that we need to use partitions separately from the assets in order to build a schedule.

One thing worth noting is that never once during this migration did it feel natural to include resources directly on the definition.