### PR TITLE
[rfc][not landable] op-land hackernews using with_resources and string indirection

### DIFF
--- a/examples/hacker_news/hacker_news/jobs/dbt_metrics.py
+++ b/examples/hacker_news/hacker_news/jobs/dbt_metrics.py
@@ -1,11 +1,11 @@
 from dagster_dbt import dbt_cli_resource
 from hacker_news.ops.dbt import hn_dbt_run, hn_dbt_test
-from hacker_news.resources import RESOURCES_PROD, RESOURCES_STAGING
 from hacker_news.resources.dbt_asset_resource import SnowflakeQueryDbtAssetResource
 from hacker_news.resources.snowflake_io_manager import SHARED_SNOWFLAKE_CONF
 
 from dagster import ResourceDefinition, graph
 from dagster.utils import file_relative_path
+from ..sensors.hn_tables_updated_sensor import make_hn_tables_updated_sensor
 
 DBT_PROJECT_DIR = file_relative_path(__file__, "../../hacker_news_dbt")
 DBT_PROFILES_DIR = DBT_PROJECT_DIR + "/config"
@@ -28,7 +28,6 @@ def dbt_metrics():
 
 dbt_prod_job = dbt_metrics.to_job(
     resource_defs={
-        **RESOURCES_PROD,
         **{
             "dbt": dbt_prod_resource,
             # this is an alternative pattern to the configured() api. If you know that you won't want to
@@ -46,15 +45,14 @@ dbt_prod_job = dbt_metrics.to_job(
 
 dbt_staging_job = dbt_metrics.to_job(
     resource_defs={
-        **RESOURCES_STAGING,
-        **{
-            "dbt": dbt_staging_resource,
-            "dbt_assets": ResourceDefinition.hardcoded_resource(
-                SnowflakeQueryDbtAssetResource(
-                    {**{"database": "DEMO_DB_STAGING"}, **SHARED_SNOWFLAKE_CONF}, "hackernews"
-                )
-            ),
-            "partition_bounds": ResourceDefinition.none_resource(),
-        },
+        "dbt": dbt_staging_resource,
+        "dbt_assets": ResourceDefinition.hardcoded_resource(
+            SnowflakeQueryDbtAssetResource(
+                {**{"database": "DEMO_DB_STAGING"}, **SHARED_SNOWFLAKE_CONF}, "hackernews"
+            )
+        ),
+        "partition_bounds": ResourceDefinition.none_resource(),
     }
 )
+
+dbt_sensor = make_hn_tables_updated_sensor("dbt_job")

--- a/examples/hacker_news/hacker_news/jobs/hacker_news_api_download.py
+++ b/examples/hacker_news/hacker_news/jobs/hacker_news_api_download.py
@@ -1,11 +1,11 @@
 from hacker_news.ops.download_items import build_comments, build_stories, download_items
 from hacker_news.ops.id_range_for_time import id_range_for_time
-from hacker_news.resources import RESOURCES_LOCAL, RESOURCES_PROD, RESOURCES_STAGING
 from hacker_news.resources.hn_resource import hn_api_subsample_client, hn_snapshot_client
 from hacker_news.resources.partition_bounds import partition_bounds
 from hacker_news.schedules.hourly_hn_download_schedule import hourly_download_config
+from ..sensors.hn_tables_updated_sensor import make_hn_tables_updated_sensor
 
-from dagster import graph, in_process_executor
+from dagster import graph, in_process_executor, build_schedule_from_partitions
 
 DOWNLOAD_TAGS = {
     "dagster-k8s/config": {
@@ -34,36 +34,27 @@ def hacker_news_api_download():
     build_stories(items)
 
 
-download_prod_job = hacker_news_api_download.to_job(
+download_prod_job = hacker_news_api_download.to_pending_job(
     resource_defs={
-        **{
-            "partition_bounds": partition_bounds,
-            "hn_client": hn_api_subsample_client.configured({"sample_rate": 10}),
-        },
-        **RESOURCES_PROD,
+        "partition_bounds": partition_bounds,
+        "hn_client": hn_api_subsample_client.configured({"sample_rate": 10}),
     },
     tags=DOWNLOAD_TAGS,
     config=hourly_download_config,
 )
 
 
-download_staging_job = hacker_news_api_download.to_job(
+download_staging_job = hacker_news_api_download.to_pending_job(
     resource_defs={
-        **{
-            "partition_bounds": partition_bounds,
-            "hn_client": hn_api_subsample_client.configured({"sample_rate": 10}),
-        },
-        **RESOURCES_STAGING,
+        "partition_bounds": partition_bounds,
+        "hn_client": hn_api_subsample_client.configured({"sample_rate": 10}),
     },
     tags=DOWNLOAD_TAGS,
     config=hourly_download_config,
 )
 
-download_local_job = hacker_news_api_download.to_job(
-    resource_defs={
-        **{"partition_bounds": partition_bounds, "hn_client": hn_snapshot_client},
-        **RESOURCES_LOCAL,
-    },
+download_local_job = hacker_news_api_download.to_pending_job(
+    resource_defs={"partition_bounds": partition_bounds, "hn_client": hn_snapshot_client},
     config={
         "resources": {
             "partition_bounds": {
@@ -75,4 +66,8 @@ download_local_job = hacker_news_api_download.to_job(
         }
     },
     executor_def=in_process_executor,
+)
+
+download_schedule = build_schedule_from_partitions(
+    job_name="download_job", partitions=hourly_download_config.partitions_def
 )

--- a/examples/hacker_news/hacker_news/jobs/story_recommender.py
+++ b/examples/hacker_news/hacker_news/jobs/story_recommender.py
@@ -6,9 +6,9 @@ from hacker_news.ops.recommender_model import (
 )
 from hacker_news.ops.user_story_matrix import build_user_story_matrix
 from hacker_news.ops.user_top_recommended_stories import build_user_top_recommended_stories
-from hacker_news.resources import RESOURCES_LOCAL, RESOURCES_PROD, RESOURCES_STAGING
 
 from dagster import ResourceDefinition, graph
+from ..sensors.hn_tables_updated_sensor import make_hn_tables_updated_sensor
 
 
 @graph
@@ -26,22 +26,15 @@ def story_recommender():
 
 
 story_recommender_prod_job = story_recommender.to_job(
-    resource_defs={
-        **RESOURCES_PROD,
-        **{"partition_bounds": ResourceDefinition.none_resource()},
-    }
+    resource_defs={"partition_bounds": ResourceDefinition.none_resource()}
 )
 
 story_recommender_staging_job = story_recommender.to_job(
-    resource_defs={
-        **RESOURCES_STAGING,
-        **{"partition_bounds": ResourceDefinition.none_resource()},
-    }
+    resource_defs={"partition_bounds": ResourceDefinition.none_resource()}
 )
 
 story_recommender_local_job = story_recommender.to_job(
-    resource_defs={
-        **RESOURCES_LOCAL,
-        **{"partition_bounds": ResourceDefinition.none_resource()},
-    }
+    resource_defs={"partition_bounds": ResourceDefinition.none_resource()}
 )
+
+recommender_schedule = make_hn_tables_updated_sensor("story_recommender_job")

--- a/examples/hacker_news/hacker_news/repo.py
+++ b/examples/hacker_news/hacker_news/repo.py
@@ -1,15 +1,18 @@
 from dagster import build_schedule_from_partitioned_job, repository
 
-from .jobs.dbt_metrics import dbt_prod_job, dbt_staging_job
+from .jobs.dbt_metrics import dbt_prod_job, dbt_staging_job, dbt_sensor
 from .jobs.hacker_news_api_download import (
     download_local_job,
     download_prod_job,
     download_staging_job,
+    download_schedule,
 )
+from hacker_news.resources import RESOURCES_LOCAL, RESOURCES_PROD, RESOURCES_STAGING
 from .jobs.story_recommender import (
     story_recommender_local_job,
     story_recommender_prod_job,
     story_recommender_staging_job,
+    recommender_schedule,
 )
 from .sensors.hn_tables_updated_sensor import make_hn_tables_updated_sensor
 from .sensors.slack_on_failure_sensor import make_slack_on_failure_sensor
@@ -18,27 +21,38 @@ from .sensors.slack_on_failure_sensor import make_slack_on_failure_sensor
 @repository
 def hacker_news_local():
     return [
-        download_local_job,
-        story_recommender_local_job,
-        dbt_staging_job,
+        with_resources(
+            [
+                download_local_job,
+                story_recommender_local_job,
+                dbt_staging_job,
+            ],
+            resource_defs=RESOURCES_LOCAL,
+        )
     ]
 
 
 @repository
 def hacker_news_prod():
     return [
-        build_schedule_from_partitioned_job(download_prod_job),
+        with_resources(
+            [download_prod_job, story_recommender_prod_job, dbt_prod_job],
+            resource_defs=RESOURCES_PROD,
+        ),
+        download_schedule,
+        recommender_schedule,
+        dbt_schedule,
         make_slack_on_failure_sensor(base_url="my_prod_dagit_url.com"),
-        make_hn_tables_updated_sensor(story_recommender_prod_job),
-        make_hn_tables_updated_sensor(dbt_prod_job),
     ]
 
 
+# Got rid of staging versions of schedules/sensors here intentionally
 @repository
 def hacker_news_staging():
     return [
-        build_schedule_from_partitioned_job(download_staging_job),
+        with_resources(
+            [download_prod_job, story_recommender_prod_job, dbt_prod_job],
+            resource_defs=RESOURCES_STAGING,
+        ),
         make_slack_on_failure_sensor(base_url="my_staging_dagit_url.com"),
-        make_hn_tables_updated_sensor(story_recommender_staging_job),
-        make_hn_tables_updated_sensor(dbt_staging_job),
     ]

--- a/examples/hacker_news/hacker_news/sensors/hn_tables_updated_sensor.py
+++ b/examples/hacker_news/hacker_news/sensors/hn_tables_updated_sensor.py
@@ -11,7 +11,7 @@ from dagster import (
 )
 
 
-def make_hn_tables_updated_sensor(job: JobDefinition) -> SensorDefinition:
+def make_hn_tables_updated_sensor(job_name: str) -> SensorDefinition:
     """
     Returns a sensor that launches the given job when the HN "comments" and "stories" tables have
     both been updated.
@@ -19,7 +19,7 @@ def make_hn_tables_updated_sensor(job: JobDefinition) -> SensorDefinition:
 
     @sensor(
         name=f"{job.name}_on_hn_tables_updated",
-        job=job,
+        pipeline_name=job_name,
     )
     def hn_tables_updated_sensor(context):
         cursor_dict = json.loads(context.cursor) if context.cursor else {}


### PR DESCRIPTION
Utilizes with_resources + string indirection on the op-forward hacker news repo. The benefits are much less clear here than in the [assets case](https://github.com/dagster-io/dagster/pull/8176), because of the fact that we use different specific resources on jobs that don't make sense to include in a global resource dict (such as partition_bounds). It's also necessary to use string indirection when targeting a job via a schedule because the pending job definitions created within each namespace can be altered by a call to with_resources (regardless of composability).