### PR TITLE
fix(dagster/decorators): op_decorator documentation update

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/op_decorator.py
@@ -22,7 +22,6 @@ from ..inference import InferredOutputProps, infer_output_props
 from ..input import In, InputDefinition
 from ..output import Out, OutputDefinition
 from ..policy import RetryPolicy
-from ..solid_definition import SolidDefinition
 from .solid_decorator import (
     DecoratedSolidFunction,
     NoContextDecoratedSolidFunction,

--- a/python_modules/dagster/dagster/core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/op_decorator.py
@@ -181,7 +181,7 @@ def _resolve_output_defs_from_outs(
 
 
 @overload
-def op(name: Callable[..., Any]) -> OpDefinition:
+def op(name: Callable[..., Any]) -> "OpDefinition":
     ...
 
 

--- a/python_modules/dagster/dagster/core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/op_decorator.py
@@ -214,7 +214,7 @@ def op(
     retry_policy: Optional[RetryPolicy] = None,
     input_defs: Optional[List[InputDefinition]] = None,
     output_defs: Optional[List[OutputDefinition]] = None,
-) -> Union[OpDefinition, _Op]:
+) -> Union["OpDefinition", _Op]:
     """
     Create an op with the specified parameters from the decorated function.
 

--- a/python_modules/dagster/dagster/core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/op_decorator.py
@@ -181,7 +181,7 @@ def _resolve_output_defs_from_outs(
 
 
 @overload
-def op(name: Callable[..., Any]) -> SolidDefinition:
+def op(name: Callable[..., Any]) -> OpDefinition:
     ...
 
 
@@ -214,7 +214,7 @@ def op(
     retry_policy: Optional[RetryPolicy] = None,
     input_defs: Optional[List[InputDefinition]] = None,
     output_defs: Optional[List[OutputDefinition]] = None,
-) -> Union[SolidDefinition, _Op]:
+) -> Union[OpDefinition, _Op]:
     """
     Create an op with the specified parameters from the decorated function.
 


### PR DESCRIPTION
Updating legacy return types from Solid to OpDefintion

### Summary & Motivation
It's weird to see legacy types for newcomers.

### How I Tested These Changes
