### PR TITLE
upload backcompat artifacts to bk

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -57,6 +57,7 @@ class PackageSpec(
             ("package_type", str),
             ("unsupported_python_versions", List[AvailablePythonVersion]),
             ("pytest_extra_cmds", Optional[Union[List[str], PytestExtraCommandsFunction]]),
+            ("pytest_post_cmds", Optional[Union[List[str], PytestExtraCommandsFunction]]),
             ("pytest_step_dependencies", Optional[Union[List[str], PytestDependenciesFunction]]),
             ("pytest_tox_factors", Optional[List[str]]),
             ("env_vars", List[str]),
@@ -90,6 +91,11 @@ class PackageSpec(
             commands or a function. Function form takes two arguments, the python version being
             tested and the tox factor (if any), and returns a list of shell commands to execute.
             Defaults to None (no additional commands).
+        pytest_post_cmds (Union[List[str], Callable[str, List[str]]], optional): Optional
+            specification  of commands to run after the main pytest invocation through tox. Can be
+            either a list of commands or a function. Function form take two arguments, the python
+            version being tested and the tox factor (if any), and returns a list of shell commands
+            execute. Defaults to None (no additional commands).
         pytest_step_dependencies (Callable[str, List[str]], optional): Optional specification of
             Buildkite dependencies (e.g. on test image build step) for pytest steps. Can be either a
             list of commands or a function. Function form takes two arguments, the python version
@@ -124,6 +130,7 @@ class PackageSpec(
         package_type: Optional[str] = None,
         unsupported_python_versions: Optional[List[AvailablePythonVersion]] = None,
         pytest_extra_cmds: Optional[Union[List[str], PytestExtraCommandsFunction]] = None,
+        pytest_post_cmds: Optional[Union[List[str], PytestExtraCommandsFunction]] = None,
         pytest_step_dependencies: Optional[Union[List[str], PytestDependenciesFunction]] = None,
         pytest_tox_factors: Optional[List[str]] = None,
         env_vars: Optional[List[str]] = None,
@@ -144,6 +151,7 @@ class PackageSpec(
             package_type,
             unsupported_python_versions or [],
             pytest_extra_cmds,
+            pytest_post_cmds,
             pytest_step_dependencies,
             pytest_tox_factors,
             env_vars or [],
@@ -206,6 +214,12 @@ class PackageSpec(
                         ]
                     else:
                         extra_commands_post = []
+
+                    if self.pytest_post_cmds:
+                        if isinstance(self.pytest_post_cmds, list):
+                            extra_commands_post += self.pytest_post_cmds
+                        elif callable(self.pytest_post_cmds):
+                            extra_commands_post += self.pytest_post_cmds(py_version, other_factor)
 
                     if isinstance(self.pytest_step_dependencies, list):
                         dependencies = self.pytest_step_dependencies

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
@@ -52,6 +52,7 @@ def build_backcompat_suite_steps() -> List[GroupStep]:
     return build_integration_suite_steps(
         os.path.join("integration_tests", "test_suites", "backcompat-test-suite"),
         pytest_extra_cmds=backcompat_extra_cmds,
+        pytest_post_cmds=backcompat_post_cmds(),
         pytest_tox_factors=tox_factors,
         upload_coverage=False,
     )
@@ -94,6 +95,18 @@ def backcompat_extra_cmds(_, factor: str) -> List[str]:
             "BACKCOMPAT_TESTS_DAGIT_HOST",
         ),
         "popd",
+    ]
+
+
+def backcompat_post_cmds() -> List[str]:
+    return [
+        "mkdir .docker_logs",
+        "docker logs dagit > .docker_logs/dagit_logs 2>&1",
+        "docker logs docker_daemon > .docker_logs/docker_daemon_logs 2>&1",
+        "docker logs dagster_grpc_server > .docker_logs/dagster_grpc_server_logs 2>&1",
+        "docker logs docker_postgresql > .docker_logs/docker_postgresql_logs 2>&1",
+        "buildkite-agent artifact upload .docker_logs",
+        "rm -rf .docker_logs",
     ]
 
 


### PR DESCRIPTION
### Summary & Motivation
debugging backcompat failures is tricky, uploading the container logs as artifacts will make it a bit easier 

### How I Tested These Changes
bk