### PR TITLE
bring back source asset metadata

### DIFF
--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -1122,6 +1122,28 @@ def opt_nullable_sequence_param(
 
 
 # ########################
+# ##### Iterable
+# ########################
+
+
+def iterable_param(
+    obj: Iterable[T],
+    param_name: str,
+    of_type: Optional[TypeOrTupleOfTypes] = None,
+    additional_message: Optional[str] = None,
+) -> Iterable[T]:
+    if not isinstance(obj, collections.abc.Iterable):
+        raise _param_type_mismatch_exception(
+            obj, (collections.abc.Iterable,), param_name, additional_message
+        )
+
+    if not of_type:
+        return obj
+
+    return _check_iterable_items(obj, of_type, "iterable")
+
+
+# ########################
 # ##### SET
 # ########################
 

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -71,6 +71,11 @@ class AssetsDefinition:
             self._selected_asset_keys = all_asset_keys
         self._can_subset = can_subset
 
+        self._metadata_by_asset_key = {
+            asset_key: node_def.resolve_output_to_origin(output_name, None)[0].metadata
+            for output_name, asset_key in asset_keys_by_output_name.items()
+        }
+
     def __call__(self, *args, **kwargs):
         return self._node_def(*args, **kwargs)
 
@@ -219,6 +224,10 @@ class AssetsDefinition:
     @property
     def partitions_def(self) -> Optional[PartitionsDefinition]:
         return self._partitions_def
+
+    @property
+    def metadata_by_asset_key(self):
+        return self._metadata_by_asset_key
 
     def get_partition_mapping(self, in_asset_key: AssetKey) -> PartitionMapping:
         if self._partitions_def is None:

--- a/python_modules/dagster/dagster/core/asset_defs/assets_job.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets_job.py
@@ -1,5 +1,17 @@
 import itertools
-from typing import AbstractSet, Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union, cast
+from typing import (
+    AbstractSet,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
 
 import dagster._check as check
 from dagster.config import Shape
@@ -32,7 +44,7 @@ from .source_asset import SourceAsset
 @experimental
 def build_assets_job(
     name: str,
-    assets: Sequence[AssetsDefinition],
+    assets: Iterable[AssetsDefinition],
     source_assets: Optional[Sequence[Union[SourceAsset, AssetsDefinition]]] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     description: Optional[str] = None,
@@ -76,7 +88,7 @@ def build_assets_job(
     """
 
     check.str_param(name, "name")
-    check.sequence_param(assets, "assets", of_type=AssetsDefinition)
+    check.iterable_param(assets, "assets", of_type=AssetsDefinition)
     check.opt_sequence_param(
         source_assets, "source_assets", of_type=(SourceAsset, AssetsDefinition)
     )
@@ -146,7 +158,7 @@ def build_assets_job(
 
 
 def build_job_partitions_from_assets(
-    assets: Sequence[AssetsDefinition],
+    assets: Iterable[AssetsDefinition],
     source_assets: Sequence[Union[SourceAsset, AssetsDefinition]],
 ) -> Optional[PartitionedConfig]:
     assets_with_partitions_defs = [assets_def for assets_def in assets if assets_def.partitions_def]
@@ -251,7 +263,7 @@ def build_source_assets_by_key(
 
 
 def build_deps(
-    assets_defs: Sequence[AssetsDefinition], source_paths: AbstractSet[AssetKey]
+    assets_defs: Iterable[AssetsDefinition], source_paths: AbstractSet[AssetKey]
 ) -> Tuple[
     Dict[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]],
     Mapping[NodeHandle, AssetsDefinition],

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -389,10 +389,10 @@ class GraphDefinition(NodeDefinition):
         check.failed(f"Could not find output mapping {output_name}")
 
     def resolve_output_to_origin(
-        self, output_name: str, handle: NodeHandle
+        self, output_name: str, handle: Optional[NodeHandle]
     ) -> Tuple[OutputDefinition, NodeHandle]:
         check.str_param(output_name, "output_name")
-        check.inst_param(handle, "handle", NodeHandle)
+        check.opt_inst_param(handle, "handle", NodeHandle)
 
         mapping = self.get_output_mapping(output_name)
         check.invariant(mapping, "Can only resolve outputs for valid output names")

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -330,14 +330,14 @@ class JobDefinition(PipelineDefinition):
         )
 
         check.invariant(
-            self.asset_layer._assets_defs != None,  # pylint:disable=protected-access
+            self.asset_layer.assets_defs_by_key is not None,
             "Asset layer must have _asset_defs argument defined",
         )
 
         new_job = build_asset_selection_job(
             name=self.name,
-            assets=self.asset_layer._assets_defs,  # pylint:disable=protected-access
-            source_assets=self.asset_layer._source_asset_defs,  # pylint:disable=protected-access
+            assets=self.asset_layer.assets_defs_by_key.values(),
+            source_assets=self.asset_layer.source_assets_by_key.values(),
             executor_def=self.executor_def,
             resource_defs=self.resource_defs,
             description=self.description,

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -1,6 +1,7 @@
 import functools
 import os
 import re
+from abc import ABC, abstractmethod
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -152,7 +153,7 @@ def package_metadata_value(label: str, raw_value: RawMetadataValue) -> "Metadata
 # ########################
 
 
-class MetadataValue:
+class MetadataValue(ABC):
     """Utility class to wrap metadata values passed into Dagster events so that they can be
     displayed in Dagit and other tooling.
 
@@ -169,6 +170,11 @@ class MetadataValue:
                 },
             )
     """
+
+    @property
+    @abstractmethod
+    def value(self) -> object:
+        raise NotImplementedError()
 
     @staticmethod
     def text(text: str) -> "TextMetadataValue":
@@ -517,6 +523,10 @@ class TextMetadataValue(  # type: ignore
             cls, check.opt_str_param(text, "text", default="")
         )
 
+    @property
+    def value(self) -> Optional[str]:
+        return self.text
+
 
 @whitelist_for_serdes(storage_name="UrlMetadataEntryData")
 class UrlMetadataValue(  # type: ignore
@@ -539,6 +549,10 @@ class UrlMetadataValue(  # type: ignore
             cls, check.opt_str_param(url, "url", default="")
         )
 
+    @property
+    def value(self) -> Optional[str]:
+        return self.url
+
 
 @whitelist_for_serdes(storage_name="PathMetadataEntryData")
 class PathMetadataValue(  # type: ignore
@@ -554,6 +568,10 @@ class PathMetadataValue(  # type: ignore
         return super(PathMetadataValue, cls).__new__(
             cls, check.opt_path_param(path, "path", default="")
         )
+
+    @property
+    def value(self) -> Optional[str]:
+        return self.path
 
 
 @whitelist_for_serdes(storage_name="JsonMetadataEntryData")
@@ -581,6 +599,10 @@ class JsonMetadataValue(
             raise DagsterInvalidMetadata("Value is a dictionary but is not JSON serializable.")
         return super(JsonMetadataValue, cls).__new__(cls, data)
 
+    @property
+    def value(self) -> Dict[str, Any]:
+        return self.data
+
 
 @whitelist_for_serdes(storage_name="MarkdownMetadataEntryData")
 class MarkdownMetadataValue(
@@ -602,6 +624,10 @@ class MarkdownMetadataValue(
         return super(MarkdownMetadataValue, cls).__new__(
             cls, check.opt_str_param(md_str, "md_str", default="")
         )
+
+    @property
+    def value(self) -> Optional[str]:
+        return self.md_str
 
 
 @whitelist_for_serdes(storage_name="PythonArtifactMetadataEntryData")
@@ -626,6 +652,10 @@ class PythonArtifactMetadataValue(
         return super(PythonArtifactMetadataValue, cls).__new__(
             cls, check.str_param(module, "module"), check.str_param(name, "name")
         )
+
+    @property
+    def value(self) -> object:
+        return self
 
 
 @whitelist_for_serdes(storage_name="FloatMetadataEntryData")
@@ -704,6 +734,10 @@ class DagsterPipelineRunMetadataValue(
             cls, check.str_param(run_id, "run_id")
         )
 
+    @property
+    def value(self) -> str:
+        return self.run_id
+
 
 @whitelist_for_serdes(storage_name="DagsterAssetMetadataEntryData")
 class DagsterAssetMetadataValue(
@@ -721,6 +755,10 @@ class DagsterAssetMetadataValue(
         return super(DagsterAssetMetadataValue, cls).__new__(
             cls, check.inst_param(asset_key, "asset_key", AssetKey)
         )
+
+    @property
+    def value(self) -> "AssetKey":
+        return self.value
 
 
 @experimental
@@ -779,6 +817,10 @@ class TableMetadataValue(
             schema,
         )
 
+    @property
+    def value(self):
+        return self
+
 
 @whitelist_for_serdes(storage_name="TableSchemaMetadataEntryData")
 class TableSchemaMetadataValue(
@@ -794,6 +836,10 @@ class TableSchemaMetadataValue(
         return super(TableSchemaMetadataValue, cls).__new__(
             cls, check.inst_param(schema, "schema", TableSchema)
         )
+
+    @property
+    def value(self) -> TableSchema:
+        return self.schema
 
 
 # ########################

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -256,6 +256,8 @@ def test_source_asset():
             assert context.resources.subresource == 9
             assert context.upstream_output.resources.subresource == 9
             assert context.upstream_output.asset_key == AssetKey("source1")
+            assert context.upstream_output.metadata == {"a": "b"}
+            assert context.upstream_output.resource_config["a"] == 7
             assert context.asset_key == AssetKey("source1")
             return 5
 
@@ -266,7 +268,11 @@ def test_source_asset():
     job = build_assets_job(
         "a",
         [asset1],
-        source_assets=[SourceAsset(AssetKey("source1"), io_manager_key="special_io_manager")],
+        source_assets=[
+            SourceAsset(
+                AssetKey("source1"), io_manager_key="special_io_manager", metadata={"a": "b"}
+            )
+        ],
         resource_defs={
             "special_io_manager": my_io_manager.configured({"a": 7}),
             "subresource": ResourceDefinition.hardcoded_resource(9),


### PR DESCRIPTION
### Summary & Motivation

After the change that eliminated the root input manager sketchness for source assets, `context.upstream_output.metadata` stopped working. A user complained.

### How I Tested These Changes

New test