### PR TITLE
Pass on graphql test suite to make them easier to generalize and call with other graphql context fixtures

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
@@ -1,12 +1,15 @@
 # pylint: disable=missing-graphene-docstring
 import json
+import sys
 
 import graphene
 from graphene.types.generic import GenericScalar
 
 import dagster._check as check
+from dagster.utils.error import serializable_error_info_from_exc_info
 
 from ..implementation.fetch_runs import get_runs, get_runs_count
+from ..implementation.utils import UserFacingGraphQLError
 from .errors import (
     GrapheneInvalidPipelineRunsFilterError,
     GraphenePythonError,
@@ -150,7 +153,9 @@ def parse_run_config_input(run_config, raise_on_error: bool):
             return json.loads(run_config)
         except json.JSONDecodeError:
             if raise_on_error:
-                raise
+                raise UserFacingGraphQLError(
+                    GraphenePythonError(serializable_error_info_from_exc_info(sys.exc_info()))
+                )
             # Pass the config through as a string so that it will return a useful validation error
             return run_config
     return run_config

--- a/python_modules/dagster-graphql/dagster_graphql/test/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/test/utils.py
@@ -5,6 +5,7 @@ from graphql import graphql
 
 import dagster._check as check
 from dagster.core.instance import DagsterInstance
+from dagster.core.test_utils import wait_for_runs_to_finish
 from dagster.core.workspace import WorkspaceProcessContext
 from dagster.core.workspace.load_target import PythonFileTarget
 
@@ -40,7 +41,7 @@ def execute_dagster_graphql(context, query, variables=None):
 
 def execute_dagster_graphql_and_finish_runs(context, query, variables=None):
     result = execute_dagster_graphql(context, query, variables)
-    context.instance.run_launcher.join()
+    wait_for_runs_to_finish(context.instance, timeout=30)
     return result
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
@@ -328,7 +328,7 @@ class InstanceManagers:
 
 class EnvironmentManagers:
     @staticmethod
-    def managed_grpc(target=None):
+    def managed_grpc(target=None, location_name="test"):
         @contextmanager
         def _mgr_fn(instance, read_only):
             """Goes out of process via grpc"""
@@ -340,14 +340,14 @@ class EnvironmentManagers:
                         python_file=loadable_target_origin.python_file,
                         attribute=loadable_target_origin.attribute,
                         working_directory=loadable_target_origin.working_directory,
-                        location_name="test",
+                        location_name=location_name,
                     )
                     if loadable_target_origin.python_file
                     else ModuleTarget(
                         module_name=loadable_target_origin.module_name,
                         attribute=loadable_target_origin.attribute,
                         working_directory=loadable_target_origin.working_directory,
-                        location_name="test",
+                        location_name=location_name,
                     )
                 ),
                 version="",
@@ -358,7 +358,7 @@ class EnvironmentManagers:
         return MarkedManager(_mgr_fn, [Marks.managed_grpc_env])
 
     @staticmethod
-    def deployed_grpc(target=None):
+    def deployed_grpc(target=None, location_name="test"):
         @contextmanager
         def _mgr_fn(instance, read_only):
             server_process = GrpcServerProcess(
@@ -374,7 +374,7 @@ class EnvironmentManagers:
                             port=api_client.port,
                             socket=api_client.socket,
                             host=api_client.host,
-                            location_name="test",
+                            location_name=location_name,
                         ),
                         version="",
                         read_only=read_only,
@@ -543,10 +543,10 @@ class GraphQLContextVariant:
         )
 
     @staticmethod
-    def sqlite_with_default_run_launcher_managed_grpc_env(target=None):
+    def sqlite_with_default_run_launcher_managed_grpc_env(target=None, location_name="test"):
         return GraphQLContextVariant(
             InstanceManagers.sqlite_instance_with_default_run_launcher(),
-            EnvironmentManagers.managed_grpc(target),
+            EnvironmentManagers.managed_grpc(target, location_name),
             test_id="sqlite_with_default_run_launcher_managed_grpc_env",
         )
 
@@ -560,26 +560,26 @@ class GraphQLContextVariant:
         )
 
     @staticmethod
-    def sqlite_with_default_run_launcher_deployed_grpc_env(target=None):
+    def sqlite_with_default_run_launcher_deployed_grpc_env(target=None, location_name="test"):
         return GraphQLContextVariant(
             InstanceManagers.sqlite_instance_with_default_run_launcher(),
-            EnvironmentManagers.deployed_grpc(target),
+            EnvironmentManagers.deployed_grpc(target, location_name),
             test_id="sqlite_with_default_run_launcher_deployed_grpc_env",
         )
 
     @staticmethod
-    def postgres_with_default_run_launcher_managed_grpc_env(target=None):
+    def postgres_with_default_run_launcher_managed_grpc_env(target=None, location_name="test"):
         return GraphQLContextVariant(
             InstanceManagers.postgres_instance_with_default_run_launcher(),
-            EnvironmentManagers.managed_grpc(target),
+            EnvironmentManagers.managed_grpc(target, location_name),
             test_id="postgres_with_default_run_launcher_managed_grpc_env",
         )
 
     @staticmethod
-    def postgres_with_default_run_launcher_deployed_grpc_env(target=None):
+    def postgres_with_default_run_launcher_deployed_grpc_env(target=None, location_name="test"):
         return GraphQLContextVariant(
             InstanceManagers.postgres_instance_with_default_run_launcher(),
-            EnvironmentManagers.deployed_grpc(target),
+            EnvironmentManagers.deployed_grpc(target, location_name),
             test_id="postgres_with_default_run_launcher_deployed_grpc_env",
         )
 
@@ -700,12 +700,20 @@ class GraphQLContextVariant:
         ]
 
     @staticmethod
-    def all_executing_variants(target=None):
+    def all_executing_variants(target=None, location_name="test"):
         return [
-            GraphQLContextVariant.sqlite_with_default_run_launcher_managed_grpc_env(target),
-            GraphQLContextVariant.sqlite_with_default_run_launcher_deployed_grpc_env(target),
-            GraphQLContextVariant.postgres_with_default_run_launcher_managed_grpc_env(target),
-            GraphQLContextVariant.postgres_with_default_run_launcher_deployed_grpc_env(target),
+            GraphQLContextVariant.sqlite_with_default_run_launcher_managed_grpc_env(
+                target, location_name
+            ),
+            GraphQLContextVariant.sqlite_with_default_run_launcher_deployed_grpc_env(
+                target, location_name
+            ),
+            GraphQLContextVariant.postgres_with_default_run_launcher_managed_grpc_env(
+                target, location_name
+            ),
+            GraphQLContextVariant.postgres_with_default_run_launcher_deployed_grpc_env(
+                target, location_name
+            ),
         ]
 
     @staticmethod
@@ -862,5 +870,7 @@ all_repos_loadable_target = LoadableTargetOrigin(
     python_file=file_relative_path(__file__, "cross_repo_asset_deps.py"),
 )
 AllRepositoryGraphQLContextTestMatrix = make_graphql_context_test_suite(
-    context_variants=GraphQLContextVariant.all_executing_variants(target=all_repos_loadable_target)
+    context_variants=GraphQLContextVariant.all_executing_variants(
+        target=all_repos_loadable_target, location_name="cross_asset_repos"
+    )
 )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_execute_pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_execute_pipeline.py
@@ -11,6 +11,7 @@ from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_s
 from graphql import parse
 
 from dagster.core.storage.pipeline_run import RunsFilter
+from dagster.core.test_utils import wait_for_runs_to_finish
 from dagster.utils import file_relative_path
 from dagster.utils.test import get_temp_file_name
 
@@ -128,9 +129,11 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
         )
 
         assert not result.errors
-        assert result.data["launchPipelineExecution"]["run"]["tags"] == [
-            {"key": "tag_key", "value": "tag_value"}
-        ]
+        tags_by_key = {
+            tag["key"]: tag["value"]
+            for tag in result.data["launchPipelineExecution"]["run"]["tags"]
+        }
+        assert tags_by_key["tag_key"] == "tag_value"
 
         # just test existence
         assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
@@ -156,9 +159,12 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
         )
 
         assert not result.errors
-        assert result.data["launchPipelineExecution"]["run"]["tags"] == [
-            {"key": "tag_key", "value": "new_tag_value"}
-        ]
+
+        tags_by_key = {
+            tag["key"]: tag["value"]
+            for tag in result.data["launchPipelineExecution"]["run"]["tags"]
+        }
+        assert tags_by_key["tag_key"] == "new_tag_value"
 
     def test_basic_start_pipeline_execution_with_non_existent_preset(self, graphql_context):
         selector = infer_pipeline_selector(graphql_context, "csv_hello_world")
@@ -300,6 +306,7 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
 
     def _csv_hello_world_event_sequence(self):
         # expected non engine event sequence from executing csv_hello_world pipeline
+
         return [
             "RunStartingEvent",
             "RunStartEvent",
@@ -342,7 +349,7 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
         non_engine_event_types = [
             message["__typename"]
             for message in run_logs["messages"]
-            if message["__typename"] != "EngineEvent"
+            if message["__typename"] not in ("EngineEvent", "RunEnqueuedEvent", "RunDequeuedEvent")
         ]
 
         assert non_engine_event_types == self._csv_hello_world_event_sequence()
@@ -372,7 +379,7 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
         assert exc_result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
 
         # block until run finishes
-        graphql_context.instance.run_launcher.join()
+        wait_for_runs_to_finish(graphql_context.instance)
 
         events_result = execute_dagster_graphql(
             graphql_context,
@@ -387,7 +394,7 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
         non_engine_event_types = [
             message["__typename"]
             for message in events_result.data["logsForRun"]["events"]
-            if message["__typename"] != "EngineEvent"
+            if message["__typename"] not in ("EngineEvent", "RunEnqueuedEvent", "RunDequeuedEvent")
         ]
         assert non_engine_event_types == self._csv_hello_world_event_sequence()
 
@@ -445,12 +452,14 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
             time.sleep(0.05)  # 50ms
 
         # block until run finishes
-        graphql_context.instance.run_launcher.join()
+        wait_for_runs_to_finish(graphql_context.instance)
         _events, _cursor = _fetch_events(cursor)
         full_logs.extend(_events)
 
         non_engine_event_types = [
-            message["__typename"] for message in full_logs if message["__typename"] != "EngineEvent"
+            message["__typename"]
+            for message in full_logs
+            if message["__typename"] not in ("EngineEvent", "RunEnqueuedEvent", "RunDequeuedEvent")
         ]
         assert non_engine_event_types == self._csv_hello_world_event_sequence()
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instance.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instance.py
@@ -24,4 +24,9 @@ BaseTestSuite: Any = make_graphql_context_test_suite(
 class TestInstanceSettings(BaseTestSuite):
     def test_instance_settings(self, graphql_context):
         results = execute_dagster_graphql(graphql_context, INSTANCE_QUERY)
-        assert results.data == {"instance": {"runQueuingSupported": True, "hasInfo": True}}
+        assert results.data == {
+            "instance": {
+                "runQueuingSupported": True,
+                "hasInfo": graphql_context.show_instance_config,
+            }
+        }

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reexecution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reexecution.py
@@ -4,6 +4,7 @@ from dagster_graphql.client.query import (
 )
 from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_selector
 
+from dagster.core.test_utils import wait_for_runs_to_finish
 from dagster.core.utils import make_new_run_id
 
 from .graphql_context_test_suite import ExecutingGraphQLContextTestMatrix
@@ -140,7 +141,7 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
         assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
         assert result.data["launchPipelineExecution"]["run"]["status"] == "STARTING"
 
-        graphql_context.instance.run_launcher.join()
+        wait_for_runs_to_finish(graphql_context.instance)
 
         result = execute_dagster_graphql(
             context=graphql_context, query=RUN_QUERY, variables={"runId": run_id}
@@ -167,7 +168,7 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
         )
         assert result.data["launchPipelineReexecution"]["__typename"] == "LaunchRunSuccess"
 
-        graphql_context.instance.run_launcher.join()
+        wait_for_runs_to_finish(graphql_context.instance)
 
         result = execute_dagster_graphql(
             context=graphql_context, query=RUN_QUERY, variables={"runId": new_run_id}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_launcher.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_launcher.py
@@ -3,6 +3,8 @@ from typing import Any
 from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
 from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_selector
 
+from dagster.core.test_utils import wait_for_runs_to_finish
+
 from .graphql_context_test_suite import GraphQLContextVariant, make_graphql_context_test_suite
 
 RUN_QUERY = """
@@ -41,7 +43,7 @@ class TestBasicLaunch(BaseTestSuite):
 
         run_id = result.data["launchPipelineExecution"]["run"]["runId"]
 
-        graphql_context.instance.run_launcher.join()
+        wait_for_runs_to_finish(graphql_context.instance)
 
         result = execute_dagster_graphql(
             context=graphql_context, query=RUN_QUERY, variables={"runId": run_id}
@@ -69,7 +71,7 @@ class TestBasicLaunch(BaseTestSuite):
 
         run_id = result.data["launchPipelineExecution"]["run"]["runId"]
 
-        graphql_context.instance.run_launcher.join()
+        wait_for_runs_to_finish(graphql_context.instance)
 
         result = execute_dagster_graphql(
             context=graphql_context, query=RUN_QUERY, variables={"runId": run_id}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -263,16 +263,15 @@ class TestGetRuns(ExecutingGraphQLContextTestMatrix):
         assert len(runs) == 1
 
         tags = runs[0]["tags"]
-        assert len(tags) == 1
 
-        assert tags[0]["key"] == "fruit"
-        assert tags[0]["value"] == "apple"
+        tags_by_key = {tag["key"]: tag["value"] for tag in tags}
+
+        assert tags_by_key["fruit"] == "apple"
 
         origin = runs[0]["repositoryOrigin"]
         assert origin
         assert origin["repositoryLocationName"] == selector["repositoryLocationName"]
         assert origin["repositoryName"] == selector["repositoryName"]
-        assert origin["repositoryLocationMetadata"]
 
         payload_two = sync_execute_get_run_log_data(
             context=graphql_context,
@@ -296,13 +295,10 @@ class TestGetRuns(ExecutingGraphQLContextTestMatrix):
         all_tags_result = execute_dagster_graphql(read_context, ALL_TAGS_QUERY)
         tags = all_tags_result.data["pipelineRunTags"]
 
-        assert len(tags) == 2
         tags_dict = {item["key"]: item["values"] for item in tags}
 
-        assert tags_dict == {
-            "fruit": ["apple"],
-            "veggie": ["carrot"],
-        }
+        assert tags_dict["fruit"] == ["apple"]
+        assert tags_dict["veggie"] == ["carrot"]
 
         # delete the second run
         result = execute_dagster_graphql(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/utils.py
@@ -3,7 +3,8 @@ from dagster_graphql.test.utils import execute_dagster_graphql
 
 from dagster import DagsterEventType
 from dagster import _check as check
-from dagster.core.workspace.context import WorkspaceRequestContext
+from dagster.core.test_utils import wait_for_runs_to_finish
+from dagster.core.workspace.context import BaseWorkspaceRequestContext
 
 
 def get_all_logs_for_finished_run_via_subscription(context, run_id):
@@ -11,7 +12,7 @@ def get_all_logs_for_finished_run_via_subscription(context, run_id):
     You should almost certainly ensure that this run has complete or terminated in order
     to get reliable results that you can test against.
     """
-    check.inst_param(context, "context", WorkspaceRequestContext)
+    check.inst_param(context, "context", BaseWorkspaceRequestContext)
 
     run = context.instance.get_run_by_id(run_id)
 
@@ -40,7 +41,7 @@ def get_all_logs_for_finished_run_via_subscription(context, run_id):
 
 
 def sync_execute_get_payload(variables, context):
-    check.inst_param(context, "context", WorkspaceRequestContext)
+    check.inst_param(context, "context", BaseWorkspaceRequestContext)
 
     result = execute_dagster_graphql(
         context, LAUNCH_PIPELINE_EXECUTION_MUTATION, variables=variables
@@ -51,20 +52,20 @@ def sync_execute_get_payload(variables, context):
     if result.data["launchPipelineExecution"]["__typename"] != "LaunchRunSuccess":
         raise Exception(result.data)
 
-    context.instance.run_launcher.join()
+    wait_for_runs_to_finish(context.instance)
 
     run_id = result.data["launchPipelineExecution"]["run"]["runId"]
     return get_all_logs_for_finished_run_via_subscription(context, run_id)
 
 
 def sync_execute_get_run_log_data(variables, context):
-    check.inst_param(context, "context", WorkspaceRequestContext)
+    check.inst_param(context, "context", BaseWorkspaceRequestContext)
     payload_data = sync_execute_get_payload(variables, context)
     return payload_data["pipelineRunLogs"]
 
 
 def sync_execute_get_events(variables, context):
-    check.inst_param(context, "context", WorkspaceRequestContext)
+    check.inst_param(context, "context", BaseWorkspaceRequestContext)
     return sync_execute_get_run_log_data(variables, context)["messages"]
 
 

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -219,6 +219,25 @@ def register_managed_run_for_test(
     )
 
 
+def wait_for_runs_to_finish(instance, timeout=20, run_tags=None):
+    total_time = 0
+    interval = 0.1
+
+    filters = RunsFilter(tags=run_tags) if run_tags else None
+
+    while True:
+        runs = instance.get_runs(filters)
+        if all([run.is_finished for run in runs]):
+            return
+
+        if total_time > timeout:
+            raise Exception("Timed out")
+
+        time.sleep(interval)
+        total_time += interval
+        interval = interval * 2
+
+
 def poll_for_finished_run(instance, run_id=None, timeout=20, run_tags=None):
     total_time = 0
     interval = 0.01


### PR DESCRIPTION
Fix miscellaneous places in the graphql tests where we rely on it being a DefaultRunLauncher or running in a specific environment, with the goal of eventually generalizing these tests and calling them with a different set of graphql contexts (see upcoming PR for that)

Test Plan: BK