### PR TITLE
[dagit] Update MenuLink to support a disabled state

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/MenuLink.tsx
+++ b/js_modules/dagit/packages/core/src/ui/MenuLink.tsx
@@ -20,9 +20,9 @@ interface MenuLinkProps
  * If you want to use a menu item as a link, use `MenuLink` and provide a `to` prop.
  */
 export const MenuLink: React.FC<MenuLinkProps> = (props) => {
-  const {icon, intent, text, ...rest} = props;
+  const {icon, intent, text, disabled, ...rest} = props;
 
-  if (rest.disabled) {
+  if (disabled) {
     return <MenuItem disabled icon={icon} intent={intent} text={text} />;
   }
   return (

--- a/js_modules/dagit/packages/core/src/ui/MenuLink.tsx
+++ b/js_modules/dagit/packages/core/src/ui/MenuLink.tsx
@@ -1,6 +1,12 @@
 // eslint-disable-next-line no-restricted-imports
-import {MenuItem} from '@blueprintjs/core';
-import {Box, Colors, CommonMenuItemProps, IconWrapper, iconWithColor} from '@dagster-io/ui';
+import {
+  Box,
+  Colors,
+  CommonMenuItemProps,
+  IconWrapper,
+  iconWithColor,
+  MenuItem,
+} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link, LinkProps} from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -16,6 +22,9 @@ interface MenuLinkProps
 export const MenuLink: React.FC<MenuLinkProps> = (props) => {
   const {icon, intent, text, ...rest} = props;
 
+  if (rest.disabled) {
+    return <MenuItem disabled icon={icon} intent={intent} text={text} />;
+  }
   return (
     <StyledMenuLink {...rest}>
       <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>


### PR DESCRIPTION
### Summary & Motivation

MenuLink inherits props from both Menu and Link, but then applies them to a Link element. The link doesn't do anything with the `disabled={true}` value (it's still clickable and looks clickable). Rather than rewrite all the CSS, I just made it render a proper MenuItem when it's disabled so all the adjustments to the icons, etc. are consistent.

### How I Tested These Changes
