### PR TITLE
[dagit] Asset graph GraphQL query audit + cleanup

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -83,10 +83,7 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
     applyingEmptyDefault,
   } = useAssetGraphData(props.explorerPath.opsQuery, props.fetchOptions);
 
-  const {liveResult, liveDataByNode} = useLiveDataForAssetKeys(
-    assetGraphData?.nodes,
-    graphAssetKeys,
-  );
+  const {liveResult, liveDataByNode} = useLiveDataForAssetKeys(graphAssetKeys);
   const liveDataRefreshState = useQueryRefreshAtInterval(liveResult, FIFTEEN_SECONDS);
 
   useDocumentTitle('Assets');

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -22,6 +22,7 @@ const MISSING_LIVE_DATA = {
   inProgressRunIds: [],
   runWhichFailedToMaterialize: null,
   lastMaterialization: null,
+  stepKey: '',
 };
 
 export const AssetNode: React.FC<{
@@ -109,7 +110,7 @@ export const AssetNode: React.FC<{
           <StatsRow>
             <span>Latest Run</span>
             <CaptionMono>
-              <AssetLatestRunWithNotices liveData={liveData} stepKey={stepKey} />
+              <AssetLatestRunWithNotices liveData={liveData} />
             </CaptionMono>
           </StatsRow>
         </Stats>
@@ -312,10 +313,14 @@ const UpstreamNotice = styled.div`
 
 export const AssetLatestRunWithNotices: React.FC<{
   liveData?: LiveDataForNode;
-  stepKey: string;
-}> = ({liveData, stepKey}) => {
-  const {lastMaterialization, unstartedRunIds, inProgressRunIds, runWhichFailedToMaterialize} =
-    liveData || MISSING_LIVE_DATA;
+}> = ({liveData}) => {
+  const {
+    lastMaterialization,
+    unstartedRunIds,
+    inProgressRunIds,
+    runWhichFailedToMaterialize,
+    stepKey,
+  } = liveData || MISSING_LIVE_DATA;
 
   return inProgressRunIds?.length > 0 ? (
     <Box flex={{gap: 4, alignItems: 'center'}}>

--- a/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
@@ -1,15 +1,14 @@
 import {pathVerticalDiagonal} from '@vx/shape';
 
 import {
-  AssetGraphLiveQuery_assetsLatestInfo,
   AssetGraphLiveQuery_assetsLatestInfo_latestRun,
   AssetGraphLiveQuery_assetNodes_assetMaterializations,
+  AssetGraphLiveQuery,
 } from './types/AssetGraphLiveQuery';
 import {
   AssetGraphQuery_assetNodes,
   AssetGraphQuery_assetNodes_assetKey,
 } from './types/AssetGraphQuery';
-import {AssetNodeLiveFragment} from './types/AssetNodeLiveFragment';
 type AssetNode = AssetGraphQuery_assetNodes;
 type AssetKey = AssetGraphQuery_assetNodes_assetKey;
 
@@ -112,6 +111,7 @@ export const buildSVGPath = pathVerticalDiagonal({
 export type ComputeStatus = 'good' | 'old' | 'none' | 'unknown';
 
 export interface LiveDataForNode {
+  stepKey: string;
   unstartedRunIds: string[]; // run in progress and step not started
   inProgressRunIds: string[]; // run in progress and step in progress
   runWhichFailedToMaterialize: AssetGraphLiveQuery_assetsLatestInfo_latestRun | null;
@@ -180,20 +180,11 @@ export const buildComputeStatusData = (graph: GraphData, liveData: LiveData) => 
   return statuses;
 };
 
-export const buildLiveData = (
-  assets: AssetDefinitionsForLiveData,
-  nodes: AssetNodeLiveFragment[],
-  assetsLatestInfo: AssetGraphLiveQuery_assetsLatestInfo[],
-) => {
+export const buildLiveData = ({assetNodes, assetsLatestInfo}: AssetGraphLiveQuery) => {
   const data: LiveData = {};
 
-  for (const liveNode of nodes) {
+  for (const liveNode of assetNodes) {
     const graphId = toGraphId(liveNode.assetKey);
-    const definition = assets[graphId]?.definition;
-    if (!definition) {
-      console.warn(`buildLiveData could not find the definition matching ${graphId}`);
-      continue;
-    }
     const lastMaterialization = liveNode.assetMaterializations[0] || null;
 
     const assetLiveRuns = assetsLatestInfo.find(
@@ -210,6 +201,7 @@ export const buildLiveData = (
 
     data[graphId] = {
       lastMaterialization,
+      stepKey: liveNode.opNames[0],
       inProgressRunIds: assetLiveRuns?.inProgressRunIds || [],
       unstartedRunIds: assetLiveRuns?.unstartedRunIds || [],
       runWhichFailedToMaterialize,

--- a/js_modules/dagit/packages/core/src/asset-graph/useLiveDataForAssetKeys.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useLiveDataForAssetKeys.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import {AssetKeyInput} from '../types/globalTypes';
 
 import {ASSET_NODE_LIVE_FRAGMENT} from './AssetNode';
-import {buildLiveData, AssetDefinitionsForLiveData} from './Utils';
+import {buildLiveData} from './Utils';
 import {AssetGraphLiveQuery, AssetGraphLiveQueryVariables} from './types/AssetGraphLiveQuery';
 
 /** Fetches the last materialization, "upstream changed", and other live state
@@ -13,33 +13,24 @@ import {AssetGraphLiveQuery, AssetGraphLiveQueryVariables} from './types/AssetGr
  * Note: The "upstream changed" flag cascades, so it may not appear if the upstream
  * node that has changed is not in scope.
  */
-export function useLiveDataForAssetKeys(
-  assets: AssetDefinitionsForLiveData | undefined,
-  graphAssetKeys: AssetKeyInput[],
-) {
+export function useLiveDataForAssetKeys(assetKeys: AssetKeyInput[]) {
   const liveResult = useQuery<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>(
     ASSETS_GRAPH_LIVE_QUERY,
     {
-      skip: graphAssetKeys.length === 0,
-      variables: {assetKeys: graphAssetKeys},
+      skip: assetKeys.length === 0,
+      variables: {assetKeys},
       notifyOnNetworkStatusChange: true,
     },
   );
 
   const liveDataByNode = React.useMemo(() => {
-    if (!liveResult.data || !assets) {
-      return {};
-    }
-
-    const {assetNodes: liveAssetNodes, assetsLatestInfo} = liveResult.data;
-
-    return buildLiveData(assets, liveAssetNodes, assetsLatestInfo);
-  }, [assets, liveResult]);
+    return liveResult.data ? buildLiveData(liveResult.data) : {};
+  }, [liveResult.data]);
 
   return {
     liveResult,
     liveDataByNode,
-    graphAssetKeys,
+    assetKeys,
   };
 }
 

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -182,7 +182,6 @@ const AssetEntryRow: React.FC<{
     };
 
     const liveData = asset && liveDataByNode[toGraphId(asset.key)];
-    const stepKey = asset && asset.definition?.opNames[0];
     const repoAddress = asset?.definition
       ? buildRepoAddress(
           asset.definition.repository.name,
@@ -228,12 +227,15 @@ const AssetEntryRow: React.FC<{
           )}
         </td>
         <td>
-          {liveData && stepKey ? (
+          {liveData ? (
             liveData.lastMaterialization ? (
               <Mono>
                 <AssetRunLink
                   runId={liveData.lastMaterialization.runId}
-                  event={{stepKey, timestamp: liveData.lastMaterialization.timestamp}}
+                  event={{
+                    stepKey: liveData.stepKey,
+                    timestamp: liveData.lastMaterialization.timestamp,
+                  }}
                 >
                   <TimestampDisplay
                     timestamp={Number(liveData.lastMaterialization.timestamp) / 1000}
@@ -247,9 +249,9 @@ const AssetEntryRow: React.FC<{
           ) : undefined}
         </td>
         <td>
-          {liveData && stepKey && (
+          {liveData && (
             <Mono>
-              <AssetLatestRunWithNotices stepKey={stepKey} liveData={liveData} />
+              <AssetLatestRunWithNotices liveData={liveData} />
             </Mono>
           )}
         </td>

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -338,8 +338,6 @@ const AssetBulkActions: React.FC<{
 export const ASSET_TABLE_DEFINITION_FRAGMENT = gql`
   fragment AssetTableDefinitionFragment on AssetNode {
     id
-    opNames
-    jobNames
     groupName
     partitionDefinition
     description

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -82,11 +82,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
   );
 
   const {upstream, downstream} = useNeighborsFromGraph(assetGraphData, assetKey);
-
-  const {liveResult, liveDataByNode} = useLiveDataForAssetKeys(
-    assetGraphData?.nodes,
-    graphAssetKeys,
-  );
+  const {liveResult, liveDataByNode} = useLiveDataForAssetKeys(graphAssetKeys);
 
   const refreshState = useMergedRefresh(
     useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS),

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
@@ -21,7 +21,7 @@ import {
   useQueryRefreshAtInterval,
 } from '../app/QueryRefresh';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment';
-import {toGraphId, tokenForAssetKey} from '../asset-graph/Utils';
+import {tokenForAssetKey} from '../asset-graph/Utils';
 import {useLiveDataForAssetKeys} from '../asset-graph/useLiveDataForAssetKeys';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {AssetGroupSelector} from '../types/globalTypes';
@@ -132,20 +132,7 @@ export const AssetsCatalogTable: React.FC<AssetCatalogTableProps> = ({
     () => displayed.map<AssetKey>((a) => ({path: a.key.path})),
     [displayed],
   );
-  const displayedDefinitionMap = React.useMemo(
-    () =>
-      Object.fromEntries(
-        displayed
-          .filter((n) => n.definition)
-          .map((n) => [toGraphId(n.key), {definition: n.definition!}]),
-      ),
-    [displayed],
-  );
-
-  const {liveDataByNode, liveResult} = useLiveDataForAssetKeys(
-    displayedDefinitionMap,
-    displayedKeys,
-  );
+  const {liveDataByNode, liveResult} = useLiveDataForAssetKeys(displayedKeys);
 
   const refreshState = useMergedRefresh(
     useQueryRefreshAtInterval(query, FIFTEEN_SECONDS),

--- a/js_modules/dagit/packages/core/src/assets/types/AssetCatalogGroupTableQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetCatalogGroupTableQuery.ts
@@ -31,8 +31,6 @@ export interface AssetCatalogGroupTableQuery_assetNodes {
   __typename: "AssetNode";
   id: string;
   assetKey: AssetCatalogGroupTableQuery_assetNodes_assetKey;
-  opNames: string[];
-  jobNames: string[];
   groupName: string | null;
   partitionDefinition: string | null;
   description: string | null;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetCatalogTableQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetCatalogTableQuery.ts
@@ -28,8 +28,6 @@ export interface AssetCatalogTableQuery_assetsOrError_AssetConnection_nodes_defi
 export interface AssetCatalogTableQuery_assetsOrError_AssetConnection_nodes_definition {
   __typename: "AssetNode";
   id: string;
-  opNames: string[];
-  jobNames: string[];
   groupName: string | null;
   partitionDefinition: string | null;
   description: string | null;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetTableDefinitionFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetTableDefinitionFragment.ts
@@ -23,8 +23,6 @@ export interface AssetTableDefinitionFragment_repository {
 export interface AssetTableDefinitionFragment {
   __typename: "AssetNode";
   id: string;
-  opNames: string[];
-  jobNames: string[];
   groupName: string | null;
   partitionDefinition: string | null;
   description: string | null;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetTableFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetTableFragment.ts
@@ -28,8 +28,6 @@ export interface AssetTableFragment_definition_repository {
 export interface AssetTableFragment_definition {
   __typename: "AssetNode";
   id: string;
-  opNames: string[];
-  jobNames: string[];
   groupName: string | null;
   partitionDefinition: string | null;
   description: string | null;


### PR DESCRIPTION
### Summary & Motivation

This PR edits a few of our Asset GraphQL queries to be more precise about the data they're loading:

- Embed stepKey in LiveDataForAsset for less args
- Asset table does not actually display opNames, jobNames, stop fetching these fields
- useLiveAssetData does not actually rely on assets anymore

### How I Tested These Changes
