### PR TITLE
[dagit] Add Materialize button to the Asset Catalog

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -1,8 +1,6 @@
 import {Box, Checkbox, NonIdealState, SplitPanelContainer} from '@dagster-io/ui';
-import flatMap from 'lodash/flatMap';
 import pickBy from 'lodash/pickBy';
 import uniq from 'lodash/uniq';
-import uniqBy from 'lodash/uniqBy';
 import without from 'lodash/without';
 import React from 'react';
 import {useHistory} from 'react-router-dom';
@@ -507,15 +505,4 @@ const opsInRange = (
     }
   }
   return uniq(ledToTarget);
-};
-
-const titleForLaunch = (nodes: GraphNode[], liveDataByNode: LiveData) => {
-  const isRematerializeForAll = (nodes.length
-    ? nodes.map((n) => liveDataByNode[n.id])
-    : Object.values(liveDataByNode)
-  ).every((e) => !!e?.lastMaterialization);
-
-  return `${isRematerializeForAll ? 'Rematerialize' : 'Materialize'} ${
-    nodes.length === 0 ? `All` : nodes.length === 1 ? `Selected` : `Selected (${nodes.length})`
-  }`;
 };

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -406,18 +406,9 @@ export const AssetGraphExplorerWithData: React.FC<
               />
 
               <LaunchAssetExecutionButton
-                title={titleForLaunch(selectedGraphNodes, liveDataByNode)}
+                assetKeys={launchGraphNodes.map((n) => n.assetKey)}
+                liveDataByNode={liveDataByNode}
                 preferredJobName={explorerPath.pipelineName}
-                assets={launchGraphNodes.map((n) => n.definition)}
-                upstreamAssetKeys={uniqBy(
-                  flatMap(launchGraphNodes.map((n) => n.definition.dependencyKeys)),
-                  (key) => JSON.stringify(key),
-                ).filter(
-                  (key) =>
-                    !launchGraphNodes.some(
-                      (n) => JSON.stringify(n.assetKey) === JSON.stringify(key),
-                    ),
-                )}
               />
             </Box>
           </Box>

--- a/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
@@ -39,8 +39,8 @@ export interface GraphData {
   downstream: {[assetId: GraphId]: {[childAssetId: GraphId]: boolean}};
   upstream: {[assetId: GraphId]: {[parentAssetId: GraphId]: boolean}};
 }
-export const isSourceAsset = (node: {jobNames: string[]; opNames: string[]}) => {
-  return node.jobNames.length === 0 && !node.opNames.length;
+export const isSourceAsset = (node: {graphName: string | null; opNames: string[]}) => {
+  return !node.graphName && !node.opNames.length;
 };
 
 export const buildGraphData = (assetNodes: AssetNode[]) => {

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphQuery.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphQuery.ts
@@ -509,12 +509,12 @@ export interface AssetGraphQuery_assetNodes {
   id: string;
   dependencyKeys: AssetGraphQuery_assetNodes_dependencyKeys[];
   dependedByKeys: AssetGraphQuery_assetNodes_dependedByKeys[];
+  partitionDefinition: string | null;
   configField: AssetGraphQuery_assetNodes_configField | null;
   graphName: string | null;
   jobNames: string[];
   opNames: string[];
   description: string | null;
-  partitionDefinition: string | null;
   computeKind: string | null;
   assetKey: AssetGraphQuery_assetNodes_assetKey;
   repository: AssetGraphQuery_assetNodes_repository;

--- a/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
@@ -140,6 +140,7 @@ const ASSET_GRAPH_QUERY = gql`
       dependedByKeys {
         path
       }
+      partitionDefinition
       ...AssetNodeFragment
     }
   }

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -10,6 +10,7 @@ import {
   Popover,
   Table,
   Mono,
+  Tooltip,
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
@@ -21,6 +22,7 @@ import {LiveData, toGraphId} from '../asset-graph/Utils';
 import {useSelectionReducer} from '../hooks/useSelectionReducer';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
+import {AnchorButton} from '../ui/AnchorButton';
 import {MenuLink} from '../ui/MenuLink';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
@@ -28,10 +30,7 @@ import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 import {AssetLink} from './AssetLink';
 import {AssetWipeDialog} from './AssetWipeDialog';
-<<<<<<< HEAD
-=======
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
->>>>>>> 3321992479 (Defer fetching data required to launch assets until you click the button!)
 import {AssetTableFragment as Asset} from './types/AssetTableFragment';
 import {AssetViewType} from './useAssetView';
 
@@ -83,20 +82,9 @@ export const AssetTable = ({
 
   return (
     <Box flex={{direction: 'column'}}>
-      <Box flex={{alignItems: 'center', gap: 12}} padding={{vertical: 8, left: 24, right: 12}}>
+      <Box flex={{alignItems: 'center', gap: 8}} padding={{vertical: 8, left: 24, right: 12}}>
         {actionBarComponents}
         <div style={{flex: 1}} />
-<<<<<<< HEAD
-        <AssetBulkActions
-          selected={Array.from(checkedAssets)}
-          clearSelection={() => onToggleAll(false)}
-        />
-=======
-        {checkedAssets.length > 0 && (
-          <div
-            style={{color: Colors.Gray500, paddingRight: 4}}
-          >{`${checkedAssets.length.toLocaleString()} assets selected`}</div>
-        )}
         {checkedAssets.some((c) => !c.definition) ? (
           <Tooltip content="One or more selected assets are not software-defined and cannot be launched directly.">
             <Button intent="primary" icon={<Icon name="materialization" />} disabled>
@@ -110,7 +98,6 @@ export const AssetTable = ({
           />
         )}
         <MoreActionsDropdown selected={checkedAssets} clearSelection={() => onToggleAll(false)} />
->>>>>>> 3321992479 (Defer fetching data required to launch assets until you click the button!)
       </Box>
       <Table>
         <thead>
@@ -283,19 +270,12 @@ const AssetEntryRow: React.FC<{
         <td>
           {asset ? (
             <Box flex={{gap: 8, alignItems: 'center'}}>
-              <Link to={`/instance/assets/${path.join('/')}`}>
-                <Button>View Details</Button>
-              </Link>
+              <AnchorButton to={`/instance/assets/${path.join('/')}`}>View Details</AnchorButton>
               <Popover
                 position="bottom-right"
                 content={
                   <Menu>
                     <MenuLink
-<<<<<<< HEAD
-                      text="View details…"
-                      to={`/instance/assets/${path.join('/')}`}
-                      icon="view_list"
-=======
                       text="Show in group"
                       to={
                         repoAddress && asset.definition?.groupName
@@ -325,10 +305,9 @@ const AssetEntryRow: React.FC<{
                       to={`/instance/assets/${path.join('/')}?view=lineage&lineageScope=downstream`}
                       disabled={!asset?.definition}
                       icon="graph_downstream"
->>>>>>> 3321992479 (Defer fetching data required to launch assets until you click the button!)
                     />
                     <MenuItem
-                      text="Wipe Asset…"
+                      text="Wipe materializations"
                       icon="delete"
                       disabled={!canWipe}
                       intent="danger"
@@ -349,7 +328,7 @@ const AssetEntryRow: React.FC<{
   },
 );
 
-const AssetBulkActions: React.FC<{
+const MoreActionsDropdown: React.FC<{
   selected: Asset[];
   clearSelection: () => void;
   requery?: RefetchQueriesFunction;
@@ -362,24 +341,25 @@ const AssetBulkActions: React.FC<{
   }
 
   const disabled = selected.length === 0;
-  const label =
-    selected.length > 1
-      ? `Wipe materializations for ${selected.length} assets`
-      : selected.length === 1
-      ? `Wipe materializations for 1 asset`
-      : `Wipe materializations`;
 
   return (
     <>
-      <Button
-        disabled={disabled}
-        icon={<Icon name="delete" />}
-        intent={disabled ? 'none' : 'danger'}
-        outlined={!disabled}
-        onClick={() => setShowBulkWipeDialog(true)}
+      <Popover
+        position="bottom-right"
+        content={
+          <Menu>
+            <MenuItem
+              text="Wipe materializations"
+              onClick={() => setShowBulkWipeDialog(true)}
+              icon={<Icon name="delete" color={disabled ? Colors.Gray600 : Colors.Red500} />}
+              disabled={disabled}
+              intent="danger"
+            />
+          </Menu>
+        }
       >
-        {label}
-      </Button>
+        <Button icon={<Icon name="expand_more" />} />
+      </Popover>
       <AssetWipeDialog
         assetKeys={selected.map((asset) => asset.key)}
         isOpen={showBulkWipeDialog}

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -28,6 +28,10 @@ import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 import {AssetLink} from './AssetLink';
 import {AssetWipeDialog} from './AssetWipeDialog';
+<<<<<<< HEAD
+=======
+import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
+>>>>>>> 3321992479 (Defer fetching data required to launch assets until you click the button!)
 import {AssetTableFragment as Asset} from './types/AssetTableFragment';
 import {AssetViewType} from './useAssetView';
 
@@ -82,10 +86,31 @@ export const AssetTable = ({
       <Box flex={{alignItems: 'center', gap: 12}} padding={{vertical: 8, left: 24, right: 12}}>
         {actionBarComponents}
         <div style={{flex: 1}} />
+<<<<<<< HEAD
         <AssetBulkActions
           selected={Array.from(checkedAssets)}
           clearSelection={() => onToggleAll(false)}
         />
+=======
+        {checkedAssets.length > 0 && (
+          <div
+            style={{color: Colors.Gray500, paddingRight: 4}}
+          >{`${checkedAssets.length.toLocaleString()} assets selected`}</div>
+        )}
+        {checkedAssets.some((c) => !c.definition) ? (
+          <Tooltip content="One or more selected assets are not software-defined and cannot be launched directly.">
+            <Button intent="primary" icon={<Icon name="materialization" />} disabled>
+              Materialize
+            </Button>
+          </Tooltip>
+        ) : (
+          <LaunchAssetExecutionButton
+            assetKeys={checkedAssets.map((c) => c.key)}
+            liveDataByNode={liveDataByNode}
+          />
+        )}
+        <MoreActionsDropdown selected={checkedAssets} clearSelection={() => onToggleAll(false)} />
+>>>>>>> 3321992479 (Defer fetching data required to launch assets until you click the button!)
       </Box>
       <Table>
         <thead>
@@ -266,9 +291,41 @@ const AssetEntryRow: React.FC<{
                 content={
                   <Menu>
                     <MenuLink
+<<<<<<< HEAD
                       text="View details…"
                       to={`/instance/assets/${path.join('/')}`}
                       icon="view_list"
+=======
+                      text="Show in group"
+                      to={
+                        repoAddress && asset.definition?.groupName
+                          ? workspacePathFromAddress(
+                              repoAddress,
+                              `/asset_groups/${asset.definition.groupName}`,
+                            )
+                          : ''
+                      }
+                      disabled={!asset?.definition}
+                      icon="asset_group"
+                    />
+                    <MenuLink
+                      text="View neighbors"
+                      to={`/instance/assets/${path.join('/')}?view=lineage&lineageScope=neighbors`}
+                      disabled={!asset?.definition}
+                      icon="graph_neighbors"
+                    />
+                    <MenuLink
+                      text="View upstream assets"
+                      to={`/instance/assets/${path.join('/')}?view=lineage&lineageScope=upstream`}
+                      disabled={!asset?.definition}
+                      icon="graph_upstream"
+                    />
+                    <MenuLink
+                      text="View downstream assets"
+                      to={`/instance/assets/${path.join('/')}?view=lineage&lineageScope=downstream`}
+                      disabled={!asset?.definition}
+                      icon="graph_downstream"
+>>>>>>> 3321992479 (Defer fetching data required to launch assets until you click the button!)
                     />
                     <MenuItem
                       text="Wipe Asset…"

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -154,10 +154,8 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
             </Box>
             {definition && definition.jobNames.length > 0 && repoAddress && upstream && (
               <LaunchAssetExecutionButton
-                assets={[definition]}
-                upstreamAssetKeys={upstream.map((u) => u.assetKey)}
-                preferredJobName={definition.jobNames[0]}
-                title={lastMaterializedAt ? 'Rematerialize' : 'Materialize'}
+                assetKeys={[definition.assetKey]}
+                liveDataByNode={liveDataByNode}
               />
             )}
           </Box>

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -1,41 +1,157 @@
-import {Button, Icon, Tooltip} from '@dagster-io/ui';
+import {gql, useApolloClient} from '@apollo/client';
+import {Button, Icon, Spinner, Tooltip} from '@dagster-io/ui';
+import uniq from 'lodash/uniq';
 import React from 'react';
 
-import {isSourceAsset} from '../asset-graph/Utils';
-import {LaunchRootExecutionButton} from '../launchpad/LaunchRootExecutionButton';
+import {showCustomAlert} from '../app/CustomAlertProvider';
+import {IExecutionSession} from '../app/ExecutionSessionStorage';
+import {usePermissions} from '../app/Permissions';
+import {isSourceAsset, LiveData, toGraphId} from '../asset-graph/Utils';
+import {useLaunchWithTelemetry} from '../launchpad/LaunchRootExecutionButton';
 import {AssetLaunchpad} from '../launchpad/LaunchpadRoot';
 import {DagsterTag} from '../runs/RunTag';
+import {LaunchPipelineExecutionVariables} from '../runs/types/LaunchPipelineExecution';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
+import {RepoAddress} from '../workspace/types';
 
-import {configSchemaForAssetNode} from './AssetConfig';
+import {ASSET_NODE_CONFIG_FRAGMENT, configSchemaForAssetNode} from './AssetConfig';
 import {LaunchAssetChoosePartitionsDialog} from './LaunchAssetChoosePartitionsDialog';
 import {AssetKey} from './types';
+import {LaunchAssetExecutionAssetNodeFragment} from './types/LaunchAssetExecutionAssetNodeFragment';
+import {
+  LaunchAssetLoaderQuery,
+  LaunchAssetLoaderQueryVariables,
+} from './types/LaunchAssetLoaderQuery';
 
-type AssetMinimal = {
-  assetKey: {path: string[]};
-  configField: any;
-  opNames: string[];
-  jobNames: string[];
-  partitionDefinition: string | null;
-  repository: {name: string; location: {name: string}};
-};
+type LaunchAssetsState =
+  | {type: 'none'}
+  | {type: 'loading'}
+  | {type: 'error'; error: string}
+  | {
+      type: 'launchpad';
+      jobName: string;
+      sessionPresets: Partial<IExecutionSession>;
+      repoAddress: RepoAddress;
+    }
+  | {
+      type: 'partitions';
+      jobName: string;
+      assets: LaunchAssetExecutionAssetNodeFragment[];
+      upstreamAssetKeys: AssetKey[];
+      repoAddress: RepoAddress;
+    }
+  | {
+      type: 'single-run';
+      executionParams: LaunchPipelineExecutionVariables['executionParams'];
+    };
 
 export const LaunchAssetExecutionButton: React.FC<{
+  assetKeys: AssetKey[]; // Memoization not required
+  liveDataByNode: LiveData;
   preferredJobName?: string;
-  assets: AssetMinimal[];
-  upstreamAssetKeys: AssetKey[];
-  title?: string;
-}> = ({assets, preferredJobName, upstreamAssetKeys, title}) => {
-  const [showingDialog, setShowingDialog] = React.useState(false);
+}> = ({assetKeys, liveDataByNode, preferredJobName}) => {
+  const {canLaunchPipelineExecution} = usePermissions();
+  const launchWithTelemetry = useLaunchWithTelemetry();
+
+  const [state, setState] = React.useState<LaunchAssetsState>({type: 'none'});
+  const client = useApolloClient();
+
+  if (!assetKeys.length || !canLaunchPipelineExecution) {
+    return (
+      <Tooltip
+        content={
+          !canLaunchPipelineExecution
+            ? 'You do not have permission to materialize assets'
+            : 'Select one or more assets to materialize.'
+        }
+      >
+        <Button intent="primary" icon={<Icon name="materialization" />} disabled>
+          Materialize
+        </Button>
+      </Tooltip>
+    );
+  }
+
+  const onClick = async () => {
+    if (state.type === 'loading') {
+      return;
+    }
+    setState({type: 'loading'});
+
+    const result = await client.query<LaunchAssetLoaderQuery, LaunchAssetLoaderQueryVariables>({
+      query: LAUNCH_ASSET_LOADER_QUERY,
+      variables: {assetKeys: assetKeys.map(({path}) => ({path}))},
+    });
+    const assets = result.data.assetNodes;
+    const next = stateForLaunchingAssets(assets, preferredJobName);
+
+    if (next.type === 'error') {
+      showCustomAlert({
+        title: 'Unable to Materialize',
+        body: next.error,
+      });
+      setState({type: 'none'});
+    } else if (next.type === 'single-run') {
+      await launchWithTelemetry({executionParams: next.executionParams}, 'toast');
+      setState({type: 'none'});
+    } else {
+      setState(next);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        intent="primary"
+        onClick={onClick}
+        icon={
+          state.type === 'loading' ? (
+            <Spinner purpose="body-text" />
+          ) : (
+            <Icon name="materialization" />
+          )
+        }
+      >
+        {titleForLaunch(assetKeys, liveDataByNode)}
+      </Button>
+      {state.type === 'launchpad' && (
+        <AssetLaunchpad
+          assetJobName={state.jobName}
+          repoAddress={state.repoAddress}
+          sessionPresets={state.sessionPresets}
+          open={true}
+          setOpen={() => setState({type: 'none'})}
+        />
+      )}
+      {state.type === 'partitions' && (
+        <LaunchAssetChoosePartitionsDialog
+          assets={state.assets}
+          upstreamAssetKeys={state.upstreamAssetKeys}
+          repoAddress={state.repoAddress}
+          assetJobName={state.jobName}
+          open={true}
+          setOpen={() => setState({type: 'none'})}
+        />
+      )}
+    </>
+  );
+};
+
+function stateForLaunchingAssets(
+  assets: LaunchAssetExecutionAssetNodeFragment[],
+  preferredJobName?: string,
+): LaunchAssetsState {
+  if (assets.some(isSourceAsset)) {
+    return {
+      type: 'error',
+      error: 'One or more source assets are selected and cannot be materialized.',
+    };
+  }
+
   const repoAddress = buildRepoAddress(
     assets[0]?.repository.name || '',
     assets[0]?.repository.location.name || '',
   );
-
-  let disabledReason = '';
-  if (assets.some(isSourceAsset)) {
-    disabledReason = 'One or more source assets are selected and cannot be materialized.';
-  }
   if (
     !assets.every(
       (a) =>
@@ -43,120 +159,143 @@ export const LaunchAssetExecutionButton: React.FC<{
         a.repository.location.name === repoAddress.location,
     )
   ) {
-    disabledReason =
-      disabledReason || 'Assets must be in the same repository to be materialized together.';
+    return {
+      type: 'error',
+      error: 'Assets must be in the same repository to be materialized together.',
+    };
   }
 
   const partitionDefinition = assets.find((a) => !!a.partitionDefinition)?.partitionDefinition;
   if (assets.some((a) => a.partitionDefinition && a.partitionDefinition !== partitionDefinition)) {
-    disabledReason =
-      disabledReason || 'Assets must share a partition definition to be materialized together.';
+    return {
+      type: 'error',
+      error: 'Assets must share a partition definition to be materialized together.',
+    };
   }
 
   const everyAssetHasJob = (jobName: string) => assets.every((a) => a.jobNames.includes(jobName));
   const jobsInCommon = assets[0] ? assets[0].jobNames.filter(everyAssetHasJob) : [];
   const jobName = jobsInCommon.find((name) => name === preferredJobName) || jobsInCommon[0];
   if (!jobName) {
-    disabledReason =
-      disabledReason || 'Assets must be in the same job to be materialized together.';
+    return {
+      type: 'error',
+      error: 'Assets must be in the same job to be materialized together.',
+    };
   }
 
   const anyAssetsHaveConfig = assets.some((a) => configSchemaForAssetNode(a));
-
   if (anyAssetsHaveConfig && partitionDefinition) {
-    disabledReason =
-      disabledReason || 'Cannot materialize assets using both asset config and partitions.';
+    return {
+      type: 'error',
+      error: 'Cannot materialize assets using both asset config and partitions.',
+    };
   }
 
-  title = title || 'Refresh';
+  // Ok! Assertions met, how do we launch this run
 
-  let tooltipChildren: React.ReactNode;
   if (anyAssetsHaveConfig) {
     const assetOpNames = assets.flatMap((a) => a.opNames || []);
-    const sessionPresets = {
-      solidSelection: assetOpNames,
-      solidSelectionQuery: assetOpNames.map((name) => `"${name}"`).join(' '),
+    return {
+      type: 'launchpad',
+      jobName,
+      repoAddress,
+      sessionPresets: {
+        solidSelection: assetOpNames,
+        solidSelectionQuery: assetOpNames.map((name) => `"${name}"`).join(' '),
+      },
     };
-    tooltipChildren = (
-      <>
-        <Button
-          icon={<Icon name="materialization" />}
-          disabled={!!disabledReason}
-          intent="primary"
-          onClick={() => setShowingDialog(true)}
-        >
-          {title}
-        </Button>
-        <AssetLaunchpad
-          assetJobName={jobName}
-          repoAddress={repoAddress}
-          sessionPresets={sessionPresets}
-          open={showingDialog}
-          setOpen={setShowingDialog}
-        />
-      </>
-    );
-  } else if (partitionDefinition) {
-    // Add ellipsis to the button title since it will open a "Choose partitions" modal
-    title =
-      title.indexOf(' (') !== -1
-        ? title.slice(0, title.indexOf(' (')) + '...' + title.slice(title.indexOf(' ('))
-        : title + '...';
-    tooltipChildren = (
-      <>
-        <Button
-          icon={<Icon name="materialization" />}
-          disabled={!!disabledReason}
-          intent="primary"
-          onClick={() => setShowingDialog(true)}
-        >
-          {title}
-        </Button>
-        <LaunchAssetChoosePartitionsDialog
-          assets={assets}
-          upstreamAssetKeys={upstreamAssetKeys}
-          repoAddress={repoAddress}
-          assetJobName={jobName}
-          open={showingDialog}
-          setOpen={setShowingDialog}
-        />
-      </>
-    );
-  } else {
-    tooltipChildren = (
-      <LaunchRootExecutionButton
-        pipelineName={jobName}
-        disabled={!!disabledReason}
-        title={title}
-        icon="materialization"
-        behavior="toast"
-        getVariables={() => ({
-          executionParams: {
-            mode: 'default',
-            executionMetadata: {
-              tags: [
-                {
-                  key: DagsterTag.StepSelection,
-                  value: assets
-                    .map((o) => o.opNames)
-                    .flat()
-                    .join(','),
-                },
-              ],
-            },
-            runConfigData: {},
-            selector: {
-              repositoryLocationName: repoAddress.location,
-              repositoryName: repoAddress.name,
-              pipelineName: jobName,
-              assetSelection: assets.map((asset) => ({
-                path: asset.assetKey.path,
-              })),
-            },
-          },
-        })}
-      />
-    );
   }
-  return <Tooltip content={disabledReason}>{tooltipChildren}</Tooltip>;
+  if (partitionDefinition) {
+    const assetKeys = new Set(assets.map((a) => JSON.stringify(a.assetKey)));
+    const upstreamAssetKeys = uniq(
+      assets.flatMap((a) => a.dependencyKeys.map(({path}) => JSON.stringify({path}))),
+    )
+      .filter((key) => !assetKeys.has(key))
+      .map((key) => JSON.parse(key));
+
+    return {
+      type: 'partitions',
+      assets,
+      jobName,
+      repoAddress,
+      upstreamAssetKeys,
+    };
+  }
+  return {
+    type: 'single-run',
+    executionParams: {
+      mode: 'default',
+      executionMetadata: {
+        tags: [
+          {
+            key: DagsterTag.StepSelection,
+            value: assets
+              .map((o) => o.opNames)
+              .flat()
+              .join(','),
+          },
+        ],
+      },
+      runConfigData: {},
+      selector: {
+        repositoryLocationName: repoAddress.location,
+        repositoryName: repoAddress.name,
+        pipelineName: jobName,
+        assetSelection: assets.map((asset) => ({
+          path: asset.assetKey.path,
+        })),
+      },
+    },
+  };
+}
+
+const titleForLaunch = (assetKeys: AssetKey[], liveDataByNode: LiveData) => {
+  const isRematerializeForAll = (assetKeys.length
+    ? assetKeys.map((n) => liveDataByNode[toGraphId(n)])
+    : Object.values(liveDataByNode)
+  ).every((e) => !!e?.lastMaterialization);
+
+  const count = assetKeys.length !== 1 ? ` (${assetKeys.length})` : '';
+
+  return `${isRematerializeForAll ? 'Rematerialize' : 'Materialize'} ${
+    assetKeys.length === 0 || assetKeys.length === Object.keys(liveDataByNode).length
+      ? `All${count}`
+      : `Selected${count}`
+  }`;
 };
+
+export const LAUNCH_ASSET_EXECUTION_ASSET_NODE_FRAGMENT = gql`
+  fragment LaunchAssetExecutionAssetNodeFragment on AssetNode {
+    id
+    opNames
+    jobNames
+    graphName
+    partitionDefinition
+    assetKey {
+      path
+    }
+    dependencyKeys {
+      path
+    }
+    repository {
+      id
+      name
+      location {
+        id
+        name
+      }
+    }
+    ...AssetNodeConfigFragment
+  }
+  ${ASSET_NODE_CONFIG_FRAGMENT}
+`;
+
+const LAUNCH_ASSET_LOADER_QUERY = gql`
+  query LaunchAssetLoaderQuery($assetKeys: [AssetKeyInput!]!) {
+    assetNodes(assetKeys: $assetKeys) {
+      id
+      ...LaunchAssetExecutionAssetNodeFragment
+    }
+  }
+  ${LAUNCH_ASSET_EXECUTION_ASSET_NODE_FRAGMENT}
+`;

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetExecutionAssetNodeFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetExecutionAssetNodeFragment.ts
@@ -1,0 +1,511 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: LaunchAssetExecutionAssetNodeFragment
+// ====================================================
+
+export interface LaunchAssetExecutionAssetNodeFragment_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_dependencyKeys {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_repository_location {
+  __typename: "RepositoryLocation";
+  id: string;
+  name: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_repository {
+  __typename: "Repository";
+  id: string;
+  name: string;
+  location: LaunchAssetExecutionAssetNodeFragment_repository_location;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes = LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  recursiveConfigTypes: LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType_recursiveConfigTypes = LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  recursiveConfigTypes: LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType_recursiveConfigTypes[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType_recursiveConfigTypes = LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  recursiveConfigTypes: LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType_recursiveConfigTypes[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_recursiveConfigTypes = LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_fields[];
+  recursiveConfigTypes: LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType_recursiveConfigTypes[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType_recursiveConfigTypes = LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+  recursiveConfigTypes: LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType_recursiveConfigTypes[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType_recursiveConfigTypes = LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+  recursiveConfigTypes: LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType_recursiveConfigTypes[];
+}
+
+export type LaunchAssetExecutionAssetNodeFragment_configField_configType = LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_EnumConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_RegularConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_CompositeConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_ScalarUnionConfigType | LaunchAssetExecutionAssetNodeFragment_configField_configType_MapConfigType;
+
+export interface LaunchAssetExecutionAssetNodeFragment_configField {
+  __typename: "ConfigTypeField";
+  name: string;
+  configType: LaunchAssetExecutionAssetNodeFragment_configField_configType;
+}
+
+export interface LaunchAssetExecutionAssetNodeFragment {
+  __typename: "AssetNode";
+  id: string;
+  opNames: string[];
+  jobNames: string[];
+  graphName: string | null;
+  partitionDefinition: string | null;
+  assetKey: LaunchAssetExecutionAssetNodeFragment_assetKey;
+  dependencyKeys: LaunchAssetExecutionAssetNodeFragment_dependencyKeys[];
+  repository: LaunchAssetExecutionAssetNodeFragment_repository;
+  configField: LaunchAssetExecutionAssetNodeFragment_configField | null;
+}

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetLoaderQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetLoaderQuery.ts
@@ -1,0 +1,521 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { AssetKeyInput } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: LaunchAssetLoaderQuery
+// ====================================================
+
+export interface LaunchAssetLoaderQuery_assetNodes_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_dependencyKeys {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_repository_location {
+  __typename: "RepositoryLocation";
+  id: string;
+  name: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_repository {
+  __typename: "Repository";
+  id: string;
+  name: string;
+  location: LaunchAssetLoaderQuery_assetNodes_repository_location;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes = LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  recursiveConfigTypes: LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType_recursiveConfigTypes = LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  recursiveConfigTypes: LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType_recursiveConfigTypes[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType_recursiveConfigTypes = LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  recursiveConfigTypes: LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType_recursiveConfigTypes[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_recursiveConfigTypes = LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_fields[];
+  recursiveConfigTypes: LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType_recursiveConfigTypes[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType_recursiveConfigTypes = LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+  recursiveConfigTypes: LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType_recursiveConfigTypes[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType_recursiveConfigTypes = LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+  recursiveConfigTypes: LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType_recursiveConfigTypes[];
+}
+
+export type LaunchAssetLoaderQuery_assetNodes_configField_configType = LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_EnumConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_RegularConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_CompositeConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_ScalarUnionConfigType | LaunchAssetLoaderQuery_assetNodes_configField_configType_MapConfigType;
+
+export interface LaunchAssetLoaderQuery_assetNodes_configField {
+  __typename: "ConfigTypeField";
+  name: string;
+  configType: LaunchAssetLoaderQuery_assetNodes_configField_configType;
+}
+
+export interface LaunchAssetLoaderQuery_assetNodes {
+  __typename: "AssetNode";
+  id: string;
+  opNames: string[];
+  jobNames: string[];
+  graphName: string | null;
+  partitionDefinition: string | null;
+  assetKey: LaunchAssetLoaderQuery_assetNodes_assetKey;
+  dependencyKeys: LaunchAssetLoaderQuery_assetNodes_dependencyKeys[];
+  repository: LaunchAssetLoaderQuery_assetNodes_repository;
+  configField: LaunchAssetLoaderQuery_assetNodes_configField | null;
+}
+
+export interface LaunchAssetLoaderQuery {
+  assetNodes: LaunchAssetLoaderQuery_assetNodes[];
+}
+
+export interface LaunchAssetLoaderQueryVariables {
+  assetKeys: AssetKeyInput[];
+}

--- a/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
@@ -61,11 +61,13 @@ export function useDidLaunchEvent(cb: () => void, delay = 1500) {
   }, [cb, delay]);
 }
 
+export type LaunchBehavior = 'open' | 'open-in-new-tab' | 'toast';
+
 export function handleLaunchResult(
   pipelineName: string,
   result: void | {data?: LaunchPipelineExecution | LaunchPipelineReexecution | null},
   history: History<unknown>,
-  options: {behavior: 'toast' | 'open' | 'open-in-new-tab'; preserveQuerystring?: boolean},
+  options: {behavior: LaunchBehavior; preserveQuerystring?: boolean},
 ) {
   const obj =
     result && result.data && 'launchPipelineExecution' in result.data


### PR DESCRIPTION
### Summary & Motivation

This PR adds a Materialize button to the Asset Catalog! The button has been refactored so that it fetches data about the selected assets when you click it. The button appears enabled whenever the selection is present and you see error messages after you click it if the assets cannot be materialized together. This eliminates a bunch of fields we required on the AssetGraphExplorer to determine the button's state and means it fits into the Asset Catalog more cleanly!




<img width="446" alt="image" src="https://user-images.githubusercontent.com/1037212/172189446-7a5adacc-4cab-4edc-a189-2353062b4039.png">

### How I Tested These Changes
