### PR TITLE
Make BaseTag inherit pointer style if not interactive

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/BaseTag.tsx
+++ b/js_modules/dagit/packages/ui/src/components/BaseTag.tsx
@@ -65,7 +65,7 @@ export const StyledTag = styled.div<StyledTagProps>`
   background-color: ${({$fillColor}) => $fillColor};
   border-radius: 8px;
   color: ${({$textColor}) => $textColor};
-  cursor: ${({$interactive}) => ($interactive ? 'pointer' : 'default')};
+  cursor: ${({$interactive}) => ($interactive ? 'pointer' : 'inherit')};
   display: inline-flex;
   flex-direction: row;
   font-size: 12px;


### PR DESCRIPTION
### Summary & Motivation

Currently, If a tag has a parent with `cursor: pointer` but the tag itself is not "interactive" then when you hover over the tag you will end up with the default style cursor. Instead it should inherit the cursor style from its ancestors.

### How I Tested These Changes

Tested this with a change in Cloud.