### PR TITLE
Restrict group names to VALID_NAME_REGEX_STR

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -25,7 +25,7 @@ from dagster.core.definitions.input import In
 from dagster.core.definitions.output import Out
 from dagster.core.definitions.partition import PartitionsDefinition
 from dagster.core.definitions.resource_definition import ResourceDefinition
-from dagster.core.definitions.utils import NoValueSentinel
+from dagster.core.definitions.utils import NoValueSentinel, check_valid_name
 from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.storage.io_manager import IOManagerDefinition
 from dagster.core.types.dagster_type import DagsterType
@@ -215,7 +215,7 @@ class _Asset:
         self.partition_mappings = partition_mappings
         self.op_tags = op_tags
         self.resource_defs = dict(check.opt_mapping_param(resource_defs, "resource_defs"))
-        self.group_name = group_name
+        self.group_name = check_valid_name(group_name) if group_name else None
 
     def __call__(self, fn: Callable) -> AssetsDefinition:
         asset_name = self.name or fn.__name__

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -1,5 +1,6 @@
 from dagster import AssetKey, AssetsDefinition, GraphOut, In, Out, graph, job, op
 from dagster.core.asset_defs import AssetIn, SourceAsset, asset, build_assets_job, multi_asset
+from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.host_representation.external_data import (
     ExternalAssetDependedBy,
     ExternalAssetDependency,
@@ -9,6 +10,7 @@ from dagster.core.host_representation.external_data import (
     external_asset_graph_from_defs,
 )
 from dagster.serdes import deserialize_json_to_dagster_namedtuple
+import pytest
 
 
 def test_single_asset_job():
@@ -55,6 +57,20 @@ def test_asset_missing_group_name():
     external_asset_nodes = external_asset_graph_from_defs([assets_job], source_assets_by_key={})
 
     assert external_asset_nodes[0].group_name is None
+
+
+def test_asset_invalid_group_name():
+    with pytest.raises(DagsterInvalidDefinitionError):
+
+        @asset(group_name="group/with/slashes")
+        def asset2():
+            return 1
+
+    with pytest.raises(DagsterInvalidDefinitionError):
+
+        @asset(group_name="group.with.dots")
+        def asset3():
+            return 1
 
 
 def test_two_asset_job():


### PR DESCRIPTION
### Summary & Motivation

An asset's group_name is a user provided string. If we disallow special characters, in the future we can use special syntax within the group name. It is easier to relax constraints than add them after users have already started using an API. This change restricts the group name to dagster valid names as defined by `check_valid_name()`. This currently allows  `r"^[A-Za-z0-9_]+$"`.

### How I Tested These Changes

Added test cases to test_external_data.py.
