### PR TITLE
Fix upgrade story for new scheme field in postgres

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/postgresql.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/postgresql.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel
 
 from ...utils.kubernetes import ExternalImage
@@ -15,5 +17,5 @@ class PostgreSQL(BaseModel):
     postgresqlPassword: str
     postgresqlDatabase: str
     postgresqlParams: dict
-    postgresqlScheme: str
+    postgresqlScheme: Optional[str]
     service: Service

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -58,7 +58,7 @@ def helm_template() -> HelmTemplate:
     )
 
 
-@pytest.mark.parametrize("postgresql_scheme", ["postgresql", "postgresql+psycopg2"])
+@pytest.mark.parametrize("postgresql_scheme", ["", "postgresql", "postgresql+psycopg2"])
 @pytest.mark.parametrize("storage", ["schedule_storage", "run_storage", "event_log_storage"])
 def test_storage_postgres_db_config(template: HelmTemplate, postgresql_scheme: str, storage: str):
     postgresql_username = "username"
@@ -97,7 +97,10 @@ def test_storage_postgres_db_config(template: HelmTemplate, postgresql_scheme: s
     assert postgres_db["db_name"] == postgresql_database
     assert postgres_db["port"] == postgresql_port
     assert postgres_db["params"] == postgresql_params
-    assert postgres_db["scheme"] == postgresql_scheme
+    if not postgresql_scheme:
+        assert "scheme" not in postgres_db
+    else:
+        assert postgres_db["scheme"] == postgresql_scheme
 
 
 def test_k8s_run_launcher_config(template: HelmTemplate):

--- a/helm/dagster/templates/helpers/instance/_postgresql.tpl
+++ b/helm/dagster/templates/helpers/instance/_postgresql.tpl
@@ -7,5 +7,7 @@ postgres_db:
   db_name: {{ .Values.postgresql.postgresqlDatabase	}}
   port: {{ .Values.postgresql.service.port }}
   params: {{- .Values.postgresql.postgresqlParams | toYaml | nindent 4 }}
+  {{- if .Values.postgresql.postgresqlScheme }}
   scheme: {{ .Values.postgresql.postgresqlScheme }}
+  {{- end }}
 {{- end }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -687,7 +687,6 @@
                 "postgresqlPassword",
                 "postgresqlDatabase",
                 "postgresqlParams",
-                "postgresqlScheme",
                 "service"
             ]
         },

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -691,7 +691,7 @@ postgresql:
   # When set, overrides the default `postgresql` scheme for the connection string.
   # (e.g., set to `postgresql+pg8000` to use the `pg8000` library).
   # See: https://docs.sqlalchemy.org/en/13/dialects/postgresql.html#dialect-postgresql
-  postgresqlScheme: "postgresql"
+  postgresqlScheme: ""
 
   service:
     port: 5432


### PR DESCRIPTION
Summary:
By changing the default to always include this, we made it so that old user code running against a new helm upgrade errors out. Instead, only set this in the instance config if they manually set it in the Helm chart.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
