### PR TITLE
Add resource defs to source asset, handle transitive dependencies

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/asset_group.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_group.py
@@ -11,9 +11,8 @@ from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.executor_definition import in_process_executor
 from dagster.core.errors import DagsterUnmetExecutorRequirementsError
 from dagster.core.execution.execute_in_process_result import ExecuteInProcessResult
+from dagster.core.execution.with_resources import with_resources
 from dagster.core.selector.subset_selector import AssetSelectionData
-from dagster.core.storage.fs_io_manager import fs_io_manager
-from dagster.utils import merge_dicts
 from dagster.utils.backcompat import ExperimentalWarning
 
 from ..definitions.asset_layer import build_asset_selection_job
@@ -106,14 +105,8 @@ class AssetGroup:
         )
         executor_def = check.opt_inst_param(executor_def, "executor_def", ExecutorDefinition)
 
-        # In the case of collisions, merge_dicts takes values from the
-        # dictionary latest in the list, so we place the user provided resource
-        # defs after the defaults.
-        resource_defs = merge_dicts({"io_manager": fs_io_manager}, resource_defs)
-
-        _validate_resource_reqs_for_asset_group(
-            asset_list=assets, source_assets=source_assets, resource_defs=resource_defs
-        )
+        assets = with_resources(assets, resource_defs)
+        source_assets = with_resources(source_assets, resource_defs)
 
         self._assets = assets
         self._source_assets = source_assets

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -376,14 +376,7 @@ class AssetsDefinition(ResourceAddable):
 
         # Ensure top-level resource requirements are met - except for
         # io_manager, since that is a default it can be resolved later.
-        ensure_requirements_satisfied(
-            merged_resource_defs,
-            [
-                requirement
-                for requirement in self.get_resource_requirements()
-                if requirement.key != "io_manager"
-            ],
-        )
+        ensure_requirements_satisfied(merged_resource_defs, list(self.get_resource_requirements()))
 
         # Get all transitive resource dependencies from other resources.
         relevant_keys = get_transitive_required_resource_keys(
@@ -404,7 +397,7 @@ class AssetsDefinition(ResourceAddable):
             asset_deps=self._asset_deps,
             selected_asset_keys=self._selected_asset_keys,
             can_subset=self._can_subset,
-            resource_defs=merged_resource_defs,
+            resource_defs=relevant_resource_defs,
         )
 
 

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -339,6 +339,7 @@ class AssetsDefinition(ResourceAddable):
             asset_deps=self._asset_deps,
             can_subset=self.can_subset,
             selected_asset_keys=selected_asset_keys & self.asset_keys,
+            resource_defs=self.resource_defs,
         )
 
     def to_source_assets(self) -> Sequence[SourceAsset]:

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -398,6 +398,7 @@ class AssetsDefinition(ResourceAddable):
             selected_asset_keys=self._selected_asset_keys,
             can_subset=self._can_subset,
             resource_defs=relevant_resource_defs,
+            group_names=self._group_names,
         )
 
 

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -370,12 +370,9 @@ class AssetsDefinition(ResourceAddable):
         return {requirement.key for requirement in self.get_resource_requirements()}
 
     def with_resources(self, resource_defs: Mapping[str, ResourceDefinition]) -> "AssetsDefinition":
-        from dagster.core.definitions.graph_definition import default_job_io_manager
         from dagster.core.execution.resources_init import get_transitive_required_resource_keys
 
-        merged_resource_defs = merge_dicts(
-            {"io_manager": default_job_io_manager}, resource_defs, self.resource_defs
-        )
+        merged_resource_defs = merge_dicts(resource_defs, self.resource_defs)
 
         # Ensure top-level resource requirements are met - except for
         # io_manager, since that is a default it can be resolved later.

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -359,6 +359,7 @@ class AssetsDefinition(ResourceAddable):
 
         return result
 
+<<<<<<< HEAD
     def get_resource_requirements(self) -> Iterator[ResourceRequirement]:
         yield from self.node_def.get_resource_requirements()  # type: ignore[attr-defined]
         for source_key, resource_def in self.resource_defs.items():
@@ -387,6 +388,16 @@ class AssetsDefinition(ResourceAddable):
             can_subset=self._can_subset,
             resource_defs=merged_resource_defs,
         )
+=======
+    @property
+    def required_resource_keys(self) -> Set[str]:
+        if isinstance(self.node_def, GraphDefinition):
+            graph_def = self.node_def.ensure_graph_def()
+            return {requirement.key for requirement in graph_def.get_resource_requirements()}
+        else:
+            solid_def = self.node_def.ensure_solid_def()
+            return solid_def.required_resource_keys
+>>>>>>> Add resource defs to source asset, handle transitive dependencies
 
 
 def _infer_asset_keys_by_input_names(

--- a/python_modules/dagster/dagster/core/asset_defs/assets_job.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets_job.py
@@ -29,7 +29,7 @@ from dagster.core.definitions.dependency import (
 )
 from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.executor_definition import ExecutorDefinition
-from dagster.core.definitions.graph_definition import GraphDefinition
+from dagster.core.definitions.graph_definition import GraphDefinition, default_job_io_manager
 from dagster.core.definitions.job_definition import JobDefinition
 from dagster.core.definitions.output import OutputDefinition
 from dagster.core.definitions.partition import PartitionedConfig, PartitionsDefinition
@@ -38,6 +38,7 @@ from dagster.core.definitions.resource_definition import ResourceDefinition
 from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.execution.with_resources import with_resources
 from dagster.core.selector.subset_selector import AssetSelectionData
+from dagster.utils import merge_dicts
 from dagster.utils.backcompat import experimental
 
 from .asset_partitions import get_upstream_partitions_for_partition_range
@@ -99,6 +100,7 @@ def build_assets_job(
     check.opt_str_param(description, "description")
     check.opt_inst_param(_asset_selection_data, "_asset_selection_data", AssetSelectionData)
     resource_defs = check.opt_mapping_param(resource_defs, "resource_defs")
+    resource_defs = merge_dicts({"io_manager": default_job_io_manager}, resource_defs)
 
     assets = with_resources(assets, resource_defs)
     source_assets = with_resources(source_assets, resource_defs)

--- a/python_modules/dagster/dagster/core/asset_defs/assets_job.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets_job.py
@@ -143,7 +143,8 @@ def build_assets_job(
                 all_resource_defs[resource_key] = resource_def
             if all_resource_defs[resource_key] != resource_def:
                 raise DagsterInvalidDefinitionError(
-                    f"Conflicting versions of resource with key '{resource_key}' were provided to different assets. When constructing a "
+                    f"Conflicting versions of resource with key '{resource_key}' "
+                    "were provided to different assets. When constructing a "
                     "job, all resource definitions provided to assets must "
                     "match by reference equality for a given key."
                 )

--- a/python_modules/dagster/dagster/core/asset_defs/source_asset.py
+++ b/python_modules/dagster/dagster/core/asset_defs/source_asset.py
@@ -136,4 +136,5 @@ class SourceAsset(
             partitions_def=self.partitions_def,
             _metadata_entries=self.metadata_entries,
             resource_defs=relevant_resource_defs,
+            group_name=self.group_name,
         )

--- a/python_modules/dagster/dagster/core/asset_defs/source_asset.py
+++ b/python_modules/dagster/dagster/core/asset_defs/source_asset.py
@@ -1,4 +1,4 @@
-from typing import Dict, Mapping, NamedTuple, Optional, Sequence, Union
+from typing import Dict, Mapping, NamedTuple, Optional, Sequence, Union, cast
 
 import dagster._check as check
 from dagster.core.definitions.events import AssetKey, CoerceableToAssetKey
@@ -63,7 +63,6 @@ class SourceAsset(
         key = AssetKey.from_coerceable(key)
         metadata = check.opt_dict_param(metadata, "metadata", key_type=str)
         metadata_entries = _metadata_entries or normalize_metadata(metadata, [], allow_invalid=True)
-        metadata_entries = normalize_metadata(metadata, [], allow_invalid=True)
         resource_defs = dict(check.opt_mapping_param(resource_defs, "resource_defs"))
         io_manager_def = check.opt_inst_param(io_manager_def, "io_manager_def", IOManagerDefinition)
         if io_manager_def:
@@ -102,7 +101,10 @@ class SourceAsset(
     @property
     def io_manager_def(self) -> Optional[IOManagerDefinition]:
         io_manager_key = self.get_io_manager_key()
-        return self.resource_defs.get(io_manager_key) if io_manager_key else None
+        return cast(
+            Optional[IOManagerDefinition],
+            self.resource_defs.get(io_manager_key) if io_manager_key else None,
+        )
 
     def with_resources(self, resource_defs) -> "SourceAsset":
         from dagster.core.execution.resources_init import get_transitive_required_resource_keys
@@ -125,7 +127,7 @@ class SourceAsset(
         }
 
         io_manager_key = (
-            self.get_io_manager_key() if self.get_io_manager_key != "io_manager" else None
+            self.get_io_manager_key() if self.get_io_manager_key() != "io_manager" else None
         )
         return SourceAsset(
             key=self.key,

--- a/python_modules/dagster/dagster/core/asset_defs/source_asset.py
+++ b/python_modules/dagster/dagster/core/asset_defs/source_asset.py
@@ -10,11 +10,12 @@ from dagster.core.definitions.metadata import (
     normalize_metadata,
 )
 from dagster.core.definitions.partition import PartitionsDefinition
+from dagster.core.definitions.resource_definition import ResourceDefinition
 from dagster.core.definitions.resource_requirement import ResourceAddable
 from dagster.core.definitions.utils import validate_group_name
 from dagster.core.errors import DagsterInvalidDefinitionError
-from dagster.core.definitions.resource_definition import ResourceDefinition
 from dagster.core.storage.io_manager import IOManagerDefinition
+from dagster.utils import merge_dicts
 
 
 class SourceAsset(
@@ -24,7 +25,6 @@ class SourceAsset(
             ("key", AssetKey),
             ("metadata_entries", Sequence[Union[MetadataEntry, PartitionMetadataEntry]]),
             ("io_manager_key", Optional[str]),
-            ("io_manager_def", Optional[IOManagerDefinition]),
             ("description", Optional[str]),
             ("partitions_def", Optional[PartitionsDefinition]),
             ("group_name", str),
@@ -65,14 +65,24 @@ class SourceAsset(
         metadata_entries = _metadata_entries or normalize_metadata(metadata, [], allow_invalid=True)
         metadata_entries = normalize_metadata(metadata, [], allow_invalid=True)
         resource_defs = dict(check.opt_mapping_param(resource_defs, "resource_defs"))
+        io_manager_def = check.opt_inst_param(io_manager_def, "io_manager_def", IOManagerDefinition)
+        if io_manager_def:
+            if not io_manager_key:
+                source_asset_path = "__".join(key.path)
+                io_manager_key = f"{source_asset_path}__io_manager"
+
+            if io_manager_key in resource_defs and resource_defs[io_manager_key] != io_manager_def:
+                raise DagsterInvalidDefinitionError(
+                    f"Provided conflicting definitions for io manager key '{io_manager_key}'. Please provide only one definition per key."
+                )
+
+            resource_defs[io_manager_key] = io_manager_def
+
         return super().__new__(
             cls,
             key=key,
             metadata_entries=metadata_entries,
             io_manager_key=check.opt_str_param(io_manager_key, "io_manager_key"),
-            io_manager_def=check.opt_inst_param(
-                io_manager_def, "io_manager_def", IOManagerDefinition
-            ),
             description=check.opt_str_param(description, "description"),
             partitions_def=check.opt_inst_param(
                 partitions_def, "partitions_def", PartitionsDefinition
@@ -87,26 +97,44 @@ class SourceAsset(
         return {entry.label: entry.entry_data for entry in self.metadata_entries}  # type: ignore
 
     def get_io_manager_key(self) -> str:
-        if not self.io_manager_key and not self.io_manager_def:
-            return "io_manager"
-        source_asset_path = "__".join(self.key.path)
-        return self.io_manager_key or f"{source_asset_path}__io_manager"
+        return self.io_manager_key or "io_manager"
+
+    @property
+    def io_manager_def(self) -> Optional[IOManagerDefinition]:
+        io_manager_key = self.get_io_manager_key()
+        return self.resource_defs.get(io_manager_key) if io_manager_key else None
 
     def with_resources(self, resource_defs) -> "SourceAsset":
-        if self.io_manager_def:
-            return self
+        from dagster.core.definitions.graph_definition import default_job_io_manager
+        from dagster.core.execution.resources_init import get_transitive_required_resource_keys
 
-        io_manager_def = resource_defs.get(self.get_io_manager_key())
+        merged_resource_defs = merge_dicts(
+            {"io_manager": default_job_io_manager}, resource_defs, self.resource_defs
+        )
+
+        io_manager_def = merged_resource_defs.get(self.get_io_manager_key())
         if not io_manager_def and self.get_io_manager_key() != "io_manager":
             raise DagsterInvalidDefinitionError(
                 f"SourceAsset with asset key {self.key} requires IO manager with key '{self.get_io_manager_key()}', but none was provided."
             )
+        relevant_keys = get_transitive_required_resource_keys(
+            {self.get_io_manager_key()}, merged_resource_defs
+        )
 
+        relevant_resource_defs = {
+            key: resource_def
+            for key, resource_def in merged_resource_defs.items()
+            if key in relevant_keys
+        }
+
+        io_manager_key = (
+            self.get_io_manager_key() if self.get_io_manager_key != "io_manager" else None
+        )
         return SourceAsset(
             key=self.key,
-            io_manager_def=io_manager_def,
-            io_manager_key=self.get_io_manager_key(),
+            io_manager_key=io_manager_key,
             description=self.description,
             partitions_def=self.partitions_def,
             _metadata_entries=self.metadata_entries,
+            resource_defs=relevant_resource_defs,
         )

--- a/python_modules/dagster/dagster/core/asset_defs/source_asset.py
+++ b/python_modules/dagster/dagster/core/asset_defs/source_asset.py
@@ -105,12 +105,9 @@ class SourceAsset(
         return self.resource_defs.get(io_manager_key) if io_manager_key else None
 
     def with_resources(self, resource_defs) -> "SourceAsset":
-        from dagster.core.definitions.graph_definition import default_job_io_manager
         from dagster.core.execution.resources_init import get_transitive_required_resource_keys
 
-        merged_resource_defs = merge_dicts(
-            {"io_manager": default_job_io_manager}, resource_defs, self.resource_defs
-        )
+        merged_resource_defs = merge_dicts(resource_defs, self.resource_defs)
 
         io_manager_def = merged_resource_defs.get(self.get_io_manager_key())
         if not io_manager_def and self.get_io_manager_key() != "io_manager":

--- a/python_modules/dagster/dagster/core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/core/definitions/dependency.py
@@ -246,9 +246,9 @@ class Node:
 
     def get_resource_requirements(
         self,
-        asset_layer: "AssetLayer",
         outer_container: "GraphDefinition",
         parent_handle: Optional["NodeHandle"] = None,
+        asset_layer: Optional["AssetLayer"] = None,
     ) -> Iterator["ResourceRequirement"]:
         from .resource_requirement import InputManagerRequirement
 

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -747,7 +747,9 @@ class GraphDefinition(NodeDefinition):
     def is_subselected(self) -> bool:
         return False
 
-    def get_resource_requirements(self, asset_layer: "AssetLayer") -> Iterator[ResourceRequirement]:
+    def get_resource_requirements(
+        self, asset_layer: Optional["AssetLayer"] = None
+    ) -> Iterator[ResourceRequirement]:
         for node in self.node_dict.values():
             yield from node.get_resource_requirements(outer_container=self, asset_layer=asset_layer)
 

--- a/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
@@ -42,10 +42,7 @@ from .metadata import MetadataEntry, PartitionMetadataEntry, RawMetadataValue, n
 from .mode import ModeDefinition
 from .node_definition import NodeDefinition
 from .preset import PresetDefinition
-from .resource_requirement import (
-    ensure_requirements_satisfied,
-    get_and_validate_transitive_resource_dependencies,
-)
+from .resource_requirement import ensure_requirements_satisfied
 from .utils import validate_tags
 from .version_strategy import VersionStrategy
 
@@ -276,7 +273,7 @@ class PipelineDefinition:
         self._graph_def.get_inputs_must_be_resolved_top_level(self._asset_layer)
 
     def _get_resource_requirements_for_mode(self, mode_def: ModeDefinition) -> Set[str]:
-        from ..execution.resources_init import get_dependencies, resolve_resource_dependencies
+        from ..execution.resources_init import get_transitive_required_resource_keys
 
         requirements = list(self._graph_def.get_resource_requirements(self.asset_layer))
         for hook_def in self._hook_defs:
@@ -288,11 +285,7 @@ class PipelineDefinition:
         ensure_requirements_satisfied(mode_def.resource_defs, requirements, mode_def.name)
         required_keys = {requirement.key for requirement in requirements}
         return required_keys.union(
-            get_and_validate_transitive_resource_dependencies(
-                mode_def.resource_defs,
-                required_resource_keys=required_keys,
-                mode_name=mode_def.name,
-            )
+            get_transitive_required_resource_keys(required_keys, mode_def.resource_defs)
         )
 
     @property

--- a/python_modules/dagster/dagster/core/definitions/resource_requirement.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_requirement.py
@@ -2,14 +2,12 @@ from abc import ABC, abstractmethod
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
-    Dict,
     Iterator,
     List,
     Mapping,
     NamedTuple,
     Optional,
     Sequence,
-    Set,
     Type,
 )
 

--- a/python_modules/dagster/dagster/core/definitions/resource_requirement.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_requirement.py
@@ -207,30 +207,3 @@ def ensure_requirements_satisfied(
             raise DagsterInvalidDefinitionError(
                 f"{requirement.describe_requirement()} was not provided{mode_descriptor}. Please provide a {str(requirement.expected_type)} to key '{requirement.key}', or change the required key to one of the following keys which points to an {str(requirement.expected_type)}: {requirement.keys_of_expected_type(resource_defs)}"
             )
-
-
-def get_and_validate_transitive_resource_dependencies(
-    resource_defs: Dict[str, "ResourceDefinition"],
-    required_resource_keys=Set[str],
-    mode_name: Optional[str] = None,
-) -> Set[str]:
-    from ..execution.resources_init import get_dependencies, resolve_resource_dependencies
-
-    requirements = []
-    resource_dependencies = resolve_resource_dependencies(resource_defs)
-    required_keys = sorted(list(required_resource_keys))
-    seen = set()
-    while required_keys:
-        required_key = required_keys.pop()
-        if required_key in seen:
-            continue
-        seen.add(required_key)
-        for requirement in resource_defs[required_key].get_resource_requirements(
-            outer_context=required_key
-        ):
-            ensure_requirements_satisfied(resource_defs, [requirement], mode_name)
-            requirements.append(requirement)
-
-        required_keys += get_dependencies(required_key, resource_dependencies)
-
-    return seen

--- a/python_modules/dagster/dagster/core/definitions/solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_definition.py
@@ -297,7 +297,7 @@ class SolidDefinition(NodeDefinition):
         outer_context: Optional[object] = None,
     ) -> Iterator[ResourceRequirement]:
         # Outer requiree in this context is the outer-calling node handle. If not provided, then just use the solid name.
-        outer_context = cast(Optional[Tuple[NodeHandle, "AssetLayer"]], outer_context)
+        outer_context = cast(Optional[Tuple[NodeHandle, Optional["AssetLayer"]]], outer_context)
         if not outer_context:
             handle = None
             asset_layer = None

--- a/python_modules/dagster/dagster/core/execution/with_resources.py
+++ b/python_modules/dagster/dagster/core/execution/with_resources.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Mapping, Optional, Sequence
 
 from dagster import _check as check
+from dagster.utils import merge_dicts
 
 from ..definitions import ResourceDefinition
 from ..definitions.resource_requirement import ResourceAddable
@@ -11,10 +12,12 @@ def with_resources(
     resource_defs: Mapping[str, ResourceDefinition],
     config: Optional[Dict[str, Any]] = None,
 ) -> Sequence[ResourceAddable]:
+    from dagster.core.storage.fs_io_manager import fs_io_manager
+
     check.mapping_param(resource_defs, "resource_defs")
     config = check.opt_dict_param(config, "config")
 
-    resource_defs = dict(resource_defs)
+    resource_defs = merge_dicts({"io_manager": fs_io_manager}, resource_defs)
     for key in resource_defs.keys():
         if key in config:
             resource_defs[key] = resource_defs[key].configured(config[key])

--- a/python_modules/dagster/dagster/core/execution/with_resources.py
+++ b/python_modules/dagster/dagster/core/execution/with_resources.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Mapping, Optional, Sequence
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, TypeVar, cast
 
 from dagster import _check as check
 from dagster.utils import merge_dicts
@@ -6,12 +6,14 @@ from dagster.utils import merge_dicts
 from ..definitions import ResourceDefinition
 from ..definitions.resource_requirement import ResourceAddable
 
+T = TypeVar("T", bound=ResourceAddable)
+
 
 def with_resources(
-    definitions: Sequence[ResourceAddable],
+    definitions: Iterable[T],
     resource_defs: Mapping[str, ResourceDefinition],
     config: Optional[Dict[str, Any]] = None,
-) -> Sequence[ResourceAddable]:
+) -> Sequence[T]:
     from dagster.core.storage.fs_io_manager import fs_io_manager
 
     check.mapping_param(resource_defs, "resource_defs")
@@ -22,8 +24,8 @@ def with_resources(
         if key in config:
             resource_defs[key] = resource_defs[key].configured(config[key])
 
-    transformed_defs = []
+    transformed_defs: List[T] = []
     for definition in definitions:
-        transformed_defs.append(definition.with_resources(resource_defs))
+        transformed_defs.append(cast(T, definition.with_resources(resource_defs)))
 
     return transformed_defs

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
@@ -155,7 +155,7 @@ def test_asset_group_missing_resources():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="SourceAsset with asset key AssetKey\(\['foo'\]\) requires IO manager with key 'foo', but none was provided.",
+        match=r"SourceAsset with asset key AssetKey\(\['foo'\]\) requires IO manager with key 'foo', but none was provided.",
     ):
         AssetGroup([], source_assets=[source_asset_io_req])
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -1455,15 +1455,18 @@ def test_source_asset_requires_resource_defs():
         def load_input(self, context):
             return 5
 
+    @resource(required_resource_keys={"bar"})
+    def foo_resource(context):
+        assert context.resources.bar == "blah"
+
     @io_manager(required_resource_keys={"foo"})
     def the_manager(context):
-        context.resources.foo == "blah"
         return MyIOManager()
 
     my_source_asset = SourceAsset(
         key=AssetKey("my_source_asset"),
         io_manager_def=the_manager,
-        resource_defs={"foo": ResourceDefinition.hardcoded_resource("blah")},
+        resource_defs={"foo": foo_resource, "bar": ResourceDefinition.hardcoded_resource("blah")},
     )
 
     @asset

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -292,7 +292,7 @@ def test_missing_io_manager():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="SourceAsset with asset key AssetKey\(\['source1'\]\) requires IO manager with key 'special_io_manager', but none was provided.",
+        match=r"SourceAsset with asset key AssetKey\(\['source1'\]\) requires IO manager with key 'special_io_manager', but none was provided.",
     ):
         build_assets_job(
             "a",
@@ -1461,7 +1461,7 @@ def test_source_asset_requires_resource_defs():
         assert context.resources.bar == "blah"
 
     @io_manager(required_resource_keys={"foo"})
-    def the_manager(context):
+    def the_manager():
         return MyIOManager()
 
     my_source_asset = SourceAsset(
@@ -1527,7 +1527,7 @@ def test_transitive_resource_deps_provided():
     @asset(
         resource_defs={"used": used_resource, "foo": ResourceDefinition.hardcoded_resource("blah")}
     )
-    def the_asset(context):
+    def the_asset():
         pass
 
     the_job = build_assets_job(name="test", assets=[the_asset])
@@ -1536,7 +1536,7 @@ def test_transitive_resource_deps_provided():
 
 def test_transitive_io_manager_dep_not_provided():
     @io_manager(required_resource_keys={"foo"})
-    def the_manager(context):
+    def the_manager():
         pass
 
     my_source_asset = SourceAsset(
@@ -1545,7 +1545,7 @@ def test_transitive_io_manager_dep_not_provided():
     )
 
     @asset
-    def my_derived_asset(my_source_asset):
+    def my_derived_asset(my_source_asset):  # pylint: disable=unused-argument
         pass
 
     with pytest.raises(

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -16,6 +16,7 @@ from dagster import (
     build_schedule_from_partitioned_job,
     daily_partitioned_config,
     daily_schedule,
+    fs_io_manager,
     graph,
     job,
     lambda_solid,
@@ -619,7 +620,14 @@ def test_source_assets():
     def my_repo():
         return [AssetGroup(assets=[], source_assets=[foo, bar])]
 
-    assert my_repo.source_assets_by_key == {AssetKey("foo"): foo, AssetKey("bar"): bar}
+    assert my_repo.source_assets_by_key == {
+        AssetKey("foo"): SourceAsset(
+            key=AssetKey("foo"), resource_defs={"io_manager": fs_io_manager}
+        ),
+        AssetKey("bar"): SourceAsset(
+            key=AssetKey("bar"), resource_defs={"io_manager": fs_io_manager}
+        ),
+    }
 
 
 def test_multiple_asset_groups_one_repo():

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
@@ -1145,8 +1145,8 @@ def test_resource_needs_resource():
         pass
 
     with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match="resource with key 'bar_resource' required by resource with key 'foo_resource' was not provided",
+        DagsterInvariantViolationError,
+        match="Resource with key 'bar_resource' required by resource with key 'foo_resource', but not provided.",
     ):
 
         @pipeline(


### PR DESCRIPTION
This adds resource_defs to source assets, which allows for transitive resource dependencies to be satisfied. Also added general checking of transitive resource deps for asset jobs.

We'd like to error out when users don't satisfy resource dependencies on the asset itself at job construction time, but we can't do that until we remove the ability to specify resources externally from the asset (outside of with_resources, which actually constructs a new asset).