### PR TITLE
docs: improve search 1/

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -11,7 +11,9 @@
   "stop_urls": [
     "https://docs.dagster.io/_modules/",
     "https://docs.dagster.io/master/",
-    "https://docs.dagster.io/\\d+\\.\\d+.\\d+/"
+    "https://docs.dagster.io/\\d+\\.\\d+.\\d+/",
+    "https://docs.dagster.io/changelog",
+    "https://docs.dagster.io/migration"
   ],
   "strip_chars": " .,;:#¶",
   "selectors": {
@@ -41,12 +43,12 @@
         "selector": "",
         "default_value": "API"
       },
-      "lvl1": ".section h1",
-      "lvl2": ".section h2",
-      "lvl3": ".section h3",
-      "lvl4": ".section h4",
-      "lvl5": ".section h5, .section .rubric, .section dt",
-      "text": ".section p, .section li"
+      "lvl1": "section h1",
+      "lvl2": "section h2",
+      "lvl3": "section h3",
+      "lvl4": "section h4",
+      "lvl5": "section h5, section .rubric, section dt",
+      "text": "section p, section li"
     }
   },
   "nb_hits": 9458

--- a/docs/next/components/Sidebar.tsx
+++ b/docs/next/components/Sidebar.tsx
@@ -38,9 +38,9 @@ const MenuItem = React.forwardRef<
         {
           "hover:bg-lavender hover:bg-opacity-50 text-blurple": match,
           "hover:text-gray-900 hover:bg-lavender hover:bg-opacity-50": !match,
-          "py-2": lvl <= 2,
           "px-2": lvl === 0,
-          "pl-3 pr-2": lvl === 2,
+          "pl-3 pr-2": lvl <= 1,
+          "py-2": lvl <= 2,
         }
       )}
       href={href}

--- a/docs/next/components/Sidebar.tsx
+++ b/docs/next/components/Sidebar.tsx
@@ -66,7 +66,9 @@ const MenuItem = React.forwardRef<
         )}
         <span
           className={cx({
+            // Map content hierarchy to levels for docs search
             "DocSearch-lvl0": lvl === 0 && match,
+            "DocSearch-lvl1": lvl === 1 && match,
             "DocSearch-lvl2": lvl === 2 && match,
           })}
         >
@@ -161,11 +163,11 @@ const SecondaryNavigation = () => {
                 href={itemWithPath.path}
                 item={sectionOrItem}
                 match={match}
-                lvl={2}
+                lvl={1}
               />
             ) : (
               <Link href={itemWithPath.path} passHref>
-                <MenuItem item={sectionOrItem} match={match} lvl={2} />
+                <MenuItem item={sectionOrItem} match={match} lvl={1} />
               </Link>
             )}
             {match && sectionOrItem.children && (

--- a/docs/next/pages/sitemap.xml.tsx
+++ b/docs/next/pages/sitemap.xml.tsx
@@ -1,4 +1,4 @@
-import { latestAllPaths } from "util/useNavigation";
+import { latestAllVersionedPaths } from "util/useNavigation";
 
 const toUrl = (host, route) => `<url><loc>http://${host}${route}</loc></url>`;
 
@@ -11,10 +11,9 @@ const createSitemap = (host, routes) =>
 const Sitemap = () => {};
 
 Sitemap.getInitialProps = ({ res, req }) => {
-  const routes = latestAllPaths().map(
+  const routes = latestAllVersionedPaths().map(
     ({ params }) => "/" + params.page.join("/")
   );
-  console.log(routes);
   const sitemap = createSitemap(req.headers.host, routes);
 
   res.setHeader("Content-Type", "text/xml");


### PR DESCRIPTION
### Summary & Motivation
What went wrong
- Changelog and migration shouldn't be included when indexing - this PR explicitly stops indexing these in [1].
- Changelog and migration and cloud site shouldn't be included in sitemap (docs.dagster.io/sitemap.xml) which is the starting point of the indexing script too - this PR removes these entries from the xml generation script in [2].
- Apidocs weren't indexed recently because the html is now using "section" id instead of "section" class - this PR changes how the search indexing script finds api docs in [3].
- Section title wasn't properly marked as class "DocSearch-lvl1" (which is what the search indexing script identifies as the section name to fill) so missing that class resulted in search results falling back to the default value "section" (see second bullet on issue DREL-296 and screenshot below) - this PR adds that class back in [4]
  <img width="200" alt="image" src="https://user-images.githubusercontent.com/4531914/172273215-59647849-638d-4091-a9e4-32d70f0c83e7.png">
  * **once we land this, reindexing should fill out all the "section" in the screenshot with correct title names**

### How I Tested These Changes
- Reran the search indexing script locally which 1) stopped crawling changelog and migration (changelog and migration entries no longer show up in the docs search) and 2) started to crawl api docs (apidocs show up in the search).
- Wait to land this to prod so we can rerun the script again to pick up the section title fix.