### PR TITLE
Move config editor to core so we can reuse in admin portal

### DIFF
--- a/js_modules/dagit/packages/core/src/configeditor/ConfigEditorDialog.tsx
+++ b/js_modules/dagit/packages/core/src/configeditor/ConfigEditorDialog.tsx
@@ -39,7 +39,7 @@ const CodeMirrorShimStyle = createGlobalStyle`
   }
 `;
 
-export const YAMLEditorDialog: React.FC<Props> = ({
+export const ConfigEditorDialog: React.FC<Props> = ({
   config,
   configSchema,
   isLoading,

--- a/js_modules/dagit/packages/core/src/configeditor/ConfigEditorDialog.tsx
+++ b/js_modules/dagit/packages/core/src/configeditor/ConfigEditorDialog.tsx
@@ -1,0 +1,125 @@
+import {
+  Box,
+  Button,
+  DialogFooter,
+  Dialog,
+  SplitPanelContainer,
+  Spinner,
+  Tooltip,
+  Icon,
+} from '@dagster-io/ui';
+import * as React from 'react';
+import {createGlobalStyle} from 'styled-components/macro';
+
+import {ConfigEditorHelp} from '../launchpad/ConfigEditorHelp';
+
+import {ConfigEditor} from './ConfigEditor';
+import {ConfigEditorHelpContext} from './ConfigEditorHelpContext';
+import {isHelpContextEqual} from './isHelpContextEqual';
+
+interface Props {
+  onConfigChange: (config: string) => void;
+  onSave: () => void;
+  onClose: () => void;
+  config: string | undefined;
+  configSchema: any | undefined;
+  isLoading: boolean;
+  saveText: string;
+  identifier: string;
+  title: string;
+  isSubmitting: boolean;
+  error?: string | null;
+  isOpen: boolean;
+}
+
+// Force code editor hints to appear above the dialog modal
+const CodeMirrorShimStyle = createGlobalStyle`
+  .CodeMirror-hints {
+    z-index: 100;
+  }
+`;
+
+export const YAMLEditorDialog: React.FC<Props> = ({
+  config,
+  configSchema,
+  isLoading,
+  isSubmitting,
+  error,
+  onSave,
+  onClose,
+  onConfigChange,
+  identifier,
+  title,
+  saveText,
+  isOpen,
+}) => {
+  const editorSplitPanelContainer = React.useRef<SplitPanelContainer | null>(null);
+  const [editorHelpContext, setEditorHelpContext] = React.useState<ConfigEditorHelpContext | null>(
+    null,
+  );
+  const editor = React.useRef<ConfigEditor | null>(null);
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      title={title}
+      onClose={onClose}
+      style={{maxWidth: '90%', minWidth: '70%', width: 1000}}
+    >
+      <CodeMirrorShimStyle />
+      <SplitPanelContainer
+        ref={editorSplitPanelContainer}
+        axis="horizontal"
+        identifier={identifier}
+        firstMinSize={100}
+        firstInitialPercent={70}
+        first={
+          !isLoading ? (
+            <ConfigEditor
+              ref={editor}
+              configCode={config!}
+              onConfigChange={onConfigChange}
+              onHelpContextChange={(next) => {
+                if (next && !isHelpContextEqual(editorHelpContext, next)) {
+                  setEditorHelpContext(next);
+                }
+              }}
+              readOnly={false}
+              checkConfig={async (_j) => {
+                return {isValid: true};
+              }}
+              runConfigSchema={configSchema}
+            />
+          ) : (
+            <Box style={{height: '100%'}} flex={{alignItems: 'center', justifyContent: 'center'}}>
+              <Spinner purpose="section" />
+            </Box>
+          )
+        }
+        second={
+          <Box style={{height: 500}}>
+            <ConfigEditorHelp
+              context={editorHelpContext}
+              allInnerTypes={configSchema?.allConfigTypes || []}
+            />
+          </Box>
+        }
+      />
+      <DialogFooter topBorder>
+        {error ? (
+          <Tooltip
+            isOpen={true}
+            content={error}
+            placement="bottom-start"
+            modifiers={{offset: {enabled: true, options: {offset: [0, 16]}}}}
+          >
+            <Icon name="warning" />
+          </Tooltip>
+        ) : null}
+        <Button intent="primary" onClick={onSave} disabled={isLoading || !!error || isSubmitting}>
+          {saveText}
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  );
+};

--- a/js_modules/dagit/packages/core/src/configeditor/ConfigEditorDialog.tsx
+++ b/js_modules/dagit/packages/core/src/configeditor/ConfigEditorDialog.tsx
@@ -1,21 +1,7 @@
-import {
-  Box,
-  Button,
-  DialogFooter,
-  Dialog,
-  SplitPanelContainer,
-  Spinner,
-  Tooltip,
-  Icon,
-} from '@dagster-io/ui';
+import {Button, DialogFooter, Dialog, Tooltip, Icon} from '@dagster-io/ui';
 import * as React from 'react';
-import {createGlobalStyle} from 'styled-components/macro';
 
-import {ConfigEditorHelp} from '../launchpad/ConfigEditorHelp';
-
-import {ConfigEditor} from './ConfigEditor';
-import {ConfigEditorHelpContext} from './ConfigEditorHelpContext';
-import {isHelpContextEqual} from './isHelpContextEqual';
+import {ConfigEditorWithSchema} from './ConfigEditorWithSchema';
 
 interface Props {
   onConfigChange: (config: string) => void;
@@ -32,13 +18,6 @@ interface Props {
   isOpen: boolean;
 }
 
-// Force code editor hints to appear above the dialog modal
-const CodeMirrorShimStyle = createGlobalStyle`
-  .CodeMirror-hints {
-    z-index: 100;
-  }
-`;
-
 export const ConfigEditorDialog: React.FC<Props> = ({
   config,
   configSchema,
@@ -53,12 +32,6 @@ export const ConfigEditorDialog: React.FC<Props> = ({
   saveText,
   isOpen,
 }) => {
-  const editorSplitPanelContainer = React.useRef<SplitPanelContainer | null>(null);
-  const [editorHelpContext, setEditorHelpContext] = React.useState<ConfigEditorHelpContext | null>(
-    null,
-  );
-  const editor = React.useRef<ConfigEditor | null>(null);
-
   return (
     <Dialog
       isOpen={isOpen}
@@ -66,44 +39,12 @@ export const ConfigEditorDialog: React.FC<Props> = ({
       onClose={onClose}
       style={{maxWidth: '90%', minWidth: '70%', width: 1000}}
     >
-      <CodeMirrorShimStyle />
-      <SplitPanelContainer
-        ref={editorSplitPanelContainer}
-        axis="horizontal"
+      <ConfigEditorWithSchema
+        onConfigChange={onConfigChange}
+        config={config}
+        configSchema={configSchema}
+        isLoading={isLoading}
         identifier={identifier}
-        firstMinSize={100}
-        firstInitialPercent={70}
-        first={
-          !isLoading ? (
-            <ConfigEditor
-              ref={editor}
-              configCode={config!}
-              onConfigChange={onConfigChange}
-              onHelpContextChange={(next) => {
-                if (next && !isHelpContextEqual(editorHelpContext, next)) {
-                  setEditorHelpContext(next);
-                }
-              }}
-              readOnly={false}
-              checkConfig={async (_j) => {
-                return {isValid: true};
-              }}
-              runConfigSchema={configSchema}
-            />
-          ) : (
-            <Box style={{height: '100%'}} flex={{alignItems: 'center', justifyContent: 'center'}}>
-              <Spinner purpose="section" />
-            </Box>
-          )
-        }
-        second={
-          <Box style={{height: 500}}>
-            <ConfigEditorHelp
-              context={editorHelpContext}
-              allInnerTypes={configSchema?.allConfigTypes || []}
-            />
-          </Box>
-        }
       />
       <DialogFooter topBorder>
         {error ? (

--- a/js_modules/dagit/packages/core/src/configeditor/ConfigEditorWithSchema.tsx
+++ b/js_modules/dagit/packages/core/src/configeditor/ConfigEditorWithSchema.tsx
@@ -1,0 +1,82 @@
+import {Box, SplitPanelContainer, Spinner} from '@dagster-io/ui';
+import * as React from 'react';
+import {createGlobalStyle} from 'styled-components/macro';
+
+import {ConfigEditorHelp} from '../launchpad/ConfigEditorHelp';
+
+import {ConfigEditor} from './ConfigEditor';
+import {ConfigEditorHelpContext} from './ConfigEditorHelpContext';
+import {isHelpContextEqual} from './isHelpContextEqual';
+
+interface Props {
+  onConfigChange: (config: string) => void;
+  config: string | undefined;
+  configSchema: any | undefined;
+  isLoading: boolean;
+  identifier: string;
+}
+
+// Force code editor hints to appear above the dialog modal
+const CodeMirrorShimStyle = createGlobalStyle`
+  .CodeMirror-hints {
+    z-index: 100;
+  }
+`;
+
+export const ConfigEditorWithSchema: React.FC<Props> = ({
+  isLoading,
+  identifier,
+  config,
+  onConfigChange,
+  configSchema,
+}) => {
+  const editorSplitPanelContainer = React.useRef<SplitPanelContainer | null>(null);
+  const [editorHelpContext, setEditorHelpContext] = React.useState<ConfigEditorHelpContext | null>(
+    null,
+  );
+  const editor = React.useRef<ConfigEditor | null>(null);
+
+  return (
+    <>
+      <CodeMirrorShimStyle />
+      <SplitPanelContainer
+        ref={editorSplitPanelContainer}
+        axis="horizontal"
+        identifier={identifier}
+        firstMinSize={100}
+        firstInitialPercent={70}
+        first={
+          !isLoading ? (
+            <ConfigEditor
+              ref={editor}
+              configCode={config!}
+              onConfigChange={onConfigChange}
+              onHelpContextChange={(next) => {
+                if (next && !isHelpContextEqual(editorHelpContext, next)) {
+                  setEditorHelpContext(next);
+                }
+              }}
+              readOnly={false}
+              checkConfig={async (_j) => {
+                return {isValid: true};
+              }}
+              runConfigSchema={configSchema}
+            />
+          ) : (
+            <Box style={{height: '100%'}} flex={{alignItems: 'center', justifyContent: 'center'}}>
+              <Spinner purpose="section" />
+            </Box>
+          )
+        }
+        second={
+          <Box style={{height: 500}}>
+            <ConfigEditorHelp
+              context={editorHelpContext}
+              allInnerTypes={configSchema?.allConfigTypes || []}
+            />
+          </Box>
+        }
+      />
+    </>
+  );
+};


### PR DESCRIPTION
### Summary & Motivation

This PR moves the config editor dialog into the dagit core library so that other packages depending on it can reuse this dialog

### How I Tested These Changes

Replaced the cloud version with this version and everything still worked