### PR TITLE
[dagit] Don't block scroll when mouse hits custom tooltip

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/BaseTag.tsx
+++ b/js_modules/dagit/packages/ui/src/components/BaseTag.tsx
@@ -19,7 +19,7 @@ const BaseTagTooltipStyle: React.CSSProperties = {
   alignItems: 'center',
   padding: '4px 8px',
   userSelect: 'text',
-  pointerEvents: 'all',
+  pointerEvents: 'none',
   borderRadius: 8,
   border: 'none',
   top: -10,


### PR DESCRIPTION
### Summary & Motivation

Because the BaseTag uses `pointer-events: none` for the custom tooltip overlay, scrolling is blocked when the mouseover happens to be on an overflowing `BaseTag`, e.g. on the Runs page.

I'm not sure we actually need this rule. Removing it resolves the issue.

### How I Tested These Changes

View Runs page with a long tag. Verify that I can scroll past it, and that interaction with the tag behaves normally.
