### PR TITLE
fix partitions when using AssetsDefinition.from_graph

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -327,6 +327,7 @@ class AssetsDefinition(ResourceAddable):
                     metadata=output_def.metadata,
                     io_manager_key=output_def.io_manager_key,
                     description=output_def.description,
+                    partitions_def=self.partitions_def,
                 )
             )
 

--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -575,6 +575,9 @@ class AssetLayer:
     def assets_defs_by_key(self) -> Mapping[AssetKey, "AssetsDefinition"]:
         return self._assets_defs_by_key
 
+    def assets_def_for_asset(self, asset_key: AssetKey) -> "AssetsDefinition":
+        return self._assets_defs_by_key[asset_key]
+
     def asset_keys_for_node(self, node_handle: NodeHandle) -> AbstractSet[AssetKey]:
         return self._asset_keys_by_node_handle[node_handle]
 
@@ -615,6 +618,18 @@ class AssetLayer:
         )
 
         return group_names
+
+    def partitions_def_for_asset(self, asset_key: AssetKey) -> Optional["PartitionsDefinition"]:
+        assets_def = self._assets_defs_by_key.get(asset_key)
+
+        if assets_def is not None:
+            return assets_def.partitions_def
+        else:
+            source_asset = self._source_assets_by_key.get(asset_key)
+            if source_asset is not None:
+                return source_asset.partitions_def
+
+        return None
 
 
 def build_asset_selection_job(

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
@@ -3,6 +3,7 @@ import pytest
 
 from dagster import (
     AssetMaterialization,
+    AssetsDefinition,
     DagsterInvalidDefinitionError,
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
@@ -13,6 +14,8 @@ from dagster import (
     PartitionsDefinition,
     SourceAsset,
     StaticPartitionsDefinition,
+    graph,
+    op,
 )
 from dagster.core.asset_defs import asset, build_assets_job, multi_asset
 from dagster.core.asset_defs.asset_partitions import (
@@ -647,3 +650,42 @@ def test_multi_asset_non_identity_partition_mapping():
     assert result.asset_materializations_for_node("downstream_asset_2") == [
         AssetMaterialization(AssetKey(["downstream_asset_2"]), partition="2")
     ]
+
+
+def test_from_graph():
+    partitions_def = StaticPartitionsDefinition(["a", "b", "c", "d"])
+
+    @op
+    def my_op(context):
+        assert context.output_asset_partition_key() == "a"
+
+    @graph
+    def upstream_asset():
+        return my_op()
+
+    @op
+    def my_op2(context, upstream_asset):
+        assert context.output_asset_partition_key() == "a"
+
+    @graph
+    def downstream_asset(upstream_asset):
+        return my_op2(upstream_asset)
+
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            assert context.asset_partition_key == "a"
+            assert context.has_asset_partitions
+
+        def load_input(self, context):
+            assert context.asset_partition_key == "a"
+            assert context.has_asset_partitions
+
+    my_job = build_assets_job(
+        "my_job",
+        assets=[
+            AssetsDefinition.from_graph(upstream_asset, partitions_def=partitions_def),
+            AssetsDefinition.from_graph(downstream_asset, partitions_def=partitions_def),
+        ],
+        resource_defs={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
+    )
+    assert my_job.execute_in_process(partition_key="a").success


### PR DESCRIPTION
### Summary & Motivation

With JobsDefinitions now containing SourceAssets (via AssetLayer), we no longer need to use config to pass down partition information.
