### PR TITLE
[assets] Allow graph_name to be None when not specified

### DIFF
--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -725,8 +725,6 @@ class ExternalAssetNode(
         # backcompat logic to handle ExternalAssetNodes serialized without op_names/graph_name
         if not op_names:
             op_names = list(filter(None, [op_name]))
-        if not graph_name:
-            graph_name = op_name
         return super(ExternalAssetNode, cls).__new__(
             cls,
             asset_key=check.inst_param(asset_key, "asset_key", AssetKey),


### PR DESCRIPTION
### Summary & Motivation

The Dagit UI shows links to a graph-backed asset's graph on the definition tab when graphName is specified, so it's important that a default is not applied and the value is null for non-graph assets. I talked with Owen about this offline and verified it doesn't break anything!

### How I Tested These Changes
