### PR TITLE
[dagit] Add a Materialize All button to Asset Details > Lineage

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -155,9 +155,6 @@ export const AssetGraphExplorerWithData: React.FC<
     selectedAssetValues.includes(tokenForAssetKey(node.definition.assetKey)),
   );
   const lastSelectedNode = selectedGraphNodes[selectedGraphNodes.length - 1];
-  const launchGraphNodes = selectedGraphNodes.length
-    ? selectedGraphNodes
-    : Object.values(assetGraphData.nodes).filter((a) => !isSourceAsset(a.definition));
 
   const {layout, loading, async} = useAssetLayout(assetGraphData);
 
@@ -404,7 +401,11 @@ export const AssetGraphExplorerWithData: React.FC<
               />
 
               <LaunchAssetExecutionButton
-                assetKeys={launchGraphNodes.map((n) => n.assetKey)}
+                context={selectedGraphNodes.length ? 'selected' : 'all'}
+                assetKeys={(selectedGraphNodes.length
+                  ? selectedGraphNodes
+                  : Object.values(assetGraphData.nodes).filter((a) => !isSourceAsset(a.definition))
+                ).map((n) => n.assetKey)}
                 liveDataByNode={liveDataByNode}
                 preferredJobName={explorerPath.pipelineName}
               />

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
@@ -1,0 +1,66 @@
+import {Box, Button, ButtonGroup, Checkbox, Colors, Icon} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {GraphData, LiveData} from '../asset-graph/Utils';
+
+import {AssetLineageScope, AssetNodeLineageGraph} from './AssetNodeLineageGraph';
+import {AssetViewParams} from './AssetView';
+import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
+import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinitionFragment';
+
+export const AssetNodeLineage: React.FC<{
+  params: AssetViewParams;
+  setParams: (params: AssetViewParams) => void;
+  assetNode: AssetNodeDefinitionFragment;
+  assetGraphData: GraphData;
+  liveDataByNode: LiveData;
+}> = ({params, setParams, assetNode, liveDataByNode, assetGraphData}) => {
+  return (
+    <>
+      <Box
+        flex={{justifyContent: 'space-between', alignItems: 'center', gap: 12}}
+        padding={{left: 24, right: 12, vertical: 12}}
+        border={{side: 'bottom', color: Colors.KeylineGray, width: 1}}
+      >
+        <ButtonGroup<AssetLineageScope>
+          activeItems={new Set([params.lineageScope || 'neighbors'])}
+          buttons={[
+            {id: 'neighbors', label: 'Nearest Neighbors', icon: 'graph_neighbors'},
+            {id: 'upstream', label: 'Upstream', icon: 'graph_upstream'},
+            {id: 'downstream', label: 'Downstream', icon: 'graph_downstream'},
+          ]}
+          onClick={(lineageScope) => setParams({...params, lineageScope})}
+        />
+        <Checkbox
+          format="switch"
+          label="Show secondary edges"
+          checked={!!params.lineageShowSecondaryEdges}
+          onChange={() =>
+            setParams({
+              ...params,
+              lineageShowSecondaryEdges: params.lineageShowSecondaryEdges ? undefined : true,
+            })
+          }
+        />
+        <div style={{flex: 1}} />
+        {Object.values(assetGraphData.nodes).length > 1 ? (
+          <LaunchAssetExecutionButton
+            assetKeys={Object.values(assetGraphData.nodes).map((n) => n.assetKey)}
+            liveDataByNode={liveDataByNode}
+            intent="none"
+            context="all"
+          />
+        ) : (
+          <Button icon={<Icon name="materialization" />} disabled>
+            Materialize all
+          </Button>
+        )}
+      </Box>
+      <AssetNodeLineageGraph
+        assetNode={assetNode}
+        liveDataByNode={liveDataByNode}
+        assetGraphData={assetGraphData}
+      />
+    </>
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -277,7 +277,7 @@ const AssetEntryRow: React.FC<{
         <td>
           {asset ? (
             <Box flex={{gap: 8, alignItems: 'center'}}>
-              <AnchorButton to={`/instance/assets/${path.join('/')}`}>View Details</AnchorButton>
+              <AnchorButton to={`/instance/assets/${path.join('/')}`}>View details</AnchorButton>
               <Popover
                 position="bottom-right"
                 content={
@@ -288,7 +288,7 @@ const AssetEntryRow: React.FC<{
                         repoAddress && asset.definition?.groupName
                           ? workspacePathFromAddress(
                               repoAddress,
-                              `/asset_groups/${asset.definition.groupName}`,
+                              `/asset-groups/${asset.definition.groupName}`,
                             )
                           : ''
                       }

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -2,9 +2,7 @@ import {gql, useQuery} from '@apollo/client';
 import {
   Alert,
   Box,
-  ButtonGroup,
   ButtonLink,
-  Checkbox,
   Colors,
   NonIdealState,
   Spinner,
@@ -34,7 +32,8 @@ import {workspacePathFromAddress} from '../workspace/workspacePath';
 import {AssetEvents} from './AssetEvents';
 import {AssetNodeDefinition, ASSET_NODE_DEFINITION_FRAGMENT} from './AssetNodeDefinition';
 import {AssetNodeInstigatorTag, ASSET_NODE_INSTIGATORS_FRAGMENT} from './AssetNodeInstigatorTag';
-import {AssetLineageScope, AssetNodeLineageGraph} from './AssetNodeLineageGraph';
+import {AssetNodeLineage} from './AssetNodeLineage';
+import {AssetLineageScope} from './AssetNodeLineageGraph';
 import {AssetPageHeader} from './AssetPageHeader';
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
 import {AssetKey} from './types';
@@ -148,7 +147,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
           </Tabs>
         }
         right={
-          <Box style={{margin: '-4px 0'}} flex={{gap: 8, alignItems: 'baseline'}}>
+          <Box style={{margin: '-4px 0'}} flex={{gap: 12, alignItems: 'baseline'}}>
             <Box margin={{top: 4}}>
               <QueryRefreshCountdown refreshState={refreshState} />
             </Box>
@@ -198,41 +197,13 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
         ) : params.view === 'lineage' ? (
           definition ? (
             assetGraphData ? (
-              <>
-                <Box
-                  flex={{justifyContent: 'space-between', alignItems: 'center'}}
-                  padding={{horizontal: 24, vertical: 12}}
-                  border={{side: 'bottom', color: Colors.KeylineGray, width: 1}}
-                >
-                  <ButtonGroup<AssetLineageScope>
-                    activeItems={new Set([params.lineageScope || 'neighbors'])}
-                    buttons={[
-                      {id: 'neighbors', label: 'Nearest Neighbors', icon: 'graph_neighbors'},
-                      {id: 'upstream', label: 'Upstream', icon: 'graph_upstream'},
-                      {id: 'downstream', label: 'Downstream', icon: 'graph_downstream'},
-                    ]}
-                    onClick={(lineageScope) => setParams({...params, lineageScope})}
-                  />
-                  <Checkbox
-                    format="switch"
-                    label="Show secondary edges"
-                    checked={params.lineageShowSecondaryEdges === true}
-                    onChange={() =>
-                      setParams({
-                        ...params,
-                        lineageShowSecondaryEdges: params.lineageShowSecondaryEdges
-                          ? undefined
-                          : true,
-                      })
-                    }
-                  />
-                </Box>
-                <AssetNodeLineageGraph
-                  assetNode={definition}
-                  liveDataByNode={liveDataByNode}
-                  assetGraphData={assetGraphData}
-                />
-              </>
+              <AssetNodeLineage
+                params={params}
+                setParams={setParams}
+                assetNode={definition}
+                liveDataByNode={liveDataByNode}
+                assetGraphData={assetGraphData}
+              />
             ) : (
               <Box style={{flex: 1}} flex={{alignItems: 'center', justifyContent: 'center'}}>
                 <Spinner purpose="page" />


### PR DESCRIPTION
### Summary & Motivation

This PR adds a "Materialize All" button to the Lineage tab of the Asset Details page. This required a few changes to the button, because we didn't want the button to be `intent=primary`. The button was also using some kinda whacky logic to decide whether to say "Materialize All" or "Materialize Selected", and I made that more explicit via a new "context" prop. 

I also moved the lineage tab contents out into it's own component, AssetNodeLineage to match AssetNodeDefinition.

<img width="1067" alt="image" src="https://user-images.githubusercontent.com/1037212/172517031-ed53826c-bfcd-4ee9-97cf-4dd0313c385c.png">


### How I Tested These Changes
