### PR TITLE
[dagit] Hold the lineage graph zoom level constant as you navigate

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -69,7 +69,7 @@ interface Props {
   onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
 }
 
-const EXPERIMENTAL_MINI_SCALE = 0.5;
+export const EXPERIMENTAL_MINI_SCALE = 0.5;
 
 export const AssetGraphExplorer: React.FC<Props> = (props) => {
   const {

--- a/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
@@ -273,17 +273,15 @@ export class SVGViewport extends React.Component<SVGViewportProps, SVGViewportSt
     this.element.current?.focus();
   }
 
-  autocenter(animate = false) {
+  autocenter(animate = false, scale?: number) {
     const el = this.element.current!;
     const ownerRect = {width: el.clientWidth, height: el.clientHeight};
 
     const dw = ownerRect.width / this.props.graphWidth;
     const dh = ownerRect.height / this.props.graphHeight;
     const desiredScale = Math.min(dw, dh);
-    const boundedScale = Math.max(
-      Math.min(desiredScale, this.props.maxAutocenterZoom),
-      MIN_AUTOCENTER_ZOOM,
-    );
+    const boundedScale =
+      scale || Math.max(Math.min(desiredScale, this.props.maxAutocenterZoom), MIN_AUTOCENTER_ZOOM);
 
     if (
       this.state.scale < boundedScale &&


### PR DESCRIPTION
### Summary & Motivation

Linear issue: https://linear.app/elementl/issue/DAGIT-69/persist-the-zoom-level-between-asset-lineage-graphs

Quick demo: https://www.loom.com/share/59617d0609ca4ffe8a2225543a0f6c91

This PR stores the zoom level of the asset lineage graph in local storage, so that you can click through nodes, toggle from upstream / downstream, etc. without the boxes resizing. (They still recenter, just not resize).

I'd like for this to not be in local storage - if you reload the page on an asset node, it should really reset the zoom and it should only be held constant as you navigate on that single page.   This is really tricky though because navigating to another node in the graph hits a new asset page (eg: `assets/foo/bar`), and we make a GraphQL query to decide whether to show the asset list or asset detail. The loading state blows away the entire AssetView and there's not a great place to  store the zoom level temporarily... 

Definitely open to other ideas for this one. I think if we can get rid of the AssetRoot query and it's loading state, that might make cleaner solutions possible (and would get rid of that loading flicker...). We should have enough context to know that the asset is an asset and not a prefix... somehow :-/ 




### How I Tested These Changes
