### PR TITLE
Added the default group name for assets defined using Out(...)

### DIFF
--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -34,6 +34,7 @@ from dagster.core.definitions.sensor_definition import (
     SensorDefinition,
 )
 from dagster.core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
+from dagster.core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.snap import PipelineSnapshot
 from dagster.serdes import DefaultNamedTupleSerializer, whitelist_for_serdes
@@ -914,7 +915,10 @@ def external_asset_graph_from_defs(
                 output_name=output_def.name,
                 output_description=output_def.description,
                 metadata_entries=output_def.metadata_entries,
-                group_name=group_names.get(asset_key),
+                # assets defined by Out(asset_key="k") do not have any group
+                # name specified we default to DEFAULT_GROUP_NAME here to ensure
+                # such assets are part of the default group
+                group_name=group_names.get(asset_key, DEFAULT_GROUP_NAME),
             )
         )
 

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -488,7 +488,7 @@ def test_explicit_asset_keys():
             depended_by=[ExternalAssetDependedBy(AssetKey("b"))],
             job_names=["assets_job"],
             output_name="a",
-            group_name=None,
+            group_name=DEFAULT_GROUP_NAME,
         ),
         ExternalAssetNode(
             asset_key=AssetKey("b"),
@@ -500,7 +500,7 @@ def test_explicit_asset_keys():
             depended_by=[],
             job_names=["assets_job"],
             output_name="b",
-            group_name=None,
+            group_name=DEFAULT_GROUP_NAME,
         ),
     ]
 


### PR DESCRIPTION
### Summary & Motivation

This is a follow up on #8226 (Default asset group name) to set the default group name for assets defined using `Out(asset_key=..)`. Such assets did not get the default group name in the original PR.
 
### How I Tested These Changes

Updated the relevant test.