### PR TITLE
chore(buildkite): separate docs only changes

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -6,9 +6,8 @@ from ..defines import GIT_REPO_ROOT
 from ..python_version import AvailablePythonVersion
 from ..step_builder import CommandStepBuilder
 from ..utils import BuildkiteStep, CommandStep, safe_getenv
-from .docs import build_docs_steps
 from .helm import build_helm_steps
-from .packages import build_packages_steps
+from .packages import build_library_packages_steps
 from .test_images import build_test_image_steps
 
 branch_name = safe_getenv("BUILDKITE_BRANCH")
@@ -24,7 +23,7 @@ def build_dagster_steps() -> List[BuildkiteStep]:
     # "Package" used loosely here to mean roughly "a directory with some python modules". For
     # instances, a directory of unrelated scripts counts as a package. All packages must have a
     # toxfile that defines the tests for that package.
-    steps += build_packages_steps()
+    steps += build_library_packages_steps()
 
     # Other linters are run in per-package environments because they rely on the dependencies of the
     # target. `black`, `isort`, and `check-manifest` are run for the whole repo at once.
@@ -32,7 +31,6 @@ def build_dagster_steps() -> List[BuildkiteStep]:
     steps += build_repo_wide_black_steps()
     steps += build_repo_wide_check_manifest_steps()
 
-    steps += build_docs_steps()
     steps += build_helm_steps()
     steps += build_sql_schema_check_steps()
     steps += build_graphql_python_client_backcompat_steps()

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
@@ -4,12 +4,14 @@ from dagster_buildkite.steps.tox import build_tox_step
 
 from ..python_version import AvailablePythonVersion
 from ..step_builder import CommandStepBuilder
-from ..utils import BuildkiteLeafStep, GroupStep
+from ..utils import BuildkiteLeafStep, BuildkiteStep, GroupStep
+from .packages import build_example_packages_steps
 
 
-def build_docs_steps() -> List[GroupStep]:
+def build_docs_steps() -> List[BuildkiteStep]:
+    steps: List[BuildkiteStep] = []
 
-    steps: List[BuildkiteLeafStep] = [
+    docs_steps: List[BuildkiteLeafStep] = [
         # Make sure snippets in built docs match source.
         # If this test is failing, it's because you may have either:
         #   (1) Updated the code that is referenced by a literal include in the documentation
@@ -50,10 +52,14 @@ def build_docs_steps() -> List[GroupStep]:
         # pylint for build scripts
         build_tox_step("docs", "pylint", command_type="pylint"),
     ]
-    return [
+    steps += [
         GroupStep(
             group=":book: docs",
             key="docs",
-            steps=steps,
+            steps=docs_steps,
         )
     ]
+
+    steps += build_example_packages_steps()
+
+    return steps


### PR DESCRIPTION
### Summary & Motivation
Saw https://linear.app/elementl/issue/CON-27#comment-aa3ddeca. We should just skip unnecessary tests when iterating on our documentation.

A docs only change is defined as when the PR only contains changes from the `examples/` or `docs/` directories.

### How I Tested These Changes
- try dagit only change, see it still works (https://buildkite.com/dagster/dagster/builds/30741)
- try docs only change, see it works (https://buildkite.com/dagster/dagster/builds/30736)
- try a library change, see all steps run (https://buildkite.com/dagster/dagster/builds/30725)
