### PR TITLE
Fix hackernews after change to AssetGroup behavior

### DIFF
--- a/examples/hacker_news_assets/hacker_news_assets_tests/test_core.py
+++ b/examples/hacker_news_assets/hacker_news_assets_tests/test_core.py
@@ -1,17 +1,23 @@
 import tempfile
 
 from dagster_pyspark import pyspark_resource
-from hacker_news_assets.core import core_assets_prod
+from hacker_news_assets.core import assets
 from hacker_news_assets.resources.hn_resource import hn_snapshot_client
 from hacker_news_assets.resources.parquet_io_manager import local_partitioned_parquet_io_manager
 
-from dagster import AssetGroup, ResourceDefinition, fs_io_manager, mem_io_manager
+from dagster import (
+    AssetGroup,
+    ResourceDefinition,
+    assets_from_package_module,
+    fs_io_manager,
+    mem_io_manager,
+)
 
 
 def test_download():
     with tempfile.TemporaryDirectory() as temp_dir:
         test_job = AssetGroup(
-            core_assets_prod.assets,
+            assets_from_package_module(assets),
             resource_defs={
                 "io_manager": fs_io_manager,
                 "partition_start": ResourceDefinition.string_resource(),

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -14,7 +14,6 @@ sys.meta_path.insert(
         }
     ),
 )
-
 from dagster.builtins import Any, Bool, Float, Int, Nothing, String
 from dagster.config import Enum, EnumValue, Field, Map, Permissive, Selector, Shape
 from dagster.config.config_schema import ConfigSchema
@@ -226,6 +225,7 @@ from dagster.core.execution.results import (
     SolidExecutionResult,
 )
 from dagster.core.execution.validate_run_config import validate_run_config
+from dagster.core.execution.with_resources import with_resources
 from dagster.core.executor.base import Executor
 from dagster.core.executor.init import InitExecutorContext
 from dagster.core.instance import DagsterInstance
@@ -488,6 +488,7 @@ __all__ = [
     "OpExecutionContext",
     "PipelineExecutionResult",
     "RetryRequested",
+    "with_resources",
     "build_resources",
     "SolidExecutionResult",
     "SolidExecutionContext",


### PR DESCRIPTION
A recently landed PR made assetgroup call with_resources, which places resource defs directly on the constituent assets. This means that each asset keeps the prod resources. In reality, we want to pull the assets that do not have any of the prod assets attached.