### PR TITLE
Deprecate asset namespace

### DIFF
--- a/docs/content/concepts/assets/software-defined-assets.mdx
+++ b/docs/content/concepts/assets/software-defined-assets.mdx
@@ -474,18 +474,18 @@ def test_uses_context():
 
 ### Multi-component asset keys
 
-Assets are often objects in systems with hierarchical namespaces, like filesystems. Because of this, it often makes sense for an asset key to be a list of strings, instead of just a single string.
+Assets are often objects in systems with hierarchical namespaces, like filesystems. Because of this, it often makes sense for an asset key to be a list of strings, instead of just a single string. To define an asset with a multi-part asset key, use the `key_prefix` argument-- this can be either a list of strings or a single string with segments delimited by "/". The full asset key is formed by prepending the `key_prefix` to the asset name (which defaults to the name of the decorated function).
 
 ```python file=/concepts/assets/multi_component_asset_key.py startafter=start_marker endbefore=end_marker
 from dagster import AssetIn, asset
 
 
-@asset(namespace=["one", "two", "three"])
+@asset(key_prefix=["one", "two", "three"])
 def upstream_asset():
     return [1, 2, 3]
 
 
-@asset(ins={"upstream_asset": AssetIn(namespace=["one", "two", "three"])})
+@asset(ins={"upstream_asset": AssetIn(key_prefix="one/two/three")})
 def downstream_asset(upstream_asset):
     return upstream_asset + [4]
 ```

--- a/examples/docs_snippets/docs_snippets/concepts/assets/multi_component_asset_key.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/multi_component_asset_key.py
@@ -3,12 +3,12 @@
 from dagster import AssetIn, asset
 
 
-@asset(namespace=["one", "two", "three"])
+@asset(key_prefix=["one", "two", "three"])
 def upstream_asset():
     return [1, 2, 3]
 
 
-@asset(ins={"upstream_asset": AssetIn(namespace=["one", "two", "three"])})
+@asset(ins={"upstream_asset": AssetIn(key_prefix="one/two/three")})
 def downstream_asset(upstream_asset):
     return upstream_asset + [4]
 

--- a/examples/hacker_news_assets/hacker_news_assets/activity_analytics/assets/activity_forecast.py
+++ b/examples/hacker_news_assets/hacker_news_assets/activity_analytics/assets/activity_forecast.py
@@ -3,6 +3,6 @@ from pandas import DataFrame
 from dagster import AssetIn, asset
 
 
-@asset(ins={"activity_daily_stats": AssetIn(namespace="activity_analytics")})
+@asset(ins={"activity_daily_stats": AssetIn(key_prefix="activity_analytics")})
 def activity_forecast(activity_daily_stats: DataFrame) -> DataFrame:
     return activity_daily_stats.head(100)

--- a/examples/hacker_news_assets/hacker_news_assets/recommender/assets/comment_stories.py
+++ b/examples/hacker_news_assets/hacker_news_assets/recommender/assets/comment_stories.py
@@ -5,8 +5,8 @@ from dagster import AssetIn, asset
 
 @asset(
     ins={
-        "stories": AssetIn(namespace="core", metadata={"columns": ["id"]}),
-        "comments": AssetIn(namespace="core", metadata={"columns": ["id", "user_id", "parent"]}),
+        "stories": AssetIn(key_prefix="core", metadata={"columns": ["id"]}),
+        "comments": AssetIn(key_prefix="core", metadata={"columns": ["id", "user_id", "parent"]}),
     },
     io_manager_key="warehouse_io_manager",
 )

--- a/examples/hacker_news_assets/hacker_news_assets/recommender/assets/recommender_model.py
+++ b/examples/hacker_news_assets/hacker_news_assets/recommender/assets/recommender_model.py
@@ -30,7 +30,7 @@ def recommender_model(user_story_matrix: IndexedCooMatrix) -> Output[TruncatedSV
 
 
 @asset(
-    ins={"stories": AssetIn(namespace="core", metadata={"columns": ["id", "title"]})},
+    ins={"stories": AssetIn(key_prefix="core", metadata={"columns": ["id", "title"]})},
     io_manager_key="warehouse_io_manager",
 )
 def component_top_stories(

--- a/examples/hacker_news_assets/hacker_news_assets_tests/test_resources/test_snowflake_io_manager.py
+++ b/examples/hacker_news_assets/hacker_news_assets_tests/test_resources/test_snowflake_io_manager.py
@@ -25,7 +25,7 @@ from dagster import (
 
 
 def mock_output_context(asset_key):
-    @asset(name=asset_key.path[-1], namespace=asset_key.path[:-1])
+    @asset(name=asset_key.path[-1], key_prefix=asset_key.path[:-1])
     def my_asset():
         pass
 

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -33,7 +33,6 @@ from dagster.seven import funcsigs
 from dagster.utils.backcompat import (
     ExperimentalWarning,
     canonicalize_backcompat_args,
-    deprecation_warning,
     experimental_decorator,
 )
 

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -20,7 +20,7 @@ from dagster.config import Field
 from dagster.config.config_schema import ConfigSchemaType
 from dagster.core.decorator_utils import get_function_params, get_valid_name_permutations
 from dagster.core.definitions.decorators.op_decorator import _Op
-from dagster.core.definitions.events import AssetKey
+from dagster.core.definitions.events import ASSET_KEY_DELIMITER, AssetKey
 from dagster.core.definitions.input import In
 from dagster.core.definitions.output import Out
 from dagster.core.definitions.partition import PartitionsDefinition
@@ -30,7 +30,12 @@ from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.storage.io_manager import IOManagerDefinition
 from dagster.core.types.dagster_type import DagsterType
 from dagster.seven import funcsigs
-from dagster.utils.backcompat import ExperimentalWarning, experimental_decorator
+from dagster.utils.backcompat import (
+    ExperimentalWarning,
+    canonicalize_backcompat_args,
+    deprecation_warning,
+    experimental_decorator,
+)
 
 from .asset_in import AssetIn
 from .assets import AssetsDefinition
@@ -48,6 +53,7 @@ def asset(
 def asset(
     name: Optional[str] = ...,
     namespace: Optional[Sequence[str]] = ...,
+    key_prefix: Optional[Union[str, Sequence[str]]] = None,
     ins: Optional[Mapping[str, AssetIn]] = ...,
     non_argument_deps: Optional[Union[Set[AssetKey], Set[str]]] = ...,
     metadata: Optional[Mapping[str, Any]] = ...,
@@ -71,6 +77,7 @@ def asset(
 def asset(
     name: Optional[Union[Callable[..., Any], Optional[str]]] = None,
     namespace: Optional[Sequence[str]] = None,
+    key_prefix: Optional[Union[str, Sequence[str]]] = None,
     ins: Optional[Mapping[str, AssetIn]] = None,
     non_argument_deps: Optional[Union[Set[AssetKey], Set[str]]] = None,
     metadata: Optional[Mapping[str, Any]] = None,
@@ -101,8 +108,11 @@ def asset(
     Args:
         name (Optional[str]): The name of the asset.  If not provided, defaults to the name of the
             decorated function.
-        namespace (Optional[Sequence[str]]): The namespace that the asset resides in.  The namespace + the
-            name forms the asset key.
+        namespace (Optional[Sequence[str]]): **Deprecated (use `key_prefix`)**. The namespace that
+            the asset resides in.  The namespace + the name forms the asset key.
+        key_prefix (Optional[Union[str, Sequence[str]]]): Optional prefix to apply to the asset key. If `Sequence[str]`,
+            elements are prepended to function name to form the asset key. If `str`, will be split on "{asset_key_delimiter}"
+            and then prepended. If `None` asset key is simply the name of the function. name forms the asset key.
         ins (Optional[Mapping[str, AssetIn]]): A dictionary that maps input names to their metadata
             and namespaces.
         non_argument_deps (Optional[Union[Set[AssetKey], Set[str]]]): Set of asset keys that are
@@ -143,9 +153,15 @@ def asset(
             @asset
             def my_asset(my_upstream_asset: int) -> int:
                 return my_upstream_asset + 1
-    """
+    """.format(
+        asset_key_delimiter=ASSET_KEY_DELIMITER
+    )
     if callable(name):
         return _Asset()(name)
+
+    key_prefix = canonicalize_backcompat_args(
+        key_prefix, "key_prefix", namespace, "namespace", "0.16.0"
+    )
 
     def inner(fn: Callable[..., Any]) -> AssetsDefinition:
         check.invariant(
@@ -154,7 +170,7 @@ def asset(
         )
         return _Asset(
             name=cast(Optional[str], name),  # (mypy bug that it can't infer name is Optional[str])
-            namespace=namespace,
+            key_prefix=key_prefix,
             ins=ins,
             non_argument_deps=_make_asset_keys(non_argument_deps),
             metadata=metadata,
@@ -178,7 +194,7 @@ class _Asset:
     def __init__(
         self,
         name: Optional[str] = None,
-        namespace: Optional[Sequence[str]] = None,
+        key_prefix: Optional[Union[str, Sequence[str]]] = None,
         ins: Optional[Mapping[str, AssetIn]] = None,
         non_argument_deps: Optional[Set[AssetKey]] = None,
         metadata: Optional[Mapping[str, Any]] = None,
@@ -196,7 +212,9 @@ class _Asset:
     ):
         self.name = name
         # if user inputs a single string, coerce to list
-        self.namespace = [namespace] if isinstance(namespace, str) else namespace
+        self.key_prefix = (
+            key_prefix.split(ASSET_KEY_DELIMITER) if isinstance(key_prefix, str) else key_prefix
+        )
         self.ins = ins or {}
         self.non_argument_deps = non_argument_deps
         self.metadata = metadata
@@ -221,9 +239,9 @@ class _Asset:
     def __call__(self, fn: Callable) -> AssetsDefinition:
         asset_name = self.name or fn.__name__
 
-        asset_ins = build_asset_ins(fn, self.namespace, self.ins or {}, self.non_argument_deps)
+        asset_ins = build_asset_ins(fn, self.key_prefix, self.ins or {}, self.non_argument_deps)
 
-        out_asset_key = AssetKey(list(filter(None, [*(self.namespace or []), asset_name])))
+        out_asset_key = AssetKey(list(filter(None, [*(self.key_prefix or []), asset_name])))
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=ExperimentalWarning)
 
@@ -436,7 +454,7 @@ def multi_asset(
 
 def build_asset_ins(
     fn: Callable,
-    asset_namespace: Optional[Sequence[str]],
+    asset_key_prefix: Optional[Sequence[str]],
     asset_ins: Mapping[str, AssetIn],
     non_argument_deps: Optional[AbstractSet[AssetKey]],
 ) -> Mapping[AssetKey, Tuple[str, In]]:
@@ -475,13 +493,13 @@ def build_asset_ins(
         if input_name in asset_ins:
             asset_key = asset_ins[input_name].asset_key
             metadata = asset_ins[input_name].metadata or {}
-            namespace = asset_ins[input_name].namespace
+            key_prefix = asset_ins[input_name].key_prefix
         else:
             metadata = {}
-            namespace = None
+            key_prefix = None
 
         asset_key = asset_key or AssetKey(
-            list(filter(None, [*(namespace or asset_namespace or []), input_name]))
+            list(filter(None, [*(key_prefix or asset_key_prefix or []), input_name]))
         )
 
         ins_by_asset_key[asset_key] = (input_name.replace("-", "_"), In(metadata=metadata))

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -37,7 +37,8 @@ if TYPE_CHECKING:
     from dagster.core.execution.context.output import OutputContext
 
 ASSET_KEY_SPLIT_REGEX = re.compile("[^a-zA-Z0-9_]")
-ASSET_KEY_STRUCTURED_DELIMITER = "."
+ASSET_KEY_DELIMITER = "/"
+ASSET_KEY_LEGACY_DELIMITER = "."
 
 
 def parse_asset_key_string(s: str) -> List[str]:
@@ -110,18 +111,18 @@ class AssetKey(NamedTuple("_AssetKey", [("path", List[str])])):
         if not self.path:
             return None
         if legacy:
-            return ASSET_KEY_STRUCTURED_DELIMITER.join(self.path)
+            return ASSET_KEY_LEGACY_DELIMITER.join(self.path)
         return seven.json.dumps(self.path)
 
     def to_user_string(self) -> str:
         """
         E.g. "first_component/second_component"
         """
-        return "/".join(self.path)
+        return ASSET_KEY_DELIMITER.join(self.path)
 
     @staticmethod
     def from_user_string(asset_key_string: str) -> "AssetKey":
-        return AssetKey(asset_key_string.split("/"))
+        return AssetKey(asset_key_string.split(ASSET_KEY_DELIMITER))
 
     @staticmethod
     def from_db_string(asset_key_string: Optional[str]) -> Optional["AssetKey"]:
@@ -141,7 +142,7 @@ class AssetKey(NamedTuple("_AssetKey", [("path", List[str])])):
     def get_db_prefix(path: List[str], legacy: Optional[bool] = False):
         check.list_param(path, "path", of_type=str)
         if legacy:
-            return ASSET_KEY_STRUCTURED_DELIMITER.join(path)
+            return ASSET_KEY_LEGACY_DELIMITER.join(path)
         return seven.json.dumps(path)[:-2]  # strip trailing '"]' from json string
 
     @staticmethod

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
@@ -827,7 +827,7 @@ def test_cycle_resolution_impossible():
 def test_asset_group_build_job_selection_multi_component():
     source_asset = SourceAsset(["apple", "banana"])
 
-    @asset(namespace="abc")
+    @asset(key_prefix="abc")
     def asset1():
         ...
 
@@ -1143,7 +1143,7 @@ def test_assets_prefixed_disambiguate():
     def asset2():
         ...
 
-    @asset(ins={"apple": AssetIn(namespace="core")})
+    @asset(ins={"apple": AssetIn(key_prefix="core")})
     def orange(apple):
         del apple
 
@@ -1165,7 +1165,7 @@ def test_assets_prefixed_disambiguate():
 def test_assets_prefixed_source_asset():
     asset1 = SourceAsset(key=AssetKey(["upstream_prefix", "asset1"]))
 
-    @asset(ins={"asset1": AssetIn(namespace="upstream_prefix")})
+    @asset(ins={"asset1": AssetIn(key_prefix="upstream_prefix")})
     def asset2(asset1):
         del asset1
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -195,14 +195,14 @@ def test_asset_key_and_inferred():
     assert _asset_keys_for_node(result, "asset_baz") == {AssetKey("asset_baz")}
 
 
-def test_asset_key_for_asset_with_namespace_list():
-    @asset(namespace=["hell", "o"])
+def test_asset_key_for_asset_with_key_prefix_list():
+    @asset(key_prefix=["hell", "o"])
     def asset_foo():
         return "foo"
 
     @asset(
         ins={"foo": AssetIn(asset_key=AssetKey("asset_foo"))}
-    )  # Should fail because asset_foo is defined with namespace, so has asset key ["hello", "asset_foo"]
+    )  # Should fail because asset_foo is defined with key_prefix, so has asset key ["hello", "asset_foo"]
     def failing_asset(foo):  # pylint: disable=unused-argument
         pass
 
@@ -225,8 +225,8 @@ def test_asset_key_for_asset_with_namespace_list():
     }
 
 
-def test_asset_key_for_asset_with_namespace_str():
-    @asset(namespace="hello")
+def test_asset_key_for_asset_with_key_prefix_str():
+    @asset(key_prefix="hello")
     def asset_foo():
         return "foo"
 
@@ -371,7 +371,7 @@ def test_multiple_non_argument_deps():
     def foo():
         pass
 
-    @asset(namespace="namespace")
+    @asset(key_prefix="key_prefix")
     def bar():
         pass
 
@@ -379,7 +379,7 @@ def test_multiple_non_argument_deps():
     def baz():
         return 1
 
-    @asset(non_argument_deps={AssetKey("foo"), AssetKey(["namespace", "bar"])})
+    @asset(non_argument_deps={AssetKey("foo"), AssetKey(["key_prefix", "bar"])})
     def qux(baz):
         return baz
 
@@ -389,21 +389,21 @@ def test_multiple_non_argument_deps():
     index = DependencyStructureIndex(dep_structure_snapshot)
 
     assert index.get_invocation("foo")
-    assert index.get_invocation("namespace__bar")
+    assert index.get_invocation("key_prefix__bar")
     assert index.get_invocation("baz")
 
     assert index.get_upstream_outputs("qux", "foo") == [
         OutputHandleSnap("foo", "result"),
     ]
-    assert index.get_upstream_outputs("qux", "namespace_bar") == [
-        OutputHandleSnap("namespace__bar", "result")
+    assert index.get_upstream_outputs("qux", "key_prefix_bar") == [
+        OutputHandleSnap("key_prefix__bar", "result")
     ]
     assert index.get_upstream_outputs("qux", "baz") == [OutputHandleSnap("baz", "result")]
 
     result = job.execute_in_process()
     assert result.success
     assert result.output_for_node("qux") == 1
-    assert _asset_keys_for_node(result, "namespace__bar") == {AssetKey(["namespace", "bar"])}
+    assert _asset_keys_for_node(result, "key_prefix__bar") == {AssetKey(["key_prefix", "bar"])}
     assert _asset_keys_for_node(result, "qux") == {AssetKey("qux")}
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -155,10 +155,49 @@ def test_asset_with_dagster_type():
     assert my_asset.op.output_defs[0].dagster_type.display_name == "String"
 
 
-def test_asset_with_namespace():
-    @asset(namespace="my_namespace")
+def test_asset_with_key_prefix():
+    @asset(key_prefix="my_key_prefix")
     def my_asset():
         pass
+
+    assert isinstance(my_asset, AssetsDefinition)
+    assert len(my_asset.op.output_defs) == 1
+    assert len(my_asset.op.input_defs) == 0
+    assert my_asset.op.name == "my_key_prefix__my_asset"
+    assert my_asset.asset_keys == {AssetKey(["my_key_prefix", "my_asset"])}
+
+    @asset(key_prefix=["one", "two", "three"])
+    def multi_component_list_asset():
+        pass
+
+    assert isinstance(multi_component_list_asset, AssetsDefinition)
+    assert len(multi_component_list_asset.op.output_defs) == 1
+    assert len(multi_component_list_asset.op.input_defs) == 0
+    assert multi_component_list_asset.op.name == "one__two__three__multi_component_list_asset"
+    assert multi_component_list_asset.asset_keys == {
+        AssetKey(["one", "two", "three", "multi_component_list_asset"])
+    }
+
+    @asset(key_prefix="one/two/three")
+    def multi_component_str_asset():
+        pass
+
+    assert isinstance(multi_component_str_asset, AssetsDefinition)
+    assert len(multi_component_str_asset.op.output_defs) == 1
+    assert len(multi_component_str_asset.op.input_defs) == 0
+    assert multi_component_str_asset.op.name == "one__two__three__multi_component_str_asset"
+    assert multi_component_str_asset.asset_keys == {
+        AssetKey(["one", "two", "three", "multi_component_str_asset"])
+    }
+
+
+def test_asset_with_namespace():
+
+    with pytest.warns(DeprecationWarning):
+
+        @asset(namespace="my_namespace")
+        def my_asset():
+            pass
 
     assert isinstance(my_asset, AssetsDefinition)
     assert len(my_asset.op.output_defs) == 1
@@ -182,15 +221,15 @@ def test_asset_with_namespace():
     }
 
 
-def test_asset_with_inputs_and_namespace():
-    @asset(namespace="my_namespace")
+def test_asset_with_inputs_and_key_prefix():
+    @asset(key_prefix="my_prefix")
     def my_asset(arg1):
         return arg1
 
     assert isinstance(my_asset, AssetsDefinition)
     assert len(my_asset.op.output_defs) == 1
     assert len(my_asset.op.input_defs) == 1
-    assert AssetKey(["my_namespace", "arg1"]) in my_asset.asset_keys_by_input_name.values()
+    assert AssetKey(["my_prefix", "arg1"]) in my_asset.asset_keys_by_input_name.values()
 
 
 def test_asset_with_context_arg():
@@ -221,10 +260,10 @@ def test_input_asset_key():
     assert AssetKey("foo") in my_asset.asset_keys_by_input_name.values()
 
 
-def test_input_asset_key_and_namespace():
-    with pytest.raises(check.CheckError, match="key and namespace cannot both be set"):
+def test_input_asset_key_and_key_prefix():
+    with pytest.raises(check.CheckError, match="key and key_prefix cannot both be set"):
 
-        @asset(ins={"arg1": AssetIn(asset_key=AssetKey("foo"), namespace="bar")})
+        @asset(ins={"arg1": AssetIn(asset_key=AssetKey("foo"), key_prefix="bar")})
         def _my_asset(arg1):
             assert arg1
 
@@ -239,6 +278,22 @@ def test_input_namespace_str():
 
 def test_input_namespace_list():
     @asset(ins={"arg1": AssetIn(namespace=["abc", "xyz"])})
+    def my_asset(arg1):
+        assert arg1
+
+    assert AssetKey(["abc", "xyz", "arg1"]) in my_asset.asset_keys_by_input_name.values()
+
+
+def test_input_key_prefix_str():
+    @asset(ins={"arg1": AssetIn(key_prefix="abc/xyz")})
+    def my_asset(arg1):
+        assert arg1
+
+    assert AssetKey(["abc", "xyz", "arg1"]) in my_asset.asset_keys_by_input_name.values()
+
+
+def test_input_key_prefix_list():
+    @asset(ins={"arg1": AssetIn(key_prefix=["abc", "xyz"])})
     def my_asset(arg1):
         assert arg1
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_io_manager.py
@@ -195,15 +195,15 @@ def test_fs_io_manager_unpicklable():
 
 
 def get_assets_job(io_manager_def, partitions_def=None):
-    asset1_namespace = ["one", "two", "three"]
+    asset1_key_prefix = ["one", "two", "three"]
 
-    @asset(namespace=["one", "two", "three"], partitions_def=partitions_def)
+    @asset(key_prefix=["one", "two", "three"], partitions_def=partitions_def)
     def asset1():
         return [1, 2, 3]
 
     @asset(
-        namespace=["four", "five"],
-        ins={"asset1": AssetIn(namespace=asset1_namespace)},
+        key_prefix=["four", "five"],
+        ins={"asset1": AssetIn(key_prefix=asset1_key_prefix)},
         partitions_def=partitions_def,
     )
     def asset2(asset1):


### PR DESCRIPTION
### Summary & Motivation

Deprecates `namespace` argument on both the `@asset` decorator and `AssetIn`. Replaces with `key_prefix`, which has _almost_ the same behavior, except you can pass a "/"-delimited string that will be split to obtain the key segments.

### How I Tested These Changes


There were a lot of tests that used the `namespace` argument-- I changed everything not designed to directly test `namespace` to use `key_prefix` instead. I retained direct tests for `namespace` and added new ones for `key_prefix`.

