### PR TITLE
Deprecate AssetGroup

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -54,7 +54,7 @@ In order to run schedules for assets, you can [build a job that materializes ass
 ```python file=concepts/partitions_schedules_sensors/schedules/schedules.py startafter=start_basic_asset_schedule endbefore=end_basic_asset_schedule
 from dagster import AssetSelection, define_asset_job
 
-asset_job = define_asset_job(AssetSelection.groups("some_asset_group"))
+asset_job = define_asset_job("asset_job", AssetSelection.groups("some_asset_group"))
 
 basic_schedule = ScheduleDefinition(job=asset_job, cron_schedule="0 0 * * *")
 ```

--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -52,7 +52,9 @@ basic_schedule = ScheduleDefinition(job=my_job, cron_schedule="0 0 * * *")
 In order to run schedules for assets, you can [build a job that materializes assets](/concepts/assets/software-defined-assets#building-jobs-that-materialize-assets) and construct a <PyObject object="ScheduleDefinition" /> similarly:
 
 ```python file=concepts/partitions_schedules_sensors/schedules/schedules.py startafter=start_basic_asset_schedule endbefore=end_basic_asset_schedule
-asset_job = AssetGroup([my_asset]).build_job("asset_job")
+from dagster import AssetSelection, define_asset_job
+
+asset_job = define_asset_job(AssetSelection.groups("some_asset_group"))
 
 basic_schedule = ScheduleDefinition(job=asset_job, cron_schedule="0 0 * * *")
 ```
@@ -113,9 +115,11 @@ do_stuff_partitioned_schedule = build_schedule_from_partitioned_job(
 The Partitioned Jobs concepts page also includes an [example of a date-partitioned asset](/concepts/partitions-schedules-sensors/partitions#partitioned-assets). You can define a schedule similarly using <PyObject object="build_schedule_from_partitioned_job"/>:
 
 ```python file=/concepts/partitions_schedules_sensors/schedule_from_partitions.py startafter=start_partitioned_asset_schedule endbefore=end_partitioned_asset_schedule
-from dagster import AssetGroup
+from dagster import define_asset_job
 
-partitioned_asset_job = AssetGroup([partitioned_asset]).build_job("partitioned_job")
+partitioned_asset_job = define_asset_job("partitioned_job").resolve(
+    [partitioned_asset], []
+)
 
 
 asset_partitioned_schedule = build_schedule_from_partitioned_job(

--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -119,7 +119,7 @@ from dagster import define_asset_job
 
 partitioned_asset_job = define_asset_job(
     "partitioned_job",
-    "*",
+    selection="*",
     partitions_def=HourlyPartitionsDefinition(start_date="2022-05-31", fmt="%Y-%m-%d"),
 )
 

--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -117,8 +117,10 @@ The Partitioned Jobs concepts page also includes an [example of a date-partition
 ```python file=/concepts/partitions_schedules_sensors/schedule_from_partitions.py startafter=start_partitioned_asset_schedule endbefore=end_partitioned_asset_schedule
 from dagster import define_asset_job
 
-partitioned_asset_job = define_asset_job("partitioned_job").resolve(
-    [partitioned_asset], []
+partitioned_asset_job = define_asset_job(
+    "partitioned_job",
+    "*",
+    partitions_def=HourlyPartitionsDefinition(start_date="2022-05-31", fmt="%Y-%m-%d"),
 )
 
 

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -86,7 +86,7 @@ This sensor iterates through all the files in `MY_DIRECTORY` and `yields` a <PyO
 To write a sensor that materializes assets, you can [build a job that materializes assets](/concepts/assets/software-defined-assets#building-jobs-that-materialize-assets):
 
 ```python file=concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_asset_job_sensor_marker endbefore=end_asset_job_sensor_marker
-asset_job = define_asset_job("asset_job", AssetSelection.all())
+asset_job = define_asset_job("asset_job", "*")
 
 
 @sensor(job=asset_job)

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -86,7 +86,7 @@ This sensor iterates through all the files in `MY_DIRECTORY` and `yields` a <PyO
 To write a sensor that materializes assets, you can [build a job that materializes assets](/concepts/assets/software-defined-assets#building-jobs-that-materialize-assets):
 
 ```python file=concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_asset_job_sensor_marker endbefore=end_asset_job_sensor_marker
-asset_job = define_asset_job("asset_job").resolve([my_asset], [])
+asset_job = define_asset_job("asset_job", AssetSelection.all())
 
 
 @sensor(job=asset_job)

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -86,7 +86,7 @@ This sensor iterates through all the files in `MY_DIRECTORY` and `yields` a <PyO
 To write a sensor that materializes assets, you can [build a job that materializes assets](/concepts/assets/software-defined-assets#building-jobs-that-materialize-assets):
 
 ```python file=concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_asset_job_sensor_marker endbefore=end_asset_job_sensor_marker
-asset_job = AssetGroup([my_asset]).build_job("asset_job")
+asset_job = define_asset_job("asset_job").resolve([my_asset], [])
 
 
 @sensor(job=asset_job)

--- a/examples/bollinger/bollinger/__init__.py
+++ b/examples/bollinger/bollinger/__init__.py
@@ -1,18 +1,16 @@
-import warnings
-
 from bollinger.resources.csv_io_manager import local_csv_io_manager
 
-from dagster import AssetGroup, ExperimentalWarning, repository
+from dagster import load_assets_from_package_name, repository, with_resources
 
 from . import lib
-
-warnings.filterwarnings("ignore", category=ExperimentalWarning)
 
 
 @repository
 def bollinger():
     return [
-        AssetGroup.from_package_name(__name__, resource_defs={"io_manager": local_csv_io_manager})
+        *with_resources(
+            load_assets_from_package_name(__name__), {"io_manager": local_csv_io_manager}
+        )
     ]
 
 

--- a/examples/bollinger/bollinger_tests/jobs_tests/test_bollinger_analysis.py
+++ b/examples/bollinger/bollinger_tests/jobs_tests/test_bollinger_analysis.py
@@ -5,13 +5,21 @@ from bollinger.assets.bollinger_analysis import (
 )
 from bollinger.resources.csv_io_manager import local_csv_io_manager
 
-from dagster import AssetGroup
+from dagster import AssetSelection
+from dagster.core.definitions.unresolved_asset_job_definition import define_asset_job
+from dagster.core.execution.with_resources import with_resources
 
 
 def test_bollinger_analysis():
-    bollinger_sda = AssetGroup(
-        assets=[sp500_anomalous_events, sp500_bollinger_bands, sp500_prices],
-        resource_defs={"io_manager": local_csv_io_manager},
+    bollinger_sda = define_asset_job(
+        "test_job",
+        AssetSelection.keys("sp500_anomalous_events", "sp500_bollinger_bands", "sp500_prices"),
+    ).resolve(
+        with_resources(
+            [sp500_anomalous_events, sp500_bollinger_bands, sp500_prices],
+            {"io_manager": local_csv_io_manager},
+        ),
+        [],
     )
-    result = bollinger_sda.build_job("test_job").execute_in_process()
+    result = bollinger_sda.execute_in_process()
     assert result.asset_materializations_for_node

--- a/examples/bollinger/bollinger_tests/jobs_tests/test_bollinger_analysis.py
+++ b/examples/bollinger/bollinger_tests/jobs_tests/test_bollinger_analysis.py
@@ -4,17 +4,14 @@ from bollinger.assets.bollinger_analysis import (
     sp500_prices,
 )
 from bollinger.resources.csv_io_manager import local_csv_io_manager
-from dagster.core.asset_defs.asset_selection import AssetSelection
 
+from dagster.core.asset_defs.asset_selection import AssetSelection
 from dagster.core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster.core.execution.with_resources import with_resources
 
 
 def test_bollinger_analysis():
-    bollinger_sda = define_asset_job(
-        "test_job",
-        AssetSelection.all(),
-    ).resolve(
+    bollinger_sda = define_asset_job("test_job", AssetSelection.all(),).resolve(
         with_resources(
             [sp500_anomalous_events, sp500_bollinger_bands, sp500_prices],
             {"io_manager": local_csv_io_manager},

--- a/examples/bollinger/bollinger_tests/jobs_tests/test_bollinger_analysis.py
+++ b/examples/bollinger/bollinger_tests/jobs_tests/test_bollinger_analysis.py
@@ -4,8 +4,8 @@ from bollinger.assets.bollinger_analysis import (
     sp500_prices,
 )
 from bollinger.resources.csv_io_manager import local_csv_io_manager
+from dagster.core.asset_defs.asset_selection import AssetSelection
 
-from dagster import AssetSelection
 from dagster.core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster.core.execution.with_resources import with_resources
 
@@ -13,7 +13,7 @@ from dagster.core.execution.with_resources import with_resources
 def test_bollinger_analysis():
     bollinger_sda = define_asset_job(
         "test_job",
-        AssetSelection.keys("sp500_anomalous_events", "sp500_bollinger_bands", "sp500_prices"),
+        AssetSelection.all(),
     ).resolve(
         with_resources(
             [sp500_anomalous_events, sp500_bollinger_bands, sp500_prices],

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedule_from_partitions.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedule_from_partitions.py
@@ -27,9 +27,11 @@ def partitioned_asset():
 
 
 # start_partitioned_asset_schedule
-from dagster import AssetGroup
+from dagster import define_asset_job
 
-partitioned_asset_job = AssetGroup([partitioned_asset]).build_job("partitioned_job")
+partitioned_asset_job = define_asset_job("partitioned_job").resolve(
+    [partitioned_asset], []
+)
 
 
 asset_partitioned_schedule = build_schedule_from_partitioned_job(

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedule_from_partitions.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedule_from_partitions.py
@@ -19,18 +19,13 @@ do_stuff_partitioned_schedule = build_schedule_from_partitioned_job(
 # end_marker
 
 
-@asset(
-    partitions_def=HourlyPartitionsDefinition(start_date="2022-05-31", fmt="%Y-%m-%d")
-)
-def partitioned_asset():
-    return 1
-
-
 # start_partitioned_asset_schedule
 from dagster import define_asset_job
 
-partitioned_asset_job = define_asset_job("partitioned_job").resolve(
-    [partitioned_asset], []
+partitioned_asset_job = define_asset_job(
+    "partitioned_job",
+    "*",
+    partitions_def=HourlyPartitionsDefinition(start_date="2022-05-31", fmt="%Y-%m-%d"),
 )
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedule_from_partitions.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedule_from_partitions.py
@@ -1,7 +1,7 @@
 # isort: skip_file
 
 from .partitioned_job import my_partitioned_config
-from dagster import asset, HourlyPartitionsDefinition
+from dagster import HourlyPartitionsDefinition
 
 # start_marker
 from dagster import build_schedule_from_partitioned_job, job
@@ -24,7 +24,7 @@ from dagster import define_asset_job
 
 partitioned_asset_job = define_asset_job(
     "partitioned_job",
-    "*",
+    selection="*",
     partitions_def=HourlyPartitionsDefinition(start_date="2022-05-31", fmt="%Y-%m-%d"),
 )
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
@@ -27,8 +27,9 @@ def my_asset():
 
 
 # start_basic_asset_schedule
+from dagster import AssetSelection, define_asset_job
 
-asset_job = AssetGroup([my_asset]).build_job("asset_job")
+asset_job = define_asset_job(AssetSelection.groups("some_asset_group"))
 
 basic_schedule = ScheduleDefinition(job=asset_job, cron_schedule="0 0 * * *")
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
@@ -1,5 +1,4 @@
 from dagster import (
-    AssetGroup,
     DefaultScheduleStatus,
     RunRequest,
     ScheduleDefinition,
@@ -29,7 +28,7 @@ def my_asset():
 # start_basic_asset_schedule
 from dagster import AssetSelection, define_asset_job
 
-asset_job = define_asset_job(AssetSelection.groups("some_asset_group"))
+asset_job = define_asset_job("asset_job", AssetSelection.groups("some_asset_group"))
 
 basic_schedule = ScheduleDefinition(job=asset_job, cron_schedule="0 0 * * *")
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -50,7 +50,7 @@ def my_asset():
 
 
 # start_asset_job_sensor_marker
-asset_job = define_asset_job("asset_job", AssetSelection.all())
+asset_job = define_asset_job("asset_job", "*")
 
 
 @sensor(job=asset_job)

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -1,7 +1,7 @@
 # isort: skip_file
 # pylint: disable=unnecessary-ellipsis
 
-from dagster import repository, DefaultSensorStatus, SkipReason, AssetGroup, asset
+from dagster import repository, DefaultSensorStatus, SkipReason, asset, define_asset_job
 
 
 # start_sensor_job_marker
@@ -50,7 +50,7 @@ def my_asset():
 
 
 # start_asset_job_sensor_marker
-asset_job = AssetGroup([my_asset]).build_job("asset_job")
+asset_job = define_asset_job("asset_job").resolve([my_asset], [])
 
 
 @sensor(job=asset_job)

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -50,7 +50,7 @@ def my_asset():
 
 
 # start_asset_job_sensor_marker
-asset_job = define_asset_job("asset_job").resolve([my_asset], [])
+asset_job = define_asset_job("asset_job", AssetSelection.all())
 
 
 @sensor(job=asset_job)

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_partitioned_asset.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_partitioned_asset.py
@@ -1,13 +1,9 @@
-from dagster import AssetGroup
+from dagster import define_asset_job
 from docs_snippets.concepts.partitions_schedules_sensors.partitioned_asset import (
     my_daily_partitioned_asset,
 )
 
 
 def test_partitioned_asset():
-    assert (
-        AssetGroup([my_daily_partitioned_asset])
-        .build_job("a")
-        .execute_in_process(partition_key="2022-01-01")
-        .success
-    )
+    my_job = define_asset_job("a").resolve([my_daily_partitioned_asset], [])
+    assert my_job.execute_in_process(partition_key="2022-01-01").success

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -328,7 +328,7 @@ _DEPRECATED = {
     "AssetGroup": (
         "dagster.core.asset_defs",
         "0.16.0",
-        "Instead, place a set of assets wrapped with `with_resources` on a repository.",
+        "Instead, place a set of assets wrapped with `with_resources` directly on a repository.",
     ),
 }
 

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -1,3 +1,4 @@
+import importlib
 import sys
 import typing
 
@@ -19,7 +20,6 @@ from dagster.config import Enum, EnumValue, Field, Map, Permissive, Selector, Sh
 from dagster.config.config_schema import ConfigSchema
 from dagster.config.config_type import Array, Noneable, ScalarUnion
 from dagster.core.asset_defs import (
-    AssetGroup,
     AssetIn,
     AssetSelection,
     AssetsDefinition,
@@ -273,7 +273,7 @@ from dagster.core.types.python_tuple import Tuple
 from dagster.serdes import deserialize_value, serialize_value
 from dagster.utils import file_relative_path
 from dagster.utils.alert import make_email_on_run_failure_sensor
-from dagster.utils.backcompat import ExperimentalWarning, rename_warning
+from dagster.utils.backcompat import ExperimentalWarning, deprecation_warning, rename_warning
 from dagster.utils.log import get_dagster_logger
 from dagster.utils.partitions import (
     create_offset_partition_selector,
@@ -300,6 +300,8 @@ from dagster.config.source import BoolSource, StringSource, IntSource  # isort:s
 # in `_DEPRECATED` is required  for us to generate the deprecation warning.
 
 if typing.TYPE_CHECKING:
+    from dagster.core.asset_defs import AssetGroup
+
     # pylint:disable=reimported
     from dagster.core.definitions import DagsterAssetMetadataValue as DagsterAssetMetadataEntryData
     from dagster.core.definitions import (
@@ -323,6 +325,14 @@ if typing.TYPE_CHECKING:
     # pylint:enable=reimported
 
 _DEPRECATED = {
+    "AssetGroup": (
+        "dagster.core.asset_defs",
+        "0.16.0",
+        "Instead, place a set of assets wrapped with `with_resources` on a repository.",
+    ),
+}
+
+_DEPRECATED_RENAMED = {
     "EventMetadataEntry": (MetadataEntry, "0.15.0"),
     "EventMetadata": (MetadataValue, "0.15.0"),
     "TextMetadataEntryData": (TextMetadataValue, "0.15.0"),
@@ -354,7 +364,13 @@ _DEPRECATED = {
 
 def __getattr__(name: str) -> typing.Any:
     if name in _DEPRECATED:
-        value, breaking_version = _DEPRECATED[name]
+        module, breaking_version, additional_warn_text = _DEPRECATED[name]
+        value = getattr(importlib.import_module(module), name)
+        stacklevel = 3 if sys.version_info >= (3, 7) else 4
+        deprecation_warning(name, breaking_version, additional_warn_text, stacklevel=stacklevel)
+        return value
+    elif name in _DEPRECATED_RENAMED:
+        value, breaking_version = _DEPRECATED_RENAMED[name]
         stacklevel = 3 if sys.version_info >= (3, 7) else 4
         rename_warning(value.__name__, name, breaking_version, stacklevel=stacklevel)
         return value

--- a/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
@@ -28,6 +28,16 @@ from dagster.core.definitions.output import OutputDefinition
 from dagster.core.types.dagster_type import DagsterType
 
 # ########################
+# ##### ASSET GROUP
+# ########################
+
+
+def test_asset_group_import():
+    with pytest.warns(DeprecationWarning, match=re.escape("AssetGroup is deprecated")):
+        getattr(dagster, "AssetGroup")
+
+
+# ########################
 # ##### METADATA IMPORTS
 # ########################
 


### PR DESCRIPTION
### Summary & Motivation

Deprecates `AssetGroup` at the import level.

### How I Tested These Changes

Added a unit test alongside other deprecation unit tests.
