### PR TITLE
Add typecheck for resolving node config

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -241,7 +241,11 @@ class GrapheneAssetNode(graphene.ObjectType):
     # TODO: Prob want a more efficient way of resolving this
     def resolve_configField(self, _graphene_info) -> Optional[GrapheneConfigTypeField]:
         op = self.get_op_definition()
-        return op.resolve_config_field(_graphene_info) if op else None
+        return (
+            op.resolve_config_field(_graphene_info)
+            if op and isinstance(op, GrapheneSolidDefinition)
+            else None
+        )
 
     def resolve_computeKind(self, _graphene_info) -> Optional[str]:
         return self._external_asset_node.compute_kind


### PR DESCRIPTION
Currently, displaying a graph-backed asset on Dagit errors with the following:

> Operation name: AssetGraphQuery
> Message: 'GrapheneCompositeSolidDefinition' object has no attribute 'resolve_config_field'

A config schema can only exist on an op. This PR adds a check to prevent resolving config schema for composite solids (graphs).

Tested in Dagit to confirm that providing launchpad config works and that providing config on `@graph` will propagate to inner ops.