### PR TITLE
fix group_name in to_source_assets

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -387,6 +387,7 @@ class AssetsDefinition(ResourceAddable):
                     description=output_def.description,
                     resource_defs=self.resource_defs,
                     partitions_def=self.partitions_def,
+                    group_name=self.group_names[asset_key],
                 )
             )
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
@@ -1263,7 +1263,7 @@ def test_add_asset_groups_different_executors():
 
 
 def test_to_source_assets():
-    @asset
+    @asset(group_name="abc")
     def my_asset():
         ...
 
@@ -1282,6 +1282,7 @@ def test_to_source_assets():
             AssetKey(["my_asset"]),
             io_manager_key="io_manager",
             resource_defs={"io_manager": fs_io_manager},
+            group_name="abc",
         ),
         SourceAsset(
             AssetKey(["my_asset_name"]),


### PR DESCRIPTION
I came across this because it was causing some strange behavior in how assets displayed in Dagit.