### PR TITLE
fix bug where issubclass(list[str], DagsterType) throws a surprising exception

### DIFF
--- a/python_modules/dagster/dagster/config/field.py
+++ b/python_modules/dagster/dagster/config/field.py
@@ -5,6 +5,7 @@ from dagster.builtins import BuiltinEnum
 from dagster.config.config_schema import ConfigSchemaType
 from dagster.core.errors import DagsterInvalidConfigError, DagsterInvalidDefinitionError
 from dagster.serdes import serialize_value
+from dagster.seven import is_subclass
 from dagster.utils import is_enum_value
 from dagster.utils.typing_api import is_closed_python_optional_type, is_typing_type
 
@@ -13,7 +14,7 @@ from .field_utils import FIELD_NO_DEFAULT_PROVIDED, Map, all_optional_type
 
 
 def _is_config_type_class(obj):
-    return isinstance(obj, type) and issubclass(obj, ConfigType)
+    return isinstance(obj, type) and is_subclass(obj, ConfigType)
 
 
 def helpful_list_error_string():
@@ -111,7 +112,7 @@ def resolve_to_config_type(dagster_type: object) -> Union[ConfigType, bool]:
             'another dagster config type. E.g. "Noneable(Permissive)" should instead be "Noneable(Permissive())".',
         )
 
-    if isinstance(dagster_type, type) and issubclass(dagster_type, DagsterType):
+    if isinstance(dagster_type, type) and is_subclass(dagster_type, DagsterType):
         raise DagsterInvalidDefinitionError(
             "You have passed a DagsterType class {dagster_type} to the config system. "
             "The DagsterType and config schema systems are separate. "

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -15,6 +15,7 @@ from dagster.core.definitions.events import DynamicOutput, Output, TypeCheck
 from dagster.core.definitions.metadata import MetadataEntry, RawMetadataValue, normalize_metadata
 from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster.serdes import whitelist_for_serdes
+from dagster.seven import is_subclass
 
 from ..definitions.resource_requirement import (
     RequiresResources,
@@ -835,12 +836,12 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
     from .transform_typing import transform_typing_type
 
     check.invariant(
-        not (isinstance(dagster_type, type) and issubclass(dagster_type, ConfigType)),
+        not is_subclass(dagster_type, ConfigType),
         "Cannot resolve a config type to a runtime type",
     )
 
     check.invariant(
-        not (isinstance(dagster_type, type) and issubclass(dagster_type, DagsterType)),
+        not is_subclass(dagster_type, DagsterType),
         "Do not pass runtime type classes. Got {}".format(dagster_type),
     )
 
@@ -907,12 +908,12 @@ def is_dynamic_output_annotation(dagster_type: object) -> bool:
     from dagster.seven.typing import get_args, get_origin
 
     check.invariant(
-        not (isinstance(dagster_type, type) and issubclass(dagster_type, ConfigType)),
+        not is_subclass(dagster_type, ConfigType),
         "Cannot resolve a config type to a runtime type",
     )
 
     check.invariant(
-        not (isinstance(dagster_type, type) and issubclass(dagster_type, DagsterType)),
+        not is_subclass(dagster_type, DagsterType),
         "Do not pass runtime type classes. Got {}".format(dagster_type),
     )
 

--- a/python_modules/dagster/dagster/seven/__init__.py
+++ b/python_modules/dagster/dagster/seven/__init__.py
@@ -168,3 +168,19 @@ def get_import_error_message(import_error):
 @contextmanager
 def nullcontext():
     yield
+
+
+def is_subclass(child_type, parent_type):
+    """Due to some pathological interactions betwen bugs in the Python typing library
+    (https://github.com/python/cpython/issues/88459 and
+    https://github.com/python/cpython/issues/89010), some types (list[str] in Python 3.9, for
+    example) pass inspect.isclass check above but then raise an exception if issubclass is called
+    with the same class. This function provides a workaround for that issue."""
+
+    if not inspect.isclass(child_type):
+        return False
+
+    try:
+        return issubclass(child_type, parent_type)
+    except TypeError:
+        return False


### PR DESCRIPTION
This issue was causing some user jobs to fail that weren't failing before, when we inadvertently made DagsterType an ABC subclass, triggering one of the cpython issues linked in the implementation of is_subclass. 

Create a new implementation that doesn't run afoul of that problem.