### PR TITLE
AssetSelection tweaks

### DIFF
--- a/python_modules/dagster/dagster/core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/core/selector/subset_selector.py
@@ -215,9 +215,9 @@ def fetch_connected(
     graph: DependencyGraph,
     *,
     direction: Direction,
-    depth: int = None,
+    depth: Optional[int] = None,
 ) -> FrozenSet[str]:
-    if not depth:
+    if depth is None:
         depth = MAX_NUM
     if direction == "downstream":
         return Traverser(graph).fetch_downstream(item, depth)

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_selection.py
@@ -6,6 +6,7 @@ import pytest
 
 from dagster.core.asset_defs.asset_selection import AssetSelection
 from dagster.core.asset_defs.decorators import asset
+from dagster.core.definitions.events import AssetKey
 
 
 @asset(group_name="ladies")
@@ -86,6 +87,9 @@ def test_asset_selection_groups(all_assets):
 
 
 def test_asset_selection_keys(all_assets):
+    sel = AssetSelection.keys(AssetKey("alice"), AssetKey("bob"))
+    assert sel.resolve(all_assets) == _asset_keys_of({alice, bob})
+
     sel = AssetSelection.keys("alice", "bob")
     assert sel.resolve(all_assets) == _asset_keys_of({alice, bob})
 


### PR DESCRIPTION
### Summary & Motivation

Tweaks `AssetSelection`:

- `AssetSelection`-creating methods are now runtime-type checked
- `AssetSelection.keys` now takes `CoerceableToAssetKey` instead of just string

### How I Tested These Changes

Unit tests
