### PR TITLE
[dagit] Make the warning icon optional in AppTopNav

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
@@ -15,9 +15,15 @@ import {WebSocketStatus} from './WebSocketProvider';
 interface Props {
   searchPlaceholder: string;
   rightOfSearchBar?: React.ReactNode;
+  showStatusWarningIcon?: boolean;
 }
 
-export const AppTopNav: React.FC<Props> = ({children, rightOfSearchBar, searchPlaceholder}) => {
+export const AppTopNav: React.FC<Props> = ({
+  children,
+  rightOfSearchBar,
+  searchPlaceholder,
+  showStatusWarningIcon = true,
+}) => {
   const history = useHistory();
 
   return (
@@ -51,7 +57,7 @@ export const AppTopNav: React.FC<Props> = ({children, rightOfSearchBar, searchPl
             <TopNavLink to="/instance">
               <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
                 Status
-                <InstanceWarningIcon />
+                {showStatusWarningIcon ? <InstanceWarningIcon /> : null}
               </Box>
             </TopNavLink>
           </ShortcutHandler>


### PR DESCRIPTION
### Summary & Motivation

In Cloud, we don't need the warning icon next to the "Status" top nav item, since in that context, daemon errors are our problem, not the user's. By not rendering the icon, we can skip performing our most common GraphQL query, `InstanceWarningQuery`.

### How I Tested These Changes

Jest specs.

Set `showStatusWarningIcon` to false in dagit-app, verify that the icon doesn't appear even though I have no daemons running.
