### PR TITLE
Add a dagster_task_definition_dict to dagster-aws (not yet used)

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_tasks.py
@@ -1,0 +1,46 @@
+from dagster_aws.ecs.tasks import dagster_task_definition_dict
+
+
+def test_create_dagster_task_definition_dict():
+    task_def_dict = dagster_task_definition_dict(
+        "my_task",
+        "foo_image:bar",
+        ["dagster", "api", "execute_run"],
+        execution_role_arn="fake-role",
+        region_name="us_east_=",
+        task_role_arn="fake-task-role",
+        env={
+            "FOO_ENV_VAR": "BAR_VALUE",
+        },
+        secrets={
+            "FOO_SECRET": "BAR_SECRET_VALUE",
+        },
+        log_group="my-log-group",
+    )
+
+    assert task_def_dict == {
+        "family": "my_task",
+        "requiresCompatibilities": ["FARGATE"],
+        "networkMode": "awsvpc",
+        "containerDefinitions": [
+            {
+                "name": "my_task",
+                "image": "foo_image:bar",
+                "environment": [{"name": "FOO_ENV_VAR", "value": "BAR_VALUE"}],
+                "command": ["dagster", "api", "execute_run"],
+                "logConfiguration": {
+                    "logDriver": "awslogs",
+                    "options": {
+                        "awslogs-group": "my-log-group",
+                        "awslogs-region": "us_east_=",
+                        "awslogs-stream-prefix": "my_task",
+                    },
+                },
+                "secrets": [{"name": "FOO_SECRET", "valueFrom": "BAR_SECRET_VALUE"}],
+            }
+        ],
+        "executionRoleArn": "fake-role",
+        "cpu": "256",
+        "memory": "512",
+        "taskRoleArn": "fake-task-role",
+    }


### PR DESCRIPTION
Summary:
Would like to add a path to the EcsRunLauncher creating a task definition from scratch. Pulled this code from the ECS agent for that purpose, will start using it next.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
