### PR TITLE
[dagster-dbt] group names on dbt assets

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -309,6 +309,11 @@ class AssetsDefinition(ResourceAddable):
                 f"Group name already exists on assets {', '.join(defined_group_names)}"
             )
 
+        replaced_group_names = {
+            output_asset_key_replacements.get(key, key): group_name
+            for key, group_name in self.group_names.items()
+        }
+
         return self.__class__(
             asset_keys_by_input_name={
                 input_name: input_asset_key_replacements.get(key, key)
@@ -337,7 +342,7 @@ class AssetsDefinition(ResourceAddable):
                 output_asset_key_replacements.get(key, key) for key in self._selected_asset_keys
             },
             resource_defs=self.resource_defs,
-            group_names={**self.group_names, **group_names},
+            group_names={**replaced_group_names, **group_names},
         )
 
     def subset_for(self, selected_asset_keys: AbstractSet[AssetKey]) -> "AssetsDefinition":

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
@@ -81,6 +81,17 @@ def test_subset_for(subset, expected_keys, expected_inputs, expected_outputs):
     assert subbed.asset_deps == abc_.asset_deps
 
 
+def test_retain_group():
+    @asset(group_name="foo")
+    def bar():
+        pass
+
+    replaced = bar.with_prefix_or_group(
+        output_asset_key_replacements={AssetKey(["bar"]): AssetKey(["baz"])}
+    )
+    assert replaced.group_names[AssetKey("baz")] == "foo"
+
+
 def test_chain_replace_and_subset_for():
     @multi_asset(
         outs={"a": Out(), "b": Out(), "c": Out()},

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -147,7 +147,7 @@ def _dbt_nodes_to_assets(
 ) -> AssetsDefinition:
 
     outs: Dict[str, Out] = {}
-    group_names: Dict[AssetKey, str] = {}
+    group_names: Dict[AssetKey, Optional[str]] = {}
     asset_ins: Dict[AssetKey, Tuple[str, In]] = {}
 
     asset_deps: Dict[AssetKey, Set[AssetKey]] = {}

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -147,7 +147,7 @@ def _dbt_nodes_to_assets(
 ) -> AssetsDefinition:
 
     outs: Dict[str, Out] = {}
-    group_names: Dict[AssetKey, Optional[str]] = {}
+    group_names: Dict[AssetKey, str] = {}
     asset_ins: Dict[AssetKey, Tuple[str, In]] = {}
 
     asset_deps: Dict[AssetKey, Set[AssetKey]] = {}
@@ -192,7 +192,9 @@ def _dbt_nodes_to_assets(
         asset_deps[asset_key] = cur_asset_deps
 
         # set the group for this asset
-        group_names[asset_key] = _get_node_group_name(node_info)
+        group_name = _get_node_group_name(node_info)
+        if group_name is not None:
+            group_names[asset_key] = group_name
 
     # prevent op name collisions between multiple dbt multi-assets
     op_name = f"run_dbt_{package_name}"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -110,6 +110,12 @@ def assert_assets_match_project(dbt_assets):
         assert dbt_assets[0].asset_keys_by_output_name[output_name] == asset_key
         assert dbt_assets[0].asset_deps[asset_key] == {AssetKey(["sort_by_calories"])}
 
+    for asset_key, group_name in dbt_assets[0].group_names.items():
+        if asset_key == AssetKey(["subdir_schema", "least_caloric"]):
+            assert group_name == "subdir"
+        else:
+            assert group_name == "default"
+
     assert dbt_assets[0].asset_keys_by_output_name["sort_by_calories"] == AssetKey(
         ["sort_by_calories"]
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -23,7 +23,15 @@ from dagster.core.asset_defs import build_assets_job
 from dagster.utils import file_relative_path
 
 
-def test_load_from_manifest_json():
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        None,
+        "snowflake",
+        ["snowflake", "dbt_schema"],
+    ],
+)
+def test_load_from_manifest_json(prefix):
     manifest_path = file_relative_path(__file__, "sample_manifest.json")
     with open(manifest_path, "r", encoding="utf8") as f:
         manifest_json = json.load(f)
@@ -32,8 +40,8 @@ def test_load_from_manifest_json():
     with open(run_results_path, "r", encoding="utf8") as f:
         run_results_json = json.load(f)
 
-    dbt_assets = load_assets_from_dbt_manifest(manifest_json=manifest_json)
-    assert_assets_match_project(dbt_assets)
+    dbt_assets = load_assets_from_dbt_manifest(manifest_json=manifest_json, key_prefix=prefix)
+    assert_assets_match_project(dbt_assets, prefix)
 
     dbt = MagicMock()
     dbt.get_run_results_json.return_value = run_results_json
@@ -89,7 +97,12 @@ def test_runtime_metadata_fn():
     ]
 
 
-def assert_assets_match_project(dbt_assets):
+def assert_assets_match_project(dbt_assets, prefix=None):
+    if prefix is None:
+        prefix = []
+    elif isinstance(prefix, str):
+        prefix = [prefix]
+
     assert len(dbt_assets) == 1
     assets_op = dbt_assets[0].op
     assert assets_op.tags == {"kind": "dbt"}
@@ -105,21 +118,21 @@ def assert_assets_match_project(dbt_assets):
         "sort_hot_cereals_by_calories",
         "cold_schema/sort_cold_cereals_by_calories",
     ]:
-        asset_key = AssetKey(asset_name.split("/"))
+        asset_key = AssetKey(prefix + asset_name.split("/"))
         output_name = asset_key.path[-1]
         assert dbt_assets[0].asset_keys_by_output_name[output_name] == asset_key
-        assert dbt_assets[0].asset_deps[asset_key] == {AssetKey(["sort_by_calories"])}
+        assert dbt_assets[0].asset_deps[asset_key] == {AssetKey(prefix + ["sort_by_calories"])}
 
     for asset_key, group_name in dbt_assets[0].group_names.items():
-        if asset_key == AssetKey(["subdir_schema", "least_caloric"]):
+        if asset_key == AssetKey(prefix + ["subdir_schema", "least_caloric"]):
             assert group_name == "subdir"
         else:
             assert group_name == "default"
 
     assert dbt_assets[0].asset_keys_by_output_name["sort_by_calories"] == AssetKey(
-        ["sort_by_calories"]
+        prefix + ["sort_by_calories"]
     )
-    assert not dbt_assets[0].asset_deps[AssetKey(["sort_by_calories"])]
+    assert not dbt_assets[0].asset_deps[AssetKey(prefix + ["sort_by_calories"])]
 
 
 def test_fail_immediately(
@@ -214,9 +227,17 @@ def test_basic(
         assert len(observations) == 0
 
 
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        None,
+        "snowflake",
+        ["snowflake", "dbt_schema"],
+    ],
+)
 @pytest.mark.parametrize("use_build", [True, False])
 def test_select_from_project(
-    dbt_seed, conn_string, test_project_dir, dbt_config_dir, use_build
+    dbt_seed, conn_string, test_project_dir, dbt_config_dir, use_build, prefix
 ):  # pylint: disable=unused-argument
 
     dbt_assets = load_assets_from_dbt_project(
@@ -224,7 +245,17 @@ def test_select_from_project(
         dbt_config_dir,
         select="sort_by_calories subdir.least_caloric",
         use_build_command=use_build,
+        key_prefix=prefix,
     )
+
+    if prefix is None:
+        prefix = []
+    elif isinstance(prefix, str):
+        prefix = [prefix]
+    assert dbt_assets[0].asset_keys == {
+        AssetKey(prefix + suffix)
+        for suffix in (["sort_by_calories"], ["subdir_schema", "least_caloric"])
+    }
 
     assert dbt_assets[0].op.name == "run_dbt_dagster_dbt_test_project_e4753"
 


### PR DESCRIPTION
### Summary & Motivation

UPDATE:

for now, just support one level of grouping, as this seems the most backwards-compatible.

I also noticed a bug w/ how the group stuff works, where if you remapped the asset keys, the group info would be left behind. This fixes that.

### How I Tested These Changes
