### PR TITLE
[dagit] Repair issue where last ten runs are missing for job

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -206,12 +206,12 @@ export const InstanceOverviewPage = () => {
   }, [bucketed, visibleRepos, searchValue]);
 
   const lastTenRunsFlattened = React.useMemo(() => {
-    if (!lastTenRunsData) {
+    if (lastTenRunsLoading || !lastTenRunsData) {
       return null;
     }
 
     const flattened: {[key: string]: RunTimeFragment[]} = {};
-    if (!lastTenRunsLoading && lastTenRunsData?.workspaceOrError.__typename === 'Workspace') {
+    if (lastTenRunsData.workspaceOrError.__typename === 'Workspace') {
       for (const locationEntry of lastTenRunsData.workspaceOrError.locationEntries) {
         if (
           locationEntry.__typename === 'WorkspaceLocationEntry' &&
@@ -243,7 +243,7 @@ export const InstanceOverviewPage = () => {
     const appendRuns = (jobItem: JobItem) => {
       const {job, repoAddress} = jobItem;
       const jobKey = makeJobKey(repoAddress, job.name);
-      const matchingRuns = lastTenRunsFlattened ? lastTenRunsFlattened[jobKey] : [];
+      const matchingRuns = lastTenRunsFlattened ? lastTenRunsFlattened[jobKey] || [] : [];
       return {...jobItem, runs: [...matchingRuns].reverse()};
     };
 


### PR DESCRIPTION
### Summary & Motivation

The Instance Overview page can crash if we're missing "last ten runs" information for a job.

I introduced this inadvertently in https://github.com/dagster-io/dagster/pull/8297. Since the loading state is now used to bail out of flattening last-10 run information but NOT return null, this useMemo now returns an empty object. This has no run data, so a JS error occurs.

TypeScript misses this because it's unsound when accessing keys in objects. Maybe at some point we should make this super strict, but it's a bit annoying so they've never enabled strictness on this by default.

Fix this by bailing early in the loading condition, and as a safeguard, using an empty array when no last-10 data exists for the job.

### How I Tested These Changes

View Instance Overview in a state that currently throws an error, verify that the error is gone.
