### PR TITLE
[dagit] Small left-nav design adjustments

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/LeftNavItem.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavItem.tsx
@@ -111,7 +111,7 @@ export const LeftNavItem = React.forwardRef(
       <ItemContainer ref={ref}>
         <Item $active={active} to={path}>
           <Icon name={leftIcon} color={active ? Colors.Blue700 : Colors.Dark} />
-          <div>{label}</div>
+          {label}
         </Item>
         {rightIcon()}
       </ItemContainer>

--- a/js_modules/dagit/packages/core/src/nav/getLeftNavItemsForOption.tsx
+++ b/js_modules/dagit/packages/core/src/nav/getLeftNavItemsForOption.tsx
@@ -80,12 +80,14 @@ export const getJobItemsForOption = (option: DagsterRepoOption) => {
 };
 
 const Label = styled.div<{$hasIcon: boolean}>`
+  flex: 1;
+  min-width: 0;
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
   gap: 8px;
-  width: ${({$hasIcon}) => ($hasIcon ? '260px' : '280px')};
+  margin-right: ${({$hasIcon}) => ($hasIcon ? '20px' : '0')};
 `;
 
 const LabelTooltipStyles = JSON.stringify({

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceRepoRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceRepoRoot.tsx
@@ -116,10 +116,7 @@ export const WorkspaceRepoRoot: React.FC<Props> = (props) => {
           <Route path="/workspace/:repoPath/graphs" exact>
             <RepositoryGraphsList repoAddress={repoAddress} />
           </Route>
-          <Route
-            path="/workspace/:repoPath/(.*)?"
-            render={() => <Redirect to={workspacePathFromAddress(repoAddress, `/jobs`)} />}
-          />
+          <Route path="/workspace/:repoPath/(.*)?" render={() => <Redirect to={tabs[0].href} />} />
         </Switch>
       </Container>
     </Box>


### PR DESCRIPTION
### Summary & Motivation

This PR makes several small tweaks to the left nav:

- If you only have asset groups or jobs (not both), we don't show the subheadings. In scenarios where you had a lot of repos with just asset groups / jobs, they got kind of repetitive. 

- If you have so many repos that the left nav scrolls, scroll the "active" item offscreen and click a section to expand it, the render would cause the nav to scroll back to the active item. This is annoying because you had to scroll back to the section you opened to click a job / asset group. I memoized the sections so the active section isn't re-rendering and moving you back.

- The width of the nav items was fixed (230px or 250px without a right hand icon), but the width of the nav itself varies based on whether there's a scrollbar. This caused the "Legacy" tag and the "Sensor" icon to overlap if the scrollbar was visible (at least in Firefox for me). To fix this I made the label a flex child with a min-width so it uses the available space, and accounted for the right icon with a margin.

I also fixed a small bug where going to the WorkspaceRoot would jump you to Jobs, which is now Tab #2. To make sure this doesn't happen in the future I replaced the fallthrough path with a reference to the tab path.

### How I Tested These Changes

![Screen Shot 2022-06-09 at 3 00 20 PM](https://user-images.githubusercontent.com/1037212/172950099-9c88f69f-106a-41ec-827c-d153300ae2e2.png)

