### PR TITLE
Type annotations for IOManager

### DIFF
--- a/python_modules/dagster/dagster/config/config_schema.py
+++ b/python_modules/dagster/dagster/config/config_schema.py
@@ -6,14 +6,14 @@ if TYPE_CHECKING:
     from dagster.config.config_type import ConfigType
     from dagster.config.field import Field
 
-# Eventually, the below `ConfigSchemaType` should be renamed to `ConfigSchema` and the class
+# Eventually, the below `UserConfigSchema` should be renamed to `ConfigSchema` and the class
 # definition should be dropped. The reason we don't do this now is that sphinx autodoc doesn't
 # support type aliases, so there is no good way to gracefully attach a docstring to this and have it
 # show up in the docs. See: https://github.com/sphinx-doc/sphinx/issues/8934
 #
 # Unfortunately mypy doesn't support recursive types, which would be used to properly define the
 # List/Dict elements of this union: `Dict[str, ConfigSchema]`, `List[ConfigSchema]`.
-ConfigSchemaType: TypeAlias = Union[
+UserConfigSchema: TypeAlias = Union[
     Type[Union[bool, float, int, str]],
     Type[Union[dict, list]],
     "ConfigType",

--- a/python_modules/dagster/dagster/config/config_type.py
+++ b/python_modules/dagster/dagster/config/config_type.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, cast
 
 import dagster._check as check
 from dagster.builtins import BuiltinEnum
-from dagster.config.config_schema import ConfigSchemaType
+from dagster.config.config_schema import UserConfigSchema
 from dagster.serdes import whitelist_for_serdes
 
 
@@ -370,7 +370,7 @@ class ScalarUnion(ConfigType):
     def __init__(
         self,
         scalar_type: typing.Any,
-        non_scalar_schema: ConfigSchemaType,
+        non_scalar_schema: UserConfigSchema,
         _key: Optional[str] = None,
     ):
         from .field import resolve_to_config_type

--- a/python_modules/dagster/dagster/config/field.py
+++ b/python_modules/dagster/dagster/config/field.py
@@ -2,7 +2,7 @@ from typing import Any, Union, overload
 
 import dagster._check as check
 from dagster.builtins import BuiltinEnum
-from dagster.config.config_schema import ConfigSchemaType
+from dagster.config.config_schema import UserConfigSchema
 from dagster.core.errors import DagsterInvalidConfigError, DagsterInvalidDefinitionError
 from dagster.serdes import serialize_value
 from dagster.seven import is_subclass
@@ -37,7 +37,7 @@ VALID_CONFIG_DESC = """
 
 
 @overload
-def resolve_to_config_type(dagster_type: Union[ConfigType, ConfigSchemaType]) -> ConfigType:
+def resolve_to_config_type(dagster_type: Union[ConfigType, UserConfigSchema]) -> ConfigType:
     pass
 
 

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -17,7 +17,7 @@ from typing import (
 import dagster._check as check
 from dagster.builtins import Nothing
 from dagster.config import Field
-from dagster.config.config_schema import ConfigSchemaType
+from dagster.config.config_schema import UserConfigSchema
 from dagster.core.decorator_utils import get_function_params, get_valid_name_permutations
 from dagster.core.definitions.decorators.op_decorator import _Op
 from dagster.core.definitions.events import AssetKey, CoercibleToAssetKeyPrefix
@@ -58,7 +58,7 @@ def asset(
     non_argument_deps: Optional[Union[Set[AssetKey], Set[str]]] = ...,
     metadata: Optional[Mapping[str, Any]] = ...,
     description: Optional[str] = ...,
-    config_schema: Optional[ConfigSchemaType] = None,
+    config_schema: Optional[UserConfigSchema] = None,
     required_resource_keys: Optional[Set[str]] = ...,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = ...,
     io_manager_def: Optional[IOManagerDefinition] = ...,
@@ -81,7 +81,7 @@ def asset(
     non_argument_deps: Optional[Union[Set[AssetKey], Set[str]]] = None,
     metadata: Optional[Mapping[str, Any]] = None,
     description: Optional[str] = None,
-    config_schema: Optional[ConfigSchemaType] = None,
+    config_schema: Optional[UserConfigSchema] = None,
     required_resource_keys: Optional[Set[str]] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     io_manager_def: Optional[IOManagerDefinition] = None,
@@ -196,7 +196,7 @@ class _Asset:
         non_argument_deps: Optional[Set[AssetKey]] = None,
         metadata: Optional[Mapping[str, Any]] = None,
         description: Optional[str] = None,
-        config_schema: Optional[ConfigSchemaType] = None,
+        config_schema: Optional[UserConfigSchema] = None,
         required_resource_keys: Optional[Set[str]] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         io_manager: Optional[Union[str, IOManagerDefinition]] = None,
@@ -310,7 +310,7 @@ def multi_asset(
     ins: Optional[Mapping[str, AssetIn]] = None,
     non_argument_deps: Optional[Union[Set[AssetKey], Set[str]]] = None,
     description: Optional[str] = None,
-    config_schema: Optional[ConfigSchemaType] = None,
+    config_schema: Optional[UserConfigSchema] = None,
     required_resource_keys: Optional[Set[str]] = None,
     compute_kind: Optional[str] = None,
     internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,

--- a/python_modules/dagster/dagster/core/definitions/decorators/composite_solid_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/composite_solid_decorator.py
@@ -2,7 +2,7 @@ from functools import update_wrapper
 from typing import Any, Callable, List, Optional, Union, overload
 
 import dagster._check as check
-from dagster.config.config_schema import ConfigSchemaType
+from dagster.config.config_schema import UserConfigSchema
 from dagster.core.decorator_utils import format_docstring_for_description
 
 from ..composition import do_composition, get_validated_config_mapping
@@ -18,7 +18,7 @@ class _CompositeSolid:
         input_defs: Optional[List[InputDefinition]] = None,
         output_defs: Optional[List[OutputDefinition]] = None,
         description: Optional[str] = None,
-        config_schema: Optional[ConfigSchemaType] = None,
+        config_schema: Optional[UserConfigSchema] = None,
         config_fn: Optional[Callable[[dict], dict]] = None,
     ):
         self.name = check.opt_str_param(name, "name")
@@ -83,7 +83,7 @@ def composite_solid(
     input_defs: Optional[List[InputDefinition]] = ...,
     output_defs: Optional[List[OutputDefinition]] = ...,
     description: Optional[str] = ...,
-    config_schema: Optional[ConfigSchemaType] = ...,
+    config_schema: Optional[UserConfigSchema] = ...,
     config_fn: Optional[Callable[[dict], dict]] = ...,
 ) -> _CompositeSolid:
     ...
@@ -94,7 +94,7 @@ def composite_solid(
     input_defs: Optional[List[InputDefinition]] = None,
     output_defs: Optional[List[OutputDefinition]] = None,
     description: Optional[str] = None,
-    config_schema: Optional[ConfigSchemaType] = None,
+    config_schema: Optional[UserConfigSchema] = None,
     config_fn: Optional[Callable[[dict], dict]] = None,
 ) -> Union[CompositeSolidDefinition, _CompositeSolid]:
     """Create a composite solid with the specified parameters from the decorated composition

--- a/python_modules/dagster/dagster/core/definitions/decorators/config_mapping_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/config_mapping_decorator.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Optional, Union, overload
 
 import dagster._check as check
-from dagster.config.config_schema import ConfigSchemaType
+from dagster.config.config_schema import UserConfigSchema
 
 from ..config import ConfigMapping
 
@@ -9,7 +9,7 @@ from ..config import ConfigMapping
 class _ConfigMapping:
     def __init__(
         self,
-        config_schema: Optional[ConfigSchemaType] = None,
+        config_schema: Optional[UserConfigSchema] = None,
         receive_processed_config_values: Optional[bool] = None,
     ):
         self.config_schema = config_schema
@@ -37,7 +37,7 @@ def config_mapping(
 @overload
 def config_mapping(
     config_fn: None = ...,
-    config_schema: ConfigSchemaType = ...,
+    config_schema: UserConfigSchema = ...,
     receive_processed_config_values: Optional[bool] = ...,
 ) -> Union[_ConfigMapping, ConfigMapping]:
     ...
@@ -45,7 +45,7 @@ def config_mapping(
 
 def config_mapping(
     config_fn: Optional[Callable[..., Any]] = None,
-    config_schema: Optional[ConfigSchemaType] = None,
+    config_schema: Optional[UserConfigSchema] = None,
     receive_processed_config_values: Optional[bool] = None,
 ) -> Union[ConfigMapping, _ConfigMapping]:
     """Create a config mapping with the specified parameters from the decorated function.

--- a/python_modules/dagster/dagster/core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/op_decorator.py
@@ -14,7 +14,7 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster.config.config_schema import ConfigSchemaType
+from dagster.config.config_schema import UserConfigSchema
 from dagster.core.decorator_utils import format_docstring_for_description
 
 from ....seven.typing import get_origin
@@ -192,7 +192,7 @@ def op(
     description: Optional[str] = ...,
     ins: Optional[Dict[str, In]] = ...,
     out: Optional[Union[Out, Dict[str, Out]]] = ...,
-    config_schema: Optional[ConfigSchemaType] = ...,
+    config_schema: Optional[UserConfigSchema] = ...,
     required_resource_keys: Optional[Set[str]] = ...,
     tags: Optional[Dict[str, Any]] = ...,
     version: Optional[str] = ...,
@@ -208,7 +208,7 @@ def op(
     description: Optional[str] = None,
     ins: Optional[Dict[str, In]] = None,
     out: Optional[Union[Out, Mapping[str, Out]]] = None,
-    config_schema: Optional[ConfigSchemaType] = None,
+    config_schema: Optional[UserConfigSchema] = None,
     required_resource_keys: Optional[Set[str]] = None,
     tags: Optional[Dict[str, Any]] = None,
     version: Optional[str] = None,

--- a/python_modules/dagster/dagster/core/definitions/decorators/pipeline_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/pipeline_decorator.py
@@ -2,7 +2,7 @@ from functools import update_wrapper
 from typing import Any, Callable, Dict, List, Optional, Set, Union, overload
 
 import dagster._check as check
-from dagster.config.config_schema import ConfigSchemaType
+from dagster.config.config_schema import UserConfigSchema
 from dagster.core.decorator_utils import format_docstring_for_description
 from dagster.core.definitions.policy import RetryPolicy
 from dagster.utils.backcompat import experimental_arg_warning
@@ -28,7 +28,7 @@ class _Pipeline:
         hook_defs: Optional[Set[HookDefinition]] = None,
         input_defs: Optional[List[InputDefinition]] = None,
         output_defs: Optional[List[OutputDefinition]] = None,
-        config_schema: Optional[ConfigSchemaType] = None,
+        config_schema: Optional[UserConfigSchema] = None,
         config_fn: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
         solid_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
@@ -125,7 +125,7 @@ def pipeline(
     hook_defs: Optional[Set[HookDefinition]] = ...,
     input_defs: Optional[List[InputDefinition]] = ...,
     output_defs: Optional[List[OutputDefinition]] = ...,
-    config_schema: Optional[ConfigSchemaType] = ...,
+    config_schema: Optional[UserConfigSchema] = ...,
     config_fn: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = ...,
     solid_retry_policy: Optional[RetryPolicy] = ...,
     version_strategy: Optional[VersionStrategy] = ...,
@@ -142,7 +142,7 @@ def pipeline(
     hook_defs: Optional[Set[HookDefinition]] = None,
     input_defs: Optional[List[InputDefinition]] = None,
     output_defs: Optional[List[OutputDefinition]] = None,
-    config_schema: Optional[ConfigSchemaType] = None,
+    config_schema: Optional[UserConfigSchema] = None,
     config_fn: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
     solid_retry_policy: Optional[RetryPolicy] = None,
     version_strategy: Optional[VersionStrategy] = None,

--- a/python_modules/dagster/dagster/core/definitions/decorators/solid_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/solid_decorator.py
@@ -14,7 +14,7 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster.config.config_schema import ConfigSchemaType
+from dagster.config.config_schema import UserConfigSchema
 from dagster.core.decorator_utils import format_docstring_for_description
 from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.types.dagster_type import DagsterTypeKind
@@ -75,7 +75,7 @@ class _Solid:
         output_defs: Optional[Sequence[OutputDefinition]] = None,
         description: Optional[str] = None,
         required_resource_keys: Optional[AbstractSet[str]] = None,
-        config_schema: Optional[ConfigSchemaType] = None,
+        config_schema: Optional[UserConfigSchema] = None,
         tags: Optional[Dict[str, Any]] = None,
         version: Optional[str] = None,
         decorator_takes_context: Optional[bool] = True,
@@ -156,7 +156,7 @@ def solid(
     description: Optional[str] = ...,
     input_defs: Optional[Sequence[InputDefinition]] = ...,
     output_defs: Optional[Sequence[OutputDefinition]] = ...,
-    config_schema: Optional[ConfigSchemaType] = ...,
+    config_schema: Optional[UserConfigSchema] = ...,
     required_resource_keys: Optional[AbstractSet[str]] = ...,
     tags: Optional[Dict[str, Any]] = ...,
     version: Optional[str] = ...,
@@ -170,7 +170,7 @@ def solid(
     description: Optional[str] = None,
     input_defs: Optional[Sequence[InputDefinition]] = None,
     output_defs: Optional[Sequence[OutputDefinition]] = None,
-    config_schema: Optional[ConfigSchemaType] = None,
+    config_schema: Optional[UserConfigSchema] = None,
     required_resource_keys: Optional[AbstractSet[str]] = None,
     tags: Optional[Dict[str, Any]] = None,
     version: Optional[str] = None,

--- a/python_modules/dagster/dagster/core/definitions/definition_config_schema.py
+++ b/python_modules/dagster/dagster/core/definitions/definition_config_schema.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union
 
 import dagster._check as check
-from dagster.config.config_schema import ConfigSchemaType
+from dagster.config.config_schema import UserConfigSchema
 from dagster.config.config_type import ConfigAnyInstance, ConfigType
 from dagster.config.evaluate_value_result import EvaluateValueResult
 from dagster.config.field import Field
@@ -13,9 +13,15 @@ from dagster.core.errors import DagsterConfigMappingFunctionError, user_code_err
 if TYPE_CHECKING:
     from dagster.core.definitions.configurable import ConfigurableDefinition
 
+CoercableToConfigSchema = Union[
+    None,
+    UserConfigSchema,
+    "IDefinitionConfigSchema",
+]
+
 
 def convert_user_facing_definition_config_schema(
-    potential_schema: Optional[Union["IDefinitionConfigSchema", ConfigSchemaType]]
+    potential_schema: CoercableToConfigSchema,
 ) -> "IDefinitionConfigSchema":
     if potential_schema is None:
         return DefinitionConfigSchema(Field(ConfigAnyInstance, is_required=False))

--- a/python_modules/dagster/dagster/core/definitions/executor_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/executor_definition.py
@@ -7,7 +7,7 @@ from typing_extensions import TypeAlias
 import dagster._check as check
 from dagster.builtins import Int
 from dagster.config import Field, Selector
-from dagster.config.config_schema import ConfigSchemaType
+from dagster.config.config_schema import UserConfigSchema
 from dagster.core.definitions.configurable import (
     ConfiguredDefinitionConfigSchema,
     NamedConfigurableDefinition,
@@ -78,7 +78,7 @@ class ExecutorDefinition(NamedConfigurableDefinition):
     def __init__(
         self,
         name: str,
-        config_schema: Optional[ConfigSchemaType] = None,
+        config_schema: Optional[UserConfigSchema] = None,
         requirements: Union[
             ExecutorRequirementsFunction, Optional[List[ExecutorRequirement]]
         ] = None,
@@ -178,7 +178,7 @@ def executor(name: ExecutorCreationFunction) -> ExecutorDefinition:
 @overload
 def executor(
     name: Optional[str] = ...,
-    config_schema: Optional[ConfigSchemaType] = ...,
+    config_schema: Optional[UserConfigSchema] = ...,
     requirements: Optional[Union[ExecutorRequirementsFunction, List[ExecutorRequirement]]] = ...,
 ) -> "_ExecutorDecoratorCallable":
     ...
@@ -186,7 +186,7 @@ def executor(
 
 def executor(
     name: Union[ExecutorCreationFunction, Optional[str]] = None,
-    config_schema: Optional[ConfigSchemaType] = None,
+    config_schema: Optional[UserConfigSchema] = None,
     requirements: Optional[Union[ExecutorRequirementsFunction, List[ExecutorRequirement]]] = None,
 ) -> Union[ExecutorDefinition, "_ExecutorDecoratorCallable"]:
     """Define an executor.

--- a/python_modules/dagster/dagster/core/definitions/input.py
+++ b/python_modules/dagster/dagster/core/definitions/input.py
@@ -73,6 +73,12 @@ class InputDefinition:
             partitions from the InputContext) which should be associated with this InputDefinition.
     """
 
+    _name: Optional[str]
+    _type_not_set: bool
+    _dagster_type: DagsterType
+    _description: Optional[str]
+    _default_value: Any
+
     def __init__(
         self,
         name=None,

--- a/python_modules/dagster/dagster/core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_definition.py
@@ -13,6 +13,8 @@ from typing import (
     overload,
 )
 
+from typing_extensions import TypeAlias
+
 import dagster._check as check
 from dagster.config.config_schema import ConfigSchemaType
 from dagster.core.decorator_utils import format_docstring_for_description
@@ -48,6 +50,8 @@ from .scoped_resources_builder import (  # type: ignore
 
 if TYPE_CHECKING:
     from dagster.core.execution.resources_init import InitResourceContext
+
+ResourceFunction: TypeAlias = Callable[["InitResourceContext"], Any]
 
 
 def is_context_provided(params: List[funcsigs.Parameter]) -> bool:
@@ -173,7 +177,10 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources):
         )
 
     def copy_for_configured(
-        self, description: Optional[str], config_schema: IDefinitionConfigSchema, _
+        self,
+        description: Optional[str],
+        config_schema: Union[ConfigSchemaType, IDefinitionConfigSchema],
+        _,
     ) -> "ResourceDefinition":
         return ResourceDefinition(
             config_schema=config_schema,

--- a/python_modules/dagster/dagster/core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_definition.py
@@ -58,7 +58,7 @@ ResourceFunction: TypeAlias = Union[
 
 
 def is_context_provided(fn: ResourceFunction) -> TypeGuard[ResourceFunctionWithContext]:
-    return len(get_function_params(fn)) == 1
+    return len(get_function_params(fn)) >= 1
 
 
 class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources):

--- a/python_modules/dagster/dagster/core/definitions/resource_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_invocation.py
@@ -6,7 +6,6 @@ import dagster._check as check
 from dagster.core.errors import DagsterInvalidConfigError, DagsterInvalidInvocationError
 
 from ...config import Shape
-from ..decorator_utils import get_function_params
 from .resource_requirement import ensure_requirements_satisfied
 
 if TYPE_CHECKING:
@@ -21,12 +20,13 @@ def resource_invocation_result(
 
     if not resource_def.resource_fn:
         return None
-    init_context = _check_invocation_requirements(resource_def, init_context)
+    _init_context = _check_invocation_requirements(resource_def, init_context)
 
+    resource_fn = resource_def.resource_fn
     val_or_gen = (
-        resource_def.resource_fn(init_context)
-        if is_context_provided(get_function_params(resource_def.resource_fn))
-        else resource_def.resource_fn()
+        resource_fn(_init_context)
+        if is_context_provided(resource_fn)
+        else resource_fn()  # type: ignore
     )
     if inspect.isgenerator(val_or_gen):
 

--- a/python_modules/dagster/dagster/core/definitions/solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_definition.py
@@ -14,7 +14,7 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster.config.config_schema import ConfigSchemaType
+from dagster.config.config_schema import UserConfigSchema
 from dagster.core.definitions.dependency import NodeHandle
 from dagster.core.definitions.policy import RetryPolicy
 from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
@@ -105,7 +105,7 @@ class SolidDefinition(NodeDefinition):
         input_defs: Sequence[InputDefinition],
         compute_fn: Union[Callable[..., Any], "DecoratedSolidFunction"],
         output_defs: Sequence[OutputDefinition],
-        config_schema: Optional[Union[ConfigSchemaType, IDefinitionConfigSchema]] = None,
+        config_schema: Optional[Union[UserConfigSchema, IDefinitionConfigSchema]] = None,
         description: Optional[str] = None,
         tags: Optional[Dict[str, str]] = None,
         required_resource_keys: Optional[AbstractSet[str]] = None,

--- a/python_modules/dagster/dagster/core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/core/execution/resources_init.py
@@ -4,7 +4,6 @@ from contextlib import ContextDecorator
 from typing import AbstractSet, Any, Callable, Deque, Dict, Optional, cast
 
 import dagster._check as check
-from dagster.core.decorator_utils import get_function_params
 from dagster.core.definitions.pipeline_definition import PipelineDefinition
 from dagster.core.definitions.resource_definition import (
     ResourceDefinition,
@@ -309,7 +308,7 @@ def single_resource_event_generator(context, resource_name, resource_def):
                 with time_execution_scope() as timer_result:
                     resource_or_gen = (
                         resource_def.resource_fn(context)
-                        if is_context_provided(get_function_params(resource_def.resource_fn))
+                        if is_context_provided(resource_def.resource_fn)
                         else resource_def.resource_fn()
                     )
 

--- a/python_modules/dagster/dagster/core/storage/io_manager.py
+++ b/python_modules/dagster/dagster/core/storage/io_manager.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from functools import update_wrapper
-from typing import TYPE_CHECKING, AbstractSet, Callable, Optional, Set, Union, cast, overload
+from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Optional, Set, Union, cast, overload
 
 from typing_extensions import TypeAlias
 
@@ -22,7 +22,10 @@ if TYPE_CHECKING:
     from dagster.core.execution.context.input import InputContext
     from dagster.core.execution.context.output import OutputContext
 
-IOManagerFunction: TypeAlias = Callable[["InitResourceContext"], "IOManager"]
+IOManagerFunction: TypeAlias = Union[
+    Callable[["InitResourceContext"], "IOManager"],
+    Callable[[], "IOManager"],
+]
 
 
 class IOManagerDefinition(ResourceDefinition, IInputManagerDefinition, IOutputManagerDefinition):
@@ -119,7 +122,7 @@ class IOManager(InputManager, OutputManager):
     """
 
     @abstractmethod
-    def load_input(self, context: "InputContext") -> object:
+    def load_input(self, context: "InputContext") -> Any:
         """User-defined method that loads an input to an op.
 
         Args:
@@ -131,7 +134,7 @@ class IOManager(InputManager, OutputManager):
         """
 
     @abstractmethod
-    def handle_output(self, context: "OutputContext", obj: object) -> None:
+    def handle_output(self, context: "OutputContext", obj: Any) -> None:
         """User-defined method that stores an output of an op.
 
         Args:

--- a/python_modules/dagster/dagster/core/storage/root_input_manager.py
+++ b/python_modules/dagster/dagster/core/storage/root_input_manager.py
@@ -10,8 +10,6 @@ from dagster.core.definitions.resource_definition import ResourceDefinition, is_
 from dagster.core.storage.input_manager import InputManager
 from dagster.utils.backcompat import experimental
 
-from ..decorator_utils import get_function_params
-
 
 class IInputManagerDefinition:
     @property
@@ -161,11 +159,7 @@ class RootInputManagerWrapper(RootInputManager):
         self._load_fn = load_fn
 
     def load_input(self, context):
-        return (
-            self._load_fn(context)
-            if is_context_provided(get_function_params(self._load_fn))
-            else self._load_fn()
-        )
+        return self._load_fn(context) if is_context_provided(self._load_fn) else self._load_fn()
 
 
 class _InputManagerDecoratorCallable:

--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
@@ -189,7 +189,7 @@ def emr_pyspark_step_launcher(context):
 
 emr_pyspark_step_launcher.__doc__ = "\n".join(
     "- **" + option + "**: " + (field.description or "")
-    for option, field in emr_pyspark_step_launcher.config_schema.config_type.fields.items()
+    for option, field in emr_pyspark_step_launcher.config_schema.config_type.fields.items()  # type: ignore
 )
 
 


### PR DESCRIPTION
### Summary & Motivation

Type annotations, plus one runtime logic change: confirm that an output context exists when calling `get_input_asset_{key,partitions}`.

### How I Tested These Changes

Existing tests
