### PR TITLE
[dagit] Don’t let description overflow on asset details page

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -63,7 +63,10 @@ export const AssetNodeDefinition: React.FC<{
             <Subheading>Description</Subheading>
             <DefinitionLocation assetNode={assetNode} repoAddress={repoAddress} />
           </Box>
-          <Box padding={{vertical: 16, horizontal: 24}} style={{flex: 1, minHeight: 120}}>
+          <Box
+            padding={{vertical: 16, horizontal: 24}}
+            style={{flex: 1, flexBasis: 'content', flexGrow: 0, minHeight: 120}}
+          >
             <Description
               description={assetNode.description || 'No description provided.'}
               maxHeight={260}


### PR DESCRIPTION
### Summary & Motivation

Recently this page became a flexbox and the min-height on this Box was giving the layout permission to crunch the content down, even if the text was larger than that. This sets the flex basis so that the "intrinsic content size" of the box goes from 120 up to 260 when the "Show More" label appears. (I faked larger content here to verify that different sizes work properly)

Before (via josh): 

![image](https://user-images.githubusercontent.com/1037212/172954465-9516b956-24b2-45d0-8618-32029e96a4f5.png)

After:
 
![image](https://user-images.githubusercontent.com/1037212/172954437-798d01f5-b8ff-4423-acb8-07c3584af8cb.png)




### How I Tested These Changes
