### PR TITLE
reorder concept super-sections in left nav

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -135,20 +135,36 @@
         ]
       },
       {
-        "title": "Resources",
+        "title": "Schedules, Sensors, & Partitions",
         "children": [
           {
-            "title": "Resources",
-            "path": "/concepts/resources"
+            "title": "Schedules",
+            "path": "/concepts/partitions-schedules-sensors/schedules"
+          },
+          {
+            "title": "Sensors",
+            "path": "/concepts/partitions-schedules-sensors/sensors"
+          },
+          {
+            "title": "Partitions",
+            "path": "/concepts/partitions-schedules-sensors/partitions"
+          },
+          {
+            "title": "Backfills",
+            "path": "/concepts/partitions-schedules-sensors/backfills"
           }
         ]
       },
       {
-        "title": "Testing",
+        "title": "IO Management",
         "children": [
           {
-            "title": "Testing",
-            "path": "/concepts/testing"
+            "title": "IO Managers",
+            "path": "/concepts/io-management/io-managers"
+          },
+          {
+            "title": "Unconnected Inputs",
+            "path": "/concepts/io-management/unconnected-inputs"
           }
         ]
       },
@@ -166,24 +182,24 @@
         ]
       },
       {
-        "title": "Dagster Types",
+        "title": "Repositories & Workspaces",
         "children": [
           {
-            "title": "Dagster Types",
-            "path": "/concepts/types"
+            "title": "Repositories",
+            "path": "/concepts/repositories-workspaces/repositories"
+          },
+          {
+            "title": "Workspaces",
+            "path": "/concepts/repositories-workspaces/workspaces"
           }
         ]
       },
       {
-        "title": "IO Management",
+        "title": "Resources",
         "children": [
           {
-            "title": "IO Managers",
-            "path": "/concepts/io-management/io-managers"
-          },
-          {
-            "title": "Unconnected Inputs",
-            "path": "/concepts/io-management/unconnected-inputs"
+            "title": "Resources",
+            "path": "/concepts/resources"
           }
         ]
       },
@@ -205,15 +221,11 @@
         ]
       },
       {
-        "title": "Repositories & Workspaces",
+        "title": "Dagster Types",
         "children": [
           {
-            "title": "Repositories",
-            "path": "/concepts/repositories-workspaces/repositories"
-          },
-          {
-            "title": "Workspaces",
-            "path": "/concepts/repositories-workspaces/workspaces"
+            "title": "Dagster Types",
+            "path": "/concepts/types"
           }
         ]
       },
@@ -231,23 +243,11 @@
         ]
       },
       {
-        "title": "Partitions, Schedules, & Sensors",
+        "title": "Testing",
         "children": [
           {
-            "title": "Schedules",
-            "path": "/concepts/partitions-schedules-sensors/schedules"
-          },
-          {
-            "title": "Sensors",
-            "path": "/concepts/partitions-schedules-sensors/sensors"
-          },
-          {
-            "title": "Partitions",
-            "path": "/concepts/partitions-schedules-sensors/partitions"
-          },
-          {
-            "title": "Backfills",
-            "path": "/concepts/partitions-schedules-sensors/backfills"
+            "title": "Testing",
+            "path": "/concepts/testing"
           }
         ]
       }

--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -26,28 +26,14 @@ Each page in this section contains:
     Ops, Jobs, and Graphs are the building blocks of Dagster code. This section
     covers how to define and use both ops and jobs.
   </LinkGridItem>
-  <LinkGridItem title="Resources" href="/concepts/resources">
-    Resources enable you to separate logic from its heavyweight external
-    dependencies. This makes testing and developing data jobs possible in
-    various environments.
-  </LinkGridItem>
-  <LinkGridItem title="Testing" href="/concepts/testing">
-    Dagster enables you to build testable and maintainable data applications.
-    This section shows that Dagster enables you to unit-test your data jobs,
-    separate business logic from external dependencies, and run data quality
-    tests.
-  </LinkGridItem>
   <LinkGridItem
-    title="Configuration System"
-    href="/concepts/configuration/config-schema"
+    title="Schedules, Sensors, and Partitions"
+    href="/concepts/partitions-schedules-sensors/schedules"
   >
-    Dagster provides a configuration system that allows you to document,
-    schematize, and error-check your configuration. This section demonstrates
-    how configurations work with different Dagster entities.
-  </LinkGridItem>
-  <LinkGridItem title="Dagster Types" href="/concepts/types">
-    Dagster includes gradual, opt-in typing for the inputs and outputs of ops.
-    This section explains how to define, use, and test types in Dagster.
+    Schedulers can launch runs on a fixed interval, while sensors allow you to
+    run based on any external state change. This section demonstrates how to
+    define them and their convenient capabilities like partitioning and
+    backfilling.
   </LinkGridItem>
   <LinkGridItem
     title="IO Management"
@@ -58,10 +44,13 @@ Each page in this section contains:
     management and shows how to define and use IO managers and other IO-related
     features.
   </LinkGridItem>
-  <LinkGridItem title="Dagit & GraphQL API" href="/concepts/dagit/dagit">
-    Dagit is a web-based interface for viewing and interacting with Dagster
-    objects. This section walks you through Dagit's functionalities and the
-    GraphQL API used to interact with Dagster programatically.
+  <LinkGridItem
+    title="Configuration"
+    href="/concepts/configuration/config-schema"
+  >
+    Dagster provides a configuration system that allows you to document,
+    schematize, and error-check your configuration. This section demonstrates
+    how configurations work with different Dagster entities.
   </LinkGridItem>
   <LinkGridItem
     title="Repositories and Workspaces"
@@ -72,18 +61,29 @@ Each page in this section contains:
     workspaces to load user code. This section shows how to define and when to
     use repositories and workspaces.
   </LinkGridItem>
-  <LinkGridItem
-    title="Schedules, Sensors, and Partitions"
-    href="/concepts/partitions-schedules-sensors/schedules"
-  >
-    Schedulers can launch runs on a fixed interval, while sensors allow you to
-    run based on any external state change. This section demonstrates how to
-    define them and their convenient capabilities like partitioning and
-    backfilling.
+  <LinkGridItem title="Resources" href="/concepts/resources">
+    Resources enable you to separate logic from its heavyweight external
+    dependencies. This makes testing and developing data jobs possible in
+    various environments.
+  </LinkGridItem>
+  <LinkGridItem title="Dagit & GraphQL API" href="/concepts/dagit/dagit">
+    Dagit is a web-based interface for viewing and interacting with Dagster
+    objects. This section walks you through Dagit's functionalities and the
+    GraphQL API used to interact with Dagster programatically.
+  </LinkGridItem>
+  <LinkGridItem title="Dagster Types" href="/concepts/types">
+    Dagster includes gradual, opt-in typing for the inputs and outputs of ops.
+    This section explains how to define, use, and test types in Dagster.
   </LinkGridItem>
   <LinkGridItem title="Logging" href="/concepts/logging/loggers">
     Dagster includes a rich and extensible logging system. This section
     showcases Dagster's built-in logger and shows how you can customize loggers
     to fit your logging and monitoring infrastructure.
+  </LinkGridItem>
+  <LinkGridItem title="Testing" href="/concepts/testing">
+    Dagster enables you to build testable and maintainable data applications.
+    This section shows that Dagster enables you to unit-test your data jobs,
+    separate business logic from external dependencies, and run data quality
+    tests.
   </LinkGridItem>
 </LinkGrid>


### PR DESCRIPTION
### Summary & Motivation

This reorders the concept sections based on somewhat-subjective opinions of importance. Some impressions:
* Almost every Dagster user uses Schedules, Sensors, and Partitions.
* Resources are a big source of confusion for early users and it's possible to use Dagster without them, so I moved them down.
* Many users don't use Dagster types.

### How I Tested These Changes

yarn dev