### PR TITLE
AssetSelection.assets

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/asset_selection.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_selection.py
@@ -19,6 +19,12 @@ class AssetSelection(ABC):
         return AllAssetSelection()
 
     @staticmethod
+    def assets(*assets_defs: AssetsDefinition) -> "KeysAssetSelection":
+        return KeysAssetSelection(
+            *(key for assets_def in assets_defs for key in assets_def.asset_keys)
+        )
+
+    @staticmethod
     def keys(*asset_keys: CoerceableToAssetKey) -> "KeysAssetSelection":
         _asset_keys = [AssetKey.from_coerceable(key) for key in asset_keys]
         return KeysAssetSelection(*_asset_keys)

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_selection.py
@@ -94,6 +94,11 @@ def test_asset_selection_keys(all_assets):
     assert sel.resolve(all_assets) == _asset_keys_of({alice, bob})
 
 
+def test_asset_selection_assets(all_assets):
+    sel = AssetSelection.assets(alice, bob)
+    assert sel.resolve(all_assets) == _asset_keys_of({alice, bob})
+
+
 def test_asset_selection_or(all_assets):
     sel = AssetSelection.keys("alice", "bob") | AssetSelection.keys("bob", "candace")
     assert sel.resolve(all_assets) == _asset_keys_of({alice, bob, candace})


### PR DESCRIPTION
### Summary & Motivation

I was writing an example for partitioned asset jobs and found it too awkward without this.

```
@asset(partitions_def=hourly_partitions_def)
def asset1():
    ...


@asset(partitions_def=hourly_partitions_def)
def asset2():
    ...


partitioned_asset_job = define_asset_job(
    name="partitioned_job",
    selection=AssetSelection.assets(asset1, asset2),
    partitions_def=hourly_partitions_def,
)
```

Controversial, I know. I think that having the words `AssetSelection` there will help make it clear that we're not actually directly referencing the assets.

### How I Tested These Changes

Added a test.
