### PR TITLE
[dagster-io/ui] Expose some text input styles

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/TextInput.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TextInput.tsx
@@ -125,3 +125,13 @@ const StyledInput = styled.input<StyledInputProps>`
       ${Colors.KeylineGray} inset 2px 2px 1.5px, rgba(58, 151, 212, 0.6) 0 0 0 3px;
   }
 `;
+
+interface TextAreaProps {
+  $resize: React.CSSProperties['resize'];
+}
+
+export const TextArea = styled.textarea<TextAreaProps>`
+  ${TextInputStyles}
+
+  ${({$resize}) => ($resize ? `resize: ${$resize};` : null)}
+`;

--- a/js_modules/dagit/packages/ui/src/components/TokenizingField.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TokenizingField.tsx
@@ -402,7 +402,7 @@ export const TokenizingField: React.FC<TokenizingFieldProps> = ({
   );
 };
 
-const StyledTagInput = styled(TagInput)`
+export const StyledTagInput = styled(TagInput)`
   border: none;
   border-radius: 8px;
   box-shadow: ${Colors.Gray300} inset 0px 0px 0px 1px, ${Colors.KeylineGray} inset 2px 2px 1.5px;


### PR DESCRIPTION
### Summary & Motivation

Expose a styled `TextArea` component, and `StyledTagInput` for non-TokenizedInput tag input cases. Used in a corresponding Cloud PR.

### How I Tested These Changes

View changes in Cloud, verify rendering.
