### PR TITLE
use DisplayableEvent in dagit log viewer

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/types/AssetEventsQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetEventsQuery.ts
@@ -207,7 +207,7 @@ export interface AssetEventsQuery_assetOrError_Asset_assetObservations {
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: AssetEventsQuery_assetOrError_Asset_assetObservations_metadataEntries[];
 }
@@ -412,7 +412,7 @@ export interface AssetEventsQuery_assetOrError_Asset_assetMaterializations {
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: AssetEventsQuery_assetOrError_Asset_assetMaterializations_metadataEntries[];
   assetLineage: AssetEventsQuery_assetOrError_Asset_assetMaterializations_assetLineage[];

--- a/js_modules/dagit/packages/core/src/assets/types/AssetMaterializationFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetMaterializationFragment.ts
@@ -209,7 +209,7 @@ export interface AssetMaterializationFragment {
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: AssetMaterializationFragment_metadataEntries[];
   assetLineage: AssetMaterializationFragment_assetLineage[];

--- a/js_modules/dagit/packages/core/src/assets/types/AssetObservationFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetObservationFragment.ts
@@ -198,7 +198,7 @@ export interface AssetObservationFragment {
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: AssetObservationFragment_metadataEntries[];
 }

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -283,7 +283,7 @@ type MaterializationEvent implements MessageEvent & StepEvent & DisplayableEvent
   stepKey: String
   solidHandleID: String
   eventType: DagsterEventType
-  label: String!
+  label: String
   description: String
   metadataEntries: [MetadataEntry!]!
   assetKey: AssetKey
@@ -363,7 +363,7 @@ interface StepEvent {
 }
 
 interface DisplayableEvent {
-  label: String!
+  label: String
   description: String
   metadataEntries: [MetadataEntry!]!
 }
@@ -540,7 +540,7 @@ enum StepEventStatus {
 }
 
 type ExpectationResult implements DisplayableEvent {
-  label: String!
+  label: String
   description: String
   metadataEntries: [MetadataEntry!]!
   success: Boolean!
@@ -651,7 +651,7 @@ type ObservationEvent implements MessageEvent & StepEvent & DisplayableEvent {
   stepKey: String
   solidHandleID: String
   eventType: DagsterEventType
-  label: String!
+  label: String
   description: String
   metadataEntries: [MetadataEntry!]!
   assetKey: AssetKey
@@ -724,7 +724,7 @@ enum ErrorSource {
 }
 
 type FailureMetadata implements DisplayableEvent {
-  label: String!
+  label: String
   description: String
   metadataEntries: [MetadataEntry!]!
 }
@@ -742,7 +742,7 @@ type ExecutionStepInputEvent implements MessageEvent & StepEvent {
 }
 
 type TypeCheck implements DisplayableEvent {
-  label: String!
+  label: String
   description: String
   metadataEntries: [MetadataEntry!]!
   success: Boolean!
@@ -756,7 +756,7 @@ type ExecutionStepOutputEvent implements MessageEvent & StepEvent & DisplayableE
   stepKey: String
   solidHandleID: String
   eventType: DagsterEventType
-  label: String!
+  label: String
   description: String
   metadataEntries: [MetadataEntry!]!
   outputName: String!
@@ -926,7 +926,7 @@ type HandledOutputEvent implements MessageEvent & StepEvent & DisplayableEvent {
   stepKey: String
   solidHandleID: String
   eventType: DagsterEventType
-  label: String!
+  label: String
   description: String
   metadataEntries: [MetadataEntry!]!
   outputName: String!
@@ -941,7 +941,7 @@ type LoadedInputEvent implements MessageEvent & StepEvent & DisplayableEvent {
   stepKey: String
   solidHandleID: String
   eventType: DagsterEventType
-  label: String!
+  label: String
   description: String
   metadataEntries: [MetadataEntry!]!
   inputName: String!
@@ -975,7 +975,7 @@ type ObjectStoreOperationEvent implements MessageEvent & StepEvent {
 }
 
 type ObjectStoreOperationResult implements DisplayableEvent {
-  label: String!
+  label: String
   description: String
   metadataEntries: [MetadataEntry!]!
   op: ObjectStoreOperationType!
@@ -1007,7 +1007,7 @@ type EngineEvent implements MessageEvent & DisplayableEvent & StepEvent {
   stepKey: String
   solidHandleID: String
   eventType: DagsterEventType
-  label: String!
+  label: String
   description: String
   metadataEntries: [MetadataEntry!]!
   error: PythonError

--- a/js_modules/dagit/packages/core/src/runs/LogsRow.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRow.tsx
@@ -104,24 +104,21 @@ export const LOGS_ROW_STRUCTURED_FRAGMENT = gql`
       level
       stepKey
     }
-    ... on MaterializationEvent {
-      assetKey {
-        path
-      }
+    ... on DisplayableEvent {
       label
       description
       metadataEntries {
         ...MetadataEntryFragment
       }
     }
-    ... on ObservationEvent {
+    ... on MaterializationEvent {
       assetKey {
         path
       }
-      label
-      description
-      metadataEntries {
-        ...MetadataEntryFragment
+    }
+    ... on ObservationEvent {
+      assetKey {
+        path
       }
     }
     ... on RunFailureEvent {
@@ -166,9 +163,6 @@ export const LOGS_ROW_STRUCTURED_FRAGMENT = gql`
           ...MetadataEntryFragment
         }
       }
-      metadataEntries {
-        ...MetadataEntryFragment
-      }
     }
     ... on StepExpectationResultEvent {
       expectationResult {
@@ -191,23 +185,14 @@ export const LOGS_ROW_STRUCTURED_FRAGMENT = gql`
     ... on HandledOutputEvent {
       outputName
       managerKey
-      metadataEntries {
-        ...MetadataEntryFragment
-      }
     }
     ... on LoadedInputEvent {
       inputName
       managerKey
       upstreamOutputName
       upstreamStepKey
-      metadataEntries {
-        ...MetadataEntryFragment
-      }
     }
     ... on EngineEvent {
-      metadataEntries {
-        ...MetadataEntryFragment
-      }
       engineError: error {
         ...PythonErrorFragment
       }

--- a/js_modules/dagit/packages/core/src/runs/types/LogsRowStructuredFragment.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/LogsRowStructuredFragment.ts
@@ -18,9 +18,688 @@ export interface LogsRowStructuredFragment_ExecutionStepSkippedEvent {
   stepKey: string | null;
 }
 
-export interface LogsRowStructuredFragment_MaterializationEvent_assetKey {
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
   __typename: "AssetKey";
   path: string[];
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries = LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries = LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry;
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck {
+  __typename: "TypeCheck";
+  label: string | null;
+  description: string | null;
+  success: boolean;
+  metadataEntries: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries[];
+}
+
+export interface LogsRowStructuredFragment_ExecutionStepOutputEvent {
+  __typename: "ExecutionStepOutputEvent";
+  message: string;
+  eventType: DagsterEventType | null;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries[];
+  outputName: string;
+  typeCheck: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type LogsRowStructuredFragment_HandledOutputEvent_metadataEntries = LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_PathMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_JsonMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_UrlMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TextMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_FloatMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_IntMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_BoolMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface LogsRowStructuredFragment_HandledOutputEvent {
+  __typename: "HandledOutputEvent";
+  message: string;
+  eventType: DagsterEventType | null;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries[];
+  outputName: string;
+  managerKey: string;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type LogsRowStructuredFragment_LoadedInputEvent_metadataEntries = LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_PathMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_JsonMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_UrlMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TextMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_FloatMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_IntMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_BoolMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface LogsRowStructuredFragment_LoadedInputEvent {
+  __typename: "LoadedInputEvent";
+  message: string;
+  eventType: DagsterEventType | null;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries[];
+  inputName: string;
+  managerKey: string;
+  upstreamOutputName: string | null;
+  upstreamStepKey: string | null;
 }
 
 export interface LogsRowStructuredFragment_MaterializationEvent_metadataEntries_PathMetadataEntry {
@@ -181,6 +860,11 @@ export interface LogsRowStructuredFragment_MaterializationEvent_metadataEntries_
 
 export type LogsRowStructuredFragment_MaterializationEvent_metadataEntries = LogsRowStructuredFragment_MaterializationEvent_metadataEntries_PathMetadataEntry | LogsRowStructuredFragment_MaterializationEvent_metadataEntries_JsonMetadataEntry | LogsRowStructuredFragment_MaterializationEvent_metadataEntries_UrlMetadataEntry | LogsRowStructuredFragment_MaterializationEvent_metadataEntries_TextMetadataEntry | LogsRowStructuredFragment_MaterializationEvent_metadataEntries_MarkdownMetadataEntry | LogsRowStructuredFragment_MaterializationEvent_metadataEntries_PythonArtifactMetadataEntry | LogsRowStructuredFragment_MaterializationEvent_metadataEntries_FloatMetadataEntry | LogsRowStructuredFragment_MaterializationEvent_metadataEntries_IntMetadataEntry | LogsRowStructuredFragment_MaterializationEvent_metadataEntries_BoolMetadataEntry | LogsRowStructuredFragment_MaterializationEvent_metadataEntries_PipelineRunMetadataEntry | LogsRowStructuredFragment_MaterializationEvent_metadataEntries_AssetMetadataEntry | LogsRowStructuredFragment_MaterializationEvent_metadataEntries_TableMetadataEntry | LogsRowStructuredFragment_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry;
 
+export interface LogsRowStructuredFragment_MaterializationEvent_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
 export interface LogsRowStructuredFragment_MaterializationEvent {
   __typename: "MaterializationEvent";
   message: string;
@@ -188,15 +872,10 @@ export interface LogsRowStructuredFragment_MaterializationEvent {
   timestamp: string;
   level: LogLevel;
   stepKey: string | null;
-  assetKey: LogsRowStructuredFragment_MaterializationEvent_assetKey | null;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: LogsRowStructuredFragment_MaterializationEvent_metadataEntries[];
-}
-
-export interface LogsRowStructuredFragment_ObservationEvent_assetKey {
-  __typename: "AssetKey";
-  path: string[];
+  assetKey: LogsRowStructuredFragment_MaterializationEvent_assetKey | null;
 }
 
 export interface LogsRowStructuredFragment_ObservationEvent_metadataEntries_PathMetadataEntry {
@@ -357,6 +1036,11 @@ export interface LogsRowStructuredFragment_ObservationEvent_metadataEntries_Tabl
 
 export type LogsRowStructuredFragment_ObservationEvent_metadataEntries = LogsRowStructuredFragment_ObservationEvent_metadataEntries_PathMetadataEntry | LogsRowStructuredFragment_ObservationEvent_metadataEntries_JsonMetadataEntry | LogsRowStructuredFragment_ObservationEvent_metadataEntries_UrlMetadataEntry | LogsRowStructuredFragment_ObservationEvent_metadataEntries_TextMetadataEntry | LogsRowStructuredFragment_ObservationEvent_metadataEntries_MarkdownMetadataEntry | LogsRowStructuredFragment_ObservationEvent_metadataEntries_PythonArtifactMetadataEntry | LogsRowStructuredFragment_ObservationEvent_metadataEntries_FloatMetadataEntry | LogsRowStructuredFragment_ObservationEvent_metadataEntries_IntMetadataEntry | LogsRowStructuredFragment_ObservationEvent_metadataEntries_BoolMetadataEntry | LogsRowStructuredFragment_ObservationEvent_metadataEntries_PipelineRunMetadataEntry | LogsRowStructuredFragment_ObservationEvent_metadataEntries_AssetMetadataEntry | LogsRowStructuredFragment_ObservationEvent_metadataEntries_TableMetadataEntry | LogsRowStructuredFragment_ObservationEvent_metadataEntries_TableSchemaMetadataEntry;
 
+export interface LogsRowStructuredFragment_ObservationEvent_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
 export interface LogsRowStructuredFragment_ObservationEvent {
   __typename: "ObservationEvent";
   message: string;
@@ -364,10 +1048,194 @@ export interface LogsRowStructuredFragment_ObservationEvent {
   timestamp: string;
   level: LogLevel;
   stepKey: string | null;
-  assetKey: LogsRowStructuredFragment_ObservationEvent_assetKey | null;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: LogsRowStructuredFragment_ObservationEvent_metadataEntries[];
+  assetKey: LogsRowStructuredFragment_ObservationEvent_assetKey | null;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: LogsRowStructuredFragment_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type LogsRowStructuredFragment_EngineEvent_metadataEntries = LogsRowStructuredFragment_EngineEvent_metadataEntries_PathMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_JsonMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_UrlMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_TextMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_MarkdownMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_PythonArtifactMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_FloatMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_IntMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_BoolMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_PipelineRunMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_AssetMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface LogsRowStructuredFragment_EngineEvent_engineError_cause {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface LogsRowStructuredFragment_EngineEvent_engineError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  cause: LogsRowStructuredFragment_EngineEvent_engineError_cause | null;
+}
+
+export interface LogsRowStructuredFragment_EngineEvent {
+  __typename: "EngineEvent";
+  message: string;
+  eventType: DagsterEventType | null;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: LogsRowStructuredFragment_EngineEvent_metadataEntries[];
+  engineError: LogsRowStructuredFragment_EngineEvent_engineError | null;
 }
 
 export interface LogsRowStructuredFragment_RunFailureEvent_pipelineFailureError_cause {
@@ -764,7 +1632,7 @@ export type LogsRowStructuredFragment_ExecutionStepInputEvent_typeCheck_metadata
 
 export interface LogsRowStructuredFragment_ExecutionStepInputEvent_typeCheck {
   __typename: "TypeCheck";
-  label: string;
+  label: string | null;
   description: string | null;
   success: boolean;
   metadataEntries: LogsRowStructuredFragment_ExecutionStepInputEvent_typeCheck_metadataEntries[];
@@ -779,342 +1647,6 @@ export interface LogsRowStructuredFragment_ExecutionStepInputEvent {
   stepKey: string | null;
   inputName: string;
   typeCheck: LogsRowStructuredFragment_ExecutionStepInputEvent_typeCheck;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries = LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry;
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck {
-  __typename: "TypeCheck";
-  label: string;
-  description: string | null;
-  success: boolean;
-  metadataEntries: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries[];
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries = LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry | LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface LogsRowStructuredFragment_ExecutionStepOutputEvent {
-  __typename: "ExecutionStepOutputEvent";
-  message: string;
-  eventType: DagsterEventType | null;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  outputName: string;
-  typeCheck: LogsRowStructuredFragment_ExecutionStepOutputEvent_typeCheck;
-  metadataEntries: LogsRowStructuredFragment_ExecutionStepOutputEvent_metadataEntries[];
 }
 
 export interface LogsRowStructuredFragment_StepExpectationResultEvent_expectationResult_metadataEntries_PathMetadataEntry {
@@ -1278,7 +1810,7 @@ export type LogsRowStructuredFragment_StepExpectationResultEvent_expectationResu
 export interface LogsRowStructuredFragment_StepExpectationResultEvent_expectationResult {
   __typename: "ExpectationResult";
   success: boolean;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: LogsRowStructuredFragment_StepExpectationResultEvent_expectationResult_metadataEntries[];
 }
@@ -1467,530 +1999,6 @@ export interface LogsRowStructuredFragment_ObjectStoreOperationEvent {
   operationResult: LogsRowStructuredFragment_ObjectStoreOperationEvent_operationResult;
 }
 
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type LogsRowStructuredFragment_HandledOutputEvent_metadataEntries = LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_PathMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_JsonMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_UrlMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TextMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_FloatMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_IntMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_BoolMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry | LogsRowStructuredFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface LogsRowStructuredFragment_HandledOutputEvent {
-  __typename: "HandledOutputEvent";
-  message: string;
-  eventType: DagsterEventType | null;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  outputName: string;
-  managerKey: string;
-  metadataEntries: LogsRowStructuredFragment_HandledOutputEvent_metadataEntries[];
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type LogsRowStructuredFragment_LoadedInputEvent_metadataEntries = LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_PathMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_JsonMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_UrlMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TextMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_FloatMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_IntMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_BoolMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry | LogsRowStructuredFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface LogsRowStructuredFragment_LoadedInputEvent {
-  __typename: "LoadedInputEvent";
-  message: string;
-  eventType: DagsterEventType | null;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  inputName: string;
-  managerKey: string;
-  upstreamOutputName: string | null;
-  upstreamStepKey: string | null;
-  metadataEntries: LogsRowStructuredFragment_LoadedInputEvent_metadataEntries[];
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: LogsRowStructuredFragment_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type LogsRowStructuredFragment_EngineEvent_metadataEntries = LogsRowStructuredFragment_EngineEvent_metadataEntries_PathMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_JsonMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_UrlMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_TextMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_MarkdownMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_PythonArtifactMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_FloatMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_IntMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_BoolMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_PipelineRunMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_AssetMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_TableMetadataEntry | LogsRowStructuredFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface LogsRowStructuredFragment_EngineEvent_engineError_cause {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-}
-
-export interface LogsRowStructuredFragment_EngineEvent_engineError {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-  cause: LogsRowStructuredFragment_EngineEvent_engineError_cause | null;
-}
-
-export interface LogsRowStructuredFragment_EngineEvent {
-  __typename: "EngineEvent";
-  message: string;
-  eventType: DagsterEventType | null;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  metadataEntries: LogsRowStructuredFragment_EngineEvent_metadataEntries[];
-  engineError: LogsRowStructuredFragment_EngineEvent_engineError | null;
-}
-
 export interface LogsRowStructuredFragment_HookErroredEvent_error_cause {
   __typename: "PythonError";
   message: string;
@@ -2025,4 +2033,4 @@ export interface LogsRowStructuredFragment_LogsCapturedEvent {
   stepKeys: string[] | null;
 }
 
-export type LogsRowStructuredFragment = LogsRowStructuredFragment_ExecutionStepSkippedEvent | LogsRowStructuredFragment_MaterializationEvent | LogsRowStructuredFragment_ObservationEvent | LogsRowStructuredFragment_RunFailureEvent | LogsRowStructuredFragment_ExecutionStepFailureEvent | LogsRowStructuredFragment_ExecutionStepUpForRetryEvent | LogsRowStructuredFragment_ExecutionStepInputEvent | LogsRowStructuredFragment_ExecutionStepOutputEvent | LogsRowStructuredFragment_StepExpectationResultEvent | LogsRowStructuredFragment_ObjectStoreOperationEvent | LogsRowStructuredFragment_HandledOutputEvent | LogsRowStructuredFragment_LoadedInputEvent | LogsRowStructuredFragment_EngineEvent | LogsRowStructuredFragment_HookErroredEvent | LogsRowStructuredFragment_LogsCapturedEvent;
+export type LogsRowStructuredFragment = LogsRowStructuredFragment_ExecutionStepSkippedEvent | LogsRowStructuredFragment_ExecutionStepOutputEvent | LogsRowStructuredFragment_HandledOutputEvent | LogsRowStructuredFragment_LoadedInputEvent | LogsRowStructuredFragment_MaterializationEvent | LogsRowStructuredFragment_ObservationEvent | LogsRowStructuredFragment_EngineEvent | LogsRowStructuredFragment_RunFailureEvent | LogsRowStructuredFragment_ExecutionStepFailureEvent | LogsRowStructuredFragment_ExecutionStepUpForRetryEvent | LogsRowStructuredFragment_ExecutionStepInputEvent | LogsRowStructuredFragment_StepExpectationResultEvent | LogsRowStructuredFragment_ObjectStoreOperationEvent | LogsRowStructuredFragment_HookErroredEvent | LogsRowStructuredFragment_LogsCapturedEvent;

--- a/js_modules/dagit/packages/core/src/runs/types/LogsScrollingTableMessageFragment.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/LogsScrollingTableMessageFragment.ts
@@ -18,9 +18,688 @@ export interface LogsScrollingTableMessageFragment_ExecutionStepSkippedEvent {
   stepKey: string | null;
 }
 
-export interface LogsScrollingTableMessageFragment_MaterializationEvent_assetKey {
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
   __typename: "AssetKey";
   path: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries = LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries = LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry;
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck {
+  __typename: "TypeCheck";
+  label: string | null;
+  description: string | null;
+  success: boolean;
+  metadataEntries: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries[];
+}
+
+export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent {
+  __typename: "ExecutionStepOutputEvent";
+  message: string;
+  eventType: DagsterEventType | null;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries[];
+  outputName: string;
+  typeCheck: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries = LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_PathMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_JsonMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_UrlMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TextMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_FloatMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_IntMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_BoolMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface LogsScrollingTableMessageFragment_HandledOutputEvent {
+  __typename: "HandledOutputEvent";
+  message: string;
+  eventType: DagsterEventType | null;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries[];
+  outputName: string;
+  managerKey: string;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries = LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_PathMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_JsonMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_UrlMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TextMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_FloatMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_IntMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_BoolMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface LogsScrollingTableMessageFragment_LoadedInputEvent {
+  __typename: "LoadedInputEvent";
+  message: string;
+  eventType: DagsterEventType | null;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries[];
+  inputName: string;
+  managerKey: string;
+  upstreamOutputName: string | null;
+  upstreamStepKey: string | null;
 }
 
 export interface LogsScrollingTableMessageFragment_MaterializationEvent_metadataEntries_PathMetadataEntry {
@@ -181,6 +860,11 @@ export interface LogsScrollingTableMessageFragment_MaterializationEvent_metadata
 
 export type LogsScrollingTableMessageFragment_MaterializationEvent_metadataEntries = LogsScrollingTableMessageFragment_MaterializationEvent_metadataEntries_PathMetadataEntry | LogsScrollingTableMessageFragment_MaterializationEvent_metadataEntries_JsonMetadataEntry | LogsScrollingTableMessageFragment_MaterializationEvent_metadataEntries_UrlMetadataEntry | LogsScrollingTableMessageFragment_MaterializationEvent_metadataEntries_TextMetadataEntry | LogsScrollingTableMessageFragment_MaterializationEvent_metadataEntries_MarkdownMetadataEntry | LogsScrollingTableMessageFragment_MaterializationEvent_metadataEntries_PythonArtifactMetadataEntry | LogsScrollingTableMessageFragment_MaterializationEvent_metadataEntries_FloatMetadataEntry | LogsScrollingTableMessageFragment_MaterializationEvent_metadataEntries_IntMetadataEntry | LogsScrollingTableMessageFragment_MaterializationEvent_metadataEntries_BoolMetadataEntry | LogsScrollingTableMessageFragment_MaterializationEvent_metadataEntries_PipelineRunMetadataEntry | LogsScrollingTableMessageFragment_MaterializationEvent_metadataEntries_AssetMetadataEntry | LogsScrollingTableMessageFragment_MaterializationEvent_metadataEntries_TableMetadataEntry | LogsScrollingTableMessageFragment_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry;
 
+export interface LogsScrollingTableMessageFragment_MaterializationEvent_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
 export interface LogsScrollingTableMessageFragment_MaterializationEvent {
   __typename: "MaterializationEvent";
   message: string;
@@ -188,15 +872,10 @@ export interface LogsScrollingTableMessageFragment_MaterializationEvent {
   timestamp: string;
   level: LogLevel;
   stepKey: string | null;
-  assetKey: LogsScrollingTableMessageFragment_MaterializationEvent_assetKey | null;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: LogsScrollingTableMessageFragment_MaterializationEvent_metadataEntries[];
-}
-
-export interface LogsScrollingTableMessageFragment_ObservationEvent_assetKey {
-  __typename: "AssetKey";
-  path: string[];
+  assetKey: LogsScrollingTableMessageFragment_MaterializationEvent_assetKey | null;
 }
 
 export interface LogsScrollingTableMessageFragment_ObservationEvent_metadataEntries_PathMetadataEntry {
@@ -357,6 +1036,11 @@ export interface LogsScrollingTableMessageFragment_ObservationEvent_metadataEntr
 
 export type LogsScrollingTableMessageFragment_ObservationEvent_metadataEntries = LogsScrollingTableMessageFragment_ObservationEvent_metadataEntries_PathMetadataEntry | LogsScrollingTableMessageFragment_ObservationEvent_metadataEntries_JsonMetadataEntry | LogsScrollingTableMessageFragment_ObservationEvent_metadataEntries_UrlMetadataEntry | LogsScrollingTableMessageFragment_ObservationEvent_metadataEntries_TextMetadataEntry | LogsScrollingTableMessageFragment_ObservationEvent_metadataEntries_MarkdownMetadataEntry | LogsScrollingTableMessageFragment_ObservationEvent_metadataEntries_PythonArtifactMetadataEntry | LogsScrollingTableMessageFragment_ObservationEvent_metadataEntries_FloatMetadataEntry | LogsScrollingTableMessageFragment_ObservationEvent_metadataEntries_IntMetadataEntry | LogsScrollingTableMessageFragment_ObservationEvent_metadataEntries_BoolMetadataEntry | LogsScrollingTableMessageFragment_ObservationEvent_metadataEntries_PipelineRunMetadataEntry | LogsScrollingTableMessageFragment_ObservationEvent_metadataEntries_AssetMetadataEntry | LogsScrollingTableMessageFragment_ObservationEvent_metadataEntries_TableMetadataEntry | LogsScrollingTableMessageFragment_ObservationEvent_metadataEntries_TableSchemaMetadataEntry;
 
+export interface LogsScrollingTableMessageFragment_ObservationEvent_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
 export interface LogsScrollingTableMessageFragment_ObservationEvent {
   __typename: "ObservationEvent";
   message: string;
@@ -364,10 +1048,194 @@ export interface LogsScrollingTableMessageFragment_ObservationEvent {
   timestamp: string;
   level: LogLevel;
   stepKey: string | null;
-  assetKey: LogsScrollingTableMessageFragment_ObservationEvent_assetKey | null;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: LogsScrollingTableMessageFragment_ObservationEvent_metadataEntries[];
+  assetKey: LogsScrollingTableMessageFragment_ObservationEvent_assetKey | null;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type LogsScrollingTableMessageFragment_EngineEvent_metadataEntries = LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_PathMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_JsonMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_UrlMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TextMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_MarkdownMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_PythonArtifactMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_FloatMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_IntMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_BoolMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_PipelineRunMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_AssetMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_engineError_cause {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent_engineError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  cause: LogsScrollingTableMessageFragment_EngineEvent_engineError_cause | null;
+}
+
+export interface LogsScrollingTableMessageFragment_EngineEvent {
+  __typename: "EngineEvent";
+  message: string;
+  eventType: DagsterEventType | null;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries[];
+  engineError: LogsScrollingTableMessageFragment_EngineEvent_engineError | null;
 }
 
 export interface LogsScrollingTableMessageFragment_RunFailureEvent_pipelineFailureError_cause {
@@ -764,7 +1632,7 @@ export type LogsScrollingTableMessageFragment_ExecutionStepInputEvent_typeCheck_
 
 export interface LogsScrollingTableMessageFragment_ExecutionStepInputEvent_typeCheck {
   __typename: "TypeCheck";
-  label: string;
+  label: string | null;
   description: string | null;
   success: boolean;
   metadataEntries: LogsScrollingTableMessageFragment_ExecutionStepInputEvent_typeCheck_metadataEntries[];
@@ -779,342 +1647,6 @@ export interface LogsScrollingTableMessageFragment_ExecutionStepInputEvent {
   stepKey: string | null;
   inputName: string;
   typeCheck: LogsScrollingTableMessageFragment_ExecutionStepInputEvent_typeCheck;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries = LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry;
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck {
-  __typename: "TypeCheck";
-  label: string;
-  description: string | null;
-  success: boolean;
-  metadataEntries: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries[];
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries = LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface LogsScrollingTableMessageFragment_ExecutionStepOutputEvent {
-  __typename: "ExecutionStepOutputEvent";
-  message: string;
-  eventType: DagsterEventType | null;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  outputName: string;
-  typeCheck: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_typeCheck;
-  metadataEntries: LogsScrollingTableMessageFragment_ExecutionStepOutputEvent_metadataEntries[];
 }
 
 export interface LogsScrollingTableMessageFragment_StepExpectationResultEvent_expectationResult_metadataEntries_PathMetadataEntry {
@@ -1278,7 +1810,7 @@ export type LogsScrollingTableMessageFragment_StepExpectationResultEvent_expecta
 export interface LogsScrollingTableMessageFragment_StepExpectationResultEvent_expectationResult {
   __typename: "ExpectationResult";
   success: boolean;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: LogsScrollingTableMessageFragment_StepExpectationResultEvent_expectationResult_metadataEntries[];
 }
@@ -1467,530 +1999,6 @@ export interface LogsScrollingTableMessageFragment_ObjectStoreOperationEvent {
   operationResult: LogsScrollingTableMessageFragment_ObjectStoreOperationEvent_operationResult;
 }
 
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries = LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_PathMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_JsonMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_UrlMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TextMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_FloatMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_IntMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_BoolMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry | LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface LogsScrollingTableMessageFragment_HandledOutputEvent {
-  __typename: "HandledOutputEvent";
-  message: string;
-  eventType: DagsterEventType | null;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  outputName: string;
-  managerKey: string;
-  metadataEntries: LogsScrollingTableMessageFragment_HandledOutputEvent_metadataEntries[];
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries = LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_PathMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_JsonMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_UrlMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TextMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_FloatMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_IntMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_BoolMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry | LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface LogsScrollingTableMessageFragment_LoadedInputEvent {
-  __typename: "LoadedInputEvent";
-  message: string;
-  eventType: DagsterEventType | null;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  inputName: string;
-  managerKey: string;
-  upstreamOutputName: string | null;
-  upstreamStepKey: string | null;
-  metadataEntries: LogsScrollingTableMessageFragment_LoadedInputEvent_metadataEntries[];
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type LogsScrollingTableMessageFragment_EngineEvent_metadataEntries = LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_PathMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_JsonMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_UrlMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TextMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_MarkdownMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_PythonArtifactMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_FloatMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_IntMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_BoolMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_PipelineRunMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_AssetMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableMetadataEntry | LogsScrollingTableMessageFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_engineError_cause {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent_engineError {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-  cause: LogsScrollingTableMessageFragment_EngineEvent_engineError_cause | null;
-}
-
-export interface LogsScrollingTableMessageFragment_EngineEvent {
-  __typename: "EngineEvent";
-  message: string;
-  eventType: DagsterEventType | null;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  metadataEntries: LogsScrollingTableMessageFragment_EngineEvent_metadataEntries[];
-  engineError: LogsScrollingTableMessageFragment_EngineEvent_engineError | null;
-}
-
 export interface LogsScrollingTableMessageFragment_HookErroredEvent_error_cause {
   __typename: "PythonError";
   message: string;
@@ -2025,4 +2033,4 @@ export interface LogsScrollingTableMessageFragment_LogsCapturedEvent {
   stepKeys: string[] | null;
 }
 
-export type LogsScrollingTableMessageFragment = LogsScrollingTableMessageFragment_ExecutionStepSkippedEvent | LogsScrollingTableMessageFragment_MaterializationEvent | LogsScrollingTableMessageFragment_ObservationEvent | LogsScrollingTableMessageFragment_RunFailureEvent | LogsScrollingTableMessageFragment_ExecutionStepFailureEvent | LogsScrollingTableMessageFragment_ExecutionStepUpForRetryEvent | LogsScrollingTableMessageFragment_ExecutionStepInputEvent | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent | LogsScrollingTableMessageFragment_StepExpectationResultEvent | LogsScrollingTableMessageFragment_ObjectStoreOperationEvent | LogsScrollingTableMessageFragment_HandledOutputEvent | LogsScrollingTableMessageFragment_LoadedInputEvent | LogsScrollingTableMessageFragment_EngineEvent | LogsScrollingTableMessageFragment_HookErroredEvent | LogsScrollingTableMessageFragment_LogsCapturedEvent;
+export type LogsScrollingTableMessageFragment = LogsScrollingTableMessageFragment_ExecutionStepSkippedEvent | LogsScrollingTableMessageFragment_ExecutionStepOutputEvent | LogsScrollingTableMessageFragment_HandledOutputEvent | LogsScrollingTableMessageFragment_LoadedInputEvent | LogsScrollingTableMessageFragment_MaterializationEvent | LogsScrollingTableMessageFragment_ObservationEvent | LogsScrollingTableMessageFragment_EngineEvent | LogsScrollingTableMessageFragment_RunFailureEvent | LogsScrollingTableMessageFragment_ExecutionStepFailureEvent | LogsScrollingTableMessageFragment_ExecutionStepUpForRetryEvent | LogsScrollingTableMessageFragment_ExecutionStepInputEvent | LogsScrollingTableMessageFragment_StepExpectationResultEvent | LogsScrollingTableMessageFragment_ObjectStoreOperationEvent | LogsScrollingTableMessageFragment_HookErroredEvent | LogsScrollingTableMessageFragment_LogsCapturedEvent;

--- a/js_modules/dagit/packages/core/src/runs/types/PipelineRunLogsSubscription.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/PipelineRunLogsSubscription.ts
@@ -19,9 +19,691 @@ export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubs
   eventType: DagsterEventType | null;
 }
 
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_assetKey {
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
   __typename: "AssetKey";
   path: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries = PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries = PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry;
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck {
+  __typename: "TypeCheck";
+  label: string | null;
+  description: string | null;
+  success: boolean;
+  metadataEntries: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent {
+  __typename: "ExecutionStepOutputEvent";
+  runId: string;
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  eventType: DagsterEventType | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries[];
+  outputName: string;
+  typeCheck: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries = PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_PathMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_JsonMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_UrlMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TextMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_FloatMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_IntMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_BoolMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_AssetMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent {
+  __typename: "HandledOutputEvent";
+  runId: string;
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  eventType: DagsterEventType | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries[];
+  outputName: string;
+  managerKey: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries = PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_PathMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_JsonMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_UrlMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TextMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_FloatMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_IntMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_BoolMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_AssetMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent {
+  __typename: "LoadedInputEvent";
+  runId: string;
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  eventType: DagsterEventType | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries[];
+  inputName: string;
+  managerKey: string;
+  upstreamOutputName: string | null;
+  upstreamStepKey: string | null;
 }
 
 export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_metadataEntries_PathMetadataEntry {
@@ -182,6 +864,11 @@ export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubs
 
 export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_metadataEntries = PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_metadataEntries_PathMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_metadataEntries_JsonMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_metadataEntries_UrlMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_metadataEntries_TextMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_metadataEntries_MarkdownMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_metadataEntries_PythonArtifactMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_metadataEntries_FloatMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_metadataEntries_IntMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_metadataEntries_BoolMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_metadataEntries_PipelineRunMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_metadataEntries_AssetMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_metadataEntries_TableMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry;
 
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
 export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent {
   __typename: "MaterializationEvent";
   runId: string;
@@ -190,15 +877,10 @@ export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubs
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  assetKey: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_assetKey | null;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_metadataEntries[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_assetKey {
-  __typename: "AssetKey";
-  path: string[];
+  assetKey: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_assetKey | null;
 }
 
 export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_metadataEntries_PathMetadataEntry {
@@ -359,6 +1041,11 @@ export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubs
 
 export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_metadataEntries = PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_metadataEntries_PathMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_metadataEntries_JsonMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_metadataEntries_UrlMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_metadataEntries_TextMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_metadataEntries_MarkdownMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_metadataEntries_PythonArtifactMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_metadataEntries_FloatMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_metadataEntries_IntMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_metadataEntries_BoolMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_metadataEntries_PipelineRunMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_metadataEntries_AssetMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_metadataEntries_TableMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_metadataEntries_TableSchemaMetadataEntry;
 
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
 export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent {
   __typename: "ObservationEvent";
   runId: string;
@@ -367,10 +1054,197 @@ export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubs
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  assetKey: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_assetKey | null;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_metadataEntries[];
+  assetKey: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_assetKey | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries = PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_PathMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_JsonMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_UrlMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TextMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_MarkdownMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_PythonArtifactMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_FloatMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_IntMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_BoolMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_PipelineRunMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_AssetMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_engineError_cause {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_engineError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  cause: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_engineError_cause | null;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent {
+  __typename: "EngineEvent";
+  runId: string;
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  eventType: DagsterEventType | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries[];
+  engineError: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_engineError | null;
+  markerStart: string | null;
+  markerEnd: string | null;
 }
 
 export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_RunFailureEvent_pipelineFailureError_cause {
@@ -770,7 +1644,7 @@ export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscript
 
 export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepInputEvent_typeCheck {
   __typename: "TypeCheck";
-  label: string;
+  label: string | null;
   description: string | null;
   success: boolean;
   metadataEntries: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepInputEvent_typeCheck_metadataEntries[];
@@ -786,343 +1660,6 @@ export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubs
   eventType: DagsterEventType | null;
   inputName: string;
   typeCheck: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepInputEvent_typeCheck;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries = PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry;
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck {
-  __typename: "TypeCheck";
-  label: string;
-  description: string | null;
-  success: boolean;
-  metadataEntries: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck_metadataEntries[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries = PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent {
-  __typename: "ExecutionStepOutputEvent";
-  runId: string;
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  eventType: DagsterEventType | null;
-  outputName: string;
-  typeCheck: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_typeCheck;
-  metadataEntries: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent_metadataEntries[];
 }
 
 export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_StepExpectationResultEvent_expectationResult_metadataEntries_PathMetadataEntry {
@@ -1286,7 +1823,7 @@ export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscript
 export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_StepExpectationResultEvent_expectationResult {
   __typename: "ExpectationResult";
   success: boolean;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_StepExpectationResultEvent_expectationResult_metadataEntries[];
 }
@@ -1477,535 +2014,6 @@ export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubs
   operationResult: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObjectStoreOperationEvent_operationResult;
 }
 
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries = PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_PathMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_JsonMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_UrlMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TextMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_FloatMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_IntMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_BoolMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_AssetMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent {
-  __typename: "HandledOutputEvent";
-  runId: string;
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  eventType: DagsterEventType | null;
-  outputName: string;
-  managerKey: string;
-  metadataEntries: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent_metadataEntries[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries = PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_PathMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_JsonMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_UrlMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TextMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_FloatMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_IntMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_BoolMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_AssetMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent {
-  __typename: "LoadedInputEvent";
-  runId: string;
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  eventType: DagsterEventType | null;
-  inputName: string;
-  managerKey: string;
-  upstreamOutputName: string | null;
-  upstreamStepKey: string | null;
-  metadataEntries: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent_metadataEntries[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries = PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_PathMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_JsonMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_UrlMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TextMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_MarkdownMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_PythonArtifactMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_FloatMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_IntMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_BoolMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_PipelineRunMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_AssetMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableMetadataEntry | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_engineError_cause {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_engineError {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-  cause: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_engineError_cause | null;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent {
-  __typename: "EngineEvent";
-  runId: string;
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  eventType: DagsterEventType | null;
-  metadataEntries: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_metadataEntries[];
-  engineError: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent_engineError | null;
-  markerStart: string | null;
-  markerEnd: string | null;
-}
-
 export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HookErroredEvent_error_cause {
   __typename: "PythonError";
   message: string;
@@ -2043,7 +2051,7 @@ export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubs
   pid: number | null;
 }
 
-export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages = PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepSkippedEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_RunFailureEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepFailureEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepUpForRetryEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepInputEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_StepExpectationResultEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObjectStoreOperationEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HookErroredEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LogsCapturedEvent;
+export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages = PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepSkippedEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepOutputEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HandledOutputEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LoadedInputEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_EngineEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_RunFailureEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepFailureEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepUpForRetryEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepInputEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_StepExpectationResultEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObjectStoreOperationEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_HookErroredEvent | PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_LogsCapturedEvent;
 
 export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess {
   __typename: "PipelineRunLogsSubscriptionSuccess";

--- a/js_modules/dagit/packages/core/src/runs/types/RunDagsterRunEventFragment.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunDagsterRunEventFragment.ts
@@ -18,9 +18,688 @@ export interface RunDagsterRunEventFragment_ExecutionStepSkippedEvent {
   eventType: DagsterEventType | null;
 }
 
-export interface RunDagsterRunEventFragment_MaterializationEvent_assetKey {
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
   __typename: "AssetKey";
   path: string[];
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries = RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries = RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry;
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck {
+  __typename: "TypeCheck";
+  label: string | null;
+  description: string | null;
+  success: boolean;
+  metadataEntries: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries[];
+}
+
+export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent {
+  __typename: "ExecutionStepOutputEvent";
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  eventType: DagsterEventType | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries[];
+  outputName: string;
+  typeCheck: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries = RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_PathMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_JsonMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_UrlMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TextMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_FloatMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_IntMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_BoolMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface RunDagsterRunEventFragment_HandledOutputEvent {
+  __typename: "HandledOutputEvent";
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  eventType: DagsterEventType | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries[];
+  outputName: string;
+  managerKey: string;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries = RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_PathMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_JsonMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_UrlMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TextMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_FloatMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_IntMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_BoolMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface RunDagsterRunEventFragment_LoadedInputEvent {
+  __typename: "LoadedInputEvent";
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  eventType: DagsterEventType | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries[];
+  inputName: string;
+  managerKey: string;
+  upstreamOutputName: string | null;
+  upstreamStepKey: string | null;
 }
 
 export interface RunDagsterRunEventFragment_MaterializationEvent_metadataEntries_PathMetadataEntry {
@@ -181,6 +860,11 @@ export interface RunDagsterRunEventFragment_MaterializationEvent_metadataEntries
 
 export type RunDagsterRunEventFragment_MaterializationEvent_metadataEntries = RunDagsterRunEventFragment_MaterializationEvent_metadataEntries_PathMetadataEntry | RunDagsterRunEventFragment_MaterializationEvent_metadataEntries_JsonMetadataEntry | RunDagsterRunEventFragment_MaterializationEvent_metadataEntries_UrlMetadataEntry | RunDagsterRunEventFragment_MaterializationEvent_metadataEntries_TextMetadataEntry | RunDagsterRunEventFragment_MaterializationEvent_metadataEntries_MarkdownMetadataEntry | RunDagsterRunEventFragment_MaterializationEvent_metadataEntries_PythonArtifactMetadataEntry | RunDagsterRunEventFragment_MaterializationEvent_metadataEntries_FloatMetadataEntry | RunDagsterRunEventFragment_MaterializationEvent_metadataEntries_IntMetadataEntry | RunDagsterRunEventFragment_MaterializationEvent_metadataEntries_BoolMetadataEntry | RunDagsterRunEventFragment_MaterializationEvent_metadataEntries_PipelineRunMetadataEntry | RunDagsterRunEventFragment_MaterializationEvent_metadataEntries_AssetMetadataEntry | RunDagsterRunEventFragment_MaterializationEvent_metadataEntries_TableMetadataEntry | RunDagsterRunEventFragment_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry;
 
+export interface RunDagsterRunEventFragment_MaterializationEvent_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
 export interface RunDagsterRunEventFragment_MaterializationEvent {
   __typename: "MaterializationEvent";
   message: string;
@@ -188,15 +872,10 @@ export interface RunDagsterRunEventFragment_MaterializationEvent {
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  assetKey: RunDagsterRunEventFragment_MaterializationEvent_assetKey | null;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: RunDagsterRunEventFragment_MaterializationEvent_metadataEntries[];
-}
-
-export interface RunDagsterRunEventFragment_ObservationEvent_assetKey {
-  __typename: "AssetKey";
-  path: string[];
+  assetKey: RunDagsterRunEventFragment_MaterializationEvent_assetKey | null;
 }
 
 export interface RunDagsterRunEventFragment_ObservationEvent_metadataEntries_PathMetadataEntry {
@@ -357,6 +1036,11 @@ export interface RunDagsterRunEventFragment_ObservationEvent_metadataEntries_Tab
 
 export type RunDagsterRunEventFragment_ObservationEvent_metadataEntries = RunDagsterRunEventFragment_ObservationEvent_metadataEntries_PathMetadataEntry | RunDagsterRunEventFragment_ObservationEvent_metadataEntries_JsonMetadataEntry | RunDagsterRunEventFragment_ObservationEvent_metadataEntries_UrlMetadataEntry | RunDagsterRunEventFragment_ObservationEvent_metadataEntries_TextMetadataEntry | RunDagsterRunEventFragment_ObservationEvent_metadataEntries_MarkdownMetadataEntry | RunDagsterRunEventFragment_ObservationEvent_metadataEntries_PythonArtifactMetadataEntry | RunDagsterRunEventFragment_ObservationEvent_metadataEntries_FloatMetadataEntry | RunDagsterRunEventFragment_ObservationEvent_metadataEntries_IntMetadataEntry | RunDagsterRunEventFragment_ObservationEvent_metadataEntries_BoolMetadataEntry | RunDagsterRunEventFragment_ObservationEvent_metadataEntries_PipelineRunMetadataEntry | RunDagsterRunEventFragment_ObservationEvent_metadataEntries_AssetMetadataEntry | RunDagsterRunEventFragment_ObservationEvent_metadataEntries_TableMetadataEntry | RunDagsterRunEventFragment_ObservationEvent_metadataEntries_TableSchemaMetadataEntry;
 
+export interface RunDagsterRunEventFragment_ObservationEvent_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
 export interface RunDagsterRunEventFragment_ObservationEvent {
   __typename: "ObservationEvent";
   message: string;
@@ -364,10 +1048,196 @@ export interface RunDagsterRunEventFragment_ObservationEvent {
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  assetKey: RunDagsterRunEventFragment_ObservationEvent_assetKey | null;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: RunDagsterRunEventFragment_ObservationEvent_metadataEntries[];
+  assetKey: RunDagsterRunEventFragment_ObservationEvent_assetKey | null;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: RunDagsterRunEventFragment_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type RunDagsterRunEventFragment_EngineEvent_metadataEntries = RunDagsterRunEventFragment_EngineEvent_metadataEntries_PathMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_JsonMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_UrlMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_TextMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_MarkdownMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_PythonArtifactMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_FloatMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_IntMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_BoolMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_PipelineRunMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_AssetMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface RunDagsterRunEventFragment_EngineEvent_engineError_cause {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent_engineError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  cause: RunDagsterRunEventFragment_EngineEvent_engineError_cause | null;
+}
+
+export interface RunDagsterRunEventFragment_EngineEvent {
+  __typename: "EngineEvent";
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  eventType: DagsterEventType | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: RunDagsterRunEventFragment_EngineEvent_metadataEntries[];
+  engineError: RunDagsterRunEventFragment_EngineEvent_engineError | null;
+  markerStart: string | null;
+  markerEnd: string | null;
 }
 
 export interface RunDagsterRunEventFragment_RunFailureEvent_pipelineFailureError_cause {
@@ -764,7 +1634,7 @@ export type RunDagsterRunEventFragment_ExecutionStepInputEvent_typeCheck_metadat
 
 export interface RunDagsterRunEventFragment_ExecutionStepInputEvent_typeCheck {
   __typename: "TypeCheck";
-  label: string;
+  label: string | null;
   description: string | null;
   success: boolean;
   metadataEntries: RunDagsterRunEventFragment_ExecutionStepInputEvent_typeCheck_metadataEntries[];
@@ -779,342 +1649,6 @@ export interface RunDagsterRunEventFragment_ExecutionStepInputEvent {
   eventType: DagsterEventType | null;
   inputName: string;
   typeCheck: RunDagsterRunEventFragment_ExecutionStepInputEvent_typeCheck;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries = RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry;
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck {
-  __typename: "TypeCheck";
-  label: string;
-  description: string | null;
-  success: boolean;
-  metadataEntries: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck_metadataEntries[];
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries = RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry | RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface RunDagsterRunEventFragment_ExecutionStepOutputEvent {
-  __typename: "ExecutionStepOutputEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  eventType: DagsterEventType | null;
-  outputName: string;
-  typeCheck: RunDagsterRunEventFragment_ExecutionStepOutputEvent_typeCheck;
-  metadataEntries: RunDagsterRunEventFragment_ExecutionStepOutputEvent_metadataEntries[];
 }
 
 export interface RunDagsterRunEventFragment_StepExpectationResultEvent_expectationResult_metadataEntries_PathMetadataEntry {
@@ -1278,7 +1812,7 @@ export type RunDagsterRunEventFragment_StepExpectationResultEvent_expectationRes
 export interface RunDagsterRunEventFragment_StepExpectationResultEvent_expectationResult {
   __typename: "ExpectationResult";
   success: boolean;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: RunDagsterRunEventFragment_StepExpectationResultEvent_expectationResult_metadataEntries[];
 }
@@ -1467,532 +2001,6 @@ export interface RunDagsterRunEventFragment_ObjectStoreOperationEvent {
   operationResult: RunDagsterRunEventFragment_ObjectStoreOperationEvent_operationResult;
 }
 
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries = RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_PathMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_JsonMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_UrlMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TextMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_FloatMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_IntMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_BoolMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_AssetMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableMetadataEntry | RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface RunDagsterRunEventFragment_HandledOutputEvent {
-  __typename: "HandledOutputEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  eventType: DagsterEventType | null;
-  outputName: string;
-  managerKey: string;
-  metadataEntries: RunDagsterRunEventFragment_HandledOutputEvent_metadataEntries[];
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries = RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_PathMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_JsonMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_UrlMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TextMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_FloatMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_IntMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_BoolMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_AssetMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableMetadataEntry | RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface RunDagsterRunEventFragment_LoadedInputEvent {
-  __typename: "LoadedInputEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  eventType: DagsterEventType | null;
-  inputName: string;
-  managerKey: string;
-  upstreamOutputName: string | null;
-  upstreamStepKey: string | null;
-  metadataEntries: RunDagsterRunEventFragment_LoadedInputEvent_metadataEntries[];
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: RunDagsterRunEventFragment_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type RunDagsterRunEventFragment_EngineEvent_metadataEntries = RunDagsterRunEventFragment_EngineEvent_metadataEntries_PathMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_JsonMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_UrlMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_TextMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_MarkdownMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_PythonArtifactMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_FloatMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_IntMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_BoolMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_PipelineRunMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_AssetMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableMetadataEntry | RunDagsterRunEventFragment_EngineEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface RunDagsterRunEventFragment_EngineEvent_engineError_cause {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent_engineError {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-  cause: RunDagsterRunEventFragment_EngineEvent_engineError_cause | null;
-}
-
-export interface RunDagsterRunEventFragment_EngineEvent {
-  __typename: "EngineEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  eventType: DagsterEventType | null;
-  metadataEntries: RunDagsterRunEventFragment_EngineEvent_metadataEntries[];
-  engineError: RunDagsterRunEventFragment_EngineEvent_engineError | null;
-  markerStart: string | null;
-  markerEnd: string | null;
-}
-
 export interface RunDagsterRunEventFragment_HookErroredEvent_error_cause {
   __typename: "PythonError";
   message: string;
@@ -2028,4 +2036,4 @@ export interface RunDagsterRunEventFragment_LogsCapturedEvent {
   pid: number | null;
 }
 
-export type RunDagsterRunEventFragment = RunDagsterRunEventFragment_ExecutionStepSkippedEvent | RunDagsterRunEventFragment_MaterializationEvent | RunDagsterRunEventFragment_ObservationEvent | RunDagsterRunEventFragment_RunFailureEvent | RunDagsterRunEventFragment_ExecutionStepFailureEvent | RunDagsterRunEventFragment_ExecutionStepUpForRetryEvent | RunDagsterRunEventFragment_ExecutionStepInputEvent | RunDagsterRunEventFragment_ExecutionStepOutputEvent | RunDagsterRunEventFragment_StepExpectationResultEvent | RunDagsterRunEventFragment_ObjectStoreOperationEvent | RunDagsterRunEventFragment_HandledOutputEvent | RunDagsterRunEventFragment_LoadedInputEvent | RunDagsterRunEventFragment_EngineEvent | RunDagsterRunEventFragment_HookErroredEvent | RunDagsterRunEventFragment_LogsCapturedEvent;
+export type RunDagsterRunEventFragment = RunDagsterRunEventFragment_ExecutionStepSkippedEvent | RunDagsterRunEventFragment_ExecutionStepOutputEvent | RunDagsterRunEventFragment_HandledOutputEvent | RunDagsterRunEventFragment_LoadedInputEvent | RunDagsterRunEventFragment_MaterializationEvent | RunDagsterRunEventFragment_ObservationEvent | RunDagsterRunEventFragment_EngineEvent | RunDagsterRunEventFragment_RunFailureEvent | RunDagsterRunEventFragment_ExecutionStepFailureEvent | RunDagsterRunEventFragment_ExecutionStepUpForRetryEvent | RunDagsterRunEventFragment_ExecutionStepInputEvent | RunDagsterRunEventFragment_StepExpectationResultEvent | RunDagsterRunEventFragment_ObjectStoreOperationEvent | RunDagsterRunEventFragment_HookErroredEvent | RunDagsterRunEventFragment_LogsCapturedEvent;

--- a/js_modules/dagit/packages/core/src/runs/types/RunLogsQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunLogsQuery.ts
@@ -37,9 +37,691 @@ export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepSki
   eventType: DagsterEventType | null;
 }
 
-export interface RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_assetKey {
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
   __typename: "AssetKey";
   path: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries = RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries = RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry;
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck {
+  __typename: "TypeCheck";
+  label: string | null;
+  description: string | null;
+  success: boolean;
+  metadataEntries: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent {
+  __typename: "ExecutionStepOutputEvent";
+  runId: string;
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  eventType: DagsterEventType | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries[];
+  outputName: string;
+  typeCheck: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries = RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent {
+  __typename: "HandledOutputEvent";
+  runId: string;
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  eventType: DagsterEventType | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries[];
+  outputName: string;
+  managerKey: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries = RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent {
+  __typename: "LoadedInputEvent";
+  runId: string;
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  eventType: DagsterEventType | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries[];
+  inputName: string;
+  managerKey: string;
+  upstreamOutputName: string | null;
+  upstreamStepKey: string | null;
 }
 
 export interface RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_metadataEntries_PathMetadataEntry {
@@ -200,6 +882,11 @@ export interface RunLogsQuery_logsForRun_EventConnection_events_MaterializationE
 
 export type RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_metadataEntries = RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_metadataEntries_TableSchemaMetadataEntry;
 
+export interface RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
 export interface RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent {
   __typename: "MaterializationEvent";
   runId: string;
@@ -208,15 +895,10 @@ export interface RunLogsQuery_logsForRun_EventConnection_events_MaterializationE
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  assetKey: RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_assetKey | null;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_metadataEntries[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_assetKey {
-  __typename: "AssetKey";
-  path: string[];
+  assetKey: RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent_assetKey | null;
 }
 
 export interface RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_metadataEntries_PathMetadataEntry {
@@ -377,6 +1059,11 @@ export interface RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent
 
 export type RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_metadataEntries = RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_metadataEntries_TableSchemaMetadataEntry;
 
+export interface RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
 export interface RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent {
   __typename: "ObservationEvent";
   runId: string;
@@ -385,10 +1072,197 @@ export interface RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  assetKey: RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_assetKey | null;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_metadataEntries[];
+  assetKey: RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent_assetKey | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_PathMetadataEntry {
+  __typename: "PathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_JsonMetadataEntry {
+  __typename: "JsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_UrlMetadataEntry {
+  __typename: "UrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TextMetadataEntry {
+  __typename: "TextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_MarkdownMetadataEntry {
+  __typename: "MarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_PythonArtifactMetadataEntry {
+  __typename: "PythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_FloatMetadataEntry {
+  __typename: "FloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_IntMetadataEntry {
+  __typename: "IntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_BoolMetadataEntry {
+  __typename: "BoolMetadataEntry";
+  label: string;
+  description: string | null;
+  boolValue: boolean | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_PipelineRunMetadataEntry {
+  __typename: "PipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_AssetMetadataEntry {
+  __typename: "AssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema {
+  __typename: "TableSchema";
+  columns: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table {
+  __typename: "Table";
+  records: string[];
+  schema: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry {
+  __typename: "TableMetadataEntry";
+  label: string;
+  description: string | null;
+  table: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
+  __typename: "TableColumnConstraints";
+  nullable: boolean;
+  unique: boolean;
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
+  __typename: "TableColumn";
+  name: string;
+  description: string | null;
+  type: string;
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
+  __typename: "TableConstraints";
+  other: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema {
+  __typename: "TableSchema";
+  columns: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
+  constraints: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry {
+  __typename: "TableSchemaMetadataEntry";
+  label: string;
+  description: string | null;
+  schema: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema;
+}
+
+export type RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries = RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry;
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_engineError_cause {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_engineError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  cause: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_engineError_cause | null;
+}
+
+export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent {
+  __typename: "EngineEvent";
+  runId: string;
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  stepKey: string | null;
+  eventType: DagsterEventType | null;
+  label: string | null;
+  description: string | null;
+  metadataEntries: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries[];
+  engineError: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_engineError | null;
+  markerStart: string | null;
+  markerEnd: string | null;
 }
 
 export interface RunLogsQuery_logsForRun_EventConnection_events_RunFailureEvent_pipelineFailureError_cause {
@@ -788,7 +1662,7 @@ export type RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepInputEve
 
 export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepInputEvent_typeCheck {
   __typename: "TypeCheck";
-  label: string;
+  label: string | null;
   description: string | null;
   success: boolean;
   metadataEntries: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepInputEvent_typeCheck_metadataEntries[];
@@ -804,343 +1678,6 @@ export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepInp
   eventType: DagsterEventType | null;
   inputName: string;
   typeCheck: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepInputEvent_typeCheck;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries = RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PathMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_JsonMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_UrlMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TextMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_FloatMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_IntMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_BoolMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_AssetMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries_TableSchemaMetadataEntry;
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck {
-  __typename: "TypeCheck";
-  label: string;
-  description: string | null;
-  success: boolean;
-  metadataEntries: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck_metadataEntries[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries = RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent {
-  __typename: "ExecutionStepOutputEvent";
-  runId: string;
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  eventType: DagsterEventType | null;
-  outputName: string;
-  typeCheck: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_typeCheck;
-  metadataEntries: RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent_metadataEntries[];
 }
 
 export interface RunLogsQuery_logsForRun_EventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries_PathMetadataEntry {
@@ -1304,7 +1841,7 @@ export type RunLogsQuery_logsForRun_EventConnection_events_StepExpectationResult
 export interface RunLogsQuery_logsForRun_EventConnection_events_StepExpectationResultEvent_expectationResult {
   __typename: "ExpectationResult";
   success: boolean;
-  label: string;
+  label: string | null;
   description: string | null;
   metadataEntries: RunLogsQuery_logsForRun_EventConnection_events_StepExpectationResultEvent_expectationResult_metadataEntries[];
 }
@@ -1495,535 +2032,6 @@ export interface RunLogsQuery_logsForRun_EventConnection_events_ObjectStoreOpera
   operationResult: RunLogsQuery_logsForRun_EventConnection_events_ObjectStoreOperationEvent_operationResult;
 }
 
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries = RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent {
-  __typename: "HandledOutputEvent";
-  runId: string;
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  eventType: DagsterEventType | null;
-  outputName: string;
-  managerKey: string;
-  metadataEntries: RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent_metadataEntries[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries = RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent {
-  __typename: "LoadedInputEvent";
-  runId: string;
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  eventType: DagsterEventType | null;
-  inputName: string;
-  managerKey: string;
-  upstreamOutputName: string | null;
-  upstreamStepKey: string | null;
-  metadataEntries: RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent_metadataEntries[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_PathMetadataEntry {
-  __typename: "PathMetadataEntry";
-  label: string;
-  description: string | null;
-  path: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_JsonMetadataEntry {
-  __typename: "JsonMetadataEntry";
-  label: string;
-  description: string | null;
-  jsonString: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_UrlMetadataEntry {
-  __typename: "UrlMetadataEntry";
-  label: string;
-  description: string | null;
-  url: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TextMetadataEntry {
-  __typename: "TextMetadataEntry";
-  label: string;
-  description: string | null;
-  text: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_MarkdownMetadataEntry {
-  __typename: "MarkdownMetadataEntry";
-  label: string;
-  description: string | null;
-  mdStr: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_PythonArtifactMetadataEntry {
-  __typename: "PythonArtifactMetadataEntry";
-  label: string;
-  description: string | null;
-  module: string;
-  name: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_FloatMetadataEntry {
-  __typename: "FloatMetadataEntry";
-  label: string;
-  description: string | null;
-  floatValue: number | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_IntMetadataEntry {
-  __typename: "IntMetadataEntry";
-  label: string;
-  description: string | null;
-  intValue: number | null;
-  intRepr: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_BoolMetadataEntry {
-  __typename: "BoolMetadataEntry";
-  label: string;
-  description: string | null;
-  boolValue: boolean | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_PipelineRunMetadataEntry {
-  __typename: "PipelineRunMetadataEntry";
-  label: string;
-  description: string | null;
-  runId: string;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_AssetMetadataEntry {
-  __typename: "AssetMetadataEntry";
-  label: string;
-  description: string | null;
-  assetKey: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_AssetMetadataEntry_assetKey;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns_constraints;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema {
-  __typename: "TableSchema";
-  columns: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_columns[];
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema_constraints | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table {
-  __typename: "Table";
-  records: string[];
-  schema: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table_schema;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry {
-  __typename: "TableMetadataEntry";
-  label: string;
-  description: string | null;
-  table: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry_table;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints {
-  __typename: "TableColumnConstraints";
-  nullable: boolean;
-  unique: boolean;
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns {
-  __typename: "TableColumn";
-  name: string;
-  description: string | null;
-  type: string;
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns_constraints;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints {
-  __typename: "TableConstraints";
-  other: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema {
-  __typename: "TableSchema";
-  columns: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_columns[];
-  constraints: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema_constraints | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry {
-  __typename: "TableSchemaMetadataEntry";
-  label: string;
-  description: string | null;
-  schema: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry_schema;
-}
-
-export type RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries = RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_PathMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_JsonMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_UrlMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TextMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_MarkdownMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_PythonArtifactMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_FloatMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_IntMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_BoolMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_PipelineRunMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_AssetMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableMetadataEntry | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries_TableSchemaMetadataEntry;
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_engineError_cause {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_engineError {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-  cause: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_engineError_cause | null;
-}
-
-export interface RunLogsQuery_logsForRun_EventConnection_events_EngineEvent {
-  __typename: "EngineEvent";
-  runId: string;
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  stepKey: string | null;
-  eventType: DagsterEventType | null;
-  metadataEntries: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_metadataEntries[];
-  engineError: RunLogsQuery_logsForRun_EventConnection_events_EngineEvent_engineError | null;
-  markerStart: string | null;
-  markerEnd: string | null;
-}
-
 export interface RunLogsQuery_logsForRun_EventConnection_events_HookErroredEvent_error_cause {
   __typename: "PythonError";
   message: string;
@@ -2061,7 +2069,7 @@ export interface RunLogsQuery_logsForRun_EventConnection_events_LogsCapturedEven
   pid: number | null;
 }
 
-export type RunLogsQuery_logsForRun_EventConnection_events = RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepSkippedEvent | RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent | RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent | RunLogsQuery_logsForRun_EventConnection_events_RunFailureEvent | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepFailureEvent | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepUpForRetryEvent | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepInputEvent | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent | RunLogsQuery_logsForRun_EventConnection_events_StepExpectationResultEvent | RunLogsQuery_logsForRun_EventConnection_events_ObjectStoreOperationEvent | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent | RunLogsQuery_logsForRun_EventConnection_events_HookErroredEvent | RunLogsQuery_logsForRun_EventConnection_events_LogsCapturedEvent;
+export type RunLogsQuery_logsForRun_EventConnection_events = RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepSkippedEvent | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepOutputEvent | RunLogsQuery_logsForRun_EventConnection_events_HandledOutputEvent | RunLogsQuery_logsForRun_EventConnection_events_LoadedInputEvent | RunLogsQuery_logsForRun_EventConnection_events_MaterializationEvent | RunLogsQuery_logsForRun_EventConnection_events_ObservationEvent | RunLogsQuery_logsForRun_EventConnection_events_EngineEvent | RunLogsQuery_logsForRun_EventConnection_events_RunFailureEvent | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepFailureEvent | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepUpForRetryEvent | RunLogsQuery_logsForRun_EventConnection_events_ExecutionStepInputEvent | RunLogsQuery_logsForRun_EventConnection_events_StepExpectationResultEvent | RunLogsQuery_logsForRun_EventConnection_events_ObjectStoreOperationEvent | RunLogsQuery_logsForRun_EventConnection_events_HookErroredEvent | RunLogsQuery_logsForRun_EventConnection_events_LogsCapturedEvent;
 
 export interface RunLogsQuery_logsForRun_EventConnection {
   __typename: "EventConnection";

--- a/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
@@ -31,7 +31,7 @@ class GrapheneMessageEvent(graphene.Interface):
 
 
 class GrapheneDisplayableEvent(graphene.Interface):
-    label = graphene.NonNull(graphene.String)
+    label = graphene.String()
     description = graphene.String()
     metadataEntries = non_null_list(GrapheneMetadataEntry)
 


### PR DESCRIPTION
Summary:
There are a bunch of duplicate fields in the logger query that exist on a shared interface - use that interface instead.

Test Plan:
View structured log viewer on a run before and after this PR, no changes

### Summary & Motivation

### How I Tested These Changes
