### PR TITLE
AssetsDefinition.asset_keys -> keys and similar

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_multi_assets.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_multi_assets.py
@@ -7,16 +7,16 @@ from docs_snippets.concepts.assets.multi_assets import (
 
 
 def test_basic():
-    assert len(my_function.asset_keys) == 2
+    assert len(my_function.keys) == 2
 
 
 def test_io_manager():
-    assert len(my_assets.asset_keys) == 2
+    assert len(my_assets.keys) == 2
 
 
 def test_subset():
-    assert len(split_actions.asset_keys) == 2
+    assert len(split_actions.keys) == 2
 
 
 def test_inter_asset_deps():
-    assert len(my_complex_assets.asset_keys) == 2
+    assert len(my_complex_assets.keys) == 2

--- a/python_modules/dagster/dagster/core/asset_defs/asset_group.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_group.py
@@ -435,7 +435,7 @@ class AssetGroup:
                     ...
 
                 result = AssetGroup([asset1]).prefixed("my_prefix")
-                assert result.assets[0].asset_key == AssetKey(["my_prefix", "asset1"])
+                assert result.assets[0].key == AssetKey(["my_prefix", "asset1"])
 
         Example with dependencies within the list of assets:
 
@@ -450,9 +450,9 @@ class AssetGroup:
                     ...
 
                 result = AssetGroup([asset1, asset2]).prefixed("my_prefix")
-                assert result.assets[0].asset_key == AssetKey(["my_prefix", "asset1"])
-                assert result.assets[1].asset_key == AssetKey(["my_prefix", "asset2"])
-                assert result.assets[1].dependency_asset_keys == {AssetKey(["my_prefix", "asset1"])}
+                assert result.assets[0].key == AssetKey(["my_prefix", "asset1"])
+                assert result.assets[1].key == AssetKey(["my_prefix", "asset2"])
+                assert result.assets[1].dependency_keys == {AssetKey(["my_prefix", "asset1"])}
 
         Examples with input prefixes provided by source assets:
 
@@ -466,8 +466,8 @@ class AssetGroup:
 
                 result = AssetGroup([asset2], source_assets=[asset1]).prefixed("my_prefix")
                 assert len(result.assets) == 1
-                assert result.assets[0].asset_key == AssetKey(["my_prefix", "asset2"])
-                assert result.assets[0].dependency_asset_keys == {AssetKey(["upstream_prefix", "asset1"])}
+                assert result.assets[0].key == AssetKey(["my_prefix", "asset2"])
+                assert result.assets[0].dependency_keys == {AssetKey(["upstream_prefix", "asset1"])}
                 assert result.source_assets[0].key == AssetKey(["upstream_prefix", "asset1"])
         """
         prefixed_assets = prefix_assets(self.assets, key_prefix)

--- a/python_modules/dagster/dagster/core/asset_defs/asset_in.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_in.py
@@ -9,7 +9,7 @@ class AssetIn(
     NamedTuple(
         "_AssetIn",
         [
-            ("asset_key", Optional[AssetKey]),
+            ("key", Optional[AssetKey]),
             ("metadata", Optional[Mapping[str, Any]]),
             ("key_prefix", Optional[Sequence[str]]),
         ],
@@ -17,25 +17,26 @@ class AssetIn(
 ):
     def __new__(
         cls,
-        asset_key: Optional[CoercibleToAssetKey] = None,
+        key: Optional[CoercibleToAssetKey] = None,
         metadata: Optional[Mapping[str, Any]] = None,
         namespace: Optional[Sequence[str]] = None,
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
+        asset_key: Optional[CoercibleToAssetKey] = None,
     ):
         key_prefix = canonicalize_backcompat_args(
             key_prefix, "key_prefix", namespace, "namespace", "0.16.0"
         )
+        key = canonicalize_backcompat_args(key, "key", asset_key, "asset_key", "0.16.0")
         if isinstance(key_prefix, str):
             key_prefix = [key_prefix]
 
         check.invariant(
-            not (asset_key and key_prefix),
-            ("Asset key and key_prefix cannot both be set on AssetIn"),
+            not (key and key_prefix), "key and key_prefix cannot both be set on AssetIn"
         )
 
         return super(AssetIn, cls).__new__(
             cls,
-            asset_key=AssetKey.from_coerceable(asset_key) if asset_key is not None else None,
+            key=AssetKey.from_coerceable(key) if key is not None else None,
             metadata=check.opt_inst_param(metadata, "metadata", Mapping),
             key_prefix=check.opt_list_param(key_prefix, "key_prefix", of_type=str),
         )

--- a/python_modules/dagster/dagster/core/asset_defs/asset_selection.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_selection.py
@@ -20,9 +20,7 @@ class AssetSelection(ABC):
 
     @staticmethod
     def assets(*assets_defs: AssetsDefinition) -> "KeysAssetSelection":
-        return KeysAssetSelection(
-            *(key for assets_def in assets_defs for key in assets_def.asset_keys)
-        )
+        return KeysAssetSelection(*(key for assets_def in assets_defs for key in assets_def.keys))
 
     @staticmethod
     def keys(*asset_keys: CoercibleToAssetKey) -> "KeysAssetSelection":

--- a/python_modules/dagster/dagster/core/asset_defs/assets_job.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets_job.py
@@ -159,8 +159,8 @@ def build_job_partitions_from_assets(
     first_assets_with_partitions_def: AssetsDefinition = assets_with_partitions_defs[0]
     for assets_def in assets_with_partitions_defs:
         if assets_def.partitions_def != first_assets_with_partitions_def.partitions_def:
-            first_asset_key = next(iter(assets_def.asset_keys)).to_string()
-            second_asset_key = next(iter(first_assets_with_partitions_def.asset_keys)).to_string()
+            first_asset_key = next(iter(assets_def.keys)).to_string()
+            second_asset_key = next(iter(first_assets_with_partitions_def.keys)).to_string()
             raise DagsterInvalidDefinitionError(
                 "When an assets job contains multiple partitions assets, they must have the "
                 f"same partitions definitions, but asset '{first_asset_key}' and asset "
@@ -194,7 +194,7 @@ def build_deps(
     Mapping[NodeHandle, AssetsDefinition],
 ]:
     # sort so that nodes get a consistent name
-    assets_defs = sorted(assets_defs, key=lambda ad: (sorted((ak for ak in ad.asset_keys))))
+    assets_defs = sorted(assets_defs, key=lambda ad: (sorted((ak for ak in ad.keys))))
 
     # if the same graph/op is used in multiple assets_definitions, their invocations must have
     # different names. we keep track of definitions that share a name and add a suffix to their
@@ -240,7 +240,7 @@ def build_deps(
                 if not input_def.dagster_type.is_nothing:
                     raise DagsterInvalidDefinitionError(
                         f"Input asset '{upstream_asset_key.to_string()}' for asset "
-                        f"'{next(iter(assets_def.asset_keys)).to_string()}' is not "
+                        f"'{next(iter(assets_def.keys)).to_string()}' is not "
                         "produced by any of the provided asset ops and is not one of the provided "
                         "sources"
                     )
@@ -292,7 +292,7 @@ def _attempt_resolve_cycles(
     # index AssetsDefinitions by their asset names
     assets_defs_by_asset_name = {}
     for assets_def in assets_defs:
-        for asset_key in assets_def.asset_keys:
+        for asset_key in assets_def.keys:
             assets_defs_by_asset_name[asset_key.to_user_string()] = assets_def
 
     # color for each asset
@@ -302,7 +302,7 @@ def _attempt_resolve_cycles(
     def _dfs(name, cur_color):
         colors[name] = cur_color
         if name in assets_defs_by_asset_name:
-            cur_node_asset_keys = assets_defs_by_asset_name[name].asset_keys
+            cur_node_asset_keys = assets_defs_by_asset_name[name].keys
         else:
             # in a SourceAsset, treat all downstream as if they're in the same node
             cur_node_asset_keys = asset_deps["downstream"][name]

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -480,7 +480,7 @@ def build_asset_ins(
         asset_key = None
 
         if input_name in asset_ins:
-            asset_key = asset_ins[input_name].asset_key
+            asset_key = asset_ins[input_name].key
             metadata = asset_ins[input_name].metadata or {}
             key_prefix = asset_ins[input_name].key_prefix
         else:

--- a/python_modules/dagster/dagster/core/asset_defs/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/core/asset_defs/load_assets_from_modules.py
@@ -54,7 +54,7 @@ def assets_and_source_assets_from_modules(
         for asset in _find_assets_in_module(module):
             if id(asset) not in asset_ids:
                 asset_ids.add(id(asset))
-                keys = asset.asset_keys if isinstance(asset, AssetsDefinition) else [asset.key]
+                keys = asset.keys if isinstance(asset, AssetsDefinition) else [asset.key]
                 for key in keys:
                     if key in asset_keys:
                         modules_str = ", ".join(set([asset_keys[key].__name__, module.__name__]))
@@ -98,7 +98,7 @@ def load_assets_from_modules(
     if group_name:
         assets = [
             asset.with_prefix_or_group(
-                group_names={asset_key: group_name for asset_key in asset.asset_keys}
+                group_names={asset_key: group_name for asset_key in asset.keys}
             )
             for asset in assets
         ]
@@ -188,7 +188,7 @@ def load_assets_from_package_module(
     if group_name:
         assets = [
             asset.with_prefix_or_group(
-                group_names={asset_key: group_name for asset_key in asset.asset_keys}
+                group_names={asset_key: group_name for asset_key in asset.keys}
             )
             for asset in assets
         ]
@@ -277,10 +277,10 @@ def prefix_assets(
             result = prefixed_asset_key_replacements([asset1, asset2], "my_prefix")
             assert result.assets[0].asset_key == AssetKey(["my_prefix", "asset1"])
             assert result.assets[1].asset_key == AssetKey(["my_prefix", "asset2"])
-            assert result.assets[1].dependency_asset_keys == {AssetKey(["my_prefix", "asset1"])}
+            assert result.assets[1].dependency_keys == {AssetKey(["my_prefix", "asset1"])}
 
     """
-    asset_keys = {asset_key for assets_def in assets_defs for asset_key in assets_def.asset_keys}
+    asset_keys = {asset_key for assets_def in assets_defs for asset_key in assets_def.keys}
 
     if isinstance(key_prefix, str):
         key_prefix = [key_prefix]
@@ -289,10 +289,10 @@ def prefix_assets(
     result_assets: List[AssetsDefinition] = []
     for assets_def in assets_defs:
         output_asset_key_replacements = {
-            asset_key: AssetKey(key_prefix + asset_key.path) for asset_key in assets_def.asset_keys
+            asset_key: AssetKey(key_prefix + asset_key.path) for asset_key in assets_def.keys
         }
         input_asset_key_replacements = {}
-        for dep_asset_key in assets_def.dependency_asset_keys:
+        for dep_asset_key in assets_def.dependency_keys:
             if dep_asset_key in asset_keys:
                 input_asset_key_replacements[dep_asset_key] = AssetKey(
                     key_prefix + dep_asset_key.path

--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -295,7 +295,7 @@ def _asset_key_to_dep_node_handles(
 
     # handle internal_asset_deps
     for node_handle, assets_defs in assets_defs_by_node_handle.items():
-        all_output_asset_keys = assets_defs.asset_keys
+        all_output_asset_keys = assets_defs.keys
         for asset_key, dep_asset_keys in assets_defs.asset_deps.items():
             for dep_asset_key in [key for key in dep_asset_keys if key in all_output_asset_keys]:
                 output_node = dep_nodes_by_asset_key[asset_key][
@@ -441,7 +441,7 @@ class AssetLayer:
         self._assets_defs_by_key = {
             key: assets_def
             for assets_def in check.opt_list_param(assets_defs, "assets_defs")
-            for key in assets_def.asset_keys
+            for key in assets_def.keys
         }
 
         # keep an index from node handle to all keys expected to be generated in that node
@@ -521,7 +521,7 @@ class AssetLayer:
                     asset_key,
                     partitions_fn=partition_fn if assets_def.partitions_def else None,
                     partitions_def=assets_def.partitions_def,
-                    is_required=asset_key in assets_def.asset_keys,
+                    is_required=asset_key in assets_def.keys,
                 )
                 io_manager_by_asset[asset_key] = inner_output_def.io_manager_key
 
@@ -700,10 +700,10 @@ def _subset_assets_defs(
 
     for asset in set(assets):
         # intersection
-        selected_subset = selected_asset_keys & asset.asset_keys
+        selected_subset = selected_asset_keys & asset.keys
         included_keys.update(selected_subset)
         # all assets in this def are selected
-        if selected_subset == asset.asset_keys:
+        if selected_subset == asset.keys:
             included_assets.add(asset)
         # no assets in this def are selected
         elif len(selected_subset) == 0:
@@ -713,11 +713,11 @@ def _subset_assets_defs(
             subset_asset = asset.subset_for(selected_asset_keys)
             included_assets.add(subset_asset)
             # subset of the asset that we don't want
-            excluded_assets.add(asset.subset_for(asset.asset_keys - subset_asset.asset_keys))
+            excluded_assets.add(asset.subset_for(asset.keys - subset_asset.keys))
         else:
             raise DagsterInvalidSubsetError(
                 f"When building job, the AssetsDefinition '{asset.node_def.name}' "
-                f"contains asset keys {sorted(list(asset.asset_keys))}, but "
+                f"contains asset keys {sorted(list(asset.keys))}, but "
                 f"attempted to select only {sorted(list(selected_subset))}. "
                 "This AssetsDefinition does not support subsetting. Please select all "
                 "asset keys produced by this asset."

--- a/python_modules/dagster/dagster/core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/core/selector/subset_selector.py
@@ -103,7 +103,7 @@ def generate_asset_dep_graph(assets_defs: Iterable["AssetsDefinition"]) -> Depen
     upstream: Dict[str, Set[str]] = {}
     downstream: Dict[str, Set[str]] = {}
     for assets_def in assets_defs:
-        for asset_key in assets_def.asset_keys:
+        for asset_key in assets_def.keys:
             asset_name = asset_key.to_user_string()
             upstream[asset_name] = set()
             downstream[asset_name] = downstream.get(asset_name, set())
@@ -232,7 +232,7 @@ def generate_asset_name_to_definition_map(
 ) -> Mapping[str, "AssetsDefinition"]:
     asset_name_map = {}
     for assets_def in assets_defs:
-        for asset_key in assets_def.asset_keys:
+        for asset_key in assets_def.keys:
             asset_name = asset_key.to_user_string()
             asset_name_map[asset_name] = assets_def
     return asset_name_map
@@ -247,7 +247,7 @@ def fetch_connected_assets_definitions(
     depth: Optional[int] = MAX_NUM,
 ) -> FrozenSet["AssetsDefinition"]:
     depth = MAX_NUM if depth is None else depth
-    names = [asset_key.to_user_string() for asset_key in asset.asset_keys]
+    names = [asset_key.to_user_string() for asset_key in asset.keys]
     connected_names = [
         n for name in names for n in fetch_connected(name, graph, direction=direction, depth=depth)
     ]
@@ -490,7 +490,7 @@ def parse_asset_selection(
 
     # special case: select *
     if len(asset_selection) == 1 and asset_selection[0] == "*":
-        return frozenset(set().union(*(ad.asset_keys for ad in assets_defs)))
+        return frozenset(set().union(*(ad.keys for ad in assets_defs)))
 
     graph = generate_asset_dep_graph(assets_defs)
     assets_set: Set[str] = set()

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
@@ -1118,7 +1118,7 @@ def test_assets_prefixed_single_asset():
         ...
 
     result = AssetGroup([asset1]).prefixed("my_prefix").assets
-    assert result[0].asset_key == AssetKey(["my_prefix", "asset1"])
+    assert result[0].key == AssetKey(["my_prefix", "asset1"])
 
 
 def test_assets_prefixed_internal_dep():
@@ -1131,9 +1131,9 @@ def test_assets_prefixed_internal_dep():
         del asset1
 
     result = AssetGroup([asset1, asset2]).prefixed("my_prefix").assets
-    assert result[0].asset_key == AssetKey(["my_prefix", "asset1"])
-    assert result[1].asset_key == AssetKey(["my_prefix", "asset2"])
-    assert set(result[1].dependency_asset_keys) == {AssetKey(["my_prefix", "asset1"])}
+    assert result[0].key == AssetKey(["my_prefix", "asset1"])
+    assert result[1].key == AssetKey(["my_prefix", "asset2"])
+    assert set(result[1].dependency_keys) == {AssetKey(["my_prefix", "asset1"])}
 
 
 def test_assets_prefixed_disambiguate():
@@ -1155,11 +1155,11 @@ def test_assets_prefixed_disambiguate():
         AssetGroup([asset2, orange, banana], source_assets=[asset1]).prefixed("my_prefix").assets
     )
     assert len(result) == 3
-    assert result[0].asset_key == AssetKey(["my_prefix", "apple"])
-    assert result[1].asset_key == AssetKey(["my_prefix", "orange"])
-    assert set(result[1].dependency_asset_keys) == {AssetKey(["core", "apple"])}
-    assert result[2].asset_key == AssetKey(["my_prefix", "banana"])
-    assert set(result[2].dependency_asset_keys) == {AssetKey(["my_prefix", "apple"])}
+    assert result[0].key == AssetKey(["my_prefix", "apple"])
+    assert result[1].key == AssetKey(["my_prefix", "orange"])
+    assert set(result[1].dependency_keys) == {AssetKey(["core", "apple"])}
+    assert result[2].key == AssetKey(["my_prefix", "banana"])
+    assert set(result[2].dependency_keys) == {AssetKey(["my_prefix", "apple"])}
 
 
 def test_assets_prefixed_source_asset():
@@ -1171,8 +1171,8 @@ def test_assets_prefixed_source_asset():
 
     result = AssetGroup([asset2], source_assets=[asset1]).prefixed("my_prefix").assets
     assert len(result) == 1
-    assert result[0].asset_key == AssetKey(["my_prefix", "asset2"])
-    assert set(result[0].dependency_asset_keys) == {AssetKey(["upstream_prefix", "asset1"])}
+    assert result[0].key == AssetKey(["my_prefix", "asset2"])
+    assert set(result[0].dependency_keys) == {AssetKey(["upstream_prefix", "asset1"])}
 
 
 def test_assets_prefixed_no_matches():
@@ -1181,8 +1181,8 @@ def test_assets_prefixed_no_matches():
         del apple
 
     result = AssetGroup([orange]).prefixed("my_prefix").assets
-    assert result[0].asset_key == AssetKey(["my_prefix", "orange"])
-    assert set(result[0].dependency_asset_keys) == {AssetKey("apple")}
+    assert result[0].key == AssetKey(["my_prefix", "orange"])
+    assert set(result[0].dependency_keys) == {AssetKey("apple")}
 
 
 def test_add_asset_groups():
@@ -1202,7 +1202,7 @@ def test_add_asset_groups():
 
     added_group = group1 + group2
     assert len(added_group.assets) == 2
-    assert sorted([asset.asset_key.to_string() for asset in added_group.assets]) == [
+    assert sorted([asset.key.to_string() for asset in added_group.assets]) == [
         AssetKey(["asset1"]).to_string(),
         AssetKey(["asset2"]).to_string(),
     ]

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_selection.py
@@ -58,7 +58,7 @@ def all_assets():
 
 
 def _asset_keys_of(assets_defs):
-    return reduce(operator.or_, [assets_def.asset_keys for assets_def in assets_defs])
+    return reduce(operator.or_, [assets_def.keys for assets_def in assets_defs])
 
 
 def test_asset_selection_all(all_assets):

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
@@ -30,11 +30,11 @@ def test_with_replaced_asset_keys():
         },
     )
 
-    assert set(replaced.dependency_asset_keys) == {
+    assert set(replaced.dependency_keys) == {
         AssetKey("input1"),
         AssetKey(["apple", "banana"]),
     }
-    assert replaced.asset_keys == {AssetKey(["prefix1", "asset1_changed"])}
+    assert replaced.keys == {AssetKey(["prefix1", "asset1_changed"])}
 
     assert replaced.asset_keys_by_input_name["input1"] == AssetKey("input1")
 
@@ -70,7 +70,7 @@ def test_subset_for(subset, expected_keys, expected_inputs, expected_outputs):
 
     subbed = abc_.subset_for({AssetKey(key) for key in subset.split(",")})
 
-    assert subbed.asset_keys == (
+    assert subbed.keys == (
         {AssetKey(key) for key in expected_keys.split(",")} if expected_keys else set()
     )
 
@@ -110,7 +110,7 @@ def test_chain_replace_and_subset_for():
         input_asset_key_replacements={AssetKey(["in1"]): AssetKey(["foo", "bar_in1"])},
     )
 
-    assert replaced_1.asset_keys == {AssetKey(["foo", "foo_a"]), AssetKey("b"), AssetKey("c")}
+    assert replaced_1.keys == {AssetKey(["foo", "foo_a"]), AssetKey("b"), AssetKey("c")}
     assert replaced_1.asset_deps == {
         AssetKey(["foo", "foo_a"]): {AssetKey(["foo", "bar_in1"]), AssetKey("in2")},
         AssetKey("b"): set(),
@@ -125,7 +125,7 @@ def test_chain_replace_and_subset_for():
     subbed_1 = replaced_1.subset_for(
         {AssetKey(["foo", "bar_in1"]), AssetKey("in3"), AssetKey(["foo", "foo_a"]), AssetKey("b")}
     )
-    assert subbed_1.asset_keys == {AssetKey(["foo", "foo_a"]), AssetKey("b")}
+    assert subbed_1.keys == {AssetKey(["foo", "foo_a"]), AssetKey("b")}
 
     replaced_2 = subbed_1.with_prefix_or_group(
         output_asset_key_replacements={
@@ -138,7 +138,7 @@ def test_chain_replace_and_subset_for():
             AssetKey(["in3"]): AssetKey(["foo", "in3"]),
         },
     )
-    assert replaced_2.asset_keys == {
+    assert replaced_2.keys == {
         AssetKey(["again", "foo", "foo_a"]),
         AssetKey(["something", "bar_b"]),
     }
@@ -163,7 +163,7 @@ def test_chain_replace_and_subset_for():
             AssetKey(["c"]),
         }
     )
-    assert subbed_2.asset_keys == {AssetKey(["again", "foo", "foo_a"])}
+    assert subbed_2.keys == {AssetKey(["again", "foo", "foo_a"])}
 
 
 def test_fail_on_subset_for_nonsubsettable():

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_from_modules.py
@@ -104,7 +104,7 @@ def test_load_assets_from_modules_with_group_name():
     def check_asset_group(assets):
         for asset in assets:
             if isinstance(asset, AssetsDefinition):
-                asset_keys = asset.asset_keys
+                asset_keys = asset.keys
                 for asset_key in asset_keys:
                     assert asset.group_names.get(asset_key) == "my_cool_group"
             elif isinstance(asset, SourceAsset):
@@ -142,7 +142,7 @@ def test_prefix(prefix):
     def check_asset_prefix(assets):
         for asset in assets:
             if isinstance(asset, AssetsDefinition):
-                asset_keys = asset.asset_keys
+                asset_keys = asset.keys
                 for asset_key in asset_keys:
                     observed_prefix = asset_key.path[:-1]
                     if len(observed_prefix) == 1:

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -90,7 +90,7 @@ def test_multi_asset_out_name_diff_from_asset_key():
         yield Output(1, "my_out_name")
         yield Output(2, "my_other_out_name")
 
-    assert my_asset.asset_keys == {AssetKey("my_asset_name"), AssetKey("my_other_asset")}
+    assert my_asset.keys == {AssetKey("my_asset_name"), AssetKey("my_other_asset")}
 
 
 def test_multi_asset_infer_from_empty_asset_key():
@@ -99,7 +99,7 @@ def test_multi_asset_infer_from_empty_asset_key():
         yield Output(1, "my_out_name")
         yield Output(2, "my_other_out_name")
 
-    assert my_asset.asset_keys == {AssetKey("my_out_name"), AssetKey("my_other_out_name")}
+    assert my_asset.keys == {AssetKey("my_out_name"), AssetKey("my_other_out_name")}
 
 
 def test_multi_asset_internal_asset_deps_metadata():
@@ -117,7 +117,7 @@ def test_multi_asset_internal_asset_deps_metadata():
         yield Output(1, "my_out_name")
         yield Output(2, "my_other_out_name")
 
-    assert my_asset.asset_keys == {AssetKey("my_out_name"), AssetKey("my_other_out_name")}
+    assert my_asset.keys == {AssetKey("my_out_name"), AssetKey("my_other_out_name")}
     assert my_asset.op.output_def_named("my_out_name").metadata == {"foo": "bar"}
     assert my_asset.op.output_def_named("my_other_out_name").metadata == {"bar": "foo"}
     assert my_asset.asset_deps == {
@@ -164,7 +164,7 @@ def test_asset_with_key_prefix():
     assert len(my_asset.op.output_defs) == 1
     assert len(my_asset.op.input_defs) == 0
     assert my_asset.op.name == "my_key_prefix__my_asset"
-    assert my_asset.asset_keys == {AssetKey(["my_key_prefix", "my_asset"])}
+    assert my_asset.keys == {AssetKey(["my_key_prefix", "my_asset"])}
 
     @asset(key_prefix=["one", "two", "three"])
     def multi_component_list_asset():
@@ -174,7 +174,7 @@ def test_asset_with_key_prefix():
     assert len(multi_component_list_asset.op.output_defs) == 1
     assert len(multi_component_list_asset.op.input_defs) == 0
     assert multi_component_list_asset.op.name == "one__two__three__multi_component_list_asset"
-    assert multi_component_list_asset.asset_keys == {
+    assert multi_component_list_asset.keys == {
         AssetKey(["one", "two", "three", "multi_component_list_asset"])
     }
 
@@ -186,7 +186,7 @@ def test_asset_with_key_prefix():
     assert len(multi_component_str_asset.op.output_defs) == 1
     assert len(multi_component_str_asset.op.input_defs) == 0
     assert multi_component_str_asset.op.name == "one__two__three__multi_component_str_asset"
-    assert multi_component_str_asset.asset_keys == {
+    assert multi_component_str_asset.keys == {
         AssetKey(["one", "two", "three", "multi_component_str_asset"])
     }
 
@@ -203,7 +203,7 @@ def test_asset_with_namespace():
     assert len(my_asset.op.output_defs) == 1
     assert len(my_asset.op.input_defs) == 0
     assert my_asset.op.name == "my_namespace__my_asset"
-    assert my_asset.asset_keys == {AssetKey(["my_namespace", "my_asset"])}
+    assert my_asset.keys == {AssetKey(["my_namespace", "my_asset"])}
 
     @asset(namespace=["one", "two", "three"])
     def multi_component_namespace_asset():
@@ -216,7 +216,7 @@ def test_asset_with_namespace():
         multi_component_namespace_asset.op.name
         == "one__two__three__multi_component_namespace_asset"
     )
-    assert multi_component_namespace_asset.asset_keys == {
+    assert multi_component_namespace_asset.keys == {
         AssetKey(["one", "two", "three", "multi_component_namespace_asset"])
     }
 
@@ -253,7 +253,7 @@ def test_asset_with_context_arg_and_dep():
 
 
 def test_input_asset_key():
-    @asset(ins={"arg1": AssetIn(asset_key=AssetKey("foo"))})
+    @asset(ins={"arg1": AssetIn(key=AssetKey("foo"))})
     def my_asset(arg1):
         assert arg1
 
@@ -263,7 +263,7 @@ def test_input_asset_key():
 def test_input_asset_key_and_key_prefix():
     with pytest.raises(check.CheckError, match="key and key_prefix cannot both be set"):
 
-        @asset(ins={"arg1": AssetIn(asset_key=AssetKey("foo"), key_prefix="bar")})
+        @asset(ins={"arg1": AssetIn(key=AssetKey("foo"), key_prefix="bar")})
         def _my_asset(arg1):
             assert arg1
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -35,7 +35,7 @@ def test_assets(schema_prefix):
         asset_key_prefix=["some", "prefix"],
     )
 
-    assert ab_assets[0].asset_keys == {AssetKey(["some", "prefix", t]) for t in destination_tables}
+    assert ab_assets[0].keys == {AssetKey(["some", "prefix", t]) for t in destination_tables}
     assert len(ab_assets[0].op.output_defs) == 2
 
     responses.add(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -252,7 +252,7 @@ def test_select_from_project(
         prefix = []
     elif isinstance(prefix, str):
         prefix = [prefix]
-    assert dbt_assets[0].asset_keys == {
+    assert dbt_assets[0].keys == {
         AssetKey(prefix + suffix)
         for suffix in (["sort_by_calories"], ["subdir_schema", "least_caloric"])
     }
@@ -522,7 +522,7 @@ def test_dbt_selects(
         )
 
     expected_asset_keys = {AssetKey(key.split("/")) for key in expected_asset_names}
-    assert dbt_assets[0].asset_keys == expected_asset_keys
+    assert dbt_assets[0].keys == expected_asset_keys
 
     result = (
         AssetGroup(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
@@ -20,7 +20,7 @@ def test_fivetran_asset_keys():
     ft_assets = build_fivetran_assets(
         connector_id=DEFAULT_CONNECTOR_ID, destination_tables=["x.foo", "y.bar"]
     )
-    assert ft_assets[0].asset_keys == {AssetKey(["x", "foo"]), AssetKey(["y", "bar"])}
+    assert ft_assets[0].keys == {AssetKey(["x", "foo"]), AssetKey(["y", "bar"])}
 
 
 @pytest.mark.parametrize("schema_prefix", ["", "the_prefix"])
@@ -51,7 +51,7 @@ def test_fivetran_asset_run(tables, should_error, schema_prefix):
     )
 
     # expect the multi asset to have one asset key and one output for each specified asset key
-    assert fivetran_assets[0].asset_keys == {AssetKey(table.split(".")) for table in tables}
+    assert fivetran_assets[0].keys == {AssetKey(table.split(".")) for table in tables}
     assert len(fivetran_assets[0].op.output_defs) == len(tables)
 
     fivetran_assets_job = build_assets_job(


### PR DESCRIPTION
### Summary & Motivation

Renames the following properties on `AssetsDefinition`:
- `asset_keys` -> `keys`
- `asset_key` -> `key`
- `dependency_asset_keys` -> `dependency_keys`

I am not 100% confident that this is the right thing to do. The reasoning is basically that `OutputDefinition` has `name`, not `output_name`, `OpDefinition` has `name`, not `op_name`, etc.

### How I Tested These Changes

bk