### PR TITLE
[with-resources changes 3/n] without_resources

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -231,7 +231,7 @@ from dagster.core.execution.results import (
     SolidExecutionResult,
 )
 from dagster.core.execution.validate_run_config import validate_run_config
-from dagster.core.execution.with_resources import with_resources
+from dagster.core.execution.with_resources import with_resources, without_resources
 from dagster.core.executor.base import Executor
 from dagster.core.executor.init import InitExecutorContext
 from dagster.core.instance import DagsterInstance
@@ -512,6 +512,7 @@ __all__ = [
     "PipelineExecutionResult",
     "RetryRequested",
     "with_resources",
+    "without_resources",
     "build_resources",
     "SolidExecutionResult",
     "SolidExecutionContext",

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -21,6 +21,7 @@ from dagster.core.definitions import (
     ResourceDefinition,
 )
 from dagster.core.definitions.events import AssetKey
+from dagster.core.definitions.output import OutputDefinition
 from dagster.core.definitions.partition import PartitionsDefinition
 from dagster.core.definitions.utils import DEFAULT_GROUP_NAME, validate_group_name
 from dagster.core.errors import DagsterInvalidInvocationError
@@ -570,6 +571,69 @@ class AssetsDefinition(ResourceAddable):
             group_names_by_key=self.group_names_by_key,
         )
 
+    def without_resources(self) -> "AssetsDefinition":
+        # In the case where we provided a system-created resource key, we need
+        # to remove it without requiring users provide it later.
+        if len(self.asset_keys) == 1 and isinstance(self.node_def, OpDefinition):
+
+            io_manager_key = io_manager_key_for_asset_key(self.asset_key)
+
+            op_def = self.op
+            output_def = op_def.output_defs[0]
+            if output_def.io_manager_key == io_manager_key_for_asset_key(self.asset_key):
+                io_manager_key = "io_manager"
+                new_required_keys = {
+                    io_manager_key,
+                    *{
+                        key
+                        for key in op_def.required_resource_keys
+                        if key != io_manager_key_for_asset_key(self.asset_key)
+                    },
+                }
+
+            else:
+                io_manager_key = output_def.io_manager_key
+                new_required_keys = op_def.required_resource_keys
+
+            output_def = OutputDefinition(
+                dagster_type=output_def.dagster_type,
+                name=output_def.name,
+                description=output_def.description,
+                is_required=output_def.is_required,
+                io_manager_key=io_manager_key,
+                metadata=output_def.metadata,
+                asset_key=output_def._asset_key,
+                asset_partitions=output_def._asset_partitions_fn,
+                asset_partitions_def=output_def._asset_partitions_def,
+            )
+
+            node_def = OpDefinition(
+                name=op_def.name,
+                input_defs=op_def.input_defs,
+                output_defs=[output_def],
+                compute_fn=op_def.compute_fn,
+                config_schema=op_def.config_schema,
+                description=op_def.description,
+                tags=op_def.tags,
+                required_resource_keys=new_required_keys,
+                version=op_def.version,
+                retry_policy=op_def.retry_policy,
+            )
+        else:
+            node_def = self.node_def
+        return AssetsDefinition(
+            asset_keys_by_input_name=self._asset_keys_by_input_name,
+            asset_keys_by_output_name=self._asset_keys_by_output_name,
+            node_def=node_def,
+            partitions_def=self._partitions_def,
+            partition_mappings=self._partition_mappings,
+            asset_deps=self._asset_deps,
+            selected_asset_keys=self._selected_asset_keys,
+            can_subset=self._can_subset,
+            resource_defs=None,
+            group_names=self._group_names,
+        )
+
 
 def _infer_keys_by_input_names(
     node_def: Union[GraphDefinition, OpDefinition], keys_by_input_name: Mapping[str, AssetKey]
@@ -662,3 +726,8 @@ def _build_invocation_context_with_included_resources(
         # If user is mocking OpExecutionContext, send it through (we don't know
         # what modifications they might be making, and we don't want to override)
         return context
+
+
+def io_manager_key_for_asset_key(asset_key: AssetKey):
+    asset_path = "__".join(asset_key.path)
+    return f"{asset_path}__io_manager"

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -590,6 +590,7 @@ class AssetsDefinition(ResourceAddable):
                 else:
                     io_manager_key = output_def.io_manager_key
 
+                # pylint: disable=protected-access
                 output_def = OutputDefinition(
                     dagster_type=output_def.dagster_type,
                     name=output_def.name,

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -584,7 +584,9 @@ class AssetsDefinition(ResourceAddable):
             replaced_io_manager_keys = set()
             for output_def in self.op.output_defs:
                 asset_key = self.keys_by_output_name.get(output_def.name)
-                if output_def.io_manager_key == io_manager_key_for_asset_key(asset_key):
+                if asset_key and output_def.io_manager_key == io_manager_key_for_asset_key(
+                    asset_key
+                ):
                     io_manager_key = DEFAULT_IO_MANAGER_KEY
                     replaced_io_manager_keys.add(io_manager_key_for_asset_key(asset_key))
                 else:
@@ -605,7 +607,7 @@ class AssetsDefinition(ResourceAddable):
                 output_defs.append(output_def)
 
             if replaced_io_manager_keys:
-                required_resource_keys = {
+                required_resource_keys: AbstractSet[str] = {
                     DEFAULT_IO_MANAGER_KEY,
                     *{
                         key
@@ -616,7 +618,7 @@ class AssetsDefinition(ResourceAddable):
             else:
                 required_resource_keys = self.op.required_resource_keys
 
-            node_def = OpDefinition(
+            node_def: NodeDefinition = OpDefinition(
                 name=self.op.name,
                 input_defs=self.op.input_defs,
                 output_defs=output_defs,

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -38,7 +38,7 @@ from dagster.utils.backcompat import (
 
 from .asset_in import AssetIn
 from .asset_out import AssetOut
-from .assets import AssetsDefinition
+from .assets import AssetsDefinition, io_manager_key_for_asset_key
 from .partition_mapping import PartitionMapping
 
 

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -269,8 +269,7 @@ class _Asset:
                 io_manager_def = check.inst_param(
                     self.io_manager, "io_manager", IOManagerDefinition
                 )
-                out_asset_resource_key = "__".join(out_asset_key.path)
-                io_manager_key = f"{out_asset_resource_key}__io_manager"
+                io_manager_key = io_manager_key_for_asset_key(out_asset_key)
                 self.resource_defs[io_manager_key] = cast(ResourceDefinition, io_manager_def)
             else:
                 io_manager_key = DEFAULT_IO_MANAGER_KEY

--- a/python_modules/dagster/dagster/core/asset_defs/source_asset.py
+++ b/python_modules/dagster/dagster/core/asset_defs/source_asset.py
@@ -85,7 +85,7 @@ class SourceAsset(
                     f"Provided conflicting definitions for io manager key '{io_manager_key}'. Please provide only one definition per key."
                 )
 
-            resource_defs[io_manager_key] = io_manager_def
+            resource_defs[cast(str, io_manager_key)] = io_manager_def
 
         return super().__new__(
             cls,

--- a/python_modules/dagster/dagster/core/asset_defs/source_asset.py
+++ b/python_modules/dagster/dagster/core/asset_defs/source_asset.py
@@ -164,7 +164,7 @@ class SourceAsset(
     def without_resources(self) -> "SourceAsset":
         from .assets import io_manager_key_for_asset_key
 
-        if self.get_io_manager_key() == "io_manager":
+        if self.get_io_manager_key() == DEFAULT_IO_MANAGER_KEY:
             io_manager_key = None
         elif self.get_io_manager_key() == io_manager_key_for_asset_key(self.key):
             io_manager_key = None

--- a/python_modules/dagster/dagster/core/definitions/resource_requirement.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_requirement.py
@@ -75,6 +75,10 @@ class ResourceAddable(ABC):
     ) -> "ResourceAddable":
         raise NotImplementedError()
 
+    @abstractmethod
+    def without_resources(self) -> "ResourceAddable":
+        raise NotImplementedError()
+
 
 class SolidDefinitionResourceRequirement(
     NamedTuple("_SolidDefinitionResourceRequirement", [("key", str), ("node_description", str)]),

--- a/python_modules/dagster/dagster/core/execution/with_resources.py
+++ b/python_modules/dagster/dagster/core/execution/with_resources.py
@@ -101,3 +101,19 @@ def with_resources(
         transformed_defs.append(cast(T, definition.with_resources(resource_defs)))
 
     return transformed_defs
+
+
+def without_resources(definitions: Iterable[T]) -> Sequence[T]:
+    """Returns a version of each provided definition without resources attached.
+
+    Provided resources will be converted to required resources.
+
+    Args:
+        definitions (Iterable[ResourceAddable]): Dagster definitions to remove resources from.
+    """
+
+    transformed_defs: List[T] = []
+    for definition in definitions:
+        transformed_defs.append(cast(T, definition.without_resources()))
+
+    return transformed_defs

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_resources.py
@@ -8,6 +8,7 @@ from dagster import (
     io_manager,
     mem_io_manager,
     resource,
+    with_resources,
 )
 from dagster.core.asset_defs import AssetsDefinition, SourceAsset, asset, build_assets_job
 from dagster.core.errors import (
@@ -16,7 +17,6 @@ from dagster.core.errors import (
     DagsterInvalidInvocationError,
     DagsterInvariantViolationError,
 )
-from dagster.core.execution.with_resources import with_resources
 from dagster.core.storage.mem_io_manager import InMemoryIOManager
 
 # pylint: disable=comparison-with-callable,unbalanced-tuple-unpacking

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_without_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_without_resources.py
@@ -2,28 +2,18 @@ import pytest
 
 from dagster import (
     AssetKey,
-    IOManager,
     Out,
     ResourceDefinition,
-    build_op_context,
     graph,
     io_manager,
-    mem_io_manager,
     op,
-    resource,
     with_resources,
     without_resources,
 )
 from dagster.core.asset_defs import AssetsDefinition, SourceAsset, asset, build_assets_job
 from dagster.core.asset_defs.assets import io_manager_key_for_asset_key
 from dagster.core.definitions.utils import DEFAULT_IO_MANAGER_KEY
-from dagster.core.errors import (
-    DagsterInvalidConfigError,
-    DagsterInvalidDefinitionError,
-    DagsterInvalidInvocationError,
-    DagsterInvariantViolationError,
-)
-from dagster.core.storage.mem_io_manager import InMemoryIOManager
+from dagster.core.errors import DagsterInvalidDefinitionError
 
 
 def test_asset():

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_without_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_without_resources.py
@@ -1,0 +1,145 @@
+import pytest
+
+from dagster import (
+    AssetKey,
+    IOManager,
+    ResourceDefinition,
+    build_op_context,
+    io_manager,
+    mem_io_manager,
+    graph,
+    op,
+    with_resources,
+    resource,
+    without_resources,
+)
+from dagster.core.asset_defs import AssetsDefinition, SourceAsset, asset, build_assets_job
+from dagster.core.errors import (
+    DagsterInvalidConfigError,
+    DagsterInvalidDefinitionError,
+    DagsterInvalidInvocationError,
+    DagsterInvariantViolationError,
+)
+from dagster.core.storage.mem_io_manager import InMemoryIOManager
+from dagster.core.asset_defs.assets import io_manager_key_for_asset_key
+
+
+def test_asset():
+    @asset(
+        resource_defs={
+            "foo": ResourceDefinition.hardcoded_resource("foo"),
+            "bar": ResourceDefinition.hardcoded_resource("bar"),
+        },
+        required_resource_keys={"baz"},
+    )
+    def the_asset():
+        pass
+
+    transformed_def = without_resources([the_asset])[0]
+    assert transformed_def.required_resource_keys == the_asset.required_resource_keys
+    assert transformed_def.resource_defs == {}
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="resource with key 'bar' required by op 'the_asset' was not provided.",
+    ):
+        with_resources([transformed_def], {})
+
+
+def test_asset_defines_io_manager():
+    @io_manager
+    def the_io_manager():
+        pass
+
+    @asset(io_manager_def=the_io_manager)
+    def the_asset():
+        return 5
+
+    assert the_asset.required_resource_keys == {io_manager_key_for_asset_key(the_asset.asset_key)}
+    transformed_def = without_resources([the_asset])[0]
+    assert transformed_def.required_resource_keys == {"io_manager"}
+
+    result = build_assets_job("test", [transformed_def]).execute_in_process()
+    assert result.success
+    assert result.output_for_node("the_asset") == 5
+
+
+def test_without_resources_graph_backed_asset():
+    @op(required_resource_keys={"foo"})
+    def the_op(context):
+        return context.resources.foo
+
+    @graph
+    def the_graph():
+        return the_op()
+
+    graph_backed = AssetsDefinition(
+        asset_keys_by_input_name={},
+        asset_keys_by_output_name={"result": AssetKey("cool_thing")},
+        node_def=the_graph,
+        resource_defs={"foo": ResourceDefinition.hardcoded_resource("bar")},
+    )
+
+    assert graph_backed.required_resource_keys == {"foo", "io_manager"}
+
+    transformed_def = without_resources([graph_backed])[0]
+
+    assert transformed_def.required_resource_keys == {"foo", "io_manager"}
+    assert transformed_def.resource_defs == {}
+
+    transformed_again = with_resources(
+        [transformed_def], {"foo": ResourceDefinition.hardcoded_resource("baz")}
+    )[0]
+
+    result = build_assets_job("test", [transformed_again]).execute_in_process()
+    assert result.success
+
+    assert result.output_for_node("the_graph") == "baz"
+
+
+def test_asset_defines_io_manager_key():
+    @io_manager
+    def the_manager():
+        pass
+
+    @asset(io_manager_key="the_key", resource_defs={"the_key": the_manager})
+    def the_asset():
+        pass
+
+    transformed_asset = without_resources([the_asset])[0]
+    assert transformed_asset.required_resource_keys == {"the_key"}
+
+
+def test_source_asset():
+    foo_resource = ResourceDefinition.hardcoded_resource("foo")
+
+    @io_manager(required_resource_keys={"foo"})
+    def the_io_manager():
+        pass
+
+    the_asset = SourceAsset(
+        key=AssetKey("the_asset"),
+        io_manager_def=the_io_manager,
+        resource_defs={"foo": foo_resource},
+    )
+    assert the_asset.resource_defs == {
+        io_manager_key_for_asset_key(AssetKey("the_asset")): the_io_manager,
+        "foo": foo_resource,
+    }
+    transformed_asset = without_resources([the_asset])[0]
+    assert transformed_asset.resource_defs == {}
+    assert transformed_asset.get_io_manager_key() == "io_manager"
+
+
+def test_source_asset_defines_io_manager_key():
+    @io_manager
+    def the_manager():
+        pass
+
+    the_asset = SourceAsset(
+        key=AssetKey("the_asset"), io_manager_key="the_key", resource_defs={"the_key": the_manager}
+    )
+    assert the_asset.get_io_manager_key() == "the_key"
+    transformed_asset = without_resources([the_asset])[0]
+    assert transformed_asset.get_io_manager_key() == "the_key"
+    assert transformed_asset.resource_defs == {}

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_without_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_without_resources.py
@@ -3,6 +3,7 @@ import pytest
 from dagster import (
     AssetKey,
     IOManager,
+    Out,
     ResourceDefinition,
     build_op_context,
     graph,
@@ -15,6 +16,7 @@ from dagster import (
 )
 from dagster.core.asset_defs import AssetsDefinition, SourceAsset, asset, build_assets_job
 from dagster.core.asset_defs.assets import io_manager_key_for_asset_key
+from dagster.core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster.core.errors import (
     DagsterInvalidConfigError,
     DagsterInvalidDefinitionError,
@@ -57,7 +59,7 @@ def test_asset_defines_io_manager():
 
     assert the_asset.required_resource_keys == {io_manager_key_for_asset_key(the_asset.asset_key)}
     transformed_def = without_resources([the_asset])[0]
-    assert transformed_def.required_resource_keys == {"io_manager"}
+    assert transformed_def.required_resource_keys == {DEFAULT_IO_MANAGER_KEY}
 
     result = build_assets_job("test", [transformed_def]).execute_in_process()
     assert result.success
@@ -80,11 +82,11 @@ def test_without_resources_graph_backed_asset():
         resource_defs={"foo": ResourceDefinition.hardcoded_resource("bar")},
     )
 
-    assert graph_backed.required_resource_keys == {"foo", "io_manager"}
+    assert graph_backed.required_resource_keys == {"foo", DEFAULT_IO_MANAGER_KEY}
 
     transformed_def = without_resources([graph_backed])[0]
 
-    assert transformed_def.required_resource_keys == {"foo", "io_manager"}
+    assert transformed_def.required_resource_keys == {"foo", DEFAULT_IO_MANAGER_KEY}
     assert transformed_def.resource_defs == {}
 
     transformed_again = with_resources(
@@ -128,7 +130,7 @@ def test_source_asset():
     }
     transformed_asset = without_resources([the_asset])[0]
     assert transformed_asset.resource_defs == {}
-    assert transformed_asset.get_io_manager_key() == "io_manager"
+    assert transformed_asset.get_io_manager_key() == DEFAULT_IO_MANAGER_KEY
 
 
 def test_source_asset_defines_io_manager_key():
@@ -143,3 +145,54 @@ def test_source_asset_defines_io_manager_key():
     transformed_asset = without_resources([the_asset])[0]
     assert transformed_asset.get_io_manager_key() == "the_key"
     assert transformed_asset.resource_defs == {}
+
+
+def test_io_manager_key_overrides_multiple_outputs():
+    # Simulate setting system-provided io manager key for multiple outs. Once https://github.com/dagster-io/dagster/issues/8650 lands, this should be replaced with using @multi_asset with AssetOut.
+
+    asset_key_a = AssetKey("a")
+    asset_key_b = AssetKey("b")
+
+    @op(
+        out={
+            "a": Out(io_manager_key=io_manager_key_for_asset_key(asset_key_a)),
+            "b": Out(io_manager_key=io_manager_key_for_asset_key(asset_key_b)),
+        }
+    )
+    def ma_op():
+        return 1
+
+    ma = AssetsDefinition(
+        node_def=ma_op,
+        keys_by_input_name={},
+        keys_by_output_name={"a": asset_key_a, "b": asset_key_b},
+    )
+
+    assert ma.required_resource_keys == {
+        io_manager_key_for_asset_key(asset_key_a),
+        io_manager_key_for_asset_key(asset_key_b),
+    }
+
+    ma_transformed = without_resources([ma])[0]
+    assert ma_transformed.required_resource_keys == {DEFAULT_IO_MANAGER_KEY}
+
+
+def test_without_resources_transitive_io_manager_deps():
+    @io_manager(required_resource_keys={"foo"})
+    def the_io_manager():
+        pass
+
+    @asset(
+        resource_defs={"foo": ResourceDefinition.hardcoded_resource("foo")},
+        io_manager_def=the_io_manager,
+    )
+    def the_asset():
+        pass
+
+    assert the_asset.required_resource_keys == {
+        "foo",
+        io_manager_key_for_asset_key(the_asset.asset_key),
+    }
+    transformed_asset = without_resources([the_asset])[0]
+    # Transitive resource dependencies are kept around, because there are is no way to specify resources as optional.
+    assert transformed_asset.required_resource_keys == {"foo", DEFAULT_IO_MANAGER_KEY}

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_without_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_without_resources.py
@@ -5,15 +5,16 @@ from dagster import (
     IOManager,
     ResourceDefinition,
     build_op_context,
+    graph,
     io_manager,
     mem_io_manager,
-    graph,
     op,
-    with_resources,
     resource,
+    with_resources,
     without_resources,
 )
 from dagster.core.asset_defs import AssetsDefinition, SourceAsset, asset, build_assets_job
+from dagster.core.asset_defs.assets import io_manager_key_for_asset_key
 from dagster.core.errors import (
     DagsterInvalidConfigError,
     DagsterInvalidDefinitionError,
@@ -21,7 +22,6 @@ from dagster.core.errors import (
     DagsterInvariantViolationError,
 )
 from dagster.core.storage.mem_io_manager import InMemoryIOManager
-from dagster.core.asset_defs.assets import io_manager_key_for_asset_key
 
 
 def test_asset():
@@ -74,8 +74,8 @@ def test_without_resources_graph_backed_asset():
         return the_op()
 
     graph_backed = AssetsDefinition(
-        asset_keys_by_input_name={},
-        asset_keys_by_output_name={"result": AssetKey("cool_thing")},
+        keys_by_input_name={},
+        keys_by_output_name={"result": AssetKey("cool_thing")},
         node_def=the_graph,
         resource_defs={"foo": ResourceDefinition.hardcoded_resource("bar")},
     )


### PR DESCRIPTION
Adds a method `without_resources` which removes all resource definitions attached to an AssetsDefinition or SourceAsset. There is some intricacy in the implementation, because in order to support directly providing io manager definitions on assets, we set a system-generated io manager key on asset definitions. When removing resources, we would want to remove that key and use the default key `io_manager` instead, since the user is never exposed to the original io manager key.