### PR TITLE
[assets] fix bugs with subsets of assets

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -723,13 +723,13 @@ def _subset_assets_defs(
                 "asset keys produced by this asset."
             )
 
-    missed_keys = selected_asset_keys - included_keys
+    missed_keys = selected_asset_keys - included_keys - {sa.key for sa in source_assets}
     if missed_keys:
         raise DagsterInvalidSubsetError(
             f"When building job, the AssetKey(s) {[key.to_user_string() for key in missed_keys]} "
-            "were selected, but are not produced by any of the provided AssetsDefinitions. Make "
-            "sure that keys are spelled correctly and that all of the expected definitions are "
-            "provided."
+            "were selected, but are not produced by any of the provided AssetsDefinitions or "
+            "SourceAssets. Make sure that keys are spelled correctly and that all of the expected "
+            "definitions are provided."
         )
     all_excluded_assets: Sequence[Union["AssetsDefinition", "SourceAsset"]] = [
         *excluded_assets,

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -802,6 +802,8 @@ def external_asset_graph_from_defs(
     for pipeline_def in pipelines:
         asset_info_by_node_output = pipeline_def.asset_layer.asset_info_by_node_output_handle
         for node_output_handle, asset_info in asset_info_by_node_output.items():
+            if not asset_info.is_required:
+                continue
             output_key = asset_info.key
             if output_key not in op_names_by_asset_key:
                 op_names_by_asset_key[output_key] = [


### PR DESCRIPTION
### Summary & Motivation

Noticed these while playing around w/ the new APIs.

Bug 1: If you have a selection like *foo, that will select all of the assets in the dependency graph that are upstream of foo, including any source assets. This is totally fine, but we had some error detecting logic that didn't take that into account.

Bug 2: When you create a job that slices through a multi-asset, originally the ExternalAssetNodes for assets that were left out of this selection still said they were part of that job. This mean that if you went to the job page, it would show assets that weren't actually part of the job.

### How I Tested These Changes

New tests failed before the changes, now they pass.
