### PR TITLE
add tags in run_request_for_partition

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -431,8 +431,6 @@ class JobDefinition(PipelineDefinition):
         run_key: Optional[str],
         tags: Optional[Dict[str, str]] = None,
     ) -> RunRequest:
-        print(tags)
-        print(run_key)
         partition_set = self.get_partition_set_def()
         if not partition_set:
             check.failed("Called run_request_for_partition on a non-partitioned job")

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -425,14 +425,17 @@ class JobDefinition(PipelineDefinition):
 
         return mode.partitioned_config.partitions_def
 
-    def run_request_for_partition(self, partition_key: str, run_key: Optional[str]) -> RunRequest:
+    def run_request_for_partition(
+        self, partition_key: str, run_key: Optional[str], tags: Optional[dict]
+    ) -> RunRequest:
         partition_set = self.get_partition_set_def()
         if not partition_set:
             check.failed("Called run_request_for_partition on a non-partitioned job")
 
         partition = partition_set.get_partition(partition_key)
         run_config = partition_set.run_config_for_partition(partition)
-        tags = partition_set.tags_for_partition(partition)
+        partition_tags = partition_set.tags_for_partition(partition)
+        tags.update(partition_tags)
         return RunRequest(run_key=run_key, run_config=run_config, tags=tags)
 
     def with_hooks(self, hook_defs: AbstractSet[HookDefinition]) -> "JobDefinition":

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -426,16 +426,24 @@ class JobDefinition(PipelineDefinition):
         return mode.partitioned_config.partitions_def
 
     def run_request_for_partition(
-        self, partition_key: str, run_key: Optional[str], tags: Optional[dict]
+        self,
+        partition_key: str,
+        run_key: Optional[str],
+        tags: Optional[Dict[str, str]] = None,
     ) -> RunRequest:
+        print(tags)
+        print(run_key)
         partition_set = self.get_partition_set_def()
         if not partition_set:
             check.failed("Called run_request_for_partition on a non-partitioned job")
 
         partition = partition_set.get_partition(partition_key)
         run_config = partition_set.run_config_for_partition(partition)
-        partition_tags = partition_set.tags_for_partition(partition)
-        tags.update(partition_tags)
+        if tags:
+            tags.update(partition_set.tags_for_partition(partition))
+        else:
+            tags = partition_set.tags_for_partition(partition)
+
         return RunRequest(run_key=run_key, run_config=run_config, tags=tags)
 
     def with_hooks(self, hook_defs: AbstractSet[HookDefinition]) -> "JobDefinition":

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -437,12 +437,13 @@ class JobDefinition(PipelineDefinition):
 
         partition = partition_set.get_partition(partition_key)
         run_config = partition_set.run_config_for_partition(partition)
-        if tags:
-            tags.update(partition_set.tags_for_partition(partition))
-        else:
-            tags = partition_set.tags_for_partition(partition)
+        run_request_tags = (
+            {**tags, **partition_set.tags_for_partition(partition)}
+            if tags
+            else partition_set.tags_for_partition(partition)
+        )
 
-        return RunRequest(run_key=run_key, run_config=run_config, tags=tags)
+        return RunRequest(run_key=run_key, run_config=run_config, tags=run_request_tags)
 
     def with_hooks(self, hook_defs: AbstractSet[HookDefinition]) -> "JobDefinition":
         """Apply a set of hooks to all op instances within the job."""

--- a/python_modules/dagster/dagster_tests/execution_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_job.py
@@ -164,6 +164,13 @@ def test_job_run_request():
         assert run_request.tags
         assert run_request.tags.get(PARTITION_NAME_TAG) == partition_key
 
+        run_request_with_tags = my_job.run_request_for_partition(
+            partition_key=partition_key, run_key=None, tags={"foo": "bar"}
+        )
+        assert run_request_with_tags.run_config == partition_fn(partition_key)
+        assert run_request_with_tags.tags
+        assert run_request_with_tags.tags.get(PARTITION_NAME_TAG) == partition_key
+
 
 # Datetime is not serializable
 @op

--- a/python_modules/dagster/dagster_tests/execution_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_job.py
@@ -170,6 +170,7 @@ def test_job_run_request():
         assert run_request_with_tags.run_config == partition_fn(partition_key)
         assert run_request_with_tags.tags
         assert run_request_with_tags.tags.get(PARTITION_NAME_TAG) == partition_key
+        assert run_request_with_tags.tags.get("foo") == "bar"
 
 
 # Datetime is not serializable


### PR DESCRIPTION
### Summary & Motivation

I use a sensor that triggers partitioned queries. I need to have additional tags as it is already possible to add when running a job. Here, the update function allows to overwrite the tags that have the same key as the partition_tags, which guarantees to always have the authentic partition tags

### How I Tested These Changes

```
@sensor(job=job)
def my_sensor(context):
    since_key = context.cursor or None
    new_s3_keys = get_s3_keys(
        "my_bucket", prefix="my_prefix/", since_key=since_key, s3_session=S3_session
    )
    if not new_s3_keys:
        return SkipReason("No new s3 files found for bucket my_s3_bucket.")
    run_requests = [
        job.run_request_for_partition(
            partition_key="2022-06-12", run_key=s3_key, tags={"my_tag": "my_value"}
        )
        for s3_key in new_s3_keys
    ]
    context.update_cursor(new_s3_keys[-1])
    return run_requests

```
