### PR TITLE
docs(graphql): add external link to GraphQL schema

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -217,6 +217,14 @@
           {
             "title": "GraphQL Python Client",
             "path": "/concepts/dagit/graphql-client"
+          },
+          {
+            "title": "GraphQL Schema",
+            "pathTemplate": [
+              "https://github.com/dagster-io/dagster/blob/",
+              "/js_modules/dagit/packages/core/src/graphql/schema.graphql"
+            ],
+            "isExternalLink": true
           }
         ]
       },

--- a/docs/next/__tests__/mdxInternalLinks.test.ts
+++ b/docs/next/__tests__/mdxInternalLinks.test.ts
@@ -13,6 +13,7 @@ import matter from "gray-matter";
 import mdx from "remark-mdx";
 import remark from "remark";
 
+const DAGSTER_DIR = path.resolve(__dirname, "../../..");
 const ROOT_DIR = path.resolve(__dirname, "../../");
 const DOCS_DIR = path.resolve(ROOT_DIR, "content");
 interface LinkElement extends Node {
@@ -91,6 +92,12 @@ test("No dead MDX links", async () => {
   expect(linkCount).toBeGreaterThan(0);
 
   expect(deadLinks).toEqual([]);
+});
+
+test("No dead GraphQL schema", async () => {
+  const graphqlSchemaExists = fileExists(path.resolve(DAGSTER_DIR, "js_modules/dagit/packages/core/src/graphql/schema.graphql"))
+
+  expect(graphqlSchemaExists).toBe(true);
 });
 
 function getMatchCandidates(targetPath: string): Array<string> {

--- a/docs/next/components/Sidebar.tsx
+++ b/docs/next/components/Sidebar.tsx
@@ -187,23 +187,42 @@ const SecondaryNavigation = () => {
 };
 
 const ThirdLevelNavigation = ({ section }) => {
-  const { asPathWithoutAnchor } = useVersion();
+  const { version } = useVersion();
+  const path = section.pathTemplate
+    ? section.pathTemplate.join(version)
+    : section.path;
 
-  return (
-    <Link key={section.path} href={section.path}>
-      <a
-        className={cx(
-          "group flex items-center px-3 py-1 text-sm text-gray-700 rounded-md",
-          {
-            "hover:bg-lavender hover:bg-opacity-50 text-blurple":
-              section.path === asPathWithoutAnchor,
-            "hover:text-gray-900 hover:bg-lavender hover:bg-opacity-50":
-              section.path !== asPathWithoutAnchor,
+  const menuItem = (
+    <a
+      className={
+        "group flex justify-between items-center px-3 py-1 text-sm text-gray-700 rounded-md"
+      }
+      href={path}
+      target={section.isExternalLink ? "_blank" : "_self"}
+    >
+      <span>{section.title}</span>
+      {section.isExternalLink && (
+        <svg
+          className={
+            "mr-2 h-4 w-4 text-gray-400 transition flex-shrink-0 group-hover:text-gray-600"
           }
-        )}
-      >
-        <span>{section.title}</span>
-      </a>
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          {Icons["ExternalLink"]}
+        </svg>
+      )}
+    </a>
+  );
+
+  return section.isExternalLink || section.isUnversioned ? (
+    menuItem
+  ) : (
+    <Link key={path} href={path}>
+      {menuItem}
     </Link>
   );
 };


### PR DESCRIPTION
### Summary & Motivation
Like linear, have a link to our GraphQL schema to show the full API spec.

### How I Tested These Changes
[vercel](https://dagster-git-rl-schema-in-docs-elementl.vercel.app/master/concepts/dagit/dagit)
