### PR TITLE
[dagit] Repair font-sizes on Safari

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
@@ -284,9 +284,11 @@ const SectionHeader = styled.button<{
   cursor: pointer;
   display: flex;
   align-items: center;
+  font-size: 14px;
   gap: 12px;
   padding: 0 12px 0 24px;
   text-align: left;
+  user-select: none;
   white-space: nowrap;
 
   height: ${({$showRepoLocation}) =>

--- a/js_modules/dagit/packages/ui/src/components/TextInput.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TextInput.tsx
@@ -86,6 +86,7 @@ export const TextInputStyles = css`
   border-radius: 8px;
   box-shadow: ${Colors.Gray300} inset 0px 0px 0px 1px, ${Colors.KeylineGray} inset 2px 2px 1.5px;
   flex-grow: 1;
+  font-size: 14px;
   line-height: 20px;
   padding: 6px 6px 6px 12px;
   margin: 0;


### PR DESCRIPTION
### Summary & Motivation

I noticed a couple of font-size issues on Safari.

- The repo name in the left nav is falling back to Safari's default font-size for `button`, which means it's way too small.
- The default font size for `TextInput` is too small.

### How I Tested These Changes

Verify font-sizes on Dagit in Safari 15.5.
