### PR TITLE
Allow number type for id in ButtonGroup

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/ButtonGroup.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ButtonGroup.tsx
@@ -19,7 +19,7 @@ interface Props<T> {
   onClick: (id: T, e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-export const ButtonGroup = <T extends string>(props: Props<T>) => {
+export const ButtonGroup = <T extends string | number>(props: Props<T>) => {
   const {activeItems, buttons, onClick} = props;
   return (
     <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>

--- a/js_modules/dagit/packages/ui/src/components/Table.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Table.tsx
@@ -18,7 +18,7 @@ export const Table = styled(HTMLTable)<TableProps>`
   & tr td {
     box-shadow: inset 0 1px 0 ${Colors.KeylineGray}, inset 1px 0 0 ${Colors.KeylineGray} !important;
   }
-  
+
   & tr th {
     color: ${Colors.Gray500};
     font-family: ${FontFamily.default};

--- a/js_modules/dagit/packages/ui/src/components/Table.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Table.tsx
@@ -34,6 +34,11 @@ export const Table = styled(HTMLTable)<TableProps>`
     padding-left: ${({$compact}) => ($compact ? '8px' : ' 24px')};
   }
 
+  & tr th:last-child,
+  & tr td:last-child {
+    border-right: 1px solid ${Colors.KeylineGray};
+  }
+
   & tr td {
     color: ${Colors.Gray900};
     font-family: ${FontFamily.monospace};

--- a/js_modules/dagit/packages/ui/src/components/Table.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Table.tsx
@@ -14,11 +14,6 @@ export const Table = styled(HTMLTable)<TableProps>`
   border: none;
   width: 100%;
 
-  & tr th,
-  & tr td {
-    box-shadow: inset 0 1px 0 ${Colors.KeylineGray}, inset 1px 0 0 ${Colors.KeylineGray} !important;
-  }
-
   & tr th {
     color: ${Colors.Gray500};
     font-family: ${FontFamily.default};

--- a/js_modules/dagit/packages/ui/src/components/Table.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Table.tsx
@@ -14,6 +14,11 @@ export const Table = styled(HTMLTable)<TableProps>`
   border: none;
   width: 100%;
 
+  & tr th,
+  & tr td {
+    box-shadow: inset 0 1px 0 ${Colors.KeylineGray}, inset 1px 0 0 ${Colors.KeylineGray} !important;
+  }
+  
   & tr th {
     color: ${Colors.Gray500};
     font-family: ${FontFamily.default};
@@ -27,11 +32,6 @@ export const Table = styled(HTMLTable)<TableProps>`
 
   & tr th:first-child {
     padding-left: ${({$compact}) => ($compact ? '8px' : ' 24px')};
-  }
-
-  & tr th:last-child,
-  & tr td:last-child {
-    border-right: 1px solid ${Colors.KeylineGray};
   }
 
   & tr td {


### PR DESCRIPTION
### Summary & Motivation

Update ButtonGroup to allow a number type (for typescript Enums which by default are number based if no value is specified/required) since a Key can be either a string or a number
