### PR TITLE
[dagit] Resolve redundant tag buttons on Launchpad

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -587,20 +587,15 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
                 onRequestClose={closeTagEditor}
               />
               <div style={{flex: 1}} />
-              {tagsFromSession.length ? null : (
-                <>
-                  <ShortcutHandler
-                    shortcutLabel="⌥T"
-                    shortcutFilter={(e) => e.code === 'KeyT' && e.altKey}
-                    onShortcut={openTagEditor}
-                  >
-                    <Button onClick={openTagEditor} icon={<Icon name="add_circle" />}>
-                      Add tags
-                    </Button>
-                  </ShortcutHandler>
-                  <SessionSettingsSpacer />
-                </>
-              )}
+              <ShortcutHandler
+                shortcutLabel="⌥T"
+                shortcutFilter={(e) => e.code === 'KeyT' && e.altKey}
+                onShortcut={openTagEditor}
+              >
+                <Button onClick={openTagEditor} icon={<Icon name="edit" />}>
+                  Edit tags
+                </Button>
+              </ShortcutHandler>
               <SessionSettingsSpacer />
               <SecondPanelToggle axis="horizontal" container={editorSplitPanelContainer} />
             </SessionSettingsBar>

--- a/js_modules/dagit/packages/core/src/launchpad/TagEditor.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/TagEditor.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Button,
-  Colors,
   DialogBody,
   DialogFooter,
   Dialog,
@@ -182,11 +181,7 @@ export const TagEditor: React.FC<ITagEditorProps> = ({
   );
 };
 
-export const TagContainer = ({
-  tagsFromSession,
-  tagsFromDefinition,
-  onRequestEdit,
-}: ITagContainerProps) => {
+export const TagContainer = ({tagsFromSession, tagsFromDefinition}: ITagContainerProps) => {
   return (
     <Container>
       <TagList>
@@ -210,47 +205,19 @@ export const TagContainer = ({
           <RunTag tag={tag} key={idx} />
         ))}
       </TagList>
-      <TagEditorLink onRequestOpen={onRequestEdit}>
-        <Group direction="row" spacing={4} alignItems="center">
-          <Icon name="edit" color={Colors.Gray500} /> Edit Tags
-        </Group>
-      </TagEditorLink>
     </Container>
   );
 };
-
-interface ITagEditorLinkProps {
-  onRequestOpen: () => void;
-  children: React.ReactNode;
-}
-
-const TagEditorLink = ({onRequestOpen, children}: ITagEditorLinkProps) => (
-  <ShortcutHandler
-    shortcutLabel="⌥T"
-    shortcutFilter={(e) => e.code === 'KeyT' && e.altKey}
-    onShortcut={onRequestOpen}
-  >
-    <Link onClick={onRequestOpen}>{children}</Link>
-  </ShortcutHandler>
-);
 
 const Container = styled.div`
   align-items: flex-start;
   display: flex;
   flex-direction: row;
 `;
+
 const TagList = styled.div`
   display: flex;
   flex: 1;
   flex-wrap: wrap;
   gap: 4px;
-`;
-const Link = styled.div`
-  color: #666;
-  cursor: pointer;
-  margin: 4px 12px;
-  font-size: 12px;
-  &:hover {
-    color: #aaa;
-  }
 `;


### PR DESCRIPTION
### Summary & Motivation

In Launchpad, we don't need an extra "Edit tags" link in the tag editor section, since we have a button to edit tags already.

Change the "Add tags" button to say "Edit tags" all the time, and remove the other link.

### How I Tested These Changes

View Launchpad, verify changes described above. Edit tags, verify correct behavior.
