### PR TITLE
Assorted type annotations

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
@@ -5,17 +5,19 @@ description: Partitioned assets and jobs enable launching backfills, where each 
 
 # Partitioned Assets and Jobs
 
-Partitioning allows software-defined assets and jobs to consume and/or produce data that is subdivided along some axis (most commonly time). These subdivisions are called _partitions_, with each partition denoted by a _partition key_.
+Partitioning allows a job or software-defined asset to correspond to a set of entities with identical structure but different parameters.
 
-A _partitioned asset_ represents a body of subdivided data. Depending on how the asset is stored, each partition might correspond to a file or a slice of a table in a database. Materializations of a partitioned asset are parameterized by a partition key, and thus scoped to a single partition.
+A _partitioned job_ is a job where each run corresponds to a partition key. Most commonly, each partition key represents a time window, so, when a job executes, it processes data within one of the time windows.
 
-A _partitioned job_ operates over subdivided data. Runs of a partitioned job are parameterized by a partition key. It's common to construct a partitioned job that materializes a collection of partitioned assets every time it runs.
+A _partitioned asset_ is an asset that's composed of a set of partitions, which can be materialized and tracked independently. Most commonly, each partition represents all the records in a data set that fall within a particular time window. Depending on where the asset is stored, each partition might correspond to a file or a slice of a table in a database.
 
-With a partitioned asset or job, you can:
+It's common to construct a partitioned job that materializes a particular set of partitioned assets every time it runs.
+
+Having defined a partitioned job or asset, you can:
 
 - View runs by partition in Dagit.
-- Define a [schedule](/concepts/partitions-schedules-sensors/schedules) that launches partition-scoped runs. For example, a job might run each day and process the data that arrived during the previous day.
-- Launch a [backfill](/concepts/partitions-schedules-sensors/backfills), which is a set of partition-scoped runs. For example, after making a code change to a partitioned job, you might want to re-run the job over all previously processed partitions.
+- Define a [schedule](/concepts/partitions-schedules-sensors/schedules) that fills in a partition each time it runs. For example, a job might run each day and process the data that arrived during the previous day.
+- Launch [backfills](/concepts/partitions-schedules-sensors/backfills), which are sets of runs that each process a different partition. For example, after making a code change, you might want to run your job on all time windows instead of just one of them.
 
 ---
 

--- a/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
@@ -5,19 +5,17 @@ description: Partitioned assets and jobs enable launching backfills, where each 
 
 # Partitioned Assets and Jobs
 
-Partitioning allows a job or software-defined asset to correspond to a set of entities with identical structure but different parameters.
+Partitioning allows software-defined assets and jobs to consume and/or produce data that is subdivided along some axis (most commonly time). These subdivisions are called _partitions_, with each partition denoted by a _partition key_.
 
-A _partitioned job_ is a job where each run corresponds to a partition key. Most commonly, each partition key represents a time window, so, when a job executes, it processes data within one of the time windows.
+A _partitioned asset_ represents a body of subdivided data. Depending on how the asset is stored, each partition might correspond to a file or a slice of a table in a database. Materializations of a partitioned asset are parameterized by a partition key, and thus scoped to a single partition.
 
-A _partitioned asset_ is an asset that's composed of a set of partitions, which can be materialized and tracked independently. Most commonly, each partition represents all the records in a data set that fall within a particular time window. Depending on where the asset is stored, each partition might correspond to a file or a slice of a table in a database.
+A _partitioned job_ operates over subdivided data. Runs of a partitioned job are parameterized by a partition key. It's common to construct a partitioned job that materializes a collection of partitioned assets every time it runs.
 
-It's common to construct a partitioned job that materializes a particular set of partitioned assets every time it runs.
-
-Having defined a partitioned job or asset, you can:
+With a partitioned asset or job, you can:
 
 - View runs by partition in Dagit.
-- Define a [schedule](/concepts/partitions-schedules-sensors/schedules) that fills in a partition each time it runs. For example, a job might run each day and process the data that arrived during the previous day.
-- Launch [backfills](/concepts/partitions-schedules-sensors/backfills), which are sets of runs that each process a different partition. For example, after making a code change, you might want to run your job on all time windows instead of just one of them.
+- Define a [schedule](/concepts/partitions-schedules-sensors/schedules) that launches partition-scoped runs. For example, a job might run each day and process the data that arrived during the previous day.
+- Launch a [backfill](/concepts/partitions-schedules-sensors/backfills), which is a set of partition-scoped runs. For example, after making a code change to a partitioned job, you might want to re-run the job over all previously processed partitions.
 
 ---
 

--- a/examples/hacker_news/hacker_news/resources/snowflake_io_manager.py
+++ b/examples/hacker_news/hacker_news/resources/snowflake_io_manager.py
@@ -1,7 +1,7 @@
 import os
 import textwrap
 from contextlib import contextmanager
-from typing import Any, Dict, Mapping, Optional, Sequence, Union, cast
+from typing import Any, Mapping, Optional, Sequence, Union, cast
 
 from pandas import DataFrame as PandasDataFrame
 from pandas import read_sql

--- a/examples/hacker_news/hacker_news/resources/snowflake_io_manager.py
+++ b/examples/hacker_news/hacker_news/resources/snowflake_io_manager.py
@@ -1,7 +1,7 @@
 import os
 import textwrap
 from contextlib import contextmanager
-from typing import Mapping, Optional, Sequence, Union
+from typing import Any, Dict, Mapping, Optional, Sequence, Union, cast
 
 from pandas import DataFrame as PandasDataFrame
 from pandas import read_sql
@@ -77,7 +77,7 @@ class SnowflakeIOManager(IOManager):
 
     def handle_output(self, context: OutputContext, obj: Union[PandasDataFrame, SparkDataFrame]):
         metadata = check.not_none(context.metadata)
-        schema, table = metadata["table"].split(".")
+        schema, table = cast(str, metadata["table"]).split(".")
 
         partition_bounds = (
             context.resources.partition_bounds if metadata.get("partitioned") is True else None
@@ -94,8 +94,9 @@ class SnowflakeIOManager(IOManager):
                 "SnowflakeIOManager only supports pandas DataFrames and spark DataFrames"
             )
 
+        columns = cast(Optional[Sequence[str]], metadata.get("columns"))
         yield MetadataEntry.text(
-            self._get_select_statement(table, schema, metadata.get("columns"), partition_bounds),
+            self._get_select_statement(table, schema, columns, partition_bounds),
             "Query",
         )
 
@@ -143,6 +144,7 @@ class SnowflakeIOManager(IOManager):
             return f"DELETE FROM {schema}.{table}"
 
     def load_input(self, context: InputContext) -> PandasDataFrame:
+        metadata: Mapping[str, Any]
         if context.upstream_output is not None:
             # loading from an upstream output
             metadata = check.not_none(context.upstream_output.metadata)
@@ -187,7 +189,7 @@ class SnowflakeIOManager(IOManager):
 
     def get_output_asset_key(self, context: OutputContext) -> AssetKey:
         metadata = check.not_none(context.metadata)
-        return AssetKey(["snowflake", *metadata["table"].split(".")])
+        return AssetKey(["snowflake", *cast(str, metadata["table"]).split(".")])
 
     def get_output_asset_partitions(self, context: OutputContext):
         metadata = check.not_none(context.metadata)

--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -92,7 +92,7 @@ def opt_bool_param(
     return default if obj is None else obj
 
 
-def bool_elem(ddict: Dict, key: str, additional_message: Optional[str] = None) -> bool:
+def bool_elem(ddict: Mapping, key: str, additional_message: Optional[str] = None) -> bool:
     dict_param(ddict, "ddict")
     str_param(key, "key")
 
@@ -351,7 +351,7 @@ def opt_two_dim_dict_param(
 
 
 def dict_elem(
-    obj: Dict,
+    obj: Mapping,
     key: str,
     key_type: Optional[TypeOrTupleOfTypes] = None,
     value_type: Optional[TypeOrTupleOfTypes] = None,
@@ -373,7 +373,7 @@ def dict_elem(
 
 
 def opt_dict_elem(
-    obj: Dict[str, Any],
+    obj: Mapping[str, Any],
     key: str,
     key_type: Optional[TypeOrTupleOfTypes] = None,
     value_type: Optional[TypeOrTupleOfTypes] = None,
@@ -395,7 +395,7 @@ def opt_dict_elem(
 
 
 def opt_nullable_dict_elem(
-    obj: Dict[str, Any],
+    obj: Mapping[str, Any],
     key: str,
     key_type: Optional[TypeOrTupleOfTypes] = None,
     value_type: Optional[TypeOrTupleOfTypes] = None,
@@ -472,7 +472,7 @@ def opt_float_param(
     return default if obj is None else obj
 
 
-def float_elem(ddict: Dict, key: str, additional_message: Optional[str] = None) -> float:
+def float_elem(ddict: Mapping, key: str, additional_message: Optional[str] = None) -> float:
     dict_param(ddict, "ddict")
     str_param(key, "key")
 
@@ -483,7 +483,7 @@ def float_elem(ddict: Dict, key: str, additional_message: Optional[str] = None) 
 
 
 def opt_float_elem(
-    ddict: Dict, key: str, additional_message: Optional[str] = None
+    ddict: Mapping, key: str, additional_message: Optional[str] = None
 ) -> Optional[float]:
     dict_param(ddict, "ddict")
     str_param(key, "key")
@@ -595,7 +595,7 @@ def int_value_param(
     return obj
 
 
-def int_elem(ddict: Dict, key: str, additional_message: Optional[str] = None) -> int:
+def int_elem(ddict: Mapping, key: str, additional_message: Optional[str] = None) -> int:
     dict_param(ddict, "ddict")
     str_param(key, "key")
 
@@ -605,7 +605,7 @@ def int_elem(ddict: Dict, key: str, additional_message: Optional[str] = None) ->
     return value
 
 
-def opt_int_elem(ddict: Dict, key: str, additional_message: Optional[str] = None) -> Optional[int]:
+def opt_int_elem(ddict: Mapping, key: str, additional_message: Optional[str] = None) -> Optional[int]:
     dict_param(ddict, "ddict")
     str_param(key, "key")
 
@@ -813,7 +813,7 @@ def two_dim_list_param(
 
 
 def list_elem(
-    ddict: Dict,
+    ddict: Mapping,
     key: str,
     of_type: Optional[TypeOrTupleOfTypes] = None,
     additional_message: Optional[str] = None,
@@ -834,7 +834,7 @@ def list_elem(
 
 
 def opt_list_elem(
-    ddict: Dict,
+    ddict: Mapping,
     key: str,
     of_type: Optional[TypeOrTupleOfTypes] = None,
     additional_message: Optional[str] = None,
@@ -1288,7 +1288,7 @@ def opt_nonempty_str_param(
     return default if obj is None or obj == "" else obj
 
 
-def str_elem(ddict: Dict, key: str, additional_message: Optional[str] = None) -> str:
+def str_elem(ddict: Mapping, key: str, additional_message: Optional[str] = None) -> str:
     dict_param(ddict, "ddict")
     str_param(key, "key")
 
@@ -1298,7 +1298,7 @@ def str_elem(ddict: Dict, key: str, additional_message: Optional[str] = None) ->
     return value
 
 
-def opt_str_elem(ddict: Dict, key: str, additional_message: Optional[str] = None) -> Optional[str]:
+def opt_str_elem(ddict: Mapping, key: str, additional_message: Optional[str] = None) -> Optional[str]:
     dict_param(ddict, "ddict")
     str_param(key, "key")
 
@@ -1510,7 +1510,7 @@ class NotImplementedCheckError(CheckError):
 def _element_check_error(
     key: object,
     value: object,
-    ddict: Dict,
+    ddict: Mapping,
     ttype: TypeOrTupleOfTypes,
     additional_message: Optional[str] = None,
 ) -> ElementCheckError:

--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -635,6 +635,16 @@ def inst_param(
         )
     return obj
 
+@overload
+def opt_inst_param(
+    obj: Optional[T],
+    param_name: str,
+    ttype: TypeOrTupleOfTypes,
+    default: None = ...,
+    additional_message: Optional[str] = None,
+) -> Optional[T]:
+    ...
+
 
 @overload
 def opt_inst_param(
@@ -645,7 +655,6 @@ def opt_inst_param(
     additional_message: Optional[str] = None,
 ) -> T:
     ...
-
 
 @overload
 def opt_inst_param(
@@ -659,7 +668,7 @@ def opt_inst_param(
 
 
 def opt_inst_param(
-    obj: T,
+    obj: Optional[T],
     param_name: str,
     ttype: TypeOrTupleOfTypes,
     default: Optional[T] = None,

--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -697,7 +697,7 @@ def list_param(
     param_name: str,
     of_type: Optional[TypeOrTupleOfTypes] = None,
     additional_message: Optional[str] = None,
-) -> List:
+) -> List[Any]:
     from dagster.utils import frozenlist
 
     if not isinstance(obj, (frozenlist, list)):
@@ -716,7 +716,7 @@ def opt_list_param(
     param_name: str,
     of_type: Optional[TypeOrTupleOfTypes] = None,
     additional_message: Optional[str] = None,
-) -> List:
+) -> List[Any]:
     """Ensures argument obj is a list or None; in the latter case, instantiates an empty list
     and returns it.
 

--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -605,7 +605,9 @@ def int_elem(ddict: Mapping, key: str, additional_message: Optional[str] = None)
     return value
 
 
-def opt_int_elem(ddict: Mapping, key: str, additional_message: Optional[str] = None) -> Optional[int]:
+def opt_int_elem(
+    ddict: Mapping, key: str, additional_message: Optional[str] = None
+) -> Optional[int]:
     dict_param(ddict, "ddict")
     str_param(key, "key")
 
@@ -635,6 +637,7 @@ def inst_param(
         )
     return obj
 
+
 @overload
 def opt_inst_param(
     obj: Optional[T],
@@ -655,6 +658,7 @@ def opt_inst_param(
     additional_message: Optional[str] = None,
 ) -> T:
     ...
+
 
 @overload
 def opt_inst_param(
@@ -1298,7 +1302,9 @@ def str_elem(ddict: Mapping, key: str, additional_message: Optional[str] = None)
     return value
 
 
-def opt_str_elem(ddict: Mapping, key: str, additional_message: Optional[str] = None) -> Optional[str]:
+def opt_str_elem(
+    ddict: Mapping, key: str, additional_message: Optional[str] = None
+) -> Optional[str]:
     dict_param(ddict, "ddict")
     str_param(key, "key")
 

--- a/python_modules/dagster/dagster/config/traversal_context.py
+++ b/python_modules/dagster/dagster/config/traversal_context.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, Optional
+from typing import Dict
 
 import dagster._check as check
 

--- a/python_modules/dagster/dagster/config/traversal_context.py
+++ b/python_modules/dagster/dagster/config/traversal_context.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict
+from typing import Dict, Optional
 
 import dagster._check as check
 
@@ -19,17 +19,21 @@ class TraversalType(Enum):
 class ContextData:
     __slots__ = ["_config_schema_snapshot", "_config_type_snap", "_stack"]
 
+    _config_schema_snapshot: ConfigSchemaSnapshot
+    _config_type_snap: ConfigTypeSnap
+    _stack: EvaluationStack
+
     def __init__(
         self,
         config_schema_snapshot: ConfigSchemaSnapshot,
         config_type_snap: ConfigTypeSnap,
         stack: EvaluationStack,
     ):
-        self._config_schema_snapshot = check.opt_inst_param(
+        self._config_schema_snapshot = check.inst_param(
             config_schema_snapshot, "config_schema_snapshot", ConfigSchemaSnapshot
         )
 
-        self._config_type_snap = check.opt_inst_param(
+        self._config_type_snap = check.inst_param(
             config_type_snap, "config_type_snap", ConfigTypeSnap
         )
 

--- a/python_modules/dagster/dagster/config/validate.py
+++ b/python_modules/dagster/dagster/config/validate.py
@@ -54,7 +54,7 @@ def is_config_scalar_valid(config_type_snap: ConfigTypeSnap, config_value: objec
         check.failed("Not a supported scalar {}".format(config_type_snap))
 
 
-def validate_config(config_schema: object, config_value: object) -> EvaluateValueResult:
+def validate_config(config_schema: object, config_value: T) -> EvaluateValueResult[T]:
 
     config_type = resolve_to_config_type(config_schema)
     config_type = check.inst(cast(ConfigType, config_type), ConfigType)
@@ -421,7 +421,7 @@ def validate_enum_config(
     return EvaluateValueResult.for_value(config_value)
 
 
-def process_config(config_type: object, config_dict: Mapping) -> EvaluateValueResult[Dict]:
+def process_config(config_type: object, config_dict: Mapping[str, object]) -> EvaluateValueResult[Mapping]:
     config_type = resolve_to_config_type(config_type)
     config_type = check.inst(cast(ConfigType, config_type), ConfigType)
     validate_evr = validate_config(config_type, config_dict)

--- a/python_modules/dagster/dagster/config/validate.py
+++ b/python_modules/dagster/dagster/config/validate.py
@@ -421,7 +421,9 @@ def validate_enum_config(
     return EvaluateValueResult.for_value(config_value)
 
 
-def process_config(config_type: object, config_dict: Mapping[str, object]) -> EvaluateValueResult[Mapping]:
+def process_config(
+    config_type: object, config_dict: Mapping[str, object]
+) -> EvaluateValueResult[Mapping]:
     config_type = resolve_to_config_type(config_type)
     config_type = check.inst(cast(ConfigType, config_type), ConfigType)
     validate_evr = validate_config(config_type, config_dict)

--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -404,7 +404,7 @@ class AssetLayer:
     _dependency_node_handles_by_asset_key: Mapping[AssetKey, Set[NodeHandle]]
     _source_assets_by_key: Mapping[AssetKey, "SourceAsset"]
     _asset_defs_by_key: Mapping[AssetKey, "AssetsDefinition"]
-    _asset_defs_by_node_handle: Mapping[NodeHandle, Set[AssetsDefinition]]
+    _asset_defs_by_node_handle: Mapping[NodeHandle, Set["AssetsDefinition"]]
     _io_manager_keys_by_asset_key: Mapping[AssetKey, str]
 
     def __init__(

--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -532,7 +532,7 @@ class AssetLayer:
                 inner_output_def, inner_node_handle = assets_def.node_def.resolve_output_to_origin(
                     output_name, handle=node_handle
                 )
-                node_output_handle = NodeOutputHandle(inner_node_handle, inner_output_def.name)
+                node_output_handle = NodeOutputHandle(check.not_none(inner_node_handle), inner_output_def.name)
                 partition_fn = lambda context: {context.partition_key}
                 asset_info_by_output[node_output_handle] = AssetOutputInfo(
                     asset_key,

--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -35,6 +35,7 @@ from .resource_definition import ResourceDefinition
 
 if TYPE_CHECKING:
     from dagster.core.definitions.assets import AssetsDefinition, SourceAsset
+    from dagster.core.definitions.job_definition import JobDefinition
     from dagster.core.definitions.resolved_asset_defs import ResolvedAssetDependencies
     from dagster.core.execution.context.output import OutputContext
 

--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -532,7 +532,9 @@ class AssetLayer:
                 inner_output_def, inner_node_handle = assets_def.node_def.resolve_output_to_origin(
                     output_name, handle=node_handle
                 )
-                node_output_handle = NodeOutputHandle(check.not_none(inner_node_handle), inner_output_def.name)
+                node_output_handle = NodeOutputHandle(
+                    check.not_none(inner_node_handle), inner_output_def.name
+                )
                 partition_fn = lambda context: {context.partition_key}
                 asset_info_by_output[node_output_handle] = AssetOutputInfo(
                     asset_key,
@@ -609,7 +611,11 @@ class AssetLayer:
     def metadata_for_asset(self, asset_key: AssetKey) -> Optional[MetadataUserInput]:
         if asset_key in self._source_assets_by_key:
             metadata = self._source_assets_by_key[asset_key].metadata
-            return {key: cast(RawMetadataValue, value.value) for key, value in metadata.items()} if metadata else None
+            return (
+                {key: cast(RawMetadataValue, value.value) for key, value in metadata.items()}
+                if metadata
+                else None
+            )
         elif asset_key in self._assets_defs_by_key:
             return self._assets_defs_by_key[asset_key].metadata_by_asset_key[asset_key]
         else:

--- a/python_modules/dagster/dagster/core/definitions/assets.py
+++ b/python_modules/dagster/dagster/core/definitions/assets.py
@@ -14,6 +14,17 @@ from typing import (
 
 import dagster._check as check
 from dagster.core.decorator_utils import get_function_params
+from dagster.core.definitions import (
+    GraphDefinition,
+    NodeDefinition,
+    NodeHandle,
+    OpDefinition,
+    ResourceDefinition,
+)
+from dagster.core.definitions.events import AssetKey
+from dagster.core.definitions.metadata import MetadataUserInput
+from dagster.core.definitions.partition import PartitionsDefinition
+from dagster.core.definitions.utils import DEFAULT_GROUP_NAME, validate_group_name
 from dagster.core.errors import DagsterInvalidInvocationError
 from dagster.utils import merge_dicts
 from dagster.utils.backcompat import deprecation_warning
@@ -52,6 +63,18 @@ class AssetsDefinition(ResourceAddable):
             meaning that they refer to other assets that are produced by this definition, or
             "external", meaning that they refer to assets that aren't produced by this definition.
     """
+
+    _node_def: NodeDefinition
+    _keys_by_input_name: Mapping[str, AssetKey]
+    _keys_by_output_name: Mapping[str, AssetKey]
+    _partitions_def: Optional[PartitionsDefinition]
+    _partition_mappings: Mapping[AssetKey, PartitionMapping]
+    _asset_deps: Mapping[AssetKey, AbstractSet[AssetKey]]
+    _resource_defs: Mapping[str, ResourceDefinition]
+    _group_names_by_key: Mapping[AssetKey, str]
+    _selected_asset_keys: AbstractSet[AssetKey]
+    _can_subset: bool
+    _metadata_by_asset_key: Mapping[AssetKey, MetadataUserInput]
 
     def __init__(
         self,

--- a/python_modules/dagster/dagster/core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/core/definitions/assets_job.py
@@ -33,8 +33,8 @@ def build_assets_job(
     source_assets: Optional[Sequence[Union[SourceAsset, AssetsDefinition]]] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     description: Optional[str] = None,
-    config: Optional[Union[ConfigMapping, Dict[str, Any], PartitionedConfig]] = None,
-    tags: Optional[Dict[str, Any]] = None,
+    config: Optional[Union[ConfigMapping, Mapping[str, object], PartitionedConfig]] = None,
+    tags: Optional[Mapping[str, object]] = None,
     executor_def: Optional[ExecutorDefinition] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
     _asset_selection_data: Optional[AssetSelectionData] = None,
@@ -188,6 +188,7 @@ def build_node_deps(
     for node_handle, assets_def in assets_defs_by_node_handle.items():
         # the key that we'll use to reference the node inside this AssetsDefinition
         node_def_name = assets_def.node_def.name
+        node_key: Union[NodeInvocation, str]
         if node_handle.name != node_def_name:
             node_key = NodeInvocation(node_def_name, alias=node_handle.name)
         else:

--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -183,7 +183,9 @@ class InProgressCompositionContext:
         solid_name = solid.given_alias if solid.given_alias else solid.node_def.name
         self._pending_invocations[solid_name] = solid
 
-    def complete(self, output: Optional[Mapping[str, OutputMapping]]) -> "CompleteCompositionContext":
+    def complete(
+        self, output: Optional[Mapping[str, OutputMapping]]
+    ) -> "CompleteCompositionContext":
         return CompleteCompositionContext.create(
             self.name,
             self.source,

--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -283,7 +283,7 @@ class PendingNodeInvocation:
         self,
         node_def: NodeDefinition,
         given_alias: Optional[str],
-        tags: Optional[frozentags],
+        tags: Optional[Mapping[str, str]],
         hook_defs: Optional[AbstractSet[HookDefinition]],
         retry_policy: Optional[RetryPolicy],
     ):

--- a/python_modules/dagster/dagster/core/definitions/config.py
+++ b/python_modules/dagster/dagster/core/definitions/config.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Callable, Dict, NamedTuple, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Mapping, NamedTuple, Optional, Union, cast
 
 import dagster._check as check
 from dagster.builtins import BuiltinEnum
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from .pipeline_definition import PipelineDefinition
 
 
-def is_callable_valid_config_arg(config: Union[Callable[..., Any], Dict[str, Any]]) -> bool:
+def is_callable_valid_config_arg(config: Union[Callable[..., Any], Mapping[str, object]]) -> bool:
     return BuiltinEnum.contains(config) or is_supported_config_python_builtin(config)
 
 

--- a/python_modules/dagster/dagster/core/definitions/decorators/graph_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/graph_decorator.py
@@ -1,5 +1,5 @@
 from functools import update_wrapper
-from typing import Any, Callable, Dict, List, Optional, Union, overload
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union, overload
 
 import dagster._check as check
 from dagster.core.decorator_utils import format_docstring_for_description
@@ -11,22 +11,32 @@ from ..output import GraphOut, OutputDefinition
 
 
 class _Graph:
+
+    name: Optional[str]
+    description: Optional[str]
+    input_defs: Sequence[InputDefinition]
+    output_defs: Optional[Sequence[OutputDefinition]]
+    ins: Optional[Mapping[str, GraphIn]]
+    out: Optional[Union[GraphOut, Mapping[str, GraphOut]]]
+    tags: Optional[Mapping[str, object]]
+    config_mapping: Optional[ConfigMapping]
+
     def __init__(
         self,
         name: Optional[str] = None,
         description: Optional[str] = None,
-        input_defs: Optional[List[InputDefinition]] = None,
-        output_defs: Optional[List[OutputDefinition]] = None,
-        ins: Optional[Dict[str, GraphIn]] = None,
-        out: Optional[Union[GraphOut, Dict[str, GraphOut]]] = None,
+        input_defs: Optional[Sequence[InputDefinition]] = None,
+        output_defs: Optional[Sequence[OutputDefinition]] = None,
+        ins: Optional[Mapping[str, GraphIn]] = None,
+        out: Optional[Union[GraphOut, Mapping[str, GraphOut]]] = None,
         tags: Optional[Dict[str, Any]] = None,
         config_mapping: Optional[ConfigMapping] = None,
     ):
         self.name = check.opt_str_param(name, "name")
         self.description = check.opt_str_param(description, "description")
-        self.input_defs = check.opt_list_param(input_defs, "input_defs", of_type=InputDefinition)
+        self.input_defs = check.opt_sequence_param(input_defs, "input_defs", of_type=InputDefinition)
         self.did_pass_outputs = output_defs is not None or out is not None
-        self.output_defs = check.opt_nullable_list_param(
+        self.output_defs = check.opt_nullable_sequence_param(
             output_defs, "output_defs", of_type=OutputDefinition
         )
         self.ins = ins

--- a/python_modules/dagster/dagster/core/definitions/decorators/graph_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/graph_decorator.py
@@ -34,7 +34,9 @@ class _Graph:
     ):
         self.name = check.opt_str_param(name, "name")
         self.description = check.opt_str_param(description, "description")
-        self.input_defs = check.opt_sequence_param(input_defs, "input_defs", of_type=InputDefinition)
+        self.input_defs = check.opt_sequence_param(
+            input_defs, "input_defs", of_type=InputDefinition
+        )
         self.did_pass_outputs = output_defs is not None or out is not None
         self.output_defs = check.opt_nullable_sequence_param(
             output_defs, "output_defs", of_type=OutputDefinition

--- a/python_modules/dagster/dagster/core/definitions/decorators/solid_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/solid_decorator.py
@@ -305,7 +305,7 @@ def resolve_checked_solid_fn_inputs(
     decorator_name: str,
     fn_name: str,
     compute_fn: DecoratedSolidFunction,
-    explicit_input_defs: List[InputDefinition],
+    explicit_input_defs: Sequence[InputDefinition],
     exclude_nothing: bool,
 ) -> List[InputDefinition]:
     """

--- a/python_modules/dagster/dagster/core/definitions/definition_config_schema.py
+++ b/python_modules/dagster/dagster/core/definitions/definition_config_schema.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, Dict, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, Union
 
 import dagster._check as check
 from dagster.config.config_schema import UserConfigSchema
@@ -99,13 +99,13 @@ class ConfiguredDefinitionConfigSchema(IDefinitionConfigSchema):
     _current_field: Optional[Field]
     _config_fn: Callable[..., object]
 
-    def __init__(self, parent_definition: "ConfigurableDefinition", config_schema: Optional[DefinitionConfigSchema], config_or_config_fn: object):
+    def __init__(self, parent_definition: "ConfigurableDefinition", config_schema: Optional[IDefinitionConfigSchema], config_or_config_fn: object):
         from .configurable import ConfigurableDefinition
 
         self.parent_def = check.inst_param(
             parent_definition, "parent_definition", ConfigurableDefinition
         )
-        check.opt_inst_param(config_schema, "config_schema", DefinitionConfigSchema)
+        check.opt_inst_param(config_schema, "config_schema", IDefinitionConfigSchema)
 
         self._current_field = config_schema.as_field() if config_schema else None
 

--- a/python_modules/dagster/dagster/core/definitions/definition_config_schema.py
+++ b/python_modules/dagster/dagster/core/definitions/definition_config_schema.py
@@ -99,7 +99,12 @@ class ConfiguredDefinitionConfigSchema(IDefinitionConfigSchema):
     _current_field: Optional[Field]
     _config_fn: Callable[..., object]
 
-    def __init__(self, parent_definition: "ConfigurableDefinition", config_schema: Optional[IDefinitionConfigSchema], config_or_config_fn: object):
+    def __init__(
+        self,
+        parent_definition: "ConfigurableDefinition",
+        config_schema: Optional[IDefinitionConfigSchema],
+        config_or_config_fn: object,
+    ):
         from .configurable import ConfigurableDefinition
 
         self.parent_def = check.inst_param(

--- a/python_modules/dagster/dagster/core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/core/definitions/dependency.py
@@ -198,7 +198,8 @@ class Node:
 
     @property
     def tags(self) -> frozentags:
-        return self.definition.tags.updated_with(self._additional_tags)
+        # Type-ignore temporarily pending assessment of right data structure for `tags`
+        return self.definition.tags.updated_with(self._additional_tags)  # type: ignore
 
     def container_maps_input(self, input_name: str) -> bool:
         return (

--- a/python_modules/dagster/dagster/core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/core/definitions/dependency.py
@@ -8,6 +8,7 @@ from typing import (
     Dict,
     Iterator,
     List,
+    Mapping,
     NamedTuple,
     Optional,
     Tuple,
@@ -772,12 +773,12 @@ InputToOutputHandleDict = Dict[SolidInputHandle, DepTypeAndOutputHandles]
 
 
 def _create_handle_dict(
-    solid_dict: Dict[str, Node],
-    dep_dict: Dict[str, Dict[str, IDependencyDefinition]],
+    solid_dict: Mapping[str, Node],
+    dep_dict: Mapping[str, Mapping[str, IDependencyDefinition]],
 ) -> InputToOutputHandleDict:
     from .composition import MappedInputPlaceholder
 
-    check.dict_param(solid_dict, "solid_dict", key_type=str, value_type=Node)
+    check.mapping_param(solid_dict, "solid_dict", key_type=str, value_type=Node)
     check.two_dim_dict_param(dep_dict, "dep_dict", value_type=IDependencyDefinition)
 
     handle_dict: InputToOutputHandleDict = {}
@@ -820,7 +821,7 @@ def _create_handle_dict(
 
 class DependencyStructure:
     @staticmethod
-    def from_definitions(solids: Dict[str, Node], dep_dict: Dict[str, Any]):
+    def from_definitions(solids: Mapping[str, Node], dep_dict: Mapping[str, Any]):
         return DependencyStructure(list(dep_dict.keys()), _create_handle_dict(solids, dep_dict))
 
     def __init__(self, solid_names: List[str], handle_dict: InputToOutputHandleDict):

--- a/python_modules/dagster/dagster/core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/core/definitions/dependency.py
@@ -108,6 +108,15 @@ class Node:
     Node invocation within a graph. Identified by its name inside the graph.
     """
 
+    name: str
+    definition: "NodeDefinition"
+    graph_definition: "GraphDefinition"
+    _additional_tags: Dict[str, str]
+    _hook_defs: AbstractSet[HookDefinition]
+    _retry_policy: Optional[RetryPolicy]
+    _input_handles: Dict[str, "SolidInputHandle"]
+    _output_handles: Dict[str, "SolidOutputHandle"]
+
     def __init__(
         self,
         name: str,
@@ -501,8 +510,12 @@ class SolidInputHandle(
     def __hash__(self):
         return hash((self.solid.name, self.input_def.name))
 
-    def __eq__(self, other):
-        return self.solid.name == other.solid.name and self.input_def.name == other.input_def.name
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, SolidInputHandle)
+            and self.solid.name == other.solid.name
+            and self.input_def.name == other.input_def.name
+        )
 
     @property
     def solid_name(self) -> str:

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -226,7 +226,7 @@ class Output(Generic[T]):
         self._metadata_entries = normalize_metadata(metadata, metadata_entries)
 
     @property
-    def metadata_entries(self) -> List[Union[PartitionMetadataEntry, MetadataEntry]]:
+    def metadata_entries(self) -> Sequence[Union[PartitionMetadataEntry, MetadataEntry]]:
         return self._metadata_entries
 
     @property
@@ -292,7 +292,7 @@ class DynamicOutput(Generic[T]):
         self._value = value
 
     @property
-    def metadata_entries(self) -> List[Union[PartitionMetadataEntry, MetadataEntry]]:
+    def metadata_entries(self) -> Sequence[Union[PartitionMetadataEntry, MetadataEntry]]:
         return self._metadata_entries
 
     @property
@@ -388,7 +388,7 @@ class AssetMaterialization(
         [
             ("asset_key", AssetKey),
             ("description", Optional[str]),
-            ("metadata_entries", List[Union[MetadataEntry, PartitionMetadataEntry]]),
+            ("metadata_entries", Sequence[Union[MetadataEntry, PartitionMetadataEntry]]),
             ("partition", Optional[str]),
         ],
     )

--- a/python_modules/dagster/dagster/core/definitions/executor_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/executor_definition.py
@@ -1,6 +1,17 @@
 from enum import Enum as PyEnum
 from functools import update_wrapper
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Sequence, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Union,
+    overload,
+)
 
 from typing_extensions import TypeAlias
 
@@ -113,7 +124,9 @@ class ExecutorDefinition(NamedConfigurableDefinition):
     def config_schema(self) -> IDefinitionConfigSchema:
         return self._config_schema
 
-    def get_requirements(self, executor_config: Mapping[str, object]) -> Sequence[ExecutorRequirement]:
+    def get_requirements(
+        self, executor_config: Mapping[str, object]
+    ) -> Sequence[ExecutorRequirement]:
         return self._requirements_fn(executor_config)
 
     @property

--- a/python_modules/dagster/dagster/core/definitions/executor_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/executor_definition.py
@@ -1,6 +1,6 @@
 from enum import Enum as PyEnum
 from functools import update_wrapper
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, overload
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Sequence, Union, overload
 
 from typing_extensions import TypeAlias
 
@@ -55,9 +55,9 @@ def multiple_process_executor_requirements() -> List[ExecutorRequirement]:
     ]
 
 
-ExecutorConfig = Dict[str, object]
+ExecutorConfig = Mapping[str, object]
 ExecutorCreationFunction: TypeAlias = Callable[["InitExecutorContext"], "Executor"]
-ExecutorRequirementsFunction: TypeAlias = Callable[[ExecutorConfig], List[ExecutorRequirement]]
+ExecutorRequirementsFunction: TypeAlias = Callable[[ExecutorConfig], Sequence[ExecutorRequirement]]
 
 
 class ExecutorDefinition(NamedConfigurableDefinition):
@@ -113,7 +113,7 @@ class ExecutorDefinition(NamedConfigurableDefinition):
     def config_schema(self) -> IDefinitionConfigSchema:
         return self._config_schema
 
-    def get_requirements(self, executor_config: Dict[str, object]) -> List[ExecutorRequirement]:
+    def get_requirements(self, executor_config: Mapping[str, object]) -> Sequence[ExecutorRequirement]:
         return self._requirements_fn(executor_config)
 
     @property

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -189,7 +189,7 @@ class GraphDefinition(NodeDefinition):
         input_mappings: Optional[List[InputMapping]] = None,
         output_mappings: Optional[List[OutputMapping]] = None,
         config: Optional[ConfigMapping] = None,
-        tags: Optional[Dict[str, Any]] = None,
+        tags: Optional[Mapping[str, Any]] = None,
         **kwargs,
     ):
         self._node_defs = _check_node_defs_arg(name, node_defs)

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -70,7 +70,9 @@ if TYPE_CHECKING:
     from .solid_definition import SolidDefinition
 
 
-def _check_node_defs_arg(graph_name: str, node_defs: Optional[Sequence[NodeDefinition]]) -> Sequence[NodeDefinition]:
+def _check_node_defs_arg(
+    graph_name: str, node_defs: Optional[Sequence[NodeDefinition]]
+) -> Sequence[NodeDefinition]:
     node_defs = node_defs or []
 
     _node_defs = check.opt_sequence_param(node_defs, "node_defs")
@@ -406,7 +408,9 @@ class GraphDefinition(NodeDefinition):
     T_Handle = TypeVar("T_Handle", bound=Optional[NodeHandle])
 
     def resolve_output_to_origin(
-        self, output_name: str, handle: Optional[NodeHandle],
+        self,
+        output_name: str,
+        handle: Optional[NodeHandle],
     ) -> Tuple[OutputDefinition, Optional[NodeHandle]]:
         check.str_param(output_name, "output_name")
         check.opt_inst_param(handle, "handle", NodeHandle)
@@ -446,7 +450,9 @@ class GraphDefinition(NodeDefinition):
         return mapped_solid.definition.input_has_default(mapping.maps_to.input_name)
 
     @property
-    def dependencies(self) -> Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]:
+    def dependencies(
+        self,
+    ) -> Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]:
         return self._dependencies
 
     @property
@@ -807,7 +813,9 @@ class SubselectedGraphDefinition(GraphDefinition):
         self,
         parent_graph_def: GraphDefinition,
         node_defs: Optional[Sequence[NodeDefinition]],
-        dependencies: Optional[Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]],
+        dependencies: Optional[
+            Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]
+        ],
         input_mappings: Optional[Sequence[InputMapping]],
         output_mappings: Optional[Sequence[OutputMapping]],
     ):
@@ -1113,5 +1121,6 @@ def _config_mapping_with_default_value(
 )
 def default_job_io_manager(init_context: "InitResourceContext"):
     from dagster.core.storage.fs_io_manager import PickledObjectFilesystemIOManager
+
     instance = check.not_none(init_context.instance)
     return PickledObjectFilesystemIOManager(base_dir=instance.storage_directory())

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -9,6 +9,7 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Union,
@@ -67,15 +68,10 @@ if TYPE_CHECKING:
     from .solid_definition import SolidDefinition
 
 
-def _check_node_defs_arg(graph_name: str, node_defs: Optional[List[NodeDefinition]]):
+def _check_node_defs_arg(graph_name: str, node_defs: Optional[Sequence[NodeDefinition]]):
     node_defs = node_defs or []
 
-    if not isinstance(node_defs, list):
-        raise DagsterInvalidDefinitionError(
-            '"nodes" arg to "{name}" is not a list. Got {val}.'.format(
-                name=graph_name, val=repr(node_defs)
-            )
-        )
+    check.sequence_param(node_defs, "node_defs")
     for node_def in node_defs:
         if isinstance(node_def, NodeDefinition):
             continue
@@ -99,12 +95,12 @@ def _check_node_defs_arg(graph_name: str, node_defs: Optional[List[NodeDefinitio
 def _create_adjacency_lists(
     solids: List[Node],
     dep_structure: DependencyStructure,
-) -> Tuple[Dict[str, Set[Node]], Dict[str, Set[Node]]]:
+) -> Tuple[Dict[str, Set[str]], Dict[str, Set[str]]]:
     visit_dict = {s.name: False for s in solids}
-    forward_edges: Dict[str, Set[Node]] = {s.name: set() for s in solids}
-    backward_edges: Dict[str, Set[Node]] = {s.name: set() for s in solids}
+    forward_edges: Dict[str, Set[str]] = {s.name: set() for s in solids}
+    backward_edges: Dict[str, Set[str]] = {s.name: set() for s in solids}
 
-    def visit(solid_name):
+    def visit(solid_name: str) -> None:
         if visit_dict[solid_name]:
             return
 
@@ -182,12 +178,12 @@ class GraphDefinition(NodeDefinition):
         self,
         name: str,
         description: Optional[str] = None,
-        node_defs: Optional[List[NodeDefinition]] = None,
+        node_defs: Optional[Sequence[NodeDefinition]] = None,
         dependencies: Optional[
             Dict[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]]
         ] = None,
-        input_mappings: Optional[List[InputMapping]] = None,
-        output_mappings: Optional[List[OutputMapping]] = None,
+        input_mappings: Optional[Sequence[InputMapping]] = None,
+        output_mappings: Optional[Sequence[OutputMapping]] = None,
         config: Optional[ConfigMapping] = None,
         tags: Optional[Mapping[str, Any]] = None,
         **kwargs,

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -190,7 +190,7 @@ class GraphDefinition(NodeDefinition):
         description: Optional[str] = None,
         node_defs: Optional[Sequence[NodeDefinition]] = None,
         dependencies: Optional[
-            Dict[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]]
+            Mapping[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]]
         ] = None,
         input_mappings: Optional[Sequence[InputMapping]] = None,
         output_mappings: Optional[Sequence[OutputMapping]] = None,

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -12,6 +12,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    TypeVar,
     Union,
     cast,
 )
@@ -402,9 +403,11 @@ class GraphDefinition(NodeDefinition):
                 return mapping
         check.failed(f"Could not find output mapping {output_name}")
 
+    T_Handle = TypeVar("T_Handle", bound=Optional[NodeHandle])
+
     def resolve_output_to_origin(
-        self, output_name: str, handle: Optional[NodeHandle]
-    ) -> Tuple[OutputDefinition, NodeHandle]:
+        self, output_name: str, handle: Optional[NodeHandle],
+    ) -> Tuple[OutputDefinition, Optional[NodeHandle]]:
         check.str_param(output_name, "output_name")
         check.opt_inst_param(handle, "handle", NodeHandle)
 
@@ -413,7 +416,7 @@ class GraphDefinition(NodeDefinition):
         mapped_solid = self.solid_named(mapping.maps_from.solid_name)
         return mapped_solid.definition.resolve_output_to_origin(
             mapping.maps_from.output_name,
-            NodeHandle(mapped_solid.name, handle),
+            NodeHandle(mapped_solid.name, handle),  # type: ignore
         )
 
     def default_value_for_input(self, input_name: str) -> object:

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -71,8 +71,8 @@ if TYPE_CHECKING:
 def _check_node_defs_arg(graph_name: str, node_defs: Optional[Sequence[NodeDefinition]]):
     node_defs = node_defs or []
 
-    check.sequence_param(node_defs, "node_defs")
-    for node_def in node_defs:
+    _node_defs = check.opt_sequence_param(node_defs, "node_defs")
+    for node_def in _node_defs:
         if isinstance(node_def, NodeDefinition):
             continue
         elif callable(node_def):

--- a/python_modules/dagster/dagster/core/definitions/input.py
+++ b/python_modules/dagster/dagster/core/definitions/input.py
@@ -114,7 +114,7 @@ class InputDefinition:
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         asset_key: Optional[Union[AssetKey, Callable[["InputContext"], AssetKey]]] = None,
         asset_partitions: Optional[Union[Set[str], Callable[["InputContext"], Set[str]]]] = None,
-        input_manager_key: Optional[str]=None
+        input_manager_key: Optional[str] = None
         # when adding new params, make sure to update combine_with_inferred below
     ):
         self._name = check_valid_name(name)

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -8,6 +8,7 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Sequence,
     Tuple,
     Type,
     Union,
@@ -66,6 +67,11 @@ if TYPE_CHECKING:
 
 
 class JobDefinition(PipelineDefinition):
+
+    _cached_partition_set: Optional["PartitionSetDefinition"]
+    _subset_selection_data: Optional[Union[OpSelectionData, AssetSelectionData]]
+    _input_values: Mapping[str, object]
+
     def __init__(
         self,
         graph_def: GraphDefinition,
@@ -76,9 +82,9 @@ class JobDefinition(PipelineDefinition):
         partitioned_config: Optional[PartitionedConfig] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
-        preset_defs: Optional[List[PresetDefinition]] = None,
-        tags: Optional[Dict[str, Any]] = None,
-        metadata: Optional[Dict[str, RawMetadataValue]] = None,
+        preset_defs: Optional[Sequence[PresetDefinition]] = None,
+        tags: Optional[Mapping[str, Any]] = None,
+        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         hook_defs: Optional[AbstractSet[HookDefinition]] = None,
         op_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -91,7 +91,7 @@ class JobDefinition(PipelineDefinition):
         _subset_selection_data: Optional[Union[OpSelectionData, AssetSelectionData]] = None,
         asset_layer: Optional[AssetLayer] = None,
         _input_values: Optional[Mapping[str, object]] = None,
-        _metadata_entries: Optional[List[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
+        _metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
         _executor_def_specified: bool = False,
         _logger_defs_specified: bool = False,
     ):
@@ -171,12 +171,12 @@ class JobDefinition(PipelineDefinition):
 
     def execute_in_process(
         self,
-        run_config: Optional[Dict[str, Any]] = None,
+        run_config: Optional[Mapping[str, Any]] = None,
         instance: Optional["DagsterInstance"] = None,
         partition_key: Optional[str] = None,
         raise_on_error: bool = True,
-        op_selection: Optional[List[str]] = None,
-        asset_selection: Optional[List[AssetKey]] = None,
+        op_selection: Optional[Sequence[str]] = None,
+        asset_selection: Optional[Sequence[AssetKey]] = None,
         run_id: Optional[str] = None,
         input_values: Optional[Mapping[str, object]] = None,
     ) -> "ExecuteInProcessResult":
@@ -188,7 +188,7 @@ class JobDefinition(PipelineDefinition):
 
 
         Args:
-            run_config (Optional[Dict[str, Any]]:
+            run_config (Optional[Mapping[str, Any]]:
                 The configuration for the run
             instance (Optional[DagsterInstance]):
                 The instance to execute against, an ephemeral one will be used if none provided.
@@ -197,7 +197,7 @@ class JobDefinition(PipelineDefinition):
                 to select run config for jobs with partitioned config.
             raise_on_error (Optional[bool]): Whether or not to raise exceptions when they occur.
                 Defaults to ``True``.
-            op_selection (Optional[List[str]]): A list of op selection queries (including single op
+            op_selection (Optional[Sequence[str]]): A list of op selection queries (including single op
                 names) to execute. For example:
                 * ``['some_op']``: selects ``some_op`` itself.
                 * ``['*some_op']``: select ``some_op`` and all its ancestors (upstream dependencies).
@@ -214,9 +214,9 @@ class JobDefinition(PipelineDefinition):
         from dagster.core.definitions.executor_definition import execute_in_process_executor
         from dagster.core.execution.execute_in_process import core_execute_in_process
 
-        run_config = check.opt_dict_param(run_config, "run_config")
-        op_selection = check.opt_list_param(op_selection, "op_selection", str)
-        asset_selection = check.opt_list_param(asset_selection, "asset_selection", AssetKey)
+        run_config = check.opt_mapping_param(run_config, "run_config")
+        op_selection = check.opt_sequence_param(op_selection, "op_selection", str)
+        asset_selection = check.opt_sequence_param(asset_selection, "asset_selection", AssetKey)
 
         check.invariant(
             not (op_selection and asset_selection),
@@ -305,7 +305,7 @@ class JobDefinition(PipelineDefinition):
 
     def get_job_def_for_subset_selection(
         self,
-        op_selection: Optional[List[str]] = None,
+        op_selection: Optional[Sequence[str]] = None,
         asset_selection: Optional[FrozenSet[AssetKey]] = None,
     ):
         check.invariant(
@@ -364,7 +364,7 @@ class JobDefinition(PipelineDefinition):
 
     def _get_job_def_for_op_selection(
         self,
-        op_selection: Optional[List[str]] = None,
+        op_selection: Optional[Sequence[str]] = None,
     ) -> "JobDefinition":
         if not op_selection:
             return self
@@ -446,7 +446,7 @@ class JobDefinition(PipelineDefinition):
         self,
         partition_key: str,
         run_key: Optional[str],
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[Mapping[str, str]] = None,
     ) -> RunRequest:
         partition_set = self.get_partition_set_def()
         if not partition_set:
@@ -588,7 +588,7 @@ def _dep_key_of(node: Node) -> NodeInvocation:
 
 def get_subselected_graph_definition(
     graph: GraphDefinition,
-    resolved_op_selection_dict: Dict,
+    resolved_op_selection_dict: Mapping,
     parent_handle: Optional[NodeHandle] = None,
 ) -> SubselectedGraphDefinition:
     deps: Dict[
@@ -605,9 +605,10 @@ def get_subselected_graph_definition(
             continue
 
         # rebuild graph if any nodes inside the graph are selected
+        definition: Union[SubselectedGraphDefinition, NodeDefinition]
         if node.is_graph and resolved_op_selection_dict[node.name] is not LeafNodeSelection:
             definition = get_subselected_graph_definition(
-                node.definition,
+                cast(GraphDefinition, node.definition),  # guaranteed by node.is_graph
                 resolved_op_selection_dict[node.name],
                 parent_handle=node_handle,
             )

--- a/python_modules/dagster/dagster/core/definitions/logger_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/logger_definition.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast, overload
 
 import dagster._check as check
 from dagster.core.errors import DagsterInvalidInvocationError
@@ -7,7 +7,10 @@ from dagster.core.errors import DagsterInvalidInvocationError
 from ..decorator_utils import get_function_params
 from .config import is_callable_valid_config_arg
 from .configurable import AnonymousConfigurableDefinition
-from .definition_config_schema import convert_user_facing_definition_config_schema
+from .definition_config_schema import (
+    CoercableToConfigSchema,
+    convert_user_facing_definition_config_schema,
+)
 
 if TYPE_CHECKING:
     from dagster.core.definitions import JobDefinition, PipelineDefinition
@@ -103,8 +106,23 @@ class LoggerDefinition(AnonymousConfigurableDefinition):
         )
 
 
+@overload
 def logger(
-    config_schema: Any = None, description: Optional[str] = None
+    config_schema: CoercableToConfigSchema, description: Optional[str] = ...
+) -> Callable[["InitLoggerFunction"], "LoggerDefinition"]:
+    ...
+
+
+@overload
+def logger(
+    config_schema: "InitLoggerFunction", description: Optional[str] = ...
+) -> "LoggerDefinition":
+    ...
+
+
+def logger(
+    config_schema: Union[CoercableToConfigSchema, "InitLoggerFunction"] = None,
+    description: Optional[str] = None,
 ) -> Union["LoggerDefinition", Callable[["InitLoggerFunction"], "LoggerDefinition"]]:
     """Define a logger.
 
@@ -120,7 +138,7 @@ def logger(
     # This case is for when decorator is used bare, without arguments.
     # E.g. @logger versus @logger()
     if callable(config_schema) and not is_callable_valid_config_arg(config_schema):
-        return LoggerDefinition(logger_fn=config_schema)
+        return LoggerDefinition(logger_fn=cast("InitLoggerFunction", config_schema))
 
     def _wrap(logger_fn: "InitLoggerFunction") -> "LoggerDefinition":
         return LoggerDefinition(

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -34,10 +34,10 @@ if TYPE_CHECKING:
 
 RawMetadataValue = Union[
     "MetadataValue",
-    dict,
+    Dict[Any, Any],
     float,
     int,
-    list,
+    List[Any],
     str,
 ]
 

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -58,7 +58,7 @@ def normalize_metadata(
     metadata: Mapping[str, RawMetadataValue],
     metadata_entries: Sequence[Union["MetadataEntry", "PartitionMetadataEntry"]],
     allow_invalid: bool = False,
-) -> List[Union["MetadataEntry", "PartitionMetadataEntry"]]:
+) -> Sequence[Union["MetadataEntry", "PartitionMetadataEntry"]]:
     if metadata and metadata_entries:
         raise DagsterInvalidMetadata(
             "Attempted to provide both `metadata` and `metadata_entries` arguments to an event. "

--- a/python_modules/dagster/dagster/core/definitions/mode.py
+++ b/python_modules/dagster/dagster/core/definitions/mode.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Dict, List, Mapping, NamedTuple, Optional
+from typing import TYPE_CHECKING, Mapping, NamedTuple, Optional, Sequence
 
 import dagster._check as check
 from dagster.core.definitions.executor_definition import ExecutorDefinition, default_executors
@@ -21,9 +21,9 @@ class ModeDefinition(
         "_ModeDefinition",
         [
             ("name", str),
-            ("resource_defs", Dict[str, ResourceDefinition]),
-            ("loggers", Dict[str, LoggerDefinition]),
-            ("executor_defs", List[ExecutorDefinition]),
+            ("resource_defs", Mapping[str, ResourceDefinition]),
+            ("loggers", Mapping[str, LoggerDefinition]),
+            ("executor_defs", Sequence[ExecutorDefinition]),
             ("description", Optional[str]),
             ("config_mapping", Optional[ConfigMapping]),
             ("partitioned_config", Optional["PartitionedConfig"]),
@@ -56,7 +56,7 @@ class ModeDefinition(
         name: Optional[str] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
-        executor_defs: Optional[List[ExecutorDefinition]] = None,
+        executor_defs: Optional[Sequence[ExecutorDefinition]] = None,
         description: Optional[str] = None,
         _config_mapping: Optional[ConfigMapping] = None,
         _partitioned_config: Optional["PartitionedConfig"] = None,
@@ -86,7 +86,7 @@ class ModeDefinition(
             name=check_valid_name(name) if name else DEFAULT_MODE_NAME,
             resource_defs=resource_defs_with_defaults,
             loggers=(
-                check.opt_dict_param(
+                check.opt_mapping_param(
                     logger_defs, "logger_defs", key_type=str, value_type=LoggerDefinition
                 )
                 or default_loggers()

--- a/python_modules/dagster/dagster/core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/node_definition.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import TYPE_CHECKING, AbstractSet, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, AbstractSet, Dict, Iterable, Iterator, Mapping, Optional, Sequence, Tuple
 
 import dagster._check as check
 from dagster.core.definitions.configurable import NamedConfigurableDefinition
@@ -152,8 +152,8 @@ class NodeDefinition(NamedConfigurableDefinition):
 
     @abstractmethod
     def resolve_output_to_origin(
-        self, output_name: str, handle: Optional[NodeHandle]
-    ) -> Tuple[OutputDefinition, NodeHandle]:
+        self, output_name: str, handle: Optional["NodeHandle"]
+    ) -> Tuple["OutputDefinition", "NodeHandle"]:
         ...
 
     @abstractmethod

--- a/python_modules/dagster/dagster/core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/node_definition.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Dict, Iterable, List, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence
 
 import dagster._check as check
 from dagster.core.definitions.configurable import NamedConfigurableDefinition
@@ -20,24 +20,14 @@ if TYPE_CHECKING:
 # base class for SolidDefinition and GraphDefinition
 # represents that this is embedable within a graph
 class NodeDefinition(NamedConfigurableDefinition):
-
-    _name: str
-    _description: Optional[str]
-    _tags: Mapping[str, str]
-    _input_dict: Mapping[str, "InputDefinition"]
-    _input_defs: Sequence["InputDefinition"]
-    _output_dict: Mapping[str, "OutputDefinition"]
-    _output_defs: Sequence["OutputDefinition"]
-    _positional_inputs = Sequence[str]
-
     def __init__(
         self,
-        name: str,
-        input_defs: Iterable[InputDefinition],
-        output_defs: Iterable[OutputDefinition],
-        description: Optional[str] = None,
-        tags: Optional[Mapping[str, str]] = None,
-        positional_inputs: Optional[Sequence[str]] = None,
+        name,
+        input_defs,
+        output_defs,
+        description=None,
+        tags=None,
+        positional_inputs=None,
     ):
         self._name = check_valid_name(name)
         self._description = check.opt_str_param(description, "description")
@@ -59,7 +49,7 @@ class NodeDefinition(NamedConfigurableDefinition):
 
     @property
     @abstractmethod
-    def node_type_str(self) -> str:
+    def node_type_str(self):
         ...
 
     @property
@@ -67,23 +57,27 @@ class NodeDefinition(NamedConfigurableDefinition):
     def is_graph_job_op_node(self) -> bool:
         ...
 
+    @abstractmethod
+    def all_dagster_types(self):
+        ...
+
     @property
-    def name(self) -> str:
+    def name(self):
         return self._name
 
-    def describe_node(self) -> str:
+    def describe_node(self):
         return f"{self.node_type_str} '{self.name}'"
 
     @property
-    def description(self) -> Optional[str]:
+    def description(self):
         return self._description
 
     @property
-    def tags(self) -> Mapping[str, str]:
+    def tags(self):
         return self._tags
 
     @property
-    def positional_inputs(self) -> Sequence[str]:
+    def positional_inputs(self):
         return self._positional_inputs
 
     @property
@@ -137,27 +131,27 @@ class NodeDefinition(NamedConfigurableDefinition):
 
     @abstractmethod
     def iterate_node_defs(self):
-        raise NotImplementedError()
+        ...
 
     @abstractmethod
     def iterate_solid_defs(self):
-        raise NotImplementedError()
+        ...
 
     @abstractmethod
     def resolve_output_to_origin(self, output_name, handle):
-        raise NotImplementedError()
+        ...
 
     @abstractmethod
     def input_has_default(self, input_name):
-        raise NotImplementedError()
+        ...
 
     @abstractmethod
     def default_value_for_input(self, input_name):
-        raise NotImplementedError()
+        ...
 
     @abstractmethod
     def input_supports_dynamic_output_dep(self, input_name):
-        raise NotImplementedError()
+        ...
 
     def all_input_output_types(self):
         for input_def in self._input_defs:
@@ -247,4 +241,4 @@ class NodeDefinition(NamedConfigurableDefinition):
     def get_inputs_must_be_resolved_top_level(
         self, asset_layer: "AssetLayer", handle: Optional["NodeHandle"] = None
     ) -> List["InputDefinition"]:
-        raise NotImplementedError()
+        ...

--- a/python_modules/dagster/dagster/core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/node_definition.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Dict, Iterable, List, Mapping, Optional, Sequence
 
 import dagster._check as check
 from dagster.core.definitions.configurable import NamedConfigurableDefinition
@@ -20,14 +20,24 @@ if TYPE_CHECKING:
 # base class for SolidDefinition and GraphDefinition
 # represents that this is embedable within a graph
 class NodeDefinition(NamedConfigurableDefinition):
+
+    _name: str
+    _description: Optional[str]
+    _tags: Mapping[str, str]
+    _input_dict: Mapping[str, "InputDefinition"]
+    _input_defs: Sequence["InputDefinition"]
+    _output_dict: Mapping[str, "OutputDefinition"]
+    _output_defs: Sequence["OutputDefinition"]
+    _positional_inputs = Sequence[str]
+
     def __init__(
         self,
-        name,
-        input_defs,
-        output_defs,
-        description=None,
-        tags=None,
-        positional_inputs=None,
+        name: str,
+        input_defs: Iterable[InputDefinition],
+        output_defs: Iterable[OutputDefinition],
+        description: Optional[str] = None,
+        tags: Optional[Mapping[str, str]] = None,
+        positional_inputs: Optional[Sequence[str]] = None,
     ):
         self._name = check_valid_name(name)
         self._description = check.opt_str_param(description, "description")
@@ -49,31 +59,31 @@ class NodeDefinition(NamedConfigurableDefinition):
 
     @property
     @abstractmethod
-    def node_type_str(self):
-        raise NotImplementedError()
+    def node_type_str(self) -> str:
+        ...
 
     @property
     @abstractmethod
     def is_graph_job_op_node(self) -> bool:
-        raise NotImplementedError()
+        ...
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
-    def describe_node(self):
+    def describe_node(self) -> str:
         return f"{self.node_type_str} '{self.name}'"
 
     @property
-    def description(self):
+    def description(self) -> Optional[str]:
         return self._description
 
     @property
-    def tags(self):
+    def tags(self) -> Mapping[str, str]:
         return self._tags
 
     @property
-    def positional_inputs(self):
+    def positional_inputs(self) -> Sequence[str]:
         return self._positional_inputs
 
     @property

--- a/python_modules/dagster/dagster/core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/node_definition.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, AbstractSet, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple
 
 import dagster._check as check
 from dagster.core.definitions.configurable import NamedConfigurableDefinition
@@ -10,7 +10,10 @@ from .hook_definition import HookDefinition
 from .utils import check_valid_name, validate_tags
 
 if TYPE_CHECKING:
+    from dagster.core.types.dagster_type import DagsterType
+
     from .asset_layer import AssetLayer
+    from .composition import PendingNodeInvocation
     from .dependency import NodeHandle
     from .graph_definition import GraphDefinition
     from .input import InputDefinition
@@ -20,14 +23,24 @@ if TYPE_CHECKING:
 # base class for SolidDefinition and GraphDefinition
 # represents that this is embedable within a graph
 class NodeDefinition(NamedConfigurableDefinition):
+
+    _name: str
+    _description: Optional[str]
+    _tags: Mapping[str, str]
+    _input_defs: Sequence["InputDefinition"]
+    _input_dict: Mapping[str, "InputDefinition"]
+    _output_defs: Sequence["OutputDefinition"]
+    _output_dict: Mapping[str, "OutputDefinition"]
+    _positional_inputs: Sequence[str]
+
     def __init__(
         self,
-        name,
-        input_defs,
-        output_defs,
-        description=None,
-        tags=None,
-        positional_inputs=None,
+        name: str,
+        input_defs: Sequence["InputDefinition"],
+        output_defs: Sequence["OutputDefinition"],
+        description: Optional[str] = None,
+        tags: Optional[Mapping[str, str]] = None,
+        positional_inputs: Optional[Sequence[str]] = None,
     ):
         self._name = check_valid_name(name)
         self._description = check.opt_str_param(description, "description")
@@ -44,12 +57,12 @@ class NodeDefinition(NamedConfigurableDefinition):
         self._positional_inputs = (
             positional_inputs
             if positional_inputs is not None
-            else list(map(lambda inp: inp.name, input_defs))
+            else [inp.name for inp in self._input_defs]
         )
 
     @property
     @abstractmethod
-    def node_type_str(self):
+    def node_type_str(self) -> str:
         ...
 
     @property
@@ -58,26 +71,26 @@ class NodeDefinition(NamedConfigurableDefinition):
         ...
 
     @abstractmethod
-    def all_dagster_types(self):
+    def all_dagster_types(self) -> Iterable["DagsterType"]:
         ...
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
-    def describe_node(self):
+    def describe_node(self) -> str:
         return f"{self.node_type_str} '{self.name}'"
 
     @property
-    def description(self):
+    def description(self) -> Optional[str]:
         return self._description
 
     @property
-    def tags(self):
+    def tags(self) -> Mapping[str, str]:
         return self._tags
 
     @property
-    def positional_inputs(self):
+    def positional_inputs(self) -> Sequence[str]:
         return self._positional_inputs
 
     @property
@@ -88,7 +101,7 @@ class NodeDefinition(NamedConfigurableDefinition):
     def input_dict(self) -> Mapping[str, "InputDefinition"]:
         return self._input_dict
 
-    def resolve_input_name_at_position(self, idx):
+    def resolve_input_name_at_position(self, idx: int) -> Optional[str]:
         if idx >= len(self._positional_inputs):
             if not (
                 len(self._input_defs) - len(self._positional_inputs) == 1
@@ -113,47 +126,49 @@ class NodeDefinition(NamedConfigurableDefinition):
     def output_dict(self) -> Mapping[str, "OutputDefinition"]:
         return self._output_dict
 
-    def has_input(self, name) -> bool:
+    def has_input(self, name: str) -> bool:
         check.str_param(name, "name")
         return name in self._input_dict
 
-    def input_def_named(self, name) -> "InputDefinition":
+    def input_def_named(self, name: str) -> "InputDefinition":
         check.str_param(name, "name")
         return self._input_dict[name]
 
-    def has_output(self, name) -> bool:
+    def has_output(self, name: str) -> bool:
         check.str_param(name, "name")
         return name in self._output_dict
 
-    def output_def_named(self, name) -> "OutputDefinition":
+    def output_def_named(self, name: str) -> "OutputDefinition":
         check.str_param(name, "name")
         return self._output_dict[name]
 
     @abstractmethod
-    def iterate_node_defs(self):
+    def iterate_node_defs(self) -> Iterable["NodeDefinition"]:
         ...
 
     @abstractmethod
-    def iterate_solid_defs(self):
+    def iterate_solid_defs(self) -> Iterable["SolidDefinition"]:
         ...
 
     @abstractmethod
-    def resolve_output_to_origin(self, output_name, handle):
+    def resolve_output_to_origin(
+        self, output_name: str, handle: Optional[NodeHandle]
+    ) -> Tuple[OutputDefinition, NodeHandle]:
         ...
 
     @abstractmethod
-    def input_has_default(self, input_name):
+    def input_has_default(self, input_name: str) -> bool:
         ...
 
     @abstractmethod
-    def default_value_for_input(self, input_name):
+    def default_value_for_input(self, input_name: str) -> object:
         ...
 
     @abstractmethod
-    def input_supports_dynamic_output_dep(self, input_name):
+    def input_supports_dynamic_output_dep(self, input_name: str) -> bool:
         ...
 
-    def all_input_output_types(self):
+    def all_input_output_types(self) -> Iterator["DagsterType"]:
         for input_def in self._input_defs:
             yield input_def.dagster_type
             yield from input_def.dagster_type.inner_types
@@ -162,7 +177,7 @@ class NodeDefinition(NamedConfigurableDefinition):
             yield output_def.dagster_type
             yield from output_def.dagster_type.inner_types
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: object, **kwargs: object) -> object:
         from .composition import PendingNodeInvocation
 
         return PendingNodeInvocation(
@@ -173,7 +188,7 @@ class NodeDefinition(NamedConfigurableDefinition):
             retry_policy=None,
         )(*args, **kwargs)
 
-    def alias(self, name):
+    def alias(self, name: str) -> "PendingNodeInvocation":
         from .composition import PendingNodeInvocation
 
         check.str_param(name, "name")
@@ -186,7 +201,7 @@ class NodeDefinition(NamedConfigurableDefinition):
             retry_policy=None,
         )
 
-    def tag(self, tags):
+    def tag(self, tags: Optional[Dict[str, str]]) -> "PendingNodeInvocation":
         from .composition import PendingNodeInvocation
 
         return PendingNodeInvocation(
@@ -197,7 +212,7 @@ class NodeDefinition(NamedConfigurableDefinition):
             retry_policy=None,
         )
 
-    def with_hooks(self, hook_defs):
+    def with_hooks(self, hook_defs: AbstractSet[HookDefinition]):
         from .composition import PendingNodeInvocation
 
         hook_defs = frozenset(check.set_param(hook_defs, "hook_defs", of_type=HookDefinition))
@@ -210,7 +225,7 @@ class NodeDefinition(NamedConfigurableDefinition):
             retry_policy=None,
         )
 
-    def with_retry_policy(self, retry_policy: RetryPolicy):
+    def with_retry_policy(self, retry_policy: RetryPolicy) -> "PendingNodeInvocation":
         from .composition import PendingNodeInvocation
 
         return PendingNodeInvocation(
@@ -240,5 +255,5 @@ class NodeDefinition(NamedConfigurableDefinition):
     @abstractmethod
     def get_inputs_must_be_resolved_top_level(
         self, asset_layer: "AssetLayer", handle: Optional["NodeHandle"] = None
-    ) -> List["InputDefinition"]:
+    ) -> Sequence["InputDefinition"]:
         ...

--- a/python_modules/dagster/dagster/core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/node_definition.py
@@ -1,5 +1,16 @@
 from abc import abstractmethod
-from typing import TYPE_CHECKING, AbstractSet, Dict, Iterable, Iterator, Mapping, Optional, Sequence, Tuple, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Dict,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+)
 
 import dagster._check as check
 from dagster.core.definitions.configurable import NamedConfigurableDefinition
@@ -152,7 +163,9 @@ class NodeDefinition(NamedConfigurableDefinition):
 
     @abstractmethod
     def resolve_output_to_origin(
-        self, output_name: str, handle: Optional["NodeHandle"],
+        self,
+        output_name: str,
+        handle: Optional["NodeHandle"],
     ) -> Tuple["OutputDefinition", Optional["NodeHandle"]]:
         ...
 

--- a/python_modules/dagster/dagster/core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/node_definition.py
@@ -9,7 +9,6 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
-    TypeVar,
 )
 
 import dagster._check as check

--- a/python_modules/dagster/dagster/core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/node_definition.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import TYPE_CHECKING, AbstractSet, Dict, Iterable, Iterator, Mapping, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, AbstractSet, Dict, Iterable, Iterator, Mapping, Optional, Sequence, Tuple, TypeVar
 
 import dagster._check as check
 from dagster.core.definitions.configurable import NamedConfigurableDefinition
@@ -152,8 +152,8 @@ class NodeDefinition(NamedConfigurableDefinition):
 
     @abstractmethod
     def resolve_output_to_origin(
-        self, output_name: str, handle: Optional["NodeHandle"]
-    ) -> Tuple["OutputDefinition", "NodeHandle"]:
+        self, output_name: str, handle: Optional["NodeHandle"],
+    ) -> Tuple["OutputDefinition", Optional["NodeHandle"]]:
         ...
 
     @abstractmethod

--- a/python_modules/dagster/dagster/core/definitions/partition.py
+++ b/python_modules/dagster/dagster/core/definitions/partition.py
@@ -3,7 +3,7 @@ import inspect
 from abc import ABC, abstractmethod
 from datetime import datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, Dict, Generic, List, NamedTuple, Optional, TypeVar, Union, cast
+from typing import Any, Callable, Generic, List, Mapping, NamedTuple, Optional, Sequence, TypeVar, Union, cast
 
 import pendulum
 from dateutil.relativedelta import relativedelta
@@ -42,16 +42,16 @@ from .utils import check_valid_name, validate_tags
 DEFAULT_DATE_FORMAT = "%Y-%m-%d"
 
 RawPartitionFunction: TypeAlias = Union[
-    Callable[[Optional[datetime]], List[Union[str, "Partition[Any]"]]],
-    Callable[[], List[Union[str, "Partition"]]],
+    Callable[[Optional[datetime]], Sequence[Union[str, "Partition[Any]"]]],
+    Callable[[], Sequence[Union[str, "Partition"]]],
 ]
 
-PartitionFunction: TypeAlias = Callable[[Optional[datetime]], List["Partition[Any]"]]
-PartitionTagsFunction: TypeAlias = Callable[["Partition"], Dict[str, str]]
-PartitionScheduleFunction: TypeAlias = Callable[[datetime], Dict[str, Any]]
+PartitionFunction: TypeAlias = Callable[[Optional[datetime]], Sequence["Partition[Any]"]]
+PartitionTagsFunction: TypeAlias = Callable[["Partition"], Mapping[str, str]]
+PartitionScheduleFunction: TypeAlias = Callable[[datetime], Mapping[str, Any]]
 PartitionSelectorFunction: TypeAlias = Callable[
     [ScheduleEvaluationContext, "PartitionSetDefinition"],
-    Union["Partition", List["Partition"], SkipReason],
+    Union["Partition", Sequence["Partition"], SkipReason],
 ]
 
 T = TypeVar("T")
@@ -94,7 +94,7 @@ def schedule_partition_range(
     timezone: Optional[str],
     execution_time_to_partition_fn: Callable,
     current_time: Optional[datetime],
-) -> List[Partition[datetime]]:
+) -> Sequence[Partition[datetime]]:
     if end and start > end:
         raise DagsterInvariantViolationError(
             'Selected date range start "{start}" is after date range end "{end}'.format(
@@ -186,14 +186,14 @@ class ScheduleType(Enum):
 
 class PartitionsDefinition(ABC, Generic[T]):
     @abstractmethod
-    def get_partitions(self, current_time: Optional[datetime] = None) -> List[Partition[T]]:
+    def get_partitions(self, current_time: Optional[datetime] = None) -> Sequence[Partition[T]]:
         ...
 
     def __str__(self) -> str:
         joined_keys = ", ".join([f"'{key}'" for key in self.get_partition_keys()])
         return joined_keys
 
-    def get_partition_keys(self, current_time: Optional[datetime] = None) -> List[str]:
+    def get_partition_keys(self, current_time: Optional[datetime] = None) -> Sequence[str]:
         return [partition.name for partition in self.get_partitions(current_time)]
 
     def get_default_partition_mapping(self):
@@ -205,7 +205,7 @@ class PartitionsDefinition(ABC, Generic[T]):
 class StaticPartitionsDefinition(
     PartitionsDefinition[str],
 ):  # pylint: disable=unsubscriptable-object
-    def __init__(self, partition_keys: List[str]):
+    def __init__(self, partition_keys: Sequence[str]):
         check.list_param(partition_keys, "partition_keys", of_type=str)
 
         # Dagit selects partition ranges following the format '2022-01-13...2022-01-14'
@@ -217,7 +217,7 @@ class StaticPartitionsDefinition(
 
     def get_partitions(
         self, current_time: Optional[datetime] = None  # pylint: disable=unused-argument
-    ) -> List[Partition[str]]:
+    ) -> Sequence[Partition[str]]:
         return self._partitions
 
     def __hash__(self):
@@ -306,7 +306,7 @@ class ScheduleTimeBasedPartitionsDefinition(
             check.opt_int_param(offset, "offset", default=1),
         )
 
-    def get_partitions(self, current_time: Optional[datetime] = None) -> List[Partition[datetime]]:
+    def get_partitions(self, current_time: Optional[datetime] = None) -> Sequence[Partition[datetime]]:
         check.opt_inst_param(current_time, "current_time", datetime)
 
         return schedule_partition_range(
@@ -363,20 +363,20 @@ class DynamicPartitionsDefinition(
     PartitionsDefinition,
     NamedTuple(
         "_DynamicPartitionsDefinition",
-        [("partition_fn", Callable[[Optional[datetime]], Union[List[Partition], List[str]]])],
+        [("partition_fn", Callable[[Optional[datetime]], Union[Sequence[Partition], Sequence[str]]])],
     ),
 ):
     def __new__(  # pylint: disable=arguments-differ
-        cls, partition_fn: Callable[[Optional[datetime]], Union[List[Partition], List[str]]]
+        cls, partition_fn: Callable[[Optional[datetime]], Union[Sequence[Partition], Sequence[str]]]
     ):
         return super(DynamicPartitionsDefinition, cls).__new__(
             cls, check.callable_param(partition_fn, "partition_fn")
         )
 
-    def get_partitions(self, current_time: Optional[datetime] = None) -> List[Partition]:
+    def get_partitions(self, current_time: Optional[datetime] = None) -> Sequence[Partition]:
         partitions = self.partition_fn(current_time)
         if all(isinstance(partition, Partition) for partition in partitions):
-            return cast(List[Partition], partitions)
+            return cast(Sequence[Partition], partitions)
         else:
             return [Partition(p) for p in partitions]
 
@@ -388,9 +388,9 @@ class PartitionSetDefinition(Generic[T]):
     Args:
         name (str): Name for this partition set
         pipeline_name (str): The name of the pipeline definition
-        partition_fn (Optional[Callable[void, List[Partition]]]): User-provided function to define
+        partition_fn (Optional[Callable[void, Sequence[Partition]]]): User-provided function to define
             the set of valid partition objects.
-        solid_selection (Optional[List[str]]): A list of solid subselection (including single
+        solid_selection (Optional[Sequence[str]]): A list of solid subselection (including single
             solid names) to execute with this partition. e.g. ``['*some_solid+', 'other_solid']``
         mode (Optional[str]): The mode to apply when executing this partition. (default: 'default')
         run_config_fn_for_partition (Callable[[Partition], Any]): A
@@ -406,10 +406,10 @@ class PartitionSetDefinition(Generic[T]):
     _name: str
     _pipeline_name: Optional[str]
     _job_name: Optional[str]
-    _solid_selection: Optional[List[str]]
+    _solid_selection: Optional[Sequence[str]]
     _mode: Optional[str]
-    _user_defined_run_config_fn_for_partition: Callable[[Partition], Dict[str, Any]]
-    _user_defined_tags_fn_for_partition: Callable[[Partition], Optional[Dict[str, str]]]
+    _user_defined_run_config_fn_for_partition: Callable[[Partition], Mapping[str, Any]]
+    _user_defined_tags_fn_for_partition: Callable[[Partition], Optional[Mapping[str, str]]]
     _partitions_def: PartitionsDefinition
 
     def __init__(
@@ -417,13 +417,13 @@ class PartitionSetDefinition(Generic[T]):
         name: str,
         pipeline_name: Optional[str] = None,
         partition_fn: Optional[RawPartitionFunction] = None,
-        solid_selection: Optional[List[str]] = None,
+        solid_selection: Optional[Sequence[str]] = None,
         mode: Optional[str] = None,
         run_config_fn_for_partition: Callable[
-            [Partition[T]], Dict[str, Any]
+            [Partition[T]], Mapping[str, Any]
         ] = lambda _partition: {},
         tags_fn_for_partition: Callable[
-            [Partition[T]], Optional[Dict[str, str]]
+            [Partition[T]], Optional[Mapping[str, str]]
         ] = lambda _partition: {},
         partitions_def: Optional[
             PartitionsDefinition[T]  # pylint: disable=unsubscriptable-object
@@ -442,7 +442,7 @@ class PartitionSetDefinition(Generic[T]):
         self._name = check_valid_name(name)
         self._pipeline_name = check.opt_str_param(pipeline_name, "pipeline_name")
         self._job_name = check.opt_str_param(job_name, "job_name")
-        self._solid_selection = check.opt_nullable_list_param(
+        self._solid_selection = check.opt_nullable_sequence_param(
             solid_selection, "solid_selection", of_type=str
         )
         self._mode = check.opt_str_param(mode, "mode", DEFAULT_MODE_NAME)
@@ -477,7 +477,7 @@ class PartitionSetDefinition(Generic[T]):
                 "Expected <Partition> | <str>, received {type}".format(type=type(x))
             )
 
-        def wrapper(current_time: Optional[datetime] = None) -> List[Partition]:
+        def wrapper(current_time: Optional[datetime] = None) -> Sequence[Partition]:
             if not current_time:
                 current_time = pendulum.now("UTC")
 
@@ -485,7 +485,7 @@ class PartitionSetDefinition(Generic[T]):
 
             if partition_fn_param_count == 1:
                 obj_list = cast(
-                    Callable[..., List[Union[Partition[T], str]]],
+                    Callable[..., Sequence[Union[Partition[T], str]]],
                     partition_fn,
                 )(current_time)
             else:
@@ -513,17 +513,17 @@ class PartitionSetDefinition(Generic[T]):
         return cast(str, self._pipeline_name or self._job_name)
 
     @property
-    def solid_selection(self) -> Optional[List[str]]:
+    def solid_selection(self) -> Optional[Sequence[str]]:
         return self._solid_selection
 
     @property
     def mode(self) -> Optional[str]:
         return self._mode
 
-    def run_config_for_partition(self, partition: Partition[T]) -> Dict[str, Any]:
+    def run_config_for_partition(self, partition: Partition[T]) -> Mapping[str, Any]:
         return copy.deepcopy(self._user_defined_run_config_fn_for_partition(partition))  # type: ignore
 
-    def tags_for_partition(self, partition: Partition[T]) -> Dict[str, str]:
+    def tags_for_partition(self, partition: Partition[T]) -> Mapping[str, str]:
         user_tags = validate_tags(
             self._user_defined_tags_fn_for_partition(partition), allow_reserved_tags=False  # type: ignore
         )
@@ -531,7 +531,7 @@ class PartitionSetDefinition(Generic[T]):
 
         return tags
 
-    def get_partitions(self, current_time: Optional[datetime] = None) -> List[Partition[T]]:
+    def get_partitions(self, current_time: Optional[datetime] = None) -> Sequence[Partition[T]]:
         """Return the set of known partitions.
 
         Arguments:
@@ -548,7 +548,7 @@ class PartitionSetDefinition(Generic[T]):
 
         raise DagsterUnknownPartitionError(f"Could not find a partition with key `{name}`")
 
-    def get_partition_names(self, current_time: Optional[datetime] = None) -> List[str]:
+    def get_partition_names(self, current_time: Optional[datetime] = None) -> Sequence[str]:
         return [part.name for part in self.get_partitions(current_time)]
 
     def create_schedule_definition(
@@ -557,7 +557,7 @@ class PartitionSetDefinition(Generic[T]):
         cron_schedule: str,
         partition_selector: PartitionSelectorFunction,
         should_execute: Optional[Callable[..., bool]] = None,
-        environment_vars: Optional[Dict[str, str]] = None,
+        environment_vars: Optional[Mapping[str, str]] = None,
         execution_timezone: Optional[str] = None,
         description: Optional[str] = None,
         decorated_fn: Optional[PartitionScheduleFunction] = None,
@@ -569,7 +569,7 @@ class PartitionSetDefinition(Generic[T]):
         Arguments:
             schedule_name (str): The name of the schedule.
             cron_schedule (str): A valid cron string for the schedule
-            partition_selector (Callable[[ScheduleEvaluationContext, PartitionSetDefinition], Union[Partition, List[Partition]]]):
+            partition_selector (Callable[[ScheduleEvaluationContext, PartitionSetDefinition], Union[Partition, Sequence[Partition]]]):
                 Function that determines the partition to use at a given execution time. Can return
                 either a single Partition or a list of Partitions. For time-based partition sets,
                 will likely be either `identity_partition_selector` or a selector returned by
@@ -697,11 +697,11 @@ class PartitionScheduleDefinition(ScheduleDefinition):
         cron_schedule: str,
         pipeline_name: Optional[str],
         tags_fn: Optional[ScheduleTagsFunction],
-        solid_selection: Optional[List[str]],
+        solid_selection: Optional[Sequence[str]],
         mode: Optional[str],
         should_execute: Optional[ScheduleShouldExecuteFunction],
         partition_set: PartitionSetDefinition,
-        environment_vars: Optional[Dict[str, str]] = None,
+        environment_vars: Optional[Mapping[str, str]] = None,
         run_config_fn: Optional[ScheduleRunConfigFunction] = None,
         execution_timezone: Optional[str] = None,
         execution_fn: Optional[ScheduleExecutionFunction] = None,
@@ -731,7 +731,7 @@ class PartitionScheduleDefinition(ScheduleDefinition):
         )
         self._decorated_fn = check.opt_callable_param(decorated_fn, "decorated_fn")
 
-    def __call__(self, *args, **kwargs) -> Dict[str, Any]:
+    def __call__(self, *args, **kwargs) -> Mapping[str, Any]:
         if not self._decorated_fn:
             raise DagsterInvalidInvocationError(
                 "Only partition schedules created using one of the partition schedule decorators "
@@ -776,9 +776,9 @@ class PartitionedConfig(Generic[T]):
     def __init__(
         self,
         partitions_def: PartitionsDefinition[T],  # pylint: disable=unsubscriptable-object
-        run_config_for_partition_fn: Callable[[Partition[T]], Dict[str, Any]],
-        decorated_fn: Optional[Callable[..., Dict[str, Any]]] = None,
-        tags_for_partition_fn: Optional[Callable[[Partition[T]], Dict[str, str]]] = None,
+        run_config_for_partition_fn: Callable[[Partition[T]], Mapping[str, Any]],
+        decorated_fn: Optional[Callable[..., Mapping[str, Any]]] = None,
+        tags_for_partition_fn: Optional[Callable[[Partition[T]], Mapping[str, str]]] = None,
     ):
         self._partitions = check.inst_param(partitions_def, "partitions_def", PartitionsDefinition)
         self._run_config_for_partition_fn = check.callable_param(
@@ -794,17 +794,17 @@ class PartitionedConfig(Generic[T]):
         return self._partitions
 
     @property
-    def run_config_for_partition_fn(self) -> Callable[[Partition[T]], Dict[str, Any]]:
+    def run_config_for_partition_fn(self) -> Callable[[Partition[T]], Mapping[str, Any]]:
         return self._run_config_for_partition_fn
 
     @property
-    def tags_for_partition_fn(self) -> Optional[Callable[[Partition[T]], Dict[str, str]]]:
+    def tags_for_partition_fn(self) -> Optional[Callable[[Partition[T]], Mapping[str, str]]]:
         return self._tags_for_partition_fn
 
-    def get_partition_keys(self, current_time: Optional[datetime] = None) -> List[str]:
+    def get_partition_keys(self, current_time: Optional[datetime] = None) -> Sequence[str]:
         return [partition.name for partition in self.partitions_def.get_partitions(current_time)]
 
-    def get_run_config_for_partition_key(self, partition_key: str) -> Dict[str, Any]:
+    def get_run_config_for_partition_key(self, partition_key: str) -> Mapping[str, Any]:
         """Generates the run config corresponding to a partition key.
 
         Args:
@@ -827,9 +827,9 @@ class PartitionedConfig(Generic[T]):
 
 
 def static_partitioned_config(
-    partition_keys: List[str],
-    tags_for_partition_fn: Optional[Callable[[str], Dict[str, str]]] = None,
-) -> Callable[[Callable[[str], Dict[str, Any]]], PartitionedConfig]:
+    partition_keys: Sequence[str],
+    tags_for_partition_fn: Optional[Callable[[str], Mapping[str, str]]] = None,
+) -> Callable[[Callable[[str], Mapping[str, Any]]], PartitionedConfig]:
     """Creates a static partitioned config for a job.
 
     The provided partition_keys returns a static list of strings identifying the set of partitions,
@@ -844,7 +844,7 @@ def static_partitioned_config(
     target job.
 
     Args:
-        partition_keys (List[str]): A list of valid partition keys, which serve as the range of
+        partition_keys (Sequence[str]): A list of valid partition keys, which serve as the range of
             values that can be provided to the decorated run config function.
 
     Returns:
@@ -852,13 +852,13 @@ def static_partitioned_config(
     """
     check.list_param(partition_keys, "partition_keys", str)
 
-    def inner(fn: Callable[[str], Dict[str, Any]]) -> PartitionedConfig:
+    def inner(fn: Callable[[str], Mapping[str, Any]]) -> PartitionedConfig:
         check.callable_param(fn, "fn")
 
-        def _run_config_wrapper(partition: Partition) -> Dict[str, Any]:
+        def _run_config_wrapper(partition: Partition) -> Mapping[str, Any]:
             return fn(partition.name)
 
-        def _tag_wrapper(partition: Partition) -> Dict[str, str]:
+        def _tag_wrapper(partition: Partition) -> Mapping[str, str]:
             return tags_for_partition_fn(partition.name) if tags_for_partition_fn else {}
 
         return PartitionedConfig(
@@ -872,9 +872,9 @@ def static_partitioned_config(
 
 
 def dynamic_partitioned_config(
-    partition_fn: Callable[[Optional[datetime]], List[str]],
-    tags_for_partition_fn: Optional[Callable[[str], Dict[str, str]]] = None,
-) -> Callable[[Callable[[str], Dict[str, Any]]], PartitionedConfig]:
+    partition_fn: Callable[[Optional[datetime]], Sequence[str]],
+    tags_for_partition_fn: Optional[Callable[[str], Mapping[str, str]]] = None,
+) -> Callable[[Callable[[str], Mapping[str, Any]]], PartitionedConfig]:
     """Creates a dynamic partitioned config for a job.
 
     The provided partition_fn returns a list of strings identifying the set of partitions, given
@@ -894,11 +894,11 @@ def dynamic_partitioned_config(
     """
     check.callable_param(partition_fn, "partition_fn")
 
-    def inner(fn: Callable[[str], Dict[str, Any]]) -> PartitionedConfig:
-        def _run_config_wrapper(partition: Partition) -> Dict[str, Any]:
+    def inner(fn: Callable[[str], Mapping[str, Any]]) -> PartitionedConfig:
+        def _run_config_wrapper(partition: Partition) -> Mapping[str, Any]:
             return fn(partition.name)
 
-        def _tag_wrapper(partition: Partition) -> Dict[str, str]:
+        def _tag_wrapper(partition: Partition) -> Mapping[str, str]:
             return tags_for_partition_fn(partition.name) if tags_for_partition_fn else {}
 
         return PartitionedConfig(

--- a/python_modules/dagster/dagster/core/definitions/partition.py
+++ b/python_modules/dagster/dagster/core/definitions/partition.py
@@ -3,7 +3,19 @@ import inspect
 from abc import ABC, abstractmethod
 from datetime import datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, Generic, List, Mapping, NamedTuple, Optional, Sequence, TypeVar, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import pendulum
 from dateutil.relativedelta import relativedelta
@@ -306,7 +318,9 @@ class ScheduleTimeBasedPartitionsDefinition(
             check.opt_int_param(offset, "offset", default=1),
         )
 
-    def get_partitions(self, current_time: Optional[datetime] = None) -> Sequence[Partition[datetime]]:
+    def get_partitions(
+        self, current_time: Optional[datetime] = None
+    ) -> Sequence[Partition[datetime]]:
         check.opt_inst_param(current_time, "current_time", datetime)
 
         return schedule_partition_range(
@@ -363,7 +377,12 @@ class DynamicPartitionsDefinition(
     PartitionsDefinition,
     NamedTuple(
         "_DynamicPartitionsDefinition",
-        [("partition_fn", Callable[[Optional[datetime]], Union[Sequence[Partition], Sequence[str]]])],
+        [
+            (
+                "partition_fn",
+                Callable[[Optional[datetime]], Union[Sequence[Partition], Sequence[str]]],
+            )
+        ],
     ),
 ):
     def __new__(  # pylint: disable=arguments-differ

--- a/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
@@ -48,18 +48,15 @@ from .mode import ModeDefinition
 from .node_definition import NodeDefinition
 from .preset import PresetDefinition
 from .resource_requirement import ensure_requirements_satisfied
+from .solid_definition import SolidDefinition
 from .utils import validate_tags
 from .version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
-    from dagster.core.execution.execute_in_process_result import ExecuteInProcessResult
     from dagster.core.host_representation import PipelineIndex
-    from dagster.core.instance import DagsterInstance
     from dagster.core.snap import ConfigSchemaSnapshot, PipelineSnapshot
 
-    from .partition import PartitionSetDefinition
     from .run_config_schema import RunConfigSchema
-    from .solid_definition import SolidDefinition
 
 
 class PipelineDefinition:
@@ -77,7 +74,7 @@ class PipelineDefinition:
       code, and to switch between them.
 
     Args:
-        solid_defs (List[SolidDefinition]): The set of solids used in this pipeline.
+        solid_defs (Sequence[SolidDefinition]): The set of solids used in this pipeline.
         name (str): The name of the pipeline. Must be unique within any
             :py:class:`RepositoryDefinition` containing the pipeline.
         description (Optional[str]): A human-readable description of the pipeline.
@@ -88,11 +85,11 @@ class PipelineDefinition:
             :py:class:`NodeInvocations <NodeInvocation>`. Values of the top level dict are
             themselves dicts, which map input names belonging to the solid or aliased solid to
             :py:class:`DependencyDefinitions <DependencyDefinition>`.
-        mode_defs (Optional[List[ModeDefinition]]): The set of modes in which this pipeline can
+        mode_defs (Optional[Sequence[ModeDefinition]]): The set of modes in which this pipeline can
             operate. Modes are used to attach resources, custom loggers, custom system storage
             options, and custom executors to a pipeline. Modes can be used, e.g., to vary available
             resource and logging implementations between local test and production runs.
-        preset_defs (Optional[List[PresetDefinition]]): A set of preset collections of configuration
+        preset_defs (Optional[Sequence[PresetDefinition]]): A set of preset collections of configuration
             options that may be used to execute a pipeline. A preset consists of an environment
             dict, an optional subset of solids to execute, and a mode selection. Presets can be used
             to ship common combinations of options to pipeline end users in Python code, and can
@@ -169,7 +166,7 @@ class PipelineDefinition:
     _resource_requirements: Mapping[str, AbstractSet[str]]
     _all_node_defs: Mapping[str, NodeDefinition]
     _parent_pipeline_def: Optional["PipelineDefinition"]
-    _cached_run_config_schemas: Dict[str, RunConfigSchema]
+    _cached_run_config_schemas: Dict[str, "RunConfigSchema"]
     _cached_external_pipeline: Any
     _version_strategy: VersionStrategy
 
@@ -193,7 +190,7 @@ class PipelineDefinition:
         ] = None,  # https://github.com/dagster-io/dagster/issues/2115
         version_strategy: Optional[VersionStrategy] = None,
         asset_layer: Optional[AssetLayer] = None,
-        metadata_entries: Optional[List[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
+        metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
     ):
         # If a graph is specified directly use it
         if isinstance(graph_def, GraphDefinition):
@@ -599,7 +596,7 @@ class PipelineDefinition:
 
         if solid.retry_policy:
             return solid.retry_policy
-        elif isinstance(definition, "SolidDefinition") and definition.retry_policy:
+        elif isinstance(definition, SolidDefinition) and definition.retry_policy:
             return definition.retry_policy
 
         # could be expanded to look in composite_solid / graph containers

--- a/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
@@ -176,7 +176,7 @@ class PipelineDefinition:
         name: Optional[str] = None,
         description: Optional[str] = None,
         dependencies: Optional[
-            Dict[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]]
+            Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]
         ] = None,
         mode_defs: Optional[Sequence[ModeDefinition]] = None,
         preset_defs: Optional[Sequence[PresetDefinition]] = None,

--- a/python_modules/dagster/dagster/core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_definition.py
@@ -316,8 +316,6 @@ def resource(
     required_resource_keys: Optional[AbstractSet[str]] = None,
     version: Optional[str] = None,
 ) -> Union[Callable[[ResourceFunction], "ResourceDefinition"], "ResourceDefinition"]:
-    Callable[[ResourceFunction], "ResourceDefinition"], "ResourceDefinition"
-]:
     """Define a resource.
 
     The decorated function should accept an :py:class:`InitResourceContext` and return an instance of

--- a/python_modules/dagster/dagster/core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_definition.py
@@ -316,6 +316,8 @@ def resource(
     required_resource_keys: Optional[AbstractSet[str]] = None,
     version: Optional[str] = None,
 ) -> Union[Callable[[ResourceFunction], "ResourceDefinition"], "ResourceDefinition"]:
+    Callable[[ResourceFunction], "ResourceDefinition"], "ResourceDefinition"
+]:
     """Define a resource.
 
     The decorated function should accept an :py:class:`InitResourceContext` and return an instance of

--- a/python_modules/dagster/dagster/core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/core/definitions/run_config.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterator, List, Mapping, NamedTuple, Optional, Set, Tuple, cast
+from typing import AbstractSet, Any, Dict, Iterator, List, Mapping, NamedTuple, Optional, Set, Tuple, cast
 
 from dagster.config import Field, Permissive, Selector
 from dagster.config.config_type import ALL_CONFIG_BUILTINS, Array, ConfigType
@@ -76,7 +76,7 @@ class RunConfigSchemaCreationData(NamedTuple):
     mode_definition: ModeDefinition
     logger_defs: Mapping[str, LoggerDefinition]
     ignored_solids: List[Node]
-    required_resources: Set[str]
+    required_resources: AbstractSet[str]
     is_using_graph_job_op_apis: bool
     direct_inputs: Mapping[str, Any]
     asset_layer: AssetLayer

--- a/python_modules/dagster/dagster/core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/core/definitions/run_config.py
@@ -295,8 +295,9 @@ def get_input_manager_input_field(
 
 
 def get_type_loader_input_field(solid: Node, input_name: str, input_def: InputDefinition) -> Field:
+    loader = check.not_none(input_def.dagster_type.loader)
     return Field(
-        input_def.dagster_type.loader.schema_type,
+        loader.schema_type,
         is_required=(
             not solid.definition.input_has_default(input_name) and not input_def.root_manager_key
         ),

--- a/python_modules/dagster/dagster/core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/core/definitions/run_config.py
@@ -213,7 +213,7 @@ def get_inputs_field(
         elif name in direct_inputs and not has_upstream:
             input_field = None
         elif inp.root_manager_key and not has_upstream:
-            input_field = get_input_manager_input_field(solid, inp, inp.root_manager_key, resource_defs)
+            input_field = get_input_manager_input_field(solid, inp, resource_defs)
         elif inp.dagster_type.loader and not has_upstream:
             input_field = get_type_loader_input_field(solid, name, inp)
         else:
@@ -248,7 +248,6 @@ def input_has_upstream(
 def get_input_manager_input_field(
     solid: Node,
     input_def: InputDefinition,
-    root_manager_key: str,
     resource_defs: Mapping[str, ResourceDefinition],
 ) -> Optional[Field]:
     if input_def.root_manager_key:

--- a/python_modules/dagster/dagster/core/definitions/run_config_schema.py
+++ b/python_modules/dagster/dagster/core/definitions/run_config_schema.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterable, NamedTuple, Optional
+from typing import Iterable, Mapping, NamedTuple, Optional
 
 import dagster._check as check
 from dagster.config.config_type import ConfigType
@@ -9,8 +9,8 @@ from .pipeline_definition import PipelineDefinition
 
 class RunConfigSchema(NamedTuple):
     run_config_schema_type: ConfigType
-    config_type_dict_by_name: Dict[str, ConfigType]
-    config_type_dict_by_key: Dict[str, ConfigType]
+    config_type_dict_by_name: Mapping[str, ConfigType]
+    config_type_dict_by_key: Mapping[str, ConfigType]
     config_mapping: Optional[ConfigMapping]
 
     def has_config_type(self, name: str) -> bool:

--- a/python_modules/dagster/dagster/core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/schedule_definition.py
@@ -2,7 +2,19 @@ import copy
 from contextlib import ExitStack
 from datetime import datetime
 from enum import Enum
-from typing import Any, Callable, Iterator, List, Mapping, NamedTuple, Optional, Sequence, TypeVar, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Iterator,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import pendulum
 from typing_extensions import TypeAlias, TypeGuard

--- a/python_modules/dagster/dagster/core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/schedule_definition.py
@@ -45,9 +45,6 @@ from .utils import check_valid_name, validate_tags
 
 T = TypeVar("T")
 
-# Preserve ScheduleExecutionContext for backcompat so type annotations don't break.
-ScheduleExecutionContext: TypeAlias = "ScheduleEvaluationContext"
-
 RunConfig: TypeAlias = Mapping[str, Any]
 RunRequestIterator: TypeAlias = Iterator[Union[RunRequest, SkipReason]]
 
@@ -489,7 +486,7 @@ class ScheduleDefinition:
             execution_fn = self._execution_fn.wrapped_fn
         else:
             execution_fn = cast(
-                Callable[[ScheduleExecutionContext], "ScheduleEvaluationFunctionReturn"],
+                Callable[[ScheduleEvaluationContext], "ScheduleEvaluationFunctionReturn"],
                 self._execution_fn,
             )
 
@@ -554,3 +551,7 @@ class ScheduleDefinition:
     @property
     def default_status(self) -> DefaultScheduleStatus:
         return self._default_status
+
+
+# Preserve ScheduleExecutionContext for backcompat so type annotations don't break.
+ScheduleExecutionContext = ScheduleEvaluationContext

--- a/python_modules/dagster/dagster/core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/sensor_definition.py
@@ -3,7 +3,6 @@ from contextlib import ExitStack
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
-    Any,
     Callable,
     Iterator,
     List,
@@ -142,7 +141,7 @@ SensorExecutionContext = SensorEvaluationContext
 
 RawSensorEvaluationFunctionReturn = Union[
     Iterator[Union[SkipReason, RunRequest]],
-    List[RunRequest],
+    Sequence[RunRequest],
     SkipReason,
     RunRequest,
     PipelineRunReaction,
@@ -175,7 +174,7 @@ class SensorDefinition:
         name (Optional[str]): The name of the sensor to create. Defaults to name of evaluation_fn
         pipeline_name (Optional[str]): (legacy) The name of the pipeline to execute when the sensor
             fires. Cannot be used in conjunction with `job` or `jobs` parameters.
-        solid_selection (Optional[List[str]]): (legacy) A list of solid subselection (including single
+        solid_selection (Optional[Sequence[str]]): (legacy) A list of solid subselection (including single
             solid names) to execute when the sensor runs. e.g. ``['*some_solid+', 'other_solid']``.
             Cannot be used in conjunction with `job` or `jobs` parameters.
         mode (Optional[str]): (legacy) The mode to apply when executing runs triggered by this
@@ -195,7 +194,7 @@ class SensorDefinition:
         name: Optional[str] = None,
         evaluation_fn: Optional[RawSensorEvaluationFunction] = None,
         pipeline_name: Optional[str] = None,
-        solid_selection: Optional[List[Any]] = None,
+        solid_selection: Optional[Sequence[str]] = None,
         mode: Optional[str] = None,
         minimum_interval_seconds: Optional[int] = None,
         description: Optional[str] = None,
@@ -239,7 +238,7 @@ class SensorDefinition:
                 RepoRelativeTarget(
                     pipeline_name=check.str_param(pipeline_name, "pipeline_name"),
                     mode=check.opt_str_param(mode, "mode") or DEFAULT_MODE_NAME,
-                    solid_selection=check.opt_nullable_list_param(
+                    solid_selection=check.opt_nullable_sequence_param(
                         solid_selection, "solid_selection", of_type=str
                     ),
                 )
@@ -326,7 +325,7 @@ class SensorDefinition:
         return self._min_interval
 
     @property
-    def targets(self) -> List[Union[DirectTarget, RepoRelativeTarget]]:
+    def targets(self) -> Sequence[Union[DirectTarget, RepoRelativeTarget]]:
         return self._targets
 
     @property
@@ -408,14 +407,14 @@ class SensorDefinition:
 
     def load_targets(
         self,
-    ) -> List[Union[PipelineDefinition, GraphDefinition, UnresolvedAssetJobDefinition]]:
+    ) -> Sequence[Union[PipelineDefinition, GraphDefinition, UnresolvedAssetJobDefinition]]:
         targets = []
         for target in self._targets:
             if isinstance(target, DirectTarget):
                 targets.append(target.load())
         return targets
 
-    def check_valid_run_requests(self, run_requests: List[RunRequest]):
+    def check_valid_run_requests(self, run_requests: Sequence[RunRequest]):
         has_multiple_targets = len(self._targets) > 1
         target_names = [target.pipeline_name for target in self._targets]
 
@@ -448,7 +447,7 @@ class SensorDefinition:
         return self._target.pipeline_name if self._target else None
 
     @property
-    def solid_selection(self) -> Optional[List[Any]]:
+    def solid_selection(self) -> Optional[Sequence[str]]:
         return self._target.solid_selection if self._target else None
 
     @property
@@ -465,19 +464,19 @@ class SensorExecutionData(
     NamedTuple(
         "_SensorExecutionData",
         [
-            ("run_requests", Optional[List[RunRequest]]),
+            ("run_requests", Optional[Sequence[RunRequest]]),
             ("skip_message", Optional[str]),
             ("cursor", Optional[str]),
-            ("pipeline_run_reactions", Optional[List[PipelineRunReaction]]),
+            ("pipeline_run_reactions", Optional[Sequence[PipelineRunReaction]]),
         ],
     )
 ):
     def __new__(
         cls,
-        run_requests: Optional[List[RunRequest]] = None,
+        run_requests: Optional[Sequence[RunRequest]] = None,
         skip_message: Optional[str] = None,
         cursor: Optional[str] = None,
-        pipeline_run_reactions: Optional[List[PipelineRunReaction]] = None,
+        pipeline_run_reactions: Optional[Sequence[PipelineRunReaction]] = None,
     ):
         check.opt_list_param(run_requests, "run_requests", RunRequest)
         check.opt_str_param(skip_message, "skip_message")
@@ -562,7 +561,7 @@ def build_sensor_context(
 
 
 AssetMaterializationFunctionReturn = Union[
-    Iterator[Union[RunRequest, SkipReason]], List[RunRequest], RunRequest, SkipReason
+    Iterator[Union[RunRequest, SkipReason]], Sequence[RunRequest], RunRequest, SkipReason
 ]
 AssetMaterializationFunction = Callable[
     ["SensorExecutionContext", "EventLogEntry"],
@@ -586,7 +585,7 @@ class AssetSensorDefinition(SensorDefinition):
 
             This function must return a generator, which must yield either a single SkipReason
             or one or more RunRequest objects.
-        solid_selection (Optional[List[str]]): (legacy) A list of solid subselection (including single
+        solid_selection (Optional[Sequence[str]]): (legacy) A list of solid subselection (including single
             solid names) to execute when the sensor runs. e.g. ``['*some_solid+', 'other_solid']``.
             Cannot be used in conjunction with `job` or `jobs` parameters.
         mode (Optional[str]): (legacy) The mode to apply when executing runs triggered by this sensor.
@@ -610,7 +609,7 @@ class AssetSensorDefinition(SensorDefinition):
             ["SensorExecutionContext", "EventLogEntry"],
             RawSensorEvaluationFunctionReturn,
         ],
-        solid_selection: Optional[List[str]] = None,
+        solid_selection: Optional[Sequence[str]] = None,
         mode: Optional[str] = None,
         minimum_interval_seconds: Optional[int] = None,
         description: Optional[str] = None,

--- a/python_modules/dagster/dagster/core/definitions/solid_container.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_container.py
@@ -13,8 +13,8 @@ if TYPE_CHECKING:
 
 
 def validate_dependency_dict(
-    dependencies: Optional[Dict[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]]],
-) -> Dict[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]]:
+    dependencies: Optional[Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]],
+) -> Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]:
     prelude = (
         'The expected type for "dependencies" is Dict[Union[str, NodeInvocation], Dict[str, '
         "DependencyDefinition]]. "
@@ -165,11 +165,11 @@ def create_execution_structure(
 
 
 def _build_pipeline_solid_dict(
-    solid_defs: List["NodeDefinition"],
-    name_to_aliases: Dict[str, Set[str]],
-    alias_to_solid_instance: Dict[str, NodeInvocation],
+    solid_defs: Sequence["NodeDefinition"],
+    name_to_aliases: Mapping[str, Set[str]],
+    alias_to_solid_instance: Mapping[str, NodeInvocation],
     graph_definition,
-) -> Dict[str, Node]:
+) -> Mapping[str, Node]:
     pipeline_solids = []
     for solid_def in solid_defs:
         uses_of_solid = name_to_aliases.get(solid_def.name, {solid_def.name})

--- a/python_modules/dagster/dagster/core/definitions/solid_container.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_container.py
@@ -13,7 +13,9 @@ if TYPE_CHECKING:
 
 
 def validate_dependency_dict(
-    dependencies: Optional[Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]],
+    dependencies: Optional[
+        Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]
+    ],
 ) -> Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]:
     prelude = (
         'The expected type for "dependencies" is Dict[Union[str, NodeInvocation], Dict[str, '

--- a/python_modules/dagster/dagster/core/definitions/solid_container.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_container.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Sequence, Set, Tuple, Union
 
 import dagster._check as check
 from dagster.core.errors import DagsterInvalidDefinitionError
@@ -72,8 +72,8 @@ def validate_dependency_dict(
 
 
 def create_execution_structure(
-    solid_defs: List["NodeDefinition"],
-    dependencies_dict: Dict[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]],
+    solid_defs: Sequence["NodeDefinition"],
+    dependencies_dict: Mapping[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]],
     graph_definition: "GraphDefinition",
 ) -> Tuple[DependencyStructure, Dict[str, Node]]:
     """This builder takes the dependencies dictionary specified during creation of the

--- a/python_modules/dagster/dagster/core/definitions/solid_container.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_container.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Sequence, Set, Tuple, Union
+from typing import TYPE_CHECKING, Mapping, Optional, Sequence, Set, Tuple, Union
 
 import dagster._check as check
 from dagster.core.errors import DagsterInvalidDefinitionError
@@ -73,9 +73,9 @@ def validate_dependency_dict(
 
 def create_execution_structure(
     solid_defs: Sequence["NodeDefinition"],
-    dependencies_dict: Mapping[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]],
+    dependencies_dict: Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]],
     graph_definition: "GraphDefinition",
-) -> Tuple[DependencyStructure, Dict[str, Node]]:
+) -> Tuple[DependencyStructure, Mapping[str, Node]]:
     """This builder takes the dependencies dictionary specified during creation of the
     PipelineDefinition object and builds (1) the execution structure and (2) a solid dependency
     dictionary.

--- a/python_modules/dagster/dagster/core/definitions/solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_definition.py
@@ -9,6 +9,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    TypeVar,
     Union,
     cast,
 )
@@ -240,9 +241,11 @@ class SolidDefinition(NodeDefinition):
     def iterate_solid_defs(self) -> Iterator["SolidDefinition"]:
         yield self
 
+    T_Handle = TypeVar("T_Handle", bound=Optional[NodeHandle])
+
     def resolve_output_to_origin(
-        self, output_name: str, handle: Optional[NodeHandle]
-    ) -> Tuple[OutputDefinition, Optional[NodeHandle]]:
+        self, output_name: str, handle: T_Handle
+    ) -> Tuple[OutputDefinition, T_Handle]:
         return self.output_def_named(output_name), handle
 
     def get_inputs_must_be_resolved_top_level(

--- a/python_modules/dagster/dagster/core/definitions/solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_definition.py
@@ -6,6 +6,7 @@ from typing import (
     Dict,
     Iterator,
     List,
+    Mapping,
     Optional,
     Sequence,
     Tuple,
@@ -108,7 +109,7 @@ class SolidDefinition(NodeDefinition):
         output_defs: Sequence[OutputDefinition],
         config_schema: Optional[Union[UserConfigSchema, IDefinitionConfigSchema]] = None,
         description: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[Mapping[str, str]] = None,
         required_resource_keys: Optional[AbstractSet[str]] = None,
         version: Optional[str] = None,
         retry_policy: Optional[RetryPolicy] = None,
@@ -401,16 +402,16 @@ class CompositeSolidDefinition(GraphDefinition):
     def __init__(
         self,
         name: str,
-        solid_defs: List[NodeDefinition],
-        input_mappings: Optional[List[InputMapping]] = None,
-        output_mappings: Optional[List[OutputMapping]] = None,
+        solid_defs: Sequence[NodeDefinition],
+        input_mappings: Optional[Sequence[InputMapping]] = None,
+        output_mappings: Optional[Sequence[OutputMapping]] = None,
         config_mapping: Optional[ConfigMapping] = None,
         dependencies: Optional[
             Dict[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]]
         ] = None,
         description: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
-        positional_inputs: Optional[List[str]] = None,
+        tags: Optional[Mapping[str, str]] = None,
+        positional_inputs: Optional[Sequence[str]] = None,
     ):
         _check_io_managers_on_composite_solid(name, input_mappings, output_mappings)
 

--- a/python_modules/dagster/dagster/core/definitions/solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_definition.py
@@ -122,7 +122,6 @@ class SolidDefinition(NodeDefinition):
     ):
         from .decorators.solid_decorator import DecoratedSolidFunction
 
-
         if isinstance(compute_fn, DecoratedSolidFunction):
             self._compute_fn = compute_fn
         else:

--- a/python_modules/dagster/dagster/core/definitions/solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_definition.py
@@ -3,7 +3,6 @@ from typing import (
     AbstractSet,
     Any,
     Callable,
-    Dict,
     Iterator,
     List,
     Mapping,
@@ -372,12 +371,12 @@ class CompositeSolidDefinition(GraphDefinition):
             configuration for the composite solid, and a configuration mapping function, which
             is called to map the configuration of the composite solid into the configuration that
             is applied to any child solids.
-        dependencies (Optional[Dict[Union[str, NodeInvocation], Dict[str, DependencyDefinition]]]):
+        dependencies (Optional[Mapping[Union[str, NodeInvocation], Mapping[str, DependencyDefinition]]]):
             A structure that declares where each solid gets its inputs. The keys at the top
             level dict are either string names of solids or NodeInvocations. The values
             are dicts that map input names to DependencyDefinitions.
         description (Optional[str]): Human readable description of this composite solid.
-        tags (Optional[Dict[str, Any]]): Arbitrary metadata for the solid. Frameworks may
+        tags (Optional[Mapping[str, Any]]): Arbitrary metadata for the solid. Frameworks may
             expect and require certain metadata to be attached to a solid. Users should generally
             not set metadata directly. Values that are not strings will be json encoded and must meet
             the criteria that `json.loads(json.dumps(value)) == value`.
@@ -413,7 +412,7 @@ class CompositeSolidDefinition(GraphDefinition):
         output_mappings: Optional[Sequence[OutputMapping]] = None,
         config_mapping: Optional[ConfigMapping] = None,
         dependencies: Optional[
-            Dict[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]]
+            Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]
         ] = None,
         description: Optional[str] = None,
         tags: Optional[Mapping[str, str]] = None,

--- a/python_modules/dagster/dagster/core/definitions/solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_definition.py
@@ -242,8 +242,8 @@ class SolidDefinition(NodeDefinition):
 
     def resolve_output_to_origin(
         self, output_name: str, handle: Optional[NodeHandle]
-    ) -> Tuple[OutputDefinition, NodeHandle]:
-        return self.output_def_named(output_name), check.not_none(handle)
+    ) -> Tuple[OutputDefinition, Optional[NodeHandle]]:
+        return self.output_def_named(output_name), handle
 
     def get_inputs_must_be_resolved_top_level(
         self, asset_layer: "AssetLayer", handle: Optional[NodeHandle] = None

--- a/python_modules/dagster/dagster/core/definitions/solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_definition.py
@@ -261,7 +261,7 @@ class SolidDefinition(NodeDefinition):
                 unresolveable_input_defs.append(input_def)
         return unresolveable_input_defs
 
-    def input_has_default(self, input_name: str) -> InputDefinition:
+    def input_has_default(self, input_name: str) -> bool:
         return self.input_def_named(input_name).has_default_value
 
     def default_value_for_input(self, input_name: str) -> InputDefinition:
@@ -475,8 +475,8 @@ class CompositeSolidDefinition(GraphDefinition):
 
 def _check_io_managers_on_composite_solid(
     name: str,
-    input_mappings: Optional[List[InputMapping]],
-    output_mappings: Optional[List[OutputMapping]],
+    input_mappings: Optional[Sequence[InputMapping]],
+    output_mappings: Optional[Sequence[OutputMapping]],
 ):
     # Ban root_manager_key on composite solids
     if input_mappings:

--- a/python_modules/dagster/dagster/core/definitions/target.py
+++ b/python_modules/dagster/dagster/core/definitions/target.py
@@ -1,4 +1,4 @@
-from typing import List, NamedTuple, Optional, Union
+from typing import NamedTuple, Optional, Sequence, Union
 
 from typing_extensions import TypeAlias
 
@@ -21,7 +21,7 @@ class RepoRelativeTarget(NamedTuple):
 
     pipeline_name: str
     mode: str
-    solid_selection: Optional[List[str]]
+    solid_selection: Optional[Sequence[str]]
 
 
 class DirectTarget(

--- a/python_modules/dagster/dagster/core/definitions/target.py
+++ b/python_modules/dagster/dagster/core/definitions/target.py
@@ -1,11 +1,17 @@
 from typing import List, NamedTuple, Optional, Union
 
+from typing_extensions import TypeAlias
+
 import dagster._check as check
 
 from .graph_definition import GraphDefinition
 from .mode import DEFAULT_MODE_NAME
 from .pipeline_definition import PipelineDefinition
 from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition
+
+ExecutableDefinition: TypeAlias = Union[
+    PipelineDefinition, GraphDefinition, UnresolvedAssetJobDefinition
+]
 
 
 class RepoRelativeTarget(NamedTuple):
@@ -21,7 +27,7 @@ class RepoRelativeTarget(NamedTuple):
 class DirectTarget(
     NamedTuple(
         "_DirectTarget",
-        [("target", Union[GraphDefinition, PipelineDefinition, UnresolvedAssetJobDefinition])],
+        [("target", ExecutableDefinition)],
     )
 ):
     """

--- a/python_modules/dagster/dagster/core/definitions/utils.py
+++ b/python_modules/dagster/dagster/core/definitions/utils.py
@@ -87,7 +87,7 @@ def struct_to_string(name: str, **kwargs: object) -> str:
     return "{name}({props_str})".format(name=name, props_str=props_str)
 
 
-def validate_tags(tags: Optional[Mapping[str, Any]], allow_reserved_tags=True) -> Dict[str, str]:
+def validate_tags(tags: Optional[Mapping[str, Any]], allow_reserved_tags=True) -> frozentags:
     valid_tags = {}
     for key, value in check.opt_dict_param(tags, "tags", key_type=str).items():
         if not isinstance(value, str):

--- a/python_modules/dagster/dagster/core/definitions/utils.py
+++ b/python_modules/dagster/dagster/core/definitions/utils.py
@@ -2,7 +2,7 @@ import keyword
 import os
 import re
 from glob import glob
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 import pkg_resources
 import yaml
@@ -87,12 +87,13 @@ def struct_to_string(name, **kwargs):
     return "{name}({props_str})".format(name=name, props_str=props_str)
 
 
-def validate_tags(tags: Optional[Dict[str, Any]], allow_reserved_tags=True) -> Dict[str, str]:
+def validate_tags(tags: Optional[Mapping[str, Any]], allow_reserved_tags=True) -> Dict[str, str]:
     valid_tags = {}
     for key, value in check.opt_dict_param(tags, "tags", key_type=str).items():
         if not isinstance(value, str):
             valid = False
             err_reason = 'Could not JSON encode value "{}"'.format(value)
+            str_val = None
             try:
                 str_val = seven.json.dumps(value)
                 err_reason = 'JSON encoding "{json}" of value "{val}" is not equivalent to original value'.format(

--- a/python_modules/dagster/dagster/core/definitions/utils.py
+++ b/python_modules/dagster/dagster/core/definitions/utils.py
@@ -47,11 +47,11 @@ class NoValueSentinel:
     """Sentinel value to distinguish unset from None"""
 
 
-def has_valid_name_chars(name):
+def has_valid_name_chars(name: str) -> bool:
     return bool(VALID_NAME_REGEX.match(name))
 
 
-def check_valid_name(name: str):
+def check_valid_name(name: str) -> str:
     check.str_param(name, "name")
     if name in DISALLOWED_NAMES:
         raise DagsterInvalidDefinitionError(
@@ -71,17 +71,17 @@ def check_valid_chars(name: str):
         )
 
 
-def is_valid_name(name):
+def is_valid_name(name: str) -> bool:
     check.str_param(name, "name")
 
     return name not in DISALLOWED_NAMES and has_valid_name_chars(name)
 
 
-def _kv_str(key, value):
-    return '{key}="{value}"'.format(key=key, value=repr(value))
+def _kv_str(key: object, value: object) -> str:
+    return f'{key}="{repr(value)}"'
 
 
-def struct_to_string(name, **kwargs):
+def struct_to_string(name: str, **kwargs: object) -> str:
     # Sort the kwargs to ensure consistent representations across Python versions
     props_str = ", ".join([_kv_str(key, value) for key, value in sorted(kwargs.items())])
     return "{name}({props_str})".format(name=name, props_str=props_str)

--- a/python_modules/dagster/dagster/core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/core/execution/build_resources.py
@@ -22,8 +22,8 @@ from .context_creation_pipeline import initialize_console_manager
 
 
 def _get_mapped_resource_config(
-    resource_defs: Mapping[str, ResourceDefinition], resource_config: Dict[str, Any]
-) -> Dict[str, ResourceConfig]:
+    resource_defs: Mapping[str, ResourceDefinition], resource_config: Mapping[str, Any]
+) -> Mapping[str, ResourceConfig]:
     resource_config_schema = define_resource_dictionary_cls(
         resource_defs, set(resource_defs.keys())
     )

--- a/python_modules/dagster/dagster/core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/core/execution/build_resources.py
@@ -54,12 +54,12 @@ def build_resources(
     context, resources will also be torn down safely.
 
     Args:
-        resources (Dict[str, Any]): Resource instances or definitions to build. All
+        resources (Mapping[str, Any]): Resource instances or definitions to build. All
             required resource dependencies to a given resource must be contained within this
             dictionary, or the resource build will fail.
         instance (Optional[DagsterInstance]): The dagster instance configured to instantiate
             resources on.
-        resource_config (Optional[Dict[str, Any]]): A dict representing the config to be
+        resource_config (Optional[Mapping[str, Any]]): A dict representing the config to be
             provided to each resource during initialization and teardown.
         pipeline_run (Optional[PipelineRun]): The pipeline run to provide during resource
             initialization and teardown. If the provided resources require either the `pipeline_run`

--- a/python_modules/dagster/dagster/core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/core/execution/context/hook.py
@@ -392,7 +392,7 @@ class BoundHookContext(HookContext):
 
 
 def build_hook_context(
-    resources: Optional[Dict[str, Any]] = None,
+    resources: Optional[Mapping[str, Any]] = None,
     mode_def: Optional[ModeDefinition] = None,
     solid: Optional[Union[SolidDefinition, PendingNodeInvocation]] = None,
     op: Optional[Union[OpDefinition, PendingNodeInvocation]] = None,
@@ -432,12 +432,12 @@ def build_hook_context(
 
     op = check.opt_inst_param(op, "op", (OpDefinition, PendingNodeInvocation))
     solid = check.opt_inst_param(solid, "solid", (SolidDefinition, PendingNodeInvocation))
-    op = op or solid
+    op_or_solid = op or solid
 
     return UnboundHookContext(
         resources=check.opt_dict_param(resources, "resources", key_type=str),
         mode_def=check.opt_inst_param(mode_def, "mode_def", ModeDefinition),
-        op=op,
+        op=op_or_solid,  # type: ignore[arg-type] # (mypy bug)
         run_id=check.opt_str_param(run_id, "run_id"),
         job_name=check.opt_str_param(job_name, "job_name"),
         op_exception=check.opt_inst_param(op_exception, "op_exception", Exception),

--- a/python_modules/dagster/dagster/core/execution/context/input.py
+++ b/python_modules/dagster/dagster/core/execution/context/input.py
@@ -306,7 +306,7 @@ class InputContext:
             partitions_def.time_window_for_partition_key(partition_key_range.end).end,
         )
 
-    def get_identifier(self) -> List[str]:
+    def get_identifier(self) -> Sequence[str]:
         """Utility method to get a collection of identifiers that as a whole represent a unique
         step input.
 

--- a/python_modules/dagster/dagster/core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/core/execution/context/invocation.py
@@ -346,7 +346,7 @@ class BoundSolidExecutionContext(OpExecutionContext):
     _solid_def: SolidDefinition
     _solid_config: Any
     _resources: "Resources"
-    _resources_config: Dict[str, Any]
+    _resources_config: Mapping[str, Any]
     _instance: DagsterInstance
     _log_manager: DagsterLogManager
     _pdb: Optional[ForkedPdb]
@@ -363,11 +363,11 @@ class BoundSolidExecutionContext(OpExecutionContext):
         solid_def: SolidDefinition,
         solid_config: Any,
         resources: "Resources",
-        resources_config: Dict[str, Any],
+        resources_config: Mapping[str, Any],
         instance: DagsterInstance,
         log_manager: DagsterLogManager,
         pdb: Optional[ForkedPdb],
-        tags: Optional[Dict[str, str]],
+        tags: Optional[Mapping[str, str]],
         hook_defs: Optional[AbstractSet[HookDefinition]],
         alias: Optional[str],
         user_events: List[UserEvent],
@@ -433,8 +433,8 @@ class BoundSolidExecutionContext(OpExecutionContext):
         return "EPHEMERAL"
 
     @property
-    def run_config(self) -> dict:
-        run_config = {}
+    def run_config(self) -> Mapping[str, object]:
+        run_config: Dict[str, object] = {}
         if self._solid_config:
             run_config["solids"] = {self._solid_def.name: {"config": self._solid_config}}
         run_config["resources"] = self._resources_config

--- a/python_modules/dagster/dagster/core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/core/execution/context/invocation.py
@@ -358,7 +358,6 @@ class BoundSolidExecutionContext(OpExecutionContext):
     _output_metadata: Dict[str, Any]
     _mapping_key: Optional[str]
 
-
     def __init__(
         self,
         solid_def: SolidDefinition,

--- a/python_modules/dagster/dagster/core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/core/execution/context/invocation.py
@@ -343,6 +343,22 @@ class BoundSolidExecutionContext(OpExecutionContext):
     been validated.
     """
 
+    _solid_def: SolidDefinition
+    _solid_config: Any
+    _resources: "Resources"
+    _resources_config: Dict[str, Any]
+    _instance: DagsterInstance
+    _log_manager: DagsterLogManager
+    _pdb: Optional[ForkedPdb]
+    _tags: Mapping[str, str]
+    _hook_defs: Optional[AbstractSet[HookDefinition]]
+    _alias: str
+    _user_events: List[UserEvent]
+    _seen_outputs: Dict[str, Union[str, Set[str]]]
+    _output_metadata: Dict[str, Any]
+    _mapping_key: Optional[str]
+
+
     def __init__(
         self,
         solid_def: SolidDefinition,
@@ -369,9 +385,9 @@ class BoundSolidExecutionContext(OpExecutionContext):
         self._hook_defs = hook_defs
         self._alias = alias if alias else self._solid_def.name
         self._resources_config = resources_config
-        self._user_events: List[UserEvent] = user_events
-        self._seen_outputs: Dict[str, Union[str, Set[str]]] = {}
-        self._output_metadata: Dict[str, Any] = output_metadata
+        self._user_events = user_events
+        self._seen_outputs = {}
+        self._output_metadata = output_metadata
         self._mapping_key = mapping_key
 
     @property
@@ -457,7 +473,7 @@ class BoundSolidExecutionContext(OpExecutionContext):
     def has_tag(self, key: str) -> bool:
         return key in self._tags
 
-    def get_tag(self, key: str) -> str:
+    def get_tag(self, key: str) -> Optional[str]:
         return self._tags.get(key)
 
     @property
@@ -476,7 +492,7 @@ class BoundSolidExecutionContext(OpExecutionContext):
     def get_mapping_key(self) -> Optional[str]:
         return self._mapping_key
 
-    def describe_op(self):
+    def describe_op(self) -> str:
         if isinstance(self.solid_def, OpDefinition):
             return f'op "{self.solid_def.name}"'
 

--- a/python_modules/dagster/dagster/core/execution/context/output.py
+++ b/python_modules/dagster/dagster/core/execution/context/output.py
@@ -1,5 +1,16 @@
 import warnings
-from typing import TYPE_CHECKING, Any, ContextManager, Iterator, List, Mapping, Optional, Sequence, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ContextManager,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Union,
+    cast,
+)
 
 import dagster._check as check
 from dagster.core.definitions.asset_layer import AssetOutputInfo
@@ -57,7 +68,6 @@ class OutputContext:
     _events: List["DagsterEvent"]
     _user_events: List[Union[AssetMaterialization, AssetObservation, Materialization]]
     _metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]]
-
 
     """
     The context object that is available to the `handle_output` method of an :py:class:`IOManager`.

--- a/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
+++ b/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
@@ -243,7 +243,7 @@ def execution_context_event_generator(
 
     log_manager = create_log_manager(context_creation_data)
     resource_defs = pipeline_def.get_required_resource_defs_for_mode(
-        context_creation_data.resolved_run_config.mode
+        check.not_none(context_creation_data.resolved_run_config.mode)
     )
 
     resources_manager = scoped_resources_builder_cm(

--- a/python_modules/dagster/dagster/core/execution/execute_in_process.py
+++ b/python_modules/dagster/dagster/core/execution/execute_in_process.py
@@ -35,7 +35,7 @@ def core_execute_in_process(
     instance: Optional[DagsterInstance],
     output_capturing_enabled: bool,
     raise_on_error: bool,
-    run_tags: Optional[Dict[str, Any]] = None,
+    run_tags: Optional[Mapping[str, object]] = None,
     run_id: Optional[str] = None,
     asset_selection: Optional[FrozenSet[AssetKey]] = None,
 ) -> ExecuteInProcessResult:

--- a/python_modules/dagster/dagster/core/execution/execute_in_process_result.py
+++ b/python_modules/dagster/dagster/core/execution/execute_in_process_result.py
@@ -138,7 +138,7 @@ class ExecuteInProcessResult:
 
         # Get output from origin node
         return _filter_outputs_by_handle(
-            self._output_capture, origin_handle, origin_output_def.name
+            self._output_capture, check.not_none(origin_handle), origin_output_def.name
         )
 
     def output_for_node(self, node_str: str, output_name: str = DEFAULT_OUTPUT) -> Any:
@@ -163,7 +163,7 @@ class ExecuteInProcessResult:
 
         # retrieve output value from resolved handle
         return _filter_outputs_by_handle(
-            self._output_capture, origin_handle, origin_output_def.name
+            self._output_capture, check.not_none(origin_handle), origin_output_def.name
         )
 
     def get_job_success_event(self):

--- a/python_modules/dagster/dagster/core/execution/execute_in_process_result.py
+++ b/python_modules/dagster/dagster/core/execution/execute_in_process_result.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union, cast
 
 import dagster._check as check
 from dagster.core.definitions import NodeDefinition, NodeHandle
@@ -16,12 +16,19 @@ from dagster.core.storage.pipeline_run import DagsterRun
 
 
 class ExecuteInProcessResult:
+
+    _node_def: NodeDefinition
+    _handle: NodeHandle
+    _event_list: Sequence[DagsterEvent]
+    _dagster_run: DagsterRun
+    _output_capture: Mapping[StepOutputHandle, Any]
+
     def __init__(
         self,
         node_def: NodeDefinition,
-        all_events: List[DagsterEvent],
+        all_events: Sequence[DagsterEvent],
         dagster_run: DagsterRun,
-        output_capture: Optional[Dict[StepOutputHandle, Any]],
+        output_capture: Optional[Mapping[StepOutputHandle, Any]],
     ):
         self._node_def = node_def
 
@@ -30,7 +37,7 @@ class ExecuteInProcessResult:
         self._event_list = all_events
         self._dagster_run = dagster_run
 
-        self._output_capture = check.opt_dict_param(
+        self._output_capture = check.opt_mapping_param(
             output_capture, "output_capture", key_type=StepOutputHandle
         )
 
@@ -40,10 +47,10 @@ class ExecuteInProcessResult:
         return self._dagster_run.is_success
 
     @property
-    def all_node_events(self) -> List[DagsterEvent]:
+    def all_node_events(self) -> Sequence[DagsterEvent]:
         """List[DagsterEvent]: All dagster events from the in-process execution."""
 
-        step_events = []
+        step_events: List[DagsterEvent] = []
 
         for node_name in self._node_def.ensure_graph_def().node_dict.keys():
             handle = NodeHandle(node_name, None)
@@ -52,7 +59,7 @@ class ExecuteInProcessResult:
         return step_events
 
     @property
-    def all_events(self) -> List[DagsterEvent]:
+    def all_events(self) -> Sequence[DagsterEvent]:
         """List[DagsterEvent]: All dagster events emitted during in-process execution."""
 
         return self._event_list
@@ -67,7 +74,7 @@ class ExecuteInProcessResult:
         """DagsterRun: the DagsterRun object for the completed execution."""
         return self._dagster_run
 
-    def events_for_node(self, node_name: str) -> List[DagsterEvent]:
+    def events_for_node(self, node_name: str) -> Sequence[DagsterEvent]:
         """Retrieves all dagster events for a specific node.
 
         Args:
@@ -82,14 +89,14 @@ class ExecuteInProcessResult:
 
     def asset_materializations_for_node(
         self, node_name
-    ) -> List[Union[Materialization, AssetMaterialization]]:
+    ) -> Sequence[Union[Materialization, AssetMaterialization]]:
         return [
             cast(StepMaterializationData, event.event_specific_data).materialization
             for event in self.events_for_node(node_name)
             if event.event_type_value == DagsterEventType.ASSET_MATERIALIZATION.value
         ]
 
-    def asset_observations_for_node(self, node_name) -> List[AssetObservation]:
+    def asset_observations_for_node(self, node_name) -> Sequence[AssetObservation]:
         return [
             cast(AssetObservationData, event.event_specific_data).asset_observation
             for event in self.events_for_node(node_name)
@@ -134,7 +141,7 @@ class ExecuteInProcessResult:
             self._output_capture, origin_handle, origin_output_def.name
         )
 
-    def output_for_node(self, node_str: str, output_name: Optional[str] = DEFAULT_OUTPUT) -> Any:
+    def output_for_node(self, node_str: str, output_name: str = DEFAULT_OUTPUT) -> Any:
         """Retrieves output value with a particular name from the in-process run of the job.
 
         Args:
@@ -191,8 +198,8 @@ class ExecuteInProcessResult:
 
 
 def _filter_events_by_handle(
-    event_list: List[DagsterEvent], handle: NodeHandle
-) -> List[DagsterEvent]:
+    event_list: Sequence[DagsterEvent], handle: NodeHandle
+) -> Sequence[DagsterEvent]:
     step_events = []
     for event in event_list:
         if event.is_step_event:
@@ -206,7 +213,7 @@ def _filter_events_by_handle(
 
 
 def _filter_outputs_by_handle(
-    output_dict: Dict[StepOutputHandle, Any],
+    output_dict: Mapping[StepOutputHandle, Any],
     node_handle: NodeHandle,
     output_name: str,
 ) -> Any:

--- a/python_modules/dagster/dagster/core/execution/execute_in_process_result.py
+++ b/python_modules/dagster/dagster/core/execution/execute_in_process_result.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Union, cast
+from typing import Any, List, Mapping, Optional, Sequence, Union, cast
 
 import dagster._check as check
 from dagster.core.definitions import NodeDefinition, NodeHandle

--- a/python_modules/dagster/dagster/core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_step.py
@@ -103,8 +103,8 @@ def _step_output_error_checked_user_event_sequence(
             output = Output(
                 value=output.value,
                 output_name=output.output_name,
-                metadata_entries=output.metadata_entries
-                + normalize_metadata(cast(Dict[str, Any], metadata), []),
+                metadata_entries=[*output.metadata_entries,
+                *normalize_metadata(cast(Dict[str, Any], metadata), [])],
             )
         else:
             if not output_def.is_dynamic:
@@ -124,8 +124,8 @@ def _step_output_error_checked_user_event_sequence(
             output = DynamicOutput(
                 value=output.value,
                 output_name=output.output_name,
-                metadata_entries=output.metadata_entries
-                + normalize_metadata(cast(Dict[str, Any], metadata), []),
+                metadata_entries=[*output.metadata_entries,
+                *normalize_metadata(cast(Dict[str, Any], metadata), [])],
                 mapping_key=output.mapping_key,
             )
 
@@ -483,7 +483,7 @@ def _get_output_asset_materializations(
     io_manager_metadata_entries: List[Union[MetadataEntry, PartitionMetadataEntry]],
 ) -> Iterator[AssetMaterialization]:
 
-    all_metadata = output.metadata_entries + io_manager_metadata_entries
+    all_metadata = [*output.metadata_entries, *io_manager_metadata_entries]
 
     if asset_partitions:
         metadata_mapping: Dict[str, List[Union[MetadataEntry, PartitionMetadataEntry]]] = {
@@ -654,8 +654,8 @@ def _create_type_materializations(
             continue
 
         for output_spec in solid_config.outputs.type_materializer_specs:
-            check.invariant(len(output_spec) == 1)
-            config_output_name, output_spec = list(output_spec.items())[0]
+            check.invariant(len(output_spec) == 1)  # type: ignore
+            config_output_name, output_spec = list(output_spec.items())[0]  # type: ignore
             if config_output_name == output_name:
                 step_output = step.step_output_named(output_name)
                 with user_code_error_boundary(

--- a/python_modules/dagster/dagster/core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_step.py
@@ -103,8 +103,10 @@ def _step_output_error_checked_user_event_sequence(
             output = Output(
                 value=output.value,
                 output_name=output.output_name,
-                metadata_entries=[*output.metadata_entries,
-                *normalize_metadata(cast(Dict[str, Any], metadata), [])],
+                metadata_entries=[
+                    *output.metadata_entries,
+                    *normalize_metadata(cast(Dict[str, Any], metadata), []),
+                ],
             )
         else:
             if not output_def.is_dynamic:
@@ -124,8 +126,10 @@ def _step_output_error_checked_user_event_sequence(
             output = DynamicOutput(
                 value=output.value,
                 output_name=output.output_name,
-                metadata_entries=[*output.metadata_entries,
-                *normalize_metadata(cast(Dict[str, Any], metadata), [])],
+                metadata_entries=[
+                    *output.metadata_entries,
+                    *normalize_metadata(cast(Dict[str, Any], metadata), []),
+                ],
                 mapping_key=output.mapping_key,
             )
 

--- a/python_modules/dagster/dagster/core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/core/execution/plan/inputs.py
@@ -336,7 +336,7 @@ class FromRootInputManager(
         from ..resolve_versions import check_valid_version, resolve_config_version
 
         solid = pipeline_def.get_solid(self.solid_handle)
-        input_manager_key = check.not_none(
+        input_manager_key: str = check.not_none(
             solid.input_def_named(self.input_name).root_manager_key
             if solid.input_def_named(self.input_name).root_manager_key
             else solid.input_def_named(self.input_name).input_manager_key
@@ -378,7 +378,7 @@ class FromRootInputManager(
     def required_resource_keys(self, pipeline_def: PipelineDefinition) -> Set[str]:
         input_def = pipeline_def.get_solid(self.solid_handle).input_def_named(self.input_name)
 
-        input_manager_key = check.not_none(
+        input_manager_key: str = check.not_none(
             input_def.root_manager_key
             if input_def.root_manager_key
             else input_def.input_manager_key

--- a/python_modules/dagster/dagster/core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/core/execution/plan/inputs.py
@@ -2,6 +2,7 @@ import hashlib
 from abc import ABC, abstractmethod
 from typing import (
     TYPE_CHECKING,
+    AbstractSet,
     Any,
     Dict,
     Iterator,
@@ -92,7 +93,7 @@ class StepInput(
         return self.source.step_output_handle_dependencies
 
 
-def join_and_hash(*args) -> Optional[str]:
+def join_and_hash(*args: Optional[str]) -> Optional[str]:
     lst = [check.opt_str_param(elem, "elem") for elem in args]
     if None in lst:
         return None
@@ -115,9 +116,9 @@ class StepInputSource(ABC):
 
     @abstractmethod
     def load_input_object(self, step_context: "StepExecutionContext", input_def: InputDefinition):
-        raise NotImplementedError()
+        ...
 
-    def required_resource_keys(self, _pipeline_def: PipelineDefinition) -> Set[str]:
+    def required_resource_keys(self, _pipeline_def: PipelineDefinition) -> AbstractSet[str]:
         return set()
 
     def get_asset_lineage(
@@ -296,7 +297,7 @@ class FromRootInputManager(
         solid_config = step_context.resolved_run_config.solids.get(str(self.solid_handle))
         config_data = solid_config.inputs.get(self.input_name) if solid_config else None
 
-        input_manager_key = (
+        input_manager_key = check.not_none(
             input_def.root_manager_key
             if input_def.root_manager_key
             else input_def.input_manager_key
@@ -326,11 +327,16 @@ class FromRootInputManager(
             ],
         )
 
-    def compute_version(self, step_versions, pipeline_def, resolved_run_config) -> Optional[str]:
+    def compute_version(
+        self,
+        step_versions: Dict[str, Optional[str]],
+        pipeline_def: PipelineDefinition,
+        resolved_run_config: ResolvedRunConfig,
+    ) -> Optional[str]:
         from ..resolve_versions import check_valid_version, resolve_config_version
 
         solid = pipeline_def.get_solid(self.solid_handle)
-        input_manager_key = (
+        input_manager_key = check.not_none(
             solid.input_def_named(self.input_name).root_manager_key
             if solid.input_def_named(self.input_name).root_manager_key
             else solid.input_def_named(self.input_name).input_manager_key
@@ -339,9 +345,9 @@ class FromRootInputManager(
             resolved_run_config.mode
         ).resource_defs[input_manager_key]
 
-        solid_config = resolved_run_config.solids.get(solid.name)
+        solid_config = resolved_run_config.solids[solid.name]
         input_config = solid_config.inputs.get(self.input_name)
-        resource_config = resolved_run_config.resources.get(input_manager_key).config
+        resource_config = check.not_none(resolved_run_config.resources.get(input_manager_key)).config
 
         version_context = ResourceVersionContext(
             resource_def=input_manager_def,
@@ -372,7 +378,7 @@ class FromRootInputManager(
     def required_resource_keys(self, pipeline_def: PipelineDefinition) -> Set[str]:
         input_def = pipeline_def.get_solid(self.solid_handle).input_def_named(self.input_name)
 
-        input_manager_key = (
+        input_manager_key = check.not_none(
             input_def.root_manager_key
             if input_def.root_manager_key
             else input_def.input_manager_key
@@ -623,16 +629,12 @@ class FromConfig(
         ):
             dagster_type = self.get_associated_input_def(step_context.pipeline_def).dagster_type
             config_data = self.get_associated_config(step_context.resolved_run_config)
+            loader = check.not_none(dagster_type.loader)
+            return loader.construct_from_config_value(step_context, config_data)
 
-            return dagster_type.loader.construct_from_config_value(step_context, config_data)
-
-    def required_resource_keys(self, pipeline_def: PipelineDefinition) -> Set[str]:
-        input_def = self.get_associated_input_def(pipeline_def)
-        return (
-            input_def.dagster_type.loader.required_resource_keys()
-            if input_def.dagster_type.loader
-            else set()
-        )
+    def required_resource_keys(self, pipeline_def: PipelineDefinition) -> AbstractSet[str]:
+        dagster_type = self.get_associated_input_def(pipeline_def).dagster_type
+        return dagster_type.loader.required_resource_keys() if dagster_type.loader else set()
 
     def compute_version(
         self,
@@ -644,8 +646,9 @@ class FromConfig(
         config_data = self.get_associated_config(resolved_run_config)
         input_def = self.get_associated_input_def(pipeline_def)
         dagster_type = input_def.dagster_type
+        loader = check.not_none(dagster_type.loader)
 
-        return dagster_type.loader.compute_loaded_input_version(config_data)
+        return loader.compute_loaded_input_version(config_data)
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/core/execution/plan/inputs.py
@@ -347,7 +347,9 @@ class FromRootInputManager(
 
         solid_config = resolved_run_config.solids[solid.name]
         input_config = solid_config.inputs.get(self.input_name)
-        resource_config = check.not_none(resolved_run_config.resources.get(input_manager_key)).config
+        resource_config = check.not_none(
+            resolved_run_config.resources.get(input_manager_key)
+        ).config
 
         version_context = ResourceVersionContext(
             resource_def=input_manager_def,

--- a/python_modules/dagster/dagster/core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/core/execution/plan/inputs.py
@@ -65,7 +65,7 @@ class StepInputData(
         return super(StepInputData, cls).__new__(
             cls,
             input_name=check.str_param(input_name, "input_name"),
-            type_check_data=check.opt_inst_param(type_check_data, "type_check_data", TypeCheckData),
+            type_check_data=check.inst_param(type_check_data, "type_check_data", TypeCheckData),
         )
 
 

--- a/python_modules/dagster/dagster/core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/plan.py
@@ -394,7 +394,7 @@ class _PlanBuilder:
                 resolved_output_def, resolved_handle = solid.definition.resolve_output_to_origin(
                     output_def.name, handle
                 )
-                step = self.get_step_by_solid_handle(resolved_handle)
+                step = self.get_step_by_solid_handle(check.not_none(resolved_handle))
                 if isinstance(step, (ExecutionStep, UnresolvedCollectExecutionStep)):
                     step_output_handle: Union[
                         StepOutputHandle, UnresolvedStepOutputHandle

--- a/python_modules/dagster/dagster/core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/plan.py
@@ -7,6 +7,7 @@ from typing import (
     List,
     NamedTuple,
     Optional,
+    Sequence,
     Set,
     Union,
     cast,
@@ -255,13 +256,13 @@ class _PlanBuilder:
 
     def _build_from_sorted_solids(
         self,
-        solids: List[Node],
+        solids: Sequence[Node],
         dependency_structure: DependencyStructure,
         parent_handle: Optional[NodeHandle] = None,
         parent_step_inputs: Optional[
             List[Union[StepInput, UnresolvedMappedStepInput, UnresolvedCollectStepInput]]
         ] = None,
-    ):
+    ) -> None:
         asset_layer = self.pipeline.get_definition().asset_layer
         for solid in solids:
             handle = NodeHandle(solid.name, parent_handle)

--- a/python_modules/dagster/dagster/core/execution/resolve_versions.py
+++ b/python_modules/dagster/dagster/core/execution/resolve_versions.py
@@ -21,7 +21,7 @@ def check_valid_version(version: str) -> None:
         )
 
 
-def resolve_config_version(config_value):
+def resolve_config_version(config_value: object):
     """Resolve a configuration value into a hashed version.
 
     If a None value is passed in, we return the result of an empty join_and_hash.

--- a/python_modules/dagster/dagster/core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/core/execution/resources_init.py
@@ -1,19 +1,7 @@
 import inspect
 from collections import deque
 from contextlib import ContextDecorator
-from typing import (
-    AbstractSet,
-    Any,
-    Callable,
-    Deque,
-    Dict,
-    Generator,
-    Mapping,
-    Optional,
-    Set,
-    Union,
-    cast,
-)
+from typing import AbstractSet, Any, Callable, Deque, Dict, Mapping, Optional, cast
 
 import dagster._check as check
 from dagster.core.definitions.pipeline_definition import PipelineDefinition
@@ -50,7 +38,7 @@ from .context.init import InitResourceContext
 
 def resource_initialization_manager(
     resource_defs: Mapping[str, ResourceDefinition],
-    resource_configs: Dict[str, ResourceConfig],
+    resource_configs: Mapping[str, ResourceConfig],
     log_manager: DagsterLogManager,
     execution_plan: Optional[ExecutionPlan],
     pipeline_run: Optional[PipelineRun],
@@ -125,7 +113,7 @@ def get_dependencies(resource_name: str, resource_deps: Mapping[str, AbstractSet
 
 def _core_resource_initialization_event_generator(
     resource_defs: Mapping[str, ResourceDefinition],
-    resource_configs: Dict[str, ResourceConfig],
+    resource_configs: Mapping[str, ResourceConfig],
     resource_log_manager: DagsterLogManager,
     resource_managers: Deque[EventGenerationManager],
     execution_plan: Optional[ExecutionPlan],
@@ -224,7 +212,7 @@ def _core_resource_initialization_event_generator(
 
 def resource_initialization_event_generator(
     resource_defs: Mapping[str, ResourceDefinition],
-    resource_configs: Dict[str, ResourceConfig],
+    resource_configs: Mapping[str, ResourceConfig],
     log_manager: DagsterLogManager,
     execution_plan: Optional[ExecutionPlan],
     pipeline_run: Optional[PipelineRun],

--- a/python_modules/dagster/dagster/core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/core/execution/resources_init.py
@@ -1,7 +1,19 @@
 import inspect
 from collections import deque
 from contextlib import ContextDecorator
-from typing import AbstractSet, Any, Callable, Deque, Dict, Generator, Mapping, Optional, Set, Union, cast
+from typing import (
+    AbstractSet,
+    Any,
+    Callable,
+    Deque,
+    Dict,
+    Generator,
+    Mapping,
+    Optional,
+    Set,
+    Union,
+    cast,
+)
 
 import dagster._check as check
 from dagster.core.definitions.pipeline_definition import PipelineDefinition
@@ -94,7 +106,9 @@ def ensure_resource_deps_satisfiable(resource_deps: Mapping[str, AbstractSet[str
         _helper(resource_key)
 
 
-def get_dependencies(resource_name: str, resource_deps: Mapping[str, AbstractSet[str]]) -> AbstractSet[str]:
+def get_dependencies(
+    resource_name: str, resource_deps: Mapping[str, AbstractSet[str]]
+) -> AbstractSet[str]:
     """Get all resources that must be initialized before resource_name can be initialized.
 
     Uses dfs to get all required dependencies from a particular resource. Assumes that resource dependencies are not cyclic (check performed by a different function).

--- a/python_modules/dagster/dagster/core/executor/init.py
+++ b/python_modules/dagster/dagster/core/executor/init.py
@@ -1,4 +1,4 @@
-from typing import Dict, Mapping, NamedTuple
+from typing import Mapping, NamedTuple
 
 import dagster._check as check
 from dagster.core.definitions import ExecutorDefinition, IPipeline

--- a/python_modules/dagster/dagster/core/executor/init.py
+++ b/python_modules/dagster/dagster/core/executor/init.py
@@ -1,4 +1,4 @@
-from typing import Dict, NamedTuple
+from typing import Dict, Mapping, NamedTuple
 
 import dagster._check as check
 from dagster.core.definitions import ExecutorDefinition, IPipeline
@@ -11,7 +11,7 @@ class InitExecutorContext(
         [
             ("job", IPipeline),
             ("executor_def", ExecutorDefinition),
-            ("executor_config", Dict[str, object]),
+            ("executor_config", Mapping[str, object]),
             ("instance", DagsterInstance),
         ],
     )
@@ -30,14 +30,14 @@ class InitExecutorContext(
         cls,
         job: IPipeline,
         executor_def: ExecutorDefinition,
-        executor_config: Dict[str, object],
+        executor_config: Mapping[str, object],
         instance: DagsterInstance,
     ):
         return super(InitExecutorContext, cls).__new__(
             cls,
             job=check.inst_param(job, "job", IPipeline),
             executor_def=check.inst_param(executor_def, "executor_def", ExecutorDefinition),
-            executor_config=check.dict_param(executor_config, "executor_config", key_type=str),
+            executor_config=check.mapping_param(executor_config, "executor_config", key_type=str),
             instance=check.inst_param(instance, "instance", DagsterInstance),
         )
 

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -311,7 +311,9 @@ class ExternalTargetData(
             cls,
             pipeline_name=check.str_param(pipeline_name, "pipeline_name"),
             mode=check.str_param(mode, "mode"),
-            solid_selection=check.opt_nullable_sequence_param(solid_selection, "solid_selection", str),
+            solid_selection=check.opt_nullable_sequence_param(
+                solid_selection, "solid_selection", str
+            ),
         )
 
 
@@ -324,7 +326,9 @@ class ExternalSensorMetadata(
     def __new__(cls, asset_keys: Optional[Sequence[AssetKey]] = None):
         return super(ExternalSensorMetadata, cls).__new__(
             cls,
-            asset_keys=check.opt_nullable_sequence_param(asset_keys, "asset_keys", of_type=AssetKey),
+            asset_keys=check.opt_nullable_sequence_param(
+                asset_keys, "asset_keys", of_type=AssetKey
+            ),
         )
 
 
@@ -532,7 +536,9 @@ class ExternalPartitionSetData(
             cls,
             name=check.str_param(name, "name"),
             pipeline_name=check.str_param(pipeline_name, "pipeline_name"),
-            solid_selection=check.opt_nullable_sequence_param(solid_selection, "solid_selection", str),
+            solid_selection=check.opt_nullable_sequence_param(
+                solid_selection, "solid_selection", str
+            ),
             mode=check.opt_str_param(mode, "mode"),
         )
 

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -207,9 +207,9 @@ class ExternalPresetData(
         [
             ("name", str),
             ("run_config", Mapping[str, object]),
-            ("solid_selection", Optional[List[str]]),
+            ("solid_selection", Optional[Sequence[str]]),
             ("mode", str),
-            ("tags", Dict[str, str]),
+            ("tags", Mapping[str, str]),
         ],
     )
 ):
@@ -217,15 +217,15 @@ class ExternalPresetData(
         cls,
         name: str,
         run_config: Optional[Mapping[str, object]],
-        solid_selection: Optional[List[str]],
+        solid_selection: Optional[Sequence[str]],
         mode: str,
-        tags: Dict[str, str],
+        tags: Mapping[str, str],
     ):
         return super(ExternalPresetData, cls).__new__(
             cls,
             name=check.str_param(name, "name"),
             run_config=check.opt_mapping_param(run_config, "run_config", key_type=str),
-            solid_selection=check.opt_nullable_list_param(
+            solid_selection=check.opt_nullable_sequence_param(
                 solid_selection, "solid_selection", of_type=str
             ),
             mode=check.str_param(mode, "mode"),
@@ -247,9 +247,9 @@ class ExternalScheduleData(
             ("name", str),
             ("cron_schedule", str),
             ("pipeline_name", str),
-            ("solid_selection", Optional[List[str]]),
+            ("solid_selection", Optional[Sequence[str]]),
             ("mode", Optional[str]),
-            ("environment_vars", Optional[Dict[str, str]]),
+            ("environment_vars", Optional[Mapping[str, str]]),
             ("partition_set_name", Optional[str]),
             ("execution_timezone", Optional[str]),
             ("description", Optional[str]),
@@ -303,28 +303,28 @@ class ExternalScheduleExecutionErrorData(
 class ExternalTargetData(
     NamedTuple(
         "_ExternalTargetData",
-        [("pipeline_name", str), ("mode", str), ("solid_selection", Optional[List[str]])],
+        [("pipeline_name", str), ("mode", str), ("solid_selection", Optional[Sequence[str]])],
     )
 ):
-    def __new__(cls, pipeline_name: str, mode: str, solid_selection: Optional[List[str]]):
+    def __new__(cls, pipeline_name: str, mode: str, solid_selection: Optional[Sequence[str]]):
         return super(ExternalTargetData, cls).__new__(
             cls,
             pipeline_name=check.str_param(pipeline_name, "pipeline_name"),
             mode=check.str_param(mode, "mode"),
-            solid_selection=check.opt_nullable_list_param(solid_selection, "solid_selection", str),
+            solid_selection=check.opt_nullable_sequence_param(solid_selection, "solid_selection", str),
         )
 
 
 @whitelist_for_serdes
 class ExternalSensorMetadata(
-    NamedTuple("_ExternalSensorMetadata", [("asset_keys", Optional[List[AssetKey]])])
+    NamedTuple("_ExternalSensorMetadata", [("asset_keys", Optional[Sequence[AssetKey]])])
 ):
     """Stores additional sensor metadata which is available on the Dagit frontend."""
 
-    def __new__(cls, asset_keys: Optional[List[AssetKey]] = None):
+    def __new__(cls, asset_keys: Optional[Sequence[AssetKey]] = None):
         return super(ExternalSensorMetadata, cls).__new__(
             cls,
-            asset_keys=check.opt_nullable_list_param(asset_keys, "asset_keys", of_type=AssetKey),
+            asset_keys=check.opt_nullable_sequence_param(asset_keys, "asset_keys", of_type=AssetKey),
         )
 
 
@@ -341,11 +341,11 @@ class ExternalSensorData(
         [
             ("name", str),
             ("pipeline_name", Optional[str]),
-            ("solid_selection", Optional[List[str]]),
+            ("solid_selection", Optional[Sequence[str]]),
             ("mode", Optional[str]),
             ("min_interval", Optional[int]),
             ("description", Optional[str]),
-            ("target_dict", Dict[str, ExternalTargetData]),
+            ("target_dict", Mapping[str, ExternalTargetData]),
             ("metadata", Optional[ExternalSensorMetadata]),
             ("default_status", Optional[DefaultSensorStatus]),
         ],
@@ -355,11 +355,11 @@ class ExternalSensorData(
         cls,
         name: str,
         pipeline_name: Optional[str] = None,
-        solid_selection: Optional[List[str]] = None,
+        solid_selection: Optional[Sequence[str]] = None,
         mode: Optional[str] = None,
         min_interval: Optional[int] = None,
         description: Optional[str] = None,
-        target_dict: Optional[Dict[str, ExternalTargetData]] = None,
+        target_dict: Optional[Mapping[str, ExternalTargetData]] = None,
         metadata: Optional[ExternalSensorMetadata] = None,
         default_status: Optional[DefaultSensorStatus] = None,
     ):
@@ -370,7 +370,7 @@ class ExternalSensorData(
                 pipeline_name: ExternalTargetData(
                     pipeline_name=check.str_param(pipeline_name, "pipeline_name"),
                     mode=check.opt_str_param(mode, "mode", DEFAULT_MODE_NAME),
-                    solid_selection=check.opt_nullable_list_param(
+                    solid_selection=check.opt_nullable_sequence_param(
                         solid_selection, "solid_selection", str
                     ),
                 )
@@ -382,7 +382,7 @@ class ExternalSensorData(
             pipeline_name=check.opt_str_param(
                 pipeline_name, "pipeline_name"
             ),  # keep legacy field populated
-            solid_selection=check.opt_nullable_list_param(
+            solid_selection=check.opt_nullable_sequence_param(
                 solid_selection, "solid_selection", str
             ),  # keep legacy field populated
             mode=check.opt_str_param(mode, "mode"),  # keep legacy field populated
@@ -428,7 +428,7 @@ class ExternalExecutionParamsData(
     def __new__(
         cls,
         run_config: Optional[Mapping[str, object]] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[Mapping[str, str]] = None,
     ):
         return super(ExternalExecutionParamsData, cls).__new__(
             cls,
@@ -498,9 +498,9 @@ class ExternalTimeWindowPartitionsDefinitionData(
 @whitelist_for_serdes
 class ExternalStaticPartitionsDefinitionData(
     ExternalPartitionsDefinitionData,
-    NamedTuple("_ExternalStaticPartitionsDefinitionData", [("partition_keys", List[str])]),
+    NamedTuple("_ExternalStaticPartitionsDefinitionData", [("partition_keys", Sequence[str])]),
 ):
-    def __new__(cls, partition_keys: List[str]):
+    def __new__(cls, partition_keys: Sequence[str]):
         return super(ExternalStaticPartitionsDefinitionData, cls).__new__(
             cls, partition_keys=check.list_param(partition_keys, "partition_keys", str)
         )
@@ -516,7 +516,7 @@ class ExternalPartitionSetData(
         [
             ("name", str),
             ("pipeline_name", str),
-            ("solid_selection", Optional[List[str]]),
+            ("solid_selection", Optional[Sequence[str]]),
             ("mode", Optional[str]),
         ],
     )
@@ -525,23 +525,23 @@ class ExternalPartitionSetData(
         cls,
         name: str,
         pipeline_name: str,
-        solid_selection: Optional[List[str]],
+        solid_selection: Optional[Sequence[str]],
         mode: Optional[str],
     ):
         return super(ExternalPartitionSetData, cls).__new__(
             cls,
             name=check.str_param(name, "name"),
             pipeline_name=check.str_param(pipeline_name, "pipeline_name"),
-            solid_selection=check.opt_nullable_list_param(solid_selection, "solid_selection", str),
+            solid_selection=check.opt_nullable_sequence_param(solid_selection, "solid_selection", str),
             mode=check.opt_str_param(mode, "mode"),
         )
 
 
 @whitelist_for_serdes
 class ExternalPartitionNamesData(
-    NamedTuple("_ExternalPartitionNamesData", [("partition_names", List[str])])
+    NamedTuple("_ExternalPartitionNamesData", [("partition_names", Sequence[str])])
 ):
-    def __new__(cls, partition_names: Optional[List[str]] = None):
+    def __new__(cls, partition_names: Optional[Sequence[str]] = None):
         return super(ExternalPartitionNamesData, cls).__new__(
             cls,
             partition_names=check.opt_list_param(partition_names, "partition_names", str),
@@ -594,10 +594,10 @@ class ExternalPartitionExecutionParamData(
 class ExternalPartitionSetExecutionParamData(
     NamedTuple(
         "_ExternalPartitionSetExecutionParamData",
-        [("partition_data", List[ExternalPartitionExecutionParamData])],
+        [("partition_data", Sequence[ExternalPartitionExecutionParamData])],
     )
 ):
-    def __new__(cls, partition_data: List[ExternalPartitionExecutionParamData]):
+    def __new__(cls, partition_data: Sequence[ExternalPartitionExecutionParamData]):
         return super(ExternalPartitionSetExecutionParamData, cls).__new__(
             cls,
             partition_data=check.list_param(

--- a/python_modules/dagster/dagster/core/host_representation/pipeline_index.py
+++ b/python_modules/dagster/dagster/core/host_representation/pipeline_index.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster.config.snap import ConfigSchemaSnapshot
@@ -16,10 +16,10 @@ class PipelineIndex:
 
     pipeline_snapshot: PipelineSnapshot
     parent_pipeline_snapshot: Optional[PipelineSnapshot]
-    _node_defs_snaps_index: Dict[str, Union[SolidDefSnap, CompositeSolidDefSnap]]
-    _dagster_type_snaps_by_name_index: Dict[str, DagsterTypeSnap]
+    _node_defs_snaps_index: Mapping[str, Union[SolidDefSnap, CompositeSolidDefSnap]]
+    _dagster_type_snaps_by_name_index: Mapping[str, DagsterTypeSnap]
     dep_structure_index: DependencyStructureIndex
-    _comp_dep_structures: Dict[str, DependencyStructureIndex]
+    _comp_dep_structures: Mapping[str, DependencyStructureIndex]
     _pipeline_snapshot_id: Optional[str]
 
     def __init__(
@@ -40,7 +40,7 @@ class PipelineIndex:
                 "Can not create PipelineIndex for pipeline_snapshot with lineage without parent_pipeline_snapshot",
             )
 
-        node_def_snaps: List[Union[SolidDefSnap, CompositeSolidDefSnap]] = [
+        node_def_snaps: Sequence[Union[SolidDefSnap, CompositeSolidDefSnap]] = [
             *pipeline_snapshot.solid_definitions_snapshot.solid_def_snaps,
             *pipeline_snapshot.solid_definitions_snapshot.composite_solid_def_snaps,
         ]
@@ -72,7 +72,7 @@ class PipelineIndex:
         return self.pipeline_snapshot.description
 
     @property
-    def tags(self) -> Dict[str, Any]:
+    def tags(self) -> Mapping[str, Any]:
         return self.pipeline_snapshot.tags
 
     @property

--- a/python_modules/dagster/dagster/core/host_representation/pipeline_index.py
+++ b/python_modules/dagster/dagster/core/host_representation/pipeline_index.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
+from typing import Any, Mapping, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster.config.snap import ConfigSchemaSnapshot
@@ -98,7 +98,7 @@ class PipelineIndex:
     def get_dep_structure_index(self, comp_solid_def_name: str) -> DependencyStructureIndex:
         return self._comp_dep_structures[comp_solid_def_name]
 
-    def get_dagster_type_snaps(self) -> List[DagsterTypeSnap]:
+    def get_dagster_type_snaps(self) -> Sequence[DagsterTypeSnap]:
         dt_namespace = self.pipeline_snapshot.dagster_type_namespace_snapshot
         return list(dt_namespace.all_dagster_type_snaps_by_key.values())
 
@@ -117,7 +117,7 @@ class PipelineIndex:
         return False
 
     @property
-    def available_modes(self) -> List[str]:
+    def available_modes(self) -> Sequence[str]:
         return [mode_def_snap.name for mode_def_snap in self.pipeline_snapshot.mode_def_snaps]
 
     def get_mode_def_snap(self, name: str) -> ModeDefSnap:

--- a/python_modules/dagster/dagster/core/host_representation/represented.py
+++ b/python_modules/dagster/dagster/core/host_representation/represented.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import AbstractSet, List, Optional, Sequence, Union
+from typing import AbstractSet, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster.config.snap import ConfigSchemaSnapshot

--- a/python_modules/dagster/dagster/core/host_representation/represented.py
+++ b/python_modules/dagster/dagster/core/host_representation/represented.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import AbstractSet, List, Optional, Union
+from typing import AbstractSet, List, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster.config.snap import ConfigSchemaSnapshot
@@ -61,7 +61,7 @@ class RepresentedPipeline(ABC):
         return self._pipeline_index.parent_pipeline_snapshot
 
     @property
-    def solid_selection(self) -> Optional[List[str]]:
+    def solid_selection(self) -> Optional[Sequence[str]]:
         return (
             self._pipeline_index.pipeline_snapshot.lineage_snapshot.solid_selection
             if self._pipeline_index.pipeline_snapshot.lineage_snapshot
@@ -85,7 +85,7 @@ class RepresentedPipeline(ABC):
     # DagsterTypes
 
     @property
-    def dagster_type_snaps(self) -> List[DagsterTypeSnap]:
+    def dagster_type_snaps(self) -> Sequence[DagsterTypeSnap]:
         return self._pipeline_index.get_dagster_type_snaps()
 
     def has_dagster_type_named(self, type_name: str) -> bool:
@@ -97,7 +97,7 @@ class RepresentedPipeline(ABC):
     # Modes
 
     @property
-    def mode_def_snaps(self) -> List[ModeDefSnap]:
+    def mode_def_snaps(self) -> Sequence[ModeDefSnap]:
         return self._pipeline_index.pipeline_snapshot.mode_def_snaps
 
     def get_mode_def_snap(self, mode_name: str) -> ModeDefSnap:

--- a/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
@@ -1,4 +1,17 @@
-from typing import AbstractSet, Any, Dict, FrozenSet, List, Mapping, NamedTuple, Optional, Sequence, Set, Union, cast
+from typing import (
+    AbstractSet,
+    Any,
+    Dict,
+    FrozenSet,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Union,
+    cast,
+)
 
 from dagster import Field, Map, Permissive, Selector, Shape
 from dagster import _check as check
@@ -178,7 +191,9 @@ class PipelineSnapshot(
             dep_structure_snapshot=check.inst_param(
                 dep_structure_snapshot, "dep_structure_snapshot", DependencyStructureSnapshot
             ),
-            mode_def_snaps=check.sequence_param(mode_def_snaps, "mode_def_snaps", of_type=ModeDefSnap),
+            mode_def_snaps=check.sequence_param(
+                mode_def_snaps, "mode_def_snaps", of_type=ModeDefSnap
+            ),
             lineage_snapshot=check.opt_inst_param(
                 lineage_snapshot, "lineage_snapshot", PipelineSnapshotLineage
             ),

--- a/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
@@ -1,4 +1,4 @@
-from typing import AbstractSet, Any, Dict, FrozenSet, List, NamedTuple, Optional, Set, Union, cast
+from typing import AbstractSet, Any, Dict, FrozenSet, List, Mapping, NamedTuple, Optional, Sequence, Set, Union, cast
 
 from dagster import Field, Map, Permissive, Selector, Shape
 from dagster import _check as check
@@ -133,15 +133,15 @@ class PipelineSnapshot(
         [
             ("name", str),
             ("description", Optional[str]),
-            ("tags", Dict[str, Any]),
+            ("tags", Mapping[str, Any]),
             ("config_schema_snapshot", ConfigSchemaSnapshot),
             ("dagster_type_namespace_snapshot", DagsterTypeNamespaceSnapshot),
             ("solid_definitions_snapshot", SolidDefinitionsSnapshot),
             ("dep_structure_snapshot", DependencyStructureSnapshot),
-            ("mode_def_snaps", List[ModeDefSnap]),
+            ("mode_def_snaps", Sequence[ModeDefSnap]),
             ("lineage_snapshot", Optional["PipelineSnapshotLineage"]),
             ("graph_def_name", str),
-            ("metadata", List[Union[MetadataEntry, PartitionMetadataEntry]]),
+            ("metadata", Sequence[Union[MetadataEntry, PartitionMetadataEntry]]),
         ],
     )
 ):
@@ -149,21 +149,21 @@ class PipelineSnapshot(
         cls,
         name: str,
         description: Optional[str],
-        tags: Optional[Dict[str, Any]],
+        tags: Optional[Mapping[str, Any]],
         config_schema_snapshot: ConfigSchemaSnapshot,
         dagster_type_namespace_snapshot: DagsterTypeNamespaceSnapshot,
         solid_definitions_snapshot: SolidDefinitionsSnapshot,
         dep_structure_snapshot: DependencyStructureSnapshot,
-        mode_def_snaps: List[ModeDefSnap],
+        mode_def_snaps: Sequence[ModeDefSnap],
         lineage_snapshot: Optional["PipelineSnapshotLineage"],
         graph_def_name: str,
-        metadata: Optional[List[Union[MetadataEntry, PartitionMetadataEntry]]],
+        metadata: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]],
     ):
         return super(PipelineSnapshot, cls).__new__(
             cls,
             name=check.str_param(name, "name"),
             description=check.opt_str_param(description, "description"),
-            tags=check.opt_dict_param(tags, "tags"),
+            tags=check.opt_mapping_param(tags, "tags"),
             config_schema_snapshot=check.inst_param(
                 config_schema_snapshot, "config_schema_snapshot", ConfigSchemaSnapshot
             ),
@@ -178,12 +178,12 @@ class PipelineSnapshot(
             dep_structure_snapshot=check.inst_param(
                 dep_structure_snapshot, "dep_structure_snapshot", DependencyStructureSnapshot
             ),
-            mode_def_snaps=check.list_param(mode_def_snaps, "mode_def_snaps", of_type=ModeDefSnap),
+            mode_def_snaps=check.sequence_param(mode_def_snaps, "mode_def_snaps", of_type=ModeDefSnap),
             lineage_snapshot=check.opt_inst_param(
                 lineage_snapshot, "lineage_snapshot", PipelineSnapshotLineage
             ),
             graph_def_name=check.str_param(graph_def_name, "graph_def_name"),
-            metadata=check.opt_list_param(metadata, "metadata"),
+            metadata=check.opt_sequence_param(metadata, "metadata"),
         )
 
     @classmethod

--- a/python_modules/dagster/dagster/core/snap/solid.py
+++ b/python_modules/dagster/dagster/core/snap/solid.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Set, Union
+from typing import Mapping, NamedTuple, Optional, Sequence, Set, Union
 
 import dagster._check as check
 from dagster.config.snap import ConfigFieldSnap, snap_from_field
@@ -11,7 +11,7 @@ from dagster.core.definitions import (
     PipelineDefinition,
     SolidDefinition,
 )
-from dagster.core.definitions.metadata import MetadataEntry
+from dagster.core.definitions.metadata import MetadataEntry, PartitionMetadataEntry
 from dagster.serdes import whitelist_for_serdes
 from dagster.serdes.serdes import DefaultNamedTupleSerializer
 
@@ -35,7 +35,7 @@ class InputDefSnap(
             ("name", str),
             ("dagster_type_key", str),
             ("description", Optional[str]),
-            ("metadata_entries", List[MetadataEntry]),
+            ("metadata_entries", Sequence[Union[MetadataEntry, PartitionMetadataEntry]]),
         ],
     )
 ):
@@ -44,7 +44,7 @@ class InputDefSnap(
         name: str,
         dagster_type_key: str,
         description: Optional[str],
-        metadata_entries: Optional[List[MetadataEntry]] = None,
+        metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
     ):
         return super(InputDefSnap, cls).__new__(
             cls,
@@ -72,7 +72,7 @@ class OutputDefSnap(
             ("dagster_type_key", str),
             ("description", Optional[str]),
             ("is_required", bool),
-            ("metadata_entries", Sequence[MetadataEntry]),
+            ("metadata_entries", Sequence[Union[MetadataEntry, PartitionMetadataEntry]]),
             ("is_dynamic", bool),
         ],
     )
@@ -187,10 +187,10 @@ def build_output_def_snap(output_def: OutputDefinition) -> OutputDefSnap:
 # instead.
 def _check_solid_def_header_args(
     name: str,
-    input_def_snaps: List[InputDefSnap],
-    output_def_snaps: List[OutputDefSnap],
+    input_def_snaps: Sequence[InputDefSnap],
+    output_def_snaps: Sequence[OutputDefSnap],
     description: Optional[str],
-    tags: Dict[str, Any],
+    tags: Mapping[str, object],
     config_field_snap: Optional[ConfigFieldSnap],
 ):
     return dict(
@@ -211,28 +211,28 @@ class CompositeSolidDefSnap(
         "_CompositeSolidDefSnap",
         [
             ("name", str),
-            ("input_def_snaps", List[InputDefSnap]),
-            ("output_def_snaps", List[OutputDefSnap]),
+            ("input_def_snaps", Sequence[InputDefSnap]),
+            ("output_def_snaps", Sequence[OutputDefSnap]),
             ("description", Optional[str]),
-            ("tags", Dict[str, Any]),
+            ("tags", Mapping[str, object]),
             ("config_field_snap", Optional[ConfigFieldSnap]),
             ("dep_structure_snapshot", DependencyStructureSnapshot),
-            ("input_mapping_snaps", List[InputMappingSnap]),
-            ("output_mapping_snaps", List[OutputMappingSnap]),
+            ("input_mapping_snaps", Sequence[InputMappingSnap]),
+            ("output_mapping_snaps", Sequence[OutputMappingSnap]),
         ],
     )
 ):
     def __new__(
         cls,
         name: str,
-        input_def_snaps: List[InputDefSnap],
-        output_def_snaps: List[OutputDefSnap],
+        input_def_snaps: Sequence[InputDefSnap],
+        output_def_snaps: Sequence[OutputDefSnap],
         description: Optional[str],
-        tags: Dict[str, Any],
+        tags: Mapping[str, object],
         config_field_snap: Optional[ConfigFieldSnap],
         dep_structure_snapshot: DependencyStructureSnapshot,
-        input_mapping_snaps: List[InputMappingSnap],
-        output_mapping_snaps: List[OutputMappingSnap],
+        input_mapping_snaps: Sequence[InputMappingSnap],
+        output_mapping_snaps: Sequence[OutputMappingSnap],
     ):
         return super(CompositeSolidDefSnap, cls).__new__(
             cls,
@@ -282,11 +282,11 @@ class SolidDefSnap(
         "_SolidDefMeta",
         [
             ("name", str),
-            ("input_def_snaps", List[InputDefSnap]),
-            ("output_def_snaps", List[OutputDefSnap]),
+            ("input_def_snaps", Sequence[InputDefSnap]),
+            ("output_def_snaps", Sequence[OutputDefSnap]),
             ("description", Optional[str]),
-            ("tags", Dict[str, Any]),
-            ("required_resource_keys", List[str]),
+            ("tags", Mapping[str, object]),
+            ("required_resource_keys", Sequence[str]),
             ("config_field_snap", Optional[ConfigFieldSnap]),
         ],
     )
@@ -294,11 +294,11 @@ class SolidDefSnap(
     def __new__(
         cls,
         name: str,
-        input_def_snaps: List[InputDefSnap],
-        output_def_snaps: List[OutputDefSnap],
+        input_def_snaps: Sequence[InputDefSnap],
+        output_def_snaps: Sequence[OutputDefSnap],
         description: Optional[str],
-        tags: Dict[str, Any],
-        required_resource_keys: List[str],
+        tags: Mapping[str, object],
+        required_resource_keys: Sequence[str],
         config_field_snap: Optional[ConfigFieldSnap],
     ):
         return super(SolidDefSnap, cls).__new__(
@@ -328,15 +328,15 @@ class SolidDefinitionsSnapshot(
     NamedTuple(
         "_SolidDefinitionsSnapshot",
         [
-            ("solid_def_snaps", List[SolidDefSnap]),
-            ("composite_solid_def_snaps", List[CompositeSolidDefSnap]),
+            ("solid_def_snaps", Sequence[SolidDefSnap]),
+            ("composite_solid_def_snaps", Sequence[CompositeSolidDefSnap]),
         ],
     )
 ):
     def __new__(
         cls,
-        solid_def_snaps: List[SolidDefSnap],
-        composite_solid_def_snaps: List[CompositeSolidDefSnap],
+        solid_def_snaps: Sequence[SolidDefSnap],
+        composite_solid_def_snaps: Sequence[CompositeSolidDefSnap],
     ):
         return super(SolidDefinitionsSnapshot, cls).__new__(
             cls,

--- a/python_modules/dagster/dagster/core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/base.py
@@ -176,15 +176,16 @@ class EventRecordsFilter(
         check.opt_list_param(asset_partitions, "asset_partitions", of_type=str)
         check.inst_param(event_type, "event_type", DagsterEventType)
 
+        # type-ignores work around mypy type inference bug
         return super(EventRecordsFilter, cls).__new__(
             cls,
             event_type=event_type,
             asset_key=check.opt_inst_param(asset_key, "asset_key", AssetKey),
             asset_partitions=asset_partitions,
-            after_cursor=check.opt_inst_param(
+            after_cursor=check.opt_inst_param(  # type: ignore
                 after_cursor, "after_cursor", (int, RunShardedEventsCursor)
             ),
-            before_cursor=check.opt_inst_param(
+            before_cursor=check.opt_inst_param(  # type: ignore
                 before_cursor, "before_cursor", (int, RunShardedEventsCursor)
             ),
             after_timestamp=check.opt_float_param(after_timestamp, "after_timestamp"),

--- a/python_modules/dagster/dagster/core/system_config/objects.py
+++ b/python_modules/dagster/dagster/core/system_config/objects.py
@@ -19,11 +19,11 @@ class SolidConfig(
         [
             ("config", object),
             ("inputs", Mapping[str, object]),
-            ("outputs", "OutputsConfig"),
+            ("outputs", Optional["OutputsConfig"]),
         ],
     )
 ):
-    def __new__(cls, config, inputs: Mapping[str, object], outputs: "OutputsConfig"):
+    def __new__(cls, config, inputs: Mapping[str, object], outputs: Optional["OutputsConfig"]):
         return super(SolidConfig, cls).__new__(
             cls,
             config,
@@ -38,7 +38,7 @@ class SolidConfig(
         return SolidConfig(
             config=config.get("config"),
             inputs=config.get("inputs") or {},
-            outputs=OutputsConfig(config["outputs"]),
+            outputs=OutputsConfig(config.get("outputs")),
         )
 
 
@@ -48,7 +48,7 @@ class OutputsConfig(NamedTuple):
     output_config_schema, and a list otherwise.
     """
 
-    config: Union[Dict, List]
+    config: Optional[Union[Dict, List]]
 
     @property
     def output_names(self) -> AbstractSet[str]:

--- a/python_modules/dagster/dagster/core/system_config/objects.py
+++ b/python_modules/dagster/dagster/core/system_config/objects.py
@@ -19,11 +19,11 @@ class SolidConfig(
         [
             ("config", object),
             ("inputs", Mapping[str, object]),
-            ("outputs", Optional["OutputsConfig"]),
+            ("outputs", "OutputsConfig"),
         ],
     )
 ):
-    def __new__(cls, config, inputs: Mapping[str, object], outputs: Optional["OutputsConfig"]):
+    def __new__(cls, config, inputs: Mapping[str, object], outputs: "OutputsConfig"):
         return super(SolidConfig, cls).__new__(
             cls,
             config,

--- a/python_modules/dagster/dagster/core/system_config/objects.py
+++ b/python_modules/dagster/dagster/core/system_config/objects.py
@@ -1,5 +1,17 @@
 """System-provided config objects and constructors."""
-from typing import AbstractSet, Any, Dict, List, Mapping, NamedTuple, Optional, Sequence, Type, Union, cast
+from typing import (
+    AbstractSet,
+    Any,
+    Dict,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Type,
+    Union,
+    cast,
+)
 
 import dagster._check as check
 from dagster.core.definitions.configurable import ConfigurableDefinition
@@ -99,13 +111,13 @@ class ResolvedRunConfig(
 ):
     def __new__(
         cls,
-        solids: Optional[Mapping[str, SolidConfig]]=None,
-        execution: Optional["ExecutionConfig"]=None,
-        resources: Optional[Mapping[str, ResourceConfig]]=None,
-        loggers: Optional[Mapping[str, Mapping[str, object]]]=None,
-        original_config_dict: Optional[Mapping[str, object]]=None,
-        mode: Optional[str]=None,
-        inputs: Optional[Mapping[str, object]]=None,
+        solids: Optional[Mapping[str, SolidConfig]] = None,
+        execution: Optional["ExecutionConfig"] = None,
+        resources: Optional[Mapping[str, ResourceConfig]] = None,
+        loggers: Optional[Mapping[str, Mapping[str, object]]] = None,
+        original_config_dict: Optional[Mapping[str, object]] = None,
+        mode: Optional[str] = None,
+        inputs: Optional[Mapping[str, object]] = None,
     ):
         check.opt_inst_param(execution, "execution", ExecutionConfig)
         check.opt_dict_param(original_config_dict, "original_config_dict")
@@ -155,7 +167,9 @@ class ResolvedRunConfig(
                 run_config
             )
 
-        config_evr = process_config(run_config_schema.run_config_schema_type, check.not_none(run_config))
+        config_evr = process_config(
+            run_config_schema.run_config_schema_type, check.not_none(run_config)
+        )
         if not config_evr.success:
             raise DagsterInvalidConfigError(
                 f"Error in config for {pipeline_def.target_type}".format(pipeline_def.name),
@@ -382,7 +396,11 @@ class ExecutionConfig(
         ],
     )
 ):
-    def __new__(cls, execution_engine_name: Optional[str], execution_engine_config: Optional[Mapping[str, object]]):
+    def __new__(
+        cls,
+        execution_engine_name: Optional[str],
+        execution_engine_config: Optional[Mapping[str, object]],
+    ):
         return super(ExecutionConfig, cls).__new__(
             cls,
             execution_engine_name=check.opt_str_param(
@@ -395,7 +413,7 @@ class ExecutionConfig(
         )
 
     @staticmethod
-    def from_dict(config: Optional[Mapping[str, object]]=None) -> "ExecutionConfig":
+    def from_dict(config: Optional[Mapping[str, object]] = None) -> "ExecutionConfig":
         check.opt_mapping_param(config, "config", key_type=str)
         if config:
             execution_engine_name, execution_engine_config = ensure_single_item(config)

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -912,7 +912,6 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
 
 
 def is_dynamic_output_annotation(dagster_type: object) -> bool:
-    from dagster.seven.typing import get_args, get_origin
 
     check.invariant(
         not (isinstance(dagster_type, type) and is_subclass(dagster_type, ConfigType)),

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -14,6 +14,7 @@ from dagster.config.config_type import Array, ConfigType
 from dagster.config.config_type import Noneable as ConfigNoneable
 from dagster.core.definitions.events import DynamicOutput, Output, TypeCheck
 from dagster.core.definitions.metadata import MetadataEntry, RawMetadataValue, normalize_metadata
+from dagster.core.definitions.node_definition import NodeDefinition
 from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster.serdes import whitelist_for_serdes
 from dagster.seven import is_subclass
@@ -840,12 +841,12 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
     from .transform_typing import transform_typing_type
 
     check.invariant(
-        not is_subclass(dagster_type, ConfigType),
+        not (isinstance(dagster_type, type) and is_subclass(dagster_type, ConfigType)),
         "Cannot resolve a config type to a runtime type",
     )
 
     check.invariant(
-        not is_subclass(dagster_type, DagsterType),
+        not (isinstance(dagster_type, type) and is_subclass(dagster_type, DagsterType)),
         "Do not pass runtime type classes. Got {}".format(dagster_type),
     )
 
@@ -912,12 +913,12 @@ def is_dynamic_output_annotation(dagster_type: object) -> bool:
     from dagster.seven.typing import get_args, get_origin
 
     check.invariant(
-        not is_subclass(dagster_type, ConfigType),
+        not (isinstance(dagster_type, type) and is_subclass(dagster_type, ConfigType)),
         "Cannot resolve a config type to a runtime type",
     )
 
     check.invariant(
-        not is_subclass(dagster_type, DagsterType),
+        not (isinstance(dagster_type, type) and is_subclass(dagster_type, ConfigType)),
         "Do not pass runtime type classes. Got {}".format(dagster_type),
     )
 

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -2,7 +2,7 @@ import typing as t
 from abc import abstractmethod
 from enum import Enum as PythonEnum
 from functools import partial
-from typing import AbstractSet as TypingAbstractSet
+from typing import AbstractSet as TypingAbstractSet, Dict
 from typing import Iterator as TypingIterator
 from typing import Mapping
 from typing import Optional as TypingOptional
@@ -835,7 +835,7 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
     from dagster.seven.typing import get_args
     from dagster.utils.typing_api import is_typing_type
 
-    from .python_dict import Dict, PythonDict
+    from .python_dict import Dict as DDict, PythonDict
     from .python_set import DagsterSetApi, PythonSet
     from .python_tuple import DagsterTupleApi, PythonTuple
     from .transform_typing import transform_typing_type
@@ -890,7 +890,7 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
     if dagster_type is None:
         return Any
 
-    if dagster_type is Dict:
+    if dagster_type is DDict:
         return PythonDict
     if isinstance(dagster_type, DagsterTupleApi):
         return PythonTuple

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -8,7 +8,7 @@ from typing import Iterator as TypingIterator
 from typing import Mapping
 from typing import Optional as TypingOptional
 from typing import Sequence, cast
-from typing_extensions import get_args, get_origin
+from typing_compat import get_args, get_origin
 
 import dagster._check as check
 from dagster.builtins import BuiltinEnum

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -3,7 +3,6 @@ from abc import abstractmethod
 from enum import Enum as PythonEnum
 from functools import partial
 from typing import AbstractSet as TypingAbstractSet
-from typing import Dict
 from typing import Iterator as TypingIterator
 from typing import Mapping
 from typing import Optional as TypingOptional
@@ -17,7 +16,6 @@ from dagster.config.config_type import Array, ConfigType
 from dagster.config.config_type import Noneable as ConfigNoneable
 from dagster.core.definitions.events import DynamicOutput, Output, TypeCheck
 from dagster.core.definitions.metadata import MetadataEntry, RawMetadataValue, normalize_metadata
-from dagster.core.definitions.node_definition import NodeDefinition
 from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster.serdes import whitelist_for_serdes
 from dagster.seven import is_subclass

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -8,6 +8,7 @@ from typing import Iterator as TypingIterator
 from typing import Mapping
 from typing import Optional as TypingOptional
 from typing import Sequence, cast
+
 from typing_compat import get_args, get_origin
 
 import dagster._check as check

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -2,11 +2,13 @@ import typing as t
 from abc import abstractmethod
 from enum import Enum as PythonEnum
 from functools import partial
-from typing import AbstractSet as TypingAbstractSet, Dict
+from typing import AbstractSet as TypingAbstractSet
+from typing import Dict
 from typing import Iterator as TypingIterator
 from typing import Mapping
 from typing import Optional as TypingOptional
 from typing import Sequence, cast
+from typing_extensions import get_args, get_origin
 
 import dagster._check as check
 from dagster.builtins import BuiltinEnum
@@ -832,10 +834,10 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
         is_supported_runtime_python_builtin,
         remap_python_builtin_for_runtime,
     )
-    from dagster.seven.typing import get_args
     from dagster.utils.typing_api import is_typing_type
 
-    from .python_dict import Dict as DDict, PythonDict
+    from .python_dict import Dict as DDict
+    from .python_dict import PythonDict
     from .python_set import DagsterSetApi, PythonSet
     from .python_tuple import DagsterTupleApi, PythonTuple
     from .transform_typing import transform_typing_type
@@ -934,7 +936,6 @@ def is_dynamic_output_annotation(dagster_type: object) -> bool:
 
 
 def _is_generic_output_annotation(dagster_type: object) -> bool:
-    from dagster.seven.typing import get_origin
 
     return dagster_type == Output or get_origin(dagster_type) == Output
 

--- a/python_modules/dagster/dagster/core/workspace/config_schema.py
+++ b/python_modules/dagster/dagster/core/workspace/config_schema.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, cast
+from typing import Dict, Mapping, cast
 
 import dagster._check as check
 from dagster.config import Field, ScalarUnion, Selector
@@ -11,9 +11,9 @@ from dagster.utils import merge_dicts
 
 
 def process_workspace_config(
-    workspace_config: Dict[str, object]
-) -> EvaluateValueResult[Dict[str, object]]:
-    workspace_config = check.dict_param(workspace_config, "workspace_config")
+    workspace_config: Mapping[str, object]
+) -> EvaluateValueResult[Mapping[str, object]]:
+    workspace_config = check.mapping_param(workspace_config, "workspace_config")
 
     return process_config(WORKSPACE_CONFIG_SCHEMA, workspace_config)
 

--- a/python_modules/dagster/dagster/loggers/__init__.py
+++ b/python_modules/dagster/dagster/loggers/__init__.py
@@ -1,12 +1,16 @@
 import logging
+from typing import TYPE_CHECKING, Mapping, Sequence, Tuple
 
 import coloredlogs
 
 from dagster import seven
 from dagster.config import Field
-from dagster.core.definitions.logger_definition import logger
 from dagster.core.utils import coerce_valid_log_level
 from dagster.utils.log import default_date_format_string, default_format_string
+
+if TYPE_CHECKING:
+    from dagster.core.definitions.logger_definition import LoggerDefinition, logger
+    from dagster.core.execution.context.logger import InitLoggerContext
 
 
 @logger(
@@ -29,7 +33,7 @@ from dagster.utils.log import default_date_format_string, default_format_string
     ),
     description="The default colored console logger.",
 )
-def colored_console_logger(init_context):
+def colored_console_logger(init_context: InitLoggerContext) -> logging.Logger:
     """This logger provides support for sending Dagster logs to stdout in a colored format. It is
     included by default on jobs which do not otherwise specify loggers.
     """
@@ -69,7 +73,7 @@ def colored_console_logger(init_context):
     ),
     description="A JSON-formatted console logger.",
 )
-def json_console_logger(init_context):
+def json_console_logger(init_context: InitLoggerContext) -> logging.Logger:
     """This logger provides support for sending Dagster logs to stdout in json format.
 
     Example:
@@ -107,7 +111,7 @@ def json_console_logger(init_context):
     return logger_
 
 
-def default_system_loggers():
+def default_system_loggers() -> Sequence[Tuple["LoggerDefinition", Mapping[str, object]]]:
     """If users don't provide configuration for any loggers, we instantiate these loggers with the
     default config.
 
@@ -116,5 +120,5 @@ def default_system_loggers():
     return [(colored_console_logger, {"name": "dagster", "log_level": "DEBUG"})]
 
 
-def default_loggers():
+def default_loggers() -> Mapping[str, "LoggerDefinition"]:
     return {"console": colored_console_logger}

--- a/python_modules/dagster/dagster/loggers/__init__.py
+++ b/python_modules/dagster/dagster/loggers/__init__.py
@@ -8,8 +8,9 @@ from dagster.config import Field
 from dagster.core.utils import coerce_valid_log_level
 from dagster.utils.log import default_date_format_string, default_format_string
 
+from dagster.core.definitions.logger_definition import LoggerDefinition, logger
+
 if TYPE_CHECKING:
-    from dagster.core.definitions.logger_definition import LoggerDefinition, logger
     from dagster.core.execution.context.logger import InitLoggerContext
 
 
@@ -33,7 +34,7 @@ if TYPE_CHECKING:
     ),
     description="The default colored console logger.",
 )
-def colored_console_logger(init_context: InitLoggerContext) -> logging.Logger:
+def colored_console_logger(init_context: "InitLoggerContext") -> logging.Logger:
     """This logger provides support for sending Dagster logs to stdout in a colored format. It is
     included by default on jobs which do not otherwise specify loggers.
     """
@@ -73,7 +74,7 @@ def colored_console_logger(init_context: InitLoggerContext) -> logging.Logger:
     ),
     description="A JSON-formatted console logger.",
 )
-def json_console_logger(init_context: InitLoggerContext) -> logging.Logger:
+def json_console_logger(init_context: "InitLoggerContext") -> logging.Logger:
     """This logger provides support for sending Dagster logs to stdout in json format.
 
     Example:

--- a/python_modules/dagster/dagster/loggers/__init__.py
+++ b/python_modules/dagster/dagster/loggers/__init__.py
@@ -5,10 +5,9 @@ import coloredlogs
 
 from dagster import seven
 from dagster.config import Field
+from dagster.core.definitions.logger_definition import LoggerDefinition, logger
 from dagster.core.utils import coerce_valid_log_level
 from dagster.utils.log import default_date_format_string, default_format_string
-
-from dagster.core.definitions.logger_definition import LoggerDefinition, logger
 
 if TYPE_CHECKING:
     from dagster.core.execution.context.logger import InitLoggerContext

--- a/python_modules/dagster/dagster/primitive_mapping.py
+++ b/python_modules/dagster/dagster/primitive_mapping.py
@@ -10,15 +10,16 @@ from .core.types.python_dict import PythonDict
 from .core.types.python_set import PythonSet
 from .core.types.python_tuple import PythonTuple
 
+# Type-ignores below are due to mypy bug tracking names imported from module's named "types".
 SUPPORTED_RUNTIME_BUILTINS = {
     int: Int,
     float: Float,
     bool: Bool,
     str: String,
-    list: List(RuntimeAny),
-    tuple: PythonTuple,
-    set: PythonSet,
-    dict: PythonDict,
+    list: List(RuntimeAny),  # type: ignore
+    tuple: PythonTuple,  # type: ignore
+    set: PythonSet,  # type: ignore
+    dict: PythonDict,  # type: ignore
 }
 
 

--- a/python_modules/dagster/dagster/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/scheduler/scheduler.py
@@ -272,7 +272,7 @@ def launch_scheduled_runs_for_schedule(
     log_verbose_checks=True,
 ):
     instance = check.inst_param(instance, "instance", DagsterInstance)
-    schedule_state = check.opt_inst_param(schedule_state, "schedule_state", InstigatorState)
+    schedule_state = check.inst_param(schedule_state, "schedule_state", InstigatorState)
     end_datetime_utc = check.inst_param(end_datetime_utc, "end_datetime_utc", datetime.datetime)
 
     instigator_origin_id = external_schedule.get_external_origin_id()

--- a/python_modules/dagster/dagster/seven/__init__.py
+++ b/python_modules/dagster/dagster/seven/__init__.py
@@ -11,6 +11,7 @@ import time
 from contextlib import contextmanager
 from datetime import timezone
 from types import ModuleType
+from typing import Any, Type
 
 import pendulum
 
@@ -170,7 +171,7 @@ def nullcontext():
     yield
 
 
-def is_subclass(child_type, parent_type):
+def is_subclass(child_type: Type[Any], parent_type: Type[Any]):
     """Due to some pathological interactions betwen bugs in the Python typing library
     (https://github.com/python/cpython/issues/88459 and
     https://github.com/python/cpython/issues/89010), some types (list[str] in Python 3.9, for

--- a/python_modules/dagster/dagster/utils/merger.py
+++ b/python_modules/dagster/dagster/utils/merger.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Mapping
+from typing import Dict, Mapping, TypeVar
 
 import dagster._check as check
 
@@ -36,7 +36,10 @@ def deep_merge_dicts(onto_dict: dict, from_dict: Mapping) -> dict:
     return _deep_merge_dicts(onto_dict, from_dict)
 
 
-def merge_dicts(*args: Mapping) -> dict:
+K, V = TypeVar("K"), TypeVar("V")
+
+
+def merge_dicts(*args: Mapping) -> Dict:
     """
     Returns a dictionary with with all the keys in all of the input dictionaries.
 

--- a/python_modules/dagster/dagster/utils/test/__init__.py
+++ b/python_modules/dagster/dagster/utils/test/__init__.py
@@ -55,7 +55,7 @@ from ..temp_file import (
 from ..typing_api import is_typing_type
 
 if TYPE_CHECKING:
-    from dagster._core.execution.results import CompositeSolidExecutionResult, SolidExecutionResult
+    from dagster.core.execution.results import CompositeSolidExecutionResult, SolidExecutionResult
 
 
 def create_test_pipeline_execution_context(
@@ -129,7 +129,7 @@ def build_pipeline_with_input_stubs(
 
     return PipelineDefinition(
         name=pipeline_def.name + "_stubbed",
-        solid_defs=pipeline_def.top_level_solid_defs + stub_solid_defs,
+        solid_defs=[*pipeline_def.top_level_solid_defs, *stub_solid_defs],
         mode_defs=pipeline_def.mode_definitions,
         dependencies=deps,  # type: ignore
     )

--- a/python_modules/dagster/dagster/utils/test/__init__.py
+++ b/python_modules/dagster/dagster/utils/test/__init__.py
@@ -4,7 +4,7 @@ import tempfile
 import uuid
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, AbstractSet, Any, Dict, Generator, Optional, Union
+from typing import TYPE_CHECKING, AbstractSet, Any, Dict, Generator, Optional, Union, overload
 
 # top-level include is dangerous in terms of incurring circular deps
 from dagster import (
@@ -22,7 +22,7 @@ from dagster import execute_pipeline, lambda_solid
 from dagster.core.definitions.logger_definition import LoggerDefinition
 from dagster.core.definitions.pipeline_base import InMemoryPipeline
 from dagster.core.definitions.resource_definition import ScopedResourcesBuilder
-from dagster.core.definitions.solid_definition import NodeDefinition
+from dagster.core.definitions.solid_definition import CompositeSolidDefinition, NodeDefinition, SolidDefinition
 from dagster.core.execution.api import create_execution_plan, scoped_pipeline_context
 from dagster.core.execution.context.system import PlanExecutionContext
 from dagster.core.execution.context_creation_pipeline import (
@@ -268,6 +268,27 @@ def yield_empty_pipeline_context(
     with scoped_pipeline_context(execution_plan, pipeline, {}, pipeline_run, instance) as context:
         yield context
 
+@overload
+def execute_solid(
+    solid_def: CompositeSolidDefinition,
+    mode_def: Optional[ModeDefinition] = ...,
+    input_values: Optional[Dict[str, object]] = ...,
+    tags: Optional[Dict[str, Any]] = ...,
+    run_config: Optional[Dict[str, object]] = ...,
+    raise_on_error: bool = ...,
+) -> "CompositeSolidExecutionResult":
+    ...
+
+@overload
+def execute_solid(
+    solid_def: SolidDefinition,
+    mode_def: Optional[ModeDefinition] = ...,
+    input_values: Optional[Dict[str, object]] = ...,
+    tags: Optional[Dict[str, Any]] = ...,
+    run_config: Optional[Dict[str, object]] = ...,
+    raise_on_error: bool = ...,
+) -> "SolidExecutionResult":
+    ...
 
 def execute_solid(
     solid_def: NodeDefinition,

--- a/python_modules/dagster/dagster/utils/test/__init__.py
+++ b/python_modules/dagster/dagster/utils/test/__init__.py
@@ -22,7 +22,11 @@ from dagster import execute_pipeline, lambda_solid
 from dagster.core.definitions.logger_definition import LoggerDefinition
 from dagster.core.definitions.pipeline_base import InMemoryPipeline
 from dagster.core.definitions.resource_definition import ScopedResourcesBuilder
-from dagster.core.definitions.solid_definition import CompositeSolidDefinition, NodeDefinition, SolidDefinition
+from dagster.core.definitions.solid_definition import (
+    CompositeSolidDefinition,
+    NodeDefinition,
+    SolidDefinition,
+)
 from dagster.core.execution.api import create_execution_plan, scoped_pipeline_context
 from dagster.core.execution.context.system import PlanExecutionContext
 from dagster.core.execution.context_creation_pipeline import (
@@ -268,6 +272,7 @@ def yield_empty_pipeline_context(
     with scoped_pipeline_context(execution_plan, pipeline, {}, pipeline_run, instance) as context:
         yield context
 
+
 @overload
 def execute_solid(
     solid_def: CompositeSolidDefinition,
@@ -279,6 +284,7 @@ def execute_solid(
 ) -> "CompositeSolidExecutionResult":
     ...
 
+
 @overload
 def execute_solid(
     solid_def: SolidDefinition,
@@ -289,6 +295,7 @@ def execute_solid(
     raise_on_error: bool = ...,
 ) -> "SolidExecutionResult":
     ...
+
 
 def execute_solid(
     solid_def: NodeDefinition,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
@@ -37,7 +37,7 @@ def solid_a_b_list():
 def test_create_pipeline_with_bad_solids_list():
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='"nodes" arg to "a_pipeline" is not a list. Got',
+        match='"nodes" arg to "a_pipeline" is not a sequence. Got',
     ):
         PipelineDefinition(
             name="a_pipeline", solid_defs=define_stub_solid("stub", [{"a key": "a value"}])

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
@@ -14,6 +14,7 @@ from dagster import (
     SolidDefinition,
     solid,
 )
+from dagster._check import ParameterCheckError
 from dagster.core.utility_solids import define_stub_solid
 
 
@@ -36,11 +37,11 @@ def solid_a_b_list():
 
 def test_create_pipeline_with_bad_solids_list():
     with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match='"nodes" arg to "a_pipeline" is not a sequence. Got',
+        ParameterCheckError,
+        match=r'Param "node_defs" is not one of \[\'Sequence\'\]',
     ):
         PipelineDefinition(
-            name="a_pipeline", solid_defs=define_stub_solid("stub", [{"a key": "a value"}])
+            name="a_pipeline", solid_defs=define_stub_solid("stub", [{"a key": "a value"}])  # type: ignore
         )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_schedule_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_schedule_invocation.py
@@ -9,9 +9,13 @@ from dagster import (
     daily_schedule,
     schedule,
 )
+from dagster.core.definitions.schedule_definition import ScheduleEvaluationContext, ScheduleExecutionContext
 from dagster.core.errors import DagsterInvalidInvocationError
 from dagster.core.test_utils import instance_for_test
 
+def test_schedule_context_backcompat():
+    # ScheduleExecutionContext is a literal alias of ScheduleEvaluationContext
+    assert isinstance(ScheduleEvaluationContext(None, None), ScheduleExecutionContext)
 
 def cron_test_schedule_factory_context():
     @schedule(cron_schedule="* * * * *", pipeline_name="no_pipeline")

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_schedule_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_schedule_invocation.py
@@ -5,20 +5,12 @@ import pytest
 from dagster import (
     DagsterInstance,
     DagsterInvariantViolationError,
-    ScheduleEvaluationContext,
-    ScheduleExecutionContext,
     build_schedule_context,
     daily_schedule,
     schedule,
 )
 from dagster.core.errors import DagsterInvalidInvocationError
 from dagster.core.test_utils import instance_for_test
-
-
-def test_schedule_context_backcompat():
-    # If an instance of ScheduleEvaluationContext is a ScheduleExecutionContext, then annotating as
-    # ScheduleExecutionContext and passing in a ScheduleEvaluationContext should pass mypy
-    assert isinstance(ScheduleEvaluationContext(None, None), ScheduleExecutionContext)
 
 
 def cron_test_schedule_factory_context():

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_schedule_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_schedule_invocation.py
@@ -9,13 +9,18 @@ from dagster import (
     daily_schedule,
     schedule,
 )
-from dagster.core.definitions.schedule_definition import ScheduleEvaluationContext, ScheduleExecutionContext
+from dagster.core.definitions.schedule_definition import (
+    ScheduleEvaluationContext,
+    ScheduleExecutionContext,
+)
 from dagster.core.errors import DagsterInvalidInvocationError
 from dagster.core.test_utils import instance_for_test
+
 
 def test_schedule_context_backcompat():
     # ScheduleExecutionContext is a literal alias of ScheduleEvaluationContext
     assert isinstance(ScheduleEvaluationContext(None, None), ScheduleExecutionContext)
+
 
 def cron_test_schedule_factory_context():
     @schedule(cron_schedule="* * * * *", pipeline_name="no_pipeline")

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -1,5 +1,5 @@
 from datetime import datetime, time
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Sequence
 
 import pendulum
 import pytest
@@ -22,7 +22,7 @@ from dagster.utils.partitions import DEFAULT_HOURLY_FORMAT_WITH_TIMEZONE
 
 
 def assert_expected_partitions(
-    generated_partitions: List[Partition], expected_partitions: List[str]
+    generated_partitions: Sequence[Partition], expected_partitions: Sequence[str]
 ):
     assert all(
         isinstance(generated_partition, Partition) for generated_partition in generated_partitions

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -121,28 +121,30 @@ def config_pipeline():
     config_solid()
 
 
-simple_partition_set = PartitionSetDefinition(
+# Type-ignores due to mypy bug with inference and lambdas
+
+simple_partition_set: PartitionSetDefinition = PartitionSetDefinition(
     name="simple_partition_set",
     pipeline_name="the_pipeline",
-    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],
+    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],  # type: ignore
 )
 
-conditionally_fail_partition_set = PartitionSetDefinition(
+conditionally_fail_partition_set: PartitionSetDefinition = PartitionSetDefinition(
     name="conditionally_fail_partition_set",
     pipeline_name="conditional_failure_pipeline",
-    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],
+    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],  # type: ignore
 )
 
-partial_partition_set = PartitionSetDefinition(
+partial_partition_set: PartitionSetDefinition = PartitionSetDefinition(
     name="partial_partition_set",
     pipeline_name="partial_pipeline",
-    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],
+    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],  # type: ignore
 )
 
-parallel_failure_partition_set = PartitionSetDefinition(
+parallel_failure_partition_set: PartitionSetDefinition = PartitionSetDefinition(
     name="parallel_failure_partition_set",
     pipeline_name="parallel_failure_pipeline",
-    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],
+    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],  # type: ignore
 )
 
 
@@ -168,7 +170,7 @@ def _large_partition_config(_):
 large_partition_set = PartitionSetDefinition(
     name="large_partition_set",
     pipeline_name="config_pipeline",
-    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],
+    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],  # type: ignore
     run_config_fn_for_partition=_large_partition_config,
 )
 

--- a/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
@@ -99,7 +99,7 @@ def test_arbitrary_metadata():
         OutputDefinition(metadata={"foo": object()})
 
     with pytest.warns(DeprecationWarning, match=re.escape("arbitrary metadata values")):
-        InputDefinition(metadata={"foo": object()})
+        InputDefinition(name="foo", metadata={"foo": object()})
 
 
 def test_metadata_entry_description():

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -368,12 +368,12 @@ def two_step_pipeline():
     end(start())
 
 
-manual_partition = PartitionSetDefinition(
+manual_partition = PartitionSetDefinition[str](
     name="manual_partition",
     pipeline_name="two_step_pipeline",
     # selects only second step
     solid_selection=["end"],
-    partition_fn=lambda: [Partition("one")],
+    partition_fn=lambda: [Partition("one")],  # type: ignore
     # includes config for first step - test that it is ignored
     run_config_fn_for_partition=lambda _: {"solids": {"start": {"inputs": {"x": {"value": 4}}}}},
 )

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
             "tabulate",
             "tqdm",
             "typing_compat",
-            "typing_extensions>=3.10",
+            "typing_extensions>=4.0.1",
             "sqlalchemy>=1.0",
             "toposort>=1.0",
             "watchdog>=0.8.3",

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -1,6 +1,6 @@
 import io
 import pickle
-from typing import Union
+from typing import Sequence, Union
 
 from dagster import (
     Field,
@@ -28,10 +28,11 @@ class PickledObjectS3IOManager(MemoizableIOManager):
         self.s3.list_objects(Bucket=self.bucket, Prefix=self.s3_prefix, MaxKeys=1)
 
     def _get_path(self, context: Union[InputContext, OutputContext]) -> str:
+        path: Sequence[str]
         if context.has_asset_key:
             path = context.get_asset_identifier()
         else:
-            path = ["storage"] + context.get_identifier()
+            path = ["storage", *context.get_identifier()]
 
         return "/".join([self.s3_prefix, *path])
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
@@ -636,6 +636,8 @@ def dbt_rpc_sync_resource(
     )
 
 
-local_dbt_rpc_resource = cast(ResourceDefinition, dbt_rpc_resource.configured({"host": "0.0.0.0", "port": 8580}))
+local_dbt_rpc_resource = cast(
+    ResourceDefinition, dbt_rpc_resource.configured({"host": "0.0.0.0", "port": 8580})
+)
 local_dbt_rpc_resource.__doc__ = """This resource defines a dbt RPC client for an RPC server running
 on 0.0.0.0:8580."""

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
@@ -5,13 +5,14 @@ import sys
 import time
 import uuid
 from base64 import standard_b64encode as b64
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 import requests
 
 from dagster import Failure, Field, IntSource, RetryRequested, StringSource
 from dagster import _check as check
 from dagster import resource
+from dagster.core.definitions.resource_definition import ResourceDefinition
 from dagster.core.utils import coerce_valid_log_level
 
 from ..dbt_resource import DbtResource
@@ -635,6 +636,6 @@ def dbt_rpc_sync_resource(
     )
 
 
-local_dbt_rpc_resource = dbt_rpc_resource.configured({"host": "0.0.0.0", "port": 8580})
+local_dbt_rpc_resource = cast(ResourceDefinition, dbt_rpc_resource.configured({"host": "0.0.0.0", "port": 8580}))
 local_dbt_rpc_resource.__doc__ = """This resource defines a dbt RPC client for an RPC server running
 on 0.0.0.0:8580."""

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_solids_i.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_solids_i.py
@@ -27,7 +27,7 @@ from dagster import (
 
 
 def output_for_solid_executed_with_rpc_resource(
-    a_solid, rpc_resource=local_dbt_rpc_resource
+    a_solid: SolidDefinition, rpc_resource=local_dbt_rpc_resource
 ) -> Tuple[SolidExecutionResult, DbtRpcOutput]:
     mode_def = ModeDefinition(resource_defs={"dbt_rpc": rpc_resource})  # use config defaults
     solid_result = execute_solid(a_solid, mode_def)

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/db_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/db_io_manager.py
@@ -116,6 +116,9 @@ class DbIOManager(IOManager):
     ) -> TableSlice:
         output_context_metadata = output_context.metadata or {}
 
+        schema: str
+        table: str
+        time_window: Optional[TimeWindow]
         if context.has_asset_key:
             asset_key_path = context.asset_key.path
             table = asset_key_path[-1]
@@ -161,7 +164,7 @@ class DbIOManager(IOManager):
             time_window = None
 
         if time_window is not None:
-            partition_expr = output_context_metadata.get("partition_expr")
+            partition_expr = cast(str, output_context_metadata.get("partition_expr"))
             if partition_expr is None:
                 raise ValueError(
                     f"Asset '{context.asset_key}' has partitions, but no 'partition_expr' metadata "
@@ -179,5 +182,5 @@ class DbIOManager(IOManager):
             schema=schema,
             database=cast(Mapping[str, str], context.resource_config)["database"],
             partition=partition,
-            columns=(context.metadata or {}).get("columns"),
+            columns=(context.metadata or {}).get("columns"),  # type: ignore  # (mypy bug)
         )

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/db_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/db_io_manager.py
@@ -136,7 +136,7 @@ class DbIOManager(IOManager):
             elif len(asset_key_path) > 1:
                 schema = asset_key_path[-2]
             elif context.resource_config and context.resource_config.get("schema"):
-                schema = context.resource_config["schema"]
+                schema = cast(str, context.resource_config["schema"])
             else:
                 schema = "public"
             time_window = (
@@ -156,9 +156,9 @@ class DbIOManager(IOManager):
                     "Schema can only be specified one way."
                 )
             elif output_context.resource_config and output_context_metadata.get("schema"):
-                schema = output_context_metadata["schema"]
+                schema = cast(str, output_context_metadata["schema"])
             elif output_context.resource_config and output_context.resource_config.get("schema"):
-                schema = output_context.resource_config["schema"]
+                schema = cast(str, output_context.resource_config["schema"])
             else:
                 schema = "public"
             time_window = None

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -53,7 +53,7 @@ class SnowflakeDbClient(DbClient):
     @staticmethod
     def delete_table_slice(context: OutputContext, table_slice: TableSlice) -> None:
         with SnowflakeConnection(
-            dict(**(context.resource_config or {}), schema=table_slice.schema), context.log
+                dict(schema=table_slice.schema, **(context.resource_config or {})), context.log  # type: ignore
         ).get_connection() as con:
             con.execute_string(_get_cleanup_statement(table_slice))
 

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -53,7 +53,7 @@ class SnowflakeDbClient(DbClient):
     @staticmethod
     def delete_table_slice(context: OutputContext, table_slice: TableSlice) -> None:
         with SnowflakeConnection(
-                dict(schema=table_slice.schema, **(context.resource_config or {})), context.log  # type: ignore
+            dict(schema=table_slice.schema, **(context.resource_config or {})), context.log  # type: ignore
         ).get_connection() as con:
             con.execute_string(_get_cleanup_statement(table_slice))
 


### PR DESCRIPTION
### Summary & Motivation

This is a large PR with a lot of type annotation improvements and a few other minor changes. Unfortunately it is difficult to break up into anything smaller because typing changes cause cascading mypy errors-- adding annotations in one place causes errors to surface in another place, which then needs type annotations added, etc. However review shouldn't be too difficult since most of the changes are pretty trivial:

- Added declarations of instance attributes to several classes. In some cases corresponding type declarations at the point of assignment of instance variables were removed.
- Many type annotations using Dict/List/Set replaced with Mapping/Sequence/AbstractSet respectively. Sometimes
  corresponding runtime type checks were also swapped (e.g. `check.list_param` > `check.sequence_param`)
- Added many missing argument and return type annotations
- Factored out a few complex Callable or Union types into more readable type aliases
- Fixed various incorrect annotations
- Added some type-ignores where added annotations triggered mypy bugs

In several other places `check.not_none` was inserted where there was an implicit assumption that a value was non-null, but this wasn't inferrable by the type-checker.

There are also a few minor runtime changes:

- dagster.config.traversal_context: config schema args should be non-optional
- dagster.core.definitions.configurable: use isinstance (legible to type-checkers) instead of custom method that calls
  isinstance

Finally, internal requires updates to match these, here's the sister PR: https://github.com/dagster-io/internal/pull/2498. That should be merged after this, which will need to be merged with the internal compatibility check still red.

### How I Tested These Changes

Existing test suite.
