### PR TITLE
refactor stephandler API to support the same yield+write pattern as other executors

### DIFF
--- a/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
+++ b/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
@@ -520,8 +520,8 @@ def create_log_manager(
     )
 
 
-def _create_context_free_log_manager(
-    instance: DagsterInstance, pipeline_run: PipelineRun, pipeline_def: PipelineDefinition
+def create_context_free_log_manager(
+    instance: DagsterInstance, pipeline_run: PipelineRun
 ) -> DagsterLogManager:
     """In the event of pipeline initialization failure, we want to be able to log the failure
     without a dependency on the PlanExecutionContext to initialize DagsterLogManager.
@@ -531,7 +531,6 @@ def _create_context_free_log_manager(
     """
     check.inst_param(instance, "instance", DagsterInstance)
     check.inst_param(pipeline_run, "pipeline_run", PipelineRun)
-    check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
 
     loggers = []
     # Use the default logger
@@ -541,7 +540,7 @@ def _create_context_free_log_manager(
                 InitLoggerContext(
                     logger_config,
                     logger_def,
-                    pipeline_def=pipeline_def,
+                    pipeline_def=None,
                     run_id=pipeline_run.run_id,
                 )
             )

--- a/python_modules/dagster/dagster/core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_plan.py
@@ -68,12 +68,11 @@ def inner_plan_execution_iterator(
                     )
                 except Exception as e:
                     yield DagsterEvent.engine_event(
-                        pipeline_context=pipeline_context,
+                        plan_context=step_context,
                         message="Exception while setting up compute log capture",
                         event_specific_data=EngineEventData(
                             error=serializable_error_info_from_exc_info(sys.exc_info())
                         ),
-                        step_handle=step_context.step.handle,
                     )
                     log_capture_error = e
 
@@ -94,12 +93,11 @@ def inner_plan_execution_iterator(
                     stack.close()
                 except Exception:
                     yield DagsterEvent.engine_event(
-                        pipeline_context=pipeline_context,
+                        plan_context=step_context,
                         message="Exception while cleaning up compute log capture",
                         event_specific_data=EngineEventData(
                             error=serializable_error_info_from_exc_info(sys.exc_info())
                         ),
-                        step_handle=step_context.step.handle,
                     )
 
             # process skips from failures or uncovered inputs

--- a/python_modules/dagster/dagster/core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/core/executor/multiprocess.py
@@ -219,14 +219,16 @@ class MultiprocessExecutor(Executor):
                             serializable_error = serializable_error_info_from_exc_info(
                                 sys.exc_info()
                             )
+                            step_context = plan_context.for_step(
+                                active_execution.get_step_by_key(key)
+                            )
                             yield DagsterEvent.engine_event(
-                                plan_context,
+                                step_context,
                                 (
                                     "Multiprocess executor: child process for step {step_key} "
                                     "unexpectedly exited with code {exit_code}"
                                 ).format(step_key=key, exit_code=crash.exit_code),
                                 EngineEventData.engine_error(serializable_error),
-                                step_handle=active_execution.get_step_by_key(key).handle,
                             )
                             step_failure_event = DagsterEvent.step_failure_event(
                                 step_context=plan_context.for_step(
@@ -318,7 +320,6 @@ def execute_step_out_of_process(
         step_context,
         "Launching subprocess for {}".format(step.key),
         EngineEventData(marker_start=DELEGATE_MARKER),
-        step_handle=step.handle,
     )
 
     for ret in execute_child_process_command(multiproc_ctx, command):

--- a/python_modules/dagster/dagster/core/executor/step_delegating/__init__.py
+++ b/python_modules/dagster/dagster/core/executor/step_delegating/__init__.py
@@ -1,2 +1,2 @@
 from .step_delegating_executor import StepDelegatingExecutor
-from .step_handler import StepHandler, StepHandlerContext
+from .step_handler import CheckStepHealthResult, StepHandler, StepHandlerContext

--- a/python_modules/dagster/dagster/core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/core/executor/step_delegating/step_delegating_executor.py
@@ -1,23 +1,20 @@
 import os
+import sys
 import time
 from typing import Dict, List, Optional, cast
 
 import pendulum
 
 import dagster._check as check
-from dagster.core.events import (
-    DagsterEvent,
-    DagsterEventType,
-    EngineEventData,
-    MetadataEntry,
-    log_step_event,
-)
+from dagster.core.events import DagsterEvent, DagsterEventType, EngineEventData, MetadataEntry
 from dagster.core.execution.context.system import PlanOrchestrationContext
+from dagster.core.execution.plan.objects import StepFailureData
 from dagster.core.execution.plan.plan import ExecutionPlan
 from dagster.core.execution.plan.step import ExecutionStep
 from dagster.core.execution.retries import RetryMode
 from dagster.core.executor.step_delegating.step_handler.base import StepHandler, StepHandlerContext
 from dagster.grpc.types import ExecuteStepArgs
+from dagster.utils.error import serializable_error_info_from_exc_info
 
 from ..base import Executor
 
@@ -27,6 +24,11 @@ DEFAULT_SLEEP_SECONDS = float(
 
 
 class StepDelegatingExecutor(Executor):
+    """This executor tails the event log for events from the steps that it spins up. It also
+    sometimes creates its own events - when it does, that event is automatically written to the
+    event log. But we wait until we later tail it from the event log database before yielding it,
+    to avoid yielding the same event multiple times to callsites."""
+
     def __init__(
         self,
         step_handler: StepHandler,
@@ -71,6 +73,8 @@ class StepDelegatingExecutor(Executor):
     ) -> StepHandlerContext:
         return StepHandlerContext(
             instance=plan_context.plan_data.instance,
+            plan_context=plan_context,
+            steps=steps,
             execute_step_args=ExecuteStepArgs(
                 pipeline_origin=plan_context.reconstructable_pipeline.get_python_origin(),
                 pipeline_run_id=plan_context.pipeline_run.run_id,
@@ -80,18 +84,8 @@ class StepDelegatingExecutor(Executor):
                 known_state=active_execution.get_known_state(),
                 should_verify_step=self._should_verify_step,
             ),
-            step_tags={step.key: step.tags for step in steps},
             pipeline_run=plan_context.pipeline_run,
         )
-
-    def _log_new_events(self, events, plan_context, running_steps):
-        # Note: this could lead to duplicated events if the returned events were already logged
-        # (they shouldn't be)
-        for event in events:
-            log_step_event(
-                plan_context.for_step(running_steps[event.step_key]),
-                event,
-            )
 
     def execute(self, plan_context: PlanOrchestrationContext, execution_plan: ExecutionPlan):
         check.inst_param(plan_context, "plan_context", PlanOrchestrationContext)
@@ -99,7 +93,7 @@ class StepDelegatingExecutor(Executor):
 
         self._event_cursor = -1  # pylint: disable=attribute-defined-outside-init
 
-        yield DagsterEvent.engine_event(
+        DagsterEvent.engine_event(
             plan_context,
             f"Starting execution with step handler {self._step_handler.name}",
             EngineEventData(),
@@ -109,7 +103,7 @@ class StepDelegatingExecutor(Executor):
             running_steps: Dict[str, ExecutionStep] = {}
 
             if plan_context.resume_from_failure:
-                yield DagsterEvent.engine_event(
+                DagsterEvent.engine_event(
                     plan_context,
                     "Resuming execution from failure",
                     EngineEventData(),
@@ -125,27 +119,48 @@ class StepDelegatingExecutor(Executor):
                 possibly_in_flight_steps = active_execution.rebuild_from_events(prior_events)
                 for step in possibly_in_flight_steps:
 
-                    yield DagsterEvent.engine_event(
-                        plan_context,
-                        "Checking on status of possibly launched steps",
-                        EngineEventData(),
-                        step.handle,
+                    step_handler_context = self._get_step_handler_context(
+                        plan_context, [step], active_execution
                     )
 
-                    # TODO: check if failure event included. For now, hacky assumption that
-                    # we don't log anything on successful check
-                    if self._step_handler.check_step_health(
-                        self._get_step_handler_context(plan_context, [step], active_execution)
-                    ):
+                    DagsterEvent.engine_event(
+                        step_handler_context.get_step_context(step.key),
+                        f"Checking on status of in-progress step {step.key} from previous run",
+                        EngineEventData(),
+                    )
+
+                    should_retry_step = False
+                    health_check = None
+
+                    try:
+                        health_check = self._step_handler.check_step_health(step_handler_context)
+                    except Exception:
+                        # For now we assume that an exception indicates that the step should be resumed.
+                        # This should probably be a separate should_resume_step method on the step handler.
+                        DagsterEvent.engine_event(
+                            step_handler_context.get_step_context(step.key),
+                            f"Including {step.key} in the new run since it raised an error when checking whether it was running",
+                            EngineEventData(
+                                error=serializable_error_info_from_exc_info(sys.exc_info())
+                            ),
+                        )
+                        should_retry_step = True
+                    else:
+                        if not health_check.is_healthy:
+                            DagsterEvent.engine_event(
+                                step_handler_context.get_step_context(step.key),
+                                f"Including step {step.key} in the new run since it is not currently running: {health_check.unhealthy_reason}",
+                            )
+                            should_retry_step = True
+
+                    if should_retry_step:
                         # health check failed, launch the step
-                        self._log_new_events(
+                        list(
                             self._step_handler.launch_step(
                                 self._get_step_handler_context(
                                     plan_context, [step], active_execution
                                 )
-                            ),
-                            plan_context,
-                            {step.key: step for step in possibly_in_flight_steps},
+                            )
                         )
 
                     running_steps[step.key] = step
@@ -158,26 +173,23 @@ class StepDelegatingExecutor(Executor):
             while not active_execution.is_complete:
 
                 if active_execution.check_for_interrupts():
+                    active_execution.mark_interrupted()
                     if not plan_context.instance.run_will_resume(plan_context.run_id):
-                        yield DagsterEvent.engine_event(
+                        DagsterEvent.engine_event(
                             plan_context,
                             "Executor received termination signal, forwarding to steps",
                             EngineEventData.interrupted(list(running_steps.keys())),
                         )
-                        active_execution.mark_interrupted()
                         for _, step in running_steps.items():
-                            self._log_new_events(
+                            list(
                                 self._step_handler.terminate_step(
                                     self._get_step_handler_context(
                                         plan_context, [step], active_execution
                                     )
-                                ),
-                                plan_context,
-                                running_steps,
+                                )
                             )
-
                     else:
-                        yield DagsterEvent.engine_event(
+                        DagsterEvent.engine_event(
                             plan_context,
                             "Executor received termination signal, not forwarding to steps because "
                             "run will be resumed",
@@ -189,7 +201,6 @@ class StepDelegatingExecutor(Executor):
                                 ]
                             ),
                         )
-                        active_execution.mark_interrupted()
 
                     return
 
@@ -198,24 +209,22 @@ class StepDelegatingExecutor(Executor):
                     plan_context.run_id,
                 ):  # type: ignore
 
+                    yield dagster_event
                     # STEP_SKIPPED events are only emitted by ActiveExecution, which already handles
                     # and yields them.
+
                     if dagster_event.is_step_skipped:
                         assert isinstance(dagster_event.step_key, str)
                         active_execution.verify_complete(plan_context, dagster_event.step_key)
-
                     else:
-                        yield dagster_event
                         active_execution.handle_event(dagster_event)
-
                         if dagster_event.is_step_success or dagster_event.is_step_failure:
                             assert isinstance(dagster_event.step_key, str)
                             del running_steps[dagster_event.step_key]
                             active_execution.verify_complete(plan_context, dagster_event.step_key)
 
                 # process skips from failures or uncovered inputs
-                for event in active_execution.plan_events_iterator(plan_context):
-                    yield event
+                list(active_execution.plan_events_iterator(plan_context))
 
                 curr_time = pendulum.now("UTC")
                 if (
@@ -223,15 +232,37 @@ class StepDelegatingExecutor(Executor):
                 ).total_seconds() >= self._check_step_health_interval_seconds:
                     last_check_step_health_time = curr_time
                     for _, step in running_steps.items():
-                        self._log_new_events(
-                            self._step_handler.check_step_health(
+
+                        step_context = plan_context.for_step(step)
+
+                        try:
+                            health_check_result = self._step_handler.check_step_health(
                                 self._get_step_handler_context(
                                     plan_context, [step], active_execution
                                 )
-                            ),
-                            plan_context,
-                            running_steps,
-                        )
+                            )
+                            if not health_check_result.is_healthy:
+                                DagsterEvent.step_failure_event(
+                                    step_context=step_context,
+                                    step_failure_data=StepFailureData(
+                                        error=None,
+                                        user_failure_data=None,
+                                    ),
+                                    message=f"Step {step.key} failed health check: {health_check_result.unhealthy_reason}",
+                                )
+                        except Exception:
+                            serializable_error = serializable_error_info_from_exc_info(
+                                sys.exc_info()
+                            )
+                            # Log a step failure event if there was an error during the health
+                            # check
+                            DagsterEvent.step_failure_event(
+                                step_context=plan_context.for_step(step),
+                                step_failure_data=StepFailureData(
+                                    error=serializable_error,
+                                    user_failure_data=None,
+                                ),
+                            )
 
                 if self._max_concurrent is not None:
                     max_steps_to_run = self._max_concurrent - len(running_steps)
@@ -243,12 +274,10 @@ class StepDelegatingExecutor(Executor):
 
                 for step in active_execution.get_steps_to_execute(max_steps_to_run):
                     running_steps[step.key] = step
-                    self._log_new_events(
+                    list(
                         self._step_handler.launch_step(
                             self._get_step_handler_context(plan_context, [step], active_execution)
-                        ),
-                        plan_context,
-                        running_steps,
+                        )
                     )
 
                 time.sleep(self._sleep_seconds)

--- a/python_modules/dagster/dagster/core/executor/step_delegating/step_handler/__init__.py
+++ b/python_modules/dagster/dagster/core/executor/step_delegating/step_handler/__init__.py
@@ -1,1 +1,1 @@
-from .base import StepHandler, StepHandlerContext
+from .base import CheckStepHealthResult, StepHandler, StepHandlerContext

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_handler.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_handler.py
@@ -1,8 +1,15 @@
 from dagster import pipeline
 from dagster.core.definitions.reconstruct import reconstructable
+from dagster.core.execution.api import create_execution_plan
+from dagster.core.execution.context.system import PlanData, PlanOrchestrationContext
+from dagster.core.execution.context_creation_pipeline import create_context_free_log_manager
+from dagster.core.execution.retries import RetryMode
+from dagster.core.executor.init import InitExecutorContext
 from dagster.core.executor.step_delegating import StepHandlerContext
 from dagster.core.test_utils import create_run_for_test, instance_for_test
 from dagster.grpc.types import ExecuteStepArgs
+
+from .test_step_delegating_executor import test_step_delegating_executor
 
 
 @pipeline
@@ -10,10 +17,40 @@ def foo_pipline():
     pass
 
 
+def _get_executor(instance, pipeline, executor_config=None):
+    return test_step_delegating_executor.executor_creation_fn(
+        InitExecutorContext(
+            job=pipeline,
+            executor_def=test_step_delegating_executor,
+            executor_config=executor_config or {"retries": {}},
+            instance=instance,
+        )
+    )
+
+
 def test_step_handler_context():
     recon_pipeline = reconstructable(foo_pipline)
     with instance_for_test() as instance:
         run = create_run_for_test(instance, pipeline_code_origin=recon_pipeline.get_python_origin())
+
+        execution_plan = create_execution_plan(recon_pipeline)
+        log_manager = create_context_free_log_manager(instance, run)
+
+        executor = _get_executor(instance, recon_pipeline)
+
+        plan_context = PlanOrchestrationContext(
+            plan_data=PlanData(
+                pipeline=recon_pipeline,
+                pipeline_run=run,
+                instance=instance,
+                execution_plan=execution_plan,
+                raise_on_error=True,
+                retry_mode=RetryMode.DISABLED,
+            ),
+            log_manager=log_manager,
+            executor=executor,
+            output_capture=None,
+        )
 
         args = ExecuteStepArgs(
             pipeline_origin=recon_pipeline.get_python_origin(),
@@ -23,8 +60,9 @@ def test_step_handler_context():
         )
         ctx = StepHandlerContext(
             instance=instance,
+            plan_context=plan_context,
+            steps=execution_plan.steps,
             execute_step_args=args,
-            step_tags={},
             pipeline_run=run,
         )
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
@@ -7,11 +7,14 @@ from dagster_k8s.container_context import K8sContainerContext
 from dagster_k8s.executor import K8sStepHandler, k8s_job_executor
 from dagster_k8s.job import UserDefinedDagsterK8sConfig
 
-from dagster import execute_pipeline, pipeline, solid
+from dagster import PipelineDefinition, execute_pipeline, solid
 from dagster.core.definitions.mode import ModeDefinition
-from dagster.core.definitions.pipeline_base import InMemoryPipeline
 from dagster.core.definitions.reconstruct import reconstructable
 from dagster.core.errors import DagsterUnmetExecutorRequirementsError
+from dagster.core.execution.api import create_execution_plan
+from dagster.core.execution.context.system import PlanData, PlanOrchestrationContext
+from dagster.core.execution.context_creation_pipeline import create_context_free_log_manager
+from dagster.core.execution.retries import RetryMode
 from dagster.core.executor.init import InitExecutorContext
 from dagster.core.executor.step_delegating.step_handler.base import StepHandlerContext
 from dagster.core.storage.fs_io_manager import fs_io_manager
@@ -19,20 +22,49 @@ from dagster.core.test_utils import create_run_for_test, environ, instance_for_t
 from dagster.grpc.types import ExecuteStepArgs
 
 
-@solid
-def foo():
-    return 1
+def _get_pipeline(name, solid_tags=None):
+    @solid(tags=solid_tags or {})
+    def foo():
+        return 1
+
+    return PipelineDefinition(
+        name=name,
+        solid_defs=[foo],
+        mode_defs=[
+            ModeDefinition(
+                executor_defs=[k8s_job_executor], resource_defs={"io_manager": fs_io_manager}
+            )
+        ],
+    )
 
 
-@pipeline(
-    mode_defs=[
-        ModeDefinition(
-            executor_defs=[k8s_job_executor], resource_defs={"io_manager": fs_io_manager}
-        )
-    ]
-)
 def bar():
-    foo()
+    return _get_pipeline("bar")
+
+
+RESOURCE_TAGS = {
+    "limits": {"cpu": "500m", "memory": "2560Mi"},
+    "requests": {"cpu": "250m", "memory": "64Mi"},
+}
+
+
+def bar_with_resources():
+    expected_resources = RESOURCE_TAGS
+    user_defined_k8s_config = UserDefinedDagsterK8sConfig(
+        container_config={"resources": expected_resources},
+    )
+    user_defined_k8s_config_json = json.dumps(user_defined_k8s_config.to_dict())
+
+    return _get_pipeline("bar_with_resources", {"dagster-k8s/config": user_defined_k8s_config_json})
+
+
+def bar_with_images():
+    # Construct Dagster solid tags with user defined k8s config.
+    user_defined_k8s_config = UserDefinedDagsterK8sConfig(
+        container_config={"image": "new-image"},
+    )
+    user_defined_k8s_config_json = json.dumps(user_defined_k8s_config.to_dict())
+    return _get_pipeline("bar_with_images", {"dagster-k8s/config": user_defined_k8s_config_json})
 
 
 @pytest.fixture
@@ -64,6 +96,47 @@ def test_requires_k8s_launcher_fail():
             execute_pipeline(reconstructable(bar), instance=instance)
 
 
+def _get_executor(instance, pipeline, executor_config=None):
+    return k8s_job_executor.executor_creation_fn(
+        InitExecutorContext(
+            job=pipeline,
+            executor_def=k8s_job_executor,
+            executor_config=executor_config or {"retries": {}},
+            instance=instance,
+        )
+    )
+
+
+def _step_handler_context(pipeline, pipeline_run, instance, executor):
+    execution_plan = create_execution_plan(pipeline)
+    log_manager = create_context_free_log_manager(instance, pipeline_run)
+
+    plan_context = PlanOrchestrationContext(
+        plan_data=PlanData(
+            pipeline=pipeline,
+            pipeline_run=pipeline_run,
+            instance=instance,
+            execution_plan=execution_plan,
+            raise_on_error=True,
+            retry_mode=RetryMode.DISABLED,
+        ),
+        log_manager=log_manager,
+        executor=executor,
+        output_capture=None,
+    )
+
+    execute_step_args = ExecuteStepArgs(
+        reconstructable(bar).get_python_origin(), pipeline_run.run_id, ["foo"]
+    )
+
+    return StepHandlerContext(
+        instance=instance,
+        plan_context=plan_context,
+        steps=execution_plan.steps,
+        execute_step_args=execute_step_args,
+    )
+
+
 def test_executor_init(k8s_run_launcher_instance):
 
     resources = {
@@ -71,17 +144,14 @@ def test_executor_init(k8s_run_launcher_instance):
         "limits": {"memory": "128Mi", "cpu": "500m"},
     }
 
-    executor = k8s_job_executor.executor_creation_fn(
-        InitExecutorContext(
-            job=InMemoryPipeline(bar),
-            executor_def=k8s_job_executor,
-            executor_config={
-                "env_vars": ["FOO_TEST"],
-                "retries": {},
-                "resources": resources,
-            },
-            instance=k8s_run_launcher_instance,
-        )
+    executor = _get_executor(
+        k8s_run_launcher_instance,
+        reconstructable(bar),
+        {
+            "env_vars": ["FOO_TEST"],
+            "retries": {},
+            "resources": resources,
+        },
     )
 
     run = create_run_for_test(
@@ -90,10 +160,11 @@ def test_executor_init(k8s_run_launcher_instance):
         pipeline_code_origin=reconstructable(bar).get_python_origin(),
     )
 
-    step_handler_context = StepHandlerContext(
-        k8s_run_launcher_instance,
-        ExecuteStepArgs(reconstructable(bar).get_python_origin(), run.run_id, ["foo_solid"]),
-        {"foo_solid": {}},
+    step_handler_context = _step_handler_context(
+        pipeline=reconstructable(bar),
+        pipeline_run=run,
+        instance=k8s_run_launcher_instance,
+        executor=executor,
     )
 
     # env vars from both launcher and the executor
@@ -115,13 +186,11 @@ def test_executor_init(k8s_run_launcher_instance):
 def test_executor_init_container_context(
     k8s_run_launcher_instance, python_origin_with_container_context
 ):
-    executor = k8s_job_executor.executor_creation_fn(
-        InitExecutorContext(
-            job=InMemoryPipeline(bar),
-            executor_def=k8s_job_executor,
-            executor_config={"env_vars": ["FOO_TEST"], "retries": {}, "max_concurrent": 4},
-            instance=k8s_run_launcher_instance,
-        )
+
+    executor = _get_executor(
+        k8s_run_launcher_instance,
+        reconstructable(bar),
+        {"env_vars": ["FOO_TEST"], "retries": {}, "max_concurrent": 4},
     )
 
     run = create_run_for_test(
@@ -130,10 +199,11 @@ def test_executor_init_container_context(
         pipeline_code_origin=python_origin_with_container_context,
     )
 
-    step_handler_context = StepHandlerContext(
-        k8s_run_launcher_instance,
-        ExecuteStepArgs(reconstructable(bar).get_python_origin(), run.run_id, ["foo_solid"]),
-        {"foo_solid": {}},
+    step_handler_context = _step_handler_context(
+        pipeline=reconstructable(bar),
+        pipeline_run=run,
+        instance=k8s_run_launcher_instance,
+        executor=executor,
     )
 
     # env vars from both launcher and the executor
@@ -179,7 +249,6 @@ def k8s_instance(kubeconfig_file):
 
 
 def test_step_handler(kubeconfig_file, k8s_instance):
-
     mock_k8s_client_batch_api = mock.MagicMock()
     handler = K8sStepHandler(
         image="bizbuz",
@@ -196,11 +265,17 @@ def test_step_handler(kubeconfig_file, k8s_instance):
         pipeline_name="bar",
         pipeline_code_origin=reconstructable(bar).get_python_origin(),
     )
-    handler.launch_step(
-        StepHandlerContext(
-            k8s_instance,
-            ExecuteStepArgs(reconstructable(bar).get_python_origin(), run.run_id, ["foo_solid"]),
-            {"foo_solid": {}},
+    list(
+        handler.launch_step(
+            _step_handler_context(
+                pipeline=reconstructable(bar),
+                pipeline_run=run,
+                instance=k8s_instance,
+                executor=_get_executor(
+                    k8s_instance,
+                    reconstructable(bar),
+                ),
+            )
         )
     )
 
@@ -230,30 +305,23 @@ def test_step_handler_user_defined_config(kubeconfig_file, k8s_instance):
         k8s_client_batch_api=mock_k8s_client_batch_api,
     )
 
-    # Construct Dagster solid tags with user defined k8s config.
-    expected_resources = {
-        "limits": {"cpu": "500m", "memory": "2560Mi"},
-        "requests": {"cpu": "250m", "memory": "64Mi"},
-    }
-    user_defined_k8s_config = UserDefinedDagsterK8sConfig(
-        container_config={"resources": expected_resources},
-    )
-    user_defined_k8s_config_json = json.dumps(user_defined_k8s_config.to_dict())
-    tags = {"dagster-k8s/config": user_defined_k8s_config_json}
-
     with environ({"FOO_TEST": "bar"}):
         run = create_run_for_test(
             k8s_instance,
             pipeline_name="bar",
-            pipeline_code_origin=reconstructable(bar).get_python_origin(),
+            pipeline_code_origin=reconstructable(bar_with_resources).get_python_origin(),
         )
-        handler.launch_step(
-            StepHandlerContext(
-                k8s_instance,
-                ExecuteStepArgs(
-                    reconstructable(bar).get_python_origin(), run.run_id, ["foo_solid"]
-                ),
-                {"foo_solid": tags},
+        list(
+            handler.launch_step(
+                _step_handler_context(
+                    pipeline=reconstructable(bar_with_resources),
+                    pipeline_run=run,
+                    instance=k8s_instance,
+                    executor=_get_executor(
+                        k8s_instance,
+                        reconstructable(bar_with_resources),
+                    ),
+                )
             )
         )
 
@@ -264,7 +332,7 @@ def test_step_handler_user_defined_config(kubeconfig_file, k8s_instance):
         assert method_name == "create_namespaced_job"
         assert kwargs["body"].spec.template.spec.containers[0].image == "bizbuz"
         job_resources = kwargs["body"].spec.template.spec.containers[0].resources
-        assert job_resources.to_dict() == expected_resources
+        assert job_resources.to_dict() == RESOURCE_TAGS
 
         env_vars = {
             env.name: env.value for env in kwargs["body"].spec.template.spec.containers[0].env
@@ -283,23 +351,22 @@ def test_step_handler_image_override(kubeconfig_file, k8s_instance):
         k8s_client_batch_api=mock_k8s_client_batch_api,
     )
 
-    # Construct Dagster solid tags with user defined k8s config.
-    user_defined_k8s_config = UserDefinedDagsterK8sConfig(
-        container_config={"image": "new-image"},
-    )
-    user_defined_k8s_config_json = json.dumps(user_defined_k8s_config.to_dict())
-    tags = {"dagster-k8s/config": user_defined_k8s_config_json}
-
     run = create_run_for_test(
         k8s_instance,
         pipeline_name="bar",
-        pipeline_code_origin=reconstructable(bar).get_python_origin(),
+        pipeline_code_origin=reconstructable(bar_with_images).get_python_origin(),
     )
-    handler.launch_step(
-        StepHandlerContext(
-            k8s_instance,
-            ExecuteStepArgs(reconstructable(bar).get_python_origin(), run.run_id, ["foo_solid"]),
-            {"foo_solid": tags},
+    list(
+        handler.launch_step(
+            _step_handler_context(
+                pipeline=reconstructable(bar_with_images),
+                pipeline_run=run,
+                instance=k8s_instance,
+                executor=_get_executor(
+                    k8s_instance,
+                    reconstructable(bar_with_images),
+                ),
+            )
         )
     )
 
@@ -333,11 +400,17 @@ def test_step_handler_with_container_context(
             pipeline_name="bar",
             pipeline_code_origin=python_origin_with_container_context,
         )
-        handler.launch_step(
-            StepHandlerContext(
-                k8s_instance,
-                ExecuteStepArgs(python_origin_with_container_context, run.run_id, ["foo_solid"]),
-                {"foo_solid": {}},
+        list(
+            handler.launch_step(
+                _step_handler_context(
+                    pipeline=reconstructable(bar),
+                    pipeline_run=run,
+                    instance=k8s_instance,
+                    executor=_get_executor(
+                        k8s_instance,
+                        reconstructable(bar),
+                    ),
+                )
             )
         )
 


### PR DESCRIPTION
This makes stephandlers follow the same write-and-yield pattern that the rest of our event write paths do. I don't actually love that pattern, but I think there is value in consistency there. This will allow us to use a consistent event write API in all our executors as we are adding new structured events like step process start / step process started / etc.