### PR TITLE
materialize_in_process method

### DIFF
--- a/docs/sphinx/sections/api/apidocs/execution.rst
+++ b/docs/sphinx/sections/api/apidocs/execution.rst
@@ -4,8 +4,8 @@ Execution
 =========
 
 
-Executing Jobs
---------------
+Materializing Assets
+--------------------
 
 .. autofunction:: materialize
 

--- a/docs/sphinx/sections/api/apidocs/execution.rst
+++ b/docs/sphinx/sections/api/apidocs/execution.rst
@@ -7,6 +7,13 @@ Execution
 Executing Jobs
 --------------
 
+.. autofunction:: materialize
+
+.. autofunction:: materialize_in_process
+
+Executing Jobs
+--------------
+
 .. autoclass:: JobDefinition
   :noindex:
   :members: execute_in_process

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -32,6 +32,7 @@ from dagster.core.asset_defs import (
     load_assets_from_package_module,
     load_assets_from_package_name,
     materialize,
+    materialize_in_process,
     multi_asset,
 )
 from dagster.core.definitions import (
@@ -577,6 +578,7 @@ __all__ = [
     "load_assets_from_package_module",
     "load_assets_from_package_name",
     "materialize",
+    "materialize_in_process",
     # types
     "Any",
     "Bool",

--- a/python_modules/dagster/dagster/core/asset_defs/__init__.py
+++ b/python_modules/dagster/dagster/core/asset_defs/__init__.py
@@ -11,5 +11,5 @@ from .load_assets_from_modules import (
     load_assets_from_package_module,
     load_assets_from_package_name,
 )
-from .materialize import materialize
+from .materialize import materialize, materialize_in_process
 from .source_asset import SourceAsset

--- a/python_modules/dagster/dagster/core/asset_defs/materialize.py
+++ b/python_modules/dagster/dagster/core/asset_defs/materialize.py
@@ -1,7 +1,8 @@
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Mapping, Optional, Sequence, Union
 
 import dagster._check as check
 
+from ..execution.build_resources import wrap_resources_for_execution
 from ..execution.execute_in_process_result import ExecuteInProcessResult
 from ..execution.with_resources import with_resources
 from ..instance import DagsterInstance
@@ -39,4 +40,38 @@ def materialize(
         "in_process_materialization_job",
         assets=assets_defs,
         source_assets=source_assets,
+    ).execute_in_process(run_config=run_config, instance=instance)
+
+
+def materialize_in_process(
+    assets: Sequence[Union[AssetsDefinition, SourceAsset]],
+    run_config: Any = None,
+    instance: Optional[DagsterInstance] = None,
+    resources: Optional[Mapping[str, object]] = None,
+) -> ExecuteInProcessResult:
+    """
+    Executes a single-threaded, in-process run which materializes provided assets.
+
+    By default, will materialize assets to memory, meaning results will not be persisted. This behavior can be changed by overriding the default io manager key "io_manager", or providing custom io manager keys to assets.
+
+    Args:
+        assets (Sequence[Union[AssetsDefinition, SourceAsset]]): The assets to materialize. Can also provide ``SourceAsset``s to fill dependencies for asset defs.
+        run_config (Optional[Any]): The run config to use for the run that materializes the assets.
+        resources (Optional[Mapping[str, object]]):
+            The resources needed for execution. Can provide resource instances directly, or resource definitions. Note that if provided resources conflict with resources directly on assets, an error will be thrown.
+    Returns:
+        ExecuteInProcessResult: The result of the execution.
+    """
+
+    assets = check.sequence_param(assets, "assets", of_type=(AssetsDefinition, SourceAsset))
+    assets_defs = [the_def for the_def in assets if isinstance(the_def, AssetsDefinition)]
+    source_assets = [the_def for the_def in assets if isinstance(the_def, SourceAsset)]
+    resource_defs = wrap_resources_for_execution(resources)
+    instance = check.opt_inst_param(instance, "instance", DagsterInstance)
+
+    return build_assets_job(
+        "in_process_materialization_job",
+        assets=assets_defs,
+        source_assets=source_assets,
+        resource_defs=resource_defs,
     ).execute_in_process(run_config=run_config, instance=instance)

--- a/python_modules/dagster/dagster/core/asset_defs/materialize.py
+++ b/python_modules/dagster/dagster/core/asset_defs/materialize.py
@@ -23,7 +23,8 @@ def materialize(
     By default, will materialize assets to the local filesystem.
 
     Args:
-        assets (Sequence[Union[AssetsDefinition, SourceAsset]]): The assets to materialize. Can also provide ``SourceAsset``s to fill dependencies for asset defs.
+        assets (Sequence[Union[AssetsDefinition, SourceAsset]]):
+            The assets to materialize. Can also provide :py:class:`SourceAsset` objects to fill dependencies for asset defs.
         run_config (Optional[Any]): The run config to use for the run that materializes the assets.
 
     Returns:
@@ -52,13 +53,19 @@ def materialize_in_process(
     """
     Executes a single-threaded, in-process run which materializes provided assets.
 
-    By default, will materialize assets to memory, meaning results will not be persisted. This behavior can be changed by overriding the default io manager key "io_manager", or providing custom io manager keys to assets.
+    By default, will materialize assets to memory, meaning results will not be
+    persisted. This behavior can be changed by overriding the default io
+    manager key "io_manager", or providing custom io manager keys to assets.
 
     Args:
-        assets (Sequence[Union[AssetsDefinition, SourceAsset]]): The assets to materialize. Can also provide ``SourceAsset``s to fill dependencies for asset defs.
+        assets (Sequence[Union[AssetsDefinition, SourceAsset]]):
+            The assets to materialize. Can also provide :py:class:`SourceAsset` objects to fill dependencies for asset defs.
         run_config (Optional[Any]): The run config to use for the run that materializes the assets.
         resources (Optional[Mapping[str, object]]):
-            The resources needed for execution. Can provide resource instances directly, or resource definitions. Note that if provided resources conflict with resources directly on assets, an error will be thrown.
+            The resources needed for execution. Can provide resource instances
+            directly, or resource definitions. Note that if provided resources
+            conflict with resources directly on assets, an error will be thrown.
+
     Returns:
         ExecuteInProcessResult: The result of the execution.
     """

--- a/python_modules/dagster/dagster/core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/core/execution/build_resources.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import Any, Dict, Generator, Optional, cast
+from typing import Any, Dict, Generator, Mapping, Optional, cast
 
 import dagster._check as check
 from dagster.config.validate import process_config
@@ -116,9 +116,9 @@ def build_resources(
 
 
 def wrap_resources_for_execution(
-    resources: Optional[Dict[str, Any]] = None
+    resources: Optional[Mapping[str, Any]] = None
 ) -> Dict[str, ResourceDefinition]:
-    resources = check.opt_dict_param(resources, "resources", key_type=str)
+    resources = check.opt_mapping_param(resources, "resources", key_type=str)
     resource_defs = {}
     # Wrap instantiated resource values in a resource definition.
     # If an instantiated IO manager is provided, wrap it in an IO manager definition.

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_materialize_in_process.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_materialize_in_process.py
@@ -1,6 +1,3 @@
-import os
-from tempfile import TemporaryDirectory
-
 import pytest
 
 from dagster import (
@@ -10,7 +7,6 @@ from dagster import (
     DagsterInvalidDefinitionError,
     GraphOut,
     IOManager,
-    MetadataValue,
     Out,
     Output,
     ResourceDefinition,
@@ -23,7 +19,6 @@ from dagster import (
     op,
     with_resources,
 )
-from dagster.core.test_utils import instance_for_test
 
 
 def test_basic_materialize_in_process():

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_materialize_in_process.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_materialize_in_process.py
@@ -194,8 +194,8 @@ def test_materialize_graph_backed_asset():
         return combine_strings(da, db)
 
     cool_thing_asset = AssetsDefinition(
-        asset_keys_by_input_name={"a": AssetKey("a"), "b": AssetKey("b")},
-        asset_keys_by_output_name={"result": AssetKey("cool_thing")},
+        keys_by_input_name={"a": AssetKey("a"), "b": AssetKey("b")},
+        keys_by_output_name={"result": AssetKey("cool_thing")},
         node_def=create_cool_thing,
     )
 
@@ -221,8 +221,8 @@ def test_materialize_multi_asset():
         return (o1, o2)
 
     thing_asset = AssetsDefinition(
-        asset_keys_by_input_name={},
-        asset_keys_by_output_name={"o1": AssetKey("thing"), "o2": AssetKey("thing_2")},
+        keys_by_input_name={},
+        keys_by_output_name={"o1": AssetKey("thing"), "o2": AssetKey("thing_2")},
         node_def=thing,
         asset_deps={AssetKey("thing"): set(), AssetKey("thing_2"): {AssetKey("thing")}},
     )

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_materialize_in_process.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_materialize_in_process.py
@@ -1,0 +1,252 @@
+import os
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from dagster import (
+    AssetKey,
+    AssetsDefinition,
+    DagsterInvalidConfigError,
+    DagsterInvalidDefinitionError,
+    GraphOut,
+    IOManager,
+    MetadataValue,
+    Out,
+    Output,
+    ResourceDefinition,
+    SourceAsset,
+    asset,
+    graph,
+    io_manager,
+    materialize_in_process,
+    multi_asset,
+    op,
+    with_resources,
+)
+from dagster.core.test_utils import instance_for_test
+
+
+def test_basic_materialize_in_process():
+    @asset
+    def the_asset():
+        return 5
+
+    result = materialize_in_process([the_asset])
+    assert result.success
+    assert len(result.asset_materializations_for_node("the_asset")[0].metadata_entries) == 0
+
+
+def test_materialize_config():
+    @asset(config_schema={"foo_str": str})
+    def the_asset_reqs_config(context):
+        assert context.op_config["foo_str"] == "foo"
+
+    assert materialize_in_process(
+        [the_asset_reqs_config],
+        run_config={"ops": {"the_asset_reqs_config": {"config": {"foo_str": "foo"}}}},
+    ).success
+
+
+def test_materialize_bad_config():
+    @asset(config_schema={"foo_str": str})
+    def the_asset_reqs_config(context):
+        assert context.op_config["foo_str"] == "foo"
+
+    with pytest.raises(DagsterInvalidConfigError, match="Error in config for job"):
+        materialize_in_process(
+            [the_asset_reqs_config],
+            run_config={"ops": {"the_asset_reqs_config": {"config": {"bad": "foo"}}}},
+        )
+
+
+def test_materialize_resources():
+    @asset(resource_defs={"foo": ResourceDefinition.hardcoded_resource("blah")})
+    def the_asset(context):
+        assert context.resources.foo == "blah"
+
+    assert materialize_in_process([the_asset]).success
+
+
+def test_materialize_resource_instances():
+    @asset(required_resource_keys={"foo", "bar"})
+    def the_asset(context):
+        assert context.resources.foo == "blah"
+        assert context.resources.bar == "baz"
+
+    assert materialize_in_process(
+        [the_asset], resources={"foo": ResourceDefinition.hardcoded_resource("blah"), "bar": "baz"}
+    ).success
+
+
+def test_materialize_resources_not_satisfied():
+    @asset(required_resource_keys={"foo"})
+    def the_asset(context):
+        assert context.resources.foo == "blah"
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="resource with key 'foo' required by op 'the_asset' was not provided",
+    ):
+        materialize_in_process([the_asset])
+
+    assert materialize_in_process(
+        with_resources([the_asset], {"foo": ResourceDefinition.hardcoded_resource("blah")})
+    ).success
+
+
+def test_materialize_conflicting_resources():
+    @asset(resource_defs={"foo": ResourceDefinition.hardcoded_resource("1")})
+    def first():
+        pass
+
+    @asset(resource_defs={"foo": ResourceDefinition.hardcoded_resource("2")})
+    def second():
+        pass
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="Conflicting versions of resource with key 'foo' were provided to different assets.",
+    ):
+        materialize_in_process([first, second])
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="resource with key 'foo' provided to job conflicts with resource provided to assets. When constructing a job, all resource definitions provided must match by reference equality for a given key.",
+    ):
+        materialize_in_process(
+            [first], resources={"foo": ResourceDefinition.hardcoded_resource("2")}
+        )
+
+
+def test_materialize_source_assets():
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            pass
+
+        def load_input(self, context):
+            return 5
+
+    @io_manager
+    def the_manager():
+        return MyIOManager()
+
+    the_source = SourceAsset(key=AssetKey(["the_source"]), io_manager_def=the_manager)
+
+    @asset
+    def the_asset(the_source):
+        return the_source + 1
+
+    result = materialize_in_process([the_asset, the_source])
+    assert result.success
+    assert result.output_for_node("the_asset") == 6
+
+
+def test_materialize_source_asset_conflicts():
+    @io_manager(required_resource_keys={"foo"})
+    def the_manager():
+        pass
+
+    @asset(resource_defs={"foo": ResourceDefinition.hardcoded_resource("1")})
+    def the_asset():
+        pass
+
+    the_source = SourceAsset(
+        key=AssetKey(["the_source"]),
+        io_manager_def=the_manager,
+        resource_defs={"foo": ResourceDefinition.hardcoded_resource("2")},
+    )
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="Conflicting versions of resource with key 'foo' were provided to different assets.",
+    ):
+        materialize_in_process([the_asset, the_source])
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="resource with key 'foo' provided to job conflicts with resource provided to assets.",
+    ):
+        materialize_in_process(
+            [the_source], resources={"foo": ResourceDefinition.hardcoded_resource("2")}
+        )
+
+
+def test_materialize_no_assets():
+    assert materialize_in_process([]).success
+
+
+def test_materialize_graph_backed_asset():
+    @asset
+    def a():
+        return "a"
+
+    @asset
+    def b():
+        return "b"
+
+    @op
+    def double_string(s):
+        return s * 2
+
+    @op
+    def combine_strings(s1, s2):
+        return s1 + s2
+
+    @graph
+    def create_cool_thing(a, b):
+        da = double_string(double_string(a))
+        db = double_string(b)
+        return combine_strings(da, db)
+
+    cool_thing_asset = AssetsDefinition(
+        asset_keys_by_input_name={"a": AssetKey("a"), "b": AssetKey("b")},
+        asset_keys_by_output_name={"result": AssetKey("cool_thing")},
+        node_def=create_cool_thing,
+    )
+
+    result = materialize_in_process([cool_thing_asset, a, b])
+    assert result.success
+    assert result.output_for_node("create_cool_thing.combine_strings") == "aaaabb"
+
+
+def test_materialize_multi_asset():
+    @op
+    def upstream_op():
+        return "foo"
+
+    @op(out={"o1": Out(), "o2": Out()})
+    def two_outputs(upstream_op):
+        o1 = upstream_op
+        o2 = o1 + "bar"
+        return o1, o2
+
+    @graph(out={"o1": GraphOut(), "o2": GraphOut()})
+    def thing():
+        o1, o2 = two_outputs(upstream_op())
+        return (o1, o2)
+
+    thing_asset = AssetsDefinition(
+        asset_keys_by_input_name={},
+        asset_keys_by_output_name={"o1": AssetKey("thing"), "o2": AssetKey("thing_2")},
+        node_def=thing,
+        asset_deps={AssetKey("thing"): set(), AssetKey("thing_2"): {AssetKey("thing")}},
+    )
+
+    @multi_asset(
+        outs={
+            "my_out_name": Out(metadata={"foo": "bar"}),
+            "my_other_out_name": Out(metadata={"bar": "foo"}),
+        },
+        internal_asset_deps={
+            "my_out_name": {AssetKey("my_other_out_name")},
+            "my_other_out_name": {AssetKey("thing")},
+        },
+    )
+    def multi_asset_with_internal_deps(thing):  # pylint: disable=unused-argument
+        yield Output(1, "my_out_name")
+        yield Output(2, "my_other_out_name")
+
+    result = materialize_in_process([thing_asset, multi_asset_with_internal_deps])
+    assert result.success
+    assert result.output_for_node("multi_asset_with_internal_deps", "my_out_name") == 1
+    assert result.output_for_node("multi_asset_with_internal_deps", "my_other_out_name") == 2


### PR DESCRIPTION
Adds a materialize_in_process method which uses the in memory io manager and in process executor to load assets. For use with testing.
