### PR TITLE
Simplify execute_in_process result

### DIFF
--- a/python_modules/dagster/dagster/core/execution/execute_in_process.py
+++ b/python_modules/dagster/dagster/core/execution/execute_in_process.py
@@ -81,13 +81,7 @@ def core_execute_in_process(
             ),
         )
 
-        event_list = []
-
-        for event in execute_run_iterable:
-            event_list.append(event)
-
-            if event.is_pipeline_event:
-                execute_instance.handle_run_event(run_id, event)
+        event_list = list(execute_run_iterable)
 
     return ExecuteInProcessResult(
         node, event_list, execute_instance.get_run_by_id(run_id), output_capture


### PR DESCRIPTION
Summary:
I think the only part of https://github.com/dagster-io/dagster/pull/6784/files that we needed was the part where the run is reloaded from the DB - the new test added in that PR still passes.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
