### PR TITLE
[assets] assorted bugfixes

### DIFF
--- a/examples/modern_data_stack_assets/modern_data_stack_assets/assets.py
+++ b/examples/modern_data_stack_assets/modern_data_stack_assets/assets.py
@@ -13,7 +13,9 @@ from .constants import *  # pylint: disable=wildcard-import,unused-wildcard-impo
 from .pandas_io_manager import pandas_io_manager
 
 airbyte_assets = build_airbyte_assets(
-    connection_id=AIRBYTE_CONNECTION_ID, destination_tables=["orders", "users"]
+    connection_id=AIRBYTE_CONNECTION_ID,
+    destination_tables=["orders", "users"],
+    asset_key_prefix=["postgres_replica"],
 )
 
 dbt_assets = load_assets_from_dbt_project(

--- a/python_modules/dagster/dagster/core/asset_defs/asset_selection.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_selection.py
@@ -5,8 +5,8 @@ from typing import AbstractSet, FrozenSet, Optional, Sequence
 
 import dagster._check as check
 from dagster.core.asset_defs.assets import AssetsDefinition
-from dagster.core.errors import DagsterInvalidSubsetError
 from dagster.core.definitions.events import AssetKey, CoercibleToAssetKey
+from dagster.core.errors import DagsterInvalidSubsetError
 from dagster.core.selector.subset_selector import (
     fetch_connected,
     generate_asset_dep_graph,

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -387,7 +387,7 @@ class AssetsDefinition(ResourceAddable):
             can_subset=self.can_subset,
             selected_asset_keys=selected_asset_keys & self.keys,
             resource_defs=self.resource_defs,
-            group_names=self._group_names,
+            group_names_by_key=self.group_names_by_key,
         )
 
     def to_source_assets(self) -> Sequence[SourceAsset]:
@@ -469,7 +469,7 @@ class AssetsDefinition(ResourceAddable):
             selected_asset_keys=self._selected_asset_keys,
             can_subset=self._can_subset,
             resource_defs=relevant_resource_defs,
-            group_names_by_key=self._group_names_by_key,
+            group_names_by_key=self.group_names_by_key,
         )
 
 

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -387,6 +387,7 @@ class AssetsDefinition(ResourceAddable):
             can_subset=self.can_subset,
             selected_asset_keys=selected_asset_keys & self.keys,
             resource_defs=self.resource_defs,
+            group_names=self._group_names,
         )
 
     def to_source_assets(self) -> Sequence[SourceAsset]:

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -236,7 +236,7 @@ class _Asset:
     def __call__(self, fn: Callable) -> AssetsDefinition:
         asset_name = self.name or fn.__name__
 
-        asset_ins = build_asset_ins(fn, self.key_prefix, self.ins or {}, self.non_argument_deps)
+        asset_ins = build_asset_ins(fn, [], self.ins or {}, self.non_argument_deps)
 
         out_asset_key = AssetKey(list(filter(None, [*(self.key_prefix or []), asset_name])))
         with warnings.catch_warnings():

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -122,7 +122,8 @@ def asset(
         metadata (Optional[Dict[str, Any]]): A dict of metadata entries for the asset.
         required_resource_keys (Optional[Set[str]]): Set of resource handles required by the op.
         io_manager_key (Optional[str]): The resource key of the IOManager used
-            for storing the output of the op as an asset, and for loading it in downstream ops (default: "io_manager"). Only one of io_manager_key and io_manager_def can be provided.
+            for storing the output of the op as an asset, and for loading it in downstream ops
+            (default: "io_manager"). Only one of io_manager_key and io_manager_def can be provided.
         io_manager_def (Optional[IOManagerDefinition]): The definition of the IOManager used for
             storing the output of the op as an asset,  and for loading it in
             downstream ops. Only one of io_manager_def and io_manager_key can be provided.
@@ -157,7 +158,15 @@ def asset(
         return _Asset()(name)
 
     key_prefix = canonicalize_backcompat_args(
-        key_prefix, "key_prefix", namespace, "namespace", "0.16.0"
+        key_prefix,
+        "key_prefix",
+        namespace,
+        "namespace",
+        "0.16.0",
+        additional_warn_txt="key_prefix applies only to the output AssetKey. If you want to modify "
+        "the prefix of the input AssetKeys as well, you can do this by explicitly setting the ins "
+        "parameter of this asset to a dictionary of the form "
+        "'input_name': AssetIn(key_prefix=...).",
     )
 
     def inner(fn: Callable[..., Any]) -> AssetsDefinition:
@@ -168,6 +177,7 @@ def asset(
         return _Asset(
             name=cast(Optional[str], name),  # (mypy bug that it can't infer name is Optional[str])
             key_prefix=key_prefix,
+            namespace=namespace,
             ins=ins,
             non_argument_deps=_make_asset_keys(non_argument_deps),
             metadata=metadata,
@@ -191,6 +201,7 @@ class _Asset:
     def __init__(
         self,
         name: Optional[str] = None,
+        namespace: Optional[Sequence[str]] = None,
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         ins: Optional[Mapping[str, AssetIn]] = None,
         non_argument_deps: Optional[Set[AssetKey]] = None,
@@ -209,6 +220,7 @@ class _Asset:
     ):
         self.name = name
 
+        self.namespace = namespace
         if isinstance(key_prefix, str):
             key_prefix = [key_prefix]
         self.key_prefix = key_prefix
@@ -236,7 +248,8 @@ class _Asset:
     def __call__(self, fn: Callable) -> AssetsDefinition:
         asset_name = self.name or fn.__name__
 
-        asset_ins = build_asset_ins(fn, [], self.ins or {}, self.non_argument_deps)
+        # for backcompat, we prefix input asset keys with the namespace
+        asset_ins = build_asset_ins(fn, self.namespace, self.ins or {}, self.non_argument_deps)
 
         out_asset_key = AssetKey(list(filter(None, [*(self.key_prefix or []), asset_name])))
         with warnings.catch_warnings():

--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -723,14 +723,6 @@ def _subset_assets_defs(
                 "asset keys produced by this asset."
             )
 
-    missed_keys = selected_asset_keys - included_keys - {sa.key for sa in source_assets}
-    if missed_keys:
-        raise DagsterInvalidSubsetError(
-            f"When building job, the AssetKey(s) {[key.to_user_string() for key in missed_keys]} "
-            "were selected, but are not produced by any of the provided AssetsDefinitions or "
-            "SourceAssets. Make sure that keys are spelled correctly and that all of the expected "
-            "definitions are provided."
-        )
     all_excluded_assets: Sequence[Union["AssetsDefinition", "SourceAsset"]] = [
         *excluded_assets,
         *source_assets,

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
@@ -377,7 +377,7 @@ def _get_assets_defs(use_multi: bool = False, allow_subset: bool = False):
             ["start+"],
             True,
             (
-                DagsterInvalidSubsetError,
+                DagsterInvalidDefinitionError,
                 r"When building job, the AssetsDefinition 'abc_' contains asset keys "
                 r"\[AssetKey\(\['a'\]\), AssetKey\(\['b'\]\), AssetKey\(\['c'\]\)\], but attempted to "
                 r"select only \[AssetKey\(\['a'\]\)\]",

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_group.py
@@ -377,7 +377,7 @@ def _get_assets_defs(use_multi: bool = False, allow_subset: bool = False):
             ["start+"],
             True,
             (
-                DagsterInvalidDefinitionError,
+                DagsterInvalidSubsetError,
                 r"When building job, the AssetsDefinition 'abc_' contains asset keys "
                 r"\[AssetKey\(\['a'\]\), AssetKey\(\['b'\]\), AssetKey\(\['c'\]\)\], but attempted to "
                 r"select only \[AssetKey\(\['a'\]\)\]",

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
@@ -2,6 +2,9 @@ import pytest
 
 from dagster import (
     AssetKey,
+    AssetsDefinition,
+    op,
+    Out,
     AssetOut,
     IOManager,
     Output,
@@ -90,6 +93,23 @@ def test_retain_group():
         output_asset_key_replacements={AssetKey(["bar"]): AssetKey(["baz"])}
     )
     assert replaced.group_names_by_key[AssetKey("baz")] == "foo"
+
+
+def test_retain_group_subset():
+    @op(out={"a": Out(), "b": Out()})
+    def ma_op():
+        return 1
+
+    ma = AssetsDefinition(
+        node_def=ma_op,
+        asset_keys_by_input_name={},
+        asset_keys_by_output_name={"a": AssetKey("a"), "b": AssetKey("b")},
+        group_names={AssetKey("a"): "foo", AssetKey("b"): "bar"},
+        can_subset=True,
+    )
+
+    subset = ma.subset_for({AssetKey("b")})
+    assert subset.group_names[AssetKey("b")] == "bar"
 
 
 def test_chain_replace_and_subset_for():

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
@@ -2,15 +2,15 @@ import pytest
 
 from dagster import (
     AssetKey,
-    AssetsDefinition,
-    op,
-    Out,
     AssetOut,
+    AssetsDefinition,
     IOManager,
+    Out,
     Output,
     ResourceDefinition,
     build_op_context,
     io_manager,
+    op,
 )
 from dagster._check import CheckError
 from dagster.core.asset_defs import AssetGroup, AssetIn, SourceAsset, asset, multi_asset

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
@@ -102,14 +102,14 @@ def test_retain_group_subset():
 
     ma = AssetsDefinition(
         node_def=ma_op,
-        asset_keys_by_input_name={},
-        asset_keys_by_output_name={"a": AssetKey("a"), "b": AssetKey("b")},
-        group_names={AssetKey("a"): "foo", AssetKey("b"): "bar"},
+        keys_by_input_name={},
+        keys_by_output_name={"a": AssetKey("a"), "b": AssetKey("b")},
+        group_names_by_key={AssetKey("a"): "foo", AssetKey("b"): "bar"},
         can_subset=True,
     )
 
     subset = ma.subset_for({AssetKey("b")})
-    assert subset.group_names[AssetKey("b")] == "bar"
+    assert subset.group_names_by_key[AssetKey("b")] == "bar"
 
 
 def test_chain_replace_and_subset_for():

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -262,8 +262,8 @@ def test_asset_with_inputs_and_key_prefix():
     assert len(my_asset.op.output_defs) == 1
     assert len(my_asset.op.input_defs) == 1
     # this functions differently than the namespace arg in this scenario
-    assert AssetKey(["my_prefix", "arg1"]) not in my_asset.asset_keys_by_input_name.values()
-    assert AssetKey(["arg1"]) in my_asset.asset_keys_by_input_name.values()
+    assert AssetKey(["my_prefix", "arg1"]) not in my_asset.keys_by_input_name.values()
+    assert AssetKey(["arg1"]) in my_asset.keys_by_input_name.values()
 
 
 def test_asset_with_context_arg():

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -261,7 +261,9 @@ def test_asset_with_inputs_and_key_prefix():
     assert isinstance(my_asset, AssetsDefinition)
     assert len(my_asset.op.output_defs) == 1
     assert len(my_asset.op.input_defs) == 1
-    assert AssetKey(["my_prefix", "arg1"]) in my_asset.keys_by_input_name.values()
+    # this functions differently than the namespace arg in this scenario
+    assert AssetKey(["my_prefix", "arg1"]) not in my_asset.asset_keys_by_input_name.values()
+    assert AssetKey(["arg1"]) in my_asset.asset_keys_by_input_name.values()
 
 
 def test_asset_with_context_arg():

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -23,7 +23,7 @@ from dagster import (
 from dagster._check import CheckError
 from dagster.core.asset_defs import asset, multi_asset
 from dagster.core.asset_defs.load_assets_from_modules import prefix_assets
-from dagster.core.errors import DagsterInvalidSubsetError
+from dagster.core.errors import DagsterInvalidSubsetError, DagsterInvalidDefinitionError
 from dagster.core.execution.with_resources import with_resources
 from dagster.core.test_utils import instance_for_test
 
@@ -173,22 +173,22 @@ def _get_assets_defs(use_multi: bool = False, allow_subset: bool = False):
         (
             "x",
             False,
-            (DagsterInvalidSubsetError, r"When building job, the AssetKey\(s\) \['x'\]"),
+            (DagsterInvalidSubsetError, r"AssetKey\(s\) {'x'} were selected"),
         ),
         (
             "x",
             True,
-            (DagsterInvalidSubsetError, r"When building job, the AssetKey\(s\) \['x'\]"),
+            (DagsterInvalidSubsetError, r"AssetKey\(s\) {'x'} were selected"),
         ),
         (
             ["start", "x"],
             False,
-            (DagsterInvalidSubsetError, r"When building job, the AssetKey\(s\) \['x'\]"),
+            (DagsterInvalidSubsetError, r"AssetKey\(s\) {'x'} were selected"),
         ),
         (
             ["start", "x"],
             True,
-            (DagsterInvalidSubsetError, r"When building job, the AssetKey\(s\) \['x'\]"),
+            (DagsterInvalidSubsetError, r"AssetKey\(s\) {'x'} were selected"),
         ),
         (["d", "e", "f"], False, None),
         (["d", "e", "f"], True, None),
@@ -413,7 +413,7 @@ def test_source_asset_selection_missing():
     def b(a):
         return a + 1
 
-    with pytest.raises(DagsterInvalidSubsetError, match="SourceAsset"):
+    with pytest.raises(DagsterInvalidDefinitionError, match="sources"):
         define_asset_job("job", selection="*b").resolve(assets=[a, b], source_assets=[])
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -23,7 +23,7 @@ from dagster import (
 from dagster._check import CheckError
 from dagster.core.asset_defs import asset, multi_asset
 from dagster.core.asset_defs.load_assets_from_modules import prefix_assets
-from dagster.core.errors import DagsterInvalidSubsetError, DagsterInvalidDefinitionError
+from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvalidSubsetError
 from dagster.core.execution.with_resources import with_resources
 from dagster.core.test_utils import instance_for_test
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -758,7 +758,7 @@ def test_bad_coerce():
 
 def test_bad_resolve():
 
-    with pytest.raises(DagsterInvalidSubsetError, match="When building job"):
+    with pytest.raises(DagsterInvalidSubsetError, match=r"AssetKey\(s\) {'foo'} were selected"):
 
         @repository
         def _fails():

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -300,12 +300,6 @@ def _get_node_metadata(node_info: Mapping[str, Any]) -> Mapping[str, Any]:
                 ]
             )
         )
-    if "database" in node_info:
-        metadata["database"] = node_info["database"]
-    if "schema" in node_info:
-        metadata["schema"] = node_info["schema"]
-    if "name" in node_info:
-        metadata["table"] = node_info["name"]
     return metadata
 
 
@@ -448,6 +442,7 @@ def load_assets_from_dbt_manifest(
     if source_key_prefix:
         if isinstance(source_key_prefix, str):
             source_key_prefix = [source_key_prefix]
+        source_key_prefix = check.list_param(source_key_prefix, "source_key_prefix", of_type=str)
         input_key_replacements = {
             input_key: AssetKey(source_key_prefix + input_key.path)
             for input_key in dbt_assets_def.asset_keys_by_input_name.values()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -379,6 +379,7 @@ def load_assets_from_dbt_project(
 def load_assets_from_dbt_manifest(
     manifest_json: Mapping[str, Any],
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
+    source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     runtime_metadata_fn: Optional[
         Callable[[SolidExecutionContext, Mapping[str, Any]], Mapping[str, Any]]
     ] = None,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -445,7 +445,7 @@ def load_assets_from_dbt_manifest(
         source_key_prefix = check.list_param(source_key_prefix, "source_key_prefix", of_type=str)
         input_key_replacements = {
             input_key: AssetKey(source_key_prefix + input_key.path)
-            for input_key in dbt_assets_def.asset_keys_by_input_name.values()
+            for input_key in dbt_assets_def.keys_by_input_name.values()
         }
         dbt_assets = [
             dbt_assets_def.with_prefix_or_group(input_asset_key_replacements=input_key_replacements)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -110,14 +110,14 @@ def _get_node_asset_key(node_info: Mapping[str, Any]) -> AssetKey:
         dbt models: a dbt model's key is the union of its model name and any schema configured on
     the model itself.
     """
-    print(node_info)
     if node_info["resource_type"] == "source":
-        pass
-    configured_schema = node_info["config"].get("schema")
-    if configured_schema is not None:
-        components = [configured_schema, node_info["name"]]
+        components = [node_info["source_name"], node_info["name"]]
     else:
-        components = [node_info["name"]]
+        configured_schema = node_info["config"].get("schema")
+        if configured_schema is not None:
+            components = [configured_schema, node_info["name"]]
+        else:
+            components = [node_info["name"]]
 
     return AssetKey(components)
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -24,7 +24,7 @@ from dagster.utils import file_relative_path
 
 
 @pytest.mark.parametrize(
-    "prefix,source_prefix",
+    "prefix",
     [
         None,
         "snowflake",
@@ -557,6 +557,27 @@ def test_static_select_invalid_selection(select, error_match):
 
     with pytest.raises(Exception, match=error_match):
         load_assets_from_dbt_manifest(manifest_json, select=select)
+
+
+def test_source_key_prefix(
+    conn_string, test_python_project_dir, dbt_python_config_dir
+):  # pylint: disable=unused-argument
+    dbt_assets = load_assets_from_dbt_project(
+        test_python_project_dir, dbt_python_config_dir, key_prefix="dbt", source_key_prefix="source"
+    )
+    assert dbt_assets[0].keys_by_input_name == {
+        "source_dagster_dbt_python_test_project_dagster_bot_labeled_users": AssetKey(
+            ["source", "dagster", "bot_labeled_users"]
+        ),
+        "source_dagster_dbt_python_test_project_raw_data_events": AssetKey(
+            ["source", "raw_data", "events"]
+        ),
+        "source_dagster_dbt_python_test_project_raw_data_users": AssetKey(
+            ["source", "raw_data", "users"]
+        ),
+    }
+
+    assert dbt_assets[0].keys_by_output_name["cleaned_users"] == AssetKey(["dbt", "cleaned_users"])
 
 
 def test_python_interleaving(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -562,7 +562,9 @@ def test_static_select_invalid_selection(select, error_match):
 def test_python_interleaving(
     conn_string, dbt_python_sources, test_python_project_dir, dbt_python_config_dir
 ):  # pylint: disable=unused-argument
-    dbt_assets = load_assets_from_dbt_project(test_python_project_dir, dbt_python_config_dir)
+    dbt_assets = load_assets_from_dbt_project(
+        test_python_project_dir, dbt_python_config_dir, key_prefix="dbt"
+    )
 
     @io_manager
     def test_io_manager(_context):
@@ -607,7 +609,7 @@ def test_python_interleaving(
 
         return TestIOManager()
 
-    @asset
+    @asset(key_prefix="dagster", ins={"cleaned_users": AssetIn(key_prefix="dbt")})
     def bot_labeled_users(cleaned_users):
         # super advanced bot labeling algorithm
         return [(uid, uid % 5 == 0) for _, uid in cleaned_users]
@@ -630,12 +632,12 @@ def test_python_interleaving(
         if event.event_type_value == "ASSET_MATERIALIZATION"
     }
     expected_asset_names = [
-        "cleaned_events",
-        "cleaned_users",
-        "daily_aggregated_events",
-        "daily_aggregated_users",
-        "bot_labeled_users",
-        "bot_labeled_events",
+        "dbt.cleaned_events",
+        "dbt.cleaned_users",
+        "dbt.daily_aggregated_events",
+        "dbt.daily_aggregated_users",
+        "dagster.bot_labeled_users",
+        "dbt.bot_labeled_events",
     ]
-    expected_keys = {AssetKey([name]) for name in expected_asset_names}
+    expected_keys = {AssetKey(name.split(".")) for name in expected_asset_names}
     assert all_keys == expected_keys

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -24,7 +24,7 @@ from dagster.utils import file_relative_path
 
 
 @pytest.mark.parametrize(
-    "prefix",
+    "prefix,source_prefix",
     [
         None,
         "snowflake",


### PR DESCRIPTION
### Summary & Motivation

This is the branch that I stacked my new demo code off of. I noticed several small issues while doing this, so I fixed them all in this branch. They are:

1. The error detection logic I used to determine if a selection of asset keys was invalid was (still) faulty. The logic said "if an asset is selected that is not provided by any AssetsDefinitions or SourceAssets, then it's an error". This is wrong because if the asset key is used as an input with type Nothing, then this is still ok.
2. key_prefix and namespace were set to function identically, but we actually don't want the key prefix to apply to the inputs of the decorated function (because this is not how the key prefix argument works in other scenarios)
3. dbt: added database, schema, and table to metadata for each asset. this makes it easier to write io managers
4. dbt: added the source schema name to the key asset key for dbt sources (previously, it was just source table name). this is necessary because source table names may overlap.
5. dbt: added a source_key_prefix argument to load_assets_from_dbt*. This is necessary because the source keys may need a different prefix that the model keys.

### How I Tested These Changes

units
