### PR TITLE
[dagit] Update the linking between asset groups + jobs

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -12,6 +12,7 @@ import {
   metadataForAssetNode,
 } from '../assets/AssetMetadata';
 import {PartitionHealthSummary, usePartitionHealthData} from '../assets/PartitionHealthSummary';
+import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {AssetKey} from '../assets/types';
 import {DagsterTypeSummary} from '../dagstertype/DagsterType';
 import {DagsterTypeFragment} from '../dagstertype/types/DagsterTypeFragment';
@@ -145,7 +146,7 @@ const Header: React.FC<{assetKey: AssetKey; opName?: string}> = ({assetKey, opNa
           </Box>
         ) : undefined}
       </SidebarTitle>
-      <AssetCatalogLink to={`/instance/assets/${assetKey.path.join('/')}`}>
+      <AssetCatalogLink to={assetDetailsPathForKey(assetKey)}>
         {'View in Asset Catalog '}
         <Icon name="open_in_new" color={Colors.Link} />
       </AssetCatalogLink>

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetForNavigationQuery.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetForNavigationQuery.ts
@@ -13,11 +13,26 @@ export interface AssetForNavigationQuery_assetOrError_AssetNotFoundError {
   __typename: "AssetNotFoundError";
 }
 
+export interface AssetForNavigationQuery_assetOrError_Asset_definition_repository_location {
+  __typename: "RepositoryLocation";
+  id: string;
+  name: string;
+}
+
+export interface AssetForNavigationQuery_assetOrError_Asset_definition_repository {
+  __typename: "Repository";
+  id: string;
+  name: string;
+  location: AssetForNavigationQuery_assetOrError_Asset_definition_repository_location;
+}
+
 export interface AssetForNavigationQuery_assetOrError_Asset_definition {
   __typename: "AssetNode";
   id: string;
   opNames: string[];
   jobNames: string[];
+  groupName: string | null;
+  repository: AssetForNavigationQuery_assetOrError_Asset_definition_repository;
 }
 
 export interface AssetForNavigationQuery_assetOrError_Asset {

--- a/js_modules/dagit/packages/core/src/asset-graph/useFindAssetLocation.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useFindAssetLocation.tsx
@@ -1,7 +1,10 @@
 import {gql, useApolloClient} from '@apollo/client';
 import React from 'react';
 
+import {AssetKey} from '../assets/types';
 import {AssetKeyInput} from '../types/globalTypes';
+import {buildRepoAddress} from '../workspace/buildRepoAddress';
+import {RepoAddress} from '../workspace/types';
 
 import {isHiddenAssetGroupJob} from './Utils';
 import {
@@ -9,11 +12,19 @@ import {
   AssetForNavigationQueryVariables,
 } from './types/AssetForNavigationQuery';
 
-export function useFindJobForAsset() {
+export interface AssetLocation {
+  assetKey: AssetKey;
+  opNames: string[];
+  jobName: string | null;
+  groupName: string | null;
+  repoAddress: RepoAddress | null;
+}
+
+export function useFindAssetLocation() {
   const apollo = useApolloClient();
 
   return React.useCallback(
-    async (key: AssetKeyInput): Promise<{opNames: string[]; jobName: string | null}> => {
+    async (key: AssetKeyInput): Promise<AssetLocation> => {
       const {data} = await apollo.query<AssetForNavigationQuery, AssetForNavigationQueryVariables>({
         query: ASSET_FOR_NAVIGATION_QUERY,
         variables: {key},
@@ -21,11 +32,16 @@ export function useFindJobForAsset() {
       if (data?.assetOrError.__typename === 'Asset' && data?.assetOrError.definition) {
         const def = data.assetOrError.definition;
         return {
+          assetKey: key,
           opNames: def.opNames,
           jobName: def.jobNames.find((jobName) => !isHiddenAssetGroupJob(jobName)) || null,
+          groupName: def.groupName,
+          repoAddress: def.repository
+            ? buildRepoAddress(def.repository.name, def.repository.location.name)
+            : null,
         };
       }
-      return {opNames: [], jobName: null};
+      return {assetKey: key, opNames: [], jobName: null, groupName: null, repoAddress: null};
     },
     [apollo],
   );
@@ -41,6 +57,15 @@ const ASSET_FOR_NAVIGATION_QUERY = gql`
           id
           opNames
           jobNames
+          groupName
+          repository {
+            id
+            name
+            location {
+              id
+              name
+            }
+          }
         }
       }
     }

--- a/js_modules/dagit/packages/core/src/assets/AssetLineageElements.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetLineageElements.tsx
@@ -1,11 +1,11 @@
 import {gql} from '@apollo/client';
 import {Box, ButtonLink, Tooltip} from '@dagster-io/ui';
-import qs from 'qs';
 import React from 'react';
 import {Link} from 'react-router-dom';
 
 import {Timestamp} from '../app/time/Timestamp';
 
+import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {AssetLineageFragment} from './types/AssetLineageFragment';
 
 const AssetLineageInfoElement: React.FC<{
@@ -16,9 +16,7 @@ const AssetLineageInfoElement: React.FC<{
   const partition_list_str = lineage_info.partitions
     .map((partition) => `"${partition}"`)
     .join(', ');
-  const to = `/instance/assets/${lineage_info.assetKey.path
-    .map(encodeURIComponent)
-    .join('/')}?${qs.stringify({asOf: timestamp})}`;
+  const to = assetDetailsPathForKey(lineage_info.assetKey, {asOf: timestamp});
 
   return (
     <Box margin={{bottom: 4}}>

--- a/js_modules/dagit/packages/core/src/assets/AssetLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetLink.tsx
@@ -2,13 +2,15 @@ import {Box, Colors, Icon} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
+import {assetDetailsPathForKey} from './assetDetailsPathForKey';
+
 export const AssetLink: React.FC<{
   path: string[];
   icon?: 'asset' | 'asset_non_sda' | 'folder';
   url?: string;
   isGroup?: boolean;
 }> = ({path, icon, url, isGroup}) => {
-  const linkUrl = url ? url : `/instance/assets/${path.map(encodeURIComponent).join('/')}`;
+  const linkUrl = url ? url : assetDetailsPathForKey({path});
 
   return (
     <Box flex={{direction: 'row', alignItems: 'center', display: 'inline-flex'}}>

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
@@ -60,6 +60,7 @@ export const AssetNodeLineage: React.FC<{
         assetNode={assetNode}
         liveDataByNode={liveDataByNode}
         assetGraphData={assetGraphData}
+        params={params}
       />
     </>
   );

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineageGraph.tsx
@@ -12,6 +12,8 @@ import {SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
 import {getJSONForKey} from '../hooks/useStateWithStorage';
 
+import {AssetViewParams} from './AssetView';
+import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {AssetKey} from './types';
 import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinitionFragment';
 
@@ -23,7 +25,8 @@ export const AssetNodeLineageGraph: React.FC<{
   assetNode: AssetNodeDefinitionFragment;
   assetGraphData: GraphData;
   liveDataByNode: LiveData;
-}> = ({assetNode, assetGraphData, liveDataByNode}) => {
+  params: AssetViewParams;
+}> = ({assetNode, assetGraphData, liveDataByNode, params}) => {
   const assetGraphId = toGraphId(assetNode.assetKey);
 
   const [highlighted, setHighlighted] = React.useState<string | null>(null);
@@ -33,7 +36,7 @@ export const AssetNodeLineageGraph: React.FC<{
   const history = useHistory();
 
   const onClickAsset = (key: AssetKey) => {
-    history.push(`/instance/assets/${key.path.join('/')}?view=lineage`);
+    history.push(assetDetailsPathForKey(key, {...params, lineageScope: 'neighbors'}));
   };
 
   React.useEffect(() => {

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeList.tsx
@@ -7,6 +7,8 @@ import {AssetNode} from '../asset-graph/AssetNode';
 import {LiveData, toGraphId} from '../asset-graph/Utils';
 import {AssetGraphQuery_assetNodes} from '../asset-graph/types/AssetGraphQuery';
 
+import {assetDetailsPathForKey} from './assetDetailsPathForKey';
+
 export const AssetNodeList: React.FC<{
   items: AssetGraphQuery_assetNodes[] | null;
   liveDataByNode: LiveData;
@@ -28,7 +30,7 @@ export const AssetNodeList: React.FC<{
           key={asset.id}
           onClick={(e) => {
             e.stopPropagation();
-            history.push(`/instance/assets/${asset.assetKey.path.join('/')}?view=definition`);
+            history.push(assetDetailsPathForKey(asset.assetKey, {view: 'definition'}));
           }}
         >
           <AssetNode

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -32,6 +32,7 @@ import {workspacePathFromAddress} from '../workspace/workspacePath';
 import {AssetLink} from './AssetLink';
 import {AssetWipeDialog} from './AssetWipeDialog';
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
+import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {AssetTableFragment as Asset} from './types/AssetTableFragment';
 import {AssetViewType} from './useAssetView';
 
@@ -190,7 +191,7 @@ const AssetEntryRow: React.FC<{
 }> = React.memo(
   ({prefixPath, path, assets, isSelected, onToggleChecked, onWipe, canWipe, liveDataByNode}) => {
     const fullPath = [...prefixPath, ...path];
-    const linkUrl = `/instance/assets/${fullPath.map(encodeURIComponent).join('/')}`;
+    const linkUrl = assetDetailsPathForKey({path: fullPath});
 
     const isGroup = assets.length > 1 || fullPath.join('/') !== assets[0].key.path.join('/');
     const asset = !isGroup ? assets[0] : null;
@@ -281,7 +282,7 @@ const AssetEntryRow: React.FC<{
         <td>
           {asset ? (
             <Box flex={{gap: 8, alignItems: 'center'}}>
-              <AnchorButton to={`/instance/assets/${path.join('/')}`}>View details</AnchorButton>
+              <AnchorButton to={assetDetailsPathForKey({path})}>View details</AnchorButton>
               <Popover
                 position="bottom-right"
                 content={
@@ -301,19 +302,28 @@ const AssetEntryRow: React.FC<{
                     />
                     <MenuLink
                       text="View neighbors"
-                      to={`/instance/assets/${path.join('/')}?view=lineage&lineageScope=neighbors`}
+                      to={assetDetailsPathForKey(
+                        {path},
+                        {view: 'lineage', lineageScope: 'neighbors'},
+                      )}
                       disabled={!asset?.definition}
                       icon="graph_neighbors"
                     />
                     <MenuLink
                       text="View upstream assets"
-                      to={`/instance/assets/${path.join('/')}?view=lineage&lineageScope=upstream`}
+                      to={assetDetailsPathForKey(
+                        {path},
+                        {view: 'lineage', lineageScope: 'upstream'},
+                      )}
                       disabled={!asset?.definition}
                       icon="graph_upstream"
                     />
                     <MenuLink
                       text="View downstream assets"
-                      to={`/instance/assets/${path.join('/')}?view=lineage&lineageScope=downstream`}
+                      to={assetDetailsPathForKey(
+                        {path},
+                        {view: 'lineage', lineageScope: 'downstream'},
+                      )}
                       disabled={!asset?.definition}
                       icon="graph_downstream"
                     />

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogRoot.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogRoot.tsx
@@ -11,6 +11,7 @@ import {ReloadAllButton} from '../workspace/ReloadAllButton';
 import {AssetPageHeader} from './AssetPageHeader';
 import {AssetView} from './AssetView';
 import {AssetsCatalogTable} from './AssetsCatalogTable';
+import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {
   AssetsCatalogRootQuery,
   AssetsCatalogRootQueryVariables,
@@ -54,9 +55,7 @@ export const AssetsCatalogRoot = () => {
       />
       <AssetsCatalogTable
         prefixPath={currentPath}
-        setPrefixPath={(prefixPath) =>
-          history.push(`/instance/assets/${prefixPath.map(encodeURIComponent).join('/')}`)
-        }
+        setPrefixPath={(prefixPath) => history.push(assetDetailsPathForKey({path: prefixPath}))}
       />
     </Page>
   ) : (

--- a/js_modules/dagit/packages/core/src/assets/assetDetailsPathForKey.tsx
+++ b/js_modules/dagit/packages/core/src/assets/assetDetailsPathForKey.tsx
@@ -1,0 +1,8 @@
+import qs from 'qs';
+
+import {AssetViewParams} from './AssetView';
+import {AssetKey} from './types';
+
+export const assetDetailsPathForKey = (key: AssetKey, query?: AssetViewParams) => {
+  return `/instance/assets/${key.path.map(encodeURIComponent).join('/')}?${qs.stringify(query)}`;
+};

--- a/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
@@ -19,6 +19,7 @@ import styled from 'styled-components/macro';
 import {copyValue} from '../app/DomUtils';
 import {assertUnreachable} from '../app/Util';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
+import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 
 import {TableSchema, TABLE_SCHEMA_FRAGMENT} from './TableSchema';
 import {MetadataEntryFragment} from './types/MetadataEntryFragment';
@@ -159,9 +160,7 @@ export const MetadataEntry: React.FC<{
       );
     case 'AssetMetadataEntry':
       return (
-        <MetadataEntryLink
-          to={`/instance/assets/${entry.assetKey.path.map(encodeURIComponent).join('/')}`}
-        >
+        <MetadataEntryLink to={assetDetailsPathForKey(entry.assetKey)}>
           {displayNameForAssetKey(entry.assetKey)}
         </MetadataEntryLink>
       );

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
@@ -4,6 +4,8 @@ import {useHistory, useParams} from 'react-router-dom';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {AssetGraphExplorer} from '../asset-graph/AssetGraphExplorer';
+import {AssetLocation} from '../asset-graph/useFindAssetLocation';
+import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntry';
 import {Loading} from '../ui/Loading';
@@ -39,6 +41,9 @@ export const PipelineExplorerSnapshotRoot = () => {
       onChangeExplorerPath={(path, mode) => {
         history[mode](`/instance/snapshots/${explorerPathToString(path)}`);
       }}
+      onNavigateToForeignNode={({assetKey}) => {
+        history.push(assetDetailsPathForKey(assetKey));
+      }}
     />
   );
 };
@@ -46,9 +51,16 @@ export const PipelineExplorerSnapshotRoot = () => {
 export const PipelineExplorerContainer: React.FC<{
   explorerPath: ExplorerPath;
   onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
+  onNavigateToForeignNode: (node: AssetLocation) => void;
   repoAddress?: RepoAddress;
   isGraph?: boolean;
-}> = ({explorerPath, repoAddress, onChangeExplorerPath, isGraph = false}) => {
+}> = ({
+  explorerPath,
+  repoAddress,
+  onChangeExplorerPath,
+  onNavigateToForeignNode,
+  isGraph = false,
+}) => {
   const [options, setOptions] = React.useState<GraphExplorerOptions>({
     explodeComposites: explorerPath.explodeComposites ?? false,
     preferAssetRendering: true,
@@ -91,6 +103,7 @@ export const PipelineExplorerContainer: React.FC<{
               fetchOptions={{pipelineSelector}}
               explorerPath={explorerPath}
               onChangeExplorerPath={onChangeExplorerPath}
+              onNavigateToForeignNode={onNavigateToForeignNode}
             />
           );
         }

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineOverviewRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineOverviewRoot.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import {useHistory, useLocation, useParams} from 'react-router-dom';
 
+import {tokenForAssetKey} from '../asset-graph/Utils';
+import {AssetLocation} from '../asset-graph/useFindAssetLocation';
+import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {buildPipelineSelector, isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
@@ -48,6 +51,25 @@ export const PipelineOverviewRoot: React.FC<Props> = (props) => {
     [history, location.search, repoAddress, isJob],
   );
 
+  const onNavigateToForeignNode = React.useCallback(
+    (node: AssetLocation) => {
+      if (!node.jobName || !node.opNames.length) {
+        // This op has no definition in any loaded repository (source asset).
+        // The best we can do is show the asset page. This will still be mostly empty,
+        // but there can be a description.
+        history.push(assetDetailsPathForKey(node.assetKey, {view: 'definition'}));
+        return;
+      }
+
+      const token = tokenForAssetKey(node.assetKey);
+      onChangeExplorerPath(
+        {...explorerPath, opNames: [token], opsQuery: '', pipelineName: node.jobName!},
+        'replace',
+      );
+    },
+    [explorerPath, history, onChangeExplorerPath],
+  );
+
   return (
     <GraphExplorerJobContext.Provider
       value={{
@@ -58,6 +80,7 @@ export const PipelineOverviewRoot: React.FC<Props> = (props) => {
         repoAddress={repoAddress}
         explorerPath={explorerPath}
         onChangeExplorerPath={onChangeExplorerPath}
+        onNavigateToForeignNode={onNavigateToForeignNode}
       />
     </GraphExplorerJobContext.Provider>
   );

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOpDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOpDefinition.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components/macro';
 
 import {breakOnUnderscores} from '../app/Util';
 import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Utils';
+import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {OpTypeSignature, OP_TYPE_SIGNATURE_FRAGMENT} from '../ops/OpTypeSignature';
 import {pluginForMetadata} from '../plugins';
 import {ConfigTypeSchema, CONFIG_TYPE_SCHEMA_FRAGMENT} from '../typeexplorer/ConfigTypeSchema';
@@ -152,10 +153,7 @@ export const SidebarOpDefinition: React.FC<SidebarOpDefinitionProps> = (props) =
       {definition.assetNodes.length > 0 && (
         <SidebarSection title="Yielded Assets">
           {definition.assetNodes.map((node) => (
-            <AssetNodeListItem
-              key={node.id}
-              to={`/instance/assets/${node.assetKey.path.join('/')}`}
-            >
+            <AssetNodeListItem key={node.id} to={assetDetailsPathForKey(node.assetKey)}>
               <Icon name="asset" /> {displayNameForAssetKey(node.assetKey)}
             </AssetNodeListItem>
           ))}

--- a/js_modules/dagit/packages/core/src/runs/LogsRowStructuredContent.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRowStructuredContent.tsx
@@ -8,6 +8,7 @@ import {Link, useLocation} from 'react-router-dom';
 import {assertUnreachable} from '../app/Util';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
+import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {AssetKey} from '../assets/types';
 import {
   LogRowStructuredContentTable,
@@ -425,8 +426,7 @@ const AssetMetadataContent: React.FC<{
     );
   }
 
-  const asOf = qs.stringify({asOf: timestamp});
-  const to = `/instance/assets/${assetKey.path.map(encodeURIComponent).join('/')}?${asOf}`;
+  const to = assetDetailsPathForKey(assetKey, {asOf: timestamp});
 
   const assetDashboardLink = (
     <span style={{marginLeft: 10}}>

--- a/js_modules/dagit/packages/core/src/runs/RunAssetKeyTags.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunAssetKeyTags.tsx
@@ -13,6 +13,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 
 import {displayNameForAssetKey, tokenForAssetKey} from '../asset-graph/Utils';
+import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {AssetKey} from '../assets/types';
 
 export const RunAssetKeyTags: React.FC<{
@@ -32,10 +33,7 @@ export const RunAssetKeyTags: React.FC<{
     return (
       <>
         {displayed.map((assetKey) => (
-          <Link
-            to={`/instance/assets/${assetKey.path.map(encodeURIComponent).join('/')}`}
-            key={tokenForAssetKey(assetKey)}
-          >
+          <Link to={assetDetailsPathForKey(assetKey)} key={tokenForAssetKey(assetKey)}>
             <Tag intent="none" interactive icon="asset">
               {displayNameForAssetKey(assetKey)}
             </Tag>
@@ -72,7 +70,7 @@ export const RunAssetKeyTags: React.FC<{
                     <tr key={tokenForAssetKey(assetKey)}>
                       <td>
                         <Link
-                          to={`/instance/assets/${assetKey.path.map(encodeURIComponent).join('/')}`}
+                          to={assetDetailsPathForKey(assetKey)}
                           key={tokenForAssetKey(assetKey)}
                         >
                           {displayNameForAssetKey(assetKey)}

--- a/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
+++ b/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Utils';
+import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {buildRepoPath} from '../workspace/buildRepoAddress';
 import {workspacePath} from '../workspace/workspacePath';
 
@@ -116,9 +117,9 @@ const secondaryDataToSearchResults = (data?: SearchSecondaryQuery) => {
   const allEntries = nodes.map(({key}) => {
     return {
       label: displayNameForAssetKey(key),
+      href: assetDetailsPathForKey(key),
       segments: key.path,
       description: 'Asset',
-      href: `/instance/assets/${key.path.map(encodeURIComponent).join('/')}`,
       type: SearchResultType.Asset,
     };
   });

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
@@ -5,6 +5,7 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {displayNameForAssetKey} from '../asset-graph/Utils';
+import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {RepositoryLink} from '../nav/RepositoryLink';
 
 import {repoAddressAsString} from './repoAddressAsString';
@@ -111,7 +112,7 @@ export const RepositoryAssetsList: React.FC<Props> = (props) => {
           <tr key={asset.id}>
             <td>
               <Box flex={{direction: 'column', gap: 4}}>
-                <Link to={`/instance/assets/${asset.assetKey.path.join('/')}`}>
+                <Link to={assetDetailsPathForKey(asset.assetKey)}>
                   {displayNameForAssetKey(asset.assetKey)}
                 </Link>
                 <Description>{asset.description}</Description>


### PR DESCRIPTION
### Summary & Motivation

This PR moves the "what if this asset isn't in the displayed graph?" handling out of `AssetGraphExplorer` into a prop, so that the group and job graphs can link to appropriate places.

On an asset group page, clicking an asset node outside the group takes you to that assets group page or to the definition if it is a source asset.

On an asset job page, clicking an asset node outside the job takes you to that asset's job page or to the definition if it is a source asset.

This addresses feedback that clicking around between groups would land you on definition pages instead of on the other groups.

To make things a bit simpler I also created a helper for generating the asset details page path. I wanted the params to be type checked, and wanted to make sure that the path components are always URL-encoded, in case someone is crazy enough to put a ? or #, etc.  in an asset key path. I realized I'd been doing it kind of inconsistently.

### How I Tested These Changes

- Clicked "foreign" links on asset jobs and asset groups, in cases where resolution succeeds and where resolution fails (source asset).