### PR TITLE
[docs] - Remove broken/unused examples from dbt guide

### DIFF
--- a/docs/content/integrations/dbt.mdx
+++ b/docs/content/integrations/dbt.mdx
@@ -376,34 +376,6 @@ from dagster_dbt import dbt_rpc_resource
 custom_resource = dbt_rpc_resource.configured({"host": HOST, "post": PORT})
 ```
 
-**dbt RPC: Select specific models to run**
-
-```python file=/integrations/dbt.py startafter=start_marker_dbt_rpc_config_select_models endbefore=end_marker_dbt_rpc_config_select_models dedent=4
-No match for startAfter value "start_marker_dbt_rpc_config_select_models"
-```
-
-For more details, [visit the official documentation on dbt's node selection syntax](https://docs.getdbt.com/reference/node-selection/syntax).
-
-**dbt RPC: Exclude specific models**
-
-```python file=/integrations/dbt.py startafter=start_marker_dbt_rpc_config_exclude_models endbefore=end_marker_dbt_rpc_config_exclude_models dedent=4
-No match for startAfter value "start_marker_dbt_rpc_config_exclude_models"
-```
-
-For more details, [visit the official documentation on dbt's node selection syntax](https://docs.getdbt.com/reference/node-selection/syntax).
-
-**dbt RPC: Configure polling interval when using a `dbt_rpc_*_and_wait` op**
-
-```python file=/integrations/dbt.py startafter=start_marker_dbt_rpc_and_wait_config_polling_interval endbefore=end_marker_dbt_rpc_and_wait_config_polling_interval dedent=4
-No match for startAfter value "start_marker_dbt_rpc_and_wait_config_polling_interval"
-```
-
-**dbt RPC: Disable default asset materializations**
-
-```python file=/integrations/dbt.py startafter=start_marker_dbt_rpc_config_disable_assets endbefore=end_marker_dbt_rpc_config_disable_assets dedent=4
-No match for endBefore value "end_marker_dbt_rpc_config_disable_assets"
-```
-
 ## Conclusion
 
 If you find a bug or want to add a feature to the `dagster-dbt` library, we invite you to [contribute](/community/contributing).


### PR DESCRIPTION
### Summary & Motivation

This PR removes sections with unused examples from the dbt integration guide. These examples were removed from `doc_snippets` and subsequent tests awhile back, but not the guide - this was likely an oversight.
