### PR TITLE
Fix for blocks_fn option

### DIFF
--- a/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
@@ -33,7 +33,7 @@ def _build_slack_blocks_and_text(
     main_body_text = text_fn(context)
 
     if blocks_fn:
-        blocks.extend(blocks_fn(context))
+        blocks_fn(context)
     else:
         blocks.append(
             {

--- a/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
@@ -33,7 +33,7 @@ def _build_slack_blocks_and_text(
     main_body_text = text_fn(context)
 
     if blocks_fn:
-        blocks_fn(context)
+        blocks: List[Dict[str, Any]] = blocks_fn(context)
     else:
         blocks.append(
             {


### PR DESCRIPTION
If user provides blocks, do not append default mrkdwn block - allow users to define block via their blocks_fn

### Summary & Motivation

### How I Tested These Changes
