### PR TITLE
[dagit] Fix launch parameters when an asset is partitioned and a graph

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchRootExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchRootExecutionButton.tsx
@@ -57,6 +57,8 @@ export function useLaunchWithTelemetry() {
       } catch (error) {
         showLaunchError(error as Error);
       }
+
+      return result.data;
     },
     [canLaunchPipelineExecution, history, launchPipelineExecution, logTelemetry],
   );


### PR DESCRIPTION
### Summary & Motivation

This fixes the issue discussed here:  https://github.com/dagster-io/dagster/issues/7899

I refactored things a bit to avoid this sort of problem in the future by sharing code between the partition case and the non-partitioned case, but the key change is sending an `assetSelection` rather than `stepKeys` in the launch mutation.

### How I Tested These Changes
