### PR TITLE
docs: default to master version when vercel env is not prod

### DIFF
--- a/docs/next/util/useVersion.ts
+++ b/docs/next/util/useVersion.ts
@@ -3,11 +3,17 @@ import { useEffect, useState } from "react";
 import ALL_VERSIONS from "../.versioned_content/_versions.json";
 import { useRouter } from "next/router";
 
-const defaultVersion =
-  process.env.NODE_ENV === "production"
-    ? ALL_VERSIONS[ALL_VERSIONS.length - 1]
-    : "master";
 export const latestVersion = ALL_VERSIONS[ALL_VERSIONS.length - 1];
+
+let defaultVersion = latestVersion;
+if (process.env.NEXT_PUBLIC_VERCEL_ENV !== "production") {
+  // We use NEXT_PUBLIC_VERCEL_ENV to default Vercel previews to master because
+  // * NEXT_PUBLIC_VERCEL_ENV is exposed to the browser
+  // * Vercel previews have NODE_ENV === "production"
+  defaultVersion = "master";
+} else if (process.env.NODE_ENV !== "production") {
+  defaultVersion = "master";
+}
 
 export function normalizeVersionPath(
   asPath: string,


### PR DESCRIPTION
### Summary & Motivation
make vercel previews default to the master branch

### How I Tested These Changes
preview defaults to the master branch