### PR TITLE
[dagit] Change compute log op when selecting in Gantt

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/Run.tsx
+++ b/js_modules/dagit/packages/core/src/runs/Run.tsx
@@ -239,6 +239,9 @@ const RunWithData: React.FC<RunWithDataProps> = ({
       } else {
         // select the step otherwise
         newSelected = [filterForExactStep];
+
+        // When only one step is selected, set the compute log key as well.
+        setComputeLogKey(stepKey);
       }
     }
 


### PR DESCRIPTION
### Summary & Motivation

When selecting a single op in the Gantt chart, go ahead and update the compute log filter as well.

### How I Tested These Changes

View a Run, click on an op. Verify that the compute log op selection changes accordingly.
