### PR TITLE
docs: when gh discussion dont use Link and open in a new tab

### DIFF
--- a/docs/next/components/Search.tsx
+++ b/docs/next/components/Search.tsx
@@ -10,6 +10,14 @@ const ACTION_KEY_DEFAULT = ["Ctrl ", "Control"];
 const ACTION_KEY_APPLE = ["⌘", "Command"];
 
 function Hit({ hit, children }) {
+  if (hit.url.startsWith("https://github.com/dagster-io/dagster/discussions")) {
+    // don't need to use Link and open in a new tab, because this is an external link
+    return (
+      <a target="_blank" href={hit.url} rel="noopener noreferrer">
+        {children}
+      </a>
+    );
+  }
   return (
     <Link href={hit.url}>
       <a>{children}</a>


### PR DESCRIPTION
### Summary & Motivation
When clicking on a github discussion in the search result, it opens a new tab, so the docs is still open on the tab they were in.

### How I Tested These Changes
https://user-images.githubusercontent.com/4531914/173751394-8896159a-0f6a-4dd0-ad9f-92c4143f4f70.mov
