### PR TITLE
[docs] - Add redirect for old Jobs page

### DIFF
--- a/docs/next/util/redirectUrls.json
+++ b/docs/next/util/redirectUrls.json
@@ -540,6 +540,11 @@
     "permanent": true
   },
   {
+    "source": "/concepts/ops-jobs-graphs/jobs-graphs",
+    "destination": "/concepts/ops-jobs-graphs/jobs",
+    "permanent": true
+  },
+  {
     "source": "/concepts/solids-pipelines/pipeline-execution",
     "destination": "/concepts/ops-jobs-graphs/job-execution",
     "permanent": true


### PR DESCRIPTION
### Summary & Motivation

This PR adds a redirect for `/concepts/ops-jobs-graphs/jobs-graphs`, which was missed in #8035 