### PR TITLE
Fix deserialization of RunsFilter

### DIFF
--- a/python_modules/dagster/dagster/core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/core/storage/pipeline_run.py
@@ -1,6 +1,7 @@
 import warnings
 from datetime import datetime
 from enum import Enum
+from inspect import Parameter
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -528,6 +529,23 @@ class RunsFilterSerializer(DefaultNamedTupleSerializer):
         # For backcompat, we store:
         # job_name as pipeline_name
         return replace_storage_keys(storage, {"job_name": "pipeline_name"})
+
+    @classmethod
+    def value_from_storage_dict(
+        cls,
+        storage_dict: Dict[str, Any],
+        klass: Type,
+        args_for_class: Mapping[str, Parameter],
+        whitelist_map: WhitelistMap,
+        descent_path: str,
+    ) -> NamedTuple:
+        # We store empty run ids as [] but only accept None
+        if "run_ids" in storage_dict and storage_dict["run_ids"] == []:
+            storage_dict["run_ids"] = None
+
+        return super().value_from_storage_dict(
+            storage_dict, klass, args_for_class, whitelist_map, descent_path
+        )
 
 
 @whitelist_for_serdes(serializer=RunsFilterSerializer)

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_pipeline_run.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_pipeline_run.py
@@ -23,6 +23,7 @@ from dagster.core.storage.pipeline_run import (
     RunsFilter,
 )
 from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
+from dagster.serdes import deserialize_as, serialize_dagster_namedtuple
 
 
 def test_queued_pipeline_origin_check():
@@ -83,3 +84,7 @@ def test_runs_filter_supports_nonempty_run_ids():
 
     with pytest.raises(CheckError):
         RunsFilter(run_ids=[])
+
+
+def test_serialize_runs_filter():
+    deserialize_as(serialize_dagster_namedtuple(RunsFilter()), RunsFilter)


### PR DESCRIPTION
A side effect of https://github.com/dagster-io/dagster/pull/7217 is that you can't serialize and deserialize runsfilters. I'm not sure where else we do that but I ran in to it for bulk action stuff

Is there a better way to hack this?