### PR TITLE
[ui] Ensure JoinedButtons works with nested Buttons

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/Button.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Button.stories.tsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 import {Button, JoinedButtons} from './Button';
 import {Group} from './Group';
 import {Icon} from './Icon';
+import {Menu, MenuItem} from './Menu';
+import {Popover} from './Popover';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -132,7 +134,18 @@ export const Joined = () => {
     <Group direction="column" spacing={8}>
       <JoinedButtons>
         <Button>Main Action</Button>
-        <Button icon={<Icon name="expand_more" />}></Button>
+        <Popover
+          position="bottom-left"
+          content={
+            <Menu>
+              <MenuItem icon="layers" text="Act fast" />
+              <MenuItem icon="history" text="Act slow" />
+              <MenuItem icon="delete" intent="danger" text="Delete it all" />
+            </Menu>
+          }
+        >
+          <Button icon={<Icon name="expand_more" />}></Button>
+        </Popover>
       </JoinedButtons>
       <JoinedButtons>
         <Button>Left</Button>

--- a/js_modules/dagit/packages/ui/src/components/Button.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Button.tsx
@@ -127,11 +127,13 @@ export const JoinedButtons = styled.div`
   display: flex;
   align-items: center;
 
-  ${StyledButton}:not(:last-child) {
+  ${StyledButton}:not(:last-child),
+  & > *:not(:last-child) ${StyledButton} {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
-  ${StyledButton}:not(:first-child) {
+  ${StyledButton}:not(:first-child),
+  & > *:not(:first-child) ${StyledButton} {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
     margin-left: 1px;


### PR DESCRIPTION
## Summary

Small CSS change to ensure that `JoinedButtons` works with nested Buttons, e.g. wrapping a Button in a popover:

```
      <JoinedButtons>
        <Button>Main Action</Button>
        <Popover
          position="bottom-left"
          content={
            <Menu>
              <MenuItem icon="layers" text="Act fast" />
              <MenuItem icon="history" text="Act slow" />
              <MenuItem icon="delete" intent="danger" text="Delete it all" />
            </Menu>
          }
        >
          <Button icon={<Icon name="expand_more" />}></Button>
        </Popover>
      </JoinedButtons>

```	

