### PR TITLE
Update runtime type checks in resource definition invocation

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_definition.py
@@ -194,7 +194,7 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources):
         )
 
     def __call__(self, *args, **kwargs):
-        from dagster.core.execution.resources_init import InitResourceContext
+        from dagster.core.execution.context.init import UnboundInitResourceContext
 
         context_provided = is_context_provided(self.resource_fn)
 
@@ -213,18 +213,22 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources):
             context_param_name = get_function_params(self.resource_fn)[0].name
 
             if args:
-                check.opt_inst_param(args[0], context_param_name, InitResourceContext)
-                return resource_invocation_result(self, args[0])
+                check.opt_inst_param(args[0], context_param_name, UnboundInitResourceContext)
+                return resource_invocation_result(
+                    self, cast(Optional[UnboundInitResourceContext], args[0])
+                )
             else:
                 if context_param_name not in kwargs:
                     raise DagsterInvalidInvocationError(
                         f"Resource initialization expected argument '{context_param_name}'."
                     )
                 check.opt_inst_param(
-                    kwargs[context_param_name], context_param_name, InitResourceContext
+                    kwargs[context_param_name], context_param_name, UnboundInitResourceContext
                 )
 
-                return resource_invocation_result(self, kwargs[context_param_name])
+                return resource_invocation_result(
+                    self, cast(Optional[UnboundInitResourceContext], kwargs[context_param_name])
+                )
         else:
             return resource_invocation_result(self, None)
 

--- a/python_modules/dagster/dagster/core/definitions/resource_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_invocation.py
@@ -16,7 +16,11 @@ if TYPE_CHECKING:
 def resource_invocation_result(
     resource_def: "ResourceDefinition", init_context: Optional["UnboundInitResourceContext"]
 ) -> Any:
-    from .resource_definition import is_context_provided
+    from ..execution.context.init import UnboundInitResourceContext
+    from .resource_definition import ResourceDefinition, is_context_provided
+
+    check.inst_param(resource_def, "resource_def", ResourceDefinition)
+    check.opt_inst_param(init_context, "init_context", UnboundInitResourceContext)
 
     if not resource_def.resource_fn:
         return None


### PR DESCRIPTION
Summary:
Right now the callsite here allows a bound resource context but then fails when it gets to the interior that only allows an unbound one. Update the runtime type checks and throw some mypy checks in there too.

Test Plan: Run a pipeline that was relying on direct resource invocation within another resource, it now fails earlier

### Summary & Motivation

### How I Tested These Changes
