### PR TITLE
Add run_request_for_partition to UnresolvedAssetJobDefinition

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -4,24 +4,38 @@ import pytest
 
 from dagster import (
     AssetKey,
+    AssetOut,
     AssetsDefinition,
     DagsterInvalidDefinitionError,
     DependencyDefinition,
     Field,
+    GraphIn,
+    GraphOut,
     IOManager,
+    In,
+    Out,
+    Output,
     ResourceDefinition,
+    StaticPartitionsDefinition,
     graph,
     io_manager,
+    multi_asset,
     op,
+    resource,
 )
 from dagster.config.source import StringSource
 from dagster.core.asset_defs import AssetIn, SourceAsset, asset, build_assets_job
-from dagster.core.definitions.output import GraphOut, Out
+from dagster.core.asset_defs.asset_group import AssetGroup
+from dagster.core.definitions.dependency import NodeHandle
+from dagster.core.definitions.executor_definition import in_process_executor
+from dagster.core.errors import DagsterInvalidSubsetError, DagsterInvariantViolationError
+from dagster.core.execution.api import execute_pipeline
 from dagster.core.snap import DependencyStructureIndex
 from dagster.core.snap.dep_snapshot import (
     OutputHandleSnap,
     build_dep_structure_snapshot_from_icontains_solids,
 )
+from dagster.core.test_utils import instance_for_test
 from dagster.utils import safe_tempfile_path
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -3,40 +3,25 @@ import os
 import pytest
 
 from dagster import (
-    AssetGroup,
     AssetKey,
-    AssetOut,
     AssetsDefinition,
     DagsterInvalidDefinitionError,
-    DagsterInvariantViolationError,
     DependencyDefinition,
     Field,
-    GraphIn,
-    GraphOut,
     IOManager,
-    In,
-    Out,
-    Output,
     ResourceDefinition,
-    StaticPartitionsDefinition,
-    execute_pipeline,
     graph,
-    in_process_executor,
     io_manager,
-    multi_asset,
     op,
-    resource,
 )
 from dagster.config.source import StringSource
 from dagster.core.asset_defs import AssetIn, SourceAsset, asset, build_assets_job
-from dagster.core.definitions.dependency import NodeHandle
-from dagster.core.errors import DagsterInvalidSubsetError
+from dagster.core.definitions.output import GraphOut, Out
 from dagster.core.snap import DependencyStructureIndex
 from dagster.core.snap.dep_snapshot import (
     OutputHandleSnap,
     build_dep_structure_snapshot_from_icontains_solids,
 )
-from dagster.core.test_utils import instance_for_test
 from dagster.utils import safe_tempfile_path
 
 


### PR DESCRIPTION
### Summary & Motivation

- Adds `run_request_for_partition` to `AssetJobDefinition`. Cut-and-pasted from `JobDefinition`. Seems less than ideal-- I think `JobDefinition` and `UnresolvedAssetsJobDefinition` should have a common ancestor, but I'm not sure what exactly should go in there.

### How I Tested These Changes

Added a new unit test.
