### PR TITLE
[dagit] Send YAML insead of parsed JSON

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -13,7 +13,6 @@ import {
 import reject from 'lodash/reject';
 import React from 'react';
 import {useHistory} from 'react-router-dom';
-import * as yaml from 'yaml';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
@@ -194,7 +193,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
       }
 
       const tags = [...partition.tagsOrError.results];
-      const runConfigData = yaml.parse(partition.runConfigOrError.yaml || '') || {};
+      const runConfigData = partition.runConfigOrError.yaml || '';
 
       const result = await launchWithTelemetry(
         {

--- a/js_modules/dagit/packages/core/src/configeditor/ConfigEditorUtils.tsx
+++ b/js_modules/dagit/packages/core/src/configeditor/ConfigEditorUtils.tsx
@@ -1,5 +1,6 @@
 import {gql} from '@apollo/client';
 import {YamlModeValidationResult} from '@dagster-io/ui';
+import yaml from 'yaml';
 
 import {ConfigEditorValidationFragment} from './types/ConfigEditorValidationFragment';
 
@@ -108,7 +109,7 @@ export function errorStackToYamlPath(entries: StackEntry[]) {
 }
 
 export function responseToYamlValidationResult(
-  configJSON: Record<string, unknown>,
+  configYaml: string,
   response: ConfigEditorValidationFragment,
 ): YamlModeValidationResult {
   if (response.__typename !== 'RunConfigValidationInvalid') {
@@ -124,7 +125,8 @@ export function responseToYamlValidationResult(
   // Errors at the top level have no stack path because they are not within any
   // dicts. To avoid highlighting the entire editor, associate them with the first
   // element of the top dict.
-  const topLevelKey = Object.keys(configJSON);
+  const parsed = yaml.parse(configYaml);
+  const topLevelKey = Object.keys(parsed);
   errors.forEach((error) => {
     if (error.path.length === 0 && topLevelKey.length) {
       error.path = [topLevelKey[0]];

--- a/js_modules/dagit/packages/core/src/instance/types/RunReExecutionQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/RunReExecutionQuery.ts
@@ -91,7 +91,7 @@ export interface RunReExecutionQuery_pipelineRunOrError_Run_stepStats {
 export interface RunReExecutionQuery_pipelineRunOrError_Run {
   __typename: "Run";
   id: string;
-  runConfig: any;
+  runConfigYaml: string;
   runId: string;
   canTerminate: boolean;
   status: RunStatus;

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
@@ -14,7 +14,6 @@ import {
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {useHistory} from 'react-router-dom';
-import * as yaml from 'yaml';
 
 import {AppContext} from '../app/AppContext';
 import {SharedToaster} from '../app/DomUtils';
@@ -136,10 +135,9 @@ export const RunActionsMenu: React.FC<{
                   icon="refresh"
                   onClick={async () => {
                     if (repoMatch && runConfigYaml) {
-                      const runConfig = yaml.parse(runConfigYaml);
                       const result = await reexecute({
                         variables: getReexecutionVariables({
-                          run: {...run, runConfig},
+                          run: {...run, runConfigYaml},
                           style: {type: 'all'},
                           repositoryLocationName: repoMatch.match.repositoryLocation.name,
                           repositoryName: repoMatch.match.repository.name,

--- a/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
@@ -16,7 +16,6 @@ import {
   StyledReadOnlyCodeMirror,
 } from '@dagster-io/ui';
 import * as React from 'react';
-import * as yaml from 'yaml';
 
 import {AppContext} from '../app/AppContext';
 import {SharedToaster} from '../app/DomUtils';
@@ -123,7 +122,7 @@ export const RunDetails: React.FC<{
 export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({run, isJob}) => {
   const [showDialog, setShowDialog] = React.useState(false);
   const {rootServerURI} = React.useContext(AppContext);
-  const runConfigYaml = yaml.stringify(run.runConfig) || '';
+  const {runConfigYaml} = run;
   const copy = useCopyToClipboard();
 
   const copyConfig = () => {

--- a/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
@@ -24,7 +24,7 @@ export const RunFragments = {
   RunFragment: gql`
     fragment RunFragment on Run {
       id
-      runConfig
+      runConfigYaml
       runId
       canTerminate
       status

--- a/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
@@ -159,7 +159,7 @@ export type ReExecutionStyle =
   | {type: 'selection'; selection: StepSelection};
 
 export function getReexecutionVariables(input: {
-  run: (RunFragment | RunTableRunFragment) & {runConfig: any};
+  run: (RunFragment | RunTableRunFragment) & {runConfigYaml: string};
   style: ReExecutionStyle;
   repositoryLocationName: string;
   repositoryName: string;
@@ -172,7 +172,7 @@ export function getReexecutionVariables(input: {
 
   const executionParams: ExecutionParams = {
     mode: run.mode,
-    runConfigData: run.runConfig,
+    runConfigData: run.runConfigYaml,
     executionMetadata: getBaseExecutionMetadata(run),
     selector: {
       repositoryLocationName,

--- a/js_modules/dagit/packages/core/src/runs/types/RunActionButtonsTestQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunActionButtonsTestQuery.ts
@@ -91,7 +91,7 @@ export interface RunActionButtonsTestQuery_pipelineRunOrError_Run_stepStats {
 export interface RunActionButtonsTestQuery_pipelineRunOrError_Run {
   __typename: "Run";
   id: string;
-  runConfig: any;
+  runConfigYaml: string;
   runId: string;
   canTerminate: boolean;
   status: RunStatus;

--- a/js_modules/dagit/packages/core/src/runs/types/RunFragment.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunFragment.ts
@@ -87,7 +87,7 @@ export interface RunFragment_stepStats {
 export interface RunFragment {
   __typename: "Run";
   id: string;
-  runConfig: any;
+  runConfigYaml: string;
   runId: string;
   canTerminate: boolean;
   status: RunStatus;

--- a/js_modules/dagit/packages/core/src/runs/types/RunRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunRootQuery.ts
@@ -91,7 +91,7 @@ export interface RunRootQuery_pipelineRunOrError_Run_stepStats {
 export interface RunRootQuery_pipelineRunOrError_Run {
   __typename: "Run";
   id: string;
-  runConfig: any;
+  runConfigYaml: string;
   runId: string;
   canTerminate: boolean;
   status: RunStatus;

--- a/js_modules/dagit/packages/ui/src/components/configeditor/codemirror-yaml/mode.tsx
+++ b/js_modules/dagit/packages/ui/src/components/configeditor/codemirror-yaml/mode.tsx
@@ -709,9 +709,7 @@ export type YamlModeValidationResult =
       errors: YamlModeValidationError[];
     };
 
-export type YamlModeValidateFunction = (
-  configJSON: Record<string, unknown>,
-) => Promise<YamlModeValidationResult>;
+export type YamlModeValidateFunction = (configYaml: string) => Promise<YamlModeValidationResult>;
 
 export type YamlModeValidationError = {
   message: string;
@@ -793,8 +791,7 @@ CodeMirror.registerHelper(
     }
 
     if (yamlDoc.errors.length === 0) {
-      const json = yamlDoc.toJSON() || {};
-      const validationResult = await checkConfig(json);
+      const validationResult = await checkConfig(text);
       if (!validationResult.isValid) {
         validationResult.errors.forEach((error) => {
           const lint = validationErrorToCodemirrorError(error, yamlDoc, codeMirrorDoc);


### PR DESCRIPTION
### Summary & Motivation

Depends on https://github.com/dagster-io/dagster/pull/8436.

When submitting run config for validation or launch, just send yaml instead of parsing it into an object first. This will allow us to handle yaml syntax properly, instead of incorrectly converting certain values (e.g. `.NAN`, strings that are numeric values).

### How I Tested These Changes

View Launchpad.

- Add some invalid yaml, verify correct linting behavior.
- Inspect validation query variables, verify that we're sending a yaml string instead of a JS object.
- Add a `.NAN`, verify that it is sent and parsed correctly -- if used in a place where a string should be, there is an error saying that it shouldn't be a float value
- Launch a run, verify that yaml string is sent and handled properly.
