### PR TITLE
[dagster-io/ui] Add canShow to Tooltip

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/Tooltip.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Tooltip.stories.tsx
@@ -1,6 +1,9 @@
 import {Meta} from '@storybook/react/types-6-0';
 import * as React from 'react';
 
+import {Box} from './Box';
+import {Button} from './Button';
+import {Checkbox} from './Checkbox';
 import {Colors} from './Colors';
 import {CustomTooltipProvider} from './CustomTooltipProvider';
 import {Group} from './Group';
@@ -111,5 +114,24 @@ export const Default = () => {
         fetch_from_redshift…
       </span>
     </Group>
+  );
+};
+
+export const CanShow = () => {
+  const [disabled, setDisabled] = React.useState(true);
+  return (
+    <Box flex={{direction: 'column', alignItems: 'flex-start', gap: 12}}>
+      <Checkbox
+        format="switch"
+        checked={disabled}
+        onChange={() => setDisabled((current) => !current)}
+        label="Disable button and show tooltip?"
+      />
+      <Tooltip content="I am a disabled button!" canShow={disabled}>
+        <Button disabled={disabled}>
+          {disabled ? 'Disabled button with tooltip' : 'Enabled button'}
+        </Button>
+      </Tooltip>
+    </Box>
   );
 };

--- a/js_modules/dagit/packages/ui/src/components/Tooltip.test.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Tooltip.test.tsx
@@ -1,0 +1,33 @@
+import {render, screen} from '@testing-library/react';
+import * as React from 'react';
+
+import {Button} from './Button';
+import {Tooltip} from './Tooltip';
+
+describe('Tooltip', () => {
+  it('renders with a tooltip wrapper if `canShow` is true', async () => {
+    render(
+      <Tooltip canShow content="Hello world">
+        <Button>Lorem</Button>
+      </Tooltip>,
+    );
+
+    const wrapper = document.getElementsByClassName('bp3-popover2-target');
+    expect(wrapper.length).toBe(1);
+    const button = screen.queryByRole('button', {name: /lorem/i});
+    expect(wrapper[0]!.contains(button));
+  });
+
+  it('does not render with a tooltip wrapper if `canShow` is false', async () => {
+    render(
+      <Tooltip canShow={false} content="Hello world">
+        <Button>Lorem</Button>
+      </Tooltip>,
+    );
+
+    const wrapper = document.getElementsByClassName('bp3-popover2-target');
+    expect(wrapper.length).toBe(0);
+    const button = screen.queryByRole('button', {name: /lorem/i});
+    expect(button).toBeVisible();
+  });
+});

--- a/js_modules/dagit/packages/ui/src/components/Tooltip.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Tooltip.tsx
@@ -27,21 +27,32 @@ const overwriteMerge = (destination: any[], source: any[]) => source;
 
 interface Props extends Tooltip2Props {
   display?: React.CSSProperties['display'];
+  canShow?: boolean;
 }
 
-export const Tooltip: React.FC<Props> = (props) => (
-  <StyledTooltip
-    {...props}
-    minimal
-    $display={props.display}
-    popoverClassName={`dagit-tooltip ${props.popoverClassName}`}
-    modifiers={deepmerge(
-      {offset: {enabled: true, options: {offset: [0, 8]}}},
-      props.modifiers || {},
-      {arrayMerge: overwriteMerge},
-    )}
-  />
-);
+export const Tooltip: React.FC<Props> = (props) => {
+  const {children, display, canShow = true, ...rest} = props;
+
+  if (!canShow) {
+    return <>{children}</>;
+  }
+
+  return (
+    <StyledTooltip
+      {...rest}
+      minimal
+      $display={display}
+      popoverClassName={`dagit-tooltip ${props.popoverClassName}`}
+      modifiers={deepmerge(
+        {offset: {enabled: true, options: {offset: [0, 8]}}},
+        props.modifiers || {},
+        {arrayMerge: overwriteMerge},
+      )}
+    >
+      {children}
+    </StyledTooltip>
+  );
+};
 
 interface StyledTooltipProps {
   $display: React.CSSProperties['display'];


### PR DESCRIPTION
### Summary & Motivation

We have a common issue in Dagit where we sometimes want to show a disabled control (e.g. a `Button`) with some information in a tooltip, for instance to indicate why the button is disabled.

Toggling tooltip-ness on an element isn't exactly supported behavior on the Blueprint tooltip component, however. If you leave the tooltip content empty, a warning appears. If you force `isOpen` to be undefined or false, it's kind of a weird hack.

This PR aims to resolve this with `MaybeTooltip`, which uses a `hasTooltip` prop to determine whether to render a tooltip wrapper on a given child component. If false, just render the child. If true, render the tooltip with the supplied props.

In this way, we can toggle tooltip-ness on `hasTooltip`, and not need to worry about sidestepping the `Tooltip` component API, rendering unwanted wrapper nodes, or triggering React warnings.

### How I Tested These Changes

Storybook example, Jest.
