### PR TITLE
add types-proto pin

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -132,7 +132,7 @@ if __name__ == "__main__":
                 "types-mock",  # version will be resolved against mock
                 "types-paramiko",  # version will be resolved against paramiko
                 "types-pkg-resources",  # version will be resolved against setuptools (contains pkg_resources)
-                "types-protobuf",  # version will be resolved against protobuf
+                "types-protobuf<=3.19.21",  # version will be resolved against protobuf (3.19.22 introduced breaking change)
                 "types-pyOpenSSL",  # version will be resolved against pyOpenSSL
                 "types-python-dateutil",  # version will be resolved against python-dateutil
                 "types-PyYAML",  # version will be resolved against PyYAML


### PR DESCRIPTION
Summary:
The new release launched a few hours ago seems to be incompatible with our current version of protobuf:

[2022-06-16T16:58:07Z] dagster/grpc/__generated__/api_pb2.py:33: error: Unexpected keyword argument "filename" for "Descriptor"  [call-arg]
[2022-06-16T16:58:07Z] .tox/mypy/lib/python3.9/site-packages/google-stubs/protobuf/descriptor.pyi:33: note: "Descriptor" defined here
[2022-06-16T16:58:07Z] dagster/grpc/__generated__/api_pb2.py:33: error: Unexpected keyword argument "create_key" for "Descriptor"  [call-arg]
[2022-06-16T16:58:07Z] .tox/mypy/lib/python3.9/site-packages/google-stubs/protobuf/descriptor.pyi:33: note: "Descriptor" defined here
[2022-06-16T16:58:07Z] dagster/grpc/__generated__/api_pb2.py:33: error: Unexpected keyword argument "fields" for "Descriptor"  [call-arg]
[2022-06-16T16:58:07Z] .tox/mypy/lib/python3.9/site-packages/google-stubs/protobuf/descriptor.pyi:33: note: "Descriptor" defined here
[2022-06-16T16:58:07Z] dagster/grpc/__generated__/api_pb2.py:33: error: Unexpected keyword argument "extensions" for "Descriptor"  [call-arg]

### Summary & Motivation

### How I Tested These Changes
