### PR TITLE
[dagit] Repair loading state on Instance Overview

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -102,7 +102,7 @@ export const InstanceOverviewPage = () => {
     fetchPolicy: 'network-only',
     notifyOnNetworkStatusChange: true,
   });
-  const {data: lastTenRunsData, loading: lastTenRunsLoading} = queryResultLastRuns;
+  const {data: lastTenRunsData} = queryResultLastRuns;
 
   const refreshState = useMergedRefresh(
     useQueryRefreshAtInterval(queryResultLastRuns, FIFTEEN_SECONDS),
@@ -129,7 +129,7 @@ export const InstanceOverviewPage = () => {
       return a.job.name.toLocaleLowerCase().localeCompare(b.job.name.toLocaleLowerCase());
     };
 
-    if (!loading && data?.workspaceOrError.__typename === 'Workspace') {
+    if (data && Object.keys(data).length && data?.workspaceOrError.__typename === 'Workspace') {
       for (const locationEntry of data.workspaceOrError.locationEntries) {
         if (
           locationEntry.__typename === 'WorkspaceLocationEntry' &&
@@ -182,7 +182,7 @@ export const InstanceOverviewPage = () => {
     neverRan.sort(sortFn);
 
     return {failed, inProgress, queued, succeeded, neverRan};
-  }, [data, loading]);
+  }, [data]);
 
   const filteredJobs = React.useMemo(() => {
     const searchToLower = searchValue.toLocaleLowerCase();
@@ -206,7 +206,7 @@ export const InstanceOverviewPage = () => {
   }, [bucketed, visibleRepos, searchValue]);
 
   const lastTenRunsFlattened = React.useMemo(() => {
-    if (lastTenRunsLoading || !lastTenRunsData) {
+    if (!lastTenRunsData || Object.keys(lastTenRunsData).length === 0) {
       return null;
     }
 
@@ -231,7 +231,7 @@ export const InstanceOverviewPage = () => {
     }
 
     return flattened;
-  }, [lastTenRunsData, lastTenRunsLoading]);
+  }, [lastTenRunsData]);
 
   const filteredJobsFlattened: JobItem[] = React.useMemo(() => {
     return Object.values(filteredJobs).reduce((accum, jobList) => {
@@ -257,7 +257,7 @@ export const InstanceOverviewPage = () => {
     };
   }, [lastTenRunsFlattened, filteredJobs]);
 
-  if (!data && loading) {
+  if (!data || Object.keys(data).length === 0) {
     return (
       <>
         <PageHeader


### PR DESCRIPTION
### Summary & Motivation

There is currently a bug in Instance Overview where the loading state clears the entire page briefly. This is because we're now checking the `loading` values on the queries to avoid the weird Apollo caching bug where reloading a repo puts us in an invalid cached state that leads to a JS error.

To resolve this, check `Object.keys()` on the query data to ensure that we're not looking at empty objects. We really shouldn't have to do this, and it may be fixed in more recent versions of Apollo, but it does the trick here.

### How I Tested These Changes

View Instance Overview.

- Refresh data, verify that there is no flash of a blank screen.
- Reload a repo, verify that it works correctly, with no JS errors.
