### PR TITLE
[dagit] “Canvas” dots on the DAGs 🎨

### DIFF
--- a/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
@@ -14,7 +14,6 @@ export interface SVGViewportInteractor {
 interface SVGViewportProps {
   graphWidth: number;
   graphHeight: number;
-  backgroundColor?: string;
   interactor: SVGViewportInteractor;
   maxZoom: number;
   maxAutocenterZoom: number;
@@ -440,13 +439,17 @@ export class SVGViewport extends React.Component<SVGViewportProps, SVGViewportSt
   };
 
   render() {
-    const {children, onClick, interactor, backgroundColor} = this.props;
+    const {children, onClick, interactor} = this.props;
     const {x, y, scale} = this.state;
+    const dotsize = Math.max(14, 30 * scale);
 
     return (
       <div
         ref={this.element}
-        style={Object.assign({backgroundColor}, SVGViewportStyles)}
+        style={Object.assign({}, SVGViewportStyles, {
+          backgroundPosition: `${x}px ${y}px`,
+          backgroundSize: `${dotsize}px`,
+        })}
         onMouseDown={(e) => interactor.onMouseDown(this, e)}
         onDoubleClick={this.onDoubleClick}
         onKeyDown={this.onKeyDown}
@@ -478,6 +481,7 @@ const SVGViewportStyles: React.CSSProperties = {
   overflow: 'hidden',
   userSelect: 'none',
   outline: 'none',
+  background: `url("data:image/svg+xml;utf8,<svg width='30px' height='30px' viewBox='0 0 80 80' xmlns='http://www.w3.org/2000/svg'><circle fill='rgba(236, 236, 236, 1)' cx='5' cy='5' r='5' /></svg>") repeat`,
 };
 
 const ZoomSliderContainer = styled.div`


### PR DESCRIPTION
### Summary & Motivation

This PR brings "canvas dots" to the DAG visualizations via an SVG css background + position + scale properties.

These stick to the viewport so they get smaller as you zoom and move with the view as you pan around. Props to @braunjj for the idea, I think it makes the viz look more polished and I never would have thought to add it.

Note: We tried using Gray100 and KeylineGray for the dot color but didn't /quite/ like either of them, so this is breaking our color palette slightly. I think it's more important that the dots are visible but not distracting than that they match a color constant.

<img width="1837" alt="image" src="https://user-images.githubusercontent.com/1037212/174337343-e30550e7-9384-4ec4-95b9-9c3f0bbfd93c.png">
<img width="1837" alt="image" src="https://user-images.githubusercontent.com/1037212/174337367-63946b1b-bfb2-4128-a77e-98783fd765db.png">


### How I Tested These Changes
