### PR TITLE
[dagit] Fix UI issues around graph backed assets

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -209,7 +209,7 @@ const OpNamesDisplay = (props: {
   repoAddress: RepoAddress;
 }) => {
   const {assetNode, repoAddress} = props;
-  const {assetKey, graphName, opNames} = assetNode;
+  const {assetKey, graphName, opNames, jobNames} = assetNode;
   const opCount = opNames.length;
 
   if (!opCount) {
@@ -232,16 +232,18 @@ const OpNamesDisplay = (props: {
     );
   }
 
-  const graphPath = workspacePathFromAddress(
-    repoAddress,
-    `/graphs/${__ASSET_JOB_PREFIX}/${graphName}/`,
-  );
+  if (!jobNames.length) {
+    return null;
+  }
 
   return (
     <Box flex={{gap: 4, alignItems: 'center'}}>
       <Icon name="schema" size={16} />
       <Mono>
-        <Link to={graphPath}>{graphName}</Link> ({opCount === 1 ? '1 op' : `${opCount} ops`})
+        <Link to={workspacePathFromAddress(repoAddress, `/graphs/${jobNames[0]}/${graphName}/`)}>
+          {graphName}
+        </Link>
+        {` (${opCount === 1 ? '1 op' : `${opCount} ops`})`}
       </Mono>
     </Box>
   );

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOpContainer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOpContainer.tsx
@@ -26,7 +26,7 @@ interface SidebarOpContainerProps {
   showingSubgraph: boolean;
   parentOpHandleID?: string;
   getInvocations?: (definitionName: string) => {handleID: string}[];
-  onEnterSubgraph: (arg: OpNameOrPath) => void;
+  onEnterSubgraph?: (arg: OpNameOrPath) => void;
   onClickOp: (arg: OpNameOrPath) => void;
   repoAddress?: RepoAddress;
   isGraph: boolean;
@@ -108,7 +108,6 @@ export const SidebarOpContainer: React.FC<SidebarOpContainerProps> = ({
     repoAddress,
   );
   if (error) {
-    console.error(error);
     return (
       <Box padding={64} flex={{justifyContent: 'center'}}>
         <NonIdealState icon="error" title="GraphQL Error - see console for details" />
@@ -121,7 +120,6 @@ export const SidebarOpContainer: React.FC<SidebarOpContainerProps> = ({
   }
 
   if (!solidContainer) {
-    console.error('Could not load ops');
     return (
       <Box padding={{vertical: 16, horizontal: 24}} style={{color: Colors.Gray500}}>
         Could not load ops.

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarTabbedContainer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarTabbedContainer.tsx
@@ -80,7 +80,6 @@ export const SidebarTabbedContainer: React.FC<ISidebarTabbedContainerProps> = (p
             handleID={parentOpHandleID}
             showingSubgraph={true}
             getInvocations={getInvocations}
-            onEnterSubgraph={onEnterSubgraph}
             onClickOp={onClickOp}
             repoAddress={repoAddress}
             isGraph={isGraph}

--- a/js_modules/dagit/packages/core/src/workspace/GraphRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/GraphRoot.tsx
@@ -36,6 +36,7 @@ export const GraphRoot: React.FC<Props> = (props) => {
   // Show the name of the composite solid we are within (-1 is the selection, -2 is current parent)
   // or the name of the pipeline tweaked to look a bit more like a graph name.
   const title = path.opNames.length > 1 ? path.opNames[path.opNames.length - 2] : path.pipelineName;
+  useDocumentTitle(`Graph: ${title}`);
 
   return (
     <div style={{height: '100%', display: 'flex', flexDirection: 'column'}}>
@@ -67,8 +68,6 @@ const GraphExplorerRoot: React.FC<Props> = (props) => {
     explodeComposites: false,
     preferAssetRendering: true,
   });
-
-  useDocumentTitle(`Graph: ${explorerPath.pipelineName}`);
 
   const parentNames = explorerPath.opNames.slice(0, explorerPath.opNames.length - 1);
   const graphResult = useQuery<GraphExplorerRootQuery, GraphExplorerRootQueryVariables>(


### PR DESCRIPTION
### Summary & Motivation

This PR makes several small changes:

- When showing a link to a graph-backed SDA's graph, we pull it's actual job name rather than the job name prefix. In my testing, the generated job was __ASSET_JOB_0, not __ASSET_JOB, and the link was broken.

- I tried showing the graph in a modal but it's nice to have the sidebar, ability to go into nested composites etc, so the I made the link still take you to the graph page and:
   + Hid the breadcrumb that would allow you to reach the "root" of the hidden asset graph. At this point, the only place the asset job is exposed is in the URL.
   + Changed the page title to match the header shown on the page, which is the op name when you're within a composite op, and not the asset job name.

- I fixed a small bug where going into a composite op still showed you the "Expand graph" button in the right sidebar. When you're viewing the contents of the parent op, you shouldn't have the option to go into it a second time.

<img width="1837" alt="image" src="https://user-images.githubusercontent.com/1037212/174341912-8ae29779-4a95-473f-b757-37aeb947e8b1.png">

  
### How I Tested These Changes

I clicked around a test asset group containing a graph-backed SDA, and also changed the __ASSET_JOB prefix in Dagit (to make it think it was a normal graph with a normal composite solid) and checked that my changes didn't break the standard ops use case