### PR TITLE
[dagit] Remove code for a disabled layout feature

### DIFF
--- a/js_modules/dagit/packages/core/src/graph/layout.ts
+++ b/js_modules/dagit/packages/core/src/graph/layout.ts
@@ -90,8 +90,6 @@ export interface ILayoutOp {
   }[];
 }
 
-const MAX_PER_ROW_ENABLED = false;
-const MAX_PER_ROW = 25;
 const OP_WIDTH = 370;
 const OP_BASE_HEIGHT = 52;
 const OP_ASSETS_ROW_HEIGHT = 22;
@@ -188,81 +186,6 @@ export function layoutOpGraph(pipelineOps: ILayoutOp[], parentOp?: ILayoutOp): O
     }
     dagreNodes[opName] = node;
   });
-
-  if (MAX_PER_ROW_ENABLED) {
-    const nodesInRows: {[key: string]: dagre.Node[]} = {};
-    g.nodes().forEach(function (opName) {
-      const node = g.node(opName);
-      if (!node) {
-        return;
-      }
-      nodesInRows[`${node.y}`] = nodesInRows[`${node.y}`] || [];
-      nodesInRows[`${node.y}`].push(node);
-    });
-
-    // OK! We're going to split the nodes in long (>MAX_PER_ROW) rows into
-    // multiple rows, shift all the subsequent rows down. Note we do this
-    // repeatedly until each row has less than MAX_PER_ROW nodes. There are
-    // a few caveats to this:
-    // - We may end up making the lines betwee nodes and their children
-    //   less direct.
-    // - We may "compact" two groups of ops separated by horizontal
-    //   whitespace on the same row into the same block.
-
-    const rows = Object.keys(nodesInRows)
-      .map((a) => Number(a))
-      .sort((a, b) => a - b);
-
-    const firstRow = nodesInRows[`${rows[0]}`];
-    const firstRowCenterX = firstRow
-      ? firstRow.reduce((s, n) => s + n.x + n.width / 2, 0) / firstRow.length
-      : 0;
-
-    for (let ii = 0; ii < rows.length; ii++) {
-      const rowKey = `${rows[ii]}`;
-      const rowNodes = nodesInRows[rowKey];
-
-      const desiredCount = Math.ceil(rowNodes.length / MAX_PER_ROW);
-      if (desiredCount === 1) {
-        continue;
-      }
-
-      for (let r = 0; r < desiredCount; r++) {
-        const newRowNodes = rowNodes.slice(r * MAX_PER_ROW, (r + 1) * MAX_PER_ROW);
-        const maxHeight = Math.max(...newRowNodes.map((n) => n.height)) + OP_BASE_HEIGHT;
-        const totalWidth = newRowNodes.reduce((sum, n) => sum + n.width + OP_BASE_HEIGHT, 0);
-
-        let x = firstRowCenterX - totalWidth / 2;
-
-        // shift the nodes before the split point so they're centered nicely
-        newRowNodes.forEach((n) => {
-          n.x = x;
-          x += n.width + OP_BASE_HEIGHT;
-        });
-
-        // shift the nodes after the split point downwards
-        const shifted = rowNodes.slice((r + 1) * MAX_PER_ROW);
-        shifted.forEach((n) => (n.y += maxHeight));
-
-        // shift all nodes in the graph beneath this row down by
-        // the height of the newly inserted row.
-        const shiftedMaxHeight = Math.max(0, ...shifted.map((n) => n.height)) + OP_BASE_HEIGHT;
-
-        for (let jj = ii + 1; jj < rows.length; jj++) {
-          nodesInRows[`${rows[jj]}`].forEach((n) => (n.y += shiftedMaxHeight));
-        }
-      }
-    }
-    let minX = Number.MAX_SAFE_INTEGER;
-    Object.keys(dagreNodes).forEach((opName) => {
-      const node = dagreNodes[opName];
-      minX = Math.min(minX, node.x - node.width / 2 - marginx);
-    });
-    Object.keys(dagreNodes).forEach((opName) => {
-      const node = dagreNodes[opName];
-      node.x -= minX;
-    });
-  }
 
   // Due to a bug in Dagre when run without an "align" value, we need to calculate
   // the total width of the graph coordinate space ourselves. We need the height


### PR DESCRIPTION
### Summary & Motivation

This was an option we built to forcibly wrap dagre layouts that got too wide. I think it's been disabled for a long time due to performance impacts and we probably won't bring it back.

### How I Tested These Changes
