### PR TITLE
[dagit] Collapsed DAG rendering of multiple edges between the same ops

### DIFF
--- a/js_modules/dagit/packages/core/src/graph/OpEdges.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpEdges.tsx
@@ -21,9 +21,18 @@ type Path = {
 const buildSVGPaths = weakmapMemoize((edges: OpLayoutEdge[], nodes: {[name: string]: OpLayout}) =>
   edges
     .map(({from, to}) => {
-      const sourceOutput = nodes[from.opName].outputs[from.edgeName];
-      const targetInput = nodes[to.opName].inputs[to.edgeName];
+      const source = nodes[from.opName];
+      const sourceOutput =
+        source.outputs[from.edgeName] ||
+        Object.values(source.outputs).find((o) => o.collapsed.includes(from.edgeName));
+
+      const target = nodes[to.opName];
+      const targetInput =
+        target.inputs[to.edgeName] ||
+        Object.values(target.inputs).find((o) => o.collapsed.includes(to.edgeName));
+
       if (!sourceOutput || !targetInput) {
+        console.log(`Unexpected error: An input or output is not reflected in the DAG layout`);
         return null;
       }
       return {

--- a/js_modules/dagit/packages/core/src/graph/OpIOBox.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpIOBox.tsx
@@ -4,7 +4,8 @@ import styled from 'styled-components/macro';
 
 import {DEFAULT_RESULT_NAME, titleOfIO} from '../app/titleOfIO';
 
-import {Edge, isHighlighted} from './common';
+import {Edge, isHighlighted, position} from './common';
+import {OpLayoutIO} from './layout';
 import {
   OpNodeDefinitionFragment,
   OpNodeDefinitionFragment_SolidDefinition_inputDefinitions,
@@ -26,7 +27,7 @@ interface OpIOBoxProps extends OpIORenderMetadata {
   item:
     | OpNodeDefinitionFragment_SolidDefinition_inputDefinitions
     | OpNodeDefinitionFragment_SolidDefinition_outputDefinitions;
-  style: React.CSSProperties;
+  layoutInfo: OpLayoutIO | undefined;
 
   // Passed through from Solid props
   minified: boolean;
@@ -43,17 +44,20 @@ export const OpIOBox: React.FC<OpIOBoxProps> = ({
   highlightedEdges,
   colorKey,
   item,
+  layoutInfo,
   onDoubleClick,
   onHighlightEdges,
-  style,
 }) => {
+  if (!layoutInfo) {
+    return null;
+  }
   const {name, type} = item;
   const highlighted = edges.some((e) => isHighlighted(highlightedEdges, e));
 
   return (
     <OpIOContainer
       title={title}
-      style={{...style, width: 'initial'}}
+      style={{...position(layoutInfo.layout), width: 'initial'}}
       onMouseEnter={() => onHighlightEdges(edges)}
       onMouseLeave={() => onHighlightEdges([])}
       onClick={(e) => {
@@ -64,25 +68,30 @@ export const OpIOBox: React.FC<OpIOBoxProps> = ({
       $colorKey={colorKey}
       $highlighted={highlighted}
     >
-      <div>
+      {minified || !layoutInfo.label ? (
         <div className="circle" />
-        {!minified && name !== DEFAULT_RESULT_NAME && <div className="label">{name}</div>}
-        {!minified && type.displayName && <div className="type">{type.displayName}</div>}
-      </div>
+      ) : (
+        <>
+          <div className="circle" />
+          {name !== DEFAULT_RESULT_NAME && <div className="label">{name}</div>}
+          {type.displayName && <div className="type">{type.displayName}</div>}
+        </>
+      )}
+      {layoutInfo.collapsed.length > 0 && (
+        <div className="count">+ {layoutInfo.collapsed.length}</div>
+      )}
     </OpIOContainer>
   );
 };
 
 const OpIOContainer = styled.div<{$colorKey: string; $highlighted: boolean}>`
-  display: block;
-  & > div {
-    display: inline-flex;
-    align-items: center;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
-    background: ${(p) => (p.$highlighted ? 'rgba(255, 255, 255, 1)' : 'rgba(255, 255, 255, 0.75)')};
-    font-size: 12px;
-  }
+  display: inline-flex;
+  align-items: center;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+  background: ${(p) => (p.$highlighted ? 'rgba(255, 255, 255, 1)' : 'rgba(255, 255, 255, 0.75)')};
+  font-size: 12px;
+
   .circle {
     width: 14px;
     height: 14px;
@@ -107,6 +116,11 @@ const OpIOContainer = styled.div<{$colorKey: string; $highlighted: boolean}>`
     font-family: ${FontFamily.monospace};
     font-weight: 700;
     border-radius: 4px;
+  }
+  .count {
+    color: ${(p) => (p.$highlighted ? Colors.Blue500 : Colors.Gray500)};
+    font-weight: 600;
+    margin-left: -3px;
   }
 `;
 

--- a/js_modules/dagit/packages/core/src/graph/OpIOBox.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpIOBox.tsx
@@ -78,7 +78,7 @@ export const OpIOBox: React.FC<OpIOBoxProps> = ({
         </>
       )}
       {layoutInfo.collapsed.length > 0 && (
-        <div className="count">+ {layoutInfo.collapsed.length}</div>
+        <div className="collapsedCount">+ {layoutInfo.collapsed.length}</div>
       )}
     </OpIOContainer>
   );
@@ -117,10 +117,11 @@ const OpIOContainer = styled.div<{$colorKey: string; $highlighted: boolean}>`
     font-weight: 700;
     border-radius: 4px;
   }
-  .count {
+  .collapsedCount {
     color: ${(p) => (p.$highlighted ? Colors.Blue500 : Colors.Gray500)};
     font-weight: 600;
     margin-left: -3px;
+    padding-right: 4px;
   }
 `;
 

--- a/js_modules/dagit/packages/core/src/graph/OpNode.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpNode.tsx
@@ -10,7 +10,7 @@ import {AssetKey} from '../assets/types';
 import {OpIOBox, metadataForIO} from './OpIOBox';
 import {OpTags, IOpTag} from './OpTags';
 import {OpLayout} from './asyncGraphLayout';
-import {Edge, IBounds} from './common';
+import {Edge, position} from './common';
 import {OpNodeDefinitionFragment} from './types/OpNodeDefinitionFragment';
 import {OpNodeInvocationFragment} from './types/OpNodeInvocationFragment';
 
@@ -143,7 +143,7 @@ export class OpNode extends React.Component<IOpNodeProps> {
             {...metadataForIO(item, invocation)}
             key={idx}
             item={item}
-            style={{...position(layout.inputs[item.name].layout)}}
+            layoutInfo={layout.inputs[item.name]}
             colorKey="input"
           />
         ))}
@@ -154,7 +154,7 @@ export class OpNode extends React.Component<IOpNodeProps> {
             {...metadataForIO(item, invocation)}
             key={idx}
             item={item}
-            style={{...position(layout.outputs[item.name].layout)}}
+            layoutInfo={layout.outputs[item.name]}
             colorKey="output"
           />
         ))}
@@ -403,11 +403,3 @@ const NodeContainer = styled.div<{
     font-size: 12px;
   }
 `;
-
-export const position = ({x, y, width, height}: IBounds) => ({
-  left: x,
-  top: y,
-  width,
-  height,
-  position: 'absolute' as const,
-});

--- a/js_modules/dagit/packages/core/src/graph/ParentOpNode.tsx
+++ b/js_modules/dagit/packages/core/src/graph/ParentOpNode.tsx
@@ -8,7 +8,6 @@ import {OpNameOrPath} from '../ops/OpNameOrPath';
 import {ExternalConnectionNode} from './ExternalConnectionNode';
 import {MappingLine} from './MappingLine';
 import {metadataForCompositeParentIO, PARENT_IN, PARENT_OUT, OpIOBox} from './OpIOBox';
-import {position} from './OpNode';
 import {SVGLabeledRect} from './SVGComponents';
 import {OpGraphLayout} from './asyncGraphLayout';
 import {Edge} from './common';
@@ -97,66 +96,68 @@ export const ParentOpNode: React.FC<ParentOpNodeProps> = (props) => {
           />
         );
       })}
-      {op.definition.inputDefinitions.map((input, idx) => {
-        const metadata = metadataForCompositeParentIO(op.definition, input);
-        const invocationInput = op.inputs.find((i) => i.definition.name === input.name)!;
+      <foreignObject width={layout.width} height={layout.height} style={{pointerEvents: 'none'}}>
+        {op.definition.inputDefinitions.map((input, idx) => {
+          const metadata = metadataForCompositeParentIO(op.definition, input);
+          const invocationInput = op.inputs.find((i) => i.definition.name === input.name)!;
 
-        return (
-          <React.Fragment key={idx}>
-            {invocationInput.dependsOn.map((dependsOn, iidx) => (
-              <ExternalConnectionNode
+          return (
+            <React.Fragment key={idx}>
+              {invocationInput.dependsOn.map((dependsOn, iidx) => (
+                <ExternalConnectionNode
+                  {...highlightingProps}
+                  {...metadata}
+                  key={iidx}
+                  labelAttachment="top"
+                  label={titleOfIO(dependsOn)}
+                  minified={minified}
+                  layout={parentLayout.dependsOn[titleOfIO(dependsOn)]}
+                  target={parentLayout.inputs[input.name].port}
+                  onDoubleClickLabel={() => props.onClickOp({path: ['..', dependsOn.solid.name]})}
+                />
+              ))}
+              <OpIOBox
                 {...highlightingProps}
                 {...metadata}
-                key={iidx}
-                labelAttachment="top"
-                label={titleOfIO(dependsOn)}
                 minified={minified}
-                layout={parentLayout.dependsOn[titleOfIO(dependsOn)]}
-                target={parentLayout.inputs[input.name].port}
-                onDoubleClickLabel={() => props.onClickOp({path: ['..', dependsOn.solid.name]})}
+                colorKey="input"
+                item={input}
+                layoutInfo={parentLayout.inputs[input.name]}
               />
-            ))}
-            <OpIOBox
-              {...highlightingProps}
-              {...metadata}
-              minified={minified}
-              colorKey="input"
-              item={input}
-              style={position(parentLayout.inputs[input.name].layout)}
-            />
-          </React.Fragment>
-        );
-      })}
-      {op.definition.outputDefinitions.map((output, idx) => {
-        const metadata = metadataForCompositeParentIO(op.definition, output);
-        const invocationOutput = op.outputs.find((i) => i.definition.name === output.name)!;
+            </React.Fragment>
+          );
+        })}
+        {op.definition.outputDefinitions.map((output, idx) => {
+          const metadata = metadataForCompositeParentIO(op.definition, output);
+          const invocationOutput = op.outputs.find((i) => i.definition.name === output.name)!;
 
-        return (
-          <React.Fragment key={idx}>
-            {invocationOutput.dependedBy.map((dependedBy, iidx) => (
-              <ExternalConnectionNode
+          return (
+            <React.Fragment key={idx}>
+              {invocationOutput.dependedBy.map((dependedBy, iidx) => (
+                <ExternalConnectionNode
+                  {...highlightingProps}
+                  {...metadata}
+                  key={iidx}
+                  labelAttachment="bottom"
+                  label={titleOfIO(dependedBy)}
+                  minified={minified}
+                  layout={parentLayout.dependedBy[titleOfIO(dependedBy)]}
+                  target={parentLayout.outputs[output.name].port}
+                  onDoubleClickLabel={() => props.onClickOp({path: ['..', dependedBy.solid.name]})}
+                />
+              ))}
+              <OpIOBox
                 {...highlightingProps}
                 {...metadata}
-                key={iidx}
-                labelAttachment="bottom"
-                label={titleOfIO(dependedBy)}
                 minified={minified}
-                layout={parentLayout.dependedBy[titleOfIO(dependedBy)]}
-                target={parentLayout.outputs[output.name].port}
-                onDoubleClickLabel={() => props.onClickOp({path: ['..', dependedBy.solid.name]})}
+                colorKey="output"
+                item={output}
+                layoutInfo={parentLayout.outputs[output.name]}
               />
-            ))}
-            <OpIOBox
-              {...highlightingProps}
-              {...metadata}
-              minified={minified}
-              colorKey="output"
-              item={output}
-              style={position(parentLayout.outputs[output.name].layout)}
-            />
-          </React.Fragment>
-        );
-      })}
+            </React.Fragment>
+          );
+        })}
+      </foreignObject>
     </>
   );
 };

--- a/js_modules/dagit/packages/core/src/graph/common.ts
+++ b/js_modules/dagit/packages/core/src/graph/common.ts
@@ -120,3 +120,11 @@ export function computeNodeKeyPrefixBoundingBoxes(layout: OpGraphLayout) {
 
   return boxes;
 }
+
+export const position = ({x, y, width, height}: IBounds) => ({
+  left: x,
+  top: y,
+  width,
+  height,
+  position: 'absolute' as const,
+});

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/multi_inputs_outputs.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/multi_inputs_outputs.py
@@ -1,0 +1,58 @@
+from dagster import Int, Out, Output, graph, op
+
+
+@op(
+    out={"out_1": Out(Int), "out_2": Out(Int)},
+)
+def first_op(_context):
+    yield Output(1, "out_1")
+    yield Output(2, "out_2")
+
+
+@op(
+    out={
+        "out_1": Out(Int),
+        "out_2": Out(Int),
+        "out_3": Out(Int),
+        "out_4": Out(Int),
+        "out_5": Out(Int),
+    },
+)
+def child_op(_context, input_1, input_2):
+    yield Output(input_1, "out_1")
+    yield Output(input_1, "out_2")
+    yield Output(input_2, "out_3")
+    yield Output(input_2, "out_4")
+    yield Output(input_2, "out_5")
+
+
+@op(
+    out={
+        "out_1": Out(Int),
+        "out_2": Out(Int),
+        "out_3": Out(Int),
+        "out_4": Out(Int),
+        "out_5": Out(Int),
+    },
+)
+def child_op_five_inputs(_context, input_1, input_2, input_3, input_4, input_5):
+    yield Output(input_1, "out_1")
+    yield Output(input_2, "out_2")
+    yield Output(input_3, "out_3")
+    yield Output(input_4, "out_4")
+    yield Output(input_5, "out_5")
+
+
+@graph(description="Demo graph with many inputs and outputs bound to the same / different ops.")
+def multi_inputs_outputs():
+    out_1, out_2 = first_op()
+    child_op(out_1, out_2)
+    c_1, c_2, c_3, c_4, c_5 = child_op(out_1, out_2)
+    child_op(c_1, c_3)
+    d_1, d_2, d_3, d_4, d_5 = child_op(c_4, c_5)
+    child_op_five_inputs(c_1, c_2, c_3, c_4, d_1)
+    e_1, e_2, e_3, e_4, e_5 = child_op_five_inputs(d_1, d_2, d_3, d_4, d_5)
+    child_op_five_inputs(e_1, e_2, e_3, e_4, e_5)
+
+
+multi_inputs_outputs_job = multi_inputs_outputs.to_job()

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/repo.py
@@ -33,6 +33,7 @@ from dagster_test.graph_job_op_toys.long_asset_keys import long_asset_keys_group
 from dagster_test.graph_job_op_toys.longitudinal import longitudinal_job
 from dagster_test.graph_job_op_toys.many_events import many_events, many_events_subset_job
 from dagster_test.graph_job_op_toys.metadata import with_metadata
+from dagster_test.graph_job_op_toys.multi_inputs_outputs import multi_inputs_outputs_job
 from dagster_test.graph_job_op_toys.notebooks import hello_world_notebook_pipeline
 from dagster_test.graph_job_op_toys.partitioned_assets import partitioned_asset_group
 from dagster_test.graph_job_op_toys.retries import retry_job
@@ -92,6 +93,7 @@ def toys_repository():
             asset_lineage_job,
             asset_lineage_partition_set,
             model_job,
+            multi_inputs_outputs_job,
             hello_world_notebook_pipeline,
             software_defined_assets,
             with_metadata,


### PR DESCRIPTION
### Summary & Motivation

This PR aims to address the bad op DAG I/O rendering shown here:
![Screen Shot 2022-06-19 at 3 13 35 PM](https://user-images.githubusercontent.com/1037212/174501781-08156bb6-5ee1-4653-b1f1-3f90a31fb129.png)

Changes: 

- If there are too many I/Os on any given op, we switch to a "dots-only" rendering, but we weren't turning off the labels until you zoomed out. This PR fixes this so the text isn't overflowing all over in the screenshot.

- If there are multiple I/Os connecting the same two ops, we sort them to avoid the unnecessary crossed lines and also compact them into a bundle.
 
- If there are a /LOT/ of inputs and outputs and even the compact rendering causes the dots to overflow (bottom of the screenshot above), we draw them closer together.


After:

![image](https://user-images.githubusercontent.com/1037212/174501889-32eb99ec-e9cf-4941-be4d-6c38983ee1e0.png)



### How I Tested These Changes

- Tested using `elementl.dagster.cloud` example
- Tested composite op and regular op rendering to make sure good rendering cases weren't impacted