### PR TITLE
[dagit] Repair empty config case in Launchpad

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -283,7 +283,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
 
     return {
       executionParams: {
-        runConfigData: currentSession.runConfigYaml,
+        runConfigData: currentSession.runConfigYaml || {},
         selector: pipelineSelector,
         mode: currentSession.mode || 'default',
         executionMetadata: {
@@ -338,6 +338,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
     // is in flight, in which case completion of this async method should not set loading=false.
     previewCounter.current += 1;
     const currentPreviewCount = previewCounter.current;
+    const configYamlOrEmpty = configYaml || '{}';
 
     dispatch({type: 'preview-loading', payload: true});
 
@@ -345,7 +346,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
       fetchPolicy: 'no-cache',
       query: PREVIEW_CONFIG_QUERY,
       variables: {
-        runConfigData: configYaml,
+        runConfigData: configYamlOrEmpty,
         pipeline: pipelineSelector,
         mode: currentSession.mode || 'default',
       },
@@ -357,13 +358,13 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
         type: 'set-preview',
         payload: {
           preview: data,
-          previewedDocument: configYaml,
+          previewedDocument: configYamlOrEmpty,
           previewLoading: isLatestRequest ? false : state.previewLoading,
         },
       });
     }
 
-    return responseToYamlValidationResult(configYaml, data.isPipelineConfigValid);
+    return responseToYamlValidationResult(configYamlOrEmpty, data.isPipelineConfigValid);
   };
 
   const tagsApplyingNewBaseTags = (newBaseTags: PipelineRunTag[]) => {

--- a/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
@@ -386,7 +386,7 @@ export const RunPreview: React.FC<RunPreviewProps> = (props) => {
           </Section>
           <Section>
             <SectionTitle>Config actions:</SectionTitle>
-            <Box flex={{direction: 'column', gap: 8}} padding={{top: 4}}>
+            <Box flex={{direction: 'column', gap: 8}} padding={{top: 4, bottom: 20}}>
               <ScaffoldConfigButton
                 onScaffoldMissingConfig={onScaffoldMissingConfig}
                 missingNodes={missingNodes}


### PR DESCRIPTION
### Summary & Motivation

The recent change to send config yaml instead of JSON led to breakages with empty configs:

- The backend doesn't like the empty string. Send an empty object instead.
- The `responseToYamlValidationResult` function tries `yaml.parse` an empty string and evaluate the resulting `Object.keys`, leading to a JS error.

Repair these by using empty objects, as-is or stringified as needed.

### How I Tested These Changes

View a job with no config required. Verify that config is considered valid by the backend.

Launch a run, verify that the run is created successfully with the empty config.
