### PR TITLE
[docs] - Clarify points in SDA upgrade guide > direct operation section

### DIFF
--- a/docs/content/guides/dagster/enriching-with-software-defined-assets.mdx
+++ b/docs/content/guides/dagster/enriching-with-software-defined-assets.mdx
@@ -32,13 +32,12 @@ Assets help track and define cross-job dependencies. For example, when viewing a
 
 ### Direct operation
 
-Using software-defined assets enables you to directly operate them in Dagit. On the [Assets page](/concepts/dagit/dagit#assets), you can:
+Using software-defined assets enables you to directly operate them in Dagit. On the [Asset's Details page](/concepts/dagit/dagit#asset-details), you can:
 
-- View the materialization history of an asset
+- View the materialization history of the asset
 - Check when the next materialization will occur
-- Launch a run to materialize the asset
-
-Drilling down to the [Asset Details page](/concepts/dagit/dagit#asset-details) for an individual asset shows the sensors or schedules for any jobs targeting the asset. It also includes a **(Re)Materialize** button, allowing you to launch a run that rematerializes the asset, including its ancestors or descendants.
+- Launch runs that materialize or re-materialize the asset, including its ancestors or descendants
+- View the sensors or schedules for jobs targeting the asset
 
 ### Improved code ergonomics
 


### PR DESCRIPTION
### Summary & Motivation

This PR updates the **Direct operation** section of the SDA upgrade guide to clarify the available data/options for assets in a Dagit page.
