### PR TITLE
Add constant for default io manager key

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/asset_group.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_group.py
@@ -9,6 +9,7 @@ import dagster._check as check
 from dagster.core.definitions.dependency import NodeHandle
 from dagster.core.definitions.events import AssetKey, CoercibleToAssetKeyPrefix
 from dagster.core.definitions.executor_definition import in_process_executor
+from dagster.core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster.core.errors import DagsterUnmetExecutorRequirementsError
 from dagster.core.execution.execute_in_process_result import ExecuteInProcessResult
 from dagster.core.selector.subset_selector import AssetSelectionData
@@ -105,7 +106,7 @@ class AssetGroup:
         resource_defs = check.opt_mapping_param(
             resource_defs, "resource_defs", key_type=str, value_type=ResourceDefinition
         )
-        resource_defs = merge_dicts({"io_manager": fs_io_manager}, resource_defs)
+        resource_defs = merge_dicts({DEFAULT_IO_MANAGER_KEY: fs_io_manager}, resource_defs)
         executor_def = check.opt_inst_param(executor_def, "executor_def", ExecutorDefinition)
 
         check_resources_satisfy_requirements(assets, source_assets, resource_defs)

--- a/python_modules/dagster/dagster/core/asset_defs/asset_out.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_out.py
@@ -5,6 +5,7 @@ from dagster.core.definitions.events import AssetKey, CoercibleToAssetKey, Coerc
 from dagster.core.definitions.input import NoValueSentinel
 from dagster.core.definitions.metadata import MetadataUserInput
 from dagster.core.definitions.output import Out
+from dagster.core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster.core.types.dagster_type import DagsterType, resolve_dagster_type
 
 
@@ -68,7 +69,7 @@ class AssetOut(
             description=check.opt_str_param(description, "description"),
             is_required=check.bool_param(is_required, "is_required"),
             io_manager_key=check.opt_str_param(
-                io_manager_key, "io_manager_key", default="io_manager"
+                io_manager_key, "io_manager_key", default=DEFAULT_IO_MANAGER_KEY
             ),
             metadata=check.opt_dict_param(metadata, "metadata", key_type=str),
         )

--- a/python_modules/dagster/dagster/core/asset_defs/assets_job.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets_job.py
@@ -32,6 +32,7 @@ from dagster.core.definitions.output import OutputDefinition
 from dagster.core.definitions.partition import PartitionedConfig, PartitionsDefinition
 from dagster.core.definitions.resource_definition import ResourceDefinition
 from dagster.core.definitions.resource_requirement import ensure_requirements_satisfied
+from dagster.core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.selector.subset_selector import AssetSelectionData
 from dagster.utils import merge_dicts
@@ -100,7 +101,7 @@ def build_assets_job(
     partitions_def = partitions_def or build_job_partitions_from_assets(assets)
 
     resource_defs = check.opt_mapping_param(resource_defs, "resource_defs")
-    resource_defs = merge_dicts({"io_manager": default_job_io_manager}, resource_defs)
+    resource_defs = merge_dicts({DEFAULT_IO_MANAGER_KEY: default_job_io_manager}, resource_defs)
 
     source_assets_by_key = build_source_assets_by_key(source_assets)
     deps, assets_defs_by_node_handle = build_deps(assets, source_assets_by_key.keys())
@@ -366,7 +367,7 @@ def _ensure_resources_dont_conflict(
                 )
     for resource_key, resource_def in resource_defs.items():
         if (
-            resource_key != "io_manager"
+            resource_key != DEFAULT_IO_MANAGER_KEY
             and resource_key in resource_defs_from_assets
             and resource_defs_from_assets[resource_key] != resource_def
         ):

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -25,7 +25,7 @@ from dagster.core.definitions.input import In
 from dagster.core.definitions.output import Out
 from dagster.core.definitions.partition import PartitionsDefinition
 from dagster.core.definitions.resource_definition import ResourceDefinition
-from dagster.core.definitions.utils import NoValueSentinel
+from dagster.core.definitions.utils import DEFAULT_IO_MANAGER_KEY, NoValueSentinel
 from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.storage.io_manager import IOManagerDefinition
 from dagster.core.types.dagster_type import DagsterType
@@ -265,7 +265,7 @@ class _Asset:
                 io_manager_key = f"{out_asset_resource_key}__io_manager"
                 self.resource_defs[io_manager_key] = cast(ResourceDefinition, io_manager_def)
             else:
-                io_manager_key = "io_manager"
+                io_manager_key = DEFAULT_IO_MANAGER_KEY
 
             out = Out(
                 metadata=self.metadata or {},

--- a/python_modules/dagster/dagster/core/asset_defs/materialize.py
+++ b/python_modules/dagster/dagster/core/asset_defs/materialize.py
@@ -2,6 +2,7 @@ from typing import Any, Mapping, Optional, Sequence, Union
 
 import dagster._check as check
 
+from ..definitions.utils import DEFAULT_IO_MANAGER_KEY
 from ..execution.build_resources import wrap_resources_for_execution
 from ..execution.execute_in_process_result import ExecuteInProcessResult
 from ..execution.with_resources import with_resources
@@ -32,7 +33,7 @@ def materialize(
     """
 
     assets = check.sequence_param(assets, "assets", of_type=(AssetsDefinition, SourceAsset))
-    assets = with_resources(assets, {"io_manager": fs_io_manager})
+    assets = with_resources(assets, {DEFAULT_IO_MANAGER_KEY: fs_io_manager})
     assets_defs = [the_def for the_def in assets if isinstance(the_def, AssetsDefinition)]
     source_assets = [the_def for the_def in assets if isinstance(the_def, SourceAsset)]
     instance = check.opt_inst_param(instance, "instance", DagsterInstance)

--- a/python_modules/dagster/dagster/core/asset_defs/source_asset.py
+++ b/python_modules/dagster/dagster/core/asset_defs/source_asset.py
@@ -17,7 +17,11 @@ from dagster.core.definitions.resource_requirement import (
     SourceAssetIOManagerRequirement,
     get_resource_key_conflicts,
 )
-from dagster.core.definitions.utils import DEFAULT_GROUP_NAME, validate_group_name
+from dagster.core.definitions.utils import (
+    DEFAULT_GROUP_NAME,
+    DEFAULT_IO_MANAGER_KEY,
+    validate_group_name,
+)
 from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
 from dagster.core.storage.io_manager import IOManagerDefinition
 from dagster.utils import merge_dicts
@@ -102,7 +106,7 @@ class SourceAsset(
         return {entry.label: entry.entry_data for entry in self.metadata_entries}  # type: ignore
 
     def get_io_manager_key(self) -> str:
-        return self.io_manager_key or "io_manager"
+        return self.io_manager_key or DEFAULT_IO_MANAGER_KEY
 
     @property
     def io_manager_def(self) -> Optional[IOManagerDefinition]:
@@ -128,7 +132,7 @@ class SourceAsset(
         merged_resource_defs = merge_dicts(resource_defs, self.resource_defs)
 
         io_manager_def = merged_resource_defs.get(self.get_io_manager_key())
-        if not io_manager_def and self.get_io_manager_key() != "io_manager":
+        if not io_manager_def and self.get_io_manager_key() != DEFAULT_IO_MANAGER_KEY:
             raise DagsterInvalidDefinitionError(
                 f"SourceAsset with asset key {self.key} requires IO manager with key '{self.get_io_manager_key()}', but none was provided."
             )
@@ -143,7 +147,9 @@ class SourceAsset(
         }
 
         io_manager_key = (
-            self.get_io_manager_key() if self.get_io_manager_key() != "io_manager" else None
+            self.get_io_manager_key()
+            if self.get_io_manager_key() != DEFAULT_IO_MANAGER_KEY
+            else None
         )
         return SourceAsset(
             key=self.key,

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -53,6 +53,7 @@ from .output import OutputDefinition, OutputMapping
 from .preset import PresetDefinition
 from .resource_requirement import ResourceRequirement
 from .solid_container import create_execution_structure, validate_dependency_dict
+from .utils import DEFAULT_IO_MANAGER_KEY
 from .version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
@@ -576,11 +577,11 @@ class GraphDefinition(NodeDefinition):
         )
         input_values = check.opt_mapping_param(input_values, "input_values")
 
-        if resource_defs and "io_manager" in resource_defs:
+        if resource_defs and DEFAULT_IO_MANAGER_KEY in resource_defs:
             resource_defs_with_defaults = resource_defs
         else:
             resource_defs_with_defaults = merge_dicts(
-                {"io_manager": default_job_io_manager}, resource_defs or {}
+                {DEFAULT_IO_MANAGER_KEY: default_job_io_manager}, resource_defs or {}
             )
 
         hooks = check.opt_set_param(hooks, "hooks", of_type=HookDefinition)

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -56,6 +56,7 @@ from .pipeline_definition import PipelineDefinition
 from .preset import PresetDefinition
 from .resource_definition import ResourceDefinition
 from .run_request import RunRequest
+from .utils import DEFAULT_IO_MANAGER_KEY
 from .version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
@@ -501,11 +502,11 @@ def _swap_default_io_man(resources: Mapping[str, ResourceDefinition], job: Pipel
 
     if (
         # pylint: disable=comparison-with-callable
-        resources.get("io_manager") in [default_job_io_manager]
+        resources.get(DEFAULT_IO_MANAGER_KEY) in [default_job_io_manager]
         and job.version_strategy is None
     ):
         updated_resources = dict(resources)
-        updated_resources["io_manager"] = mem_io_manager
+        updated_resources[DEFAULT_IO_MANAGER_KEY] = mem_io_manager
         return updated_resources
 
     return resources

--- a/python_modules/dagster/dagster/core/definitions/mode.py
+++ b/python_modules/dagster/dagster/core/definitions/mode.py
@@ -8,7 +8,7 @@ from dagster.utils.merger import merge_dicts
 from .config import ConfigMapping
 from .logger_definition import LoggerDefinition
 from .resource_definition import ResourceDefinition
-from .utils import check_valid_name
+from .utils import DEFAULT_IO_MANAGER_KEY, check_valid_name
 
 DEFAULT_MODE_NAME = "default"
 
@@ -72,13 +72,13 @@ class ModeDefinition(
             if not key.isidentifier():
                 check.failed(f"Resource key '{key}' must be a valid Python identifier.")
 
-        if resource_defs and "io_manager" in resource_defs:
+        if resource_defs and DEFAULT_IO_MANAGER_KEY in resource_defs:
             resource_defs_with_defaults = resource_defs
         else:
             from dagster.core.storage.mem_io_manager import mem_io_manager
 
             resource_defs_with_defaults = merge_dicts(
-                {"io_manager": mem_io_manager}, resource_defs or {}
+                {DEFAULT_IO_MANAGER_KEY: mem_io_manager}, resource_defs or {}
             )
 
         return super(ModeDefinition, cls).__new__(

--- a/python_modules/dagster/dagster/core/definitions/output.py
+++ b/python_modules/dagster/dagster/core/definitions/output.py
@@ -26,7 +26,7 @@ from dagster.utils.backcompat import experimental_arg_warning
 
 from .inference import InferredOutputProps
 from .input import NoValueSentinel
-from .utils import DEFAULT_OUTPUT, check_valid_name
+from .utils import DEFAULT_IO_MANAGER_KEY, DEFAULT_OUTPUT, check_valid_name
 
 if TYPE_CHECKING:
     from dagster.core.definitions.partition import PartitionsDefinition
@@ -91,7 +91,7 @@ class OutputDefinition:
         self._io_manager_key = check.opt_str_param(
             io_manager_key,
             "io_manager_key",
-            default="io_manager",
+            default=DEFAULT_IO_MANAGER_KEY,
         )
         self._metadata = check.opt_dict_param(metadata, "metadata", key_type=str)
         self._metadata_entries = check.is_list(
@@ -424,7 +424,7 @@ class Out(
             description=description,
             is_required=check.bool_param(is_required, "is_required"),
             io_manager_key=check.opt_str_param(
-                io_manager_key, "io_manager_key", default="io_manager"
+                io_manager_key, "io_manager_key", default=DEFAULT_IO_MANAGER_KEY
             ),
             metadata=metadata,
             asset_key=asset_key,

--- a/python_modules/dagster/dagster/core/definitions/resource_requirement.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_requirement.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 from ..errors import DagsterInvalidDefinitionError
+from .utils import DEFAULT_IO_MANAGER_KEY
 
 if TYPE_CHECKING:
     from ..types.dagster_type import DagsterType
@@ -235,5 +236,5 @@ def get_resource_key_conflicts(
     other_resource_defs: Mapping[str, "ResourceDefinition"],
 ) -> AbstractSet[str]:
     overlapping_keys = set(resource_defs.keys()).intersection(set(other_resource_defs.keys()))
-    overlapping_keys = {key for key in overlapping_keys if key != "io_manager"}
+    overlapping_keys = {key for key in overlapping_keys if key != DEFAULT_IO_MANAGER_KEY}
     return overlapping_keys

--- a/python_modules/dagster/dagster/core/definitions/solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_definition.py
@@ -39,6 +39,7 @@ from .resource_requirement import (
     SolidDefinitionResourceRequirement,
 )
 from .solid_invocation import solid_invocation_result
+from .utils import DEFAULT_IO_MANAGER_KEY
 
 if TYPE_CHECKING:
     from .asset_layer import AssetLayer
@@ -481,7 +482,7 @@ def _check_io_managers_on_composite_solid(
     if output_mappings:
         for output_mapping in output_mappings:
             output_def = output_mapping.definition
-            if output_def.io_manager_key != "io_manager":
+            if output_def.io_manager_key != DEFAULT_IO_MANAGER_KEY:
                 raise DagsterInvalidDefinitionError(
                     "IO manager cannot be set on a composite solid: "
                     f'io_manager_key "{output_def.io_manager_key}" '

--- a/python_modules/dagster/dagster/core/definitions/utils.py
+++ b/python_modules/dagster/dagster/core/definitions/utils.py
@@ -16,6 +16,7 @@ from dagster.utils.yaml_utils import merge_yaml_strings, merge_yamls
 
 DEFAULT_OUTPUT = "result"
 DEFAULT_GROUP_NAME = "default"  # asset group_name used when none is provided
+DEFAULT_IO_MANAGER_KEY = "io_manager"
 
 DISALLOWED_NAMES = set(
     [

--- a/python_modules/dagster/dagster/core/execution/with_resources.py
+++ b/python_modules/dagster/dagster/core/execution/with_resources.py
@@ -6,6 +6,7 @@ from dagster.utils import merge_dicts
 from ...config import Shape
 from ..definitions import ResourceDefinition
 from ..definitions.resource_requirement import ResourceAddable
+from ..definitions.utils import DEFAULT_IO_MANAGER_KEY
 from ..errors import DagsterInvalidConfigError, DagsterInvalidInvocationError
 
 T = TypeVar("T", bound=ResourceAddable)
@@ -73,7 +74,7 @@ def with_resources(
         resource_config_by_key, "resource_config_by_key"
     )
 
-    resource_defs = merge_dicts({"io_manager": fs_io_manager}, resource_defs)
+    resource_defs = merge_dicts({DEFAULT_IO_MANAGER_KEY: fs_io_manager}, resource_defs)
 
     for key, resource_def in resource_defs.items():
         if key in resource_config_by_key:


### PR DESCRIPTION
We use the default io manager key all over the place as a plain string, which gives me major heebie jeebies. Changes to use an importable constant.

I would feel even better about being able to annotate it in docstrings using this constant as well. Was thinking maybe we could interpolate it, or better yet just reference it using sphinx machinery and export it.