### PR TITLE
Add default_logger_defs arg to repository

### DIFF
--- a/docs/content/concepts/logging/loggers.mdx
+++ b/docs/content/concepts/logging/loggers.mdx
@@ -193,6 +193,31 @@ width={2048}
 height={804}
 />
 
+### Specifying Default Loggers
+
+Default loggers can be specified on a <PyObject object="repository" decorator /> using the `default_logger_defs` argument. These loggers will be added to every job specified on the repository, and will be used for any materializatons of software-defined assets provided to the repository.
+
+Note that `default_logger_defs` are provided in addition to whatever loggers already exist on a job. For example, by default, every job has system loggers provided. Those default loggers will be used in addition to those provided by `default_logger_defs`.
+
+```python file=/concepts/logging/custom_logger.py startafter=start_default_logger_repo endbefore=end_default_logger_repo
+from dagster import repository, define_asset_job, asset
+
+
+@asset
+def some_asset():
+    ...
+
+
+the_job = define_asset_job("the_job", selection="*")
+
+
+@repository(default_logger_defs={"json_logger": json_console_logger})
+def the_repo():
+    # When loading this repository in dagit, json_logger will now be used when
+    # the_job runs, or some_asset materializes.
+    return [the_job, some_asset]
+```
+
 ### Testing Custom Loggers
 
 You can unit test the initialization method of a logger by invoking it.
@@ -211,9 +236,7 @@ from dagster import build_init_logger_context
 
 
 def test_init_json_console_logger_with_context():
-    logger_ = json_console_logger(
-        build_init_logger_context(logger_config={"name": "my_logger"})
-    )
+    logger_ = json_console_logger(build_init_logger_context(logger_config={"name": "my_logger"}))
     assert logger_.level == 20
     assert logger_.name == "my_logger"
 ```

--- a/docs/content/concepts/logging/loggers.mdx
+++ b/docs/content/concepts/logging/loggers.mdx
@@ -236,7 +236,9 @@ from dagster import build_init_logger_context
 
 
 def test_init_json_console_logger_with_context():
-    logger_ = json_console_logger(build_init_logger_context(logger_config={"name": "my_logger"}))
+    logger_ = json_console_logger(
+        build_init_logger_context(logger_config={"name": "my_logger"})
+    )
     assert logger_.level == 20
     assert logger_.name == "my_logger"
 ```

--- a/docs/content/concepts/logging/loggers.mdx
+++ b/docs/content/concepts/logging/loggers.mdx
@@ -193,11 +193,11 @@ width={2048}
 height={804}
 />
 
-### Specifying Default Loggers
+### Specifying Default Repository Loggers
 
 Default loggers can be specified on a <PyObject object="repository" decorator /> using the `default_logger_defs` argument. These loggers will be added to every job specified on the repository, and will be used for any materializatons of software-defined assets provided to the repository.
 
-Note that `default_logger_defs` are provided in addition to whatever loggers already exist on a job. For example, by default, every job has system loggers provided. Those default loggers will be used in addition to those provided by `default_logger_defs`.
+Note that if you explicitly specify loggers on a job, they will override those provided to `default_logger_defs`.
 
 ```python file=/concepts/logging/custom_logger.py startafter=start_default_logger_repo endbefore=end_default_logger_repo
 from dagster import repository, define_asset_job, asset

--- a/examples/docs_snippets/docs_snippets/concepts/logging/custom_logger.py
+++ b/examples/docs_snippets/docs_snippets/concepts/logging/custom_logger.py
@@ -61,11 +61,30 @@ from dagster import build_init_logger_context
 
 
 def test_init_json_console_logger_with_context():
-    logger_ = json_console_logger(
-        build_init_logger_context(logger_config={"name": "my_logger"})
-    )
+    logger_ = json_console_logger(build_init_logger_context(logger_config={"name": "my_logger"}))
     assert logger_.level == 20
     assert logger_.name == "my_logger"
 
 
 # end_custom_logger_testing_context
+
+# start_default_logger_repo
+from dagster import repository, define_asset_job, asset
+
+
+@asset
+def some_asset():
+    ...
+
+
+the_job = define_asset_job("the_job", selection="*")
+
+
+@repository(default_logger_defs={"json_logger": json_console_logger})
+def the_repo():
+    # When loading this repository in dagit, json_logger will now be used when
+    # the_job runs, or some_asset materializes.
+    return [the_job, some_asset]
+
+
+# end_default_logger_repo

--- a/examples/docs_snippets/docs_snippets/concepts/logging/custom_logger.py
+++ b/examples/docs_snippets/docs_snippets/concepts/logging/custom_logger.py
@@ -61,7 +61,9 @@ from dagster import build_init_logger_context
 
 
 def test_init_json_console_logger_with_context():
-    logger_ = json_console_logger(build_init_logger_context(logger_config={"name": "my_logger"}))
+    logger_ = json_console_logger(
+        build_init_logger_context(logger_config={"name": "my_logger"})
+    )
     assert logger_.level == 20
     assert logger_.name == "my_logger"
 

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/logging_tests/test_custom.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/logging_tests/test_custom.py
@@ -1,10 +1,13 @@
 import yaml
 
-from dagster.utils import file_relative_path
+from dagster.loggers import default_loggers
+from dagster.utils import file_relative_path, merge_dicts
 from docs_snippets.concepts.logging.custom_logger import (
     demo_job,
+    json_console_logger,
     test_init_json_console_logger,
     test_init_json_console_logger_with_context,
+    the_repo,
 )
 
 
@@ -24,3 +27,9 @@ def test_json_logger():
 def test_testing_examples():
     test_init_json_console_logger()
     test_init_json_console_logger_with_context()
+
+
+def test_default_logger_repo_example():
+    assert the_repo.get_job("the_job").loggers == merge_dicts(
+        {"json_logger": json_console_logger}, default_loggers()
+    )

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/logging_tests/test_custom.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/logging_tests/test_custom.py
@@ -30,6 +30,4 @@ def test_testing_examples():
 
 
 def test_default_logger_repo_example():
-    assert the_repo.get_job("the_job").loggers == merge_dicts(
-        {"json_logger": json_console_logger}, default_loggers()
-    )
+    assert the_repo.get_job("the_job").loggers == {"json_logger": json_console_logger}

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/logging_tests/test_custom.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/logging_tests/test_custom.py
@@ -1,7 +1,6 @@
 import yaml
 
-from dagster.loggers import default_loggers
-from dagster.utils import file_relative_path, merge_dicts
+from dagster.utils import file_relative_path
 from docs_snippets.concepts.logging.custom_logger import (
     demo_job,
     json_console_logger,

--- a/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
@@ -281,5 +281,8 @@ def repository(
         return _Repository()(name)
 
     return _Repository(
-        name=name, description=description, default_executor_def=default_executor_def
+        name=name,
+        description=description,
+        default_executor_def=default_executor_def,
+        default_logger_defs=default_logger_defs,
     )

--- a/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
@@ -1,11 +1,12 @@
 from functools import update_wrapper
-from typing import Any, Callable, List, Optional, Union, overload
+from typing import Any, Callable, List, Mapping, Optional, Union, overload
 
 import dagster._check as check
 from dagster.core.errors import DagsterInvalidDefinitionError
 
 from ..executor_definition import ExecutorDefinition
 from ..graph_definition import GraphDefinition
+from ..logger_definition import LoggerDefinition
 from ..partition import PartitionSetDefinition
 from ..pipeline_definition import PipelineDefinition
 from ..repository_definition import (
@@ -34,11 +35,15 @@ class _Repository:
         name: Optional[str] = None,
         description: Optional[str] = None,
         default_executor_def: Optional[ExecutorDefinition] = None,
+        default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
     ):
         self.name = check.opt_str_param(name, "name")
         self.description = check.opt_str_param(description, "description")
         self.default_executor_def = check.opt_inst_param(
             default_executor_def, "default_executor_def", ExecutorDefinition
+        )
+        self.default_logger_defs = check.opt_mapping_param(
+            default_logger_defs, "default_logger_defs", key_type=str, value_type=LoggerDefinition
         )
 
     def __call__(self, fn: Callable[[], Any]) -> RepositoryDefinition:
@@ -83,7 +88,9 @@ class _Repository:
                     f"Got {bad_definitions_str}."
                 )
             repository_data = CachingRepositoryData.from_list(
-                repository_definitions, default_executor_def=self.default_executor_def
+                repository_definitions,
+                default_executor_def=self.default_executor_def,
+                default_logger_defs=self.default_logger_defs,
             )
 
         elif isinstance(repository_definitions, dict):
@@ -131,6 +138,7 @@ def repository(
     name: Optional[str] = ...,
     description: Optional[str] = ...,
     default_executor_def: Optional[ExecutorDefinition] = ...,
+    default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = ...,
 ) -> _Repository:
     ...
 
@@ -139,6 +147,7 @@ def repository(
     name: Optional[Union[str, Callable[..., Any]]] = None,
     description: Optional[str] = None,
     default_executor_def: Optional[ExecutorDefinition] = None,
+    default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
 ) -> Union[RepositoryDefinition, _Repository]:
     """Create a repository from the decorated function.
 

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -574,7 +574,6 @@ class GraphDefinition(NodeDefinition):
 
         tags = check.opt_dict_param(tags, "tags", key_type=str)
         executor_def_specified = executor_def is not None
-        logger_defs_specified = logger_defs is not None
         executor_def = check.opt_inst_param(
             executor_def, "executor_def", ExecutorDefinition, default=multi_or_in_process_executor
         )
@@ -642,7 +641,6 @@ class GraphDefinition(NodeDefinition):
             _input_values=input_values,
             _subset_selection_data=_asset_selection_data,
             _executor_def_specified=executor_def_specified,
-            _logger_defs_specified=logger_defs_specified,
         ).get_job_def_for_subset_selection(op_selection)
 
     def coerce_to_job(self):

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -574,6 +574,7 @@ class GraphDefinition(NodeDefinition):
 
         tags = check.opt_dict_param(tags, "tags", key_type=str)
         executor_def_specified = executor_def is not None
+        logger_defs_specified = logger_defs is not None
         executor_def = check.opt_inst_param(
             executor_def, "executor_def", ExecutorDefinition, default=multi_or_in_process_executor
         )
@@ -641,6 +642,7 @@ class GraphDefinition(NodeDefinition):
             _input_values=input_values,
             _subset_selection_data=_asset_selection_data,
             _executor_def_specified=executor_def_specified,
+            _logger_defs_specified=logger_defs_specified,
         ).get_job_def_for_subset_selection(op_selection)
 
     def coerce_to_job(self):

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -87,6 +87,7 @@ class JobDefinition(PipelineDefinition):
         _input_values: Optional[Mapping[str, object]] = None,
         _metadata_entries: Optional[List[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
         _executor_def_specified: bool = False,
+        _logger_defs_specified: bool = False,
     ):
 
         # Exists for backcompat - JobDefinition is implemented as a single-mode pipeline.
@@ -99,6 +100,7 @@ class JobDefinition(PipelineDefinition):
         )
 
         self._executor_def_specified = _executor_def_specified
+        self._logger_defs_specified = _logger_defs_specified
         self._cached_partition_set: Optional["PartitionSetDefinition"] = None
         self._subset_selection_data = check.opt_inst_param(
             _subset_selection_data,
@@ -240,6 +242,7 @@ class JobDefinition(PipelineDefinition):
             asset_layer=self.asset_layer,
             _input_values=input_values,
             _executor_def_specified=self._executor_def_specified,
+            _logger_defs_specified=self._logger_defs_specified,
         )
 
         ephemeral_job = ephemeral_job.get_job_def_for_subset_selection(
@@ -382,6 +385,7 @@ class JobDefinition(PipelineDefinition):
                 graph_def=sub_graph,
                 version_strategy=self.version_strategy,
                 _executor_def_specified=self._executor_def_specified,
+                _logger_defs_specified=self._logger_defs_specified,
                 _subset_selection_data=OpSelectionData(
                     op_selection=op_selection,
                     resolved_op_selection=set(
@@ -473,6 +477,7 @@ class JobDefinition(PipelineDefinition):
             asset_layer=self.asset_layer,
             _subset_selection_data=self._subset_selection_data,
             _executor_def_specified=self._executor_def_specified,
+            _logger_defs_specified=self._logger_defs_specified,
         )
 
         update_wrapper(job_def, self, updated=())
@@ -517,15 +522,10 @@ class JobDefinition(PipelineDefinition):
             asset_layer=self.asset_layer,
             _input_values=self._input_values,
             _executor_def_specified=True,
+            _logger_defs_specified=self._logger_defs_specified,
         )
 
     def with_logger_defs(self, logger_defs: Mapping[str, LoggerDefinition]) -> "JobDefinition":
-        conflicting_keys = set(logger_defs.keys()).intersection(self.loggers.keys())
-        if conflicting_keys:
-            raise DagsterInvalidDefinitionError(
-                f"Provided logger defs conflict with logger defs on job '{self.name}'. The following logger keys conflict: {sorted(list(conflicting_keys))}"
-            )
-        logger_defs = merge_dicts(logger_defs, self.loggers)
         return JobDefinition(
             graph_def=self.graph,
             resource_defs=dict(self.resource_defs),
@@ -545,6 +545,7 @@ class JobDefinition(PipelineDefinition):
             asset_layer=self.asset_layer,
             _input_values=self._input_values,
             _executor_def_specified=self._executor_def_specified,
+            _logger_defs_specified=True,
         )
 
 

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -87,6 +87,7 @@ class JobDefinition(PipelineDefinition):
         _input_values: Optional[Mapping[str, object]] = None,
         _metadata_entries: Optional[List[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
         _executor_def_specified: bool = False,
+        _logger_defs_specified: bool = False,
     ):
 
         # Exists for backcompat - JobDefinition is implemented as a single-mode pipeline.
@@ -99,6 +100,7 @@ class JobDefinition(PipelineDefinition):
         )
 
         self._executor_def_specified = _executor_def_specified
+        self._logger_defs_specified = _logger_defs_specified
         self._cached_partition_set: Optional["PartitionSetDefinition"] = None
         self._subset_selection_data = check.opt_inst_param(
             _subset_selection_data,
@@ -382,6 +384,7 @@ class JobDefinition(PipelineDefinition):
                 graph_def=sub_graph,
                 version_strategy=self.version_strategy,
                 _executor_def_specified=self._executor_def_specified,
+                _logger_defs_specified=self._logger_defs_specified,
                 _subset_selection_data=OpSelectionData(
                     op_selection=op_selection,
                     resolved_op_selection=set(
@@ -473,6 +476,7 @@ class JobDefinition(PipelineDefinition):
             asset_layer=self.asset_layer,
             _subset_selection_data=self._subset_selection_data,
             _executor_def_specified=self._executor_def_specified,
+            _logger_defs_specified=self._logger_defs_specified,
         )
 
         update_wrapper(job_def, self, updated=())
@@ -517,6 +521,30 @@ class JobDefinition(PipelineDefinition):
             asset_layer=self.asset_layer,
             _input_values=self._input_values,
             _executor_def_specified=True,
+            _logger_defs_specified=self._logger_defs_specified,
+        )
+
+    def with_logger_defs(self, logger_defs: Mapping[str, LoggerDefinition]) -> "JobDefinition":
+        return JobDefinition(
+            graph_def=self.graph,
+            resource_defs=dict(self.resource_defs),
+            executor_def=self.executor_def,
+            logger_defs=logger_defs,
+            config_mapping=self.config_mapping,
+            partitioned_config=self.partitioned_config,
+            name=self.name,
+            description=self.description,
+            preset_defs=self.preset_defs,
+            tags=self.tags,
+            _metadata_entries=self.metadata,
+            hook_defs=self.hook_defs,
+            op_retry_policy=self._solid_retry_policy,
+            version_strategy=self.version_strategy,
+            _subset_selection_data=self._subset_selection_data,
+            asset_layer=self.asset_layer,
+            _input_values=self._input_values,
+            _executor_def_specified=self._executor_def_specified,
+            _logger_defs_specified=True,
         )
 
 

--- a/python_modules/dagster/dagster/core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/repository_definition.py
@@ -800,7 +800,8 @@ class CachingRepositoryData(RepositoryData):
 
         if default_logger_defs:
             for name, job_def in jobs.items():
-                jobs[name] = job_def.with_logger_defs(default_logger_defs)
+                if not job_def._logger_defs_specified:  # pylint: disable=protected-access
+                    jobs[name] = job_def.with_logger_defs(default_logger_defs)
 
         return CachingRepositoryData(
             pipelines=pipelines,

--- a/python_modules/dagster/dagster/core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/repository_definition.py
@@ -24,6 +24,7 @@ from .events import AssetKey
 from .executor_definition import ExecutorDefinition
 from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .job_definition import JobDefinition
+from .logger_definition import LoggerDefinition
 from .partition import PartitionScheduleDefinition, PartitionSetDefinition
 from .pipeline_definition import PipelineDefinition
 from .schedule_definition import ScheduleDefinition
@@ -635,6 +636,7 @@ class CachingRepositoryData(RepositoryData):
             ]
         ],
         default_executor_def: Optional[ExecutorDefinition] = None,
+        default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
     ) -> "CachingRepositoryData":
         """Static constructor.
 
@@ -795,6 +797,11 @@ class CachingRepositoryData(RepositoryData):
             for name, job_def in jobs.items():
                 if not job_def._executor_def_specified:  # pylint: disable=protected-access
                     jobs[name] = job_def.with_executor_def(default_executor_def)
+
+        if default_logger_defs:
+            for name, job_def in jobs.items():
+                if not job_def._logger_defs_specified:
+                    jobs[name] = job_def.with_logger_defs(default_logger_defs)
 
         return CachingRepositoryData(
             pipelines=pipelines,

--- a/python_modules/dagster/dagster/core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/repository_definition.py
@@ -800,8 +800,7 @@ class CachingRepositoryData(RepositoryData):
 
         if default_logger_defs:
             for name, job_def in jobs.items():
-                if not job_def._logger_defs_specified:
-                    jobs[name] = job_def.with_logger_defs(default_logger_defs)
+                jobs[name] = job_def.with_logger_defs(default_logger_defs)
 
         return CachingRepositoryData(
             pipelines=pipelines,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -46,7 +46,6 @@ from dagster.core.definitions.executor_definition import (
 from dagster.core.definitions.partition import PartitionedConfig, StaticPartitionsDefinition
 from dagster.core.errors import DagsterInvalidSubsetError
 from dagster.loggers import default_loggers
-from dagster.utils import merge_dicts
 
 # pylint: disable=comparison-with-callable
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -1566,7 +1566,7 @@ def test_default_loggers_keys_conflict():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="Provided logger defs conflict with logger defs on job 'the_job'. The following logger keys conflict: \['foo'\]",
+        match=r"Provided logger defs conflict with logger defs on job 'the_job'. The following logger keys conflict: \['foo'\]",
     ):
 
         @repository(default_logger_defs={"foo": some_logger})

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -1485,10 +1485,9 @@ def test_default_loggers_assets_repo():
     def the_repo():
         return [no_logger_provided, the_asset]
 
-    # pylint: disable=comparison-with-callable
     assert the_repo.get_job("__ASSET_JOB").loggers == {"foo": basic}
 
-    assert the_repo.get_job("no_loggers_provided").loggers == {"foo": basic}
+    assert the_repo.get_job("no_logger_provided").loggers == {"foo": basic}
 
 
 def test_default_loggers_jobs_and_pipelines():
@@ -1514,7 +1513,7 @@ def test_default_loggers_jobs_and_pipelines():
     def op_job_no_loggers():
         pass
 
-    @job(logger_defs=default_loggers)
+    @job(logger_defs=default_loggers())
     def job_explicitly_specifies_default_loggers():
         pass
 
@@ -1526,11 +1525,11 @@ def test_default_loggers_jobs_and_pipelines():
     def the_repo():
         return [
             the_asset,
-            op_job_with_executor,
-            op_job_no_executor,
+            op_job_with_loggers,
+            op_job_no_loggers,
             unresolved_job,
             the_pipeline,
-            job_explicitly_defines_default_loggers,
+            job_explicitly_specifies_default_loggers,
         ]
 
     assert the_repo.get_pipeline("the_pipeline").mode_definitions[0].loggers == default_loggers()
@@ -1539,8 +1538,6 @@ def test_default_loggers_jobs_and_pipelines():
 
     assert the_repo.get_job("op_job_with_loggers").loggers == {"foo": custom_logger}
 
-    assert the_repo.get_job("op_job_no_executor").loggers == {"foo": other_custom_logger}
+    assert the_repo.get_job("op_job_no_loggers").loggers == {"foo": other_custom_logger}
 
-    assert (
-        the_repo.get_job("job_explicitly_specifies_default_executor").loggers == default_loggers()
-    )
+    assert the_repo.get_job("job_explicitly_specifies_default_loggers").loggers == default_loggers()

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -46,6 +46,7 @@ from dagster.core.definitions.executor_definition import (
 from dagster.core.definitions.partition import PartitionedConfig, StaticPartitionsDefinition
 from dagster.core.errors import DagsterInvalidSubsetError
 from dagster.loggers import default_loggers
+from dagster.utils import merge_dicts
 
 # pylint: disable=comparison-with-callable
 
@@ -1485,9 +1486,11 @@ def test_default_loggers_assets_repo():
     def the_repo():
         return [no_logger_provided, the_asset]
 
-    assert the_repo.get_job("__ASSET_JOB").loggers == {"foo": basic}
+    assert the_repo.get_job("__ASSET_JOB").loggers == merge_dicts({"foo": basic}, default_loggers())
 
-    assert the_repo.get_job("no_logger_provided").loggers == {"foo": basic}
+    assert the_repo.get_job("no_logger_provided").loggers == merge_dicts(
+        {"foo": basic}, default_loggers()
+    )
 
 
 def test_default_loggers_jobs_and_pipelines():
@@ -1505,7 +1508,7 @@ def test_default_loggers_jobs_and_pipelines():
     def other_custom_logger(_):
         pass
 
-    @job(logger_defs={"foo": custom_logger})
+    @job(logger_defs={"bar": custom_logger})
     def op_job_with_loggers():
         pass
 
@@ -1534,10 +1537,38 @@ def test_default_loggers_jobs_and_pipelines():
 
     assert the_repo.get_pipeline("the_pipeline").mode_definitions[0].loggers == default_loggers()
 
-    assert the_repo.get_job("asset_job").loggers == {"foo": other_custom_logger}
+    assert the_repo.get_job("asset_job").loggers == merge_dicts(
+        {"foo": other_custom_logger}, default_loggers()
+    )
 
-    assert the_repo.get_job("op_job_with_loggers").loggers == {"foo": custom_logger}
+    assert the_repo.get_job("op_job_with_loggers").loggers == {
+        "bar": custom_logger,
+        "foo": other_custom_logger,
+    }
 
-    assert the_repo.get_job("op_job_no_loggers").loggers == {"foo": other_custom_logger}
+    assert the_repo.get_job("op_job_no_loggers").loggers == merge_dicts(
+        {"foo": other_custom_logger}, default_loggers()
+    )
 
-    assert the_repo.get_job("job_explicitly_specifies_default_loggers").loggers == default_loggers()
+    assert the_repo.get_job("job_explicitly_specifies_default_loggers").loggers == merge_dicts(
+        {"foo": other_custom_logger}, default_loggers()
+    )
+
+
+def test_default_loggers_keys_conflict():
+    @logger
+    def some_logger():
+        pass
+
+    @job(logger_defs={"foo": some_logger})
+    def the_job():
+        pass
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="Provided logger defs conflict with logger defs on job 'the_job'. The following logger keys conflict: \['foo'\]",
+    ):
+
+        @repository(default_logger_defs={"foo": some_logger})
+        def the_repo():
+            return [the_job]


### PR DESCRIPTION
Adds a `default_logger_defs` argument to the repository. Default logger defs are applied to asset jobs, and jobs where no loggers are explicitly specified.