### PR TITLE
group-based asset dependency resolution

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/asset_group.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_group.py
@@ -189,10 +189,12 @@ class AssetGroup:
 
         selected_asset_keys: FrozenSet[AssetKey] = frozenset()
         if isinstance(selection, str):
-            selected_asset_keys = parse_asset_selection(self.assets, [selection])
+            selected_asset_keys = parse_asset_selection(
+                self.assets, self.source_assets, [selection]
+            )
         elif isinstance(selection, list):
             selection = check.opt_list_param(selection, "selection", of_type=str)
-            selected_asset_keys = parse_asset_selection(self.assets, selection)
+            selected_asset_keys = parse_asset_selection(self.assets, self.source_assets, selection)
         elif isinstance(selection, FrozenSet):
             check.opt_set_param(selection, "selection", of_type=AssetKey)
             selected_asset_keys = selection

--- a/python_modules/dagster/dagster/core/asset_defs/asset_selection.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_selection.py
@@ -1,10 +1,11 @@
 import operator
 from abc import ABC
 from functools import reduce
-from typing import AbstractSet, FrozenSet, Optional, Sequence
+from typing import AbstractSet, FrozenSet, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster.core.asset_defs.assets import AssetsDefinition
+from dagster.core.asset_defs.source_asset import SourceAsset
 from dagster.core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster.core.errors import DagsterInvalidSubsetError
 from dagster.core.selector.subset_selector import (
@@ -49,8 +50,10 @@ class AssetSelection(ABC):
         check.inst_param(other, "other", AssetSelection)
         return AndAssetSelection(self, other)
 
-    def resolve(self, all_assets: Sequence[AssetsDefinition]) -> FrozenSet[AssetKey]:
-        check.sequence_param(all_assets, "all_assets", AssetsDefinition)
+    def resolve(
+        self, all_assets: Sequence[Union[AssetsDefinition, SourceAsset]]
+    ) -> FrozenSet[AssetKey]:
+        check.sequence_param(all_assets, "all_assets", (AssetsDefinition, SourceAsset))
         return Resolver(all_assets).resolve(self)
 
 
@@ -96,10 +99,20 @@ class UpstreamAssetSelection(AssetSelection):
 
 
 class Resolver:
-    def __init__(self, all_assets: Sequence[AssetsDefinition]):
-        self.all_assets = all_assets
-        self.asset_dep_graph = generate_asset_dep_graph(list(all_assets))
-        self.all_assets_by_name = generate_asset_name_to_definition_map(all_assets)
+    def __init__(self, all_assets: Sequence[Union[AssetsDefinition, SourceAsset]]):
+        assets_defs = []
+        source_assets = []
+        for asset in all_assets:
+            if isinstance(asset, SourceAsset):
+                source_assets.append(asset)
+            elif isinstance(asset, AssetsDefinition):
+                assets_defs.append(asset)
+            else:
+                check.failed(f"Expected SourceAsset or AssetsDefinition, got {type(asset)}")
+
+        self.assets_defs = assets_defs
+        self.asset_dep_graph = generate_asset_dep_graph(assets_defs, source_assets)
+        self.all_assets_by_name = generate_asset_name_to_definition_map(assets_defs)
 
     def resolve(self, root_node: AssetSelection) -> FrozenSet[AssetKey]:
         return frozenset(
@@ -130,7 +143,7 @@ class Resolver:
         elif isinstance(node, GroupsAssetSelection):
             return reduce(
                 operator.or_,
-                [_match_groups(assets_def, set(node.children)) for assets_def in self.all_assets],
+                [_match_groups(assets_def, set(node.children)) for assets_def in self.assets_defs],
             )
         elif isinstance(node, KeysAssetSelection):
             specified_keys = set([child.to_user_string() for child in node.children])

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -295,7 +295,7 @@ class AssetsDefinition(ResourceAddable):
 
     @property
     def input_names(self) -> Iterable[str]:
-        return self._keys_by_input_name.keys()
+        return self.keys_by_input_name.keys()
 
     @property
     def key(self) -> AssetKey:

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -294,6 +294,10 @@ class AssetsDefinition(ResourceAddable):
         return self._asset_deps
 
     @property
+    def input_names(self) -> Iterable[str]:
+        return self._keys_by_input_name.keys()
+
+    @property
     def key(self) -> AssetKey:
         check.invariant(
             len(self.keys) == 1,

--- a/python_modules/dagster/dagster/core/asset_defs/resolved_asset_deps.py
+++ b/python_modules/dagster/dagster/core/asset_defs/resolved_asset_deps.py
@@ -1,0 +1,75 @@
+from typing import AbstractSet, Dict, Iterable, List, Mapping, Sequence, Set, Tuple
+
+from dagster.core.definitions.events import AssetKey
+from dagster.core.errors import DagsterInvalidDefinitionError
+
+from .assets import AssetsDefinition
+from .source_asset import SourceAsset
+
+
+class ResolvedAssetDependencies:
+    def __init__(
+        self, assets_defs: Iterable[AssetsDefinition], source_assets: Iterable[SourceAsset]
+    ):
+        self._deps_by_assets_def_id = resolve_assets_def_deps(assets_defs, source_assets)
+
+    def get_resolved_upstream_asset_keys(
+        self, assets_def: AssetsDefinition, asset_key: AssetKey
+    ) -> AbstractSet[AssetKey]:
+        return self._deps_by_assets_def_id[id(assets_def)].values()
+
+    def get_resolved_asset_key_for_input(
+        self, assets_def: AssetsDefinition, input_name: str
+    ) -> AssetKey:
+        return self._deps_by_assets_def_id[id(assets_def)][input_name]
+
+
+def resolve_assets_def_deps(
+    assets_defs: Iterable[AssetsDefinition], source_assets: Iterable[SourceAsset]
+) -> Mapping[int, Mapping[str, AssetKey]]:
+    """
+    For each AssetsDefinition, resolves its inputs to upstream asset keys. Matches based on either
+    of two criteria:
+    - The input asset key exactly matches an asset key.
+    - The input asset key has one component, that component matches the final component of an asset
+        key, and they're both in the same asset group.
+    """
+    asset_keys_by_group_and_name: Dict[Tuple[str, str], AssetKey] = {}
+    for assets_def in assets_defs:
+        for key in assets_def.keys:
+            asset_keys_by_group_and_name[(assets_def.group_names_by_key[key], key.path[-1])] = key
+    for source_asset in source_assets:
+        asset_keys_by_group_and_name[
+            (source_asset.group_name, source_asset.key.path[-1])
+        ] = source_asset.key
+
+    asset_keys = set(asset_keys_by_group_and_name.values())
+
+    result: Mapping[int, Mapping[str, AssetKey]] = {}
+    for assets_def in assets_defs:
+        group = (
+            next(iter(assets_def.group_names_by_key.values()))
+            if len(assets_def.group_names_by_key) == 1
+            else None
+        )
+
+        dep_keys_by_input_name: Dict[str, AssetKey] = {}
+        for input_name, upstream_asset_key in assets_def.keys_by_input_name.items():
+            group_and_upstream_name = (group, upstream_asset_key.path[-1])
+            if upstream_asset_key in asset_keys:
+                dep_keys_by_input_name[input_name] = upstream_asset_key
+            elif group is not None and group_and_upstream_name in asset_keys_by_group_and_name:
+                dep_keys_by_input_name[input_name] = asset_keys_by_group_and_name[
+                    group_and_upstream_name
+                ]
+            else:
+                raise DagsterInvalidDefinitionError(
+                    f"Input asset '{upstream_asset_key.to_string()}' for asset "
+                    f"'{next(iter(assets_def.keys)).to_string()}' is not "
+                    "produced by any of the provided asset ops and is not one of the provided "
+                    "sources"
+                )
+
+        result[id(assets_def)] = dep_keys_by_input_name
+
+    return result

--- a/python_modules/dagster/dagster/core/asset_defs/resolved_asset_deps.py
+++ b/python_modules/dagster/dagster/core/asset_defs/resolved_asset_deps.py
@@ -1,13 +1,21 @@
-from typing import AbstractSet, Dict, Iterable, List, Mapping, Sequence, Set, Tuple
+from typing import AbstractSet, Dict, Iterable, Mapping, Tuple, cast
 
 from dagster.core.definitions.events import AssetKey
 from dagster.core.errors import DagsterInvalidDefinitionError
+from dagster.utils.backcompat import experimental_warning
 
 from .assets import AssetsDefinition
 from .source_asset import SourceAsset
 
 
 class ResolvedAssetDependencies:
+    """
+    An asset can depend on another asset without specifying the full asset key for the upstream
+    asset, if the name and groups match.
+
+    ResolvedAssetDependencies maps these flexible dependencies to precise key-based dependencies.
+    """
+
     def __init__(
         self, assets_defs: Iterable[AssetsDefinition], source_assets: Iterable[SourceAsset]
     ):
@@ -16,23 +24,34 @@ class ResolvedAssetDependencies:
     def get_resolved_upstream_asset_keys(
         self, assets_def: AssetsDefinition, asset_key: AssetKey
     ) -> AbstractSet[AssetKey]:
-        return self._deps_by_assets_def_id[id(assets_def)].values()
+        resolved_keys_by_unresolved_key = self._deps_by_assets_def_id.get(id(assets_def), {})
+        unresolved_upstream_keys = assets_def.asset_deps[asset_key]
+        return {
+            resolved_keys_by_unresolved_key.get(unresolved_key, unresolved_key)
+            for unresolved_key in unresolved_upstream_keys
+        }
 
     def get_resolved_asset_key_for_input(
         self, assets_def: AssetsDefinition, input_name: str
     ) -> AssetKey:
-        return self._deps_by_assets_def_id[id(assets_def)][input_name]
+        unresolved_asset_key_for_input = assets_def.node_keys_by_input_name[input_name]
+        return self._deps_by_assets_def_id.get(id(assets_def), {}).get(
+            unresolved_asset_key_for_input, unresolved_asset_key_for_input
+        )
 
 
 def resolve_assets_def_deps(
     assets_defs: Iterable[AssetsDefinition], source_assets: Iterable[SourceAsset]
-) -> Mapping[int, Mapping[str, AssetKey]]:
+) -> Mapping[int, Mapping[AssetKey, AssetKey]]:
     """
     For each AssetsDefinition, resolves its inputs to upstream asset keys. Matches based on either
     of two criteria:
     - The input asset key exactly matches an asset key.
     - The input asset key has one component, that component matches the final component of an asset
         key, and they're both in the same asset group.
+
+    The returned dictionary only contains entries for assets definitions with group-resolved asset
+    dependencies.
     """
     asset_keys_by_group_and_name: Dict[Tuple[str, str], AssetKey] = {}
     for assets_def in assets_defs:
@@ -45,7 +64,9 @@ def resolve_assets_def_deps(
 
     asset_keys = set(asset_keys_by_group_and_name.values())
 
-    result: Mapping[int, Mapping[str, AssetKey]] = {}
+    warned = False
+
+    result: Dict[int, Mapping[AssetKey, AssetKey]] = {}
     for assets_def in assets_defs:
         group = (
             next(iter(assets_def.group_names_by_key.values()))
@@ -53,23 +74,38 @@ def resolve_assets_def_deps(
             else None
         )
 
-        dep_keys_by_input_name: Dict[str, AssetKey] = {}
-        for input_name, upstream_asset_key in assets_def.keys_by_input_name.items():
-            group_and_upstream_name = (group, upstream_asset_key.path[-1])
-            if upstream_asset_key in asset_keys:
-                dep_keys_by_input_name[input_name] = upstream_asset_key
-            elif group is not None and group_and_upstream_name in asset_keys_by_group_and_name:
-                dep_keys_by_input_name[input_name] = asset_keys_by_group_and_name[
-                    group_and_upstream_name
-                ]
-            else:
-                raise DagsterInvalidDefinitionError(
-                    f"Input asset '{upstream_asset_key.to_string()}' for asset "
-                    f"'{next(iter(assets_def.keys)).to_string()}' is not "
-                    "produced by any of the provided asset ops and is not one of the provided "
-                    "sources"
-                )
+        resolved_keys_by_unresolved_key: Dict[AssetKey, AssetKey] = {}
+        for input_name, upstream_key in assets_def.keys_by_input_name.items():
+            if upstream_key not in asset_keys and len(upstream_key) == 1:
+                group_and_upstream_name = (group, upstream_key.path[-1])
+                if group is not None and group_and_upstream_name in asset_keys_by_group_and_name:
+                    resolved_key = asset_keys_by_group_and_name[
+                        cast(Tuple[str, str], group_and_upstream_name)
+                    ]
+                    resolved_keys_by_unresolved_key[upstream_key] = resolved_key
 
-        result[id(assets_def)] = dep_keys_by_input_name
+                    if not warned:
+                        experimental_warning(
+                            f"Asset {next(iter(assets_def.keys)).to_string()}'s dependency "
+                            f"'{upstream_key.path[-1]}' was resolved to upstream asset "
+                            f"{resolved_key.to_string()}, because the name matches and they're in the same "
+                            "group. This is experimental functionality that may change in a future "
+                            "release"
+                        )
+
+                        warned = True
+                elif (
+                    upstream_key not in asset_keys
+                    and not assets_def.node_def.input_def_named(input_name).dagster_type.is_nothing
+                ):
+                    raise DagsterInvalidDefinitionError(
+                        f"Input asset '{upstream_key.to_string()}' for asset "
+                        f"'{next(iter(assets_def.keys)).to_string()}' is not "
+                        "produced by any of the provided asset ops and is not one of the provided "
+                        "sources"
+                    )
+
+        if resolved_keys_by_unresolved_key:
+            result[id(assets_def)] = resolved_keys_by_unresolved_key
 
     return result

--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -500,14 +500,16 @@ class AssetLayer:
             source_asset.key: source_asset.get_io_manager_key() for source_asset in source_assets
         }
         for node_handle, assets_def in assets_defs_by_node_handle.items():
-            asset_deps.update(assets_def.asset_deps)
+            for key in assets_def.keys:
+                asset_deps[key] = resolved_asset_deps.get_resolved_upstream_asset_keys(
+                    assets_def, key
+                )
 
             for input_name in assets_def.node_keys_by_input_name.keys():
-                node_input_handle = NodeInputHandle(node_handle, input_name)
                 resolved_asset_key = resolved_asset_deps.get_resolved_asset_key_for_input(
                     assets_def, input_name
                 )
-                asset_key_by_input[node_input_handle] = resolved_asset_key
+                asset_key_by_input[NodeInputHandle(node_handle, input_name)] = resolved_asset_key
                 # resolve graph input to list of op inputs that consume it
                 node_input_handles = _resolve_input_to_destinations(
                     input_name, assets_def.node_def, node_handle

--- a/python_modules/dagster/dagster/core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/unresolved_asset_job_definition.py
@@ -115,7 +115,7 @@ class UnresolvedAssetJobDefinition(
             source_assets=source_assets,
             description=self.description,
             tags=self.tags,
-            asset_selection=self.selection.resolve(assets),
+            asset_selection=self.selection.resolve([*assets, *source_assets]),
             partitions_def=self.partitions_def,
         )
 

--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -322,6 +322,15 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
         else:
             return asset_output_info.key
 
+    def asset_key_for_input(self, input_name: str) -> AssetKey:
+        key = self.pipeline_def.asset_layer.asset_key_for_input(
+            node_handle=self.op_handle, input_name=input_name
+        )
+        if key is None:
+            check.failed(f"Input '{input_name}' has no asset")
+        else:
+            return key
+
     def output_asset_partition_key(self, output_name: str = "result") -> str:
         deprecation_warning(
             "OpExecutionContext.output_asset_partition_key",

--- a/python_modules/dagster/dagster/utils/backcompat.py
+++ b/python_modules/dagster/dagster/utils/backcompat.py
@@ -121,6 +121,14 @@ class ExperimentalWarning(Warning):
     pass
 
 
+def experimental_warning(message: str, stacklevel: int = 3) -> None:
+    warnings.warn(
+        f"{message}. {EXPERIMENTAL_WARNING_HELP}",
+        ExperimentalWarning,
+        stacklevel=stacklevel,
+    )
+
+
 def experimental_fn_warning(name: str, stacklevel: int = 3) -> None:
     """Utility for warning that a function is experimental"""
     warnings.warn(


### PR DESCRIPTION
### Summary & Motivation

When asset keys are long, getting them to match up when specifying dependencies can be hard and fiddly.  Owen and I have both personally experienced this when dogfooding, and I've observed users report it as well.

This PR proposes falling back to matching based on the last segment of the asset key, if both assets are in the same group.

For now, this is marked experimental. The big drawback here is that asset dependency resolution becomes a more complicated decision tree, and thus can be more difficult to debug.  I think we should feel this out for a few releases before marking it stable. 

A couple interesting edge cases to point out:
* Assets within a multi-asset can belong to different groups. In this case, we turn don't do group-based dependency resolution.
* Two assets within the same group can have the same name. In this case, we turn don't do group-based dependency resolution.

### How I Tested These Changes

Added tests. Observed experimental warning.