### PR TITLE
[dagit] Add timezone and 24h format to humanCronString

### DIFF
--- a/js_modules/dagit/packages/core/src/app/time/timestampToString.tsx
+++ b/js_modules/dagit/packages/core/src/app/time/timestampToString.tsx
@@ -1,3 +1,4 @@
+import memoize from 'lodash/memoize';
 import moment from 'moment-timezone';
 
 import {TimeFormat, DEFAULT_TIME_FORMAT} from './TimestampFormat';
@@ -30,6 +31,4 @@ export const timestampToString = (config: Config) => {
   });
 };
 
-export const timeZoneAbbr = (tzIn: string) => {
-  return moment().tz(tzIn).zoneAbbr();
-};
+export const timeZoneAbbr = memoize((tzIn: string) => moment().tz(tzIn).zoneAbbr());

--- a/js_modules/dagit/packages/core/src/assets/types/AssetNodeInstigatorsFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNodeInstigatorsFragment.ts
@@ -21,6 +21,7 @@ export interface AssetNodeInstigatorsFragment_jobs_schedules {
   id: string;
   name: string;
   cronSchedule: string;
+  executionTimezone: string | null;
   scheduleState: AssetNodeInstigatorsFragment_jobs_schedules_scheduleState;
 }
 

--- a/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
@@ -48,6 +48,7 @@ export interface AssetQuery_assetOrError_Asset_definition_jobs_schedules {
   id: string;
   name: string;
   cronSchedule: string;
+  executionTimezone: string | null;
   scheduleState: AssetQuery_assetOrError_Asset_definition_jobs_schedules_scheduleState;
 }
 

--- a/js_modules/dagit/packages/core/src/nav/LeftNavItem.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavItem.tsx
@@ -50,13 +50,18 @@ export const LeftNavItem = React.forwardRef(
         }
 
         if (scheduleCount) {
-          return scheduleCount === 1 ? (
-            <div>
-              Schedule: <strong>{humanCronString(schedules[0].cronSchedule)}</strong>
-            </div>
-          ) : (
-            `${scheduleCount} schedules`
-          );
+          if (scheduleCount === 1) {
+            const schedule = schedules[0];
+            const {cronSchedule, executionTimezone} = schedule;
+            return (
+              <div>
+                Schedule:{' '}
+                <strong>{humanCronString(cronSchedule, executionTimezone || 'UTC')}</strong>
+              </div>
+            );
+          }
+
+          return `${scheduleCount} schedules`;
         }
 
         return sensorCount === 1 ? (

--- a/js_modules/dagit/packages/core/src/nav/ScheduleAndSensorDialog.tsx
+++ b/js_modules/dagit/packages/core/src/nav/ScheduleAndSensorDialog.tsx
@@ -77,7 +77,9 @@ export const ScheduleAndSensorDialog = ({
                         {schedule.name}
                       </Link>
                     </td>
-                    <td>{humanCronString(schedule.cronSchedule)}</td>
+                    <td>
+                      {humanCronString(schedule.cronSchedule, schedule.executionTimezone || 'UTC')}
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/js_modules/dagit/packages/core/src/nav/ScheduleOrSensorTag.tsx
+++ b/js_modules/dagit/packages/core/src/nav/ScheduleOrSensorTag.tsx
@@ -70,13 +70,14 @@ const MatchingSchedule: React.FC<{
   repoAddress: RepoAddress;
   showSwitch: boolean;
 }> = ({schedule, repoAddress, showSwitch}) => {
-  const running = schedule.scheduleState.status === 'RUNNING';
+  const {cronSchedule, executionTimezone, scheduleState} = schedule;
+  const running = scheduleState.status === 'RUNNING';
   const tag = (
     <Tag intent={running ? 'primary' : 'none'} icon="schedule">
       <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
         Schedule:
         <Link to={workspacePathFromAddress(repoAddress, `/schedules/${schedule.name}`)}>
-          {humanCronString(schedule.cronSchedule)}
+          {humanCronString(cronSchedule, executionTimezone || 'UTC')}
         </Link>
         {showSwitch ? (
           <ScheduleSwitch size="small" repoAddress={repoAddress} schedule={schedule} />
@@ -98,6 +99,9 @@ const MatchingSchedule: React.FC<{
             <span style={{fontFamily: FontFamily.monospace, marginLeft: '4px'}}>
               ({schedule.cronSchedule})
             </span>
+          </div>
+          <div>
+            Timezone: <strong>{schedule.executionTimezone || 'UTC'}</strong>
           </div>
         </Box>
       }

--- a/js_modules/dagit/packages/core/src/nav/types/JobMetadataFragment.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/JobMetadataFragment.ts
@@ -22,6 +22,7 @@ export interface JobMetadataFragment_schedules {
   mode: string;
   name: string;
   cronSchedule: string;
+  executionTimezone: string | null;
   scheduleState: JobMetadataFragment_schedules_scheduleState;
 }
 

--- a/js_modules/dagit/packages/core/src/nav/types/JobMetadataQuery.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/JobMetadataQuery.ts
@@ -26,6 +26,7 @@ export interface JobMetadataQuery_pipelineOrError_Pipeline_schedules {
   mode: string;
   name: string;
   cronSchedule: string;
+  executionTimezone: string | null;
   scheduleState: JobMetadataQuery_pipelineOrError_Pipeline_schedules_scheduleState;
 }
 

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleDetails.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleDetails.tsx
@@ -153,7 +153,7 @@ export const ScheduleDetails: React.FC<{
             <td>
               {cronSchedule ? (
                 <Group direction="row" spacing={8}>
-                  <span>{humanCronString(cronSchedule)}</span>
+                  <span>{humanCronString(cronSchedule, executionTimezone || 'UTC')}</span>
                   <Code>({cronSchedule})</Code>
                 </Group>
               ) : (

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleSwitch.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleSwitch.tsx
@@ -100,6 +100,7 @@ export const SCHEDULE_SWITCH_FRAGMENT = gql`
     id
     name
     cronSchedule
+    executionTimezone
     scheduleState {
       id
       selectorId

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesTable.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesTable.tsx
@@ -2,7 +2,6 @@ import {Box, Button, Colors, Icon, Menu, Popover, Table, Tag, Tooltip} from '@da
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
-import {timeZoneAbbr} from '../app/time/timestampToString';
 import {TickTag} from '../instigation/InstigationTick';
 import {InstigatedRunStatus} from '../instigation/InstigationUtils';
 import {PipelineReference} from '../pipelines/PipelineReference';
@@ -168,10 +167,7 @@ const ScheduleRow: React.FC<{
       <td>
         {cronSchedule ? (
           <Tooltip position="bottom" content={cronSchedule}>
-            <span>
-              {humanCronString(cronSchedule)}
-              {executionTimezone ? ` ${timeZoneAbbr(executionTimezone)}` : ` UTC`}
-            </span>
+            <span>{humanCronString(cronSchedule, executionTimezone || 'UTC')}</span>
           </Tooltip>
         ) : (
           <span style={{color: Colors.Gray300}}>None</span>

--- a/js_modules/dagit/packages/core/src/schedules/humanCronString.test.ts
+++ b/js_modules/dagit/packages/core/src/schedules/humanCronString.test.ts
@@ -6,4 +6,90 @@ describe('humanCronString', () => {
     expect(humanCronString('@weekly')).toBe('At 12:00 AM, only on Sunday');
     expect(humanCronString('@monthly')).toBe('At 12:00 AM, on day 1 of the month');
   });
+
+  describe('Timezone', () => {
+    it('shows timezone if provided, if cron specifies a time', () => {
+      const timezone = 'America/Chicago';
+      expect(humanCronString('@daily', timezone)).toBe('At 12:00 AM CDT');
+      expect(humanCronString('@weekly', timezone)).toBe('At 12:00 AM CDT, only on Sunday');
+      expect(humanCronString('@monthly', timezone)).toBe('At 12:00 AM CDT, on day 1 of the month');
+      expect(humanCronString('0 23 ? * MON-FRI', timezone)).toBe(
+        'At 11:00 PM CDT, Monday through Friday',
+      );
+      expect(humanCronString('0 23 * * *', timezone)).toBe('At 11:00 PM CDT');
+    });
+
+    it('does not show timezone even if provided, if cron does not specify a time', () => {
+      const timezone = 'America/Chicago';
+      expect(humanCronString('* * * * *', timezone)).toBe('Every minute');
+      expect(humanCronString('* * * 6-8 *', timezone)).toBe('Every minute, June through August');
+      expect(humanCronString('* * * * MON-FRI', timezone)).toBe(
+        'Every minute, Monday through Friday',
+      );
+    });
+
+    it('shows timezone (UTC) if provided, if cron specifies a time', () => {
+      const timezone = 'UTC';
+      expect(humanCronString('@daily', timezone)).toBe('At 12:00 AM UTC');
+      expect(humanCronString('@weekly', timezone)).toBe('At 12:00 AM UTC, only on Sunday');
+      expect(humanCronString('@monthly', timezone)).toBe('At 12:00 AM UTC, on day 1 of the month');
+      expect(humanCronString('0 23 ? * MON-FRI', timezone)).toBe(
+        'At 11:00 PM UTC, Monday through Friday',
+      );
+      expect(humanCronString('0 23 * * *', timezone)).toBe('At 11:00 PM UTC');
+    });
+
+    describe('Invalid timezone', () => {
+      beforeEach(() => {
+        // `moment-timezone` will spew to the console, which is expected and not useful to us here.
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+      });
+
+      it('skips showing timezone if invalid', () => {
+        const timezone = 'FooBar';
+        expect(humanCronString('@daily', timezone)).toBe('At 12:00 AM');
+        expect(humanCronString('@weekly', timezone)).toBe('At 12:00 AM, only on Sunday');
+        expect(humanCronString('@monthly', timezone)).toBe('At 12:00 AM, on day 1 of the month');
+        expect(humanCronString('0 23 ? * MON-FRI', timezone)).toBe(
+          'At 11:00 PM, Monday through Friday',
+        );
+        expect(humanCronString('0 23 * * *', timezone)).toBe('At 11:00 PM');
+      });
+    });
+  });
+
+  describe('24-hour format', () => {
+    const timezone = 'Europe/Berlin';
+    let dateSpy;
+    let languageGetter;
+
+    beforeAll(() => {
+      languageGetter = jest.spyOn(window.navigator, 'language', 'get');
+      languageGetter.mockReturnValue('de-DE');
+      dateSpy = jest.spyOn(Date.prototype, 'toLocaleTimeString');
+      dateSpy.mockReturnValue('00:00:00');
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('shows 24h format if locale uses it, and shows timezone if provided, if cron specifies a time', () => {
+      expect(humanCronString('@daily', timezone)).toBe('At 00:00 CEST');
+      expect(humanCronString('@weekly', timezone)).toBe('At 00:00 CEST, only on Sunday');
+      expect(humanCronString('@monthly', timezone)).toBe('At 00:00 CEST, on day 1 of the month');
+      expect(humanCronString('0 23 ? * MON-FRI', timezone)).toBe(
+        'At 23:00 CEST, Monday through Friday',
+      );
+      expect(humanCronString('0 23 * * *', timezone)).toBe('At 23:00 CEST');
+    });
+
+    it('shows 24h format if locale uses it, does not show timezone if not provided', () => {
+      expect(humanCronString('@daily')).toBe('At 00:00');
+      expect(humanCronString('@weekly')).toBe('At 00:00, only on Sunday');
+      expect(humanCronString('@monthly')).toBe('At 00:00, on day 1 of the month');
+      expect(humanCronString('0 23 ? * MON-FRI')).toBe('At 23:00, Monday through Friday');
+      expect(humanCronString('0 23 * * *')).toBe('At 23:00');
+    });
+  });
 });

--- a/js_modules/dagit/packages/core/src/schedules/humanCronString.ts
+++ b/js_modules/dagit/packages/core/src/schedules/humanCronString.ts
@@ -1,9 +1,44 @@
 import cronstrue from 'cronstrue';
+import memoize from 'lodash/memoize';
 
-export const humanCronString = (cronSchedule: string) => {
+import {timeZoneAbbr} from '../app/time/timestampToString';
+
+const formatOptions = memoize((language: string) => {
+  const date = new Date();
+  const timeString = date.toLocaleTimeString(language);
+  const use24HourTimeFormat = !timeString.endsWith('AM') && !timeString.endsWith('PM');
+  return {use24HourTimeFormat};
+});
+
+export const humanCronString = (cronSchedule: string, longTimezone?: string) => {
+  const human = convertString(cronSchedule);
+
+  if (longTimezone) {
+    // Find the "At XX:YY" string and insert the timezone abbreviation.
+    const timeMatch = human.match(/^At [0-9: APM]+/);
+    if (timeMatch) {
+      let shortTimezone;
+      try {
+        shortTimezone = timeZoneAbbr(longTimezone);
+      } catch (e) {
+        // Failed to extract a timezone abbreviation. Skip rendering the timezone.
+        shortTimezone = null;
+      }
+
+      const stringMatch = timeMatch[0];
+      if (stringMatch && shortTimezone) {
+        return human.replace(stringMatch, `${stringMatch} ${shortTimezone}`);
+      }
+    }
+  }
+
+  return human;
+};
+
+const convertString = (cronSchedule: string) => {
   const standardCronString = convertIfSpecial(cronSchedule);
   try {
-    return cronstrue.toString(standardCronString);
+    return cronstrue.toString(standardCronString, formatOptions(navigator.language));
   } catch {
     return 'Invalid cron string';
   }

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleSwitchFragment.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleSwitchFragment.ts
@@ -21,5 +21,6 @@ export interface ScheduleSwitchFragment {
   id: string;
   name: string;
   cronSchedule: string;
+  executionTimezone: string | null;
   scheduleState: ScheduleSwitchFragment_scheduleState;
 }

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
@@ -89,6 +89,7 @@ const ROOT_WORKSPACE_QUERY = gql`
                 schedules {
                   id
                   cronSchedule
+                  executionTimezone
                   mode
                   name
                   pipelineName

--- a/js_modules/dagit/packages/core/src/workspace/types/RootWorkspaceQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/RootWorkspaceQuery.ts
@@ -42,6 +42,7 @@ export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_l
   __typename: "Schedule";
   id: string;
   cronSchedule: string;
+  executionTimezone: string | null;
   mode: string;
   name: string;
   pipelineName: string;


### PR DESCRIPTION
### Summary & Motivation

Modify `humanCronString` to support our schedule needs a bit more.

- Sniff whether the user's current locale uses 24-hour time formatting. If so, use that for the human cron string.
- Add a "long timezone" argument to `humanCronString()`. If provided, use the moment-timezone abbreviator on that timezone string and insert it into the time portion of eligible crons.

See the Jest test for various cases.

Updated existing callsites to use the timezone parameter for `executionTimezone`, falling back to UTC in cases where the execution timezone is not provided.

Also updated the schedule tag tooltip to include execution timezone.

<img width="289" alt="Screen Shot 2022-06-21 at 10 53 58 AM" src="https://user-images.githubusercontent.com/2823852/174849583-68488bb2-ffa0-47a1-a0e7-bc2d7fe04304.png">

### How I Tested These Changes

Jest. View cron strings throughout Dagit, verify that they include timezone information where applicable.
