### PR TITLE
Add resource_defs arg to multi_assets

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
@@ -449,6 +449,9 @@ def test_multi_asset_resources_execution():
         resource_defs={"foo": foo_manager, "bar": bar_manager, "baz": baz_resource},
     )
     def my_asset(context):
+        # Required io manager keys are available on the context, same behavoir as ops
+        assert hasattr(context.resources, "foo")
+        assert hasattr(context.resources, "bar")
         yield Output(1, "key1")
         yield Output(2, "key2")
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -487,6 +487,30 @@ def test_multi_asset_resource_defs():
     def my_asset():
         pass
 
+    assert my_asset.required_resource_keys == {"foo", "bar", "baz"}
+
     ensure_requirements_satisfied(
         my_asset.resource_defs, list(my_asset.get_resource_requirements())
     )
+
+
+def test_asset_io_manager_def():
+    @io_manager
+    def the_manager():
+        pass
+
+    @asset(io_manager_def=the_manager)
+    def the_asset():
+        pass
+
+    # If IO manager def is passed directly, then it doesn't appear as a
+    # required resource key on the underlying op.
+    assert set(the_asset.node_def.required_resource_keys) == set()
+
+    @asset(io_manager_key="blah", resource_defs={"blah": the_manager})
+    def other_asset():
+        pass
+
+    # If IO manager def is provided as a resource def, it appears in required
+    # resource keys on the underlying op.
+    assert set(other_asset.node_def.required_resource_keys) == {"blah"}


### PR DESCRIPTION
Adds resource_defs as an arg to multi_assets. Along the way, made some small tweaks to the way required_resource_keys were generated for regular SDAs, namely that io manager defs provided do not end up in the required resource keys of an asset. Also added documentation for the resource_defs arg of @asset