### PR TITLE
[dagit] Add control for graph depth on the Asset Lineage page, default to 5

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
@@ -1,7 +1,9 @@
 import {gql, useQuery} from '@apollo/client';
+import keyBy from 'lodash/keyBy';
 import React from 'react';
 
 import {filterByQuery, GraphQueryItem} from '../app/GraphQueryImpl';
+import {AssetKey} from '../assets/types';
 import {AssetGroupSelector, PipelineSelector} from '../types/globalTypes';
 
 import {ASSET_NODE_FRAGMENT} from './AssetNode';
@@ -17,6 +19,11 @@ export interface AssetGraphFetchScope {
   pipelineSelector?: PipelineSelector;
   groupSelector?: AssetGroupSelector;
 }
+
+export type AssetGraphQueryItem = GraphQueryItem & {
+  node: AssetNode;
+};
+
 /** Fetches data for rendering an asset graph:
  *
  * @param pipelineSelector: Optionally scope to an asset job, or pass null for the global graph
@@ -88,11 +95,7 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
 type AssetNode = AssetGraphQuery_assetNodes;
 
 const buildGraphQueryItems = (nodes: AssetNode[]) => {
-  const items: {
-    [name: string]: GraphQueryItem & {
-      node: AssetNode;
-    };
-  } = {};
+  const items: {[name: string]: AssetGraphQueryItem} = {};
 
   for (const node of nodes) {
     const name = tokenForAssetKey(node.assetKey);
@@ -128,6 +131,34 @@ const removeEdgesToHiddenAssets = (graphData: GraphData) => {
       }
     }
   }
+};
+
+export const calculateGraphDistances = (items: AssetGraphQueryItem[], assetKey: AssetKey) => {
+  const map = keyBy(items, (g) => g.name);
+  const start = map[tokenForAssetKey(assetKey)];
+  if (!start) {
+    return {upstream: 0, downstream: 0};
+  }
+
+  const bfsUpstream = (ins: AssetGraphQueryItem['inputs'], depth: number): number => {
+    const next = ins
+      .flatMap((i) => i.dependsOn.map((d) => d.solid.name))
+      .map((name) => map[name].inputs);
+
+    return Math.max(depth, ...next.map((nextIns) => bfsUpstream(nextIns, depth + 1)));
+  };
+  const bfsDownstream = (outs: AssetGraphQueryItem['outputs'], depth: number): number => {
+    const next = outs
+      .flatMap((i) => i.dependedBy.map((d) => d.solid.name))
+      .map((name) => map[name].outputs);
+
+    return Math.max(depth, ...next.map((nextOuts) => bfsDownstream(nextOuts, depth + 1)));
+  };
+
+  return {
+    upstream: bfsUpstream(start.inputs, 0),
+    downstream: bfsDownstream(start.outputs, 0),
+  };
 };
 
 const ASSET_GRAPH_QUERY = gql`

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -47,6 +47,7 @@ export interface AssetViewParams {
   view?: 'activity' | 'definition' | 'lineage';
   lineageScope?: AssetLineageScope;
   lineageShowSecondaryEdges?: boolean;
+  lineageDepth?: number;
   partition?: string;
   time?: string;
   asOf?: string;
@@ -71,12 +72,17 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
     : null;
 
   const token = tokenForAssetKey(assetKey);
-  const {assetGraphData, graphAssetKeys} = useAssetGraphData(
+
+  const defaultDepth = params.lineageScope === 'neighbors' ? 2 : 5;
+  const requestedDepth = Number(params.lineageDepth) || defaultDepth;
+  const depthStr = ''.padEnd(requestedDepth, '+');
+
+  const {assetGraphData, graphAssetKeys, graphQueryItems} = useAssetGraphData(
     params.view === 'lineage' && params.lineageScope === 'upstream'
-      ? `*"${token}"`
+      ? `${depthStr}"${token}"`
       : params.view === 'lineage' && params.lineageScope === 'downstream'
-      ? `"${token}"*`
-      : `++"${token}"++`,
+      ? `"${token}"${depthStr}`
+      : `${depthStr}"${token}"${depthStr}`,
     {hideEdgesToNodesOutsideQuery: !params.lineageShowSecondaryEdges},
   );
 
@@ -203,6 +209,8 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
                 assetNode={definition}
                 liveDataByNode={liveDataByNode}
                 assetGraphData={assetGraphData}
+                requestedDepth={requestedDepth}
+                graphQueryItems={graphQueryItems}
               />
             ) : (
               <Box style={{flex: 1}} flex={{alignItems: 'center', justifyContent: 'center'}}>


### PR DESCRIPTION
### Summary & Motivation
![Jun-21-2022 14-58-19](https://user-images.githubusercontent.com/1037212/174887515-28b9f6ed-bef8-47b8-97f1-bd52d51f914f.gif)

This PR adds the depth control above to the lineage views and makes the upstream / downstream perspectives default to 5 layers.

### How I Tested These Changes
