### PR TITLE
[dagit] Move Asset “Upstream Changed” computation to Python

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -48,7 +48,6 @@ import {
   GraphNode,
   isSourceAsset,
   tokenForAssetKey,
-  buildComputeStatusData,
 } from './Utils';
 import {AssetGraphLayout} from './layout';
 import {AssetGraphQuery_assetNodes} from './types/AssetGraphQuery';
@@ -262,11 +261,6 @@ export const AssetGraphExplorerWithData: React.FC<
     }
   };
 
-  const computeStatuses = React.useMemo(
-    () => (assetGraphData ? buildComputeStatusData(assetGraphData, liveDataByNode) : {}),
-    [assetGraphData, liveDataByNode],
-  );
-
   return (
     <SplitPanelContainer
       identifier="explorer"
@@ -330,7 +324,6 @@ export const AssetGraphExplorerWithData: React.FC<
                           <AssetNode
                             definition={graphNode.definition}
                             liveData={liveDataByNode[graphNode.id]}
-                            computeStatus={computeStatuses[graphNode.id]}
                             selected={selectedGraphNodes.includes(graphNode)}
                           />
                         )}

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -10,9 +10,10 @@ import {NodeHighlightColors} from '../graph/OpNode';
 import {OpTags} from '../graph/OpTags';
 import {linkToRunEvent, titleForRun} from '../runs/RunUtils';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
+import {AssetComputeStatus} from '../types/globalTypes';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';
 
-import {ComputeStatus, displayNameForAssetKey, LiveDataForNode} from './Utils';
+import {displayNameForAssetKey, LiveDataForNode} from './Utils';
 import {ASSET_NODE_ANNOTATIONS_MAX_WIDTH, ASSET_NODE_NAME_MAX_LENGTH} from './layout';
 import {AssetNodeFragment} from './types/AssetNodeFragment';
 
@@ -21,16 +22,16 @@ const MISSING_LIVE_DATA = {
   inProgressRunIds: [],
   runWhichFailedToMaterialize: null,
   lastMaterialization: null,
+  computeStatus: AssetComputeStatus.NONE,
   stepKey: '',
 };
 
 export const AssetNode: React.FC<{
   definition: AssetNodeFragment;
   liveData?: LiveDataForNode;
-  computeStatus?: ComputeStatus;
   selected: boolean;
   inAssetCatalog?: boolean;
-}> = React.memo(({definition, selected, liveData, inAssetCatalog, computeStatus}) => {
+}> = React.memo(({definition, selected, liveData, inAssetCatalog}) => {
   const firstOp = definition.opNames.length ? definition.opNames[0] : null;
   const computeName = definition.graphName || definition.opNames[0] || null;
 
@@ -42,7 +43,7 @@ export const AssetNode: React.FC<{
     maxLength: ASSET_NODE_NAME_MAX_LENGTH,
   });
 
-  const {lastMaterialization} = liveData || MISSING_LIVE_DATA;
+  const {lastMaterialization, computeStatus} = liveData || MISSING_LIVE_DATA;
 
   return (
     <AssetNodeContainer $selected={selected}>
@@ -56,13 +57,7 @@ export const AssetNode: React.FC<{
           </div>
           <div style={{flex: 1}} />
           <div style={{maxWidth: ASSET_NODE_ANNOTATIONS_MAX_WIDTH}}>
-            {computeStatus === 'old' && (
-              <UpstreamNotice>
-                upstream
-                <br />
-                changed
-              </UpstreamNotice>
-            )}
+            <ComputeStatusNotice computeStatus={computeStatus} />
           </div>
         </Name>
         {definition.description && !inAssetCatalog && (
@@ -190,7 +185,6 @@ export const ASSET_NODE_FRAGMENT = gql`
     jobNames
     opNames
     description
-    partitionDefinition
     computeKind
     assetKey {
       path
@@ -303,6 +297,17 @@ const UpstreamNotice = styled.div`
   margin-right: -6px;
   border-top-right-radius: 3px;
 `;
+
+export const ComputeStatusNotice: React.FC<{computeStatus: AssetComputeStatus}> = ({
+  computeStatus,
+}) =>
+  computeStatus === AssetComputeStatus.OUT_OF_DATE ? (
+    <UpstreamNotice>
+      upstream
+      <br />
+      changed
+    </UpstreamNotice>
+  ) : null;
 
 export const AssetLatestRunWithNotices: React.FC<{
   liveData?: LiveDataForNode;

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphLiveQuery.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphLiveQuery.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AssetKeyInput, RunStatus } from "./../../types/globalTypes";
+import { AssetKeyInput, AssetComputeStatus, RunStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: AssetGraphLiveQuery
@@ -48,6 +48,7 @@ export interface AssetGraphLiveQuery_assetsLatestInfo_latestRun {
 export interface AssetGraphLiveQuery_assetsLatestInfo {
   __typename: "AssetLatestInfo";
   assetKey: AssetGraphLiveQuery_assetsLatestInfo_assetKey;
+  computeStatus: AssetComputeStatus;
   unstartedRunIds: string[];
   inProgressRunIds: string[];
   latestRun: AssetGraphLiveQuery_assetsLatestInfo_latestRun | null;

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphQuery.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphQuery.ts
@@ -29,7 +29,6 @@ export interface AssetGraphQuery_assetNodes {
   id: string;
   dependencyKeys: AssetGraphQuery_assetNodes_dependencyKeys[];
   dependedByKeys: AssetGraphQuery_assetNodes_dependedByKeys[];
-  partitionDefinition: string | null;
   graphName: string | null;
   jobNames: string[];
   opNames: string[];

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetNodeFragment.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetNodeFragment.ts
@@ -19,7 +19,6 @@ export interface AssetNodeFragment {
   jobNames: string[];
   opNames: string[];
   description: string | null;
-  partitionDefinition: string | null;
   computeKind: string | null;
   assetKey: AssetNodeFragment_assetKey;
 }

--- a/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
@@ -140,7 +140,6 @@ const ASSET_GRAPH_QUERY = gql`
       dependedByKeys {
         path
       }
-      partitionDefinition
       ...AssetNodeFragment
     }
   }

--- a/js_modules/dagit/packages/core/src/asset-graph/useLiveDataForAssetKeys.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useLiveDataForAssetKeys.tsx
@@ -44,6 +44,7 @@ const ASSETS_GRAPH_LIVE_QUERY = gql`
       assetKey {
         path
       }
+      computeStatus
       unstartedRunIds
       inProgressRunIds
       latestRun {

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineageGraph.tsx
@@ -7,7 +7,7 @@ import {AssetConnectedEdges} from '../asset-graph/AssetEdges';
 import {EXPERIMENTAL_MINI_SCALE} from '../asset-graph/AssetGraphExplorer';
 import {AssetNodeMinimal, AssetNode} from '../asset-graph/AssetNode';
 import {ForeignNode} from '../asset-graph/ForeignNode';
-import {buildComputeStatusData, GraphData, LiveData, toGraphId} from '../asset-graph/Utils';
+import {GraphData, LiveData, toGraphId} from '../asset-graph/Utils';
 import {SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
 import {getJSONForKey} from '../hooks/useStateWithStorage';
@@ -46,11 +46,6 @@ export const AssetNodeLineageGraph: React.FC<{
       viewportEl.current.focus();
     }
   }, [viewportEl, layout, assetGraphId]);
-
-  const computeStatuses = React.useMemo(
-    () => buildComputeStatusData(assetGraphData, liveDataByNode),
-    [assetGraphData, liveDataByNode],
-  );
 
   if (!layout || loading) {
     return (
@@ -106,7 +101,6 @@ export const AssetNodeLineageGraph: React.FC<{
                   <AssetNode
                     definition={graphNode.definition}
                     liveData={liveDataByNode[graphNode.id]}
-                    computeStatus={computeStatuses[graphNode.id]}
                     selected={graphNode.id === assetGraphId}
                   />
                 )}

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -18,7 +18,11 @@ import styled from 'styled-components/macro';
 
 import {usePermissions} from '../app/Permissions';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
-import {AssetLatestRunWithNotices, AssetRunLink} from '../asset-graph/AssetNode';
+import {
+  AssetLatestRunWithNotices,
+  AssetRunLink,
+  ComputeStatusNotice,
+} from '../asset-graph/AssetNode';
 import {LiveData, toGraphId} from '../asset-graph/Utils';
 import {useSelectionReducer} from '../hooks/useSelectionReducer';
 import {RepositoryLink} from '../nav/RepositoryLink';
@@ -129,7 +133,7 @@ export const AssetTable = ({
             </th>
             <th>{view === 'directory' ? 'Asset Key Prefix' : 'Asset Key'}</th>
             <th style={{width: 340}}>Defined In</th>
-            <th style={{width: 200}}>Materialized</th>
+            <th style={{width: 265}}>Materialized</th>
             <th style={{width: 115}}>Latest Run</th>
             <th style={{width: 80}}>Actions</th>
           </tr>
@@ -252,24 +256,27 @@ const AssetEntryRow: React.FC<{
         </td>
         <td>
           {liveData ? (
-            liveData.lastMaterialization ? (
-              <Mono>
-                <AssetRunLink
-                  runId={liveData.lastMaterialization.runId}
-                  event={{
-                    stepKey: liveData.stepKey,
-                    timestamp: liveData.lastMaterialization.timestamp,
-                  }}
-                >
-                  <TimestampDisplay
-                    timestamp={Number(liveData.lastMaterialization.timestamp) / 1000}
-                    timeFormat={{showSeconds: false, showTimezone: false}}
-                  />
-                </AssetRunLink>
-              </Mono>
-            ) : (
-              <span>–</span>
-            )
+            <Box flex={{gap: 8, alignItems: 'center'}}>
+              {liveData.lastMaterialization ? (
+                <Mono style={{flex: 1}}>
+                  <AssetRunLink
+                    runId={liveData.lastMaterialization.runId}
+                    event={{
+                      stepKey: liveData.stepKey,
+                      timestamp: liveData.lastMaterialization.timestamp,
+                    }}
+                  >
+                    <TimestampDisplay
+                      timestamp={Number(liveData.lastMaterialization.timestamp) / 1000}
+                      timeFormat={{showSeconds: false, showTimezone: false}}
+                    />
+                  </AssetRunLink>
+                </Mono>
+              ) : (
+                <span>–</span>
+              )}
+              <ComputeStatusNotice computeStatus={liveData?.computeStatus} />
+            </Box>
           ) : undefined}
         </td>
         <td>

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -1,6 +1,7 @@
 import {gql, useQuery} from '@apollo/client';
 import {
   Alert,
+  BaseTag,
   Box,
   ButtonLink,
   Colors,
@@ -26,6 +27,7 @@ import {useLiveDataForAssetKeys} from '../asset-graph/useLiveDataForAssetKeys';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {useDidLaunchEvent} from '../runs/RunUtils';
+import {AssetComputeStatus} from '../types/globalTypes';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
@@ -95,6 +97,9 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
   // Avoid thrashing the materializations UI (which chooses a different default query based on whether
   // data is partitioned) by waiting for the definition to be loaded. (null OR a valid definition)
   const isDefinitionLoaded = definition !== undefined;
+  const isUpstreamChanged =
+    liveDataByNode[toGraphId(assetKey)]?.computeStatus === AssetComputeStatus.OUT_OF_DATE;
+
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', width: '100%', overflowY: 'auto'}}>
       <AssetPageHeader
@@ -123,6 +128,18 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
                 </Link>
               </Tag>
             )}
+            {isUpstreamChanged ? (
+              <Box
+                onClick={() => setParams({...params, view: 'lineage', lineageScope: 'upstream'})}
+              >
+                <BaseTag
+                  fillColor={Colors.Yellow50}
+                  textColor={Colors.Yellow700}
+                  label="Upstream changed"
+                  interactive
+                />
+              </Box>
+            ) : undefined}
           </>
         }
         tabs={

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2249,9 +2249,19 @@ type Permission {
 type AssetLatestInfo {
   assetKey: AssetKey!
   latestMaterialization: MaterializationEvent
+  computeStatus: AssetComputeStatus!
   unstartedRunIds: [String!]!
   inProgressRunIds: [String!]!
   latestRun: Run
+}
+
+"""
+An enumeration.
+"""
+enum AssetComputeStatus {
+  NONE
+  UP_TO_DATE
+  OUT_OF_DATE
 }
 
 union EventConnectionOrError = EventConnection | RunNotFoundError | PythonError

--- a/js_modules/dagit/packages/core/src/types/globalTypes.ts
+++ b/js_modules/dagit/packages/core/src/types/globalTypes.ts
@@ -7,6 +7,12 @@
 // START Enums and Input Objects
 //==============================================================
 
+export enum AssetComputeStatus {
+  NONE = "NONE",
+  OUT_OF_DATE = "OUT_OF_DATE",
+  UP_TO_DATE = "UP_TO_DATE",
+}
+
 export enum BackfillStatus {
   CANCELED = "CANCELED",
   COMPLETED = "COMPLETED",

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -19,6 +19,7 @@ from dagster.core.host_representation.external_data import (
     ExternalTimeWindowPartitionsDefinitionData,
 )
 
+from ..implementation.fetch_runs import AssetComputeStatus
 from ..implementation.loader import BatchMaterializationLoader, CrossRepoAssetDependedByLoader
 from . import external
 from .asset_key import GrapheneAssetKey
@@ -79,6 +80,7 @@ class GrapheneAssetDependency(graphene.ObjectType):
 class GrapheneAssetLatestInfo(graphene.ObjectType):
     assetKey = graphene.NonNull(GrapheneAssetKey)
     latestMaterialization = graphene.Field(GrapheneMaterializationEvent)
+    computeStatus = graphene.NonNull(graphene.Enum.from_enum(AssetComputeStatus))
     unstartedRunIds = non_null_list(graphene.String)
     inProgressRunIds = non_null_list(graphene.String)
     latestRun = graphene.Field(GrapheneRun)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -115,6 +115,7 @@ GET_ASSET_LATEST_RUN_STATS = """
             assetKey {
                 path
             }
+            computeStatus
             latestMaterialization {
                 timestamp
                 runId
@@ -780,6 +781,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
 
         assert result["asset_1"]["latestRun"] == None
         assert result["asset_1"]["latestMaterialization"] == None
+        assert result["asset_1"]["computeStatus"] == "NONE"
 
         # Test with 1 run on all assets
         first_run_id = _create_run(graphql_context, "failure_assets_job")
@@ -802,10 +804,13 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
 
         assert result["asset_1"]["latestRun"]["id"] == first_run_id
         assert result["asset_1"]["latestMaterialization"]["runId"] == first_run_id
+        assert result["asset_1"]["computeStatus"] == "UP_TO_DATE"
         assert result["asset_2"]["latestRun"]["id"] == first_run_id
         assert result["asset_2"]["latestMaterialization"] == None
+        assert result["asset_2"]["computeStatus"] == "NONE"
         assert result["asset_3"]["latestRun"]["id"] == first_run_id
         assert result["asset_3"]["latestMaterialization"] == None
+        assert result["asset_3"]["computeStatus"] == "NONE"
 
         # Confirm that asset selection is respected
         run_id = _create_run(
@@ -828,8 +833,11 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         assert result.data["assetsLatestInfo"]
         result = get_response_by_asset(result.data["assetsLatestInfo"])
         assert result["asset_1"]["latestRun"]["id"] == first_run_id
+        assert result["asset_1"]["computeStatus"] == "UP_TO_DATE"
         assert result["asset_2"]["latestRun"]["id"] == first_run_id
+        assert result["asset_2"]["computeStatus"] == "NONE"
         assert result["asset_3"]["latestRun"]["id"] == run_id
+        assert result["asset_3"]["computeStatus"] == "OUT_OF_DATE"
 
     def test_get_run_materialization(self, graphql_context, snapshot):
         _create_run(graphql_context, "single_asset_pipeline")


### PR DESCRIPTION
### Summary & Motivation

Hey folks! This PR is my attempt to extend @clairelin135's excellent work on the `assetsLatestInfo` resolver to calculate the "upstream changed" status of each asset in Python instead of in Dagit. There are several reasons for this change:

- The "upstream changed" state of assets cascade. Given `A => B => C`, if B is older than A, both B and C display "upstream changed". This means that calculating this value for a given asset requires the latest materialization timestamps of ALL upstream assets across repos, asset groups, etc. Dagit increasingly does not have this info loaded (asset group pages, etc.). We're computing "upstream changed" with the subset of data it *does* have, and it produces inconsistent results based on what subgraph of assets you're looking at.

- The "upstream changed" calculation currently ignores partitioned assets and source assets, and Dagit needs to request partition definitions, etc. just for the purposes of running this algorithm.

- Having this computed server side allows us to render the status in more places more easily!

The backend implementation of this is a basic translation of the JS version, so it may not be the most performant / pythonic approach! Super open to changes.

**Specific Behaviors:**

- Assets have a "NONE" status if they have never been materialized.

- Assets have an "OUT_OF_DATE" status if:
   + One of their dependencies has a newer materialization date
   + One of their dependencies has a NONE or OUT_OF_DATE status.

- Assets have an "UP_TO_DATE" status if:
    + They are partitioned assets (not supported)
    + They are source assets (not tracked)
    + They do not match the NONE or OUT_OF_DATE conditions
    
If you have a partitioned asset (always UP_TO_DATE) which "sinks" into an unpartitioned asset, the unpartitioned asset essentially does not consider the partitioned asset, but will still consider other inputs. (Addresses https://github.com/dagster-io/dagster/issues/7434) I /think/ this is the best way to do this but I'm open to thoughts!


New UI:

In the asset catalog!
![image](https://user-images.githubusercontent.com/1037212/174906528-eaa2623b-4f5c-4156-a5c7-f99e689e7bcf.png)

In the top nav on asset details! (clicking this takes you to upstream lineage)
![image](https://user-images.githubusercontent.com/1037212/174906576-d2e255e3-b7bb-4270-a17d-44164e153d96.png)

 
### How I Tested These Changes

