### PR TITLE
k8s executor pass args via env var

### DIFF
--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -315,7 +315,7 @@ def verify_step(instance, pipeline_run, retry_state, step_keys_to_execute):
         "interactively."
     ),
 )
-@click.argument("input_json", type=click.STRING)
+@click.argument("input_json", type=click.STRING, envvar="DAGSTER_EXECUTE_STEP_ARGS")
 def execute_step_command(input_json):
     with capture_interrupts():
 

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -236,12 +236,23 @@ class ExecuteStepArgs(
             ),
         )
 
-    def get_command_args(self) -> List[str]:
-        return _get_entry_point(self.pipeline_origin) + [
-            "api",
-            "execute_step",
-            serialize_dagster_namedtuple(self),
-        ]
+    def get_command_args(self, skip_serialized_namedtuple=False) -> List[str]:
+        """
+        Get the command args to run this step. If skip_serialized_namedtuple is True, then get_command_env should
+        be used to pass the args to Click using an env var.
+        """
+        return (
+            _get_entry_point(self.pipeline_origin)
+            + ["api", "execute_step"]
+            + ([serialize_dagster_namedtuple(self)] if not skip_serialized_namedtuple else [])
+        )
+
+    def get_command_env(self) -> List[Dict[str, str]]:
+        """
+        Get the env vars for overriding the Click args of this step. Used in conjuction with
+        get_command_args(skip_serialized_namedtuple=True).
+        """
+        return [{"name": "DAGSTER_EXECUTE_STEP_ARGS", "value": serialize_dagster_namedtuple(self)}]
 
 
 @whitelist_for_serdes

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -538,6 +538,7 @@ def construct_dagster_k8s_job(
     pod_name=None,
     component=None,
     labels=None,
+    env_vars=None,
 ):
     """Constructs a Kubernetes Job object for a dagster-graphql invocation.
 
@@ -598,11 +599,11 @@ def construct_dagster_k8s_job(
     additional_labels = {k: sanitize_k8s_label(v) for k, v in (labels or {}).items()}
     dagster_labels = merge_dicts(k8s_common_labels, additional_labels)
 
-    env = (
-        [{"name": "DAGSTER_HOME", "value": job_config.dagster_home}]
-        if job_config.dagster_home
-        else []
-    )
+    env = env_vars or []
+
+    if job_config.dagster_home:
+        env.append({"name": "DAGSTER_HOME", "value": job_config.dagster_home})
+
     if job_config.postgres_password_secret:
         env.append(
             {


### PR DESCRIPTION
Update:

changed to using env var for the full argument using the click feature. Not currently zipping- I think this buys us the time to make the proper change of filtering known state down to what's required.

---

For https://github.com/dagster-io/dagster/issues/8314

From https://elementl-workspace.slack.com/archives/C03D094F23G/p1654870219039639, could also
- gzip
- pass the whole input json as an env

Now that I type this out maybe that second option makes the most sense?