### PR TITLE
GraphQL Fix indexing on deleted run

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -170,7 +170,10 @@ def get_assets_live_info(graphene_info, step_keys_by_asset: Mapping[AssetKey, Li
             list(unstarted_run_ids_by_asset.get(asset_key, [])),
             list(in_progress_run_ids_by_asset.get(asset_key, [])),
             GrapheneRun(run_records_by_run_id[latest_run_ids_by_asset[asset_key]])
+            # Dagit error occurs if a run is terminated at the same time that this endpoint is called
+            # so we check to make sure the run ID exists in the run records
             if asset_key in latest_run_ids_by_asset
+            and latest_run_ids_by_asset[asset_key] in run_records_by_run_id
             else None,
         )
         for asset_key in step_keys_by_asset.keys()


### PR DESCRIPTION
A rare error occurs when an asset run is deleted at the same time that Dagit attempts to load the latest run by asset:
https://dagster.slack.com/archives/C01U954MEER/p1655917412099299

I wasn't able to replicate the error (I think the timing has to be exactly right) but I think this fix will prevent this error from occurring again.