### PR TITLE
[dagit] Repair dialog ordering for confirmation/alert dialogs

### DIFF
--- a/js_modules/dagit/packages/core/src/app/CustomAlertProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/CustomAlertProvider.tsx
@@ -23,7 +23,10 @@ export const showCustomAlert = (opts: Partial<ICustomAlert>) => {
   setCustomAlert(Object.assign({body: '', title: 'Error'}, opts));
 };
 
+const REMOVAL_DELAY = 500;
+
 export const CustomAlertProvider = () => {
+  const [mounted, setMounted] = React.useState(false);
   const [alert, setAlert] = React.useState(() => CurrentAlert);
   const body = React.useRef<HTMLDivElement>(null);
 
@@ -35,6 +38,19 @@ export const CustomAlertProvider = () => {
     return () => document.removeEventListener(CURRENT_ALERT_CHANGED, setter);
   }, []);
 
+  // When an alert is set, allow the Dialog to be mounted. When it is cleared,
+  // remove the Dialog from the tree so that its root node doesn't linger in the DOM
+  // and cause subsequent z-index bugs.
+  React.useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    if (!!alert) {
+      setMounted(true);
+    } else {
+      timer = setTimeout(() => setMounted(false), REMOVAL_DELAY);
+    }
+    return () => timer && clearTimeout(timer);
+  }, [alert]);
+
   const onCopy = React.useCallback(
     (e: React.MouseEvent) => {
       const copyElement = copySelector ? body.current!.querySelector(copySelector) : body.current;
@@ -44,6 +60,10 @@ export const CustomAlertProvider = () => {
     },
     [copySelector],
   );
+
+  if (!mounted) {
+    return null;
+  }
 
   return (
     <Dialog

--- a/js_modules/dagit/packages/core/src/app/CustomConfirmationProvider.test.tsx
+++ b/js_modules/dagit/packages/core/src/app/CustomConfirmationProvider.test.tsx
@@ -1,0 +1,100 @@
+import {Button} from '@dagster-io/ui';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import {act} from 'react-dom/test-utils';
+
+import {CustomConfirmationProvider, useConfirmation} from './CustomConfirmationProvider';
+
+describe('CustomConfirmationProvider', () => {
+  const Test = () => {
+    const [confirmed, setConfirmed] = React.useState(false);
+    const confirm = useConfirmation();
+    const onClick = async () => {
+      await confirm({title: 'r u sure about this', description: 'it could be a bad idea'});
+      setConfirmed(true);
+    };
+    return (
+      <>
+        <Button onClick={onClick}>Terminate</Button>
+        <div>Confirmed? {String(confirmed)}</div>
+      </>
+    );
+  };
+
+  it('must not render a Dialog initially', async () => {
+    render(
+      <CustomConfirmationProvider>
+        <Test />
+      </CustomConfirmationProvider>,
+    );
+
+    expect(screen.queryByRole('button', {name: /cancel/i})).toBeNull();
+  });
+
+  it('must render a Dialog when `confirm` is executed', async () => {
+    render(
+      <CustomConfirmationProvider>
+        <Test />
+      </CustomConfirmationProvider>,
+    );
+
+    const button = screen.queryByRole('button', {name: /terminate/i}) as HTMLButtonElement;
+    userEvent.click(button);
+
+    expect(screen.queryByText(/r u sure about this/i)).toBeVisible();
+  });
+
+  it('must perform confirmation correctly', async () => {
+    render(
+      <CustomConfirmationProvider>
+        <Test />
+      </CustomConfirmationProvider>,
+    );
+
+    const button = screen.queryByRole('button', {name: /terminate/i}) as HTMLButtonElement;
+    userEvent.click(button);
+
+    const confirmationButton = screen.queryByRole('button', {
+      name: /confirm/i,
+    }) as HTMLButtonElement;
+
+    // Resolves the promise.
+    await act(async () => {
+      userEvent.click(confirmationButton);
+    });
+
+    expect(screen.queryByText(/confirmed\? true/i)).toBeVisible();
+  });
+
+  it('must remove the confirmation Dialog from the DOM afterward', async () => {
+    jest.useFakeTimers();
+
+    render(
+      <CustomConfirmationProvider>
+        <Test />
+      </CustomConfirmationProvider>,
+    );
+
+    const button = screen.queryByRole('button', {name: /terminate/i}) as HTMLButtonElement;
+    userEvent.click(button);
+
+    const confirmationButton = screen.queryByRole('button', {
+      name: /confirm/i,
+    }) as HTMLButtonElement;
+
+    // Resolves the promise.
+    await act(async () => {
+      userEvent.click(confirmationButton);
+    });
+
+    expect(screen.queryByText(/confirmed\? true/i)).toBeVisible();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const dialogContainers = document.querySelectorAll('.bp3-dialog');
+    expect(dialogContainers).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
### Summary & Motivation

Resolves #8423.

The Dialog components used for `CustomConfirmationProvider` and `CustomAlertProvider` are reused singleton components that, once rendered initially, remain in the DOM forever.

The problem is that when one of these is opened from another Dialog after already having been rendered before (and therefore already existing in the DOM), the DOM order causes the confirmation or alert Dialog to sit behind the Dialog that opened it.

We could strap on our helmets and start some z-index wars, but I think I prefer this instead: don't leave the confirmation or alert Dialog sitting in the DOM once we're done with it. Unmount it after a delay, then remount it when a new confirmation/alert arrives. The delay allows the fade-out animation to be visible to the user before the unmount occurs.

Open to thoughts on this.

### How I Tested These Changes

View asset config dialog that requires some scaffolding. Open scaffold Dialog (confirmation), then close both dialogs. Repeat, and verify that the confirmation dialog now properly sits on top of the config dialog.

I also added a jest test that includes testing the unmount behavior.
