### PR TITLE
Move check in execute_step that the run exists outside of a try-catch block

### DIFF
--- a/python_modules/dagster/dagster/cli/api.py
+++ b/python_modules/dagster/dagster/cli/api.py
@@ -351,12 +351,12 @@ def _execute_step_command_body(
         if args.step_keys_to_execute and len(args.step_keys_to_execute) == 1
         else None
     )
+    check.inst(
+        pipeline_run,
+        PipelineRun,
+        "Pipeline run with id '{}' not found for step execution".format(args.pipeline_run_id),
+    )
     try:
-        check.inst(
-            pipeline_run,
-            PipelineRun,
-            "Pipeline run with id '{}' not found for step execution".format(args.pipeline_run_id),
-        )
         check.inst(
             pipeline_run.pipeline_code_origin,
             PipelinePythonOrigin,


### PR DESCRIPTION
Summary:
If this fails, we hit an error when trying to log the error event to the event log since it needs to have a run ID

### Summary & Motivation

### How I Tested These Changes
