### PR TITLE
Allow op def / resource def invocation when resources are required, but no used in body of op/resource.

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_definition.py
@@ -229,6 +229,10 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources):
                 return resource_invocation_result(
                     self, cast(Optional[UnboundInitResourceContext], kwargs[context_param_name])
                 )
+        elif len(args) + len(kwargs) > 0:
+            raise DagsterInvalidInvocationError(
+                f"Attempted to invoke resource with argument, but underlying function has no context argument. Either specify a context argument on the resource function, or remove the passed-in argument."
+            )
         else:
             return resource_invocation_result(self, None)
 

--- a/python_modules/dagster/dagster/core/definitions/resource_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_invocation.py
@@ -50,16 +50,18 @@ def resource_invocation_result(
 def _check_invocation_requirements(
     resource_def: "ResourceDefinition", init_context: Optional["UnboundInitResourceContext"]
 ) -> "InitResourceContext":
+    from dagster.core.definitions.resource_definition import is_context_provided
     from dagster.core.execution.context.init import InitResourceContext, build_init_resource_context
 
-    if resource_def.required_resource_keys and init_context is None:
+    context_provided = is_context_provided(resource_def.resource_fn)
+    if context_provided and resource_def.required_resource_keys and init_context is None:
         raise DagsterInvalidInvocationError(
             "Resource has required resources, but no context was provided. Use the "
             "`build_init_resource_context` function to construct a context with the required "
             "resources."
         )
 
-    if init_context is not None and resource_def.required_resource_keys:
+    if context_provided and init_context is not None and resource_def.required_resource_keys:
         ensure_requirements_satisfied(
             init_context._resource_defs,  # pylint: disable=protected-access
             list(resource_def.get_resource_requirements()),

--- a/python_modules/dagster/dagster/core/definitions/solid_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_invocation.py
@@ -75,7 +75,11 @@ def _check_invocation_requirements(
     """
 
     # Check resource requirements
-    if solid_def.required_resource_keys and context is None:
+    if (
+        solid_def.required_resource_keys
+        and solid_def.compute_fn.has_context_arg()
+        and context is None
+    ):
         node_label = solid_def.node_type_str  # string "solid" for solids, "op" for ops
         raise DagsterInvalidInvocationError(
             f'{node_label} "{solid_def.name}" has required resources, but no context was provided. Use the'

--- a/python_modules/dagster/dagster/core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/core/execution/context/invocation.py
@@ -301,10 +301,10 @@ def _validate_resource_requirements(
     resource_defs: Mapping[str, ResourceDefinition], solid_def: SolidDefinition
 ) -> None:
     """Validate correctness of resources against required resource keys"""
-
-    for requirement in solid_def.get_resource_requirements():
-        if not requirement.is_io_manager_requirement:
-            ensure_requirements_satisfied(resource_defs, [requirement])
+    if solid_def.compute_fn.has_context_arg():
+        for requirement in solid_def.get_resource_requirements():
+            if not requirement.is_io_manager_requirement:
+                ensure_requirements_satisfied(resource_defs, [requirement])
 
 
 def _resolve_bound_config(solid_config: Any, solid_def: SolidDefinition) -> Any:

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_invocation.py
@@ -213,3 +213,19 @@ def test_resource_invocation_kitchen_sink_config():
     }
 
     assert kitchen_sink(build_init_resource_context(config=resource_config)) == resource_config
+
+
+def test_resource_dep_no_context():
+    @resource(required_resource_keys={"foo"})
+    def the_resource():
+        pass
+
+    the_resource()
+
+    with pytest.raises(
+        DagsterInvalidInvocationError,
+        match="Attempted to invoke resource with argument, but underlying "
+        "function has no context argument. Either specify a context argument on "
+        "the resource function, or remove the passed-in argument.",
+    ):
+        the_resource(None)

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
@@ -1074,3 +1074,20 @@ def test_get_mapping_key():
         assert context.get_mapping_key() == "the_key"  # Ensure bound context has mapping key
 
     basic_op(context)
+
+
+def test_required_resource_keys_no_context_invocation():
+    @op(required_resource_keys={"foo"})
+    def uses_resource_no_context():
+        pass
+
+    uses_resource_no_context()
+
+    with pytest.raises(
+        DagsterInvalidInvocationError,
+        match="Too many input arguments were provided for op "
+        "'uses_resource_no_context'. This may be because an argument was "
+        "provided for the context parameter, but no context parameter was "
+        "defined for the solid.",
+    ):
+        uses_resource_no_context(None)


### PR DESCRIPTION
It's possible to specify an op definition or resource definition that requires a resource to be initialized, but doesn't explicitly use it within the body of the op. We don't handle this case gracefully when invoking, because we expect all ops/resources that have resource requirements to have a context argument. This fixes the case for both ops and resources.