### PR TITLE
Implement output event equality checking

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -141,7 +141,6 @@ class AssetsDefinition(ResourceAddable):
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
         group_name: Optional[str] = None,
-        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     ) -> "AssetsDefinition":
         """
         Constructs an AssetsDefinition from a GraphDefinition.
@@ -171,7 +170,6 @@ class AssetsDefinition(ResourceAddable):
             internal_asset_deps,
             partitions_def,
             group_name,
-            resource_defs,
         )
 
     @staticmethod
@@ -221,7 +219,6 @@ class AssetsDefinition(ResourceAddable):
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
         group_name: Optional[str] = None,
-        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     ) -> "AssetsDefinition":
         node_def = check.inst_param(node_def, "node_def", (GraphDefinition, OpDefinition))
         keys_by_input_name = check.opt_dict_param(

--- a/python_modules/dagster/dagster/core/asset_defs/assets.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets.py
@@ -141,6 +141,7 @@ class AssetsDefinition(ResourceAddable):
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
         group_name: Optional[str] = None,
+        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     ) -> "AssetsDefinition":
         """
         Constructs an AssetsDefinition from a GraphDefinition.
@@ -170,6 +171,7 @@ class AssetsDefinition(ResourceAddable):
             internal_asset_deps,
             partitions_def,
             group_name,
+            resource_defs,
         )
 
     @staticmethod
@@ -219,6 +221,7 @@ class AssetsDefinition(ResourceAddable):
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
         group_name: Optional[str] = None,
+        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     ) -> "AssetsDefinition":
         node_def = check.inst_param(node_def, "node_def", (GraphDefinition, OpDefinition))
         keys_by_input_name = check.opt_dict_param(

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -237,6 +237,21 @@ class Output(Generic[T]):
     def output_name(self) -> str:
         return self._output_name
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Output):
+            return False
+        metadata_entries_equal = len(self.metadata_entries) == len(other.metadata_entries) and all(
+            [
+                this_entry == other_entry
+                for this_entry, other_entry in zip(self.metadata_entries, other.metadata_entries)
+            ]
+        )
+        return (
+            self.value == other.value
+            and self.output_name == other.output_name
+            and metadata_entries_equal
+        )
+
 
 class DynamicOutput(Generic[T]):
     """
@@ -298,6 +313,22 @@ class DynamicOutput(Generic[T]):
     @property
     def output_name(self) -> str:
         return self._output_name
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, DynamicOutput):
+            return False
+        metadata_entries_equal = len(self.metadata_entries) == len(other.metadata_entries) and all(
+            [
+                this_entry == other_entry
+                for this_entry, other_entry in zip(self.metadata_entries, other.metadata_entries)
+            ]
+        )
+        return (
+            self.value == other.value
+            and self.output_name == other.output_name
+            and self.mapping_key == other.mapping_key
+            and metadata_entries_equal
+        )
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -238,18 +238,11 @@ class Output(Generic[T]):
         return self._output_name
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Output):
-            return False
-        metadata_entries_equal = len(self.metadata_entries) == len(other.metadata_entries) and all(
-            [
-                this_entry == other_entry
-                for this_entry, other_entry in zip(self.metadata_entries, other.metadata_entries)
-            ]
-        )
         return (
-            self.value == other.value
+            isinstance(other, Output)
+            and self.value == other.value
             and self.output_name == other.output_name
-            and metadata_entries_equal
+            and self.metadata_entries == other.metadata_entries
         )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_output_events.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_output_events.py
@@ -1,0 +1,35 @@
+from dagster import Output, DynamicOutput
+
+
+def test_output_object_equality():
+    def _get_output():
+        return Output(5, output_name="foo", metadata={"foo": "bar"})
+
+    assert _get_output() == _get_output()
+
+    assert not _get_output() == Output(6, output_name="foo", metadata={"foo": "bar"})
+    assert not _get_output() == Output(5, output_name="diff", metadata={"foo": "bar"})
+
+    assert not _get_output() == Output(5, output_name="foo", metadata={"foo": "baz"})
+
+    assert not _get_output() == DynamicOutput(
+        5, output_name="foo", metadata={"foo": "bar"}, mapping_key="blah"
+    )
+
+
+def test_dynamic_output_object_equality():
+    def _get_output():
+        return DynamicOutput(5, output_name="foo", mapping_key="bar", metadata={"foo": "bar"})
+
+    assert _get_output() == _get_output()
+
+    assert not _get_output() == DynamicOutput(
+        6, output_name="foo", metadata={"foo": "bar"}, mapping_key="bar"
+    )
+    assert not _get_output() == DynamicOutput(
+        5, output_name="diff", metadata={"foo": "bar"}, mapping_key="bar"
+    )
+
+    assert not _get_output() == DynamicOutput(
+        5, output_name="foo", metadata={"foo": "baz"}, mapping_key="bar"
+    )

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_output_events.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_output_events.py
@@ -1,4 +1,4 @@
-from dagster import Output, DynamicOutput
+from dagster import DynamicOutput, Output
 
 
 def test_output_object_equality():


### PR DESCRIPTION
Resolves https://github.com/dagster-io/dagster/issues/8593.

Useful for certain testing flows; ie I invoke an op that produces a list of DynamicOutputs, I want to check that the output produced is the right one without having to manually deconstruct.