### PR TITLE
Allow run_id to be set from context builder APIs, thread run_id through resource init

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/resource_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_invocation.py
@@ -86,6 +86,7 @@ def _check_invocation_requirements(
         resource_def=resource_def,
         instance=init_context.instance,
         log_manager=init_context.log,
+        run_id=init_context.run_id,
     )
 
 

--- a/python_modules/dagster/dagster/core/definitions/utils.py
+++ b/python_modules/dagster/dagster/core/definitions/utils.py
@@ -17,6 +17,7 @@ from dagster.utils.yaml_utils import merge_yaml_strings, merge_yamls
 DEFAULT_OUTPUT = "result"
 DEFAULT_GROUP_NAME = "default"  # asset group_name used when none is provided
 DEFAULT_IO_MANAGER_KEY = "io_manager"
+EPHEMERAL_RUN_ID = "EPHEMERAL"
 
 DISALLOWED_NAMES = set(
     [

--- a/python_modules/dagster/dagster/core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/core/execution/context/invocation.py
@@ -70,6 +70,7 @@ class UnboundSolidExecutionContext(OpExecutionContext):
 
         self._solid_config = solid_config
         self._mapping_key = mapping_key
+        self._run_id = run_id
 
         self._instance_provided = (
             check.opt_inst_param(instance, "instance", DagsterInstance) is not None
@@ -88,6 +89,7 @@ class UnboundSolidExecutionContext(OpExecutionContext):
             resources=self._resource_defs,
             instance=instance,
             resource_config=resources_config,
+            run_id=self._run_id,
         )
         self._resources = self._resources_cm.__enter__()  # pylint: disable=no-member
         self._resources_contain_cm = isinstance(self._resources, IContainsGenerator)
@@ -98,7 +100,6 @@ class UnboundSolidExecutionContext(OpExecutionContext):
         self._partition_key = partition_key
         self._user_events: List[UserEvent] = []
         self._output_metadata: Dict[str, Any] = {}
-        self._run_id = run_id
 
     def __enter__(self):
         self._cm_scope_entered = True

--- a/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
+++ b/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
@@ -256,6 +256,7 @@ def execution_context_event_generator(
         instance=instance,
         emit_persistent_events=True,
         pipeline_def_for_backwards_compat=pipeline_def,
+        run_id=None,
     )
     yield from resources_manager.generate_setup_events()
     scoped_resources_builder = check.inst(resources_manager.get_object(), ScopedResourcesBuilder)

--- a/python_modules/dagster/dagster/core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/core/execution/resources_init.py
@@ -58,6 +58,7 @@ def resource_initialization_manager(
     instance: Optional[DagsterInstance],
     emit_persistent_events: Optional[bool],
     pipeline_def_for_backwards_compat: Optional[PipelineDefinition],
+    run_id: Optional[str],
 ):
     generator = resource_initialization_event_generator(
         resource_defs=resource_defs,
@@ -69,6 +70,7 @@ def resource_initialization_manager(
         instance=instance,
         emit_persistent_events=emit_persistent_events,
         pipeline_def_for_backwards_compat=pipeline_def_for_backwards_compat,
+        run_id=run_id,
     )
     return EventGenerationManager(generator, ScopedResourcesBuilder)
 
@@ -134,6 +136,7 @@ def _core_resource_initialization_event_generator(
     instance: Optional[DagsterInstance],
     emit_persistent_events: Optional[bool],
     pipeline_def_for_backwards_compat: Optional[PipelineDefinition],
+    run_id: Optional[str],
 ):
 
     pipeline_name = ""  # Must be initialized to a string to satisfy typechecker
@@ -180,6 +183,7 @@ def _core_resource_initialization_event_generator(
                     resources=resources,
                     instance=instance,
                     pipeline_def_for_backwards_compat=pipeline_def_for_backwards_compat,
+                    run_id=run_id,
                 )
                 manager = single_resource_generation_manager(
                     resource_context, resource_name, resource_def
@@ -232,6 +236,7 @@ def resource_initialization_event_generator(
     instance: Optional[DagsterInstance],
     emit_persistent_events: Optional[bool],
     pipeline_def_for_backwards_compat: Optional[PipelineDefinition],
+    run_id: Optional[str],
 ):
     check.inst_param(log_manager, "log_manager", DagsterLogManager)
     resource_keys_to_init = check.opt_set_param(
@@ -268,6 +273,7 @@ def resource_initialization_event_generator(
             instance=instance,
             emit_persistent_events=emit_persistent_events,
             pipeline_def_for_backwards_compat=pipeline_def_for_backwards_compat,
+            run_id=run_id,
         )
     except GeneratorExit:
         # Shouldn't happen, but avoid runtime-exception in case this generator gets GC-ed

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_build_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_build_resources.py
@@ -2,6 +2,7 @@ import pytest
 
 from dagster import Field, resource
 from dagster.core.definitions.resource_definition import IContainsGenerator
+from dagster.core.definitions.utils import EPHEMERAL_RUN_ID
 from dagster.core.errors import DagsterResourceFunctionError
 from dagster.core.execution.build_resources import build_resources
 
@@ -99,3 +100,16 @@ def test_context_manager_resource():
         assert resources.cm_resource == "foo"
 
     assert tore_down == ["yes"]
+
+
+def test_build_resources_run_id():
+    @resource
+    def the_resource_uses_default(context):
+        assert context.run_id == EPHEMERAL_RUN_ID
+
+    @resource
+    def the_resource_changes_default(context):
+        assert context.run_id == "foo"
+
+    build_resources(resources={"the_resource": the_resource_uses_default}, run_id="foo")
+    build_resources(resources={"the_resource": the_resource_changes_default})

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_invocation.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 import pytest
 
 from dagster import Field, Noneable, Selector, build_init_resource_context, resource
+from dagster.core.definitions.utils import EPHEMERAL_RUN_ID
 from dagster.core.errors import (
     DagsterInvalidConfigError,
     DagsterInvalidDefinitionError,
@@ -213,3 +214,17 @@ def test_resource_invocation_kitchen_sink_config():
     }
 
     assert kitchen_sink(build_init_resource_context(config=resource_config)) == resource_config
+
+
+def test_run_id():
+    @resource
+    def doesnt_change_default(context):
+        assert context.run_id == EPHEMERAL_RUN_ID
+
+    doesnt_change_default(None)
+
+    @resource
+    def changes_default(context):
+        assert context.run_id == "FOO"
+
+    changes_default(build_init_resource_context(run_id="FOO"))


### PR DESCRIPTION
Solves https://github.com/dagster-io/dagster/issues/6091 + some extras.

Allows setting a custom run_id value when using `build_resources`, `build_init_resource_context`, or `build_op_context`. Still defaults to using the old ephemeral run id so as to not break anyone.