### PR TITLE
[dagit] Clean up tab focus on Firefox

### DIFF
--- a/js_modules/dagit/packages/app/src/index.tsx
+++ b/js_modules/dagit/packages/app/src/index.tsx
@@ -49,6 +49,14 @@ const SettingsLink = styled(Link)`
   &:active ${IconWrapper} {
     background: ${Colors.White};
   }
+
+  &:focus {
+    outline: none;
+
+    ${IconWrapper} {
+      background: ${Colors.White};
+    }
+  }
 `;
 
 ReactDOM.render(

--- a/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
@@ -187,6 +187,11 @@ export const TopNavLink = styled(Link)`
     color: ${Colors.White};
     text-decoration: none;
   }
+
+  :focus {
+    outline: none !important;
+    color: ${Colors.White};
+  }
 `;
 
 export const AppTopNavContainer = styled.div`


### PR DESCRIPTION
### Summary & Motivation

Clean up top nav tab focus on Firefox, using a shift in text color instead of the blue outline.

At some point we should think through focus outlines throughout the app, since I think we're pretty inconsistent. We have some nice, thorough styles, and some that we haven't touched at all.

### How I Tested These Changes

Load Dagit in Firefox, verify that top nav items use white text color to demonstrate focus, instead of blue lines that look too broken too keep around.
