### PR TITLE
[dagit] Repair cron string regex for timezone

### DIFF
--- a/js_modules/dagit/packages/core/src/schedules/humanCronString.test.ts
+++ b/js_modules/dagit/packages/core/src/schedules/humanCronString.test.ts
@@ -28,6 +28,30 @@ describe('humanCronString', () => {
       );
     });
 
+    it('shows timezones on actual times, if cron is showing "X minutes..." or "X seconds..."', () => {
+      const timezone = 'America/Chicago';
+      expect(humanCronString('0 5 0/1 * * ?', timezone)).toBe('At 5 minutes past the hour');
+      expect(humanCronString('30 * * 6-8 *', timezone)).toBe(
+        'At 30 minutes past the hour, June through August',
+      );
+      expect(humanCronString('30 */5 * * * *', timezone)).toBe(
+        'At 30 seconds past the minute, every 5 minutes',
+      );
+      expect(humanCronString('2,4-5 1 * * *', timezone)).toBe(
+        'At 2 and 4 through 5 minutes past the hour, at 01:00 AM CDT',
+      );
+    });
+
+    it('shows timezone in complex time cases', () => {
+      const timezone = 'America/Chicago';
+      expect(humanCronString('2-59/3 1,9,22 11-26 1-6 ?', timezone)).toBe(
+        'Every 3 minutes, minutes 2 through 59 past the hour, at 01:00 AM CDT, 09:00 AM CDT, and 10:00 PM CDT, between day 11 and 26 of the month, January through June',
+      );
+      expect(humanCronString('12-50 0-10 6 * * * 2022', timezone)).toBe(
+        'Seconds 12 through 50 past the minute, minutes 0 through 10 past the hour, at 06:00 AM CDT, only in 2022',
+      );
+    });
+
     it('shows timezone (UTC) if provided, if cron specifies a time', () => {
       const timezone = 'UTC';
       expect(humanCronString('@daily', timezone)).toBe('At 12:00 AM UTC');
@@ -90,6 +114,15 @@ describe('humanCronString', () => {
       expect(humanCronString('@monthly')).toBe('At 00:00, on day 1 of the month');
       expect(humanCronString('0 23 ? * MON-FRI')).toBe('At 23:00, Monday through Friday');
       expect(humanCronString('0 23 * * *')).toBe('At 23:00');
+    });
+
+    it('shows timezone in complex time cases', () => {
+      expect(humanCronString('2-59/3 1,9,22 11-26 1-6 ?', timezone)).toBe(
+        'Every 3 minutes, minutes 2 through 59 past the hour, at 01:00 CEST, 09:00 CEST, and 22:00 CEST, between day 11 and 26 of the month, January through June',
+      );
+      expect(humanCronString('12-50 0-10 22 * * * 2022', timezone)).toBe(
+        'Seconds 12 through 50 past the minute, minutes 0 through 10 past the hour, at 22:00 CEST, only in 2022',
+      );
     });
   });
 });

--- a/js_modules/dagit/packages/core/src/schedules/humanCronString.ts
+++ b/js_modules/dagit/packages/core/src/schedules/humanCronString.ts
@@ -11,13 +11,13 @@ const formatOptions = memoize((language: string) => {
 });
 
 export const humanCronString = (cronSchedule: string, longTimezone?: string) => {
-  const human = convertString(cronSchedule);
+  let human = convertString(cronSchedule);
 
   if (longTimezone) {
     // Find the "At XX:YY" string and insert the timezone abbreviation.
-    const timeMatch = human.match(/^At [0-9: APM]+/);
+    const timeMatch = human.match(/[0-9]{1,2}:[0-9]{2}( [A|P]M)?/g);
     if (timeMatch) {
-      let shortTimezone;
+      let shortTimezone: string | null;
       try {
         shortTimezone = timeZoneAbbr(longTimezone);
       } catch (e) {
@@ -25,9 +25,11 @@ export const humanCronString = (cronSchedule: string, longTimezone?: string) => 
         shortTimezone = null;
       }
 
-      const stringMatch = timeMatch[0];
-      if (stringMatch && shortTimezone) {
-        return human.replace(stringMatch, `${stringMatch} ${shortTimezone}`);
+      if (timeMatch.length && shortTimezone) {
+        timeMatch.forEach((stringMatch) => {
+          human = human.replace(stringMatch, `${stringMatch} ${shortTimezone}`);
+        });
+        return human;
       }
     }
   }


### PR DESCRIPTION
### Summary & Motivation

The regex I wrote for extracting times from human-readable cron strings was insufficient, so we end up inserting timezones in bad places.

Clean this up, and add a bunch of test cases from https://github.com/bradymholt/cRonstrue/blob/master/test/cronstrue.ts to make sure we've got better coverage.

### How I Tested These Changes

Jest
