### PR TITLE
Parse incoming config into YAML on the client rather than in python on the server

### DIFF
--- a/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
@@ -235,7 +235,7 @@ export const useInitialDataForMode = (
     if (presetsForMode.length === 1 && partitionSetsForMode.length === 0) {
       return {
         base: {presetName: presetsForMode[0].name, tags: null},
-        runConfigYaml: presetsForMode[0].runConfigYaml,
+        runConfigYaml: presetsForMode[0].runConfig.yaml,
       };
     }
 

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1603,6 +1603,7 @@ type RunRequest {
   runKey: String
   tags: [PipelineTag!]!
   runConfigYaml: String!
+  runConfig: RunConfigData!
 }
 
 type PartitionSet {
@@ -1759,6 +1760,7 @@ type SensorMetadata {
 type PipelinePreset {
   name: String!
   solidSelection: [String!]
+  runConfig: RunConfigData!
   runConfigYaml: String!
   mode: String!
   tags: [PipelineTag!]!

--- a/js_modules/dagit/packages/core/src/instance/types/RunReExecutionQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/RunReExecutionQuery.ts
@@ -91,7 +91,7 @@ export interface RunReExecutionQuery_pipelineRunOrError_Run_stepStats {
 export interface RunReExecutionQuery_pipelineRunOrError_Run {
   __typename: "Run";
   id: string;
-  runConfigYaml: string;
+  runConfig: any;
   runId: string;
   canTerminate: boolean;
   status: RunStatus;

--- a/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -395,7 +395,7 @@ export const CONFIG_EDITOR_GENERATOR_PIPELINE_FRAGMENT = gql`
       name
       mode
       solidSelection
-      runConfigYaml
+      runConfig
       tags {
         key
         value

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -390,7 +390,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
     onSaveSession({
       base: {presetName: preset.name, tags: newBaseTags},
       name: preset.name,
-      runConfigYaml: preset.runConfigYaml || '',
+      runConfigYaml: preset.runConfig.yaml || '',
       solidSelection: preset.solidSelection,
       solidSelectionQuery: preset.solidSelection === null ? '*' : preset.solidSelection.join(','),
       mode: preset.mode,

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupFromRunRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupFromRunRoot.tsx
@@ -77,7 +77,8 @@ const LaunchpadSetupFromRunAllowedRoot: React.FC<Props> = (props) => {
       return;
     }
 
-    const {runConfigYaml, mode, solidSelection} = run;
+    const {runConfig, mode, solidSelection} = run;
+    const runConfigYaml = runConfig.yaml;
     if (runConfigYaml || mode || solidSelection) {
       // Name the session after this run ID.
       const newSession: Partial<IExecutionSession> = {name: `From run ${run.id.slice(0, 8)}`};
@@ -136,7 +137,7 @@ const CONFIG_FOR_RUN_QUERY = gql`
       ... on Run {
         id
         mode
-        runConfigYaml
+        runConfig
         solidSelection
       }
       ...PythonErrorFragment

--- a/js_modules/dagit/packages/core/src/launchpad/types/ConfigEditorGeneratorPipelineFragment.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/types/ConfigEditorGeneratorPipelineFragment.ts
@@ -18,7 +18,7 @@ export interface ConfigEditorGeneratorPipelineFragment_presets {
   name: string;
   mode: string;
   solidSelection: string[] | null;
-  runConfigYaml: string;
+  runConfig: any;
   tags: ConfigEditorGeneratorPipelineFragment_presets_tags[];
 }
 

--- a/js_modules/dagit/packages/core/src/launchpad/types/ConfigForRunQuery.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/types/ConfigForRunQuery.ts
@@ -15,7 +15,7 @@ export interface ConfigForRunQuery_runOrError_Run {
   __typename: "Run";
   id: string;
   mode: string;
-  runConfigYaml: string;
+  runConfig: any;
   solidSelection: string[] | null;
 }
 

--- a/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadRootQuery.ts
@@ -40,7 +40,7 @@ export interface LaunchpadRootQuery_pipelineOrError_Pipeline_presets {
   name: string;
   mode: string;
   solidSelection: string[] | null;
-  runConfigYaml: string;
+  runConfig: any;
   tags: LaunchpadRootQuery_pipelineOrError_Pipeline_presets_tags[];
 }
 

--- a/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadSessionPipelineFragment.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadSessionPipelineFragment.ts
@@ -18,7 +18,7 @@ export interface LaunchpadSessionPipelineFragment_presets {
   name: string;
   mode: string;
   solidSelection: string[] | null;
-  runConfigYaml: string;
+  runConfig: any;
   tags: LaunchpadSessionPipelineFragment_presets_tags[];
 }
 

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
@@ -84,7 +84,7 @@ export const RunActionsMenu: React.FC<{
 
   const pipelineRun =
     data?.pipelineRunOrError?.__typename === 'Run' ? data?.pipelineRunOrError : null;
-  const runConfigYaml = pipelineRun?.runConfigYaml;
+  const runConfigYaml = pipelineRun?.runConfig.yaml;
 
   const repoMatch = useRepositoryForRun(pipelineRun);
   const isFinished = doneStatuses.has(run.status);
@@ -137,7 +137,8 @@ export const RunActionsMenu: React.FC<{
                     if (repoMatch && runConfigYaml) {
                       const result = await reexecute({
                         variables: getReexecutionVariables({
-                          run: {...run, runConfigYaml},
+                          run,
+                          runConfigYaml,
                           style: {type: 'all'},
                           repositoryLocationName: repoMatch.match.repositoryLocation.name,
                           repositoryName: repoMatch.match.repository.name,
@@ -383,7 +384,7 @@ const PIPELINE_ENVIRONMENT_YAML_QUERY = gql`
         id
         pipelineName
         pipelineSnapshotId
-        runConfigYaml
+        runConfig
         ...RunFragmentForRepositoryMatch
       }
     }

--- a/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
@@ -122,7 +122,8 @@ export const RunDetails: React.FC<{
 export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({run, isJob}) => {
   const [showDialog, setShowDialog] = React.useState(false);
   const {rootServerURI} = React.useContext(AppContext);
-  const {runConfigYaml} = run;
+  const {runConfig} = run;
+  const runConfigYaml = runConfig.yaml;
   const copy = useCopyToClipboard();
 
   const copyConfig = () => {

--- a/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
@@ -24,7 +24,7 @@ export const RunFragments = {
   RunFragment: gql`
     fragment RunFragment on Run {
       id
-      runConfigYaml
+      runConfig
       runId
       canTerminate
       status

--- a/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
@@ -159,12 +159,13 @@ export type ReExecutionStyle =
   | {type: 'selection'; selection: StepSelection};
 
 export function getReexecutionVariables(input: {
-  run: (RunFragment | RunTableRunFragment) & {runConfigYaml: string};
+  run: RunFragment | RunTableRunFragment;
+  runConfigYaml: string;
   style: ReExecutionStyle;
   repositoryLocationName: string;
   repositoryName: string;
 }) {
-  const {run, style, repositoryLocationName, repositoryName} = input;
+  const {run, runConfigYaml, style, repositoryLocationName, repositoryName} = input;
 
   if (!run || !run.pipelineSnapshotId) {
     return undefined;
@@ -172,7 +173,7 @@ export function getReexecutionVariables(input: {
 
   const executionParams: ExecutionParams = {
     mode: run.mode,
-    runConfigData: run.runConfigYaml,
+    runConfigData: runConfigYaml,
     executionMetadata: getBaseExecutionMetadata(run),
     selector: {
       repositoryLocationName,

--- a/js_modules/dagit/packages/core/src/runs/types/PipelineEnvironmentYamlQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/PipelineEnvironmentYamlQuery.ts
@@ -23,7 +23,7 @@ export interface PipelineEnvironmentYamlQuery_pipelineRunOrError_Run {
   id: string;
   pipelineName: string;
   pipelineSnapshotId: string | null;
-  runConfigYaml: string;
+  runConfig: any;
   repositoryOrigin: PipelineEnvironmentYamlQuery_pipelineRunOrError_Run_repositoryOrigin | null;
 }
 

--- a/js_modules/dagit/packages/core/src/runs/types/RunActionButtonsTestQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunActionButtonsTestQuery.ts
@@ -91,7 +91,7 @@ export interface RunActionButtonsTestQuery_pipelineRunOrError_Run_stepStats {
 export interface RunActionButtonsTestQuery_pipelineRunOrError_Run {
   __typename: "Run";
   id: string;
-  runConfigYaml: string;
+  runConfig: any;
   runId: string;
   canTerminate: boolean;
   status: RunStatus;

--- a/js_modules/dagit/packages/core/src/runs/types/RunFragment.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunFragment.ts
@@ -87,7 +87,7 @@ export interface RunFragment_stepStats {
 export interface RunFragment {
   __typename: "Run";
   id: string;
-  runConfigYaml: string;
+  runConfig: any;
   runId: string;
   canTerminate: boolean;
   status: RunStatus;

--- a/js_modules/dagit/packages/core/src/runs/types/RunRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunRootQuery.ts
@@ -91,7 +91,7 @@ export interface RunRootQuery_pipelineRunOrError_Run_stepStats {
 export interface RunRootQuery_pipelineRunOrError_Run {
   __typename: "Run";
   id: string;
-  runConfigYaml: string;
+  runConfig: any;
   runId: string;
   canTerminate: boolean;
   status: RunStatus;

--- a/js_modules/dagit/packages/core/src/runs/useJobReExecution.tsx
+++ b/js_modules/dagit/packages/core/src/runs/useJobReExecution.tsx
@@ -33,6 +33,7 @@ export const useJobReExecution = (run: RunFragment | undefined | null) => {
 
       const variables = getReexecutionVariables({
         run,
+        runConfigYaml: run.runConfig.yaml,
         style,
         repositoryLocationName: repoMatch.match.repositoryLocation.name,
         repositoryName: repoMatch.match.repository.name,

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
@@ -247,7 +247,7 @@ const NextTickMenuItems: React.FC<{
 
   if (evaluationResult.runRequests.length === 1) {
     const runRequest = evaluationResult.runRequests[0];
-    const runConfigYaml = runRequest ? runRequest.runConfigYaml : '';
+    const runConfigYaml = runRequest ? runRequest.runConfig.yaml : '';
     return (
       <>
         <MenuItem
@@ -339,7 +339,7 @@ const NextTickDialog: React.FC<{
             <Subheading>Config</Subheading>
           </Box>
           <StyledReadOnlyCodeMirror
-            value={selectedRunRequest.runConfigYaml}
+            value={selectedRunRequest.runConfig.yaml}
             options={{lineNumbers: true, mode: 'yaml'}}
           />
         </div>
@@ -402,7 +402,7 @@ const NextTickDialog: React.FC<{
                                   schedule.pipelineName
                                 }/playground/setup?${qs.stringify({
                                   mode: schedule.mode,
-                                  config: runRequest.runConfigYaml,
+                                  config: runRequest.runConfig.yaml,
                                   solidSelection: schedule.solidSelection,
                                 })}`,
                               )}
@@ -442,7 +442,7 @@ const NextTickDialog: React.FC<{
           <Button
             autoFocus={false}
             onClick={() => {
-              copy(selectedRunRequest.runConfigYaml);
+              copy(selectedRunRequest.runConfig.yaml);
               SharedToaster.show({
                 intent: 'success',
                 icon: 'copy_to_clipboard_done',
@@ -470,7 +470,7 @@ const SCHEDULE_TICK_CONFIG_QUERY = gql`
           evaluationResult {
             runRequests {
               runKey
-              runConfigYaml
+              runConfig
               tags {
                 key
                 value

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleTickConfigQuery.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleTickConfigQuery.ts
@@ -22,7 +22,7 @@ export interface ScheduleTickConfigQuery_scheduleOrError_Schedule_futureTick_eva
 export interface ScheduleTickConfigQuery_scheduleOrError_Schedule_futureTick_evaluationResult_runRequests {
   __typename: "RunRequest";
   runKey: string | null;
-  runConfigYaml: string;
+  runConfig: any;
   tags: ScheduleTickConfigQuery_scheduleOrError_Schedule_futureTick_evaluationResult_runRequests_tags[];
 }
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -26,6 +26,7 @@ from ..implementation.fetch_sensors import get_sensor_next_tick
 from ..implementation.loader import RepositoryScopedBatchLoader
 from .errors import GraphenePythonError
 from .repository_origin import GrapheneRepositoryOrigin
+from .runs import GrapheneRunConfigData
 from .tags import GraphenePipelineTag
 from .util import non_null_list
 
@@ -231,6 +232,7 @@ class GrapheneRunRequest(graphene.ObjectType):
     runKey = graphene.String()
     tags = non_null_list(GraphenePipelineTag)
     runConfigYaml = graphene.NonNull(graphene.String)
+    runConfig = graphene.NonNull(GrapheneRunConfigData)
 
     class Meta:
         name = "RunRequest"
@@ -248,6 +250,9 @@ class GrapheneRunRequest(graphene.ObjectType):
 
     def resolve_runConfigYaml(self, _graphene_info):
         return yaml.dump(self._run_request.run_config, default_flow_style=False, allow_unicode=True)
+
+    def resolve_runConfig(self, _graphene_info):
+        return self._run_request.run_config
 
 
 class GrapheneFutureInstigationTicks(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -644,6 +644,7 @@ class GrapheneIPipelineSnapshot(graphene.Interface):
 class GraphenePipelinePreset(graphene.ObjectType):
     name = graphene.NonNull(graphene.String)
     solidSelection = graphene.List(graphene.NonNull(graphene.String))
+    runConfig = graphene.NonNull(GrapheneRunConfigData)
     runConfigYaml = graphene.NonNull(graphene.String)
     mode = graphene.NonNull(graphene.String)
     tags = non_null_list(GraphenePipelineTag)
@@ -663,6 +664,9 @@ class GraphenePipelinePreset(graphene.ObjectType):
 
     def resolve_solidSelection(self, _graphene_info):
         return self._active_preset_data.solid_selection
+
+    def resolve_runConfig(self, _graphene_info):
+        self._active_preset_data.run_config
 
     def resolve_runConfigYaml(self, _graphene_info):
         yaml_str = yaml.safe_dump(


### PR DESCRIPTION
Summary:
This is mostly a workaround for a weird pyyaml issue where it interprets numeric strings as octal - since we are representing the config as dictionaries on the server, it seems reasonable to me to expose them that way in the graphql API as well? (With the caveat that GenericScalars are weird / kind of a graphql anti-pattern).

Test Plan:
Very that config with numeric strings:

["0001234", "0001235", "0001236", "0001237"]

is rendered correctly in the launchpad and still launches correctly

Verify that job re-execution and config editing and local run config storage still works

### Summary & Motivation

### How I Tested These Changes
