### PR TITLE
add docs for data retention config

### DIFF
--- a/docs/content/deployment/dagster-instance.mdx
+++ b/docs/content/deployment/dagster-instance.mdx
@@ -475,3 +475,21 @@ When you aren't [running your own gRPC server](/concepts/repositories-workspaces
 code_servers:
   local_startup_timeout: 120
 ```
+
+### Data retention
+
+The `retention` key lets you configure how long Dagster retains certain types of data that have diminishing value over time, like schedule/sensor tick data. If you want to clean up old ticks to minimize storage concerns and improve query performance, you can set retention policy using the `retention` config key:
+
+```yaml file=/deploying/dagster_instance/dagster.yaml startafter=start_marker_retention endbefore=end_marker_retention
+# Configures how long Dagster keeps sensor / schedule tick data
+retention:
+  schedule:
+    purge_after_days: 90 # sets retention policy for schedule ticks of all types
+  sensor:
+    purge_after_days:
+      skipped: 7
+      failure: 30
+      success: -1 # keep success ticks indefinitely
+```
+
+By default, Dagster retains skipped sensor ticks for 7 days and retains all other ticks indefinitely.

--- a/examples/docs_snippets/docs_snippets/deploying/dagster_instance/dagster.yaml
+++ b/examples/docs_snippets/docs_snippets/deploying/dagster_instance/dagster.yaml
@@ -330,3 +330,17 @@ code_servers:
   local_startup_timeout: 120
 
 # end_marker_code_servers
+
+# start_marker_retention
+
+# Configures how long Dagster keeps sensor / schedule tick data
+retention:
+  schedule:
+    purge_after_days: 90 # sets retention policy for schedule ticks of all types
+  sensor:
+    purge_after_days:
+      skipped: 7
+      failure: 30
+      success: -1 # keep success ticks indefinitely
+
+# end_marker_retention

--- a/examples/docs_snippets/docs_snippets_tests/deploying_tests/dagster_instance_tests/snapshots/snap_test_dagster_instance.py
+++ b/examples/docs_snippets/docs_snippets_tests/deploying_tests/dagster_instance_tests/snapshots/snap_test_dagster_instance.py
@@ -10,6 +10,7 @@ snapshots["test_instance_yaml 1"] = [
     "code_servers",
     "compute_logs",
     "local_artifact_storage",
+    "retention",
     "run_coordinator",
     "run_launcher",
     "run_monitoring",


### PR DESCRIPTION
### Summary & Motivation

Allow users to configure retention policy for schedule/sensor ticks.

### How I Tested These Changes
None