### PR TITLE
SDA-related updates to resource and partition pages

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
@@ -100,7 +100,45 @@ A few rules govern partition-to-partition dependencies:
 
   For example, if an asset with a <PyObject object="DailyPartitionsDefinition" /> depends on an asset with an <PyObject object="HourlyPartitionsDefinition" />, then partition `2022-04-12` of the daily asset the would depend on 24 partitions of the hourly asset: `2022-04-12-00:00` through `2022-04-12-23:00`.
 
-## Partitioned Jobs
+## Partitioned Asset Jobs
+
+A partitioned asset job is a job that materializes a particular set of partitioned assets every time it runs.
+
+```python file=/concepts/partitions_schedules_sensors/partitioned_asset_job.py
+from dagster import (
+    AssetSelection,
+    HourlyPartitionsDefinition,
+    asset,
+    define_asset_job,
+    repository,
+)
+
+hourly_partitions_def = HourlyPartitionsDefinition(start_date="2022-05-31-00:00")
+
+
+@asset(partitions_def=hourly_partitions_def)
+def asset1():
+    ...
+
+
+@asset(partitions_def=hourly_partitions_def)
+def asset2():
+    ...
+
+
+partitioned_asset_job = define_asset_job(
+    name="asset_1_and_2_job",
+    selection=AssetSelection.assets(asset1, asset2),
+    partitions_def=hourly_partitions_def,
+)
+
+
+@repository
+def repo():
+    return [asset1, asset2, partitioned_asset_job]
+```
+
+## Partitioned Non-Asset Jobs
 
 ### Relevant APIs
 
@@ -115,7 +153,7 @@ A few rules govern partition-to-partition dependencies:
 | <PyObject object="dynamic_partitioned_config" decorator /> | Decorator for constructing partitioned config for a set of partition keys that can grow over time.  |
 | <PyObject object="build_schedule_from_partitioned_job" />  | A function that constructs a schedule whose interval matches the partitioning of a partitioned job. |
 
-You define a partitioned job by constructing a <PyObject object="PartitionedConfig" /> object and supplying it when you construct your job.
+When defining a job that doesn't use software-defined assets, you can make it partitioned by supplying <PyObject object="PartitionedConfig" /> object as its config.
 
 ### Defining a Job with Time Partitions
 
@@ -281,44 +319,6 @@ def antarctica_schedule():
 ```
 
 Refer to the [Schedules documentation](/concepts/partitions-schedules-sensors/schedules#schedules-from-partitioned-assets-and-jobs) for more info about constructing both schedule types.
-
-## Partitioned Asset Jobs
-
-A partitioned asset job is a job that materializes a particular set of partitioned assets every time it runs.
-
-```python file=/concepts/partitions_schedules_sensors/partitioned_asset_job.py
-from dagster import (
-    AssetSelection,
-    HourlyPartitionsDefinition,
-    asset,
-    define_asset_job,
-    repository,
-)
-
-hourly_partitions_def = HourlyPartitionsDefinition(start_date="2022-05-31-00:00")
-
-
-@asset(partitions_def=hourly_partitions_def)
-def asset1():
-    ...
-
-
-@asset(partitions_def=hourly_partitions_def)
-def asset2():
-    ...
-
-
-partitioned_asset_job = define_asset_job(
-    name="asset_1_and_2_job",
-    selection=AssetSelection.assets(asset1, asset2),
-    partitions_def=hourly_partitions_def,
-)
-
-
-@repository
-def repo():
-    return [asset1, asset2, partitioned_asset_job]
-```
 
 ## Testing
 

--- a/docs/content/concepts/resources.mdx
+++ b/docs/content/concepts/resources.mdx
@@ -50,26 +50,59 @@ def cereal_fetcher(init_context):
 
 ---
 
-## Accessing resources
+## Using resources
 
-- [In ops](#in-ops)
-- [In software-defined assets](#in-software-defined-assets)
+- [With software-defined assets](#using-resources-with-software-defined-assets)
+- [With ops](#using-resources-with-ops)
 
-### In software-defined assets
+### Using resources with software-defined assets
+
+- [Accessing resources](#accessing-resources-in-software-defined-assets)
+- [Providing resources](#providing-resources-to-software-defined-assets)
+
+#### Accessing resources in software-defined assets
 
 Software-defined assets use resource keys to access resources:
 
-```python file=/concepts/assets/asset_config.py startafter=start_example endbefore=end_example
-@asset(config_schema={"api_endpoint": str})
-def my_configurable_asset(context):
-    api_endpoint = context.op_config["api_endpoint"]
-    data = requests.get(f"{api_endpoint}/data").json()
-    return data
+```python file=/concepts/resources/resources.py startafter=start_asset_use_resource endbefore=end_asset_use_resource
+from dagster import asset
+
+
+@asset(required_resource_keys={"foo"})
+def asset_requires_resource(context):
+    do_something_with_resource(context.resources.foo)
 ```
 
-### In ops
+#### Providing resources to software-defined assets
 
-Ops use resource keys to access resources:
+Resources can be provided to software-defined assets using the <PyObject object="with_resources" /> function. This function takes in a sequence of assets and returns transformed versions of those assets with the provided resources specified:
+
+```python file=/concepts/resources/resources.py startafter=start_asset_provide_resource endbefore=end_asset_provide_resource
+from dagster import repository, with_resources
+
+
+@repository
+def repo():
+    return [
+        *with_resources(
+            definitions=[asset_requires_resource],
+            resource_defs={"foo": foo_resource},
+        )
+    ]
+```
+
+When defining asset jobs (using <PyObject object="define_asset_job" />), you don't need to provide resources to the job directly. The job will make use of the resources provided to the assets.
+
+---
+
+### Using resources with ops
+
+- [Accessing resources](#accessing-resources-in-ops)
+- [Providing resources](#providing-resources-to-ops)
+
+#### Accessing resources in ops
+
+Like software-defined assets, ops use resource keys to access resources:
 
 ```python file=/concepts/resources/resources.py startafter=start_op_with_resources_example endbefore=end_op_with_resources_example
 from dagster import op
@@ -82,35 +115,7 @@ def op_requires_resources(context):
     context.resources.database.execute_query(CREATE_TABLE_1_QUERY)
 ```
 
----
-
-## Providing resources
-
-- [To software-defined assets](#to-software-defined-assets)
-- [To jobs](#to-jobs)
-
-### To software-defined assets
-
-Resources can be provided to software-defined assets using the <PyObject object="with_resources" /> function. This function takes in a sequence of assets and returns transformed versions of those assets with the provided resources specified:
-
-```python file=/concepts/resources/resources.py startafter=start_with_resources_example endbefore=end_with_resources_example
-from dagster import with_resources, asset, resource
-
-
-@asset(required_resource_keys={"foo"})
-def asset_requires_resource(context):
-    do_something_with_resource(context.resources.foo)
-
-
-@resource
-def foo_resource():
-    ...
-
-
-transformed_asset = with_resources([asset_requires_resource], {"foo": foo_resource})[0]
-```
-
-### To jobs
+#### Providing resources to ops
 
 Jobs provide resources to the ops inside them. A job has a dictionary that maps resource keys to resource definitions. You can supply this dictionary to the `resource_defs` argument when using either of the ways to construct a job: <PyObject object="GraphDefinition" method="to_job" /> or <PyObject object="job" decorator />.
 
@@ -125,12 +130,8 @@ def do_database_stuff():
     op_requires_resources()
 
 
-do_database_stuff_prod = do_database_stuff.to_job(
-    resource_defs={"database": database_resource_a}
-)
-do_database_stuff_dev = do_database_stuff.to_job(
-    resource_defs={"database": database_resource_b}
-)
+do_database_stuff_prod = do_database_stuff.to_job(resource_defs={"database": database_resource_a})
+do_database_stuff_dev = do_database_stuff.to_job(resource_defs={"database": database_resource_b})
 ```
 
 Supplying resources to the <PyObject object="job" decorator />, i.e. when there aren't multiple jobs for the same graph, is also useful. For example, if you want to use an off-the-shelf resource or supply configuration in one place instead of in every op.

--- a/examples/docs_snippets/docs_snippets/concepts/resources/resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/resources.py
@@ -108,12 +108,8 @@ def do_database_stuff():
     op_requires_resources()
 
 
-do_database_stuff_prod = do_database_stuff.to_job(
-    resource_defs={"database": database_resource_a}
-)
-do_database_stuff_dev = do_database_stuff.to_job(
-    resource_defs={"database": database_resource_b}
-)
+do_database_stuff_prod = do_database_stuff.to_job(resource_defs={"database": database_resource_a})
+do_database_stuff_dev = do_database_stuff.to_job(resource_defs={"database": database_resource_b})
 
 
 # end_graph_example
@@ -247,8 +243,8 @@ def do_something_with_resource(_):
     pass
 
 
-# start_with_resources_example
-from dagster import with_resources, asset, resource
+# start_asset_use_resource
+from dagster import asset
 
 
 @asset(required_resource_keys={"foo"})
@@ -256,12 +252,26 @@ def asset_requires_resource(context):
     do_something_with_resource(context.resources.foo)
 
 
+# end_asset_use_resource
+
+
 @resource
 def foo_resource():
     ...
 
 
-transformed_asset = with_resources([asset_requires_resource], {"foo": foo_resource})[0]
+# start_asset_provide_resource
+from dagster import repository, with_resources
 
 
-# end_with_resources_example
+@repository
+def repo():
+    return [
+        *with_resources(
+            definitions=[asset_requires_resource],
+            resource_defs={"foo": foo_resource},
+        )
+    ]
+
+
+# end_asset_provide_resource

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/resources_tests/test_resources.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/resources_tests/test_resources.py
@@ -11,7 +11,6 @@ from docs_snippets.concepts.resources.resources import (
     test_cm_resource,
     test_my_resource,
     test_my_resource_with_context,
-    transformed_asset,
     use_db_connection,
     uses_db_connection,
 )
@@ -63,7 +62,3 @@ def test_cm_resource_op():
 
 def test_build_resources_example():
     uses_db_connection()
-
-
-def test_with_resources_example():
-    transformed_asset(build_op_context())


### PR DESCRIPTION
### Summary & Motivation

A set of concept page changes based on reading through the pages and questions we got in slack last week.

**Partitions page**
- On the partitions page, moved the partitioned asset jobs section up next to the partitioned asset section, because they'll often be used in tandem.

**Resources page**
- Fixed a snippet that was an example for config instead of resources.
- Moved "accessing resources in assets" next to "providing resources to assets", because they're likely to be used together.
- Updated the providing resources to assets example to be a little more realistic (with a repo), and clarified how asset jobs get their resources.

### How I Tested These Changes

Manual inspection