### PR TITLE
[dagit] Make "Add to filter" an append action

### DIFF
--- a/js_modules/dagit/packages/core/src/pipelines/PipelineRunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineRunsRoot.tsx
@@ -6,6 +6,7 @@ import {
   Page,
   Tag,
   TokenizingFieldValue,
+  tokenToString,
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {useParams} from 'react-router-dom';
@@ -23,6 +24,7 @@ import {
   RunsFilterInput,
   runsFilterForSearchTokens,
   useQueryPersistedRunFilters,
+  RunFilterToken,
 } from '../runs/RunsFilterInput';
 import {useCursorPaginatedQuery} from '../runs/useCursorPaginatedQuery';
 import {Loading} from '../ui/Loading';
@@ -85,6 +87,16 @@ export const PipelineRunsRoot: React.FC<Props> = (props) => {
     },
   });
 
+  const onAddTag = React.useCallback(
+    (token: RunFilterToken) => {
+      const tokenAsString = tokenToString(token);
+      if (!filterTokens.some((token) => tokenToString(token) === tokenAsString)) {
+        setFilterTokens([...filterTokens, token]);
+      }
+    },
+    [filterTokens, setFilterTokens],
+  );
+
   const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
 
   return (
@@ -122,7 +134,7 @@ export const PipelineRunsRoot: React.FC<Props> = (props) => {
                 <StickyTableContainer $top={0}>
                   <RunTable
                     runs={displayed}
-                    onSetFilter={setFilterTokens}
+                    onAddTag={onAddTag}
                     actionBarComponents={
                       <RunsFilterInput
                         enabledFilters={ENABLED_FILTERS}

--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -36,7 +36,7 @@ import {RunTableRunFragment} from './types/RunTableRunFragment';
 interface RunTableProps {
   runs: RunTableRunFragment[];
   filter?: RunsFilter;
-  onSetFilter?: (search: RunFilterToken[]) => void;
+  onAddTag?: (token: RunFilterToken) => void;
   nonIdealState?: React.ReactNode;
   actionBarComponents?: React.ReactNode;
   highlightedIds?: string[];
@@ -45,7 +45,7 @@ interface RunTableProps {
 }
 
 export const RunTable = (props: RunTableProps) => {
-  const {runs, filter, onSetFilter, nonIdealState, highlightedIds, actionBarComponents} = props;
+  const {runs, filter, onAddTag, nonIdealState, highlightedIds, actionBarComponents} = props;
   const allIds = runs.map((r) => r.runId);
 
   const [{checkedIds}, {onToggleFactory, onToggleAll}] = useSelectionReducer(allIds);
@@ -139,7 +139,7 @@ export const RunTable = (props: RunTableProps) => {
               canTerminateOrDelete={canTerminateOrDelete}
               run={run}
               key={run.runId}
-              onSetFilter={onSetFilter}
+              onAddTag={onAddTag}
               checked={checkedIds.has(run.runId)}
               additionalColumns={props.additionalColumnsForRow?.(run)}
               onToggleChecked={onToggleFactory(run.runId)}
@@ -189,7 +189,7 @@ export const RUN_TABLE_RUN_FRAGMENT = gql`
 const RunRow: React.FC<{
   run: RunTableRunFragment;
   canTerminateOrDelete: boolean;
-  onSetFilter?: (search: RunFilterToken[]) => void;
+  onAddTag?: (token: RunFilterToken) => void;
   checked?: boolean;
   onToggleChecked?: (values: {checked: boolean; shiftKey: boolean}) => void;
   additionalColumns?: React.ReactNode[];
@@ -197,7 +197,7 @@ const RunRow: React.FC<{
 }> = ({
   run,
   canTerminateOrDelete,
-  onSetFilter,
+  onAddTag,
   checked,
   onToggleChecked,
   additionalColumns,
@@ -270,7 +270,7 @@ const RunRow: React.FC<{
           <RunTags
             tags={run.tags}
             mode={isJob ? (run.mode !== 'default' ? run.mode : null) : run.mode}
-            onSetFilter={onSetFilter}
+            onAddTag={onAddTag}
           />
         </Box>
       </td>

--- a/js_modules/dagit/packages/core/src/runs/RunTags.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTags.tsx
@@ -18,8 +18,8 @@ export const priorityTagSet = new Set([
 export const RunTags: React.FC<{
   tags: TagType[];
   mode: string | null;
-  onSetFilter?: (search: RunFilterToken[]) => void;
-}> = React.memo(({tags, onSetFilter, mode}) => {
+  onAddTag?: (token: RunFilterToken) => void;
+}> = React.memo(({tags, onAddTag, mode}) => {
   const copy = useCopyToClipboard();
 
   const actions = React.useMemo(() => {
@@ -33,17 +33,17 @@ export const RunTags: React.FC<{
       },
     ];
 
-    if (onSetFilter) {
+    if (onAddTag) {
       list.push({
         label: 'Add tag to filter',
         onClick: (tag: TagType) => {
-          onSetFilter([{token: 'tag', value: `${tag.key}=${tag.value}`}]);
+          onAddTag({token: 'tag', value: `${tag.key}=${tag.value}`});
         },
       });
     }
 
     return list;
-  }, [copy, onSetFilter]);
+  }, [copy, onAddTag]);
 
   const displayedTags = React.useMemo(() => {
     const priority = [];

--- a/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
@@ -12,6 +12,7 @@ import {
   Tag,
   Heading,
   TokenizingFieldValue,
+  tokenToString,
 } from '@dagster-io/ui';
 import isEqual from 'lodash/isEqual';
 import * as React from 'react';
@@ -38,6 +39,7 @@ import {
   RunsFilterInput,
   runsFilterForSearchTokens,
   useQueryPersistedRunFilters,
+  RunFilterToken,
 } from './RunsFilterInput';
 import {QueueDaemonStatusQuery} from './types/QueueDaemonStatusQuery';
 import {RunsRootQuery, RunsRootQueryVariables} from './types/RunsRootQuery';
@@ -114,6 +116,16 @@ export const RunsRoot = () => {
       }
     },
     [filterTokens, setFilterTokens, staticStatusTags],
+  );
+
+  const onAddTag = React.useCallback(
+    (token: RunFilterToken) => {
+      const tokenAsString = tokenToString(token);
+      if (!filterTokens.some((token) => tokenToString(token) === tokenAsString)) {
+        setFilterTokensWithStatus([...filterTokens, token]);
+      }
+    },
+    [filterTokens, setFilterTokensWithStatus],
   );
 
   const enabledFilters = React.useMemo(() => {
@@ -245,7 +257,7 @@ export const RunsRoot = () => {
                 <StickyTableContainer $top={0}>
                   <RunTable
                     runs={pipelineRunsOrError.results.slice(0, PAGE_SIZE)}
-                    onSetFilter={setFilterTokensWithStatus}
+                    onAddTag={onAddTag}
                     filter={filter}
                     actionBarComponents={
                       showScheduled ? null : (

--- a/js_modules/dagit/packages/ui/src/components/TokenizingField.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TokenizingField.tsx
@@ -92,8 +92,11 @@ export function tokenizedValueFromString(
   return {value: str};
 }
 
+export const tokenToString = (v: TokenizingFieldValue) =>
+  v.token ? `${v.token}:${v.value}` : v.value;
+
 export const tokensAsStringArray = (value: TokenizingFieldValue[]) =>
-  value.filter((v) => v.value !== '').map((v) => (v.token ? `${v.token}:${v.value}` : v.value));
+  value.filter((v) => v.value !== '').map(tokenToString);
 
 export const stringFromValue = (value: TokenizingFieldValue[]) =>
   tokensAsStringArray(value).join(',');
@@ -429,7 +432,6 @@ export const TokenizingField: React.FC<TokenizingFieldProps> = ({
           ) : undefined
         }
       />
-      <StyledTagInput />
     </Popover>
   );
 };


### PR DESCRIPTION
### Summary & Motivation

Resolves #8025.

When adding a tag to the filter in a Runs view, make it an "append" action instead of a replacement action. This allows the user to add multiple tags through the tooltip action.

If the appended tag already exists in the list, no-op.

### How I Tested These Changes

View Runs page. Append some tags, verify that they are appended and that the query string updates properly. Try to add a tag that's already there, verify no-op.
