### PR TITLE
[dagit] Repair multi empty line config editor

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -338,7 +338,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
     // is in flight, in which case completion of this async method should not set loading=false.
     previewCounter.current += 1;
     const currentPreviewCount = previewCounter.current;
-    const configYamlOrEmpty = configYaml || '{}';
+    const configYamlOrEmpty = configYaml.trim() || '{}';
 
     dispatch({type: 'preview-loading', payload: true});
 


### PR DESCRIPTION
### Summary & Motivation

Yaml parsing fails when the config editor is empty but not actually empty, e.g. `\n\n\n\n`. Trim the yaml before parsing to clean this up.

### How I Tested These Changes

View config editor, add some newlines and no other text. Verify that there are no yaml parsing errors.
