### PR TITLE
Explicitly disallow assets with resources in materialize_to_memory, use mem_io_manager as every io manager

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/source_asset.py
+++ b/python_modules/dagster/dagster/core/asset_defs/source_asset.py
@@ -203,3 +203,6 @@ class SourceAsset(
         )
         for source_key, resource_def in self.resource_defs.items():
             yield from resource_def.get_resource_requirements(outer_context=source_key)
+
+    def __str__(self) -> str:
+        return f"SourceAsset with key {self.key.to_string()}"


### PR DESCRIPTION
As the title. I think there are a few worlds that make sense for materialize_to_memory:
1. explicitly disallow any resource defs to be provided on assets that are passed in to materialize_to_memory
    - this makes testing assets more difficult, as `without_resources` will always have to be used whenever `resource_defs` are used.
2. explicitly disallow only io manager defs to be provided on assets that are passed in to materialize_to_memory
    - this makes the particular case of removing io manager defs more confusing, as your escape hatch is using `without_resources`, which will remove all resources from your asset, not just io manager defs. (maybe we want just a `without_io_managers`?)
 3. We just ignore whichever io managers are on your assets, and provide mem_io_manager. We still use your provided resources that aren't io managers.
      - slightly magical but also probably the most useful of the bunch.
 5. We ignore whichever io managers are on your assets and ignore the resources you provide (this one doesn't really make sense).