### PR TITLE
RFC: Use instance.python_log_level when determining default system logger level

### DIFF
--- a/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
+++ b/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
@@ -63,7 +63,7 @@ def initialize_console_manager(
 ) -> DagsterLogManager:
     # initialize default colored console logger
     loggers = []
-    for logger_def, logger_config in default_system_loggers():
+    for logger_def, logger_config in default_system_loggers(instance):
         loggers.append(
             logger_def.logger_fn(
                 InitLoggerContext(
@@ -503,7 +503,7 @@ def create_log_manager(
             )
 
     if not loggers:
-        for (logger_def, logger_config) in default_system_loggers():
+        for (logger_def, logger_config) in default_system_loggers(context_creation_data.instance):
             loggers.append(
                 logger_def.logger_fn(
                     InitLoggerContext(
@@ -534,7 +534,7 @@ def create_context_free_log_manager(
 
     loggers = []
     # Use the default logger
-    for (logger_def, logger_config) in default_system_loggers():
+    for (logger_def, logger_config) in default_system_loggers(instance):
         loggers += [
             logger_def.logger_fn(
                 InitLoggerContext(

--- a/python_modules/dagster/dagster/core/execution/host_mode.py
+++ b/python_modules/dagster/dagster/core/execution/host_mode.py
@@ -89,7 +89,7 @@ def host_mode_execution_context_event_generator(
 
     loggers = []
 
-    for (logger_def, logger_config) in default_system_loggers():
+    for (logger_def, logger_config) in default_system_loggers(instance):
         loggers.append(
             logger_def.logger_fn(
                 InitLoggerContext(

--- a/python_modules/dagster/dagster/loggers/__init__.py
+++ b/python_modules/dagster/dagster/loggers/__init__.py
@@ -81,13 +81,20 @@ def json_console_logger(init_context):
     return logger_
 
 
-def default_system_loggers():
+def default_system_loggers(instance):
     """If users don't provide configuration for any loggers, we instantiate these loggers with the
     default config.
 
     Returns:
         List[Tuple[LoggerDefinition, dict]]: Default loggers and their associated configs."""
-    return [(colored_console_logger, {"name": "dagster", "log_level": "DEBUG"})]
+
+    log_level = instance.python_log_level if (instance and instance.python_log_level) else "DEBUG"
+    return [
+        (
+            colored_console_logger,
+            {"name": "dagster", "log_level": log_level},
+        )
+    ]
 
 
 def default_loggers():


### PR DESCRIPTION
Summary:
This makes it so that if you set python_log_level to INFO in your dagster.yaml, it applies to the console output from dagit

### Summary & Motivation

### How I Tested These Changes
