### PR TITLE
Materialize has resources arg, materialize_to_memory sets mem_io_manager for all io managers

### DIFF
--- a/docs/content/concepts/testing.mdx
+++ b/docs/content/concepts/testing.mdx
@@ -194,7 +194,9 @@ def my_foo_resource(context):
 
 
 def test_op_resource_def():
-    context = build_op_context(resources={"foo": my_foo_resource.configured({"my_str": "bar"})})
+    context = build_op_context(
+        resources={"foo": my_foo_resource.configured({"my_str": "bar"})}
+    )
     assert op_requires_foo(context) == "found bar"
 ```
 

--- a/docs/content/concepts/testing.mdx
+++ b/docs/content/concepts/testing.mdx
@@ -194,9 +194,7 @@ def my_foo_resource(context):
 
 
 def test_op_resource_def():
-    context = build_op_context(
-        resources={"foo": my_foo_resource.configured({"my_str": "bar"})}
-    )
+    context = build_op_context(resources={"foo": my_foo_resource.configured({"my_str": "bar"})})
     assert op_requires_foo(context) == "found bar"
 ```
 
@@ -292,34 +290,6 @@ def test_data_assets():
     assert result.success
     # Materialized objects can be accessed in terms of the underlying op
     materialized_data = result.output_for_node("structured_data")
-    ...
-```
-
-In addition to providing <PyObject object="AssetsDefinition" /> objects, <PyObject object="SourceAsset" /> objects can also be provided:
-
-```python file=/concepts/ops_jobs_graphs/unit_tests.py startafter=start_materialize_source_asset endbefore=end_materialize_source_asset
-from dagster import asset, SourceAsset, materialize_to_memory, AssetKey
-
-the_source = SourceAsset(
-    key=AssetKey("repository_a_asset"), io_manager_def=source_io_manager
-)
-
-
-@asset
-def repository_b_asset(repository_a_asset):
-    ...
-
-
-@asset
-def other_repository_b_asset(repository_a_asset):
-    ...
-
-
-def test_repository_b_assets():
-    result = materialize_to_memory(
-        [the_source, repository_b_asset, other_repository_b_asset]
-    )
-    assert result.success
     ...
 ```
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
@@ -130,7 +130,9 @@ def my_foo_resource(context):
 
 
 def test_op_resource_def():
-    context = build_op_context(resources={"foo": my_foo_resource.configured({"my_str": "bar"})})
+    context = build_op_context(
+        resources={"foo": my_foo_resource.configured({"my_str": "bar"})}
+    )
     assert op_requires_foo(context) == "found bar"
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
@@ -132,7 +132,9 @@ def my_foo_resource(context):
 
 
 def test_op_resource_def():
-    context = build_op_context(resources={"foo": my_foo_resource.configured({"my_str": "bar"})})
+    context = build_op_context(
+        resources={"foo": my_foo_resource.configured({"my_str": "bar"})}
+    )
     assert op_requires_foo(context) == "found bar"
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
@@ -132,9 +132,7 @@ def my_foo_resource(context):
 
 
 def test_op_resource_def():
-    context = build_op_context(
-        resources={"foo": my_foo_resource.configured({"my_str": "bar"})}
-    )
+    context = build_op_context(resources={"foo": my_foo_resource.configured({"my_str": "bar"})})
     assert op_requires_foo(context) == "found bar"
 
 
@@ -302,46 +300,6 @@ def test_data_assets():
 
 # end_materialize_asset
 
-
-@io_manager
-def source_io_manager():
-    class MyIOManager(IOManager):
-        def handle_output(self, context, obj):
-            pass
-
-        def load_input(self, context):
-            return "foo"
-
-    return MyIOManager()
-
-
-# start_materialize_source_asset
-from dagster import asset, SourceAsset, materialize_to_memory, AssetKey
-
-the_source = SourceAsset(
-    key=AssetKey("repository_a_asset"), io_manager_def=source_io_manager
-)
-
-
-@asset
-def repository_b_asset(repository_a_asset):
-    ...
-
-
-@asset
-def other_repository_b_asset(repository_a_asset):
-    ...
-
-
-def test_repository_b_assets():
-    result = materialize_to_memory(
-        [the_source, repository_b_asset, other_repository_b_asset]
-    )
-    assert result.success
-    ...
-
-
-# end_materialize_source_asset
 
 # start_materialize_resources
 from dagster import asset, resource, materialize_to_memory

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
@@ -9,8 +9,6 @@ from dagster import (
     Output,
     Out,
     op,
-    io_manager,
-    IOManager,
     graph,
 )
 
@@ -132,9 +130,7 @@ def my_foo_resource(context):
 
 
 def test_op_resource_def():
-    context = build_op_context(
-        resources={"foo": my_foo_resource.configured({"my_str": "bar"})}
-    )
+    context = build_op_context(resources={"foo": my_foo_resource.configured({"my_str": "bar"})})
     assert op_requires_foo(context) == "found bar"
 
 

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/ops_jobs_graphs_tests/test_unit_test_examples.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/ops_jobs_graphs_tests/test_unit_test_examples.py
@@ -11,7 +11,6 @@ from docs_snippets.concepts.ops_jobs_graphs.unit_tests import (
     test_op_resource_def,
     test_op_with_context,
     test_op_with_invocation,
-    test_repository_b_assets,
 )
 
 
@@ -27,5 +26,4 @@ def test_unit_tests():
     test_asset_with_inputs()
     test_asset_with_service()
     test_data_assets()
-    test_repository_b_assets()
     test_asset_requires_service()

--- a/python_modules/dagster/dagster/core/asset_defs/materialize.py
+++ b/python_modules/dagster/dagster/core/asset_defs/materialize.py
@@ -72,7 +72,9 @@ def materialize_to_memory(
     """
     Executes a single-threaded, in-process run which materializes provided assets in memory.
 
-    Will explicitly use :py:func:`mem_io_manager` for all required io manager keys. If any io managers are directly provided using the `resources` argument, a :py:class:`DagsterInvariantViolationError` will be thrown.
+    Will explicitly use :py:func:`mem_io_manager` for all required io manager
+    keys. If any io managers are directly provided using the `resources`
+    argument, a :py:class:`DagsterInvariantViolationError` will be thrown.
 
     Args:
         assets (Sequence[Union[AssetsDefinition, SourceAsset]]):
@@ -80,7 +82,7 @@ def materialize_to_memory(
         run_config (Optional[Any]): The run config to use for the run that materializes the assets.
         resources (Optional[Mapping[str, object]]):
             The resources needed for execution. Can provide resource instances
-            directly, or resource definitions. Note that if provided resources
+            directly, or resource definitions. If provided resources
             conflict with resources directly on assets, an error will be thrown.
         partition_key: (Optional[str])
             The string partition key that specifies the run config to execute. Can only be used

--- a/python_modules/dagster/dagster/core/asset_defs/materialize.py
+++ b/python_modules/dagster/dagster/core/asset_defs/materialize.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional, Sequence, Union
+from typing import Any, Mapping, Optional, Sequence, Union, Set
 
 import dagster._check as check
 
@@ -11,12 +11,17 @@ from ..storage.fs_io_manager import fs_io_manager
 from .assets import AssetsDefinition
 from .assets_job import build_assets_job
 from .source_asset import SourceAsset
+from ..storage.io_manager import IOManagerDefinition
+from ..storage.mem_io_manager import mem_io_manager
+from ..errors import DagsterInvariantViolationError
+from dagster.utils import merge_dicts
 
 
 def materialize(
     assets: Sequence[Union[AssetsDefinition, SourceAsset]],
     run_config: Any = None,
     instance: Optional[DagsterInstance] = None,
+    resources: Optional[Mapping[str, object]] = None,
     partition_key: Optional[str] = None,
 ) -> ExecuteInProcessResult:
     """
@@ -27,6 +32,10 @@ def materialize(
     Args:
         assets (Sequence[Union[AssetsDefinition, SourceAsset]]):
             The assets to materialize. Can also provide :py:class:`SourceAsset` objects to fill dependencies for asset defs.
+        resources (Optional[Mapping[str, object]]):
+            The resources needed for execution. Can provide resource instances
+            directly, or resource definitions. Note that if provided resources
+            conflict with resources directly on assets, an error will be thrown.
         run_config (Optional[Any]): The run config to use for the run that materializes the assets.
         partition_key: (Optional[str])
             The string partition key that specifies the run config to execute. Can only be used
@@ -42,11 +51,14 @@ def materialize(
     source_assets = [the_def for the_def in assets if isinstance(the_def, SourceAsset)]
     instance = check.opt_inst_param(instance, "instance", DagsterInstance)
     partition_key = check.opt_str_param(partition_key, "partition_key")
+    resources = check.opt_mapping_param(resources, "resources", key_type=str)
+    resource_defs = wrap_resources_for_execution(resources)
 
     return build_assets_job(
         "in_process_materialization_job",
         assets=assets_defs,
         source_assets=source_assets,
+        resource_defs=resource_defs,
     ).execute_in_process(run_config=run_config, instance=instance, partition_key=partition_key)
 
 
@@ -58,11 +70,9 @@ def materialize_to_memory(
     partition_key: Optional[str] = None,
 ) -> ExecuteInProcessResult:
     """
-    Executes a single-threaded, in-process run which materializes provided assets.
+    Executes a single-threaded, in-process run which materializes provided assets in memory.
 
-    By default, will materialize assets to memory, meaning results will not be
-    persisted. This behavior can be changed by overriding the default io
-    manager key "io_manager", or providing custom io manager keys to assets.
+    Will explicitly use :py:func:`mem_io_manager` for all required io manager keys. If any io managers are directly provided using the `resources` argument, a :py:class:`DagsterInvariantViolationError` will be thrown.
 
     Args:
         assets (Sequence[Union[AssetsDefinition, SourceAsset]]):
@@ -80,9 +90,22 @@ def materialize_to_memory(
     """
 
     assets = check.sequence_param(assets, "assets", of_type=(AssetsDefinition, SourceAsset))
+    resource_defs = wrap_resources_for_execution(resources)
+
+    io_manager_keys = _get_required_io_manager_keys(assets)
+    for io_manager_key in io_manager_keys:
+        if io_manager_key in resource_defs:
+            raise DagsterInvariantViolationError(
+                "Attempted to call `materialize_to_memory` with a resource "
+                f"provided for io manager key '{io_manager_key}'. Do not "
+                "provide resources for io manager keys when calling "
+                "`materialize_to_memory`, as it will override io management "
+                "behavior for all keys."
+            )
+    resource_defs = merge_dicts({key: mem_io_manager for key in io_manager_keys}, resource_defs)
     assets_defs = [the_def for the_def in assets if isinstance(the_def, AssetsDefinition)]
     source_assets = [the_def for the_def in assets if isinstance(the_def, SourceAsset)]
-    resource_defs = wrap_resources_for_execution(resources)
+
     instance = check.opt_inst_param(instance, "instance", DagsterInstance)
     partition_key = check.opt_str_param(partition_key, "partition_key")
 
@@ -92,3 +115,14 @@ def materialize_to_memory(
         source_assets=source_assets,
         resource_defs=resource_defs,
     ).execute_in_process(run_config=run_config, instance=instance, partition_key=partition_key)
+
+
+def _get_required_io_manager_keys(
+    assets: Sequence[Union[AssetsDefinition, SourceAsset]]
+) -> Set[str]:
+    io_manager_keys = set()
+    for asset in assets:
+        for requirement in asset.get_resource_requirements():
+            if requirement.expected_type == IOManagerDefinition:
+                io_manager_keys.add(requirement.key)
+    return io_manager_keys

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets.py
@@ -21,6 +21,7 @@ from dagster._check import CheckError
 from dagster.core.asset_defs import AssetGroup, AssetIn, SourceAsset, asset, multi_asset
 from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
 from dagster.core.storage.mem_io_manager import InMemoryIOManager
+from dagster.core.test_utils import instance_for_test
 
 
 def test_with_replaced_asset_keys():
@@ -454,7 +455,8 @@ def test_multi_asset_resources_execution():
         yield Output(1, "key1")
         yield Output(2, "key2")
 
-    materialize_to_memory([my_asset])
+    with instance_for_test() as instance:
+        materialize([my_asset], instance=instance)
 
     assert foo_list == [1]
     assert bar_list == [2]
@@ -522,12 +524,14 @@ def test_graph_backed_asset_io_manager():
             "the_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager()),
         },
     )
-    result = materialize([asset_provided_resources])
-    assert result.success
-    assert events == [
-        "entered handle_output for basic.the_op",
-        "entered handle_input for basic.the_op",
-    ]
+
+    with instance_for_test() as instance:
+        result = materialize([asset_provided_resources], instance=instance)
+        assert result.success
+        assert events == [
+            "entered handle_output for basic.the_op",
+            "entered handle_input for basic.the_op",
+        ]
 
 
 def test_group_name_requirements():

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_materialize.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_materialize.py
@@ -252,3 +252,7 @@ def test_materialize_partition_key():
     with instance_for_test() as instance:
         result = materialize([the_asset], partition_key="2022-02-02", instance=instance)
         assert result.success
+
+
+def test_materialize_provided_resources():
+    pass

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_materialize_to_memory.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_materialize_to_memory.py
@@ -139,7 +139,10 @@ def test_materialize_source_assets():
 
     with pytest.raises(
         DagsterInvariantViolationError,
-        match="Attempted to call `materialize_to_memory` with a resource provided for io manager key 'the_source__io_manager'. Do not provide resources for io manager keys when calling `materialize_to_memory`, as it will override io management behavior for all keys.",
+        match="Attempted to call `materialize_to_memory` with a resource "
+        "provided for io manager key 'the_source__io_manager'. Do not provide "
+        "resources for io manager keys when calling `materialize_to_memory`, as "
+        "it will override io management behavior for all keys.",
     ):
         materialize_to_memory([the_asset, the_source])
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_materialize_to_memory.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_materialize_to_memory.py
@@ -5,6 +5,7 @@ from dagster import (
     AssetsDefinition,
     DagsterInvalidConfigError,
     DagsterInvalidDefinitionError,
+    DagsterInvariantViolationError,
     DailyPartitionsDefinition,
     GraphOut,
     IOManager,
@@ -85,9 +86,13 @@ def test_materialize_resources_not_satisfied():
     ):
         materialize_to_memory([the_asset])
 
-    assert materialize_to_memory(
-        with_resources([the_asset], {"foo": ResourceDefinition.hardcoded_resource("blah")})
-    ).success
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="Attempted to call `materialize_to_memory` with a resource provided for io manager key 'io_manager'. Do not provide resources for io manager keys when calling `materialize_to_memory`, as it will override io management behavior for all keys.",
+    ):
+        materialize_to_memory(
+            with_resources([the_asset], {"foo": ResourceDefinition.hardcoded_resource("blah")})
+        )
 
 
 def test_materialize_conflicting_resources():
@@ -132,39 +137,11 @@ def test_materialize_source_assets():
     def the_asset(the_source):
         return the_source + 1
 
-    result = materialize_to_memory([the_asset, the_source])
-    assert result.success
-    assert result.output_for_node("the_asset") == 6
-
-
-def test_materialize_source_asset_conflicts():
-    @io_manager(required_resource_keys={"foo"})
-    def the_manager():
-        pass
-
-    @asset(resource_defs={"foo": ResourceDefinition.hardcoded_resource("1")})
-    def the_asset():
-        pass
-
-    the_source = SourceAsset(
-        key=AssetKey(["the_source"]),
-        io_manager_def=the_manager,
-        resource_defs={"foo": ResourceDefinition.hardcoded_resource("2")},
-    )
-
     with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match="Conflicting versions of resource with key 'foo' were provided to different assets.",
+        DagsterInvariantViolationError,
+        match="Attempted to call `materialize_to_memory` with a resource provided for io manager key 'the_source__io_manager'. Do not provide resources for io manager keys when calling `materialize_to_memory`, as it will override io management behavior for all keys.",
     ):
         materialize_to_memory([the_asset, the_source])
-
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match="resource with key 'foo' provided to job conflicts with resource provided to assets.",
-    ):
-        materialize_to_memory(
-            [the_source], resources={"foo": ResourceDefinition.hardcoded_resource("2")}
-        )
 
 
 def test_materialize_no_assets():
@@ -258,4 +235,35 @@ def test_materialize_to_memory_partition_key():
 
 
 def test_materialize_to_memory_provided_io_manager_instance():
-    pass
+    @io_manager
+    def the_manager():
+        pass
+
+    @asset(io_manager_key="blah")
+    def the_asset():
+        pass
+
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="Attempted to call `materialize_to_memory` with a resource "
+        "provided for io manager key 'blah'. Do not provide resources for io "
+        "manager keys when calling `materialize_to_memory`, as it will override "
+        "io management behavior for all keys.",
+    ):
+        materialize_to_memory([the_asset], resources={"blah": the_manager})
+
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            pass
+
+        def load_input(self, context):
+            pass
+
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="Attempted to call `materialize_to_memory` with a resource "
+        "provided for io manager key 'blah'. Do not provide resources for io "
+        "manager keys when calling `materialize_to_memory`, as it will override "
+        "io management behavior for all keys.",
+    ):
+        materialize_to_memory([the_asset], resources={"blah": MyIOManager()})

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_materialize_to_memory.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_materialize_to_memory.py
@@ -255,3 +255,7 @@ def test_materialize_to_memory_partition_key():
 
     result = materialize_to_memory([the_asset], partition_key="2022-02-02")
     assert result.success
+
+
+def test_materialize_to_memory_provided_io_manager_instance():
+    pass


### PR DESCRIPTION
More closely aligns `materialize` and `materialize_to_memory`. Now both have `resources` arguments. 
`materialize_to_memory` now errors if any io managers are provided to the function, or exist on the assets themselves.