### PR TITLE
docs: update external links for github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,19 @@
 contact_links:
-  - name: Ask a question, get help, or share ideas 💭
-    url: https://github.com/dagster-io/dagster/discussions/category_choices
-    about: Discuss everything
-
-  - name: Join Dagster Slack Community 🔗
-    url: https://dagster-slackin.herokuapp.com/
-    about: Get help with issues, discuss Dagster and data engineering topics, and stay up to date with new releases and community events
+  - name: 🌟 Star us on Github
+    url: https://github.com/dagster-io/dagster
+    about: Show your support by starring the project!
+  - name: 🐦 Follow us on Twitter
+    url: https://twitter.com/dagsterio
+    about: Get notifications about Dagster content from our Twitter account.
+  - name: 📺 Subscribe to our YouTube channel
+    url: https://www.youtube.com/channel/UCfLnv9X8jyHTe6gJ4hVBo9Q
+    about: Watch videos about Dagster content from our YouTube account.
+  - name: 📚 Read our blog posts
+    url: https://dagster.io/blog
+    about: Read about the latest updates in Dagster.
+  - name: 👋 Join us on Slack
+    url: https://dagster.io/slack
+    about: Connect with thousands of other data practitioners building with Dagster. Share knowledge, get help, and contribute to the open-source project.
+  - name: ✏️ Start a Github Discussion
+    url: https://github.com/dagster-io/dagster/discussions
+    about: Interact with the community and Dagster core team over Github Discussions.

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Join our community here:
 
 - 🌟 [Star us on Github](https://github.com/dagster-io/dagster)
 - 🐦 [Follow us on Twitter](https://twitter.com/dagsterio)
-- 📺 [Subscribe to our YouTube Channel](https://www.youtube.com/channel/UCfLnv9X8jyHTe6gJ4hVBo9Q)
-- 📚 [Read our Blog Posts](https://dagster.io/blog)
+- 📺 [Subscribe to our YouTube channel](https://www.youtube.com/channel/UCfLnv9X8jyHTe6gJ4hVBo9Q)
+- 📚 [Read our blog posts](https://dagster.io/blog)
 - 👋 [Join us on Slack](https://dagster.io/slack)
 - ✏️ [Start a Github Discussion](https://github.com/dagster-io/dagster/discussions)
 


### PR DESCRIPTION
### Summary & Motivation
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

We have these links in the README. Surface them again when a user tries to support an issue.

### How I Tested These Changes
N/A - once PR is merged, try creating an issue to see that template has updated.
