### PR TITLE
docs: prevent blank github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,4 @@
+blank_issues_enabled: false
 contact_links:
   - name: 🌟 Star us on Github
     url: https://github.com/dagster-io/dagster


### PR DESCRIPTION
### Summary & Motivation
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

We should enforce that users use our templates.

### How I Tested These Changes
N/A
