### PR TITLE
fix(dagster-dbt): add check for dbt-core before executing CLI commands

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
@@ -26,6 +26,13 @@ def execute_cli(
     docs_url: Optional[str] = None,
 ) -> DbtCliOutput:
     """Executes a command on the dbt CLI in a subprocess."""
+    try:
+        import dbt  # pylint: disable=unused-import
+    except ImportError as e:
+        raise check.CheckError(
+            "You must have `dbt-core` installed in order to execute dbt CLI commands."
+        ) from e
+
     check.str_param(executable, "executable")
     check.str_param(command, "command")
     check.dict_param(flags_dict, "flags_dict", key_type=str)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_utils.py
@@ -1,0 +1,29 @@
+import logging
+import os
+import sys
+
+import pytest
+from dagster_dbt.cli.utils import execute_cli
+
+import dagster._check as check
+
+
+def test_execute_cli_requires_dbt_installed(monkeypatch, test_project_dir, dbt_config_dir):
+    monkeypatch.setitem(sys.modules, "dbt", None)
+
+    with pytest.raises(check.CheckError):
+        execute_cli(
+            executable="dbt",
+            command="ls",
+            log=logging.getLogger(__name__),
+            flags_dict={
+                "project-dir": test_project_dir,
+                "profiles-dir": dbt_config_dir,
+                "select": "*",
+                "resource-type": "model",
+                "output": "json",
+            },
+            warn_error=False,
+            ignore_handled_error=False,
+            target_path=os.path.join(test_project_dir, "target"),
+        )

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -35,6 +35,7 @@ if __name__ == "__main__":
         install_requires=[
             f"dagster{pin}",
             f"dagster-pandas{pin}",
+            "dbt-core",
             "pandas",
             "requests",
             "attrs",
@@ -43,7 +44,6 @@ if __name__ == "__main__":
         extras_require={
             "test": [
                 "Jinja2",
-                "dbt-core",
                 "dbt-rpc",
                 "dbt-postgres",
                 "matplotlib",


### PR DESCRIPTION
### Summary & Motivation
Add a check that `dbt-core` is installed before running CLI commands.

Alternatively, we can specify `dbt-core` and `dbt-rpc` as dependencies on the python package, although they are not explicitly imported for their Python library.

Do both. In the rare case that somehow `dbt-core` is uninstalled while `dagster-dbt` is, we can still receive a helpful error message.

### How I Tested These Changes
pytest
