### PR TITLE
hold shift to force asset config modal

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -115,7 +115,7 @@ export const LaunchAssetExecutionButton: React.FC<{
 
   return (
     <>
-      <Tooltip content="shift-click to open the config editor">
+      <Tooltip content="Shift+click to add configuration">
         <Button
           intent={intent}
           onClick={onClick}

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -96,7 +96,8 @@ export const LaunchAssetExecutionButton: React.FC<{
       variables: {assetKeys: assetKeys.map(({path}) => ({path}))},
     });
     const assets = result.data.assetNodes;
-    const next = stateForLaunchingAssets(assets, e, preferredJobName);
+    const forceLaunchpad = e.shiftKey;
+    const next = stateForLaunchingAssets(assets, forceLaunchpad, preferredJobName);
 
     if (next.type === 'error') {
       showCustomAlert({
@@ -154,7 +155,7 @@ export const LaunchAssetExecutionButton: React.FC<{
 
 function stateForLaunchingAssets(
   assets: LaunchAssetExecutionAssetNodeFragment[],
-  mouseEvent: React.MouseEvent<any>,
+  forceLaunchpad: boolean,
   preferredJobName?: string,
 ): LaunchAssetsState {
   if (assets.some(isSourceAsset)) {
@@ -209,7 +210,7 @@ function stateForLaunchingAssets(
 
   // Ok! Assertions met, how do we launch this run
 
-  if (anyAssetsHaveConfig || mouseEvent.shiftKey) {
+  if (anyAssetsHaveConfig || forceLaunchpad) {
     const assetOpNames = assets.flatMap((a) => a.opNames || []);
     return {
       type: 'launchpad',

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -85,7 +85,7 @@ export const LaunchAssetExecutionButton: React.FC<{
     );
   }
 
-  const onClick = async () => {
+  const onClick = async (e: React.MouseEvent<any>) => {
     if (state.type === 'loading') {
       return;
     }
@@ -96,7 +96,7 @@ export const LaunchAssetExecutionButton: React.FC<{
       variables: {assetKeys: assetKeys.map(({path}) => ({path}))},
     });
     const assets = result.data.assetNodes;
-    const next = stateForLaunchingAssets(assets, preferredJobName);
+    const next = stateForLaunchingAssets(assets, e, preferredJobName);
 
     if (next.type === 'error') {
       showCustomAlert({
@@ -114,19 +114,21 @@ export const LaunchAssetExecutionButton: React.FC<{
 
   return (
     <>
-      <Button
-        intent={intent}
-        onClick={onClick}
-        icon={
-          state.type === 'loading' ? (
-            <Spinner purpose="body-text" />
-          ) : (
-            <Icon name="materialization" />
-          )
-        }
-      >
-        {label}
-      </Button>
+      <Tooltip content="shift-click to open the config editor">
+        <Button
+          intent={intent}
+          onClick={onClick}
+          icon={
+            state.type === 'loading' ? (
+              <Spinner purpose="body-text" />
+            ) : (
+              <Icon name="materialization" />
+            )
+          }
+        >
+          {label}
+        </Button>
+      </Tooltip>
       {state.type === 'launchpad' && (
         <AssetLaunchpad
           assetJobName={state.jobName}
@@ -152,6 +154,7 @@ export const LaunchAssetExecutionButton: React.FC<{
 
 function stateForLaunchingAssets(
   assets: LaunchAssetExecutionAssetNodeFragment[],
+  mouseEvent: React.MouseEvent<any>,
   preferredJobName?: string,
 ): LaunchAssetsState {
   if (assets.some(isSourceAsset)) {
@@ -206,7 +209,7 @@ function stateForLaunchingAssets(
 
   // Ok! Assertions met, how do we launch this run
 
-  if (anyAssetsHaveConfig) {
+  if (anyAssetsHaveConfig || mouseEvent.shiftKey) {
     const assetOpNames = assets.flatMap((a) => a.opNames || []);
     return {
       type: 'launchpad',


### PR DESCRIPTION
### Summary & Motivation

Changes behavior of the asset materialize button so that, when you hold "shift", the asset config modal always pops up. This change applies everywhere the asset materialize button appears (graph explorer, asset details page, etc). Also adds a tooltip explaining this behavior.

Note that "shift" was chosen over alt/ctrl because: ctrl-click is already taken by the browser (brings up context menu, like right-click), and both alt and ctrl bring up shortcuts. But I'm definitely open to reconsidering the modifier. 

Note also that ultimately we want to add an ellipsis to the button text when holding down the modifier, but that's not in this  PR because it's a bit tricky and we want this in tmrw's release.

Resolves #8524.

### How I Tested These Changes

Manually in dagit.