### PR TITLE
Option to skip daemon heartbeats with no errors

### DIFF
--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -2037,6 +2037,13 @@ class DagsterInstance:
             self, daemon_types=daemon_types or self.get_required_daemon_types(), ignore_errors=True
         )
 
+    @property
+    def daemon_skip_heartbeats_without_errors(self):
+        # If enabled, daemon threads won't write heartbeats unless they encounter an error. This is
+        # enabled in cloud, where we don't need to use heartbeats to check if daemons are running, but
+        # do need to surface errors to users. This is an optimization to reduce DB writes.
+        return False
+
     # backfill
     def get_backfills(self, status=None, cursor=None, limit=None):
         return self._run_storage.get_backfills(status=status, cursor=cursor, limit=limit)

--- a/python_modules/dagster/dagster/daemon/controller.py
+++ b/python_modules/dagster/dagster/daemon/controller.py
@@ -253,11 +253,14 @@ class DagsterDaemonController:
         start_time = time.time()
         last_heartbeat_check_time = start_time
         while True:
-            # Wait until a daemon has been unhealthy for a long period of time
-            # before potentially restarting it due to a hanging or failed daemon
             with raise_interrupts_as(KeyboardInterrupt):
                 time.sleep(THREAD_CHECK_INTERVAL)
                 self.check_daemon_threads()
+
+                if self._instance.daemon_skip_heartbeats_without_errors:
+                    # If we're skipping heartbeats without errors, we just check the threads.
+                    # If there's no errors, the daemons won't be writing heartbeats.
+                    continue
 
                 now = time.time()
                 # Give the daemon enough time to send an initial heartbeat before checking

--- a/python_modules/dagster/dagster/daemon/daemon.py
+++ b/python_modules/dagster/dagster/daemon/daemon.py
@@ -111,7 +111,11 @@ class DagsterDaemon(AbstractContextManager):
                     daemon_generator.close()
 
     def _check_add_heartbeat(
-        self, instance, daemon_uuid, heartbeat_interval_seconds, error_interval_seconds
+        self,
+        instance: DagsterInstance,
+        daemon_uuid,
+        heartbeat_interval_seconds,
+        error_interval_seconds,
     ):
         error_max_time = pendulum.now("UTC").subtract(seconds=error_interval_seconds)
 
@@ -120,6 +124,10 @@ class DagsterDaemon(AbstractContextManager):
             if earliest_timestamp >= error_max_time:
                 break
             self._errors.pop()
+
+        if instance.daemon_skip_heartbeats_without_errors and not self._errors:
+            # no errors to report, so we don't write a heartbeat
+            return
 
         curr_time = pendulum.now("UTC")
 


### PR DESCRIPTION
Disabled by default

Option to only send heartbeats when they contain errors. Useful in cloud where we don't need to rely on them to know if the daemons are alive. See https://github.com/dagster-io/internal/pull/2450?no-redirect=1 for more context

Under test in https://app.graphite.dev/github/pr/dagster-io/internal/2450