### PR TITLE
[dagit] Add Analytics context

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppProvider.tsx
@@ -34,6 +34,7 @@ import {LayoutProvider} from './LayoutProvider';
 import {PermissionsProvider} from './Permissions';
 import {patchCopyToRemoveZeroWidthUnderscores} from './Util';
 import {WebSocketProvider} from './WebSocketProvider';
+import {AnalyticsContext, dummyAnalytics} from './analytics';
 import {TimezoneProvider} from './time/TimezoneContext';
 
 import './blueprint.css';
@@ -157,6 +158,8 @@ export const AppProvider: React.FC<AppProviderProps> = (props) => {
     [basePath, rootServerURI, staticPathRoot, telemetryEnabled],
   );
 
+  const analytics = React.useMemo(() => dummyAnalytics(), []);
+
   return (
     <AppContext.Provider value={appContextValue}>
       <WebSocketProvider websocketClient={websocketClient}>
@@ -174,7 +177,9 @@ export const AppProvider: React.FC<AppProviderProps> = (props) => {
               <TimezoneProvider>
                 <WorkspaceProvider>
                   <CustomConfirmationProvider>
-                    <LayoutProvider>{props.children}</LayoutProvider>
+                    <AnalyticsContext.Provider value={analytics}>
+                      <LayoutProvider>{props.children}</LayoutProvider>
+                    </AnalyticsContext.Provider>
                   </CustomConfirmationProvider>
                   <CustomTooltipProvider />
                   <CustomAlertProvider />

--- a/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
@@ -15,6 +15,7 @@ import {useStateWithStorage} from '../hooks/useStateWithStorage';
 
 import {FeatureFlag, getFeatureFlags, setFeatureFlags} from './Flags';
 import {SHORTCUTS_STORAGE_KEY} from './ShortcutHandler';
+import {useTrackPageView} from './analytics';
 import {TimezoneSelect} from './time/TimezoneSelect';
 import {automaticLabel} from './time/browserTimezone';
 
@@ -22,6 +23,7 @@ export interface SettingsRootProps {
   tabs?: React.ReactNode;
 }
 const UserSettingsRoot: React.FC<SettingsRootProps> = ({tabs}) => {
+  useTrackPageView();
   useDocumentTitle('User settings');
 
   const [flags, setFlags] = React.useState<FeatureFlag[]>(() => getFeatureFlags());

--- a/js_modules/dagit/packages/core/src/app/analytics.test.tsx
+++ b/js_modules/dagit/packages/core/src/app/analytics.test.tsx
@@ -1,0 +1,127 @@
+import {act, render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import {Route, Switch} from 'react-router-dom';
+
+import {TestProvider} from '../testing/TestProvider';
+
+import {AnalyticsContext, GenericAnalytics, useTrackEvent, useTrackPageView} from './analytics';
+
+describe('Analytics', () => {
+  const createMockAnalytics = () => ({
+    page: jest.fn(),
+    track: jest.fn(),
+  });
+
+  const Test: React.FC<{mockAnalytics: GenericAnalytics}> = ({children, mockAnalytics}) => {
+    return <AnalyticsContext.Provider value={mockAnalytics}>{children}</AnalyticsContext.Provider>;
+  };
+
+  describe('Page view tracking', () => {
+    const Page = () => {
+      useTrackPageView();
+      return <div>Hello</div>;
+    };
+
+    it('tracks page views', async () => {
+      jest.useFakeTimers();
+      const mockAnalytics = createMockAnalytics();
+
+      await act(async () => {
+        render(
+          <TestProvider routerProps={{initialEntries: ['/foo/hello']}}>
+            <Test mockAnalytics={mockAnalytics}>
+              <Switch>
+                <Route path="/foo/:bar?">
+                  <Page />
+                </Route>
+              </Switch>
+            </Test>
+          </TestProvider>,
+        );
+      });
+
+      jest.advanceTimersByTime(400);
+      const {page} = mockAnalytics;
+      expect(page).toHaveBeenCalledTimes(1);
+
+      // Track both the react-router Route path and the actual location pathname
+      expect(page.mock.calls[0][0]).toBe('/foo/:bar?');
+      expect(page.mock.calls[0][1]).toBe('/foo/hello');
+    });
+  });
+
+  describe('Event tracking', () => {
+    const Page = () => {
+      const trackEvent = useTrackEvent();
+      const onClick = () => {
+        trackEvent('userClick');
+      };
+      return <button onClick={onClick}>Hello</button>;
+    };
+
+    it('tracks events, e.g. button clicks', async () => {
+      jest.useFakeTimers();
+      const mockAnalytics = createMockAnalytics();
+
+      await act(async () => {
+        render(
+          <TestProvider routerProps={{initialEntries: ['/foo/hello']}}>
+            <Test mockAnalytics={mockAnalytics}>
+              <Switch>
+                <Route path="/foo/:bar?">
+                  <Page />
+                </Route>
+              </Switch>
+            </Test>
+          </TestProvider>,
+        );
+      });
+
+      const button = screen.getByRole('button');
+      act(() => {
+        userEvent.click(button);
+      });
+
+      const {track} = mockAnalytics;
+      expect(track).toHaveBeenCalledTimes(1);
+
+      // Track both the react-router Route path and the actual location pathname
+      expect(track.mock.calls[0][0]).toBe('userClick');
+      expect(track.mock.calls[0][1]).toEqual({path: '/foo/:bar?', specificPath: '/foo/hello'});
+    });
+  });
+
+  describe('Overriding Analytics context value', () => {
+    const Page = () => {
+      useTrackPageView();
+      return <div>Hello</div>;
+    };
+
+    it('tracks page views with overidding functions', async () => {
+      jest.useFakeTimers();
+      const mockAnalytics = createMockAnalytics();
+      const overrideAnalytics = createMockAnalytics();
+
+      await act(async () => {
+        render(
+          <TestProvider routerProps={{initialEntries: ['/foo/hello']}}>
+            <Test mockAnalytics={mockAnalytics}>
+              <Test mockAnalytics={overrideAnalytics}>
+                <Switch>
+                  <Route path="/foo/:bar?">
+                    <Page />
+                  </Route>
+                </Switch>
+              </Test>
+            </Test>
+          </TestProvider>,
+        );
+      });
+
+      jest.advanceTimersByTime(400);
+      expect(mockAnalytics.page).toHaveBeenCalledTimes(0);
+      expect(overrideAnalytics.page).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/app/analytics.tsx
+++ b/js_modules/dagit/packages/core/src/app/analytics.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import {useLocation, useRouteMatch} from 'react-router-dom';
+
+export interface GenericAnalytics {
+  identify?: (userId: string) => void;
+  page: (path: string, specificPath: string) => void;
+  track: (eventName: string, properties?: Record<string, any>) => void;
+}
+
+export const AnalyticsContext = React.createContext<GenericAnalytics>(undefined!);
+
+const PAGEVIEW_DELAY = 300;
+
+const usePageContext = () => {
+  const match = useRouteMatch();
+  const {pathname: specificPath} = useLocation();
+  const {path} = match;
+  return React.useMemo(() => ({path, specificPath}), [path, specificPath]);
+};
+
+const useAnalytics = () => {
+  const analytics = React.useContext(AnalyticsContext);
+  if (!analytics) {
+    throw new Error('Analytics may only be used within `AnalyticsContext.Provider`.');
+  }
+  return analytics;
+};
+
+export const dummyAnalytics = () => ({
+  identify: (id: string) => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('[Identify]', id);
+    }
+  },
+  page: (path: string, specificPath: string) => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('[Pageview]', {path, specificPath});
+    }
+  },
+  track: (eventName: string, properties?: Record<string, any>) => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('[Event]', eventName, properties);
+    }
+  },
+});
+
+export const useTrackPageView = () => {
+  const analytics = useAnalytics();
+  const {path, specificPath} = usePageContext();
+
+  React.useEffect(() => {
+    // Wait briefly to allow redirects.
+    const timer = setTimeout(() => {
+      analytics.page(path, specificPath);
+    }, PAGEVIEW_DELAY);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [analytics, path, specificPath]);
+};
+
+export const useTrackEvent = () => {
+  const analytics = useAnalytics();
+  const pathValues = usePageContext();
+
+  return React.useCallback(
+    (eventName: string, properties?: Record<string, any>) => {
+      analytics.track(eventName, {...properties, ...pathValues});
+    },
+    [analytics, pathValues],
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/AssetGroupRoot.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetGroupRoot.tsx
@@ -2,6 +2,7 @@ import {Page, PageHeader, Heading, Box, Tag, Tabs} from '@dagster-io/ui';
 import * as React from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
+import {useTrackPageView} from '../app/analytics';
 import {AssetGraphExplorer} from '../asset-graph/AssetGraphExplorer';
 import {AssetLocation} from '../asset-graph/useFindAssetLocation';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
@@ -29,6 +30,8 @@ export const AssetGroupRoot: React.FC<{repoAddress: RepoAddress; tab: 'lineage' 
   repoAddress,
   tab,
 }) => {
+  useTrackPageView();
+
   const {groupName, 0: path} = useParams<AssetGroupRootParams>();
   const history = useHistory();
 

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogRoot.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogRoot.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import {useHistory} from 'react-router';
 import {useParams} from 'react-router-dom';
 
+import {useTrackPageView} from '../app/analytics';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {ReloadAllButton} from '../workspace/ReloadAllButton';
@@ -18,6 +19,8 @@ import {
 } from './types/AssetsCatalogRootQuery';
 
 export const AssetsCatalogRoot = () => {
+  useTrackPageView();
+
   const params = useParams();
   const history = useHistory();
   const currentPath: string[] = (params['0'] || '')

--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useCursorPaginatedQuery} from '../runs/useCursorPaginatedQuery';
 import {Loading} from '../ui/Loading';
@@ -27,6 +28,8 @@ import {InstanceHealthForBackfillsQuery} from './types/InstanceHealthForBackfill
 const PAGE_SIZE = 25;
 
 export const InstanceBackfills = () => {
+  useTrackPageView();
+
   const queryData = useQuery<InstanceHealthForBackfillsQuery>(INSTANCE_HEALTH_FOR_BACKFILLS_QUERY);
 
   const {queryResult, paginationProps} = useCursorPaginatedQuery<

--- a/js_modules/dagit/packages/core/src/instance/InstanceConfig.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceConfig.tsx
@@ -16,6 +16,7 @@ import * as React from 'react';
 import {createGlobalStyle} from 'styled-components/macro';
 
 import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
+import {useTrackPageView} from '../app/analytics';
 
 import {InstanceTabs} from './InstanceTabs';
 import {InstanceConfigQuery} from './types/InstanceConfigQuery';
@@ -33,6 +34,8 @@ const InstanceConfigStyle = createGlobalStyle`
 `;
 
 export const InstanceConfig = React.memo(() => {
+  useTrackPageView();
+
   const queryResult = useQuery<InstanceConfigQuery>(INSTANCE_CONFIG_QUERY, {
     fetchPolicy: 'cache-and-network',
     notifyOnNetworkStatusChange: true,

--- a/js_modules/dagit/packages/core/src/instance/InstanceHealthPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceHealthPage.tsx
@@ -3,6 +3,7 @@ import {Box, Colors, PageHeader, Heading, Subheading} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {useTrackPageView} from '../app/analytics';
 
 import {DaemonList} from './DaemonList';
 import {INSTANCE_HEALTH_FRAGMENT} from './InstanceHealthFragment';
@@ -10,6 +11,8 @@ import {InstanceTabs} from './InstanceTabs';
 import {InstanceHealthQuery} from './types/InstanceHealthQuery';
 
 export const InstanceHealthPage = () => {
+  useTrackPageView();
+
   const queryData = useQuery<InstanceHealthQuery>(INSTANCE_HEALTH_QUERY, {
     fetchPolicy: 'cache-and-network',
     notifyOnNetworkStatusChange: true,

--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -17,6 +17,7 @@ import * as React from 'react';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useMergedRefresh, useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {ScheduleOrSensorTag} from '../nav/ScheduleOrSensorTag';
 import {LegacyPipelineTag} from '../pipelines/LegacyPipelineTag';
@@ -85,6 +86,8 @@ const initialState: State = {
 };
 
 export const InstanceOverviewPage = () => {
+  useTrackPageView();
+
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const {allRepos, visibleRepos} = React.useContext(WorkspaceContext);
   const {searchValue} = state;

--- a/js_modules/dagit/packages/core/src/instance/InstanceSchedules.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceSchedules.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {useTrackPageView} from '../app/analytics';
 import {INSTIGATION_STATE_FRAGMENT} from '../instigation/InstigationUtils';
 import {UnloadableSchedules} from '../instigation/Unloadable';
 import {SCHEDULE_FRAGMENT} from '../schedules/ScheduleUtils';
@@ -19,6 +20,8 @@ import {InstanceTabs} from './InstanceTabs';
 import {InstanceSchedulesQuery} from './types/InstanceSchedulesQuery';
 
 export const InstanceSchedules = React.memo(() => {
+  useTrackPageView();
+
   const queryData = useQuery<InstanceSchedulesQuery>(INSTANCE_SCHEDULES_QUERY, {
     fetchPolicy: 'cache-and-network',
     notifyOnNetworkStatusChange: true,

--- a/js_modules/dagit/packages/core/src/instance/InstanceSensors.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceSensors.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
+import {useTrackPageView} from '../app/analytics';
 import {INSTIGATION_STATE_FRAGMENT} from '../instigation/InstigationUtils';
 import {UnloadableSensors} from '../instigation/Unloadable';
 import {SENSOR_FRAGMENT} from '../sensors/SensorFragment';
@@ -19,6 +20,8 @@ import {InstanceTabs} from './InstanceTabs';
 import {InstanceSensorsQuery} from './types/InstanceSensorsQuery';
 
 export const InstanceSensors = React.memo(() => {
+  useTrackPageView();
+
   const queryData = useQuery<InstanceSensorsQuery>(INSTANCE_SENSORS_QUERY, {
     fetchPolicy: 'cache-and-network',
     notifyOnNetworkStatusChange: true,

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
@@ -6,6 +6,7 @@ import {Redirect, useParams} from 'react-router-dom';
 import {IExecutionSession} from '../app/ExecutionSessionStorage';
 import {usePermissions} from '../app/Permissions';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {useTrackPageView} from '../app/analytics';
 import {explorerPathFromString, useStripSnapshotFromPath} from '../pipelines/PipelinePathUtils';
 import {useJobTitle} from '../pipelines/useJobTitle';
 import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
@@ -88,6 +89,8 @@ interface Props {
 }
 
 const LaunchpadAllowedRoot: React.FC<Props> = (props) => {
+  useTrackPageView();
+
   const {pipelinePath, repoAddress, launchpadType, sessionPresets} = props;
   const explorerPath = explorerPathFromString(pipelinePath);
   const {pipelineName} = explorerPath;

--- a/js_modules/dagit/packages/core/src/ops/OpsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/ops/OpsRoot.tsx
@@ -17,6 +17,7 @@ import {useHistory, useLocation, useParams} from 'react-router-dom';
 import {AutoSizer, CellMeasurer, CellMeasurerCache, List} from 'react-virtualized';
 import styled from 'styled-components/macro';
 
+import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {Loading} from '../ui/Loading';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
@@ -117,10 +118,12 @@ interface Props {
 }
 
 export const OpsRoot: React.FC<Props> = (props) => {
+  useTrackPageView();
+  useDocumentTitle('Ops');
+
   const {name} = useParams<{name?: string}>();
   const {repoAddress} = props;
 
-  useDocumentTitle('Ops');
   const repositorySelector = repoAddressToSelector(repoAddress);
 
   const queryResult = useQuery<OpsRootQuery, OpsRootQueryVariables>(OPS_ROOT_QUERY, {

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {useTrackPageView} from '../app/analytics';
 import {AssetGraphExplorer} from '../asset-graph/AssetGraphExplorer';
 import {AssetLocation} from '../asset-graph/useFindAssetLocation';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
@@ -28,6 +29,8 @@ import {
 } from './types/PipelineExplorerRootQuery';
 
 export const PipelineExplorerSnapshotRoot = () => {
+  useTrackPageView();
+
   const params = useParams();
   const explorerPath = explorerPathFromString(params['0']);
   const {pipelineName, snapshotId} = explorerPath;

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineOverviewRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineOverviewRoot.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {useHistory, useLocation, useParams} from 'react-router-dom';
 
+import {useTrackPageView} from '../app/analytics';
 import {tokenForAssetKey} from '../asset-graph/Utils';
 import {AssetLocation} from '../asset-graph/useFindAssetLocation';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
@@ -24,6 +25,8 @@ interface Props {
 }
 
 export const PipelineOverviewRoot: React.FC<Props> = (props) => {
+  useTrackPageView();
+
   const {repoAddress} = props;
   const history = useHistory();
   const location = useLocation();

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineRunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineRunsRoot.tsx
@@ -17,6 +17,7 @@ import {
   QueryRefreshCountdown,
   useQueryRefreshAtInterval,
 } from '../app/QueryRefresh';
+import {useTrackPageView} from '../app/analytics';
 import {RunTable, RUN_TABLE_RUN_FRAGMENT} from '../runs/RunTable';
 import {RunsQueryRefetchContext} from '../runs/RunUtils';
 import {
@@ -44,6 +45,8 @@ interface Props {
 }
 
 export const PipelineRunsRoot: React.FC<Props> = (props) => {
+  useTrackPageView();
+
   const {pipelinePath} = useParams<{pipelinePath: string}>();
   const {repoAddress = null} = props;
   const explorerPath = explorerPathFromString(pipelinePath);

--- a/js_modules/dagit/packages/core/src/runs/RunRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunRoot.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import {useParams} from 'react-router-dom';
 
 import {formatElapsedTime} from '../app/Util';
+import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
@@ -20,6 +21,8 @@ import {assetKeysForRun} from './RunUtils';
 import {RunRootQuery, RunRootQueryVariables} from './types/RunRootQuery';
 
 export const RunRoot = () => {
+  useTrackPageView();
+
   const {runId} = useParams<{runId: string}>();
 
   const {data, loading} = useQuery<RunRootQuery, RunRootQueryVariables>(RUN_ROOT_QUERY, {

--- a/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
@@ -24,6 +24,7 @@ import {
   QueryRefreshCountdown,
   useQueryRefreshAtInterval,
 } from '../app/QueryRefresh';
+import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useCanSeeConfig} from '../instance/useCanSeeConfig';
 import {RunStatus} from '../types/globalTypes';
@@ -64,7 +65,9 @@ const selectedTabId = (filterTokens: TokenizingFieldValue[]) => {
 };
 
 export const RunsRoot = () => {
+  useTrackPageView();
   useDocumentTitle('Runs');
+
   const [filterTokens, setFilterTokens] = useQueryPersistedRunFilters();
   const filter = runsFilterForSearchTokens(filterTokens);
   const [showScheduled, setShowScheduled] = React.useState(false);

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleRoot.tsx
@@ -5,6 +5,7 @@ import {useParams} from 'react-router-dom';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
 import {TicksTable} from '../instigation/TickHistory';
@@ -32,6 +33,8 @@ interface Props {
 }
 
 export const ScheduleRoot: React.FC<Props> = (props) => {
+  useTrackPageView();
+
   const {repoAddress} = props;
   const {scheduleName} = useParams<{scheduleName: string}>();
 

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesRoot.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {UnloadableSchedules} from '../instigation/Unloadable';
 import {InstigationType} from '../types/globalTypes';
@@ -18,7 +19,9 @@ import {SchedulesTable} from './SchedulesTable';
 import {SchedulesRootQuery, SchedulesRootQueryVariables} from './types/SchedulesRootQuery';
 
 export const SchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
+  useTrackPageView();
   useDocumentTitle('Schedules');
+
   const repositorySelector = repoAddressToSelector(repoAddress);
 
   const queryResult = useQuery<SchedulesRootQuery, SchedulesRootQueryVariables>(

--- a/js_modules/dagit/packages/core/src/search/SearchDialog.tsx
+++ b/js_modules/dagit/packages/core/src/search/SearchDialog.tsx
@@ -7,6 +7,7 @@ import {useHistory, useLocation} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {ShortcutHandler} from '../app/ShortcutHandler';
+import {useTrackEvent} from '../app/analytics';
 
 import {SearchResults} from './SearchResults';
 import {SearchResult} from './types';
@@ -60,6 +61,7 @@ export const SearchDialog: React.FC<{searchPlaceholder: string}> = ({searchPlace
   const location = useLocation();
   const history = useHistory();
   const {performBootstrapQuery, loading, performSearch} = useRepoSearch();
+  const trackEvent = useTrackEvent();
 
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const {shown, queryString, results, highlight, loaded} = state;
@@ -68,9 +70,10 @@ export const SearchDialog: React.FC<{searchPlaceholder: string}> = ({searchPlace
   const numRenderedResults = renderedResults.length;
 
   const openSearch = React.useCallback(() => {
+    trackEvent('userOpenSearch');
     performBootstrapQuery();
     dispatch({type: 'show-dialog'});
-  }, [performBootstrapQuery]);
+  }, [performBootstrapQuery, trackEvent]);
 
   const onChange = React.useCallback((e) => {
     dispatch({type: 'change-query', queryString: e.target.value});
@@ -135,7 +138,7 @@ export const SearchDialog: React.FC<{searchPlaceholder: string}> = ({searchPlace
   return (
     <>
       <ShortcutHandler
-        onShortcut={() => dispatch({type: 'show-dialog'})}
+        onShortcut={openSearch}
         shortcutLabel="/"
         shortcutFilter={(e) =>
           e.key === '/' && !e.altKey && !e.metaKey && !e.shiftKey && !e.ctrlKey

--- a/js_modules/dagit/packages/core/src/sensors/SensorRoot.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorRoot.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import {useParams} from 'react-router-dom';
 
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
 import {TicksTable, TickHistoryTimeline} from '../instigation/TickHistory';
@@ -18,6 +19,8 @@ import {SensorPreviousRuns} from './SensorPreviousRuns';
 import {SensorRootQuery, SensorRootQueryVariables} from './types/SensorRootQuery';
 
 export const SensorRoot: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) => {
+  useTrackPageView();
+
   const {sensorName} = useParams<{sensorName: string}>();
   useDocumentTitle(`Sensor: ${sensorName}`);
 

--- a/js_modules/dagit/packages/core/src/sensors/SensorsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorsRoot.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
 import {INSTIGATION_STATE_FRAGMENT} from '../instigation/InstigationUtils';
@@ -23,8 +24,10 @@ interface Props {
 }
 
 export const SensorsRoot = (props: Props) => {
-  const {repoAddress} = props;
+  useTrackPageView();
   useDocumentTitle('Sensors');
+
+  const {repoAddress} = props;
   const repositorySelector = repoAddressToSelector(repoAddress);
 
   const queryResult = useQuery<SensorsRootQuery, SensorsRootQueryVariables>(SENSORS_ROOT_QUERY, {

--- a/js_modules/dagit/packages/core/src/testing/TestProvider.tsx
+++ b/js_modules/dagit/packages/core/src/testing/TestProvider.tsx
@@ -5,6 +5,7 @@ import {MemoryRouter, MemoryRouterProps} from 'react-router-dom';
 import {AppContext, AppContextValue} from '../app/AppContext';
 import {PermissionsContext, PermissionsFromJSON} from '../app/Permissions';
 import {WebSocketContext, WebSocketContextType} from '../app/WebSocketProvider';
+import {AnalyticsContext} from '../app/analytics';
 import {PermissionFragment} from '../app/types/PermissionFragment';
 import {WorkspaceProvider} from '../workspace/WorkspaceContext';
 
@@ -57,15 +58,25 @@ export const TestProvider: React.FC<Props> = (props) => {
     });
   }, [permissionOverrides]);
 
+  const analytics = React.useMemo(
+    () => ({
+      page: () => {},
+      track: () => {},
+    }),
+    [],
+  );
+
   return (
     <AppContext.Provider value={{...testValue, ...appContextProps}}>
       <WebSocketContext.Provider value={websocketValue}>
         <PermissionsContext.Provider value={permissions}>
-          <MemoryRouter {...routerProps}>
-            <ApolloTestProvider {...apolloProps} typeDefs={typeDefs}>
-              <WorkspaceProvider>{props.children}</WorkspaceProvider>
-            </ApolloTestProvider>
-          </MemoryRouter>
+          <AnalyticsContext.Provider value={analytics}>
+            <MemoryRouter {...routerProps}>
+              <ApolloTestProvider {...apolloProps} typeDefs={typeDefs}>
+                <WorkspaceProvider>{props.children}</WorkspaceProvider>
+              </ApolloTestProvider>
+            </MemoryRouter>
+          </AnalyticsContext.Provider>
         </PermissionsContext.Provider>
       </WebSocketContext.Provider>
     </AppContext.Provider>

--- a/js_modules/dagit/packages/core/src/workspace/GraphRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/GraphRoot.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {explodeCompositesInHandleGraph} from '../pipelines/CompositeSupport';
@@ -28,6 +29,8 @@ interface Props {
 }
 
 export const GraphRoot: React.FC<Props> = (props) => {
+  useTrackPageView();
+
   const {repoAddress} = props;
   const params = useParams();
 

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
+import {useTrackPageView} from '../app/analytics';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {RepositoryLink} from '../nav/RepositoryLink';
@@ -51,6 +52,8 @@ interface Props {
 }
 
 export const RepositoryAssetsList: React.FC<Props> = (props) => {
+  useTrackPageView();
+
   const {repoAddress} = props;
   const repositorySelector = repoAddressToSelector(repoAddress);
 

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryGraphsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryGraphsList.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
+import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 
 import {repoAddressAsString} from './repoAddressAsString';
@@ -65,7 +66,10 @@ interface Item {
   path: string;
   repoAddress: RepoAddress;
 }
+
 export const RepositoryGraphsList: React.FC<Props> = (props) => {
+  useTrackPageView();
+
   const {repoAddress} = props;
   const repositorySelector = repoAddressToSelector(repoAddress);
 

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryPipelinesList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryPipelinesList.tsx
@@ -2,6 +2,7 @@ import {gql, useQuery} from '@apollo/client';
 import {Box, NonIdealState} from '@dagster-io/ui';
 import * as React from 'react';
 
+import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {PipelineTable, PIPELINE_TABLE_FRAGMENT} from '../pipelines/PipelineTable';
 
@@ -38,6 +39,8 @@ interface Props {
 }
 
 export const RepositoryPipelinesList: React.FC<Props> = (props) => {
+  useTrackPageView();
+
   const {display, repoAddress} = props;
   const repositorySelector = repoAddressToSelector(repoAddress);
 

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewRoot.tsx
@@ -12,6 +12,7 @@ import {
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
+import {useTrackPageView} from '../app/analytics';
 import {LoadingSpinner} from '../ui/Loading';
 
 import {ReloadAllButton} from './ReloadAllButton';
@@ -21,6 +22,7 @@ import {buildRepoPath} from './buildRepoAddress';
 import {workspacePath} from './workspacePath';
 
 export const WorkspaceOverviewRoot = () => {
+  useTrackPageView();
   const {loading, error, options} = useRepositoryOptions();
 
   const content = () => {

--- a/js_modules/dagit/packages/core/src/workspace/WorkspacePipelineRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspacePipelineRoot.tsx
@@ -2,6 +2,7 @@ import {Alert, Box, NonIdealState, Page, PageHeader, Table, Heading} from '@dags
 import * as React from 'react';
 import {Link, Redirect, useLocation, useParams, useRouteMatch} from 'react-router-dom';
 
+import {useTrackPageView} from '../app/analytics';
 import {explorerPathFromString} from '../pipelines/PipelinePathUtils';
 import {LoadingSpinner} from '../ui/Loading';
 
@@ -11,6 +12,8 @@ import {findRepoContainingPipeline} from './findRepoContainingPipeline';
 import {workspacePath, workspacePathFromAddress} from './workspacePath';
 
 export const WorkspacePipelineRoot = () => {
+  useTrackPageView();
+
   const params = useParams<{pipelinePath: string}>();
   const {pipelinePath} = params;
 


### PR DESCRIPTION
### Summary & Motivation

Add an `AnalyticsContext` provide to the `AppProvider` root.

- Define a `GenericAnalytics` interface that we can override in Cloud with our chosen analytics tracking library.
- Add `AnalyticsContext.Provider` to the `AppProvider` root.
- In open source, we just log page views and tracked events to the console, and only in JS dev. This means any analytics tracking is a no-op for open source consumers.

I have created two React hooks for analytics usage.

- `useTrackPageView`, which should be added to any location in Dagit for which we consider rendering to be a "page view". Note that this work is a bit manual and requires us to adhere to a certain convention about what counts as a page view.
  - Under the hood, this uses the nearest react-router match to allow us to track both the RR route path (e.g. `/instance/runs/:runId`) as well as the actual location pathname (`/instance/runs/[actual-run-id]`).
  - This fires after a brief delay, to ensure that we aren't doing a redirect or something.
- `useTrackEvent`, which returns a function that can be imperatively called when a tracked event occurs.
  - This also uses the RR route path information.

I have added page tracking calls throughout the app, as well as a single event tracker on opening search. Again, in open source these are all no-ops.

### How I Tested These Changes

View Dagit in JS dev. Verify that as I navigate the app, pageviews show up in the console with the appropriate values. Open search dialog, verify that the tracked event shows up in console.
