### PR TITLE
Load asset launchpad for assets with configurable resources

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -208,9 +208,13 @@ function stateForLaunchingAssets(
     };
   }
 
+  const requiredResources = assets.flatMap((a) => a.requiredResources.map((r) => r.resourceKey));
+  // temporary until a cleaner way to query the config requirements of resources is available
+  const anyResourcesHaveConfig = requiredResources.length >= 1;
+
   // Ok! Assertions met, how do we launch this run
 
-  if (anyAssetsHaveConfig || forceLaunchpad) {
+  if (anyAssetsHaveConfig || anyResourcesHaveConfig || forceLaunchpad) {
     const assetOpNames = assets.flatMap((a) => a.opNames || []);
     return {
       type: 'launchpad',
@@ -293,6 +297,9 @@ export const LAUNCH_ASSET_EXECUTION_ASSET_NODE_FRAGMENT = gql`
         id
         name
       }
+    }
+    requiredResources {
+      resourceKey
     }
     ...AssetNodeConfigFragment
   }

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetExecutionAssetNodeFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetExecutionAssetNodeFragment.ts
@@ -30,6 +30,11 @@ export interface LaunchAssetExecutionAssetNodeFragment_repository {
   location: LaunchAssetExecutionAssetNodeFragment_repository_location;
 }
 
+export interface LaunchAssetExecutionAssetNodeFragment_requiredResources {
+  __typename: "ResourceRequirement";
+  resourceKey: string;
+}
+
 export interface LaunchAssetExecutionAssetNodeFragment_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {
   __typename: "ArrayConfigType" | "NullableConfigType";
   key: string;
@@ -556,5 +561,6 @@ export interface LaunchAssetExecutionAssetNodeFragment {
   assetKey: LaunchAssetExecutionAssetNodeFragment_assetKey;
   dependencyKeys: LaunchAssetExecutionAssetNodeFragment_dependencyKeys[];
   repository: LaunchAssetExecutionAssetNodeFragment_repository;
+  requiredResources: LaunchAssetExecutionAssetNodeFragment_requiredResources[];
   configField: LaunchAssetExecutionAssetNodeFragment_configField | null;
 }

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetLoaderQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetLoaderQuery.ts
@@ -32,6 +32,11 @@ export interface LaunchAssetLoaderQuery_assetNodes_repository {
   location: LaunchAssetLoaderQuery_assetNodes_repository_location;
 }
 
+export interface LaunchAssetLoaderQuery_assetNodes_requiredResources {
+  __typename: "ResourceRequirement";
+  resourceKey: string;
+}
+
 export interface LaunchAssetLoaderQuery_assetNodes_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {
   __typename: "ArrayConfigType" | "NullableConfigType";
   key: string;
@@ -558,6 +563,7 @@ export interface LaunchAssetLoaderQuery_assetNodes {
   assetKey: LaunchAssetLoaderQuery_assetNodes_assetKey;
   dependencyKeys: LaunchAssetLoaderQuery_assetNodes_dependencyKeys[];
   repository: LaunchAssetLoaderQuery_assetNodes_repository;
+  requiredResources: LaunchAssetLoaderQuery_assetNodes_requiredResources[];
   configField: LaunchAssetLoaderQuery_assetNodes_configField | null;
 }
 

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -397,6 +397,7 @@ type AssetNode {
   dependencyKeys: [AssetKey!]!
   description: String
   graphName: String
+  groupName: String
   id: ID!
   jobNames: [String!]!
   jobs: [Pipeline!]!
@@ -409,7 +410,7 @@ type AssetNode {
   partitionKeys: [String!]!
   partitionDefinition: String
   repository: Repository!
-  groupName: String
+  requiredResources: [ResourceRequirement!]!
 }
 
 type AssetKey {

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
+from typing import TYPE_CHECKING, List, Optional, Sequence, Union
 
 import graphene
 from dagster_graphql.implementation.events import iterate_metadata_entries
@@ -8,7 +8,6 @@ from dagster_graphql.schema.solids import (
     GrapheneCompositeSolidDefinition,
     GrapheneResourceRequirement,
     GrapheneSolidDefinition,
-    build_solid_definition,
 )
 
 from dagster import AssetKey
@@ -207,7 +206,8 @@ class GrapheneAssetNode(graphene.ObjectType):
                 or self._external_asset_node.op_name
             )
             self._node_definition_snap = self.get_external_pipeline().get_node_def_snap(node_key)
-        return check.not_none(self._node_definition_snap)
+        # weird mypy bug causes mistyped _node_definition_snap
+        return check.not_none(self._node_definition_snap)  # type: ignore
 
     def get_partition_keys(self) -> Sequence[str]:
         # TODO: Add functionality for dynamic partitions definition

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from typing import Union
 
 import graphene
 from dagster_graphql.implementation.events import iterate_metadata_entries
@@ -674,7 +675,9 @@ class GrapheneCompositeSolidDefinition(graphene.ObjectType, ISolidDefinitionMixi
         return []
 
 
-def build_solid_definition(represented_pipeline, solid_def_name):
+def build_solid_definition(
+    represented_pipeline: RepresentedPipeline, solid_def_name: str
+) -> Union[GrapheneSolidDefinition, GrapheneCompositeSolidDefinition]:
     check.inst_param(represented_pipeline, "represented_pipeline", RepresentedPipeline)
     check.str_param(solid_def_name, "solid_def_name")
 

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/resources.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/resources.py
@@ -12,7 +12,7 @@ from dagster import (
 
 
 def define_resource(num):
-    @resource(config_schema=Field(Int, is_required=True))
+    @resource(config_schema=Field(Int, is_required=False))
     def a_resource(context):
         return num if context.resource_config is None else context.resource_config
 

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/resources.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/resources.py
@@ -1,4 +1,4 @@
-from dagster import Field, Int, graph, op, reconstructable, resource
+from dagster import Field, Int, asset, graph, op, reconstructable, repository, resource, with_resources
 
 
 def define_resource(num):
@@ -41,6 +41,20 @@ def resource_ops():
 
 
 resource_job = resource_ops.to_job(resource_defs=lots_of_resources)
+
+@asset(required_resource_keys={"R1"})
+def resource_asset(context):
+    return context.resources.R1
+
+@repository
+def resource_repo():
+    return [
+        resource_job,
+        *with_resources(
+            [resource_asset],
+            resource_defs=lots_of_resources,
+        )
+    ]
 
 if __name__ == "__main__":
     result = reconstructable(resource_job).execute_in_process()

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/resources.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/resources.py
@@ -1,8 +1,18 @@
-from dagster import Field, Int, asset, graph, op, reconstructable, repository, resource, with_resources
+from dagster import (
+    Field,
+    Int,
+    asset,
+    graph,
+    op,
+    reconstructable,
+    repository,
+    resource,
+    with_resources,
+)
 
 
 def define_resource(num):
-    @resource(config_schema=Field(Int, is_required=False))
+    @resource(config_schema=Field(Int, is_required=True))
     def a_resource(context):
         return num if context.resource_config is None else context.resource_config
 
@@ -42,9 +52,11 @@ def resource_ops():
 
 resource_job = resource_ops.to_job(resource_defs=lots_of_resources)
 
+
 @asset(required_resource_keys={"R1"})
 def resource_asset(context):
     return context.resources.R1
+
 
 @repository
 def resource_repo():
@@ -53,8 +65,9 @@ def resource_repo():
         *with_resources(
             [resource_asset],
             resource_defs=lots_of_resources,
-        )
+        ),
     ]
+
 
 if __name__ == "__main__":
     result = reconstructable(resource_job).execute_in_process()


### PR DESCRIPTION
### Summary & Motivation

Makes sure the asset launchpad loads when materializing a set of assets where one or more has configurable resources. Fixes #8469. Fixes #8629.

This required modifying the graphql representation of asset nodes with an added `required_resources` resolver. Along the way I also made some tweaks to the way info off the backing op/graph is pulled in general (continuation of work done for adding asset config). @prha for graphql review

On the frontend, the current behavior is just to get the list of required resources, and if _any_ are present, to load the asset config modal. That is, I don't presently check if the resources require config (which would require another query), which is undesirable. @bengotow do you know if there's an existing query I can use for this purpose?

### How I Tested These Changes

Modified `graphs_jobs_ops_toys/resources.py` and ensured that the launchpad loads for the sample asset (which has a resource) in that repo.
