### PR TITLE
[dagster-dbt] rework dagster dbt logging, cleanup

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -31,7 +31,7 @@ from dagster.core.errors import DagsterInvalidSubsetError
 
 
 def _load_manifest_for_project(
-    project_dir: str, profiles_dir: str, target_dir: str, select: str
+    project_dir: str, profiles_dir: str, target_dir: str, select: str, target: Optional[str] = None
 ) -> Tuple[Mapping[str, Any], DbtCliOutput]:
     # running "dbt ls" regenerates the manifest.json, which includes a superset of the actual
     # "dbt ls" output
@@ -45,10 +45,13 @@ def _load_manifest_for_project(
             "select": select,
             "resource-type": "model",
             "output": "json",
+            "target": target,
         },
         warn_error=False,
         ignore_handled_error=False,
         target_path=target_dir,
+        json_log_format=True,
+        capture_logs=True,
     )
     manifest_path = os.path.join(target_dir, "manifest.json")
     with open(manifest_path, "r", encoding="utf8") as f:
@@ -143,6 +146,7 @@ def _get_node_description(node_info):
 def _dbt_nodes_to_assets(
     dbt_nodes: Mapping[str, Any],
     select: str,
+    target: Optional[str],
     selected_unique_ids: AbstractSet[str],
     runtime_metadata_fn: Optional[
         Callable[[SolidExecutionContext, Mapping[str, Any]], Mapping[str, RawMetadataValue]]
@@ -232,10 +236,13 @@ def _dbt_nodes_to_assets(
             ]
 
         try:
+            kwargs = {"select": subselect}
+            if target:
+                kwargs["target"] = target
             if use_build_command:
-                dbt_output = context.resources.dbt.build(select=subselect)
+                dbt_output = context.resources.dbt.build(**kwargs)
             else:
-                dbt_output = context.resources.dbt.run(select=subselect)
+                dbt_output = context.resources.dbt.run(**kwargs)
         finally:
             # in the case that the project only partially runs successfully, still attempt to generate
             # events for the parts that were successful
@@ -308,6 +315,7 @@ def load_assets_from_dbt_project(
     profiles_dir: Optional[str] = None,
     target_dir: Optional[str] = None,
     select: Optional[str] = None,
+    target: Optional[str] = None,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     runtime_metadata_fn: Optional[
@@ -318,19 +326,22 @@ def load_assets_from_dbt_project(
     use_build_command: bool = False,
 ) -> Sequence[AssetsDefinition]:
     """
-    Loads a set of DBT models from a DBT project into Dagster assets.
+    Loads a set of dbt models from a dbt project into Dagster assets.
 
     Creates one Dagster asset for each dbt model. All assets will be re-materialized using a single
-    `dbt run` command.
+    `dbt run` or `dbt build` command.
 
     Args:
-        project_dir (Optional[str]): The directory containing the DBT project to load.
+        project_dir (Optional[str]): The directory containing the dbt project to load.
         profiles_dir (Optional[str]): The profiles directory to use for loading the DBT project.
             Defaults to a directory called "config" inside the project_dir.
-        target_dir (Optional[str]): The target directory where DBT will place compiled artifacts.
+        target_dir (Optional[str]): The target directory where dbt will place compiled artifacts.
             Defaults to "target" underneath the project_dir.
-        select (Optional[str]): A DBT selection string for the models in a project that you want
+        select (Optional[str]): A dbt selection string for the models in a project that you want
             to include. Defaults to "*".
+        target (Optional[str]): The target dbt profile to run against. Defaults to the default
+            profile configured in your dbt project. If set, a target does not need to be configured
+            on the `dbt_cli_resource`.
         key_prefix (Optional[Union[str, List[str]]]): A prefix to apply to all models in the dbt
             project. Does not apply to sources.
         source_key_prefix (Optional[Union[str, List[str]]]): A prefix to apply to all sources in the
@@ -342,8 +353,10 @@ def load_assets_from_dbt_project(
             assets. When other ops are downstream of the loaded assets, the IOManager specified
             here determines how the inputs to those ops are loaded. Defaults to "io_manager".
         node_info_to_asset_key: (Mapping[str, Any] -> AssetKey): A function that takes a dictionary
-            of dbt node info and returns the AssetKey that you want to represent that node. By
-            default, the asset key will simply be the name of the dbt model.
+            of dbt metadata and returns the AssetKey that you want to represent a given model or
+            source. By default:
+                dbt model -> AssetKey([model_name])
+                dbt source -> AssetKey([source_name, table_name])
         use_build_command: (bool): Flag indicating if you want to use `dbt build` as the core computation
             for this asset, rather than `dbt run`.
 
@@ -363,12 +376,13 @@ def load_assets_from_dbt_project(
     )
     return load_assets_from_dbt_manifest(
         manifest_json=manifest_json,
+        select=select,
+        target=target,
         key_prefix=key_prefix,
         source_key_prefix=source_key_prefix,
         runtime_metadata_fn=runtime_metadata_fn,
         io_manager_key=io_manager_key,
         selected_unique_ids=selected_unique_ids,
-        select=select,
         node_info_to_asset_key=node_info_to_asset_key,
         use_build_command=use_build_command,
     )
@@ -376,6 +390,8 @@ def load_assets_from_dbt_project(
 
 def load_assets_from_dbt_manifest(
     manifest_json: Mapping[str, Any],
+    select: Optional[str] = None,
+    target: Optional[str] = None,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     runtime_metadata_fn: Optional[
@@ -383,7 +399,6 @@ def load_assets_from_dbt_manifest(
     ] = None,
     io_manager_key: Optional[str] = None,
     selected_unique_ids: Optional[AbstractSet[str]] = None,
-    select: Optional[str] = None,
     node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey] = _get_node_asset_key,
     use_build_command: bool = False,
 ) -> Sequence[AssetsDefinition]:
@@ -396,6 +411,11 @@ def load_assets_from_dbt_manifest(
     Args:
         manifest_json (Optional[Mapping[str, Any]]): The contents of a DBT manifest.json, which contains
             a set of models to load into assets.
+        select (Optional[str]): A dbt selection string for the models in a project that you want
+            to include. Defaults to "*".
+        target (Optional[str]): The target dbt profile to run against. Defaults to the default
+            profile configured in your dbt project. If set, a target does not need to be configured
+            on the `dbt_cli_resource`.
         key_prefix (Optional[Union[str, List[str]]]): A prefix to apply to all models in the dbt
             project. Does not apply to sources.
         source_key_prefix (Optional[Union[str, List[str]]]): A prefix to apply to all sources in the
@@ -435,6 +455,7 @@ def load_assets_from_dbt_manifest(
         runtime_metadata_fn=runtime_metadata_fn,
         io_manager_key=io_manager_key,
         select=select,
+        target=target,
         selected_unique_ids=selected_unique_ids,
         node_info_to_asset_key=node_info_to_asset_key,
         use_build_command=use_build_command,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/constants.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/constants.py
@@ -97,4 +97,15 @@ CLI_COMMON_OPTIONS_CONFIG_SCHEMA = {
         is_required=False,
         description="The url for where dbt docs are being served for this project.",
     ),
+    "json_log_format": Field(
+        config=bool,
+        description="When True, dbt will invoked with the `--log-format json` flag, allowing "
+        "Dagster to parse the log messages and emit simpler log messages to the event log.",
+        default_value=True,
+    ),
+    "capture_logs": Field(
+        config=bool,
+        description="When True, logs emitted from dbt will be logged to the Dagster event log.",
+        default_value=True,
+    ),
 }

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
@@ -1,7 +1,7 @@
 import json
 import os
 import subprocess
-from typing import Any, Dict, Optional
+from typing import Any, Mapping, Optional, Sequence
 
 import dagster._check as check
 from dagster.core.utils import coerce_valid_log_level
@@ -15,15 +15,51 @@ from .constants import DBT_RUN_RESULTS_COMMANDS, DEFAULT_DBT_TARGET_PATH
 from .types import DbtCliOutput
 
 
+def _create_command_list(
+    executable: str,
+    warn_error: bool,
+    json_log_format: bool,
+    command: str,
+    flags_dict: Mapping[str, Any],
+) -> Sequence[str]:
+
+    prefix = [executable]
+    if warn_error:
+        prefix += ["--warn-error"]
+    if json_log_format:
+        prefix += ["--no-use-color", "--log-format", "json"]
+
+    full_command = command.split(" ")
+    for flag, value in flags_dict.items():
+        if not value:
+            continue
+
+        full_command.append(f"--{flag}")
+
+        if isinstance(value, bool):
+            pass
+        elif isinstance(value, list):
+            check.list_param(value, f"config.{flag}", of_type=str)
+            full_command += value
+        elif isinstance(value, dict):
+            full_command.append(json.dumps(value))
+        else:
+            full_command.append(str(value))
+
+    return prefix + full_command
+
+
 def execute_cli(
     executable: str,
     command: str,
-    flags_dict: Dict[str, Any],
+    flags_dict: Mapping[str, Any],
     log: Any,
     warn_error: bool,
     ignore_handled_error: bool,
     target_path: str,
     docs_url: Optional[str] = None,
+    json_log_format: bool = True,
+    capture_logs: bool = True,
 ) -> DbtCliOutput:
     """Executes a command on the dbt CLI in a subprocess."""
     check.str_param(executable, "executable")
@@ -31,74 +67,71 @@ def execute_cli(
     check.dict_param(flags_dict, "flags_dict", key_type=str)
     check.bool_param(warn_error, "warn_error")
     check.bool_param(ignore_handled_error, "ignore_handled_error")
+    check.bool_param(capture_logs, "capture_logs")
 
-    # Format the dbt CLI flags in the command..
-    warn_error = ["--warn-error"] if warn_error else []
-    command_list = [
-        executable,
-        "--no-use-color",
-        "--log-format",
-        "json",
-        *warn_error,
-        *command.split(" "),
-    ]
-
-    for flag, value in flags_dict.items():
-        if not value:
-            continue
-
-        command_list.append(f"--{flag}")
-
-        if isinstance(value, bool):
-            # If a bool flag (and is True), the presence of the flag itself is enough.
-            continue
-
-        if isinstance(value, list):
-            check.list_param(value, f"config.{flag}", of_type=str)
-            command_list += value
-            continue
-
-        if isinstance(value, dict):
-            command_list.append(json.dumps(value))
-            continue
-
-        command_list.append(str(value))
+    command_list = _create_command_list(
+        executable=executable,
+        warn_error=warn_error,
+        json_log_format=json_log_format,
+        command=command,
+        flags_dict=flags_dict,
+    )
 
     # Execute the dbt CLI command in a subprocess.
     full_command = " ".join(command_list)
-    log.info(f"Executing command: {full_command}")
+    log.info(f"Executing command: {' '.join(command_list)}")
 
     return_code = 0
-    logs = []
-    output = []
 
-    process = subprocess.Popen(command_list, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    # raw lines
+    raw_output = ""
+
+    # parsed messages from the log output
+    messages = []
+
+    # json dictionaries for each line (if applicable)
+    json_lines = []
+
+    process = subprocess.Popen(
+        command_list,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
     for raw_line in process.stdout or []:
-        line = raw_line.decode("utf-8")
-        output.append(line)
-        try:
-            json_line = json.loads(line)
-        except json.JSONDecodeError:
-            log.info(line.rstrip())
-        else:
-            logs.append(json_line)
-            level = coerce_valid_log_level(
-                json_line.get("levelname", json_line.get("level", "info"))
-            )
-            log.log(level, json_line.get("message", json_line.get("msg", line.rstrip())))
+        line = raw_line.decode("utf-8").rstrip()
+        raw_output += f"\n{raw_line}"
+
+        log_level = "info"
+        message = line
+
+        if json_log_format:
+            try:
+                json_line = json.loads(line)
+                json_lines.append(json_line)
+            except json.JSONDecodeError:
+                pass
+            else:
+                message = json_line.get("message", json_line.get("msg", message))
+                log_level = json_line.get("levelname", json_line.get("level", "debug"))
+
+        messages.append(message)
+        if capture_logs:
+            log.log(coerce_valid_log_level(log_level), message)
 
     process.wait()
     return_code = process.returncode
 
     log.info("dbt exited with return code {return_code}".format(return_code=return_code))
 
-    raw_output = "\n".join(output)
-
     if return_code == 2:
-        raise DagsterDbtCliFatalRuntimeError(logs=logs, raw_output=raw_output)
+        raise DagsterDbtCliFatalRuntimeError(
+            logs=json_lines, raw_output=raw_output, messages=messages
+        )
 
     if return_code == 1 and not ignore_handled_error:
-        raise DagsterDbtCliHandledRuntimeError(logs=logs, raw_output=raw_output)
+        raise DagsterDbtCliHandledRuntimeError(
+            logs=json_lines, raw_output=raw_output, messages=messages
+        )
 
     run_results = (
         parse_run_results(flags_dict["project-dir"], target_path)
@@ -110,13 +143,13 @@ def execute_cli(
         command=full_command,
         return_code=return_code,
         raw_output=raw_output,
-        logs=logs,
+        logs=json_lines,
         result=run_results,
         docs_url=docs_url,
     )
 
 
-def parse_run_results(path: str, target_path: str = DEFAULT_DBT_TARGET_PATH) -> Dict[str, Any]:
+def parse_run_results(path: str, target_path: str = DEFAULT_DBT_TARGET_PATH) -> Mapping[str, Any]:
     """Parses the `target/run_results.json` artifact that is produced by a dbt process."""
     run_results_path = os.path.join(path, target_path, "run_results.json")
     try:
@@ -133,7 +166,7 @@ def remove_run_results(path: str, target_path: str = DEFAULT_DBT_TARGET_PATH):
         os.remove(run_results_path)
 
 
-def parse_manifest(path: str, target_path: str = DEFAULT_DBT_TARGET_PATH) -> Dict[str, Any]:
+def parse_manifest(path: str, target_path: str = DEFAULT_DBT_TARGET_PATH) -> Mapping[str, Any]:
     """Parses the `target/manifest.json` artifact that is produced by a dbt process."""
     manifest_path = os.path.join(path, target_path, "manifest.json")
     try:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Any, Dict, List
+from typing import Any, Mapping, Sequence
 
 from dagster import Failure, MetadataEntry
 from dagster import _check as check
@@ -12,9 +12,9 @@ class DagsterDbtError(Failure, ABC):
 class DagsterDbtCliUnexpectedOutputError(DagsterDbtError):
     """Represents an error when parsing the output of a dbt CLI command."""
 
-    invalid_line_nos: List[int]
+    invalid_line_nos: Sequence[int]
 
-    def __init__(self, invalid_line_nos: List[int]):
+    def __init__(self, invalid_line_nos: Sequence[int]):
         check.list_param(invalid_line_nos, "invalid_line_nos", int)
         line_nos_str = ", ".join(map(str, invalid_line_nos))
         description = f"dbt CLI emitted unexpected output on lines {line_nos_str}"
@@ -28,15 +28,21 @@ class DagsterDbtCliUnexpectedOutputError(DagsterDbtError):
 class DagsterDbtCliRuntimeError(DagsterDbtError, ABC):
     """Represents an error while executing a dbt CLI command."""
 
-    def __init__(self, description: str, logs: List[Dict[str, Any]], raw_output: str):
+    def __init__(
+        self,
+        description: str,
+        logs: Sequence[Mapping[str, Any]],
+        raw_output: str,
+        messages: Sequence[str],
+    ):
         metadata_entries = [
             MetadataEntry(
                 "Parsed CLI Output (JSON)",
                 value={"logs": logs},
             ),
             MetadataEntry(
-                "Parsed CLI Output (JSON) Message Attributes",
-                value=DagsterDbtCliRuntimeError.stitch_messages(logs),
+                "Parsed CLI Messages",
+                value="\n".join(messages),
             ),
             MetadataEntry(
                 "Raw CLI Output",
@@ -45,27 +51,19 @@ class DagsterDbtCliRuntimeError(DagsterDbtError, ABC):
         ]
         super().__init__(description, metadata_entries)
 
-    @staticmethod
-    def stitch_messages(logs: List[dict]) -> str:
-        return "\n".join(
-            log["message"].strip("\n")
-            for log in logs
-            if isinstance(log.get("message"), str)  # defensive
-        )
-
 
 class DagsterDbtCliHandledRuntimeError(DagsterDbtCliRuntimeError):
     """Represents a model error reported by the dbt CLI at runtime (return code 1)."""
 
-    def __init__(self, logs: List[Dict[str, Any]], raw_output: str):
-        super().__init__("Handled error in the dbt CLI (return code 1)", logs, raw_output)
+    def __init__(self, logs: Sequence[Mapping[str, Any]], raw_output: str, messages: Sequence[str]):
+        super().__init__("Handled error in the dbt CLI (return code 1)", logs, raw_output, messages)
 
 
 class DagsterDbtCliFatalRuntimeError(DagsterDbtCliRuntimeError):
     """Represents a fatal error in the dbt CLI (return code 2)."""
 
-    def __init__(self, logs: List[Dict[str, Any]], raw_output: str):
-        super().__init__("Fatal error in the dbt CLI (return code 2)", logs, raw_output)
+    def __init__(self, logs: Sequence[Mapping[str, Any]], raw_output: str, messages: Sequence[str]):
+        super().__init__("Fatal error in the dbt CLI (return code 2)", logs, raw_output, messages)
 
 
 class DagsterDbtRpcUnexpectedPollOutputError(DagsterDbtError):

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_test_project/dbt_config/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_test_project/dbt_config/profiles.yml
@@ -11,3 +11,13 @@ dagster_dbt_test_project:
       schema: test-schema
       threads: 2
       keepalives_idle: 0
+    dev2:
+      type: postgres
+      host: "{{ env_var('POSTGRES_TEST_DB_DBT_HOST') }}"
+      user: test
+      pass: test
+      port: 5432
+      dbname: test
+      schema: test-schema2
+      threads: 2
+      keepalives_idle: 0

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -17,7 +17,6 @@ from dagster import (
     ResourceDefinition,
     asset,
     io_manager,
-    materialize_to_memory,
     repository,
 )
 from dagster.core.asset_defs import build_assets_job
@@ -226,23 +225,6 @@ def test_basic(
         assert len(observations) == 17
     else:
         assert len(observations) == 0
-
-
-def test_custom_target(
-    dbt_seed, conn_string, test_project_dir, dbt_config_dir, capsys
-):  # pylint: disable=unused-argument
-    dbt_assets = load_assets_from_dbt_project(test_project_dir, dbt_config_dir, target="dev2")
-
-    materialize_to_memory(
-        dbt_assets,
-        resources={
-            "dbt": dbt_cli_resource.configured(
-                {"project_dir": test_project_dir, "profiles_dir": dbt_config_dir}
-            )
-        },
-    )
-    captured = capsys.readouterr()
-    assert "test-schema2" in captured.err
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Summary & Motivation

resolves: https://github.com/dagster-io/dagster/issues/8601 and unticked requests for the ability to turn off `--log-format json`.

This is a whole rabbit hole, but essentially the way we were handling the output of the dbt cli command was a bit confusing and somewhat incorrect. This corrects some issues and refactors a bit of code around that area.

First, this resolves a longstanding issue where, if your dbt command had an error, the error message would not show human-readable information (as we were not correctly parsing the json lines). The below screenshot is taken after the changes. Prior to the changes, the parsed output (the thing that you can actually read) would be empty, and the main visible metadata would be the bottom thing (which is pretty unreadable).

![Screen Shot 2022-06-29 at 3 49 45 PM](https://user-images.githubusercontent.com/22457492/176558659-deae71ef-1af4-4f74-a3dd-5ca5e7ef1963.png)

Next, this allows the user to tell Dagster not to insert the "--log-format json" flag when invoking dbt. In an ideal world, there'd be no reason to turn this off, because there should be no material impact on execution when using this flag, and we should be able to parse out json-formatted log lines and display them in dagit better than just reading raw text.

However, it turns out that due to a bug in the dbt-bigquery adapter, this log format flag can actually cause dbt to  produce unhelpful errors in cases where it should emit helpful ones: https://github.com/dbt-labs/dbt-bigquery/issues/206

I submitted a PR to correct this behavior on dbt's side, but it's possible that there are other places where this could crop up (and it's unclear exactly when my PR would get merged in), so it's now a config option. I tried to keep the dagit experience relatively consistent when this option is turned off, but some sacrifices had to be made. For example, we can't tell what log level each message was originally at, so all logs are set to the INFO level when you do this. There's also a dbt-produced timestamp at the start of each of these lines, which I decided not to attempt to remove:

![Screen Shot 2022-06-29 at 3 59 18 PM](https://user-images.githubusercontent.com/22457492/176559642-6e9756e4-901f-47a6-9b8c-39b5f068b35c.png)


Finally, this PR adds a new target argument to load_assets_from_dbt_manifest. This is due to an unfortunate git mishap, but it's a tiny low risk change so it's here now.

### How I Tested These Changes

unit tests, dagit workflow