### PR TITLE
[assets] Fix issue with graph backed assets + partitions

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -446,12 +446,13 @@ class AssetLayer:
 
         # keep an index from node handle to all keys expected to be generated using that node
         self._asset_keys_by_node_handle: Dict[NodeHandle, Set[AssetKey]] = defaultdict(set)
-        _asset_info_by_key = {
-            asset_info.key: asset_info
+        _required_asset_keys = {
+            asset_info.key
             for asset_info in self._asset_info_by_node_output_handle.values()
+            if asset_info.is_required
         }
         for asset_key, node_handles in self._dependency_node_handles_by_asset_key.items():
-            if _asset_info_by_key[asset_key].is_required:
+            if asset_key in _required_asset_keys:
                 for node_handle in node_handles:
                     self._asset_keys_by_node_handle[node_handle].add(asset_key)
 

--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -444,11 +444,16 @@ class AssetLayer:
             for key in assets_def.keys
         }
 
-        # keep an index from node handle to all keys expected to be generated in that node
+        # keep an index from node handle to all keys expected to be generated using that node
         self._asset_keys_by_node_handle: Dict[NodeHandle, Set[AssetKey]] = defaultdict(set)
-        for node_output_handle, asset_info in self._asset_info_by_node_output_handle.items():
-            if asset_info.is_required:
-                self._asset_keys_by_node_handle[node_output_handle.node_handle].add(asset_info.key)
+        _asset_info_by_key = {
+            asset_info.key: asset_info
+            for asset_info in self._asset_info_by_node_output_handle.values()
+        }
+        for asset_key, node_handles in self._dependency_node_handles_by_asset_key.items():
+            if _asset_info_by_key[asset_key].is_required:
+                for node_handle in node_handles:
+                    self._asset_keys_by_node_handle[node_handle].add(asset_key)
 
         self._io_manager_keys_by_asset_key = check.opt_dict_param(
             io_manager_keys_by_asset_key,


### PR DESCRIPTION
### Summary & Motivation

report: https://dagster.slack.com/archives/C01U954MEER/p1656497541526939

This issue arises because we use the `asset_keys_for_node()` function to determine which asset keys (and therefore which AssetsDefinition object) maps to a the node we are currently executing. With graph-backed assets, it may be the case that the node we're currently executing does not produce any assets itself (instead, a downstream node may produce the asset).

This PR makes it so that any op on the critical path of the creation of a given asset is mapped to that asset in the asset layer.

More simply, if you have a graph backed asset `some_asset`:

graph: (op1 -> op2)

And op2 creates the asset (op1 is just a helper), then `asset_keys_for_node(op1)` will return `some_asset` instead of an empty set.

### How I Tested These Changes

Unit test.
