### PR TITLE
Feature/phazure/8602 dagster_databricks - support configuration of job / cluster permissions

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
@@ -9,7 +9,7 @@ See:
 - https://docs.databricks.com/dev-tools/api/latest/clusters.html
 - https://docs.databricks.com/dev-tools/api/latest/libraries.html
 """
-from dagster import Bool, Field, Int, Permissive, Selector, Shape, String
+from dagster import Array, Bool, Field, Int, Permissive, Selector, Shape, String
 
 
 def _define_autoscale():
@@ -623,4 +623,50 @@ def define_databricks_secrets_config():
         "variables must be stored as Databricks secrets and specified here, which will ensure "
         "they are re-exported as environment variables accessible to Dagster upon execution.",
         is_required=False,
+    )
+
+
+def _define_accessor():
+    return Selector(
+        {"group_name": str, "user_name": str},
+        description="Group or User that shall access the target.",
+    )
+
+
+def _define_databricks_job_permission():
+    job_permission_levels = [
+        "NO_PERMISSIONS",
+        "CAN_VIEW",
+        "CAN_MANAGE_RUN",
+        "IS_OWNER",
+        "CAN_MANAGE",
+    ]
+    return Field(
+        {
+            permission_level: Field(Array(_define_accessor()), is_required=False)
+            for permission_level in job_permission_levels
+        },
+        description="job permission spec; ref: https://docs.databricks.com/security/access-control/jobs-acl.html#job-permissions",
+        is_required=False,
+    )
+
+
+def _define_databricks_cluster_permission():
+    cluster_permission_levels = ["NO_PERMISSIONS", "CAN_ATTACH_TO", "CAN_RESTART", "CAN_MANAGE"]
+    return Field(
+        {
+            permission_level: Field(Array(_define_accessor()), is_required=False)
+            for permission_level in cluster_permission_levels
+        },
+        description="cluster permission spec; ref: https://docs.databricks.com/security/access-control/cluster-acl.html#cluster-level-permissions",
+        is_required=False,
+    )
+
+
+def define_databricks_permissions():
+    return Field(
+        {
+            "job_permissions": _define_databricks_job_permission(),
+            "cluster_permissions": _define_databricks_cluster_permission(),
+        }
     )

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -70,13 +70,16 @@ class DatabricksClient:
 
         self.client.dbfs.close(handle=handle)  # pylint: disable=no-member
 
+    def get_run(self, databricks_run_id):
+        return self.client.jobs.get_run(databricks_run_id)  # pylint: disable=no-member
+
     def get_run_state(self, databricks_run_id):
         """Get the state of a run by Databricks run ID (_not_ dagster run ID).
 
         Return a `DatabricksRunState` object. Note that the `result_state`
         attribute may be `None` if the run hasn't yet terminated.
         """
-        run = self.client.jobs.get_run(databricks_run_id)  # pylint: disable=no-member
+        run = self.get_run(databricks_run_id)
         state = run["state"]
         result_state = state.get("result_state")
         if result_state:

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -1,5 +1,4 @@
 import io
-import json
 import os.path
 import pickle
 import tempfile
@@ -307,7 +306,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
             job_id = run_info["job_id"]
             log.debug(f"Updating job permissions with following json: {job_permissions}")
             response = api_client.perform_query(
-                method="PATCH", path=f"permissions/jobs/{job_id}", data=json.dumps(job_permissions)
+                method="PATCH", path=f"/permissions/jobs/{job_id}", data=job_permissions
             )
             log.info(f"Successfully updated cluster permissions | Response: {response}")
 
@@ -322,8 +321,8 @@ class DatabricksPySparkStepLauncher(StepLauncher):
             log.debug(f"Updating cluster permissions with following json: {cluster_permissions}")
             response = api_client.perform_query(
                 method="PATCH",
-                path=f"permissions/clusters/{cluster_id}",
-                data=json.dumps(cluster_permissions),
+                path=f"/permissions/clusters/{cluster_id}",
+                data=cluster_permissions,
             )
             log.info(f"Successfully updated cluster permissions | Response: {response}")
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
@@ -221,7 +221,7 @@ def test_pyspark_databricks(
     )
     assert result.success
     assert mock_request_patch.call_count == 2
-    assert mock_get_run.call_count == 2
+    assert mock_get_run.call_count == 1
     assert mock_get_run_state.call_count == 6
     assert mock_get_step_events.call_count == 6
     assert mock_put_file.call_count == 4


### PR DESCRIPTION
### Summary & Motivation
Original issue: https://github.com/dagster-io/dagster/issues/8603

For productionized jobs which use databricks_pyspark_step_launcher, the databricks token provided is typically that of a prod service principal to align with best practices. When debugging, it can be helpful for developers to have access to the complete databricks job run within the Databricks workspace - however, because the databricks job run (and cluster) is owned only by the service principal, developers won't have access unless the permissions are explicitly added separately via the Databricks API. It would be great if we could provide the configurations to add these permissions within the DatabricksPySparkStepLauncher class.

### How I Tested These Changes
Tested by building / installing a new wheel for dagster_databricks.