### PR TITLE
Fix error with list as output type for ops

### DIFF
--- a/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
@@ -140,8 +140,10 @@ def _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):
                     value=element.value,
                     metadata_entries=element.metadata_entries,
                 )
-            elif isinstance(element, list) and all(
-                [isinstance(event, DynamicOutput) for event in element]
+            elif (
+                isinstance(element, list)
+                and len(element) > 0
+                and all([isinstance(event, DynamicOutput) for event in element])
             ):
                 if not output_def.is_dynamic:
                     raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
@@ -14,7 +14,6 @@ from dagster.core.definitions import (
 from dagster.core.definitions.decorators.solid_decorator import DecoratedSolidFunction
 from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.types.dagster_type import DagsterTypeKind
-from dagster.seven.typing import get_origin
 
 
 def create_solid_compute_wrapper(solid_def: SolidDefinition):
@@ -101,6 +100,8 @@ def _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):
                         check.failed(
                             f"{context.describe_op()} has a single dynamic output named '{output_defs[0].name}', which expects either a list of DynamicOutputs to be returned, or DynamicOutput objects to be yielded. Received instead an object of type {type(event)}"
                         )
+        else:
+            yield result
 
     elif len(output_defs) == 1:
         if result is None and output_defs[0].is_required is False:

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -1198,3 +1198,12 @@ def test_required_io_manager_op_access():
 
     result = the_job.execute_in_process()
     assert result.success
+
+
+def test_list_out_op():
+    @op(out={"list_out": Out(List[str]), "other_out": Out(int)})
+    def test_op():
+        return ([], 5)
+
+    result = execute_op_in_graph(test_op)
+    assert result.success


### PR DESCRIPTION
Fixes https://github.com/dagster-io/dagster/issues/8565. `all(...)` evaluates to true on an empty list.