### PR TITLE
Allow run status sensors to support unresolved asset jobs

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/run_status_sensor_definition.py
@@ -14,6 +14,7 @@ from dagster.core.definitions.sensor_definition import (
     SkipReason,
     is_context_provided,
 )
+from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 from dagster.core.errors import (
     DagsterInvalidDefinitionError,
     DagsterInvalidInvocationError,
@@ -272,9 +273,9 @@ def run_failure_sensor(
     name: Optional[Union[Callable[..., Any], str]] = None,
     minimum_interval_seconds: Optional[int] = None,
     description: Optional[str] = None,
-    monitored_jobs: Optional[List[Union[PipelineDefinition, GraphDefinition]]] = None,
+    monitored_jobs: Optional[List[Union[PipelineDefinition, GraphDefinition, UnresolvedAssetJobDefinition]]] = None,
     monitored_pipelines: Optional[List[str]] = None,
-    job_selection: Optional[List[Union[PipelineDefinition, GraphDefinition]]] = None,
+    job_selection: Optional[List[Union[PipelineDefinition, GraphDefinition, UnresolvedAssetJobDefinition]]] = None,
     pipeline_selection: Optional[List[str]] = None,
     default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
     request_job: Optional[Union[GraphDefinition, JobDefinition]] = None,
@@ -295,7 +296,7 @@ def run_failure_sensor(
         minimum_interval_seconds (Optional[int]): The minimum number of seconds that will elapse
             between sensor evaluations.
         description (Optional[str]): A human-readable description of the sensor.
-        monitored_jobs (Optional[List[Union[JobDefinition, GraphDefinition]]]): The jobs that
+        monitored_jobs (Optional[List[Union[JobDefinition, GraphDefinition, UnresolvedAssetJobDefinition]]]): The jobs that
             will be monitored by this failure sensor. Defaults to None, which means the alert will
             be sent when any job in the repository fails.
         monitored_pipelines (Optional[List[str]]): (legacy) Names of the pipelines that will be monitored by
@@ -372,7 +373,7 @@ class RunStatusSensorDefinition(SensorDefinition):
         minimum_interval_seconds (Optional[int]): The minimum number of seconds that will elapse
             between sensor evaluations.
         description (Optional[str]): A human-readable description of the sensor.
-        monitored_jobs (Optional[List[Union[JobDefinition, GraphDefinition]]]): The jobs that
+        monitored_jobs (Optional[List[Union[JobDefinition, GraphDefinition, UnresolvedAssetJobDefinition]]]): The jobs that
             will be monitored by this sensor. Defaults to None, which means the alert will be sent
             when any job in the repository fails.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
@@ -393,7 +394,7 @@ class RunStatusSensorDefinition(SensorDefinition):
         monitored_pipelines: Optional[List[str]] = None,
         minimum_interval_seconds: Optional[int] = None,
         description: Optional[str] = None,
-        monitored_jobs: Optional[List[Union[PipelineDefinition, GraphDefinition]]] = None,
+        monitored_jobs: Optional[List[Union[PipelineDefinition, GraphDefinition, UnresolvedAssetJobDefinition]]] = None,
         default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
         request_job: Optional[Union[GraphDefinition, JobDefinition]] = None,
         request_jobs: Optional[Sequence[Union[GraphDefinition, JobDefinition]]] = None,
@@ -408,7 +409,7 @@ class RunStatusSensorDefinition(SensorDefinition):
         check.opt_int_param(minimum_interval_seconds, "minimum_interval_seconds")
         check.opt_str_param(description, "description")
         check.opt_list_param(
-            monitored_jobs, "monitored_jobs", (PipelineDefinition, GraphDefinition)
+            monitored_jobs, "monitored_jobs", (PipelineDefinition, GraphDefinition, UnresolvedAssetJobDefinition)
         )
         check.inst_param(default_status, "default_status", DefaultSensorStatus)
 
@@ -620,8 +621,8 @@ def run_status_sensor(
     name: Optional[str] = None,
     minimum_interval_seconds: Optional[int] = None,
     description: Optional[str] = None,
-    monitored_jobs: Optional[List[Union[PipelineDefinition, GraphDefinition]]] = None,
-    job_selection: Optional[List[Union[PipelineDefinition, GraphDefinition]]] = None,
+    monitored_jobs: Optional[List[Union[PipelineDefinition, GraphDefinition, UnresolvedAssetJobDefinition]]] = None,
+    job_selection: Optional[List[Union[PipelineDefinition, GraphDefinition, UnresolvedAssetJobDefinition]]] = None,
     default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
     request_job: Optional[Union[GraphDefinition, JobDefinition]] = None,
     request_jobs: Optional[Sequence[Union[GraphDefinition, JobDefinition]]] = None,
@@ -650,9 +651,9 @@ def run_status_sensor(
         minimum_interval_seconds (Optional[int]): The minimum number of seconds that will elapse
             between sensor evaluations.
         description (Optional[str]): A human-readable description of the sensor.
-        monitored_jobs (Optional[List[Union[PipelineDefinition, GraphDefinition]]]): Jobs that will
-            be monitored by this sensor. Defaults to None, which means the alert will be sent when
-            any job in the repository matches the requested run_status.
+        monitored_jobs (Optional[List[Union[PipelineDefinition, GraphDefinition, UnresolvedAssetJobDefinition]]]):
+            Jobs that will be monitored by this sensor. Defaults to None, which means the alert will
+            be sent when any job in the repository matches the requested run_status.
         job_selection (Optional[List[Union[PipelineDefinition, GraphDefinition]]]): (deprecated in favor of monitored_jobs)
             Jobs that will be monitored by this sensor. Defaults to None, which means the alert will be sent when
             any job in the repository matches the requested run_status.

--- a/python_modules/dagster/dagster/utils/alert.py
+++ b/python_modules/dagster/dagster/utils/alert.py
@@ -9,6 +9,7 @@ from dagster.core.errors import DagsterInvalidDefinitionError
 if TYPE_CHECKING:
     from dagster.core.definitions.graph_definition import GraphDefinition
     from dagster.core.definitions.pipeline_definition import PipelineDefinition
+    from dagster.core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
     from dagster.core.definitions.run_status_sensor_definition import (
         PipelineFailureSensorContext,
         RunFailureSensorContext,
@@ -192,7 +193,7 @@ def make_email_on_run_failure_sensor(
     smtp_port: Optional[int] = None,
     name: Optional[str] = None,
     dagit_base_url: Optional[str] = None,
-    job_selection: Optional[List[Union["PipelineDefinition", "GraphDefinition"]]] = None,
+    job_selection: Optional[List[Union["PipelineDefinition", "GraphDefinition", "UnresolvedAssetJobDefinition"]]] = None,
     default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
 ):
     """Create a job failure sensor that sends email via the SMTP protocol.


### PR DESCRIPTION
### Summary & Motivation

Allows run status sensors to target asset jobs. All this required was an adjustment to the static type checking.

### How I Tested These Changes

Existing BK tests.
