### PR TITLE
[dagit] Display last asset key component on DAG rather than truncated path

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -13,7 +13,7 @@ import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {AssetComputeStatus} from '../types/globalTypes';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';
 
-import {displayNameForAssetKey, LiveDataForNode} from './Utils';
+import {LiveDataForNode} from './Utils';
 import {ASSET_NODE_ANNOTATIONS_MAX_WIDTH, ASSET_NODE_NAME_MAX_LENGTH} from './layout';
 import {AssetNodeFragment} from './types/AssetNodeFragment';
 
@@ -39,9 +39,7 @@ export const AssetNode: React.FC<{
   // a single step, so just use the first one.
   const stepKey = firstOp || '';
 
-  const displayName = withMiddleTruncation(displayNameForAssetKey(definition.assetKey), {
-    maxLength: ASSET_NODE_NAME_MAX_LENGTH,
-  });
+  const displayName = definition.assetKey.path[definition.assetKey.path.length - 1];
 
   const {lastMaterialization, computeStatus} = liveData || MISSING_LIVE_DATA;
 
@@ -53,7 +51,9 @@ export const AssetNode: React.FC<{
             <Icon name="asset" />
           </span>
           <div style={{overflow: 'hidden', textOverflow: 'ellipsis', marginTop: -1}}>
-            {displayName}
+            {withMiddleTruncation(displayName, {
+              maxLength: ASSET_NODE_NAME_MAX_LENGTH,
+            })}
           </div>
           <div style={{flex: 1}} />
           <div style={{maxWidth: ASSET_NODE_ANNOTATIONS_MAX_WIDTH}}>
@@ -133,11 +133,13 @@ export const AssetNodeMinimal: React.FC<{
   selected: boolean;
   definition: AssetNodeFragment;
 }> = ({selected, definition}) => {
+  const displayName = definition.assetKey.path[definition.assetKey.path.length - 1];
+
   return (
     <MinimalAssetNodeContainer $selected={selected}>
       <MinimalAssetNodeBox $selected={selected}>
         <MinimalName style={{fontSize: 28}}>
-          {withMiddleTruncation(displayNameForAssetKey(definition.assetKey), {maxLength: 17})}
+          {withMiddleTruncation(displayName, {maxLength: 17})}
         </MinimalName>
       </MinimalAssetNodeBox>
     </MinimalAssetNodeContainer>


### PR DESCRIPTION
### Summary & Motivation

The motivation behind this change is documented in Linear here: https://linear.app/elementl/issue/DAGIT-103/only-display-the-last-part-of-the-asset-key-in-the-asset-node

Key improvements:
- Fewer scenarios where asset node labels are truncated
- Fewer scenarios where the op name does not match the displayed name



Before: 
<img width="1840" alt="image" src="https://user-images.githubusercontent.com/1037212/176768784-2c95b892-1aca-4d10-82ed-26bdb80daba0.png">


After:
<img width="1840" alt="image" src="https://user-images.githubusercontent.com/1037212/176768748-d2c359c7-afd5-4e7f-9df8-3a43efe40c2b.png">


### How I Tested These Changes
