### PR TITLE
docs: improve left nav for items with children DREL-359

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -71,6 +71,7 @@
     "title": "Concepts",
     "icon": "Menu",
     "path": "/concepts",
+    "isDefaultOpen": true,
     "children": [
       {
         "title": "Assets",
@@ -405,6 +406,7 @@
     "title": "Guides",
     "icon": "Search",
     "path": "/guides",
+    "isDefaultOpen": true,
     "children": [
       {
         "title": "Upgrading to Software-Defined Assets",

--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -406,7 +406,6 @@
     "title": "Guides",
     "icon": "Search",
     "path": "/guides",
-    "isDefaultOpen": true,
     "children": [
       {
         "title": "Upgrading to Software-Defined Assets",

--- a/docs/next/components/Sidebar.tsx
+++ b/docs/next/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import { Transition } from "@headlessui/react";
 import { Search } from "components/Search";
 import Icons from "../components/Icons";
 import Link from "./Link";
+import NextLink from "next/link";
 import cx from "classnames";
 import { useNavigation } from "../util/useNavigation";
 import { useVersion } from "../util/useVersion";
@@ -16,22 +17,21 @@ const getCurrentSection = (navigation) => {
   );
   return match || navigation.find((item) => item.path === "/");
 };
-interface FancyButtonProps {
+interface MenuItemProps {
   item: any;
   match: boolean;
   lvl: number;
-  href?: string;
 }
 
 const MenuItem = React.forwardRef<
   HTMLAnchorElement,
-  React.PropsWithChildren<FancyButtonProps>
->(({ item, match, lvl, href }, ref) => {
+  React.PropsWithChildren<MenuItemProps>
+>(({ item, match, lvl }, ref) => {
   const rightIcon = item.isExternalLink
     ? Icons["ExternalLink"]
     : item.children && (match ? Icons["ChevronDown"] : Icons["ChevronRight"]);
 
-  return (
+  const children: JSX.Element = (
     <a
       className={cx(
         "transition group flex justify-between items-center font-medium rounded-md text-gray-800 dark:text-gray-200",
@@ -43,7 +43,7 @@ const MenuItem = React.forwardRef<
           "py-2": lvl <= 2,
         }
       )}
-      href={href}
+      href={item.path}
       ref={ref}
       target={item.isExternalLink ? "_blank" : "_self"}
       rel="noopener noreferrer"
@@ -84,6 +84,18 @@ const MenuItem = React.forwardRef<
       )}
     </a>
   );
+
+  return item.isExternalLink ? (
+    children
+  ) : item.isUnversioned ? (
+    <NextLink href={item.path} passHref>
+      {children}
+    </NextLink>
+  ) : (
+    <Link href={item.path} passHref>
+      {children}
+    </Link>
+  );
 });
 
 const TopLevelNavigation = () => {
@@ -97,13 +109,7 @@ const TopLevelNavigation = () => {
 
         return (
           <div key={item.path}>
-            {item.isExternalLink || item.isUnversioned ? (
-              <MenuItem href={item.path} item={item} match={match} lvl={0} />
-            ) : (
-              <Link href={item.path} passHref>
-                <MenuItem item={item} match={match} lvl={0} />
-              </Link>
-            )}
+            <MenuItem item={item} match={match} lvl={0} />
             {match && (
               <div className="mt-2">
                 <div
@@ -149,18 +155,7 @@ const SecondaryNavigation = () => {
 
         return (
           <div key={itemWithPath.path}>
-            {itemWithPath.isExternalLink || itemWithPath.isUnversioned ? (
-              <MenuItem
-                href={itemWithPath.path}
-                item={sectionOrItem}
-                match={match}
-                lvl={1}
-              />
-            ) : (
-              <Link href={itemWithPath.path} passHref>
-                <MenuItem item={sectionOrItem} match={match} lvl={1} />
-              </Link>
-            )}
+            <MenuItem item={itemWithPath} match={match} lvl={1} />
             {match && sectionOrItem.children && (
               <div className="border-l ml-5 mt-2">
                 <div
@@ -188,7 +183,6 @@ const SecondaryNavigation = () => {
 
 const ThirdLevelNavigation = ({ section }) => {
   const { asPathWithoutAnchor } = useVersion();
-
   return (
     <Link key={section.path} href={section.path}>
       <a

--- a/docs/next/components/Sidebar.tsx
+++ b/docs/next/components/Sidebar.tsx
@@ -7,7 +7,12 @@ import Icons from "../components/Icons";
 import Link from "./Link";
 import NextLink from "next/link";
 import cx from "classnames";
-import { useNavigation, flatten, getNavKey } from "../util/useNavigation";
+import {
+  useNavigation,
+  flatten,
+  getNavKey,
+  getNavLvl,
+} from "../util/useNavigation";
 import { useVersion } from "../util/useVersion";
 
 const getCurrentSection = (navigation) => {
@@ -117,7 +122,7 @@ const MenuItem = React.forwardRef<
 
 const RecursiveNavigation = ({
   itemOrSection,
-  lvl,
+  parentKey,
   idx,
   navKeysToExpanded,
   setNavKeysToExpanded,
@@ -125,7 +130,8 @@ const RecursiveNavigation = ({
   const { asPathWithoutAnchor } = useVersion();
   const navigation = useNavigation();
   const currentSection = getCurrentSection(navigation);
-  const navKey = getNavKey(lvl, idx);
+  const navKey = getNavKey(parentKey, idx);
+  const lvl = getNavLvl(navKey);
 
   const onClick = (key) => {
     setNavKeysToExpanded((prevState) => {
@@ -134,6 +140,7 @@ const RecursiveNavigation = ({
     });
   };
 
+  // Note: this logic is based on path which could be improved by having parent info in itemOrSection
   const match =
     itemOrSection == currentSection ||
     itemOrSection.path === asPathWithoutAnchor ||
@@ -178,7 +185,7 @@ const RecursiveNavigation = ({
               <RecursiveNavigation
                 key={idx}
                 itemOrSection={item}
-                lvl={lvl + 1}
+                parentKey={navKey}
                 idx={idx}
                 navKeysToExpanded={navKeysToExpanded}
                 setNavKeysToExpanded={setNavKeysToExpanded}
@@ -209,7 +216,7 @@ const TopLevelNavigation = () => {
           <RecursiveNavigation
             key={idx}
             itemOrSection={itemOrSection}
-            lvl={0}
+            parentKey={""}
             idx={idx}
             navKeysToExpanded={navKeysToExpanded}
             setNavKeysToExpanded={setNavKeysToExpanded}

--- a/docs/next/components/Sidebar.tsx
+++ b/docs/next/components/Sidebar.tsx
@@ -129,7 +129,6 @@ const RecursiveNavigation = ({
 
   const onClick = (key) => {
     setNavKeysToExpanded((prevState) => {
-      console.log("assets", key);
       const updatedValues = { [key]: !prevState[key] };
       return { ...prevState, ...updatedValues };
     });

--- a/docs/next/components/Sidebar.tsx
+++ b/docs/next/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { Transition } from "@headlessui/react";
 
@@ -7,7 +7,7 @@ import Icons from "../components/Icons";
 import Link from "./Link";
 import NextLink from "next/link";
 import cx from "classnames";
-import { useNavigation } from "../util/useNavigation";
+import { useNavigation, flatten, getNavKey } from "../util/useNavigation";
 import { useVersion } from "../util/useVersion";
 
 const getCurrentSection = (navigation) => {
@@ -21,33 +21,31 @@ interface MenuItemProps {
   item: any;
   match: boolean;
   lvl: number;
+  onClick: () => void;
+  expanded: boolean;
 }
 
 const MenuItem = React.forwardRef<
   HTMLAnchorElement,
   React.PropsWithChildren<MenuItemProps>
->(({ item, match, lvl }, ref) => {
+>(({ item, match, lvl, onClick, expanded }, ref) => {
   const rightIcon = item.isExternalLink
     ? Icons["ExternalLink"]
-    : item.children && (match ? Icons["ChevronDown"] : Icons["ChevronRight"]);
+    : item.children &&
+      (expanded ? Icons["ChevronDown"] : Icons["ChevronRight"]);
 
+  const itemClassName = cx(
+    "w-full transition group flex justify-between items-center rounded-md text-gray-700 dark:text-gray-200",
+    {
+      "hover:bg-lavender hover:bg-opacity-50 text-blurple": match,
+      "hover:text-gray-900 hover:bg-lavender hover:bg-opacity-50": !match,
+      "px-2 py-2 pl-3 pr-2 font-semibold": lvl === 0,
+      "py-2 pl-3 pr-2 font-medium": lvl >= 1,
+      "px-3 py-1 text-sm": lvl >= 2,
+    }
+  );
   const children: JSX.Element = (
-    <a
-      className={cx(
-        "transition group flex justify-between items-center font-medium rounded-md text-gray-800 dark:text-gray-200",
-        {
-          "hover:bg-lavender hover:bg-opacity-50 text-blurple": match,
-          "hover:text-gray-900 hover:bg-lavender hover:bg-opacity-50": !match,
-          "px-2": lvl === 0,
-          "pl-3 pr-2": lvl <= 1,
-          "py-2": lvl <= 2,
-        }
-      )}
-      href={item.path}
-      ref={ref}
-      target={item.isExternalLink ? "_blank" : "_self"}
-      rel="noopener noreferrer"
-    >
+    <>
       <div className="flex justify-start">
         {item.icon && (
           <svg
@@ -66,7 +64,6 @@ const MenuItem = React.forwardRef<
         )}
         <span>{item.title}</span>
       </div>
-
       {rightIcon && (
         <svg
           className={cx("mr-2 h-4 w-4 text-gray-400 transition flex-shrink-0", {
@@ -82,123 +79,145 @@ const MenuItem = React.forwardRef<
           {rightIcon}
         </svg>
       )}
+    </>
+  );
+  const hyperlink: JSX.Element = (
+    <a
+      className={itemClassName}
+      href={item.path}
+      onClick={onClick}
+      ref={ref}
+      target={item.isExternalLink ? "_blank" : "_self"}
+      rel="noopener noreferrer"
+    >
+      {children}
     </a>
   );
 
-  return item.isExternalLink ? (
-    children
-  ) : item.isUnversioned ? (
-    <NextLink href={item.path} passHref>
+  return item.path === undefined ? (
+    // no link
+    <button className={itemClassName} onClick={onClick}>
       {children}
+    </button>
+  ) : item.isExternalLink ? (
+    // external link
+    hyperlink
+  ) : item.isUnversioned ? (
+    // unversioned link
+    <NextLink href={item.path} passHref>
+      {hyperlink}
     </NextLink>
   ) : (
+    // versioned link
     <Link href={item.path} passHref>
-      {children}
+      {hyperlink}
     </Link>
   );
 });
 
-const TopLevelNavigation = () => {
+const RecursiveNavigation = ({
+  itemOrSection,
+  lvl,
+  idx,
+  navKeysToExpanded,
+  setNavKeysToExpanded,
+}) => {
+  const { asPathWithoutAnchor } = useVersion();
   const navigation = useNavigation();
   const currentSection = getCurrentSection(navigation);
+  const navKey = getNavKey(lvl, idx);
 
+  const onClick = (key) => {
+    setNavKeysToExpanded((prevState) => {
+      console.log("assets", key);
+      const updatedValues = { [key]: !prevState[key] };
+      return { ...prevState, ...updatedValues };
+    });
+  };
+
+  const match =
+    itemOrSection == currentSection ||
+    itemOrSection.path === asPathWithoutAnchor ||
+    (itemOrSection.children &&
+      itemOrSection.children.find((item) => item.path === asPathWithoutAnchor));
+
+  const expanded = Boolean(navKeysToExpanded[navKey]);
+
+  // Display item
+  if (!itemOrSection?.children) {
+    return (
+      <MenuItem
+        item={itemOrSection}
+        match={match}
+        lvl={lvl}
+        onClick={() => onClick(navKey)}
+        expanded={expanded}
+      />
+    );
+  }
+
+  // Display section
   return (
-    <div className="space-y-1">
-      {navigation.map((item) => {
-        const match = item == currentSection;
-
-        return (
-          <div key={item.path}>
-            <MenuItem item={item} match={match} lvl={0} />
-            {match && (
-              <div className="mt-2">
-                <div
-                  className="ml-1"
-                  role="group"
-                  aria-labelledby="second-level-nav"
-                >
-                  <div className="border-l ml-5">
-                    <SecondaryNavigation />
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
-        );
+    <div
+      className={cx({
+        "mt-1 ml-1 space-y-1": lvl >= 2,
       })}
+      role="group"
+      aria-labelledby={`${lvl + 1}-level-nav`}
+    >
+      <MenuItem
+        item={itemOrSection}
+        match={match}
+        lvl={lvl}
+        onClick={() => onClick(navKey)}
+        expanded={expanded}
+      />
+      {expanded &&
+        itemOrSection.children.map((item, idx) => {
+          return (
+            <div className="border-l ml-6" key={idx}>
+              <RecursiveNavigation
+                key={idx}
+                itemOrSection={item}
+                lvl={lvl + 1}
+                idx={idx}
+                navKeysToExpanded={navKeysToExpanded}
+                setNavKeysToExpanded={setNavKeysToExpanded}
+              />
+            </div>
+          );
+        })}
     </div>
   );
 };
 
-const SecondaryNavigation = () => {
+const TopLevelNavigation = () => {
   const navigation = useNavigation();
-  const currentSection = getCurrentSection(navigation);
-  const { asPathWithoutAnchor } = useVersion();
 
-  if (!currentSection?.children) {
-    return null;
-  }
+  const [navKeysToExpanded, setNavKeysToExpanded] = useState<{
+    [key: string]: boolean;
+  }>(
+    flatten(navigation).reduce((map, obj) => {
+      map[obj.key] = obj.isDefaultOpen;
+      return map;
+    })
+  );
 
   return (
-    <>
-      {currentSection.children.map((sectionOrItem) => {
-        const match =
-          sectionOrItem.path === asPathWithoutAnchor ||
-          (sectionOrItem.children &&
-            sectionOrItem.children.find(
-              (item) => item.path === asPathWithoutAnchor
-            ));
-
-        const itemWithPath = sectionOrItem.path
-          ? sectionOrItem
-          : sectionOrItem.children[0];
-
+    <div className="space-y-1">
+      {navigation.map((itemOrSection, idx) => {
         return (
-          <div key={itemWithPath.path}>
-            <MenuItem item={itemWithPath} match={match} lvl={1} />
-            {match && sectionOrItem.children && (
-              <div className="border-l ml-5 mt-2">
-                <div
-                  className="mt-1 ml-1 space-y-1"
-                  role="group"
-                  aria-labelledby="third-level-nav"
-                >
-                  {sectionOrItem.children.map((section) => {
-                    return (
-                      <ThirdLevelNavigation
-                        key={section.title}
-                        section={section}
-                      />
-                    );
-                  })}
-                </div>
-              </div>
-            )}
-          </div>
+          <RecursiveNavigation
+            key={idx}
+            itemOrSection={itemOrSection}
+            lvl={0}
+            idx={idx}
+            navKeysToExpanded={navKeysToExpanded}
+            setNavKeysToExpanded={setNavKeysToExpanded}
+          />
         );
       })}
-    </>
-  );
-};
-
-const ThirdLevelNavigation = ({ section }) => {
-  const { asPathWithoutAnchor } = useVersion();
-  return (
-    <Link key={section.path} href={section.path}>
-      <a
-        className={cx(
-          "group flex items-center px-3 py-1 text-sm text-gray-700 rounded-md",
-          {
-            "hover:bg-lavender hover:bg-opacity-50 text-blurple":
-              section.path === asPathWithoutAnchor,
-            "hover:text-gray-900 hover:bg-lavender hover:bg-opacity-50":
-              section.path !== asPathWithoutAnchor,
-          }
-        )}
-      >
-        <span>{section.title}</span>
-      </a>
-    </Link>
+    </div>
   );
 };
 

--- a/docs/next/util/useNavigation.ts
+++ b/docs/next/util/useNavigation.ts
@@ -10,13 +10,18 @@ type NavEntry = {
   isUnversioned?: boolean;
   isExternalLink?: boolean;
 };
-export function flatten(yx: any) {
+
+export const getNavKey = (lvl: number, idx: number) => {
+  return `${lvl}-${idx}`;
+};
+
+export function flatten(yx: any, lvl: number = 0) {
   const xs = JSON.parse(JSON.stringify(yx));
 
-  return xs.reduce((acc: any, x: any) => {
-    acc = acc.concat(x);
+  return xs.reduce((acc: any, x: any, idx: number) => {
+    acc = acc.concat({ key: getNavKey(lvl, idx), ...x });
     if (x.children) {
-      acc = acc.concat(flatten(x.children));
+      acc = acc.concat(flatten(x.children, lvl + 1));
       x.children = [];
     }
     return acc;

--- a/docs/next/util/useNavigation.ts
+++ b/docs/next/util/useNavigation.ts
@@ -11,17 +11,23 @@ type NavEntry = {
   isExternalLink?: boolean;
 };
 
-export const getNavKey = (lvl: number, idx: number) => {
-  return `${lvl}-${idx}`;
+export const getNavKey = (parentKey: string, idx: number) => {
+  return parentKey ? `${parentKey}-${idx}` : `${idx}`;
 };
 
-export function flatten(yx: any, lvl: number = 0) {
+export const getNavLvl = (navKey: string) => {
+  return navKey.split("-").length - 1;
+};
+
+export function flatten(yx: any, parentKey: string = "") {
   const xs = JSON.parse(JSON.stringify(yx));
 
   return xs.reduce((acc: any, x: any, idx: number) => {
-    acc = acc.concat({ key: getNavKey(lvl, idx), ...x });
+    const navKey = getNavKey(parentKey, idx);
+    // console.log(navKey, x);
+    acc = acc.concat({ key: navKey, ...x });
     if (x.children) {
-      acc = acc.concat(flatten(x.children, lvl + 1));
+      acc = acc.concat(flatten(x.children, navKey));
       x.children = [];
     }
     return acc;


### PR DESCRIPTION
### Summary & Motivation
This PR:
- allows to open and close items in the sidebar without leaving the current page
- allows to open multiple items in the sidebar at a time
- allows to set default open section via `"isDefaultOpen": true` in `_navigation.json` [OPEN: which ones do we want to open by default]
 
### How I Tested These Changes
preview