### PR TITLE
refactor run storage to enable backfill status queries

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1678,6 +1678,7 @@ type PartitionStatuses {
 type PartitionStatus {
   id: String!
   partitionName: String!
+  runId: String
   runStatus: RunStatus
   runDuration: Float
 }
@@ -1700,10 +1701,10 @@ type PartitionBackfill {
   partitionSetName: String!
   timestamp: Float!
   partitionSet: PartitionSet
-  runs(limit: Int): [Run!]!
   unfinishedRuns(limit: Int): [Run!]!
   error: PythonError
   partitionRunStats: BackfillRunStats!
+  partitionStatuses: PartitionStatuses!
 }
 
 enum BulkActionStatus {

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1701,6 +1701,7 @@ type PartitionBackfill {
   partitionSetName: String!
   timestamp: Float!
   partitionSet: PartitionSet
+  runs(limit: Int): [Run!]!
   unfinishedRuns(limit: Int): [Run!]!
   error: PythonError
   partitionRunStats: BackfillRunStats!

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -172,24 +172,38 @@ def _apply_cursor_limit_reverse(items, cursor, limit, reverse):
 def get_partition_set_partition_statuses(
     graphene_info, repository_handle, partition_set_name, job_name
 ):
-    from ..schema.partition_sets import GraphenePartitionStatus, GraphenePartitionStatuses
-
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
     check.str_param(partition_set_name, "partition_set_name")
-    partition_data_by_name = {
-        partition_data.partition: partition_data
-        for partition_data in graphene_info.context.instance.run_storage.get_run_partition_data(
-            partition_set_name, job_name, repository_handle.get_external_origin().get_id()
+    check.str_param(job_name, "job_name")
+
+    run_partition_data = graphene_info.context.instance.run_storage.get_run_partition_data(
+        runs_filter=RunsFilter(
+            pipeline_name=job_name,
+            tags={PARTITION_SET_TAG: partition_set_name},
         )
-    }
+    )
     names_result = graphene_info.context.get_external_partition_names(
         repository_handle, partition_set_name
     )
-    status_results = []
 
-    for name in names_result.partition_names:
+    return partition_statuses_from_run_partition_data(
+        partition_set_name, run_partition_data, names_result.partition_names
+    )
+
+
+def partition_statuses_from_run_partition_data(
+    partition_set_name, run_partition_data, partition_names
+):
+    from ..schema.partition_sets import GraphenePartitionStatus, GraphenePartitionStatuses
+
+    partition_data_by_name = {
+        partition_data.partition: partition_data for partition_data in run_partition_data
+    }
+
+    results = []
+    for name in partition_names:
         if not partition_data_by_name.get(name):
-            status_results.append(
+            results.append(
                 GraphenePartitionStatus(
                     id=f"{partition_set_name}:{name}",
                     partitionName=name,
@@ -197,10 +211,11 @@ def get_partition_set_partition_statuses(
             )
             continue
         partition_data = partition_data_by_name[name]
-        status_results.append(
+        results.append(
             GraphenePartitionStatus(
                 id=f"{partition_set_name}:{name}",
                 partitionName=name,
+                runId=partition_data.run_id,
                 runStatus=partition_data.status,
                 runDuration=partition_data.end_time - partition_data.start_time
                 if partition_data.end_time and partition_data.start_time
@@ -208,7 +223,7 @@ def get_partition_set_partition_statuses(
             )
         )
 
-    return GraphenePartitionStatuses(results=status_results)
+    return GraphenePartitionStatuses(results=results)
 
 
 def get_partition_set_partition_runs(graphene_info, partition_set):

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -179,7 +179,6 @@ def get_partition_set_partition_statuses(
     run_partition_data = graphene_info.context.instance.run_storage.get_run_partition_data(
         runs_filter=RunsFilter(
             pipeline_name=job_name,
-            tags={PARTITION_SET_TAG: partition_set_name},
         )
     )
     names_result = graphene_info.context.get_external_partition_names(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -124,6 +124,10 @@ class GraphenePartitionBackfill(graphene.ObjectType):
     partitionSetName = graphene.NonNull(graphene.String)
     timestamp = graphene.NonNull(graphene.Float)
     partitionSet = graphene.Field("dagster_graphql.schema.partition_sets.GraphenePartitionSet")
+    runs = graphene.Field(
+        non_null_list("dagster_graphql.schema.pipelines.pipeline.GrapheneRun"),
+        limit=graphene.Int(),
+    )
     unfinishedRuns = graphene.Field(
         non_null_list("dagster_graphql.schema.pipelines.pipeline.GrapheneRun"),
         limit=graphene.Int(),
@@ -253,6 +257,12 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             numPartitionsWithRuns=len(partition_run_data),
             numTotalRuns=len(partition_run_data),  # hack, but this is unused
         )
+
+    def resolve_runs(self, graphene_info):
+        from .pipelines.pipeline import GrapheneRun
+
+        records = self._get_records(graphene_info)
+        return [GrapheneRun(record) for record in records]
 
     def resolve_numPartitions(self, _graphene_info):
         return len(self._backfill_job.partition_names)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -2,9 +2,10 @@ import graphene
 
 import dagster._check as check
 from dagster.core.execution.backfill import BulkActionStatus, PartitionBackfill
-from dagster.core.storage.pipeline_run import PipelineRunStatus, RunsFilter
-from dagster.core.storage.tags import PARTITION_NAME_TAG
+from dagster.core.storage.pipeline_run import FINISHED_STATUSES, PipelineRunStatus, RunsFilter
+from dagster.core.storage.tags import BACKFILL_ID_TAG
 
+from ..implementation.fetch_partition_sets import partition_statuses_from_run_partition_data
 from .errors import (
     GrapheneInvalidOutputError,
     GrapheneInvalidStepError,
@@ -123,21 +124,21 @@ class GraphenePartitionBackfill(graphene.ObjectType):
     partitionSetName = graphene.NonNull(graphene.String)
     timestamp = graphene.NonNull(graphene.Float)
     partitionSet = graphene.Field("dagster_graphql.schema.partition_sets.GraphenePartitionSet")
-    runs = graphene.Field(
-        non_null_list("dagster_graphql.schema.pipelines.pipeline.GrapheneRun"),
-        limit=graphene.Int(),
-    )
     unfinishedRuns = graphene.Field(
         non_null_list("dagster_graphql.schema.pipelines.pipeline.GrapheneRun"),
         limit=graphene.Int(),
     )
     error = graphene.Field(GraphenePythonError)
     partitionRunStats = graphene.NonNull(GrapheneBackfillRunStats)
+    partitionStatuses = graphene.NonNull(
+        "dagster_graphql.schema.partition_sets.GraphenePartitionStatuses"
+    )
 
     def __init__(self, backfill_job):
         self._backfill_job = check.opt_inst_param(backfill_job, "backfill_job", PartitionBackfill)
 
         self._records = None
+        self._partition_run_data = None
 
         super().__init__(
             backfillId=backfill_job.backfill_id,
@@ -149,110 +150,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             timestamp=backfill_job.backfill_timestamp,
         )
 
-    def _get_records(self, graphene_info):
-        if self._records == None:
-            filters = RunsFilter.for_backfill(self._backfill_job.backfill_id)
-            self._records = graphene_info.context.instance.get_run_records(
-                filters=filters,
-            )
-        return self._records
-
-    def resolve_unfinishedRuns(self, graphene_info):
-        from .pipelines.pipeline import GrapheneRun
-
-        records = self._get_records(graphene_info)
-        return [GrapheneRun(record) for record in records if not record.pipeline_run.is_finished]
-
-    def resolve_backfillStatus(self, graphene_info):
-        if self._backfill_job.status == BulkActionStatus.REQUESTED:
-            return GrapheneBackfillStatus.REQUESTED
-        if self._backfill_job.status == BulkActionStatus.CANCELED:
-            return GrapheneBackfillStatus.CANCELED
-        if self._backfill_job.status == BulkActionStatus.FAILED:
-            return GrapheneBackfillStatus.FAILED
-        if self._backfill_job.status == BulkActionStatus.COMPLETED:
-            records = self._get_records(graphene_info)
-
-            is_done = all(record.pipeline_run.is_finished for record in records)
-            if not is_done:
-                return GrapheneBackfillStatus.IN_PROGRESS
-            else:
-                num_success = len(
-                    [
-                        record
-                        for record in records
-                        if record.pipeline_run.status == PipelineRunStatus.SUCCESS
-                    ]
-                )
-                if num_success == len(self._backfill_job.partition_names):
-                    return GrapheneBackfillStatus.COMPLETED
-                else:
-                    return GrapheneBackfillStatus.INCOMPLETE
-
-    def resolve_partitionRunStats(self, graphene_info):
-        records = self._get_records(graphene_info)
-
-        by_partition_records = {}
-
-        for record in records:
-            partition = record.pipeline_run.tags.get(PARTITION_NAME_TAG)
-            if partition and partition not in by_partition_records:  # get latest for each partition
-                by_partition_records[partition] = record
-
-        num_queued = 0
-        num_in_progress = 0
-        num_succeeded = 0
-        num_failed = 0
-
-        for _partition, record in by_partition_records.items():
-            status = record.pipeline_run.status
-            if status == PipelineRunStatus.QUEUED:
-                num_queued = num_queued + 1
-            elif not record.pipeline_run.is_finished:
-                num_in_progress = num_in_progress + 1
-            elif status == PipelineRunStatus.SUCCESS:
-                num_succeeded = num_succeeded + 1
-            elif status in {PipelineRunStatus.FAILURE, PipelineRunStatus.CANCELED}:
-                num_failed = num_failed + 1
-            else:
-                check.invariant(False, f"Unexpected PipelineRunStatus {status}")
-
-        return GrapheneBackfillRunStats(
-            numQueued=num_queued,
-            numInProgress=num_in_progress,
-            numSucceeded=num_succeeded,
-            numFailed=num_failed,
-            numPartitionsWithRuns=len(by_partition_records),
-            numTotalRuns=len(records),
-        )
-
-    def resolve_runs(self, graphene_info):
-        from .pipelines.pipeline import GrapheneRun
-
-        records = self._get_records(graphene_info)
-        return [GrapheneRun(record) for record in records]
-
-    def resolve_numPartitions(self, _graphene_info):
-        return len(self._backfill_job.partition_names)
-
-    def resolve_numRequested(self, graphene_info):
-        if self._backfill_job.status == BulkActionStatus.COMPLETED:
-            return len(self._backfill_job.partition_names)
-
-        records = self._get_records(graphene_info)
-
-        run_count = len(records)
-        checkpoint = self._backfill_job.last_submitted_partition_name
-        return max(
-            run_count,
-            self._backfill_job.partition_names.index(checkpoint) + 1
-            if checkpoint and checkpoint in self._backfill_job.partition_names
-            else 0,
-        )
-
-    def resolve_partitionSet(self, graphene_info):
-        from ..schema.partition_sets import GraphenePartitionSet
-
+    def _get_partition_set(self, graphene_info):
         origin = self._backfill_job.partition_set_origin
         location_name = origin.external_repository_origin.repository_location_origin.location_name
         repository_name = origin.external_repository_origin.repository_name
@@ -272,10 +170,125 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         if not external_partition_sets:
             return None
 
-        partition_set = external_partition_sets[0]
+        return external_partition_sets[0]
+
+    def _get_records(self, graphene_info):
+        if self._records == None:
+            filters = RunsFilter.for_backfill(self._backfill_job.backfill_id)
+            self._records = graphene_info.context.instance.get_run_records(
+                filters=filters,
+            )
+        return self._records
+
+    def _get_partition_run_data(self, graphene_info):
+        if self._partition_run_data is None:
+            self._partition_run_data = (
+                graphene_info.context.instance.run_storage.get_run_partition_data(
+                    runs_filter=RunsFilter(
+                        tags={
+                            BACKFILL_ID_TAG: self._backfill_job.backfill_id,
+                        }
+                    )
+                )
+            )
+        return self._partition_run_data
+
+    def resolve_unfinishedRuns(self, graphene_info):
+        from .pipelines.pipeline import GrapheneRun
+
+        records = self._get_records(graphene_info)
+        return [GrapheneRun(record) for record in records if not record.pipeline_run.is_finished]
+
+    def resolve_backfillStatus(self, graphene_info):
+        if self._backfill_job.status == BulkActionStatus.REQUESTED:
+            return GrapheneBackfillStatus.REQUESTED
+        if self._backfill_job.status == BulkActionStatus.CANCELED:
+            return GrapheneBackfillStatus.CANCELED
+        if self._backfill_job.status == BulkActionStatus.FAILED:
+            return GrapheneBackfillStatus.FAILED
+        if self._backfill_job.status == BulkActionStatus.COMPLETED:
+            partition_run_data = self._get_partition_run_data(graphene_info)
+            is_done = all(partition.status in FINISHED_STATUSES for partition in partition_run_data)
+            if not is_done:
+                return GrapheneBackfillStatus.IN_PROGRESS
+            else:
+                num_success = len(
+                    [
+                        partition
+                        for partition in partition_run_data
+                        if partition.status == PipelineRunStatus.SUCCESS
+                    ]
+                )
+                if num_success == len(self._backfill_job.partition_names):
+                    return GrapheneBackfillStatus.COMPLETED
+                else:
+                    return GrapheneBackfillStatus.INCOMPLETE
+
+    def resolve_partitionRunStats(self, graphene_info):
+        partition_run_data = self._get_partition_run_data(graphene_info)
+
+        num_queued = 0
+        num_in_progress = 0
+        num_succeeded = 0
+        num_failed = 0
+
+        for partition in partition_run_data:
+            status = partition.status
+            if status == PipelineRunStatus.QUEUED:
+                num_queued = num_queued + 1
+            elif not status in FINISHED_STATUSES:
+                num_in_progress = num_in_progress + 1
+            elif status == PipelineRunStatus.SUCCESS:
+                num_succeeded = num_succeeded + 1
+            elif status in {PipelineRunStatus.FAILURE, PipelineRunStatus.CANCELED}:
+                num_failed = num_failed + 1
+            else:
+                check.invariant(False, f"Unexpected PipelineRunStatus {status}")
+
+        return GrapheneBackfillRunStats(
+            numQueued=num_queued,
+            numInProgress=num_in_progress,
+            numSucceeded=num_succeeded,
+            numFailed=num_failed,
+            numPartitionsWithRuns=len(partition_run_data),
+            numTotalRuns=len(partition_run_data),  # hack, but this is unused
+        )
+
+    def resolve_numPartitions(self, _graphene_info):
+        return len(self._backfill_job.partition_names)
+
+    def resolve_numRequested(self, graphene_info):
+        if self._backfill_job.status == BulkActionStatus.COMPLETED:
+            return len(self._backfill_job.partition_names)
+
+        partition_run_data = self._get_partition_run_data(graphene_info)
+
+        checkpoint = self._backfill_job.last_submitted_partition_name
+        return max(
+            len(partition_run_data),
+            self._backfill_job.partition_names.index(checkpoint) + 1
+            if checkpoint and checkpoint in self._backfill_job.partition_names
+            else 0,
+        )
+
+    def resolve_partitionSet(self, graphene_info):
+        from ..schema.partition_sets import GraphenePartitionSet
+
+        partition_set = self._get_partition_set(graphene_info)
+
+        if not partition_set:
+            return None
+
         return GraphenePartitionSet(
-            external_repository_handle=repository.handle,
+            external_repository_handle=partition_set.repository_handle,
             external_partition_set=partition_set,
+        )
+
+    def resolve_partitionStatuses(self, graphene_info):
+        partition_set_name = self._backfill_job.partition_set_origin.partition_set_name
+        partition_run_data = self._get_partition_run_data(graphene_info)
+        return partition_statuses_from_run_partition_data(
+            partition_set_name, partition_run_data, self._backfill_job.partition_names
         )
 
     def resolve_error(self, _):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -52,6 +52,7 @@ class GraphenePartitionRunConfigOrError(graphene.Union):
 class GraphenePartitionStatus(graphene.ObjectType):
     id = graphene.NonNull(graphene.String)
     partitionName = graphene.NonNull(graphene.String)
+    runId = graphene.Field(graphene.String)
     runStatus = graphene.Field(GrapheneRunStatus)
     runDuration = graphene.Field(graphene.Float)
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -35,7 +35,6 @@ PARTITION_PROGRESS_QUERY = """
           numSucceeded
           numFailed
           numPartitionsWithRuns
-          numTotalRuns
         }
         unfinishedRuns {
           id
@@ -358,7 +357,6 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
             "numInProgress": 1,  # "5"
             "numSucceeded": 1,  # "4"
             "numFailed": 2,  # "2,3"
-            "numTotalRuns": 8,
         }
 
         assert len(result.data["partitionBackfillOrError"]["unfinishedRuns"]) == 4
@@ -425,7 +423,6 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
             "numInProgress": 0,
             "numSucceeded": 4,
             "numFailed": 0,
-            "numTotalRuns": 4,
         }
 
         assert result.data["partitionBackfillOrError"]["backfillStatus"] == "COMPLETED"
@@ -481,7 +478,6 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
             "numInProgress": 0,
             "numSucceeded": 3,
             "numFailed": 1,
-            "numTotalRuns": 4,
         }
 
         assert result.data["partitionBackfillOrError"]["backfillStatus"] == "INCOMPLETE"

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1314,13 +1314,9 @@ class DagsterInstance:
         return self._run_storage.supports_bucket_queries
 
     @traced
-    def get_run_partition_data(
-        self, partition_set_name: str, job_name: str, repository_label: str
-    ) -> List[RunPartitionData]:
+    def get_run_partition_data(self, runs_filter: RunsFilter) -> List[RunPartitionData]:
         """Get run partition data for a given partitioned job."""
-        return self._run_storage.get_run_partition_data(
-            partition_set_name, job_name, repository_label
-        )
+        return self._run_storage.get_run_partition_data(runs_filter)
 
     def wipe(self):
         self._run_storage.wipe()

--- a/python_modules/dagster/dagster/core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/core/storage/pipeline_run.py
@@ -113,6 +113,12 @@ NON_IN_PROGRESS_RUN_STATUSES = [
     PipelineRunStatus.CANCELED,
 ]
 
+FINISHED_STATUSES = [
+    PipelineRunStatus.SUCCESS,
+    PipelineRunStatus.FAILURE,
+    PipelineRunStatus.CANCELED,
+]
+
 
 @whitelist_for_serdes
 class PipelineRunStatsSnapshot(
@@ -455,11 +461,7 @@ class PipelineRun(
 
     @property
     def is_finished(self):
-        return (
-            self.status == PipelineRunStatus.SUCCESS
-            or self.status == PipelineRunStatus.FAILURE
-            or self.status == PipelineRunStatus.CANCELED
-        )
+        return self.status in FINISHED_STATUSES
 
     @property
     def is_success(self):

--- a/python_modules/dagster/dagster/core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/core/storage/runs/base.py
@@ -324,12 +324,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
         return True
 
     @abstractmethod
-    def get_run_partition_data(
-        self,
-        partition_set_name: str,
-        job_name: str,
-        repository_label: str,
-    ) -> List[RunPartitionData]:
+    def get_run_partition_data(self, runs_filter: RunsFilter) -> List[RunPartitionData]:
         """Get run partition data for a given partitioned job."""
 
     def migrate(self, print_fn: Optional[Callable] = None, force_rebuild_all: bool = False):

--- a/python_modules/dagster/dagster/core/storage/runs/in_memory.py
+++ b/python_modules/dagster/dagster/core/storage/runs/in_memory.py
@@ -15,7 +15,7 @@ from dagster.core.snap import (
     create_execution_plan_snapshot_id,
     create_pipeline_snapshot_id,
 )
-from dagster.core.storage.tags import PARTITION_NAME_TAG, PARTITION_SET_TAG
+from dagster.core.storage.tags import PARTITION_NAME_TAG
 from dagster.daemon.types import DaemonHeartbeat
 from dagster.utils import EPOCH, frozendict, merge_dicts
 
@@ -339,16 +339,9 @@ class InMemoryRunStorage(RunStorage):
             for root_run_id, run_group in root_run_id_to_group.items()
         }
 
-    def get_run_partition_data(
-        self, partition_set_name: str, job_name: str, repository_label: str
-    ) -> List[RunPartitionData]:
+    def get_run_partition_data(self, runs_filter: RunsFilter) -> List[RunPartitionData]:
         """Get run partition data for a given partitioned job."""
-        check.str_param(partition_set_name, "partition_set_name")
-        check.str_param(job_name, "job_name")
-
-        run_filter = build_run_filter(
-            RunsFilter(pipeline_name=job_name, tags={PARTITION_SET_TAG: partition_set_name})
-        )
+        run_filter = build_run_filter(runs_filter)
         matching_runs = list(filter(run_filter, list(self._runs.values())[::-1]))
         _partition_data_by_partition = {}
         for run in matching_runs:

--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -815,17 +815,10 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
         return defensively_unpack_pipeline_snapshot_query(logging, row) if row else None
 
-    def get_run_partition_data(
-        self, partition_set_name: str, job_name: str, repository_label: str
-    ) -> List[RunPartitionData]:
+    def get_run_partition_data(self, runs_filter: RunsFilter) -> List[RunPartitionData]:
         if self.has_built_index(RUN_PARTITIONS) and self.has_run_stats_index_cols():
             query = self._runs_query(
-                filters=RunsFilter(
-                    pipeline_name=job_name,
-                    tags={
-                        PARTITION_SET_TAG: partition_set_name,
-                    },
-                ),
+                filters=runs_filter,
                 columns=["run_id", "status", "start_time", "end_time", "partition"],
             )
             rows = self.fetchall(query)
@@ -846,14 +839,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
             return list(_partition_data_by_partition.values())
         else:
-            query = self._runs_query(
-                filters=RunsFilter(
-                    pipeline_name=job_name,
-                    tags={
-                        PARTITION_SET_TAG: partition_set_name,
-                    },
-                ),
-            )
+            query = self._runs_query(filters=runs_filter)
             rows = self.fetchall(query)
             _partition_data_by_partition = {}
             for row in rows:

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
@@ -1126,7 +1126,12 @@ class TestRunStorage:
             },
         )
         storage.add_run(three)
-        partition_data = storage.get_run_partition_data("foo_set", "foo_pipeline", "fake@fake")
+        partition_data = storage.get_run_partition_data(
+            runs_filter=RunsFilter(
+                pipeline_name="foo_pipeline",
+                tags={PARTITION_SET_TAG: "foo_set"},
+            )
+        )
         assert len(partition_data) == 3
         assert {_.partition for _ in partition_data} == {"one", "two", "three"}
         assert {_.run_id for _ in partition_data} == {one.run_id, two_retried.run_id, three.run_id}


### PR DESCRIPTION
### Summary & Motivation
We changed the signature of the get_run_partition_data to better support efficient fetching of backfill status of backfills with large amounts of runs. This lets of fetch run status without incurring the large serdes cost of the actual run body which dwarfs query time for large backfills.

### How I Tested These Changes
BK

