### PR TITLE
docs: fix prev/next pagination DREL-345

### DIFF
--- a/docs/next/components/Pagination.tsx
+++ b/docs/next/components/Pagination.tsx
@@ -2,10 +2,10 @@ import { flatten, useNavigation } from "util/useNavigation";
 
 import Link from "./Link";
 import React from "react";
-import { useRouter } from "next/router";
+import { useVersion } from "../util/useVersion";
 
 const Pagination = () => {
-  const { asPath } = useRouter();
+  const { asPath } = useVersion();
   const navigation = useNavigation();
   const flattenedNavigation = flatten(navigation).filter(
     (n: { path: any }) => n.path


### PR DESCRIPTION
### Summary & Motivation
the problem was bc we didn't use the normalized (remove <version> from the path) `asPath` for pulling the right `currentIndex` for the page.
### How I Tested These Changes
before:
![Screen Shot 2022-06-30 at 3 58 57 PM](https://user-images.githubusercontent.com/4531914/176792346-4de170eb-815d-4e4f-9753-c8e7357f663e.png)

after:
![Screen Shot 2022-06-30 at 3 59 01 PM](https://user-images.githubusercontent.com/4531914/176792339-6da084b1-f632-4cea-9f4d-b9bc60631e33.png)

