### PR TITLE
docs: no github repo url hardcoded

### DIFF
--- a/docs/next/components/mdx/MDXRenderer.tsx
+++ b/docs/next/components/mdx/MDXRenderer.tsx
@@ -215,7 +215,7 @@ const RightSidebar = ({
           </div>
           <div className="py-2 px-4 flex items-center group">
             <GitHubButton
-              href="https://github.com/dagster-io/dagster"
+              href={process.env.DAGSTER_REPO_URL}
               data-icon="octicon-star"
               data-show-count="true"
               aria-label="Star dagster-io/dagster on GitHub"


### PR DESCRIPTION
### Summary & Motivation
no need to show gh star count in previews or local. so turn it off to avoid being rate limited.

### How I Tested These Changes
local and preview don't show the star