### PR TITLE
docs: docs test should capture Next Image broken links and fix broken links

### DIFF
--- a/docs/content/integrations/dagstermill.mdx
+++ b/docs/content/integrations/dagstermill.mdx
@@ -191,7 +191,7 @@ Now we are ready to execute a job that flows the output of arbitrary Python code
 
 <Image
 alt="iris_classify.png"
-src="/images/guides/data_science/iris_classify.png"
+src="/images/guides/data_science/iris_pipeline.png"
 width={1680}
 height={874}
 />

--- a/docs/content/tutorial/assets/asset-graph.mdx
+++ b/docs/content/tutorial/assets/asset-graph.mdx
@@ -126,6 +126,10 @@ dagit -f complex_asset_graph.py
 
 Navigate to <http://127.0.0.1:3000>. From the **Assets** page, click an asset and then the **Lineage** tab:
 
-\<Image src="/images/guides/asset-tutorial/complex_asset_graph.png" width={2662} height={1618}
+<Image
+src="/images/guides/asset-tutorial/complex_asset_graph.png"
+width={2662}
+height={1618}
+/>
 
 If you click the "Materialize All" button, you'll see that `cereals` executes first, followed by `nabisco_cereals` and `cereal_protein_fractions` executing in parallel, since they don't depend on each other's outputs. Finally, `highest_protein_nabisco_cereal` executes last, only after `nabisco_cereals` and `cereal_protein_fractions` have both executed.

--- a/docs/content/tutorial/assets/asset-graph.mdx
+++ b/docs/content/tutorial/assets/asset-graph.mdx
@@ -52,9 +52,10 @@ dagit -f serial_asset_graph.py
 Navigate to <http://127.0.0.1:3000>. From the **Assets** page, click an asset and then the **Lineage** tab:
 
 <Image
+alt="Serial asset graph"
 src="/images/guides/asset-tutorial/serial_asset_graph.png"
-width={2662}
-height={1618}
+width={1331}
+height={874}
 />
 
 <br />
@@ -127,9 +128,10 @@ dagit -f complex_asset_graph.py
 Navigate to <http://127.0.0.1:3000>. From the **Assets** page, click an asset and then the **Lineage** tab:
 
 <Image
+alt="Complex asset graph"
 src="/images/guides/asset-tutorial/complex_asset_graph.png"
-width={2662}
-height={1618}
+width={1331}
+height={874}
 />
 
 If you click the "Materialize All" button, you'll see that `cereals` executes first, followed by `nabisco_cereals` and `cereal_protein_fractions` executing in parallel, since they don't depend on each other's outputs. Finally, `highest_protein_nabisco_cereal` executes last, only after `nabisco_cereals` and `cereal_protein_fractions` have both executed.

--- a/docs/content/tutorial/assets/defining-an-asset.mdx
+++ b/docs/content/tutorial/assets/defining-an-asset.mdx
@@ -57,9 +57,10 @@ Serving dagit on http://127.0.0.1:3000 in process 70635
 You should be able to navigate to <http://127.0.0.1:3000> in your web browser and view your asset.
 
 <Image
+alt="Define an asset"
 src="/images/guides/asset-tutorial/defining_an_asset.png"
-width={2662}
-height={1618}
+width={1331}
+height={874}
 />
 
 Click the **Materialize** button to launch a run that materializes the asset. After the run completes, the **Activity** tab on the **Assets** page will contain information about the run.
@@ -67,9 +68,10 @@ Click the **Materialize** button to launch a run that materializes the asset. Af
 Click the run ID in the **Activity** tab to view details about the run. A page including a structured stream of logs and events that occurred during the run will display:
 
 <Image
+alt="Asset run"
 src="/images/guides/asset-tutorial/asset_run.png"
-width={2662}
-height={1618}
+width={1331}
+height={874}
 />
 
 In this view, you can filter and search through the logs corresponding to the run that's materializing your asset.
@@ -77,9 +79,10 @@ In this view, you can filter and search through the logs corresponding to the ru
 Click the **cereals** link in the upper left corner of the page - next to the **Success** indicator in the image below - to navigate back to the **Asset details** page:
 
 <Image
+alt="Asset details"
 src="/images/guides/asset-tutorial/asset_details.png"
-width={2662}
-height={1618}
+width={1331}
+height={874}
 />
 
 Success!

--- a/docs/content/tutorial/assets/defining-an-asset.mdx
+++ b/docs/content/tutorial/assets/defining-an-asset.mdx
@@ -57,7 +57,7 @@ Serving dagit on http://127.0.0.1:3000 in process 70635
 You should be able to navigate to <http://127.0.0.1:3000> in your web browser and view your asset.
 
 <Image
-src="/images/dagster/guides/asset-tutorial/defining-an-asset/defining_an_asset.png"
+src="/images/guides/asset-tutorial/defining_an_asset.png"
 width={2662}
 height={1618}
 />
@@ -67,7 +67,7 @@ Click the **Materialize** button to launch a run that materializes the asset. Af
 Click the run ID in the **Activity** tab to view details about the run. A page including a structured stream of logs and events that occurred during the run will display:
 
 <Image
-src="/images/dagster/guides/asset-tutorial/defining-an-asset/asset_run.png"
+src="/images/guides/asset-tutorial/asset_run.png"
 width={2662}
 height={1618}
 />
@@ -77,7 +77,7 @@ In this view, you can filter and search through the logs corresponding to the ru
 Click the **cereals** link in the upper left corner of the page - next to the **Success** indicator in the image below - to navigate back to the **Asset details** page:
 
 <Image
-src="/images/dagster/guides/asset-tutorial/defining-an-asset/asset_details.png"
+src="/images/guides/asset-tutorial/asset_details.png"
 width={2662}
 height={1618}
 />

--- a/docs/next/__tests__/mdxInternalLinks.test.ts
+++ b/docs/next/__tests__/mdxInternalLinks.test.ts
@@ -8,6 +8,7 @@ import masterNavigation from "../../content/_navigation.json";
 import generateToc from "mdast-util-toc";
 import { getItems, getIds } from "../components/mdx/SidebarNavigation";
 import matter from "gray-matter";
+import parse from "html-react-parser";
 
 // remark
 import mdx from "remark-mdx";
@@ -16,7 +17,7 @@ import remark from "remark";
 const ROOT_DIR = path.resolve(__dirname, "../../");
 const DOCS_DIR = path.resolve(ROOT_DIR, "content");
 interface LinkElement extends Node {
-  type: "link" | "image";
+  type: "link" | "image" | "html";
   url: string;
 }
 
@@ -129,9 +130,22 @@ function isLinkLegit(
     const allAnchors = collectHeadingsAsAnchors(astStore[targetFilePath]);
     return allAnchors.includes(anchor);
   }
+  console.log("rawTarget", rawTarget, path);
 
   return false;
 }
+
+export const getNextImageElement = (node) => {
+  // handle <Image>
+  if (node.type === "html") {
+    const root = parse(node.value, { trim: true });
+
+    if ((root as any).type === "image") {
+      return { url: (root as any).props.src, type: "html" } as LinkElement;
+    }
+  }
+  return;
+};
 
 // traverse the mdx ast to find all internal links
 function collectInternalLinks(
@@ -141,8 +155,19 @@ function collectInternalLinks(
   const externalLinkRegex = /^(https?:\/\/|mailto:)/;
   const result: Array<string> = [];
 
-  visit(tree, ["link", "image"], (node: LinkElement, index) => {
-    const { url } = node;
+  visit(tree, ["link", "image", "html"], (node: LinkElement, index) => {
+    let linkNode = node;
+    if (node.type === "html") {
+      const nextImageElement = getNextImageElement(node);
+      if (nextImageElement) {
+        linkNode = nextImageElement;
+      } else {
+        return;
+      }
+    }
+
+    const { url } = linkNode;
+    // console.log(linkNode, url);
     if (url.match(externalLinkRegex)) {
       return;
     }

--- a/docs/next/package.json
+++ b/docs/next/package.json
@@ -61,6 +61,7 @@
     "@types/jest": "^27.4.0",
     "@types/node": "^14.14.22",
     "@types/react": "^17.0.0",
+    "html-react-parser": "^2.0.0",
     "jest": "^27.5.1",
     "node-html-parser": "^5.3.3",
     "prettier": "^2.2.1",

--- a/docs/next/yarn.lock
+++ b/docs/next/yarn.lock
@@ -3502,7 +3502,7 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
-domhandler@^4.2.0, domhandler@^4.3.1:
+domhandler@4.3.1, domhandler@^4.2.0, domhandler@^4.2.2, domhandler@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
   integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
@@ -3547,6 +3547,11 @@ entities@2.2.0, entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+entities@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
+  integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -4126,6 +4131,14 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
+html-dom-parser@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/html-dom-parser/-/html-dom-parser-2.0.0.tgz#ece281d47c233bb67982cacde8db7c70e404587c"
+  integrity sha512-PwVjg12yfWunpH2WjwjaYNKcZyKKm20kclTfMQohiRzfgYiXX0dR7nXIIKnHneghMDvB0rKFZLEAe11ykOfpcg==
+  dependencies:
+    domhandler "4.3.1"
+    htmlparser2 "7.2.0"
+
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
@@ -4138,6 +4151,16 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+html-react-parser@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-2.0.0.tgz#d056ef75534d8f3dfdb611196008fdcf8b392f67"
+  integrity sha512-AI1lhybWGi8w4QkGtEIS3iSGAjeFGaonxl/+CzqzCeNT3g3z/yx2NKsA93trnv2BLjhe+juGLmLeTSUkyYWk9Q==
+  dependencies:
+    domhandler "4.3.1"
+    html-dom-parser "2.0.0"
+    react-property "2.0.0"
+    style-to-js "1.1.1"
+
 html-tags@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
@@ -4147,6 +4170,16 @@ html-void-elements@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.5.tgz#ce9159494e86d95e45795b166c2021c2cfca4483"
   integrity sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==
+
+htmlparser2@7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-7.2.0.tgz#8817cdea38bbc324392a90b1990908e81a65f5a5"
+  integrity sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.2.2"
+    domutils "^2.8.0"
+    entities "^3.0.1"
 
 http-errors@1.8.1:
   version "1.8.1"
@@ -5950,6 +5983,11 @@ react-medium-image-zoom@^4.3.5:
     react-use "^17.2.1"
     tslib "^2.1.0"
 
+react-property@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.0.tgz#2156ba9d85fa4741faf1918b38efc1eae3c6a136"
+  integrity sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==
+
 react-universal-interface@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/react-universal-interface/-/react-universal-interface-0.6.2.tgz#5e8d438a01729a4dbbcbeeceb0b86be146fe2b3b"
@@ -6590,6 +6628,13 @@ strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+style-to-js@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/style-to-js/-/style-to-js-1.1.1.tgz#417786986cda61d4525c80aed9d1123a6a7af9b8"
+  integrity sha512-RJ18Z9t2B02sYhZtfWKQq5uplVctgvjTfLWT7+Eb1zjUjIrWzX5SdlkwLGQozrqarTmEzJJ/YmdNJCUNI47elg==
+  dependencies:
+    style-to-object "0.3.0"
 
 style-to-object@0.3.0, style-to-object@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
### Summary & Motivation
the docs test didn't cover broken links from Next Image (i.e. `<Image>`) which led to broken images on prod.

### How I Tested These Changes
`yarn test` threw expected errors:
![Screen Shot 2022-06-30 at 5 33 55 PM](https://user-images.githubusercontent.com/4531914/176800197-7af3738e-2ca0-4095-9f4e-bf13a2f8049e.png)

