### PR TITLE
[dagit] React Router v6 compatibility

### DIFF
--- a/js_modules/dagit/packages/app/package.json
+++ b/js_modules/dagit/packages/app/package.json
@@ -17,6 +17,7 @@
     "react-is": "^17.0.2",
     "react-router": "^5.2.1",
     "react-router-dom": "^5.3.0",
+    "react-router-dom-v5-compat": "^6.3.0",
     "web-vitals": "^2.1.3"
   },
   "devDependencies": {

--- a/js_modules/dagit/packages/core/package.json
+++ b/js_modules/dagit/packages/core/package.json
@@ -27,6 +27,7 @@
     "react-dom": "^17.0.2",
     "react-router": "^5.2.1",
     "react-router-dom": "^5.3.0",
+    "react-router-dom-v5-compat": "^6.3.0",
     "styled-components": "^5.3.3"
   },
   "dependencies": {
@@ -131,6 +132,7 @@
     "react-refresh": "0.9.0",
     "react-router": "^5.2.1",
     "react-router-dom": "^5.3.0",
+    "react-router-dom-v5-compat": "^6.3.0",
     "rgb-hex": "^4.0.0",
     "styled-components": "^5.3.3",
     "ts-node": "9.1.1",

--- a/js_modules/dagit/packages/core/src/app/AppProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppProvider.tsx
@@ -22,6 +22,7 @@ import {
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {BrowserRouter} from 'react-router-dom';
+import {CompatRouter} from 'react-router-dom-v5-compat';
 import {createGlobalStyle} from 'styled-components/macro';
 import {SubscriptionClient} from 'subscriptions-transport-ws';
 
@@ -182,19 +183,21 @@ export const AppProvider: React.FC<AppProviderProps> = (props) => {
         <ApolloProvider client={apolloClient}>
           <PermissionsProvider>
             <BrowserRouter basename={basePath || ''}>
-              <TimezoneProvider>
-                <WorkspaceProvider>
-                  <CustomConfirmationProvider>
-                    <AnalyticsContext.Provider value={analytics}>
-                      <InstancePageContext.Provider value={instancePageValue}>
-                        <LayoutProvider>{props.children}</LayoutProvider>
-                      </InstancePageContext.Provider>
-                    </AnalyticsContext.Provider>
-                  </CustomConfirmationProvider>
-                  <CustomTooltipProvider />
-                  <CustomAlertProvider />
-                </WorkspaceProvider>
-              </TimezoneProvider>
+              <CompatRouter>
+                <TimezoneProvider>
+                  <WorkspaceProvider>
+                    <CustomConfirmationProvider>
+                      <AnalyticsContext.Provider value={analytics}>
+                        <InstancePageContext.Provider value={instancePageValue}>
+                          <LayoutProvider>{props.children}</LayoutProvider>
+                        </InstancePageContext.Provider>
+                      </AnalyticsContext.Provider>
+                    </CustomConfirmationProvider>
+                    <CustomTooltipProvider />
+                    <CustomAlertProvider />
+                  </WorkspaceProvider>
+                </TimezoneProvider>
+              </CompatRouter>
             </BrowserRouter>
           </PermissionsProvider>
         </ApolloProvider>

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -5532,6 +5532,7 @@ __metadata:
     react-is: ^17.0.2
     react-router: ^5.2.1
     react-router-dom: ^5.3.0
+    react-router-dom-v5-compat: ^6.3.0
     source-map-explorer: ^2.5.0
     typescript: 4.7.3
     web-vitals: ^2.1.3
@@ -5635,6 +5636,7 @@ __metadata:
     react-refresh: 0.9.0
     react-router: ^5.2.1
     react-router-dom: ^5.3.0
+    react-router-dom-v5-compat: ^6.3.0
     react-virtualized: ^9.22.3
     remark: ^13.0.0
     remark-gfm: 1.0.0
@@ -5658,6 +5660,7 @@ __metadata:
     react-dom: ^17.0.2
     react-router: ^5.2.1
     react-router-dom: ^5.3.0
+    react-router-dom-v5-compat: ^6.3.0
     styled-components: ^5.3.3
   languageName: unknown
   linkType: soft
@@ -18406,6 +18409,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"history@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "history@npm:5.3.0"
+  dependencies:
+    "@babel/runtime": ^7.7.6
+  checksum: d73c35df49d19ac172f9547d30a21a26793e83f16a78386d99583b5bf1429cc980799fcf1827eb215d31816a6600684fba9686ce78104e23bd89ec239e7c726f
+  languageName: node
+  linkType: hard
+
 "hmac-drbg@npm:^1.0.1":
   version: 1.0.1
   resolution: "hmac-drbg@npm:1.0.1"
@@ -26383,6 +26395,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-router-dom-v5-compat@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "react-router-dom-v5-compat@npm:6.3.0"
+  dependencies:
+    history: ^5.3.0
+    react-router: 6.3.0
+  peerDependencies:
+    react: ">=16.8"
+    react-dom: ">=16.8"
+    react-router-dom: 4 || 5
+  checksum: ee82b48078bac91cea3b8c499954cbf13f9261daef87e5032695946652b594b2f0590d279448ac59dd26a1c0d208a7c53d3aef2e97dcd0335f4af82df228f197
+  languageName: node
+  linkType: hard
+
 "react-router-dom@npm:^5.3.0":
   version: 5.3.0
   resolution: "react-router-dom@npm:5.3.0"
@@ -26441,6 +26467,17 @@ __metadata:
   peerDependencies:
     react: ">=16.8"
   checksum: 081a89237ab4f32195d1f2173bc4b3d95637cd6942a4d1a9e90d4ac8c80faa95528255ca2ec44c1e88c1b369e712c4ca74cba5ae3acef6fc30a51a62805b95a4
+  languageName: node
+  linkType: hard
+
+"react-router@npm:6.3.0":
+  version: 6.3.0
+  resolution: "react-router@npm:6.3.0"
+  dependencies:
+    history: ^5.2.0
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 7be673f5e72104be01e6ab274516bdb932efd93305243170690f6560e3bd1035dd1df3d3c9ce1e0f452638a2529f43a1e77dcf0934fc8031c4783da657be13ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary & Motivation

Implement the first step toward upgrading to React Router v6.

https://github.com/remix-run/react-router/discussions/8753

### How I Tested These Changes

View Dagit, verify that there are no ill effects from adding the `CompatRouter`.
