### PR TITLE
[dagit] Bring back the global asset graph as an “all asset groups” view

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -1,8 +1,17 @@
-import {Box, Checkbox, NonIdealState, SplitPanelContainer} from '@dagster-io/ui';
+import {
+  Box,
+  Checkbox,
+  Colors,
+  Icon,
+  Mono,
+  NonIdealState,
+  SplitPanelContainer,
+} from '@dagster-io/ui';
 import pickBy from 'lodash/pickBy';
 import uniq from 'lodash/uniq';
 import without from 'lodash/without';
 import React from 'react';
+import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {GraphQueryItem} from '../app/GraphQueryImpl';
@@ -12,12 +21,12 @@ import {
   QueryRefreshState,
   useQueryRefreshAtInterval,
 } from '../app/QueryRefresh';
+import {withMiddleTruncation} from '../app/Util';
 import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
 import {AssetKey} from '../assets/types';
 import {SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
 import {closestNodeInDirection} from '../graph/common';
-import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {
   GraphExplorerOptions,
   OptionsOverlay,
@@ -36,6 +45,8 @@ import {SidebarPipelineOrJobOverview} from '../pipelines/SidebarPipelineOrJobOve
 import {useDidLaunchEvent} from '../runs/RunUtils';
 import {GraphQueryInput} from '../ui/GraphQueryInput';
 import {Loading} from '../ui/Loading';
+import {buildRepoPath} from '../workspace/buildRepoAddress';
+import {workspacePath} from '../workspace/workspacePath';
 
 import {AssetConnectedEdges} from './AssetEdges';
 import {AssetNode, AssetNodeMinimal} from './AssetNode';
@@ -62,13 +73,14 @@ interface Props {
   setOptions?: (options: GraphExplorerOptions) => void;
 
   fetchOptions: AssetGraphFetchScope;
+  fetchOptionFilters?: React.ReactNode;
 
   explorerPath: ExplorerPath;
   onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
   onNavigateToForeignNode: (node: AssetLocation) => void;
 }
 
-export const EXPERIMENTAL_MINI_SCALE = 0.5;
+export const MINIMAL_SCALE = 0.5;
 
 export const AssetGraphExplorer: React.FC<Props> = (props) => {
   const {
@@ -83,7 +95,6 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
   const {liveResult, liveDataByNode} = useLiveDataForAssetKeys(graphAssetKeys);
   const liveDataRefreshState = useQueryRefreshAtInterval(liveResult, FIFTEEN_SECONDS);
 
-  useDocumentTitle('Assets');
   useDidLaunchEvent(liveResult.refetch);
 
   return (
@@ -296,6 +307,69 @@ export const AssetGraphExplorerWithData: React.FC<
                 <SVGContainer width={layout.width} height={layout.height}>
                   <AssetConnectedEdges highlighted={highlighted} edges={layout.edges} />
 
+                  {Object.values(layout.groups)
+                    .sort((a, b) => a.id.length - b.id.length)
+                    .map(
+                      ({
+                        id,
+                        bounds,
+                        groupName,
+                        repositoryName,
+                        repositoryLocationName,
+                        repositoryDisambiguationRequired,
+                      }) => (
+                        <foreignObject
+                          x={bounds.x}
+                          y={bounds.y}
+                          width={bounds.width}
+                          height={bounds.height}
+                          key={id}
+                        >
+                          <Mono
+                            style={{
+                              opacity: _scale > MINIMAL_SCALE ? (_scale - MINIMAL_SCALE) / 0.2 : 0,
+                              fontWeight: 600,
+                              display: 'flex',
+                              gap: 6,
+                            }}
+                          >
+                            <Icon name="asset_group" size={20} />
+                            <Box flex={{direction: 'column'}}>
+                              <Link
+                                style={{color: Colors.Gray900}}
+                                onClick={(e) => e.stopPropagation()}
+                                to={workspacePath(
+                                  repositoryName,
+                                  repositoryLocationName,
+                                  `/asset-groups/${groupName}`,
+                                )}
+                              >
+                                {groupName}
+                              </Link>
+                              {repositoryDisambiguationRequired && (
+                                <GroupRepoName>
+                                  {withMiddleTruncation(
+                                    buildRepoPath(repositoryName, repositoryLocationName),
+                                    {maxLength: 45},
+                                  )}
+                                </GroupRepoName>
+                              )}
+                            </Box>
+                          </Mono>
+
+                          <GroupOutline
+                            style={{
+                              top: repositoryDisambiguationRequired ? 24 + 18 : 24,
+                              border: `${Math.max(2, 2 / _scale)}px dashed ${Colors.Gray300}`,
+                              background: `rgba(223, 223, 223, ${
+                                0.4 - Math.max(0, _scale - MINIMAL_SCALE) * 0.3
+                              })`,
+                            }}
+                          />
+                        </foreignObject>
+                      ),
+                    )}
+
                   {Object.values(layout.nodes).map(({id, bounds}) => {
                     const graphNode = assetGraphData.nodes[id];
                     const path = JSON.parse(id);
@@ -315,7 +389,7 @@ export const AssetGraphExplorerWithData: React.FC<
                       >
                         {!graphNode || !graphNode.definition.opNames.length ? (
                           <ForeignNode assetKey={{path}} />
-                        ) : _scale < EXPERIMENTAL_MINI_SCALE ? (
+                        ) : _scale < MINIMAL_SCALE ? (
                           <AssetNodeMinimal
                             definition={graphNode.definition}
                             selected={selectedGraphNodes.includes(graphNode)}
@@ -382,6 +456,8 @@ export const AssetGraphExplorerWithData: React.FC<
             </Box>
           </Box>
           <QueryOverlay>
+            {props.fetchOptionFilters}
+
             <GraphQueryInput
               items={graphQueryItems}
               value={explorerPath.opsQuery}
@@ -417,6 +493,18 @@ export const AssetGraphExplorerWithData: React.FC<
 const SVGContainer = styled.svg`
   overflow: visible;
   border-radius: 0;
+`;
+
+const GroupOutline = styled.div`
+  inset: 0;
+  position: absolute;
+  border-radius: 10px;
+  pointer-events: none;
+`;
+
+const GroupRepoName = styled.div`
+  font-size: 0.8rem;
+  line-height: 0.7rem;
 `;
 
 // Helpers

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphQuery.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphQuery.ts
@@ -9,6 +9,19 @@ import { PipelineSelector, AssetGroupSelector } from "./../../types/globalTypes"
 // GraphQL query operation: AssetGraphQuery
 // ====================================================
 
+export interface AssetGraphQuery_assetNodes_repository_location {
+  __typename: "RepositoryLocation";
+  id: string;
+  name: string;
+}
+
+export interface AssetGraphQuery_assetNodes_repository {
+  __typename: "Repository";
+  id: string;
+  name: string;
+  location: AssetGraphQuery_assetNodes_repository_location;
+}
+
 export interface AssetGraphQuery_assetNodes_dependencyKeys {
   __typename: "AssetKey";
   path: string[];
@@ -27,6 +40,8 @@ export interface AssetGraphQuery_assetNodes_assetKey {
 export interface AssetGraphQuery_assetNodes {
   __typename: "AssetNode";
   id: string;
+  groupName: string | null;
+  repository: AssetGraphQuery_assetNodes_repository;
   dependencyKeys: AssetGraphQuery_assetNodes_dependencyKeys[];
   dependedByKeys: AssetGraphQuery_assetNodes_dependedByKeys[];
   graphName: string | null;

--- a/js_modules/dagit/packages/core/src/assets/AssetGroupRoot.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetGroupRoot.tsx
@@ -17,6 +17,7 @@ import {ReloadAllButton} from '../workspace/ReloadAllButton';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
+import {AssetGlobalLineageLink} from './AssetPageHeader';
 import {AssetsCatalogTable} from './AssetsCatalogTable';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 
@@ -87,11 +88,15 @@ export const AssetGroupRoot: React.FC<{repoAddress: RepoAddress; tab: 'lineage' 
           </Tag>
         }
         tabs={
-          <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
+          <Box
+            flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
+            margin={{right: 4}}
+          >
             <Tabs selectedTabId={tab}>
               <TabLink id="lineage" title="Lineage" to={`${groupPath}/lineage`} />
               <TabLink id="list" title="List" to={`${groupPath}/list`} />
             </Tabs>
+            <AssetGlobalLineageLink />
           </Box>
         }
       />

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineageGraph.tsx
@@ -4,7 +4,7 @@ import {useHistory} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {AssetConnectedEdges} from '../asset-graph/AssetEdges';
-import {EXPERIMENTAL_MINI_SCALE} from '../asset-graph/AssetGraphExplorer';
+import {MINIMAL_SCALE} from '../asset-graph/AssetGraphExplorer';
 import {AssetNodeMinimal, AssetNode} from '../asset-graph/AssetNode';
 import {ForeignNode} from '../asset-graph/ForeignNode';
 import {GraphData, LiveData, toGraphId} from '../asset-graph/Utils';
@@ -92,7 +92,7 @@ export const AssetNodeLineageGraph: React.FC<{
               >
                 {!graphNode || !graphNode.definition.opNames.length ? (
                   <ForeignNode assetKey={{path}} />
-                ) : scale < EXPERIMENTAL_MINI_SCALE ? (
+                ) : scale < MINIMAL_SCALE ? (
                   <AssetNodeMinimal
                     definition={graphNode.definition}
                     selected={graphNode.id === assetGraphId}

--- a/js_modules/dagit/packages/core/src/assets/AssetPageHeader.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPageHeader.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import {BreadcrumbProps, Breadcrumbs} from '@blueprintjs/core';
-import {Box, Colors, PageHeader, Heading} from '@dagster-io/ui';
+import {Box, Colors, PageHeader, Heading, Icon} from '@dagster-io/ui';
 import React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -43,6 +43,15 @@ export const AssetPageHeader: React.FC<Props> = ({assetKey, ...extra}) => {
   );
 };
 
+export const AssetGlobalLineageLink = () => (
+  <Link to="/instance/asset-groups">
+    <Box flex={{gap: 4}}>
+      <Icon color={Colors.Link} name="schema" />
+      View global asset lineage
+    </Box>
+  </Link>
+);
+
 const BreadcrumbsWithSlashes = styled(Breadcrumbs)`
   & li:not(:first-child)::after {
     background: none;
@@ -54,6 +63,7 @@ const BreadcrumbsWithSlashes = styled(Breadcrumbs)`
     line-height: 16px;
   }
 `;
+
 const BreadcrumbLink = styled(Link)`
   color: ${Colors.Gray800};
 

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogRoot.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogRoot.tsx
@@ -9,7 +9,7 @@ import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {ReloadAllButton} from '../workspace/ReloadAllButton';
 
-import {AssetPageHeader} from './AssetPageHeader';
+import {AssetGlobalLineageLink, AssetPageHeader} from './AssetPageHeader';
 import {AssetView} from './AssetView';
 import {AssetsCatalogTable} from './AssetsCatalogTable';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
@@ -54,7 +54,12 @@ export const AssetsCatalogRoot = () => {
     <Page>
       <AssetPageHeader
         assetKey={{path: currentPath}}
-        right={<ReloadAllButton label="Reload definitions" />}
+        right={
+          <Box flex={{gap: 12, alignItems: 'center'}}>
+            <AssetGlobalLineageLink />
+            <ReloadAllButton label="Reload definitions" />
+          </Box>
+        }
       />
       <AssetsCatalogTable
         prefixPath={currentPath}

--- a/js_modules/dagit/packages/core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
@@ -1,0 +1,86 @@
+import {Page, PageHeader, Heading} from '@dagster-io/ui';
+import * as React from 'react';
+import {useHistory, useParams} from 'react-router-dom';
+
+import {AssetGraphExplorer} from '../asset-graph/AssetGraphExplorer';
+import {AssetGraphFetchScope} from '../asset-graph/useAssetGraphData';
+import {AssetLocation} from '../asset-graph/useFindAssetLocation';
+import {useDocumentTitle} from '../hooks/useDocumentTitle';
+import {RepoFilterButton} from '../instance/RepoFilterButton';
+import {
+  ExplorerPath,
+  explorerPathFromString,
+  explorerPathToString,
+} from '../pipelines/PipelinePathUtils';
+import {ReloadAllButton} from '../workspace/ReloadAllButton';
+import {WorkspaceContext} from '../workspace/WorkspaceContext';
+
+import {assetDetailsPathForKey} from './assetDetailsPathForKey';
+
+interface AssetGroupRootParams {
+  0: string;
+}
+
+const __GLOBAL__ = '__GLOBAL__';
+
+export const AssetsGroupsGlobalGraphRoot: React.FC = () => {
+  const {0: path} = useParams<AssetGroupRootParams>();
+  const {allRepos, visibleRepos} = React.useContext(WorkspaceContext);
+  const history = useHistory();
+
+  useDocumentTitle(`Global Asset Lineage`);
+
+  const onChangeExplorerPath = React.useCallback(
+    (path: ExplorerPath, mode: 'push' | 'replace') => {
+      history[mode](
+        `/instance/asset-groups${explorerPathToString({...path, pipelineName: __GLOBAL__}).replace(
+          __GLOBAL__,
+          '',
+        )}`,
+      );
+    },
+    [history],
+  );
+
+  const onNavigateToForeignNode = React.useCallback(
+    (node: AssetLocation) => {
+      history.push(assetDetailsPathForKey(node.assetKey, {view: 'definition'}));
+    },
+    [history],
+  );
+
+  const fetchOptions = React.useMemo(() => {
+    const options: AssetGraphFetchScope = {
+      hideEdgesToNodesOutsideQuery: false,
+      hideNodesMatching: (node) => {
+        return !visibleRepos.some(
+          (repo) =>
+            repo.repositoryLocation.name === node.repository.location.name &&
+            repo.repository.name === node.repository.name,
+        );
+      },
+    };
+    return options;
+  }, [visibleRepos]);
+
+  return (
+    <Page style={{display: 'flex', flexDirection: 'column', paddingBottom: 0}}>
+      <PageHeader
+        title={<Heading>Global Asset Lineage</Heading>}
+        right={
+          <div style={{marginBottom: -8}}>
+            <ReloadAllButton label="Reload definitions" />
+          </div>
+        }
+      />
+      <AssetGraphExplorer
+        fetchOptions={fetchOptions}
+        fetchOptionFilters={<>{allRepos.length > 1 && <RepoFilterButton />}</>}
+        options={{preferAssetRendering: true, explodeComposites: true}}
+        explorerPath={explorerPathFromString(__GLOBAL__ + path || '/')}
+        onChangeExplorerPath={onChangeExplorerPath}
+        onNavigateToForeignNode={onNavigateToForeignNode}
+      />
+    </Page>
+  );
+};

--- a/js_modules/dagit/packages/core/src/instance/InstanceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceRoot.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import {Redirect, Route, Switch, useLocation} from 'react-router-dom';
 
 import {AssetsCatalogRoot} from '../assets/AssetsCatalogRoot';
+import {AssetsGroupsGlobalGraphRoot} from '../assets/AssetsGroupsGlobalGraphRoot';
 import {RunRoot} from '../runs/RunRoot';
 import {RunsRoot} from '../runs/RunsRoot';
 import {SnapshotRoot} from '../snapshots/SnapshotRoot';
@@ -20,6 +21,9 @@ export const InstanceRoot = () => {
   return (
     <MainContent ref={main}>
       <Switch>
+        <Route path="/instance/asset-groups(/?.*)">
+          <AssetsGroupsGlobalGraphRoot />
+        </Route>
         <Route path="/instance/assets(/?.*)">
           <AssetsCatalogRoot />
         </Route>

--- a/js_modules/dagit/packages/core/src/instance/RepoFilterButton.tsx
+++ b/js_modules/dagit/packages/core/src/instance/RepoFilterButton.tsx
@@ -33,6 +33,7 @@ export const RepoFilterButton: React.FC = () => {
       </Dialog>
 
       <Button
+        intent="none"
         icon={<Icon name="folder" />}
         rightIcon={<Icon name="expand_more" />}
         onClick={() => setOpen(true)}

--- a/js_modules/dagit/packages/core/src/pipelines/GraphNotices.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphNotices.tsx
@@ -86,6 +86,7 @@ const LoadingContainer = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  z-index: 2;
 `;
 
 const CenteredContainer = styled.div`
@@ -93,6 +94,7 @@ const CenteredContainer = styled.div`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  z-index: 2;
 `;
 
 const LargeDAGContainer = styled.div`


### PR DESCRIPTION
### Summary & Motivation

This PR adds a new `/instance/asset-groups` page (currently not linked to from anywhere) that restores the "Global Asset Graph" as an "All Asset Groups" page. The plan is to share this with customers that ask for it, while also collecting some feedback about what they're using it for.

Eventually, this will probably get a link / placement within Josh's new designs.

Features:

- A repository filter lets you filter down the groups that are displayed.

- The group outlines are back! They appear whenever a DAG is rendering content that spans more than one asset group, which includes the lineage views. I /think/ this is nice, but we should give it a spin and see. We could alternatively only show the grouping on this global graph. 

- I fixed a few size calculations and z-indexes that were causing slight rendering issues.

Caveats / Questions:

- We currently show just the asset group name, not it's repo + location, but we do show a separate box for each repo's group (eg: in my screenshots, there are 6 "default" groups and not just one.) I think this is clean and probably clear enough for people who are familiar with the assets, but I'm not 100% sure.

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/1037212/176934734-4019dd43-0f38-47ce-a8d0-d7ab47b7c685.png">
<img width="1840" alt="image" src="https://user-images.githubusercontent.com/1037212/176934754-9d7440bd-9775-4b3d-bf7d-647af996db10.png">

### How I Tested These Changes
