### PR TITLE
[dagit] Always show “Materialize” instead of “Rematerialize” based on status

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -376,7 +376,6 @@ export const AssetGraphExplorerWithData: React.FC<
                   ? selectedGraphNodes
                   : Object.values(assetGraphData.nodes).filter((a) => !isSourceAsset(a.definition))
                 ).map((n) => n.assetKey)}
-                liveDataByNode={liveDataByNode}
                 preferredJobName={explorerPath.pipelineName}
               />
             </Box>

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
@@ -82,7 +82,6 @@ export const AssetNodeLineage: React.FC<{
         {Object.values(assetGraphData.nodes).length > 1 ? (
           <LaunchAssetExecutionButton
             assetKeys={Object.values(assetGraphData.nodes).map((n) => n.assetKey)}
-            liveDataByNode={liveDataByNode}
             intent="none"
             context="all"
           />

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -106,10 +106,7 @@ export const AssetTable = ({
               </Button>
             </Tooltip>
           ) : (
-            <LaunchAssetExecutionButton
-              assetKeys={checkedAssets.map((c) => c.key)}
-              liveDataByNode={liveDataByNode}
-            />
+            <LaunchAssetExecutionButton assetKeys={checkedAssets.map((c) => c.key)} />
           )}
           <MoreActionsDropdown selected={checkedAssets} clearSelection={() => onToggleAll(false)} />
         </Box>

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -175,10 +175,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
               <QueryRefreshCountdown refreshState={refreshState} />
             </Box>
             {definition && definition.jobNames.length > 0 && repoAddress && upstream && (
-              <LaunchAssetExecutionButton
-                assetKeys={[definition.assetKey]}
-                liveDataByNode={liveDataByNode}
-              />
+              <LaunchAssetExecutionButton assetKeys={[definition.assetKey]} />
             )}
           </Box>
         }

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {IExecutionSession} from '../app/ExecutionSessionStorage';
 import {usePermissions} from '../app/Permissions';
-import {isSourceAsset, LiveData, toGraphId} from '../asset-graph/Utils';
+import {isSourceAsset} from '../asset-graph/Utils';
 import {useLaunchWithTelemetry} from '../launchpad/LaunchRootExecutionButton';
 import {AssetLaunchpad} from '../launchpad/LaunchpadRoot';
 import {DagsterTag} from '../runs/RunTag';
@@ -48,11 +48,10 @@ type LaunchAssetsState =
 
 export const LaunchAssetExecutionButton: React.FC<{
   assetKeys: AssetKey[]; // Memoization not required
-  liveDataByNode: LiveData;
   context?: 'all' | 'selected';
   intent?: 'primary' | 'none';
   preferredJobName?: string;
-}> = ({assetKeys, liveDataByNode, preferredJobName, context, intent = 'primary'}) => {
+}> = ({assetKeys, preferredJobName, context, intent = 'primary'}) => {
   const {canLaunchPipelineExecution} = usePermissions();
   const launchWithTelemetry = useLaunchWithTelemetry();
 
@@ -60,12 +59,7 @@ export const LaunchAssetExecutionButton: React.FC<{
   const client = useApolloClient();
 
   const count = assetKeys.length > 1 ? ` (${assetKeys.length})` : '';
-  const isRematerializeForAll = (assetKeys.length
-    ? assetKeys.map((n) => liveDataByNode[toGraphId(n)])
-    : Object.values(liveDataByNode)
-  ).every((e) => !!e?.lastMaterialization);
-
-  const label = `${isRematerializeForAll ? 'Rematerialize' : 'Materialize'}${
+  const label = `Materialize${
     context === 'all' ? ` all${count}` : context === 'selected' ? ` selected${count}` : count
   }`;
 


### PR DESCRIPTION
### Summary & Motivation

We were previously toggling the materialize button on asset views between "Materialize" and "Rematerialize" based on whether existing materializations existed for all the selected assets. This is confusing now that we support partitioned / configured assets, because the user may not think of their work as "rebuilding" the existing materialization.

Rather than keep this and scope it very narrowly to non-partitioned, non-configured assets, just remove the "Rematerialize" state entirely.

### How I Tested These Changes
