### PR TITLE
prevent multiple sensor evaluations from multithreaded race conditions

### DIFF
--- a/python_modules/dagster/dagster/core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/core/scheduler/instigation.py
@@ -41,10 +41,14 @@ class SensorInstigatorData(
     NamedTuple(
         "_SensorInstigatorData",
         [
+            # the last completed tick timestamp, exposed to the context as a deprecated field
             ("last_tick_timestamp", Optional[float]),
             ("last_run_key", Optional[str]),
             ("min_interval", Optional[int]),
             ("cursor", Optional[str]),
+            # the last time a tick was initiated, used to prevent issuing multiple threads from
+            # evaluating ticks within the minimum interval
+            ("last_tick_start_timestamp", Optional[float]),
         ],
     )
 ):
@@ -54,6 +58,7 @@ class SensorInstigatorData(
         last_run_key: Optional[str] = None,
         min_interval: Optional[int] = None,
         cursor: Optional[str] = None,
+        last_tick_start_timestamp: Optional[float] = None,
     ):
         return super(SensorInstigatorData, cls).__new__(
             cls,
@@ -61,6 +66,7 @@ class SensorInstigatorData(
             check.opt_str_param(last_run_key, "last_run_key"),
             check.opt_int_param(min_interval, "min_interval"),
             check.opt_str_param(cursor, "cursor"),
+            check.opt_float_param(last_tick_start_timestamp, "last_tick_start_timestamp"),
         )
 
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
@@ -198,7 +198,7 @@ def test_failure_after_run_created_before_run_launched(crash_location, crash_sig
 
             launch_process = spawn_ctx.Process(
                 target=_test_launch_sensor_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime.add(seconds=1), None],
+                args=[instance.get_ref(), frozen_datetime.add(seconds=31), None],
             )
             launch_process.start()
             launch_process.join(timeout=60)
@@ -282,7 +282,7 @@ def test_failure_after_run_launched(crash_location, crash_signal, capfd):
 
             launch_process = spawn_ctx.Process(
                 target=_test_launch_sensor_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime.add(seconds=1), None],
+                args=[instance.get_ref(), frozen_datetime.add(seconds=31), None],
             )
             launch_process.start()
             launch_process.join(timeout=60)


### PR DESCRIPTION
### Summary & Motivation
Seeing more than expected runs generated from the stress test.

Typically we can hit these race conditions if the evaluation takes longer than the minimum interval (30 seconds).

### How I Tested These Changes
BK
