### PR TITLE
[dagster-dbt] Allow SDAs generated with load_assets_from_dbt* to be partitioned

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -155,7 +155,7 @@ def _dbt_nodes_to_assets(
     node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey] = _get_node_asset_key,
     use_build_command: bool = False,
     partitions_def: Optional[PartitionsDefinition] = None,
-    partition_key_to_vars_fn: Optional[Callable[[str], Dict[str, Any]]] = None,
+    partition_key_to_vars_fn: Optional[Callable[[str], Mapping[str, Any]]] = None,
 ) -> AssetsDefinition:
 
     outs: Dict[str, Out] = {}
@@ -329,7 +329,7 @@ def load_assets_from_dbt_project(
     node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey] = _get_node_asset_key,
     use_build_command: bool = False,
     partitions_def: Optional[PartitionsDefinition] = None,
-    partition_key_to_vars_fn: Optional[Callable[[str], Dict[str, Any]]] = None,
+    partition_key_to_vars_fn: Optional[Callable[[str], Mapping[str, Any]]] = None,
 ) -> Sequence[AssetsDefinition]:
     """
     Loads a set of dbt models from a dbt project into Dagster assets.
@@ -409,7 +409,7 @@ def load_assets_from_dbt_manifest(
     node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey] = _get_node_asset_key,
     use_build_command: bool = False,
     partitions_def: Optional[PartitionsDefinition] = None,
-    partition_key_to_vars_fn: Optional[Callable[[str], Dict[str, Any]]] = None,
+    partition_key_to_vars_fn: Optional[Callable[[str], Mapping[str, Any]]] = None,
 ) -> Sequence[AssetsDefinition]:
     """
     Loads a set of dbt models, described in a manifest.json, into Dagster assets.


### PR DESCRIPTION
### Summary & Motivation

Addresses: https://github.com/dagster-io/dagster/issues/7683

A very minimal implementation allowing for partitioned dbt assets. Adds two new parameters, partitions_def and partition_key_to_vars_fn, which allows the user to define a function that takes the current partition key (e.g. "2022-01-01") and returns a dictionary (e.g. `{"run_date": "2022-01-01"}`).

Users that want to have multiple different partitions will need to load_assets_from_dbt_... multiple times, e.g.

```python

hourly_dbt_assets = load_assets_from_dbt_project(..., select="tag:hourly", partitions_def=HourlyPartitionsDefinition(...))
daily_dbt_assets = load_assets_from_dbt_project(..., select="tag:daily", partitions_def=DailyPartitionsDefinition(...))
```

### How I Tested These Changes
