### PR TITLE
skip threaded sensor tests in py36

### DIFF
--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -1,6 +1,7 @@
 import os
 import random
 import string
+import sys
 import tempfile
 import time
 from contextlib import contextmanager
@@ -386,7 +387,8 @@ def get_sensor_executors():
     return [
         SynchronousExecutor(),
         pytest.param(
-            SingleThreadPoolExecutor(), marks=pytest.mark.xfail(reason="multithreaded timeouts")
+            SingleThreadPoolExecutor(),
+            marks=pytest.mark.skipif(sys.version_info.minor < 7, reason="multithreaded timeouts"),
         ),
     ]
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -385,10 +385,15 @@ def workspace_load_target(attribute="the_repo"):
 
 def get_sensor_executors():
     return [
-        SynchronousExecutor(),
+        pytest.param(
+            SynchronousExecutor(),
+            marks=pytest.mark.skipif(sys.version_info.minor != 9, reason="multithreaded timeouts"),
+            id="synchronous",
+        ),
         pytest.param(
             SingleThreadPoolExecutor(),
-            marks=pytest.mark.skipif(sys.version_info.minor < 7, reason="multithreaded timeouts"),
+            marks=pytest.mark.skipif(sys.version_info.minor != 9, reason="multithreaded timeouts"),
+            id="threadpool",
         ),
     ]
 


### PR DESCRIPTION
### Summary & Motivation
We previously marked tests as failed, but because these are just triggering timeouts (because they're slow), running them (even when marked fail) will cause the test suite to fail.  Instead, just skip on py36.

### How I Tested These Changes
Inspection, BK.
