### PR TITLE
Improve race condition in run monitor

### DIFF
--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1611,6 +1611,7 @@ class DagsterInstance:
         from dagster.core.events import DagsterEvent, DagsterEventType
 
         check.inst_param(pipeline_run, "pipeline_run", PipelineRun)
+
         message = check.opt_str_param(
             message,
             "message",

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1611,7 +1611,6 @@ class DagsterInstance:
         from dagster.core.events import DagsterEvent, DagsterEventType
 
         check.inst_param(pipeline_run, "pipeline_run", PipelineRun)
-        
         message = check.opt_str_param(
             message,
             "message",

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1618,16 +1618,6 @@ class DagsterInstance:
             "This run has been marked as failed from outside the execution context.",
         )
 
-        run = self.get_run_by_id(pipeline_run.run_id)
-        if run is None:
-            raise DagsterInvariantViolationError(
-                f"Could not load run {pipeline_run.run_id} that was passed to report_run_failed"
-            )
-        if run.status not in IN_PROGRESS_RUN_STATUSES:
-            raise DagsterInvariantViolationError(
-                f"Run {run.run_id} with status {run.status} is not in a state that can be failed"
-            )
-
         dagster_event = DagsterEvent(
             event_type_value=DagsterEventType.PIPELINE_FAILURE.value,
             pipeline_name=pipeline_run.pipeline_name,

--- a/python_modules/dagster/dagster/daemon/monitoring/monitoring_daemon.py
+++ b/python_modules/dagster/dagster/daemon/monitoring/monitoring_daemon.py
@@ -42,7 +42,7 @@ def count_resume_run_attempts(instance: DagsterInstance, run_id: str):
 def monitor_started_run(instance: DagsterInstance, workspace, run, logger):
     check.invariant(run.status == PipelineRunStatus.STARTED)
     check_health_result = instance.run_launcher.check_run_worker_health(run)
-    if check_health_result.status != WorkerStatus.RUNNING:
+    if check_health_result.status not in [WorkerStatus.RUNNING, WorkerStatus.SUCCESS]:
         num_prev_attempts = count_resume_run_attempts(instance, run.run_id)
         if num_prev_attempts < instance.run_monitoring_max_resume_run_attempts:
             msg = (
@@ -61,7 +61,7 @@ def monitor_started_run(instance: DagsterInstance, workspace, run, logger):
             if instance.run_launcher.supports_resume_run:
                 msg = (
                     f"Detected run worker status {check_health_result}. Marking run {run.run_id} as "
-                    "failed, because it has surpassed the configured maximum attempts to resume the run: {max_resume_run_attempts}."
+                    f"failed, because it has surpassed the configured maximum attempts to resume the run: {max_resume_run_attempts}."
                 )
             else:
                 msg = (

--- a/python_modules/dagster/dagster/daemon/monitoring/monitoring_daemon.py
+++ b/python_modules/dagster/dagster/daemon/monitoring/monitoring_daemon.py
@@ -70,7 +70,7 @@ def monitor_started_run(instance: DagsterInstance, workspace, run, logger):
             if instance.run_launcher.supports_resume_run:
                 msg = (
                     f"Detected run worker status {check_health_result}. Marking run {run.run_id} as "
-                    f"failed, because it has surpassed the configured maximum attempts to resume the "
+                    "failed, because it has surpassed the configured maximum attempts to resume the "
                     f"run: {instance.run_monitoring_max_resume_run_attempts}."
                 )
             else:

--- a/python_modules/dagster/dagster/daemon/monitoring/monitoring_daemon.py
+++ b/python_modules/dagster/dagster/daemon/monitoring/monitoring_daemon.py
@@ -61,7 +61,7 @@ def monitor_started_run(instance: DagsterInstance, workspace, run, logger):
             if instance.run_launcher.supports_resume_run:
                 msg = (
                     f"Detected run worker status {check_health_result}. Marking run {run.run_id} as "
-                    f"failed, because it has surpassed the configured maximum attempts to resume the run: {max_resume_run_attempts}."
+                    f"failed, because it has surpassed the configured maximum attempts to resume the run: {instance.run_monitoring_max_resume_run_attempts}."
                 )
             else:
                 msg = (

--- a/python_modules/dagster/dagster/daemon/monitoring/monitoring_daemon.py
+++ b/python_modules/dagster/dagster/daemon/monitoring/monitoring_daemon.py
@@ -49,7 +49,7 @@ def monitor_started_run(instance: DagsterInstance, workspace, run, logger):
         if status_changed:
             msg = (
                 f"Detected run status changed during monitoring loop: "
-                f"{run.status} -> {new_run.status}, disregarding for now"
+                f"{run.status} -> {recheck_run.status}, disregarding for now"
             )
             logger.info(msg)
             return

--- a/python_modules/dagster/dagster/daemon/monitoring/monitoring_daemon.py
+++ b/python_modules/dagster/dagster/daemon/monitoring/monitoring_daemon.py
@@ -44,6 +44,15 @@ def monitor_started_run(instance: DagsterInstance, workspace, run, logger):
     check_health_result = instance.run_launcher.check_run_worker_health(run)
     if check_health_result.status not in [WorkerStatus.RUNNING, WorkerStatus.SUCCESS]:
         num_prev_attempts = count_resume_run_attempts(instance, run.run_id)
+        recheck_run = instance.get_run_by_id(run.run_id)
+        status_changed = run.status != recheck_run.status
+        if status_changed:
+            msg = (
+                f"Detected run status changed during monitoring loop: "
+                f"{run.status} -> {new_run.status}, disregarding for now"
+            )
+            logger.info(msg)
+            return
         if num_prev_attempts < instance.run_monitoring_max_resume_run_attempts:
             msg = (
                 f"Detected run worker status {check_health_result}. Resuming run {run.run_id} with "
@@ -61,7 +70,8 @@ def monitor_started_run(instance: DagsterInstance, workspace, run, logger):
             if instance.run_launcher.supports_resume_run:
                 msg = (
                     f"Detected run worker status {check_health_result}. Marking run {run.run_id} as "
-                    f"failed, because it has surpassed the configured maximum attempts to resume the run: {instance.run_monitoring_max_resume_run_attempts}."
+                    f"failed, because it has surpassed the configured maximum attempts to resume the "
+                    f"run: {instance.run_monitoring_max_resume_run_attempts}."
                 )
             else:
                 msg = (


### PR DESCRIPTION
### Summary & Motivation
The run monitor seems to rely on the results of the initial `get_runs` results, not taking into account the status of the run may have changed since that scan.  This can sometimes result in the run being marked as failed after it has succeeded.

`resume_run` already checks the status of the run before modification.

Added some additional logic in `monitor_started_run` to trust `check_run_worker_health` if it reports the run as succeeded, checks that the run status has not changed, and fixed a small bug with f-string.

### How I Tested These Changes
bk