### PR TITLE
Add MetaDataEntry.path to PickledObjectS3IOManager

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -2,7 +2,7 @@ import io
 import pickle
 from typing import Union
 
-from dagster import Field, InputContext, MemoizableIOManager, MetadataEntry, OutputContext, StringSource
+from dagster import Field, InputContext, MemoizableIOManager, MetadataValue, OutputContext, StringSource
 from dagster import _check as check
 from dagster import io_manager
 from dagster.utils import PICKLE_PROTOCOL
@@ -76,7 +76,7 @@ class PickledObjectS3IOManager(MemoizableIOManager):
         pickled_obj = pickle.dumps(obj, PICKLE_PROTOCOL)
         pickled_obj_bytes = io.BytesIO(pickled_obj)
         self.s3.upload_fileobj(pickled_obj_bytes, self.bucket, key)
-        yield MetadataEntry.path(path, label="uri")
+        context.add_output_metadata({"uri": MetadataValue.path(key)})
 
 
 @io_manager(

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -2,7 +2,14 @@ import io
 import pickle
 from typing import Union
 
-from dagster import Field, InputContext, MemoizableIOManager, MetadataValue, OutputContext, StringSource
+from dagster import (
+    Field,
+    InputContext,
+    MemoizableIOManager,
+    MetadataValue,
+    OutputContext,
+    StringSource,
+)
 from dagster import _check as check
 from dagster import io_manager
 from dagster.utils import PICKLE_PROTOCOL

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -2,7 +2,7 @@ import io
 import pickle
 from typing import Union
 
-from dagster import Field, InputContext, MemoizableIOManager, MetadataValue, OutputContext, StringSource
+from dagster import Field, InputContext, MemoizableIOManager, MetadataEntry, OutputContext, StringSource
 from dagster import _check as check
 from dagster import io_manager
 from dagster.utils import PICKLE_PROTOCOL
@@ -66,7 +66,8 @@ class PickledObjectS3IOManager(MemoizableIOManager):
 
     def handle_output(self, context, obj):
         key = self._get_path(context)
-        context.log.debug(f"Writing S3 object at: {self._uri_for_key(key)}")
+        path = self._uri_for_key(key)
+        context.log.debug(f"Writing S3 object at: {path}")
 
         if self._has_object(key):
             context.log.warning(f"Removing existing S3 key: {key}")
@@ -75,7 +76,7 @@ class PickledObjectS3IOManager(MemoizableIOManager):
         pickled_obj = pickle.dumps(obj, PICKLE_PROTOCOL)
         pickled_obj_bytes = io.BytesIO(pickled_obj)
         self.s3.upload_fileobj(pickled_obj_bytes, self.bucket, key)
-        context.add_output_metadata({"path": MetadataValue.path(self._uri_for_key(key))})
+        yield MetadataEntry.path(path, label="uri")
 
 
 @io_manager(

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -76,7 +76,7 @@ class PickledObjectS3IOManager(MemoizableIOManager):
         pickled_obj = pickle.dumps(obj, PICKLE_PROTOCOL)
         pickled_obj_bytes = io.BytesIO(pickled_obj)
         self.s3.upload_fileobj(pickled_obj_bytes, self.bucket, key)
-        context.add_output_metadata({"uri": MetadataValue.path(key)})
+        context.add_output_metadata({"uri": MetadataValue.path(path)})
 
 
 @io_manager(

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -2,7 +2,7 @@ import io
 import pickle
 from typing import Union
 
-from dagster import Field, InputContext, MemoizableIOManager, OutputContext, StringSource
+from dagster import Field, InputContext, MemoizableIOManager, MetadataValue, OutputContext, StringSource
 from dagster import _check as check
 from dagster import io_manager
 from dagster.utils import PICKLE_PROTOCOL
@@ -75,6 +75,7 @@ class PickledObjectS3IOManager(MemoizableIOManager):
         pickled_obj = pickle.dumps(obj, PICKLE_PROTOCOL)
         pickled_obj_bytes = io.BytesIO(pickled_obj)
         self.s3.upload_fileobj(pickled_obj_bytes, self.bucket, key)
+        context.add_output_metadata({"path": MetadataValue.path(self._uri_for_key(key))})
 
 
 @io_manager(


### PR DESCRIPTION
### Summary & Motivation
I noticed this was missing and fixed this little issue.
The uri now can be observed in the Asset view, too. 

### How I Tested These Changes
Running Dagster locally with these modifications produces the desired result:

![image](https://user-images.githubusercontent.com/49863538/177189119-5a1688b3-0d32-4986-99ca-669844b24a73.png)
