### PR TITLE
[Job Log perf] Use rAF to call throttleSetNodes

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -168,15 +168,13 @@ const useLogsProviderWithSubscription = (runId: string) => {
       }
       const queuedLogs = [...queue.current];
       queue.current = [];
-      const queuedMessages = ([] as RunDagsterRunEventFragment[]).concat(
-        ...queuedLogs.map((log) => log.messages),
-      );
+      const queuedMessages = queuedLogs.flatMap((log) => log.messages);
       const lastLog = queuedLogs[queuedLogs.length - 1];
       const hasMore = lastLog.hasMorePastEvents;
       const cursor = lastLog.cursor;
 
       dispatch({type: 'append', queued: queuedMessages, hasMore, cursor});
-      const nextPipelineStatus = pipelineStatusFromMessages(lastLog.messages);
+      const nextPipelineStatus = pipelineStatusFromMessages(queuedMessages);
 
       // If we're still loading past events, don't sync to the cache -- event chunks could
       // give us `status` values that don't match the actual state of the run.


### PR DESCRIPTION
### Summary & Motivation

There is a performance edge cases where `throttleSetNodes`'  does not end up batching logs. This happens when react rendering takes as long or longer than the `BATCH_INTERVAL` of 100ms. In that case, by the time we're done rendering, the BATCH_INTERVAL time has elapsed, and the next call to `throttleSetNodes` ends up causing another re-render before any other calls can be batched with it. To get around this problem we're using `requestAnimationFrame` so that at least all calls within a single animation frame end up getting batched together. This ends up being important for jobs with extremely high parallelism as they can have multiple messages arriving at the same time for each thread the job is executing on. 

I also looked into setting `{leading: false}` as an option to `throttle` so that it fires after `100ms` and not at the start but that doesn't solve the problem and we end up in the same situation.


### How I Tested These Changes

I modified many_events to have a lot of parallelism and set `max_concurrent = 36`

I took a bunch of chrome performance profiles and added console.log's to verify that websocket messages within the same animation frame are actually getting batched together.

This is an example of receiving 23 messages within 100ms:
<img width="1073" alt="Screen Shot 2022-07-05 at 6 11 36 AM" src="https://user-images.githubusercontent.com/2286579/177305359-3a8cd3cb-3526-4bea-bd07-e5831f588e93.png">

Before this change those 23 messages would lead to 23 consecutive react renders and cause the frames to be much longer: (Note all of the red corners indicating long frames)
<img width="1069" alt="Screen Shot 2022-07-05 at 6 00 23 AM" src="https://user-images.githubusercontent.com/2286579/177306017-5413a903-9aba-47e4-8093-69546ba2742c.png">

After- Very few frames have red corners:
<img width="1074" alt="Screen Shot 2022-07-05 at 5 59 43 AM" src="https://user-images.githubusercontent.com/2286579/177306110-9d3c318d-d9fc-44fe-bc5f-40e9b9779769.png">



In my profiling I found that what  pushes rendering over the 100ms mark is the Gantt chart. If we could virtualize it to minimize its rendering cost that would help out a lot.
