### PR TITLE
Ensure graph inputs/outputs are included in all_dagster_types

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -193,7 +193,6 @@ class GraphDefinition(NodeDefinition):
         **kwargs,
     ):
         self._node_defs = _check_node_defs_arg(name, node_defs)
-        self._dagster_type_dict = construct_dagster_type_dictionary(self._node_defs)
         self._dependencies = validate_dependency_dict(dependencies)
         self._dependency_structure, self._node_dict = create_execution_structure(
             self._node_defs, self._dependencies, graph_definition=self
@@ -230,6 +229,7 @@ class GraphDefinition(NodeDefinition):
         # must happen after base class construction as properties are assumed to be there
         # eager computation to detect cycles
         self.solids_in_topological_order = self._solids_in_topological_order()
+        self._dagster_type_dict = construct_dagster_type_dictionary([self])
 
     def _solids_in_topological_order(self):
 

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -27,7 +27,9 @@ from .builtin_config_schemas import BuiltinSchemas
 from .config_schema import DagsterTypeLoader, DagsterTypeMaterializer
 
 if t.TYPE_CHECKING:
-    from dagster.core.definitions.node_definition import NodeDefinition
+    from dagster.core.definitions.node_definition import (  # pylint: disable=unused-import
+        NodeDefinition,
+    )
     from dagster.core.execution.context.system import (  # pylint: disable=unused-import
         StepExecutionContext,
         TypeCheckContext,

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -958,7 +958,7 @@ ALL_RUNTIME_BUILTINS = list(_RUNTIME_MAP.values())
 def construct_dagster_type_dictionary(
     node_defs: Sequence["NodeDefinition"],
 ) -> Mapping[str, DagsterType]:
-    from dagster.core.definitions.solid_definition import CompositeSolidDefinition
+    from dagster.core.definitions.graph_definition import GraphDefinition
 
     type_dict_by_name = {t.unique_name: t for t in ALL_RUNTIME_BUILTINS}
     type_dict_by_key = {t.key: t for t in ALL_RUNTIME_BUILTINS}
@@ -987,7 +987,7 @@ def construct_dagster_type_dictionary(
                     ).format(type_name=dagster_type.display_name)
                 )
 
-        if isinstance(node_def, CompositeSolidDefinition):
+        if isinstance(node_def, GraphDefinition):
             for child_node_def in node_def.node_defs:
                 process_node_def(child_node_def)
 

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -4,8 +4,9 @@ from enum import Enum as PythonEnum
 from functools import partial
 from typing import AbstractSet as TypingAbstractSet
 from typing import Iterator as TypingIterator
+from typing import Mapping
 from typing import Optional as TypingOptional
-from typing import cast
+from typing import Sequence, cast
 
 import dagster._check as check
 from dagster.builtins import BuiltinEnum
@@ -26,6 +27,7 @@ from .builtin_config_schemas import BuiltinSchemas
 from .config_schema import DagsterTypeLoader, DagsterTypeMaterializer
 
 if t.TYPE_CHECKING:
+    from dagster.core.definitions.node_definition import NodeDefinition
     from dagster.core.execution.context.system import (  # pylint: disable=unused-import
         StepExecutionContext,
         TypeCheckContext,
@@ -951,11 +953,18 @@ def resolve_python_type_to_dagster_type(python_type: t.Type) -> DagsterType:
 ALL_RUNTIME_BUILTINS = list(_RUNTIME_MAP.values())
 
 
-def construct_dagster_type_dictionary(solid_defs):
+def construct_dagster_type_dictionary(
+    node_defs: Sequence["NodeDefinition"],
+) -> Mapping[str, DagsterType]:
+    from dagster.core.definitions.solid_definition import CompositeSolidDefinition
+
     type_dict_by_name = {t.unique_name: t for t in ALL_RUNTIME_BUILTINS}
     type_dict_by_key = {t.key: t for t in ALL_RUNTIME_BUILTINS}
-    for solid_def in solid_defs:
-        for dagster_type in solid_def.all_dagster_types():
+
+    def process_node_def(node_def: "NodeDefinition"):
+        input_output_types = list(node_def.all_input_output_types())
+        for dagster_type in input_output_types:
+
             # We don't do uniqueness check on key because with classes
             # like Array, Noneable, etc, those are ephemeral objects
             # and it is perfectly fine to have many of them.
@@ -975,6 +984,13 @@ def construct_dagster_type_dictionary(solid_defs):
                         "Dagster types have must have unique names."
                     ).format(type_name=dagster_type.display_name)
                 )
+
+        if isinstance(node_def, CompositeSolidDefinition):
+            for child_node_def in node_def.node_defs:
+                process_node_def(child_node_def)
+
+    for node_def in node_defs:
+        process_node_def(node_def)
 
     return type_dict_by_key
 


### PR DESCRIPTION
### Summary & Motivation

This fixes a bug (I don't think there is a tracking issue) raised in this slack conversation: https://dagster.slack.com/archives/C023MS97478/p1655325725181169

The issue is that types defined for inputs/outputs of a `GraphDefinition` weren't being included in it's `all_dagster_types` output (only types of child ops were).

### How I Tested These Changes

Reproed the issue in the slack thread (which manifested through a GraphQL error in dagit), made some changes, error disappeared.

Also added a unit test.
