### PR TITLE
Add get_daemon_statuses instance method

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
@@ -5,7 +5,6 @@ import graphene
 import dagster._check as check
 from dagster.core.instance import DagsterInstance, is_dagit_telemetry_enabled
 from dagster.core.launcher.base import RunLauncher
-from dagster.daemon.controller import get_daemon_statuses
 from dagster.daemon.types import DaemonStatus
 
 from .errors import GraphenePythonError
@@ -77,19 +76,14 @@ class GrapheneDaemonHealth(graphene.ObjectType):
 
     def resolve_daemonStatus(self, _graphene_info, daemon_type):
         check.str_param(daemon_type, "daemon_type")
-        status_by_type = get_daemon_statuses(
-            self._instance, daemon_types=[daemon_type], ignore_errors=True
+        return GrapheneDaemonStatus(
+            self._instance.get_daemon_statuses(daemon_types=[daemon_type])[daemon_type]
         )
-        return GrapheneDaemonStatus(status_by_type[daemon_type])
 
     def resolve_allDaemonStatuses(self, _graphene_info):
         return [
             GrapheneDaemonStatus(daemon_status)
-            for daemon_status in get_daemon_statuses(
-                self._instance,
-                daemon_types=self._instance.get_required_daemon_types(),
-                ignore_errors=True,
-            ).values()
+            for daemon_status in self._instance.get_daemon_statuses().values()
         ]
 
 

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -105,7 +105,7 @@ if TYPE_CHECKING:
     from dagster.core.storage.runs import RunStorage
     from dagster.core.storage.schedules import ScheduleStorage
     from dagster.core.workspace.workspace import IWorkspace
-    from dagster.daemon.types import DaemonHeartbeat
+    from dagster.daemon.types import DaemonHeartbeat, DaemonStatus
 
 
 def _check_run_equality(
@@ -2022,6 +2022,20 @@ class DagsterInstance:
         if self.run_retries_enabled:
             daemons.append(EventLogConsumerDaemon.daemon_type())
         return daemons
+
+    def get_daemon_statuses(
+        self, daemon_types: Optional[List[str]] = None
+    ) -> Dict[str, "DaemonStatus"]:
+        """
+        Get the current status of the daemons. If daemon_types aren't provided, defaults to all
+        required types. Returns a dict of daemon type to status.
+        """
+        from dagster.daemon.controller import get_daemon_statuses
+
+        check.opt_list_param(daemon_types, "daemon_types", of_type=str)
+        return get_daemon_statuses(
+            self, daemon_types=daemon_types or self.get_required_daemon_types(), ignore_errors=True
+        )
 
     # backfill
     def get_backfills(self, status=None, cursor=None, limit=None):


### PR DESCRIPTION
Need this method on the instance so I can fork it in cloud (forking via gql hit the weird resolver issues)

Under test via https://github.com/dagster-io/dagster/blob/4dbfa80c8f5b9fd61880b6d2f574c08a9fe0f28d/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_daemon_health.py