### PR TITLE
Restore sensor daemon yielding when evaluating sensors synchronously

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
@@ -45,7 +45,7 @@ def _create_sensor_tick(graphql_context):
                 graphql_context.instance,
                 logger,
                 workspace,
-                executor=SingleThreadPoolExecutor(),
+                threadpool_executor=SingleThreadPoolExecutor(),
                 debug_futures=futures,
             )
         )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -512,7 +512,7 @@ def _create_tick(graphql_context):
                 graphql_context.instance,
                 logger,
                 workspace,
-                executor=SingleThreadPoolExecutor(),
+                threadpool_executor=SingleThreadPoolExecutor(),
                 debug_futures=futures,
             )
         )

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
@@ -44,7 +44,7 @@ def _test_launch_sensor_runs_in_subprocess(instance_ref, execution_datetime, deb
                         instance,
                         logger,
                         workspace,
-                        executor=SingleThreadPoolExecutor(),
+                        threadpool_executor=SingleThreadPoolExecutor(),
                         debug_crash_flags=debug_crash_flags,
                         debug_futures=futures,
                     )

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -44,11 +44,7 @@ from dagster.core.test_utils import (
 )
 from dagster.core.workspace.load_target import PythonFileTarget
 from dagster.daemon import get_default_daemon_logger
-from dagster.daemon.sensor import (
-    SynchronousExecutor,
-    execute_sensor_iteration,
-    execute_sensor_iteration_loop,
-)
+from dagster.daemon.sensor import execute_sensor_iteration, execute_sensor_iteration_loop
 from dagster.seven.compat.pendulum import create_pendulum_time, to_timezone
 
 
@@ -386,13 +382,13 @@ def workspace_load_target(attribute="the_repo"):
 def get_sensor_executors():
     return [
         pytest.param(
-            SynchronousExecutor(),
-            marks=pytest.mark.skipif(sys.version_info.minor != 9, reason="multithreaded timeouts"),
+            None,
+            marks=pytest.mark.skipif(sys.version_info.minor != 9, reason="timeouts"),
             id="synchronous",
         ),
         pytest.param(
             SingleThreadPoolExecutor(),
-            marks=pytest.mark.skipif(sys.version_info.minor != 9, reason="multithreaded timeouts"),
+            marks=pytest.mark.skipif(sys.version_info.minor != 9, reason="timeouts"),
             id="threadpool",
         ),
     ]
@@ -406,7 +402,7 @@ def evaluate_sensors(instance, workspace, executor, timeout=75):
             instance,
             logger,
             workspace,
-            executor=executor,
+            threadpool_executor=executor,
             debug_futures=futures,
         )
     )


### PR DESCRIPTION
### Summary & Motivation
Large sensors yielding a lot of run requests can cause the sensor daemon to stop heartbeating.  This PR restores the yielding behavior for the synchronous evaluation, but perform the full evaluation when delegating to a thread pool.

### How I Tested These Changes
BK