### PR TITLE
chore: mark snapshots as generated

### DIFF
--- a/python_modules/dagster-graphql/.gitattributes
+++ b/python_modules/dagster-graphql/.gitattributes
@@ -1,0 +1,1 @@
+dagster_graphql_tests/**/snapshots/* linguist-generated=true

--- a/python_modules/dagster/.gitattributes
+++ b/python_modules/dagster/.gitattributes
@@ -1,0 +1,1 @@
+dagster_tests/**/snapshots/* linguist-generated=true


### PR DESCRIPTION
### Summary & Motivation
As the title. Snapshot tests files should be inspected, but having them marked as generated helps differentiate the real changes from the generated changes.

### How I Tested These Changes
Check stack.
