### PR TITLE
Update asset ID to contain repository location and name

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetDefinedInMultipleReposNotice.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetDefinedInMultipleReposNotice.tsx
@@ -11,6 +11,10 @@ export const AssetDefinedInMultipleReposNotice: React.FC<{
   assetId: string;
   loadedFromRepo: RepoAddress;
 }> = ({assetId, loadedFromRepo}) => {
+  function get_asset_key_from_id(id: string) {
+    return id.split('.').pop();
+  }
+
   const {data} = useQuery<AssetIdScanQuery>(ASSET_ID_SCAN_QUERY);
   const otherRepos =
     data?.repositoriesOrError.__typename === 'RepositoryConnection'
@@ -18,9 +22,10 @@ export const AssetDefinedInMultipleReposNotice: React.FC<{
           (r) => r.name !== loadedFromRepo.name || r.location.name !== loadedFromRepo.location,
         )
       : [];
-
   const otherReposWithAsset = otherRepos.filter((r) =>
-    r.assetNodes.some((a) => a.id === assetId && a.opNames.length),
+    r.assetNodes.some(
+      (a) => get_asset_key_from_id(a.id) === get_asset_key_from_id(assetId) && a.opNames.length,
+    ),
   );
 
   if (otherReposWithAsset.length === 0) {

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -185,3 +185,18 @@ def get_assets_for_run_id(graphene_info, run_id):
         if record.is_dagster_event and record.dagster_event.asset_key
     ]
     return [GrapheneAsset(key=asset_key) for asset_key in asset_keys]
+
+
+def get_unique_asset_id(
+    asset_key: AssetKey, repository_location_name: str = None, repository_name: str = None
+) -> str:
+    repository_identifier = (
+        f"{repository_location_name}.{repository_name}"
+        if repository_location_name and repository_name
+        else ""
+    )
+    return (
+        f"{repository_identifier}.{asset_key.to_string()}"
+        if repository_identifier
+        else f"{asset_key.to_string()}"
+    )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -145,6 +145,8 @@ class GrapheneAssetNode(graphene.ObjectType):
         materialization_loader: Optional[BatchMaterializationLoader] = None,
         depended_by_loader: Optional[CrossRepoAssetDependedByLoader] = None,
     ):
+        from ..implementation.fetch_assets import get_unique_asset_id
+
         self._repository_location = check.inst_param(
             repository_location,
             "repository_location",
@@ -166,7 +168,9 @@ class GrapheneAssetNode(graphene.ObjectType):
         self._node_definition_snap = None  # lazily loaded
 
         super().__init__(
-            id=external_asset_node.asset_key.to_string(),
+            id=get_unique_asset_id(
+                external_asset_node.asset_key, repository_location.name, external_repository.name
+            ),
             assetKey=external_asset_node.asset_key,
             description=external_asset_node.op_description,
             opName=external_asset_node.op_name,


### PR DESCRIPTION
### Summary & Motivation

Resolving issue https://github.com/dagster-io/dagster/issues/8705

This PR modifies the `id` field of `GrapheneAsset` and `GrapheneAssetNode` to contain repository location name and repository name (if exists). This ensures that there will not be collisions when an asset is loaded as a derived asset in one repository and a source asset in another repository.

I searched through the instances where the `id` field is used in the front end and found one spot where the implementation needed to be changed, let me know how my changes look!

### How I Tested These Changes

Locally in Dagit
