### PR TITLE
add windows testing to buildkite

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/platform.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/platform.py
@@ -1,0 +1,47 @@
+from enum import Enum
+import os
+from typing import List, Sequence
+
+from dagster_buildkite.utils import is_release_branch, safe_getenv
+
+class AvailablePlatform(str, Enum):
+
+    UNIX = "unix"
+    WINDOWS = "windows"
+
+    @classmethod
+    def get_all(cls) -> Sequence["AvailablePlatform"]:
+        return list(cls)
+
+    @classmethod
+    def get_default(cls) -> "AvailablePlatform":
+        return cls["UNIX"]
+
+    @classmethod
+    def get_pytest_defaults(cls) -> Sequence["AvailablePlatform"]:
+
+        branch_name = safe_getenv("BUILDKITE_BRANCH")
+        commit_message = safe_getenv("BUILDKITE_MESSAGE")
+        if branch_name == "master" or is_release_branch(branch_name):
+            return cls.get_all()
+        else:
+
+            # environment variable-specified defaults
+            # branch name or commit message-specified defaults
+            test_platforms = os.environ.get("TEST_PYTHON_VERSIONS", "")
+
+            env_vars = [branch_name, commit_message, test_platforms]
+
+            specified_platforms: List[AvailablePlatform] = []
+            for platform in cls.get_all():
+                marker = f"test-{platform}"
+                if any(marker in v for v in env_vars):
+                    specified_platforms.append(platform)
+            if any("test-all" in v or "test-all-platforms" in v for v in env_vars):
+                specified_platforms += cls.get_all()
+
+            return (
+                list(set(specified_platforms))
+                if len(specified_platforms) > 0
+                else [cls.get_default()]
+            )

--- a/.buildkite/dagster-buildkite/dagster_buildkite/python_version.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/python_version.py
@@ -1,6 +1,6 @@
 import os
 from enum import Enum
-from typing import List
+from typing import List, Sequence
 
 from dagster_buildkite.utils import is_release_branch, safe_getenv
 
@@ -15,7 +15,7 @@ class AvailablePythonVersion(str, Enum):
     V3_10 = "3.10.5"
 
     @classmethod
-    def get_all(cls) -> List["AvailablePythonVersion"]:
+    def get_all(cls) -> Sequence["AvailablePythonVersion"]:
         return list(cls)
 
     @classmethod
@@ -23,7 +23,7 @@ class AvailablePythonVersion(str, Enum):
         return cls["V3_9"]
 
     @classmethod
-    def get_pytest_defaults(cls) -> List["AvailablePythonVersion"]:
+    def get_pytest_defaults(cls) -> Sequence["AvailablePythonVersion"]:
 
         branch_name = safe_getenv("BUILDKITE_BRANCH")
         commit_message = safe_getenv("BUILDKITE_MESSAGE")
@@ -42,7 +42,7 @@ class AvailablePythonVersion(str, Enum):
                 marker = f"test-{cls.to_tox_factor(version)}"
                 if any(marker in v for v in env_vars):
                     specified_versions.append(version)
-            if any("test-all" in v for v in env_vars):
+            if any("test-all" in v or "test-all-pythons" in v for v in env_vars):
                 specified_versions += cls.get_all()
 
             return (

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/test_project.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/test_project.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Sequence
 
 from ..images.versions import (
     BUILDKITE_BUILD_TEST_PROJECT_IMAGE_IMAGE_VERSION,
@@ -9,7 +9,7 @@ from ..step_builder import CommandStepBuilder
 from ..utils import BuildkiteLeafStep, GroupStep
 
 
-def build_test_project_steps() -> List[GroupStep]:
+def build_test_project_steps() -> Sequence[GroupStep]:
     """This set of tasks builds and pushes Docker images, which are used by the dagster-airflow and
     the dagster-k8s tests
     """
@@ -112,7 +112,7 @@ def _test_project_step_key(version: AvailablePythonVersion) -> str:
     return f"sample-project-{AvailablePythonVersion.to_tox_factor(version)}"
 
 
-def test_project_depends_fn(version: AvailablePythonVersion, _) -> List[str]:
+def test_project_depends_fn(version: AvailablePythonVersion, _) -> Sequence[str]:
     return [_test_project_step_key(version)]
 
 
@@ -120,5 +120,5 @@ def _test_project_core_step_key(version: AvailablePythonVersion) -> str:
     return f"sample-project-core-{AvailablePythonVersion.to_tox_factor(version)}"
 
 
-def test_project_core_depends_fn(version: AvailablePythonVersion, _) -> List[str]:
+def test_project_core_depends_fn(version: AvailablePythonVersion, _) -> Sequence[str]:
     return [_test_project_core_step_key(version)]

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/tox.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/tox.py
@@ -1,8 +1,9 @@
 import os
 import re
 import shlex
-from typing import List, Optional
+from typing import Optional, Sequence
 
+from dagster_buildkite.platform import AvailablePlatform
 from dagster_buildkite.python_version import AvailablePythonVersion
 from dagster_buildkite.step_builder import BuildkiteQueue, CommandStepBuilder
 from dagster_buildkite.utils import CommandStep, make_buildkite_section_header
@@ -21,11 +22,12 @@ def build_tox_step(
     base_label: Optional[str] = None,
     command_type: str = "miscellaneous",
     python_version: Optional[AvailablePythonVersion] = None,
+    platform: Optional[AvailablePlatform] = None,
     tox_file: Optional[str] = None,
-    extra_commands_pre: Optional[List[str]] = None,
-    extra_commands_post: Optional[List[str]] = None,
-    env_vars: Optional[List[str]] = None,
-    dependencies: Optional[List[str]] = None,
+    extra_commands_pre: Optional[Sequence[str]] = None,
+    extra_commands_post: Optional[Sequence[str]] = None,
+    env_vars: Optional[Sequence[str]] = None,
+    dependencies: Optional[Sequence[str]] = None,
     retries: Optional[int] = None,
     timeout_in_minutes: Optional[int] = None,
     queue: Optional[BuildkiteQueue] = None,
@@ -65,7 +67,7 @@ def build_tox_step(
         .with_retry(retries)
         .with_dependencies(dependencies)
         .with_queue(queue)
-        .on_test_image(python_version, env_vars or [])
+        .on_test_image(python_version, platform, env_vars or [])
     ).build()
 
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from typing import Dict, List, Optional, Union
+from typing import Dict, Mapping, Optional, Sequence, Union
 
 import yaml
 from typing_extensions import Literal, TypeAlias, TypedDict
@@ -23,20 +23,20 @@ BUILD_CREATOR_EMAIL_TO_SLACK_CHANNEL_MAP = {
 
 
 class CommandStep(TypedDict, total=False):
-    agents: Dict[str, str]
-    commands: List[str]
-    depends_on: List[str]
+    agents: Mapping[str, str]
+    commands: Sequence[str]
+    depends_on: Sequence[str]
     key: str
     label: str
-    plugins: List[Dict[str, object]]
-    retry: Dict[str, object]
+    plugins: Sequence[Mapping[str, object]]
+    retry: Mapping[str, object]
     timeout_in_minutes: int
 
 
 class GroupStep(TypedDict):
     group: str
     key: str
-    steps: List["BuildkiteLeafStep"]  # no nested groups
+    steps: Sequence["BuildkiteLeafStep"]  # no nested groups
 
 
 # use alt syntax because of `async` and `if` reserved words
@@ -46,7 +46,7 @@ TriggerStep = TypedDict(
         "trigger": str,
         "label": str,
         "async": Optional[bool],
-        "build": Dict[str, object],
+        "build": Mapping[str, object],
         "branches": Optional[str],
         "if": Optional[str],
     },
@@ -111,7 +111,7 @@ def check_for_release() -> bool:
     return False
 
 
-def network_buildkite_container(network_name: str) -> List[str]:
+def network_buildkite_container(network_name: str) -> Sequence[str]:
     return [
         # hold onto your hats, this is docker networking at its best. First, we figure out
         # the name of the currently running container...
@@ -127,7 +127,7 @@ def network_buildkite_container(network_name: str) -> List[str]:
 
 def connect_sibling_docker_container(
     network_name: str, container_name: str, env_variable: str
-) -> List[str]:
+) -> Sequence[str]:
     return [
         # Now, we grab the IP address of the target container from within the target
         # bridge network and export it; this will let the tox tests talk to the target cot.


### PR DESCRIPTION
### Summary & Motivation

- Adds windows testing to BK. This was apparently attempted in the past (there was an old `buildkite-integration-windows` image that wasn't being used) but didn't get off the ground.
- Some minor type annotation adjustments to `dagster-buildkite`

### How I Tested These Changes

Pushed with `test-windows` to see if windows tests work.
