### PR TITLE
[hacker news] add missing key prefix to activity analytics python assets

### DIFF
--- a/examples/hacker_news_assets/hacker_news_assets/activity_analytics/__init__.py
+++ b/examples/hacker_news_assets/hacker_news_assets/activity_analytics/__init__.py
@@ -4,14 +4,16 @@ from dagster import AssetSelection, define_asset_job, load_assets_from_package_m
 
 from . import assets
 
+ACTIVITY_ANALYTICS = "activity_analytics"
+
 activity_analytics_assets = load_assets_from_package_module(
-    package_module=assets, key_prefix=["snowflake"], group_name="activity_analytics"
+    package_module=assets,
+    key_prefix=["snowflake", ACTIVITY_ANALYTICS],
+    group_name=ACTIVITY_ANALYTICS,
 )
 
 
 activity_analytics_assets_sensor = make_hn_tables_updated_sensor(
     # selecting by group allows us to include the activity_analytics assets that are defined in dbt
-    define_asset_job(
-        "activity_analytics_job", selection=AssetSelection.groups("activity_analytics")
-    )
+    define_asset_job("activity_analytics_job", selection=AssetSelection.groups(ACTIVITY_ANALYTICS))
 )


### PR DESCRIPTION
I missed these when I did my post-0.15.0 hacker news refactor