### PR TITLE
fix gql resolver for graph-backed assets resources

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -238,7 +238,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             ]
             external_pipeline = self.get_external_pipeline()
             constituent_resource_key_sets = [
-                self.get_required_resources(external_pipeline.get_node_def_snap(name))
+                self.get_required_resource_keys_rec(external_pipeline.get_node_def_snap(name))
                 for name in constituent_node_names
             ]
             return [key for res_key_set in constituent_resource_key_sets for key in res_key_set]


### PR DESCRIPTION
### Summary & Motivation

Fixes a bug in the resolver for required resource keys of graph-backed assets. The issue was calling a misspelled method that does not exist. Trying to figure out why `mypy` did not catch this.

### How I Tested These Changes

- Reproed issue, eliminated issue after change

Since we are doing a patch release today or tomorrow, putting this out without an additional test, but some tests are coming in a follow-up PR.