### PR TITLE
Document k8s_job_op permissions, remove cronjobs permission from helm chart

### DIFF
--- a/examples/docs_snippets/docs_snippets/deploying/kubernetes/k8s_job_op_rbac.yaml
+++ b/examples/docs_snippets/docs_snippets/deploying/kubernetes/k8s_job_op_rbac.yaml
@@ -1,0 +1,8 @@
+rules:
+  - apiGroups: ["batch"]
+      resources: ["jobs", "jobs/status"]
+      verbs: ["*"]
+  # The empty arg "" corresponds to the core API group
+  - apiGroups: [""]
+      resources: ["pods", "pods/log", "pods/status"]
+      verbs: ["*"]'

--- a/helm/dagster/charts/dagster-user-deployments/templates/role.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/role.yaml
@@ -5,25 +5,13 @@ metadata:
   name: {{ template "dagster.fullname" . }}-role
   labels: {{ include "dagster.labels" . | nindent 4 }}
 
-#
-# It is tricky to figure out the correct rules to use here, because K8s sub-resources are not
-# documented. See https://stackoverflow.com/a/51289417/11295366 for notes on how to get a list of
-# available subresources.
-#
-# The CLI command `kubectl api-resources -o wide` is also useful for understanding resources/verbs.
-#
-# The auth CLI can also be useful for verifying that access has been applied correctly. Note that
-# you MUST ensure you've fully-qualified the service account as shown below, or else kubectl will
-# lie to you about permissions.
-#
-# kubectl auth can-i --list --as system:serviceaccount:default:<release name>-dagster
-#
+# Allow the Dagster service account to read and write Kubernetes jobs and pods.
 rules:
-- apiGroups: ["batch"]
-  resources: ["jobs", "jobs/status", "cronjobs"]
-  verbs: ["*"]
-# The empty arg "" corresponds to the core API group
-- apiGroups: [""]
-  resources: ["pods", "pods/log", "pods/status"]
-  verbs: ["*"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "jobs/status"]
+    verbs: ["*"]
+  # The empty arg "" corresponds to the core API group
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/status"]
+    verbs: ["*"]
 {{- end -}}

--- a/helm/dagster/templates/role.yaml
+++ b/helm/dagster/templates/role.yaml
@@ -8,25 +8,14 @@ metadata:
     chart: {{ template "dagster.chart" .  }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-#
-# It is tricky to figure out the correct rules to use here, because K8s sub-resources are not
-# documented. See https://stackoverflow.com/a/51289417/11295366 for notes on how to get a list of
-# available subresources.
-#
-# The CLI command `kubectl api-resources -o wide` is also useful for understanding resources/verbs.
-#
-# The auth CLI can also be useful for verifying that access has been applied correctly. Note that
-# you MUST ensure you've fully-qualified the service account as shown below, or else kubectl will
-# lie to you about permissions.
-#
-# kubectl auth can-i --list --as system:serviceaccount:default:<release name>-dagster
-#
+
+# Allow the Dagster service account to read and write Kubernetes jobs and pods.
 rules:
-- apiGroups: ["batch"]
-  resources: ["jobs", "jobs/status", "cronjobs"]
-  verbs: ["*"]
-# The empty arg "" corresponds to the core API group
-- apiGroups: [""]
-  resources: ["pods", "pods/log", "pods/status"]
-  verbs: ["*"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "jobs/status"]
+    verbs: ["*"]
+  # The empty arg "" corresponds to the core API group
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/status"]
+    verbs: ["*"]
 {{- end -}}

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -88,11 +88,14 @@ def k8s_job_op(context):
     For example:
 
     .. literalinclude:: ../../../../../../python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_example_k8s_job_op.py
-       :start-after: start_marker
-       :end-before: end_marker
-       :language: python
+      :start-after: start_marker
+      :end-before: end_marker
+      :language: python
 
+    The service account that is used to run this job should have the following RBAC permissions:
 
+    .. literalinclude:: ../../../../../../examples/docs_snippets/docs_snippets/deploying/kubernetes/k8s_job_op_rbac.yaml
+       :language: YAML
     """
 
     config = context.op_config


### PR DESCRIPTION
Summary:
Noticed this when checking what permissions we need for the k8s_job_op to work - we haven't used k8s cronjobs for some time.

Also remove a somewhat unhelpful comment and instead explain why the permissions that are set are there.

### Summary & Motivation

### How I Tested These Changes
