### PR TITLE
[dagit] Add analytics.group

### DIFF
--- a/js_modules/dagit/packages/core/src/app/analytics.tsx
+++ b/js_modules/dagit/packages/core/src/app/analytics.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {useLocation, useRouteMatch} from 'react-router-dom';
 
 export interface GenericAnalytics {
+  group?: (groupId: string, traits: Record<string, any>) => void;
   identify?: (userId: string) => void;
   page: (path: string, specificPath: string) => void;
   track: (eventName: string, properties?: Record<string, any>) => void;
@@ -27,6 +28,11 @@ const useAnalytics = () => {
 };
 
 export const dummyAnalytics = () => ({
+  group: (groupId: string, traits: Record<string, any>) => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('[Group]', groupId, traits);
+    }
+  },
   identify: (id: string) => {
     if (process.env.NODE_ENV !== 'production') {
       console.log('[Identify]', id);


### PR DESCRIPTION
### Summary & Motivation

Add `analytics.group` to `GenericAnalytics`, as this is something we want to be able to do in Cloud.

### How I Tested These Changes

Buildkite, verify that it can be called as expected in Cloud.
