### PR TITLE
Change PickledObjectS3IOManager to accomodate optional s3_prefix

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -23,7 +23,7 @@ class PickledObjectS3IOManager(MemoizableIOManager):
         s3_prefix=None,
     ):
         self.bucket = check.str_param(s3_bucket, "s3_bucket")
-        self.s3_prefix = check.str_param(s3_prefix, "s3_prefix")
+        self.s3_prefix = check.opt_str_param(s3_prefix, "s3_prefix")
         self.s3 = s3_session
         self.s3.list_objects(Bucket=self.bucket, Prefix=self.s3_prefix, MaxKeys=1)
 


### PR DESCRIPTION
### Summary & Motivation

I think I might have found an issue:
```python

>>> obj = PickledObjectS3IOManager(s3_bucket="a", s3_session=session)
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/Users/ripplekhera/code/venvs/kona-venv/lib/python3.9/site-packages/dagster_aws/s3/io_manager.py", line 19, in __init__
    self.s3_prefix = check.str_param(s3_prefix, "s3_prefix")
  File "/Users/ripplekhera/code/venvs/kona-venv/lib/python3.9/site-packages/dagster/_check/__init__.py", line 1239, in str_param
    raise _param_type_mismatch_exception(obj, str, param_name, additional_message)
dagster._check.ParameterCheckError: Param "s3_prefix" is not a str. Got None which is type <class 'NoneType'>.

```

### How I Tested These Changes
