### PR TITLE
Retrieve minimal set of asset records for assetsLatestInfo

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -1,7 +1,7 @@
 from typing import Dict, List
 
 import graphene
-from dagster_graphql.implementation.fetch_runs import get_assets_live_info
+from dagster_graphql.implementation.fetch_runs import get_assets_latest_info
 
 import dagster._check as check
 from dagster.core.definitions.events import AssetKey
@@ -614,7 +614,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
             if node.assetKey in asset_keys
         }
 
-        return get_assets_live_info(graphene_info, step_keys_by_asset)
+        return get_assets_latest_info(graphene_info, step_keys_by_asset)
 
     def resolve_logsForRun(self, graphene_info, runId, afterCursor=None, limit=None):
         return get_logs_for_run(graphene_info, runId, afterCursor, limit)

--- a/python_modules/dagster/dagster/core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/in_memory.py
@@ -260,7 +260,7 @@ class InMemoryEventLogStorage(EventLogStorage, ConfigurableClass):
     ) -> Iterable[AssetRecord]:
         records = []
         for asset_key, asset in self._assets.items():
-            if not asset_keys or asset_key in asset_keys:
+            if asset_keys is None or asset_key in asset_keys:
                 wipe_timestamp = self._wiped_asset_keys.get(asset_key)
                 if (
                     not wipe_timestamp

--- a/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
@@ -913,7 +913,7 @@ class SqlEventLogStorage(EventLogStorage):
             result.extend(rows)
             should_query = bool(has_more) and bool(limit) and len(result) < cast(int, limit)
 
-        is_partial_query = bool(asset_keys) or bool(prefix) or bool(limit) or bool(cursor)
+        is_partial_query = asset_keys is not None or bool(prefix) or bool(limit) or bool(cursor)
         if not is_partial_query and self._can_mark_assets_as_migrated(rows):
             self.enable_secondary_index(ASSET_KEY_INDEX_COLS)
 
@@ -945,7 +945,7 @@ class SqlEventLogStorage(EventLogStorage):
                 ]
             )
 
-        is_partial_query = bool(asset_keys) or bool(prefix) or bool(limit) or bool(cursor)
+        is_partial_query = asset_keys is not None or bool(prefix) or bool(limit) or bool(cursor)
         if self.has_asset_key_index_cols() and not is_partial_query:
             # if the schema has been migrated, fetch the last_materialization_timestamp to see if
             # we can lazily migrate the data table

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_assets.py
@@ -130,6 +130,9 @@ def test_backcompat_asset_materializations():
             c_mat = storage.get_latest_materialization_events([c]).get(c)
             _validate_materialization(c, c_mat)
 
+            mat_by_key = storage.get_latest_materialization_events([])
+            assert len(mat_by_key) == 0
+
             mat_by_key = storage.get_latest_materialization_events([a, b, c])
             assert mat_by_key.get(a) is None
             _validate_materialization(b, mat_by_key.get(b))

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -1985,6 +1985,8 @@ class TestEventLogStorage:
                     )
                     records = storage.get_asset_records([my_asset_key])
                     assert len(records) == 1
+                    records = storage.get_asset_records([])  # should select no assets
+                    assert len(records) == 0
                     records = storage.get_asset_records()  # should select all assets
                     assert len(records) == 2
 


### PR DESCRIPTION
### Summary & Motivation

This PR makes two small changes to the GraphQL resolver for assetsLatestInfo to resolve performance issues:

- Rather than retrieve the latest materialization of all asset nodes, we traverse the asset node graph and load only the materializations that we will need to compute upstream changed.

- If we fetch the list of asset nodes required and it's empty (either because there are no SDAs or because the step_keys_by_asset array passed in was empty), exit early to avoid calling `get_asset_records` with `[]`, which it interprets as "All"

### How I Tested These Changes

I tested these changes manually by logging the asset records that were being fetched as I loaded different views in Dagit, confirming that it was just the upstream assets.