### PR TITLE
Fix issue where partitioned assets with resources fail materialization in dagit

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetConfig.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetConfig.tsx
@@ -2,7 +2,7 @@ import {gql} from '@apollo/client';
 
 import {
   SidebarAssetQuery_assetNodeOrError_AssetNode_configField as ConfigField,
-  SidebarAssetQuery_assetNodeOrError_AssetNode_configField_configType_CompositeConfigType as AssetConfigSchema,
+  SidebarAssetQuery_assetNodeOrError_AssetNode_configField_configType_CompositeConfigType as ConfigSchema,
 } from '../asset-graph/types/SidebarAssetQuery';
 import {CONFIG_TYPE_SCHEMA_FRAGMENT} from '../typeexplorer/ConfigTypeSchema';
 
@@ -10,9 +10,9 @@ export interface HasConfigField {
   configField: ConfigField | null;
 }
 
-export function configSchemaForAssetNode(assetNode: HasConfigField): AssetConfigSchema | null {
-  if (assetNode.configField) {
-    const configSchema = assetNode.configField.configType as AssetConfigSchema;
+function configSchemaForObject(obj: HasConfigField): ConfigSchema | null {
+  if (obj.configField) {
+    const configSchema = obj.configField.configType as ConfigSchema;
     if (configSchema.fields) {
       return configSchema.fields.length > 1 ? configSchema : null;
     } else {
@@ -21,6 +21,14 @@ export function configSchemaForAssetNode(assetNode: HasConfigField): AssetConfig
   } else {
     return null;
   }
+}
+
+export function configSchemaForAssetNode(obj: HasConfigField): ConfigSchema | null {
+  return configSchemaForObject(obj);
+}
+
+export function configSchemaForResource(obj: HasConfigField): ConfigSchema | null {
+  return configSchemaForObject(obj);
 }
 
 export const ASSET_NODE_CONFIG_FRAGMENT = gql`

--- a/js_modules/dagit/packages/core/src/assets/AssetConfig.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetConfig.tsx
@@ -10,7 +10,7 @@ export interface HasConfigField {
   configField: ConfigField | null;
 }
 
-function configSchemaForObject(obj: HasConfigField): ConfigSchema | null {
+export function configSchemaForAssetNode(obj: HasConfigField): ConfigSchema | null {
   if (obj.configField) {
     const configSchema = obj.configField.configType as ConfigSchema;
     if (configSchema.fields) {
@@ -21,14 +21,6 @@ function configSchemaForObject(obj: HasConfigField): ConfigSchema | null {
   } else {
     return null;
   }
-}
-
-export function configSchemaForAssetNode(obj: HasConfigField): ConfigSchema | null {
-  return configSchemaForObject(obj);
-}
-
-export function configSchemaForResource(obj: HasConfigField): ConfigSchema | null {
-  return configSchemaForObject(obj);
 }
 
 export const ASSET_NODE_CONFIG_FRAGMENT = gql`

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -19,7 +19,6 @@ import {RepoAddress} from '../workspace/types';
 import {
   ASSET_NODE_CONFIG_FRAGMENT,
   configSchemaForAssetNode,
-  configSchemaForResource,
 } from './AssetConfig';
 import {LaunchAssetChoosePartitionsDialog} from './LaunchAssetChoosePartitionsDialog';
 import {AssetKey} from './types';
@@ -107,7 +106,7 @@ export const LaunchAssetExecutionButton: React.FC<{
     const assets = result.data.assetNodes;
     const forceLaunchpad = e.shiftKey;
 
-    const next = await stateForLaunchingAssets(assets, forceLaunchpad, preferredJobName, client);
+    const next = await stateForLaunchingAssets(client, assets, forceLaunchpad, preferredJobName);
 
     if (next.type === 'error') {
       showCustomAlert({
@@ -164,10 +163,10 @@ export const LaunchAssetExecutionButton: React.FC<{
 };
 
 async function stateForLaunchingAssets(
+  client: ApolloClient<any>,
   assets: LaunchAssetExecutionAssetNodeFragment[],
   forceLaunchpad: boolean,
   preferredJobName?: string,
-  client: ApolloClient<any>,
 ): Promise<LaunchAssetsState> {
   if (assets.some(isSourceAsset)) {
     return {
@@ -234,7 +233,8 @@ async function stateForLaunchingAssets(
     };
   }
   const resources = pipeline.modes[0].resources.filter((r) => requiredResources.includes(r.name));
-  const anyResourcesHaveConfig = resources.some((a) => configSchemaForResource(a));
+  const anyResourcesHaveConfig = resources.some((r) => r.configField);
+  console.log('resources', resources, 'anyHaveConfig', anyResourcesHaveConfig);
 
   const anyAssetsHaveConfig = assets.some((a) => configSchemaForAssetNode(a));
   if ((anyAssetsHaveConfig || anyResourcesHaveConfig) && partitionDefinition) {

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -246,18 +246,6 @@ async function stateForLaunchingAssets(
 
   // Ok! Assertions met, how do we launch this run
 
-  if (anyAssetsHaveConfig || anyResourcesHaveConfig || forceLaunchpad) {
-    const assetOpNames = assets.flatMap((a) => a.opNames || []);
-    return {
-      type: 'launchpad',
-      jobName,
-      repoAddress,
-      sessionPresets: {
-        solidSelection: assetOpNames,
-        solidSelectionQuery: assetOpNames.map((name) => `"${name}"`).join(' '),
-      },
-    };
-  }
   if (partitionDefinition) {
     const assetKeys = new Set(assets.map((a) => JSON.stringify(a.assetKey)));
     const upstreamAssetKeys = uniq(
@@ -272,6 +260,18 @@ async function stateForLaunchingAssets(
       jobName,
       repoAddress,
       upstreamAssetKeys,
+    };
+  }
+  if (anyAssetsHaveConfig || anyResourcesHaveConfig || forceLaunchpad) {
+    const assetOpNames = assets.flatMap((a) => a.opNames || []);
+    return {
+      type: 'launchpad',
+      jobName,
+      repoAddress,
+      sessionPresets: {
+        solidSelection: assetOpNames,
+        solidSelectionQuery: assetOpNames.map((name) => `"${name}"`).join(' '),
+      },
     };
   }
   return {

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -230,11 +230,10 @@ async function stateForLaunchingAssets(
     };
   }
   const resources = pipeline.modes[0].resources.filter((r) => requiredResources.includes(r.name));
-  const anyResourcesHaveConfig = resources.some((r) => r.configField);
-  console.log('resources', resources, 'anyHaveConfig', anyResourcesHaveConfig);
+  const anyResourcesHaveRequiredConfig = resources.some((r) => r.configField?.isRequired);
 
   const anyAssetsHaveConfig = assets.some((a) => configSchemaForAssetNode(a));
-  if ((anyAssetsHaveConfig || anyResourcesHaveConfig) && partitionDefinition) {
+  if ((anyAssetsHaveConfig || anyResourcesHaveRequiredConfig) && partitionDefinition) {
     return {
       type: 'error',
       error: 'Cannot materialize assets using both asset/resource config and partitions.',
@@ -243,7 +242,7 @@ async function stateForLaunchingAssets(
 
   // Ok! Assertions met, how do we launch this run
 
-  if (anyAssetsHaveConfig || anyResourcesHaveConfig || forceLaunchpad) {
+  if (anyAssetsHaveConfig || anyResourcesHaveRequiredConfig || forceLaunchpad) {
     const assetOpNames = assets.flatMap((a) => a.opNames || []);
     return {
       type: 'launchpad',
@@ -357,6 +356,7 @@ const LAUNCH_ASSET_LOADER_RESOURCE_QUERY = gql`
             description
             configField {
               name
+              isRequired
               configType {
                 ...ConfigTypeSchemaFragment
                 recursiveConfigTypes {

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -16,10 +16,7 @@ import {CONFIG_TYPE_SCHEMA_FRAGMENT} from '../typeexplorer/ConfigTypeSchema';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
 
-import {
-  ASSET_NODE_CONFIG_FRAGMENT,
-  configSchemaForAssetNode,
-} from './AssetConfig';
+import {ASSET_NODE_CONFIG_FRAGMENT, configSchemaForAssetNode} from './AssetConfig';
 import {LaunchAssetChoosePartitionsDialog} from './LaunchAssetChoosePartitionsDialog';
 import {AssetKey} from './types';
 import {LaunchAssetExecutionAssetNodeFragment} from './types/LaunchAssetExecutionAssetNodeFragment';

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetLoaderResourceQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetLoaderResourceQuery.ts
@@ -526,6 +526,7 @@ export type LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resour
 export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField {
   __typename: "ConfigTypeField";
   name: string;
+  isRequired: boolean;
   configType: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType;
 }
 

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetLoaderResourceQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetLoaderResourceQuery.ts
@@ -1,0 +1,559 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { PipelineSelector } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: LaunchAssetLoaderResourceQuery
+// ====================================================
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_PipelineNotFoundError {
+  __typename: "PipelineNotFoundError" | "InvalidSubsetError" | "PythonError";
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_EnumConfigType_values {
+  __typename: "EnumConfigValue";
+  value: string;
+  description: string | null;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  values: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_EnumConfigType_values[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes = LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  recursiveConfigTypes: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_values {
+  __typename: "EnumConfigValue";
+  value: string;
+  description: string | null;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_EnumConfigType_values {
+  __typename: "EnumConfigValue";
+  value: string;
+  description: string | null;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  values: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_EnumConfigType_values[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes = LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  values: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_values[];
+  recursiveConfigTypes: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_EnumConfigType_values {
+  __typename: "EnumConfigValue";
+  value: string;
+  description: string | null;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  values: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_EnumConfigType_values[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes = LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  recursiveConfigTypes: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_EnumConfigType_values {
+  __typename: "EnumConfigValue";
+  value: string;
+  description: string | null;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  values: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_EnumConfigType_values[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes = LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_fields[];
+  recursiveConfigTypes: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_EnumConfigType_values {
+  __typename: "EnumConfigValue";
+  value: string;
+  description: string | null;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  values: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_EnumConfigType_values[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes = LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+  recursiveConfigTypes: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_EnumConfigType_values {
+  __typename: "EnumConfigValue";
+  value: string;
+  description: string | null;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  values: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_EnumConfigType_values[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+  defaultValueAsJson: string | null;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes = LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_ArrayConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_EnumConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_RegularConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_ScalarUnionConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+  recursiveConfigTypes: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes[];
+}
+
+export type LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType = LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_EnumConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_RegularConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_CompositeConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ScalarUnionConfigType | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_MapConfigType;
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField {
+  __typename: "ConfigTypeField";
+  name: string;
+  configType: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources {
+  __typename: "Resource";
+  name: string;
+  description: string | null;
+  configField: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField | null;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes {
+  __typename: "Mode";
+  id: string;
+  resources: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources[];
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline {
+  __typename: "Pipeline";
+  id: string;
+  modes: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes[];
+}
+
+export type LaunchAssetLoaderResourceQuery_pipelineOrError = LaunchAssetLoaderResourceQuery_pipelineOrError_PipelineNotFoundError | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline;
+
+export interface LaunchAssetLoaderResourceQuery {
+  pipelineOrError: LaunchAssetLoaderResourceQuery_pipelineOrError;
+}
+
+export interface LaunchAssetLoaderResourceQueryVariables {
+  pipelineSelector: PipelineSelector;
+}


### PR DESCRIPTION
### Summary & Motivation

This PR adjusts the behavior of the asset materialization button (LaunchAssetExecutionButton). Fixes #8810 

Old behavior:

If an asset had any associated resources, the launchpad modal would show. This included partitioned assets. Showing the launchpad modal would prevent the partition dialog from showing.

New behavior:

If any asset has a partition definition:

- It is an error if any asset has config OR a required resource with required config
- Otherwise, the partition window will show instead of the launchpad. This means you can't add optional config to resources at runtime

If no asset has a partition definition:

- The launchpad modal will show if any asset or resource has a config schema (regardless of whether it is required)

---

This fixes two problems: (1) launchpad modal is overly aggressive for assets with resources that don't require configuration; (2) partitioned assets with (non-configurable) resources were being blocked from materialization in dagit.

The implementation required running a second query in LaunchAssetExecutionButton to retrieve resource info off the pipeline. This is not ideal and we'll probably want to change it later.

### How I Tested These Changes

- Tried "Materialize All" on the `core` asset group in `examples/hacker_news_assets` => partition dialog
- Tried "Materialize" on the `resource_asset` for `dagster_test/graph_job_op_toys/resources.py`. It has a config schema so it shows the asset modal.