### PR TITLE
override batch loader to use asset records instead of legacy event materialization method

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -295,7 +295,10 @@ class BatchMaterializationLoader:
 
     def _fetch(self):
         self._fetched = True
-        self._materializations = self._instance.get_latest_materialization_events(self._asset_keys)
+        self._materializations = {
+            record.asset_entry.asset_key: record.asset_entry.last_materialization
+            for record in self._instance.get_asset_records(self._asset_keys)
+        }
 
 
 class CrossRepoAssetDependedByLoader:


### PR DESCRIPTION
### Summary & Motivation
In OSS this is a no-op, but in cloud, this hits an expensive back-compat query because of the way that code is structured.

For now, prefer the `get_asset_records` API which proactively prefers the asset_key table-based queries over the backcompat event log fetches.

### How I Tested These Changes
BK