### PR TITLE
Remove unused backfill stats graphql field

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1704,7 +1704,6 @@ type PartitionBackfill {
   runs(limit: Int): [Run!]!
   unfinishedRuns(limit: Int): [Run!]!
   error: PythonError
-  partitionRunStats: BackfillRunStats!
   partitionStatuses: PartitionStatuses!
 }
 
@@ -1722,15 +1721,6 @@ enum BackfillStatus {
   IN_PROGRESS
   COMPLETED
   INCOMPLETE
-}
-
-type BackfillRunStats {
-  numQueued: Int!
-  numInProgress: Int!
-  numSucceeded: Int!
-  numFailed: Int!
-  numPartitionsWithRuns: Int!
-  numTotalRuns: Int!
 }
 
 type FutureInstigationTicks {

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -97,18 +97,6 @@ class GrapheneBackfillStatus(graphene.Enum):
         name = "BackfillStatus"
 
 
-class GrapheneBackfillRunStats(graphene.ObjectType):
-    class Meta:
-        name = "BackfillRunStats"
-
-    numQueued = graphene.NonNull(graphene.Int)
-    numInProgress = graphene.NonNull(graphene.Int)
-    numSucceeded = graphene.NonNull(graphene.Int)
-    numFailed = graphene.NonNull(graphene.Int)
-    numPartitionsWithRuns = graphene.NonNull(graphene.Int)
-    numTotalRuns = graphene.NonNull(graphene.Int)
-
-
 class GraphenePartitionBackfill(graphene.ObjectType):
     class Meta:
         name = "PartitionBackfill"
@@ -133,7 +121,6 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         limit=graphene.Int(),
     )
     error = graphene.Field(GraphenePythonError)
-    partitionRunStats = graphene.NonNull(GrapheneBackfillRunStats)
     partitionStatuses = graphene.NonNull(
         "dagster_graphql.schema.partition_sets.GraphenePartitionStatuses"
     )
@@ -227,36 +214,6 @@ class GraphenePartitionBackfill(graphene.ObjectType):
                     return GrapheneBackfillStatus.COMPLETED
                 else:
                     return GrapheneBackfillStatus.INCOMPLETE
-
-    def resolve_partitionRunStats(self, graphene_info):
-        partition_run_data = self._get_partition_run_data(graphene_info)
-
-        num_queued = 0
-        num_in_progress = 0
-        num_succeeded = 0
-        num_failed = 0
-
-        for partition in partition_run_data:
-            status = partition.status
-            if status == PipelineRunStatus.QUEUED:
-                num_queued = num_queued + 1
-            elif not status in FINISHED_STATUSES:
-                num_in_progress = num_in_progress + 1
-            elif status == PipelineRunStatus.SUCCESS:
-                num_succeeded = num_succeeded + 1
-            elif status in {PipelineRunStatus.FAILURE, PipelineRunStatus.CANCELED}:
-                num_failed = num_failed + 1
-            else:
-                check.invariant(False, f"Unexpected PipelineRunStatus {status}")
-
-        return GrapheneBackfillRunStats(
-            numQueued=num_queued,
-            numInProgress=num_in_progress,
-            numSucceeded=num_succeeded,
-            numFailed=num_failed,
-            numPartitionsWithRuns=len(partition_run_data),
-            numTotalRuns=len(partition_run_data),  # hack, but this is unused
-        )
 
     def resolve_runs(self, graphene_info):
         from .pipelines.pipeline import GrapheneRun

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -493,7 +493,8 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert run_stats.get("queued") == 0
         assert run_stats.get("in_progress") == 0
         assert run_stats.get("success") == 3
-        assert run_stats.get("failure") == 1
+        assert run_stats.get("failure") == 0
+        assert run_stats.get("canceled") == 1
 
         assert result.data["partitionBackfillOrError"]["backfillStatus"] == "INCOMPLETE"
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -29,16 +29,11 @@ PARTITION_PROGRESS_QUERY = """
         fromFailure
         reexecutionSteps
         backfillStatus
-        partitionRunStats {
-          numQueued
-          numInProgress
-          numSucceeded
-          numFailed
-          numPartitionsWithRuns
-        }
-        unfinishedRuns {
-          id
-          canTerminate
+        partitionStatuses {
+          results {
+            partitionName
+            runStatus
+          }
         }
       }
       ... on PythonError {
@@ -103,6 +98,25 @@ def _seed_runs(graphql_context, partition_runs: List[Tuple[str, PipelineRunStatu
             status=status,
             tags={**PipelineRun.tags_for_backfill_id(backfill_id), PARTITION_NAME_TAG: partition},
         )
+
+
+def _get_run_stats(partition_statuses):
+    return {
+        "total": len(partition_statuses),
+        "queued": len([status for status in partition_statuses if status["runStatus"] == "QUEUED"]),
+        "in_progress": len(
+            [status for status in partition_statuses if status["runStatus"] == "STARTED"]
+        ),
+        "success": len(
+            [status for status in partition_statuses if status["runStatus"] == "SUCCESS"]
+        ),
+        "failure": len(
+            [status for status in partition_statuses if status["runStatus"] == "FAILURE"]
+        ),
+        "canceled": len(
+            [status for status in partition_statuses if status["runStatus"] == "CANCELED"]
+        ),
+    }
 
 
 class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
@@ -351,15 +365,15 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data["partitionBackfillOrError"]["status"] == "REQUESTED"
         assert result.data["partitionBackfillOrError"]["numPartitions"] == 4
         assert result.data["partitionBackfillOrError"]["backfillStatus"] == "REQUESTED"
-        assert result.data["partitionBackfillOrError"]["partitionRunStats"] == {
-            "numPartitionsWithRuns": 4,
-            "numQueued": 0,
-            "numInProgress": 1,  # "5"
-            "numSucceeded": 1,  # "4"
-            "numFailed": 2,  # "2,3"
-        }
-
-        assert len(result.data["partitionBackfillOrError"]["unfinishedRuns"]) == 4
+        run_stats = _get_run_stats(
+            result.data["partitionBackfillOrError"]["partitionStatuses"]["results"]
+        )
+        assert run_stats.get("total") == 4
+        assert run_stats.get("queued") == 0
+        assert run_stats.get("in_progress") == 1
+        assert run_stats.get("success") == 1
+        assert run_stats.get("failure") == 1
+        assert run_stats.get("canceled") == 1
 
         backfill = graphql_context.instance.get_backfill(backfill_id)
 
@@ -417,13 +431,14 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data["partitionBackfillOrError"]["status"] == "COMPLETED"
         assert result.data["partitionBackfillOrError"]["numPartitions"] == 4
 
-        assert result.data["partitionBackfillOrError"]["partitionRunStats"] == {
-            "numPartitionsWithRuns": 4,
-            "numQueued": 0,
-            "numInProgress": 0,
-            "numSucceeded": 4,
-            "numFailed": 0,
-        }
+        run_stats = _get_run_stats(
+            result.data["partitionBackfillOrError"]["partitionStatuses"]["results"]
+        )
+        assert run_stats.get("total") == 4
+        assert run_stats.get("queued") == 0
+        assert run_stats.get("in_progress") == 0
+        assert run_stats.get("success") == 4
+        assert run_stats.get("failure") == 0
 
         assert result.data["partitionBackfillOrError"]["backfillStatus"] == "COMPLETED"
 
@@ -471,14 +486,14 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data["partitionBackfillOrError"]["__typename"] == "PartitionBackfill"
         assert result.data["partitionBackfillOrError"]["status"] == "COMPLETED"
         assert result.data["partitionBackfillOrError"]["numPartitions"] == 4
-
-        assert result.data["partitionBackfillOrError"]["partitionRunStats"] == {
-            "numPartitionsWithRuns": 4,
-            "numQueued": 0,
-            "numInProgress": 0,
-            "numSucceeded": 3,
-            "numFailed": 1,
-        }
+        run_stats = _get_run_stats(
+            result.data["partitionBackfillOrError"]["partitionStatuses"]["results"]
+        )
+        assert run_stats.get("total") == 4
+        assert run_stats.get("queued") == 0
+        assert run_stats.get("in_progress") == 0
+        assert run_stats.get("success") == 3
+        assert run_stats.get("failure") == 1
 
         assert result.data["partitionBackfillOrError"]["backfillStatus"] == "INCOMPLETE"
 


### PR DESCRIPTION
### Summary & Motivation
The backfill / partition status refactor made this run-based change obsolete.

### How I Tested These Changes
BK