### PR TITLE
Extract ECS task overrides

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -1,7 +1,7 @@
 import warnings
 from collections import namedtuple
 from contextlib import suppress
-from typing import Dict
+from typing import Any, Dict
 
 import boto3
 from botocore.exceptions import ClientError
@@ -236,7 +236,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
             }
         ]
 
-        overrides = {
+        overrides: Dict[str, Any] = {
             "containerOverrides": container_overrides,
             # taskOverrides expects cpu/memory as strings
             **cpu_and_memory_overrides,


### PR DESCRIPTION
This makes it easier to extend in the future and also prevents an
additional storage call to look up the run's tags when we already have
the run.