### PR TITLE
[asset-defs] allow multi assets to have group names

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/asset_out.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_out.py
@@ -20,6 +20,7 @@ class AssetOut(
             ("description", Optional[str]),
             ("is_required", bool),
             ("dagster_type", Union[DagsterType, Type[NoValueSentinel]]),
+            ("group_name", Optional[str]),
         ],
     )
 ):
@@ -44,6 +45,8 @@ class AssetOut(
             For example, users can provide a file path if the data object will be stored in a
             filesystem, or provide information of a database table when it is going to load the data
             into the table.
+        group_name (Optional[str]): A string name used to organize multiple assets into groups. If
+            not provided, the name "default" is used.
     """
 
     def __new__(
@@ -55,6 +58,7 @@ class AssetOut(
         is_required: bool = True,
         io_manager_key: Optional[str] = None,
         metadata: Optional[MetadataUserInput] = None,
+        group_name: Optional[str] = None,
     ):
         if isinstance(key_prefix, str):
             key_prefix = [key_prefix]
@@ -72,6 +76,7 @@ class AssetOut(
                 io_manager_key, "io_manager_key", default=DEFAULT_IO_MANAGER_KEY
             ),
             metadata=check.opt_dict_param(metadata, "metadata", key_type=str),
+            group_name=check.opt_str_param(group_name, "group_name"),
         )
 
     def to_out(self) -> Out:

--- a/python_modules/dagster/dagster/core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/asset_decorator.py
@@ -335,6 +335,7 @@ def multi_asset(
     op_tags: Optional[Dict[str, Any]] = None,
     can_subset: bool = False,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
+    group_name: Optional[str] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a combined definition of multiple assets that are computed using the same op and same
     upstream assets.
@@ -381,6 +382,8 @@ def multi_asset(
             A mapping of resource keys to resource definitions. These resources
             will be initialized during execution, and can be accessed from the
             context within the body of the function.
+        group_name (Optional[str]): A string name used to organize multiple assets into groups. This
+            group name will be applied to all assets produced by this multi_asset.
     """
     asset_deps = check.opt_dict_param(
         internal_asset_deps, "internal_asset_deps", key_type=str, value_type=set
@@ -459,11 +462,23 @@ def multi_asset(
         keys_by_output_name = {
             output_name: asset_key for asset_key, (output_name, _) in asset_outs.items()
         }
+
+        # source group names from the AssetOuts (if any)
         group_names_by_key = {
             keys_by_output_name[output_name]: out.group_name
             for output_name, out in outs.items()
             if isinstance(out, AssetOut) and out.group_name is not None
         }
+        if group_name:
+            check.invariant(
+                not group_names_by_key,
+                "Cannot set group_name parameter on multi_asset if one or more of the AssetOuts "
+                "supplied to this multi_asset have a group_name defined.",
+            )
+            group_names_by_key = {
+                asset_key: group_name for asset_key in keys_by_output_name.values()
+            }
+
         return AssetsDefinition(
             keys_by_input_name=keys_by_input_name,
             keys_by_output_name=keys_by_output_name,

--- a/python_modules/dagster/dagster/core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/asset_decorator.py
@@ -459,6 +459,11 @@ def multi_asset(
         keys_by_output_name = {
             output_name: asset_key for asset_key, (output_name, _) in asset_outs.items()
         }
+        group_names_by_key = {
+            keys_by_output_name[output_name]: out.group_name
+            for output_name, out in outs.items()
+            if isinstance(out, AssetOut) and out.group_name is not None
+        }
         return AssetsDefinition(
             keys_by_input_name=keys_by_input_name,
             keys_by_output_name=keys_by_output_name,
@@ -473,6 +478,7 @@ def multi_asset(
             else None,
             can_subset=can_subset,
             resource_defs=resource_defs,
+            group_names_by_key=group_names_by_key,
         )
 
     return inner

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -157,6 +157,46 @@ def test_multi_asset_group_names():
     }
 
 
+def test_multi_asset_group_name():
+    @multi_asset(
+        outs={
+            "out1": AssetOut(key=AssetKey(["cool", "key1"])),
+            "out2": Out(),
+            "out3": AssetOut(),
+            "out4": AssetOut(key_prefix="prefix4"),
+            "out5": AssetOut(),
+        },
+        group_name="bar",
+    )
+    def my_asset():
+        pass
+
+    assert my_asset.group_names_by_key == {
+        AssetKey(["cool", "key1"]): "bar",
+        AssetKey("out2"): "bar",
+        AssetKey("out3"): "bar",
+        AssetKey(["prefix4", "out4"]): "bar",
+        AssetKey("out5"): "bar",
+    }
+
+
+def test_multi_asset_group_names_and_group_name():
+    with pytest.raises(check.CheckError):
+
+        @multi_asset(
+            outs={
+                "out1": AssetOut(group_name="foo", key=AssetKey(["cool", "key1"])),
+                "out2": Out(),
+                "out3": AssetOut(),
+                "out4": AssetOut(group_name="bar", key_prefix="prefix4"),
+                "out5": AssetOut(group_name="bar"),
+            },
+            group_name="something",
+        )
+        def my_asset():
+            pass
+
+
 def test_multi_asset_internal_asset_deps_metadata():
     @multi_asset(
         outs={

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -135,6 +135,28 @@ def test_multi_asset_infer_from_empty_asset_key():
     assert my_asset.keys == {AssetKey("my_out_name"), AssetKey("my_other_out_name")}
 
 
+def test_multi_asset_group_names():
+    @multi_asset(
+        outs={
+            "out1": AssetOut(group_name="foo", key=AssetKey(["cool", "key1"])),
+            "out2": Out(),
+            "out3": AssetOut(),
+            "out4": AssetOut(group_name="bar", key_prefix="prefix4"),
+            "out5": AssetOut(group_name="bar"),
+        }
+    )
+    def my_asset():
+        pass
+
+    assert my_asset.group_names_by_key == {
+        AssetKey(["cool", "key1"]): "foo",
+        AssetKey("out2"): "default",
+        AssetKey("out3"): "default",
+        AssetKey(["prefix4", "out4"]): "bar",
+        AssetKey("out5"): "bar",
+    }
+
+
 def test_multi_asset_internal_asset_deps_metadata():
     @multi_asset(
         outs={


### PR DESCRIPTION
### Summary & Motivation

Addresses: https://github.com/dagster-io/dagster/issues/8787

For this implementation, it seemed more natural to include this field as a part of the AssetOut class, rather than maintain this as a separate mapping.

### How I Tested These Changes

Unit tests