### PR TITLE
[dagit] Remove frame-ancestors restriction

### DIFF
--- a/js_modules/dagit/packages/app/.dagster.js
+++ b/js_modules/dagit/packages/app/.dagster.js
@@ -65,8 +65,6 @@ module.exports = {
         'style-src': isEnvDevelopment
           ? [`'unsafe-inline'`, `'self'`, `'unsafe-eval'`]
           : [`'self'`, `'nonce-NONCE-PLACEHOLDER'`],
-        // `frame-ancestors` is not supported in `meta` tags.
-        ...(isEnvDevelopment ? {} : {'frame-ancestors': `'none'`}),
       },
       options: {
         hashEnabled: {


### PR DESCRIPTION
### Summary & Motivation

Remove `frame-ancestors` CSP restriction. We don't need this for open source.

### How I Tested These Changes

View Dagit, verify that the CSP is correct.
