### PR TITLE
[dagit] Update CRA, simplify CSP

### DIFF
--- a/js_modules/dagit/packages/app/.dagster.js
+++ b/js_modules/dagit/packages/app/.dagster.js
@@ -12,59 +12,58 @@ const path = require('path');
 const dagitCorePath = path.resolve('../core/src');
 const dagitUIPath = path.resolve('../ui/src');
 
+const noncePlaceholder = 'NONCE-PLACEHOLDER';
+
 module.exports = {
   /**
-  * Proxy origin, probably defined via env var, e.g. `process.env.REACT_APP_BACKEND_ORIGIN`.
-  */
+   * Proxy origin, probably defined via env var, e.g. `process.env.REACT_APP_BACKEND_ORIGIN`.
+   */
   proxyOrigin: process.env.REACT_APP_BACKEND_ORIGIN,
 
   /**
-  * Modules that must be deduped for the Webpack build, e.g. `react`. Ex:
-  *
-  * {
-  *   react: path.resolve(pathToLocalDagit, 'node_modules/react'),
-  * }
-  */
+   * Nonce placeholder string, to be replaced at runtime by server.
+   */
+  noncePlaceholder,
+
+  /**
+   * Modules that must be deduped for the Webpack build, e.g. `react`. Ex:
+   *
+   * {
+   *   react: path.resolve(pathToLocalDagit, 'node_modules/react'),
+   * }
+   */
   moduleAliases: {
     '@dagster-io/dagit-core': dagitCorePath,
     '@dagster-io/ui': dagitUIPath,
   },
 
   /**
-  * `src` paths that must be babelified by Webpack, e.g. linked packages that are also
-  * development targets, but are outside of the CRA's own `src` directory. Ex:
-  *
-  * [
-  *   path.resolve(pathToLocalDagit, 'packages/core/src'),
-  * ]
-  */
+   * `src` paths that must be babelified by Webpack, e.g. linked packages that are also
+   * development targets, but are outside of the CRA's own `src` directory. Ex:
+   *
+   * [
+   *   path.resolve(pathToLocalDagit, 'packages/core/src'),
+   * ]
+   */
   srcPaths: [dagitCorePath, dagitUIPath],
 
   /**
-  * CSP Configuration. Receives the webpack environment to return the appropriate CSP
-  * values based on prod/dev/etc. Values are supplied to `CspHtmlWebpackPlugin`.
-  */
+   * CSP Configuration. Receives the webpack environment to return the appropriate CSP
+   * values based on prod/dev/etc. Values are supplied to `CspHtmlWebpackPlugin`.
+   */
   csp: (webpackEnv) => {
-    const isEnvDevelopment = webpackEnv === 'development';
     return {
+      // https://csp.withgoogle.com/docs/strict-csp.html
       policy: {
-        'default-src': `'none'`,
-        'base-uri': `'self'`,
-        // It shouldn't be necessary to specify WS here, but Safari is broken.
-        // https://bugs.webkit.org/show_bug.cgi?id=201591
-        'connect-src': [`'self'`, 'ws:', 'wss:'],
-        'font-src': [`'self'`, 'data:'],
-        'frame-src': isEnvDevelopment ? [`http://localhost:*`, `'self'`] : `'self'`,
-        'img-src': [`'self'`, 'data:'],
-        'manifest-src': `'self'`,
-        // Allow inline `script` and `style` in development because we don't generate a
-        // nonce when running Webpack devserver.
-        'script-src': isEnvDevelopment
-          ? [`'unsafe-inline'`, `'self'`, `'unsafe-eval'`]
-          : [`'self'`, `'nonce-NONCE-PLACEHOLDER'`],
-        'style-src': isEnvDevelopment
-          ? [`'unsafe-inline'`, `'self'`, `'unsafe-eval'`]
-          : [`'self'`, `'nonce-NONCE-PLACEHOLDER'`],
+        'base-uri': `'none'`,
+        'object-src': `'none'`,
+        'script-src': [
+          `'nonce-${noncePlaceholder}'`,
+          `'unsafe-inline'`,
+          `'strict-dynamic'`,
+          `https:`,
+          'http:',
+        ],
       },
       options: {
         hashEnabled: {

--- a/js_modules/dagit/packages/app/package.json
+++ b/js_modules/dagit/packages/app/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@dagster-io/eslint-config": "workspace:*",
-    "@dagster-io/react-scripts": "5.0.3",
+    "@dagster-io/react-scripts": "5.0.4",
     "@types/jest": "^27.4.0",
     "@types/node": "^16.11.20",
     "@types/react": "17.0.4",

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -5497,7 +5497,7 @@ __metadata:
     "@blueprintjs/select": ^3.16.4
     "@dagster-io/dagit-core": "workspace:*"
     "@dagster-io/eslint-config": "workspace:*"
-    "@dagster-io/react-scripts": 5.0.3
+    "@dagster-io/react-scripts": 5.0.4
     "@dagster-io/ui": "workspace:*"
     "@types/jest": ^27.4.0
     "@types/node": ^16.11.20
@@ -5675,9 +5675,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dagster-io/react-scripts@npm:5.0.3":
-  version: 5.0.3
-  resolution: "@dagster-io/react-scripts@npm:5.0.3"
+"@dagster-io/react-scripts@npm:5.0.4":
+  version: 5.0.4
+  resolution: "@dagster-io/react-scripts@npm:5.0.4"
   dependencies:
     "@babel/core": ^7.16.0
     "@dagster-io/eslint-config": ^1.0.1
@@ -5741,7 +5741,7 @@ __metadata:
       optional: true
   bin:
     react-scripts: bin/react-scripts.js
-  checksum: e72b6cd1bbd734e3c1e41616fbaae95eca2fdc4b2c040bdd9a425e314ea1738502af79d8b0ed48af0167f855bdcc1393aaf4c851e693b5481f6f878b280a5999
+  checksum: 42fecc6b13a4f1b980d1239f63a67dccfa68d79a9c66acad28ed2c02aa8d38ce5503e1a93532471028a871b34ee5c8bb6e2dbc2889a3a60437a37e765ffa1535
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary & Motivation

Update `@dagster-io/react-scripts` to pull in changes to allow using a simpler CSP with `strict-dynamic`, and update the CSP as suggested by Google: https://csp.withgoogle.com/docs/strict-csp.html.

### How I Tested These Changes

`yarn build`, load prod build of Dagit. Verify that the CSP looks correct and behaves as expected. Click around in the app, verify that no rogue CSP violations show up.

Repeat with JS dev build, verify same.
