### PR TITLE
include airflow_operator_to_op in apidoc

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-airflow.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-airflow.rst
@@ -17,4 +17,6 @@ Airflow (dagster-airflow)
 
 .. autofunction:: make_dagster_repo_from_airflow_example_dags
 
+.. autofunction:: airflow_operator_to_op
+
 .. autofunction:: make_dagster_pipeline_from_airflow_dag


### PR DESCRIPTION
This came up in conversations a couple times recently and I wanted to be able to send over a link.