### PR TITLE
add metadata_by_output_name

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -618,7 +618,7 @@ class AssetLayer:
                 else None
             )
         elif asset_key in self._assets_defs_by_key:
-            return self._assets_defs_by_key[asset_key].metadata_by_asset_key[asset_key]
+            return self._assets_defs_by_key[asset_key].metadata_by_key[asset_key]
         else:
             check.failed(f"Couldn't find key {asset_key}")
 

--- a/python_modules/dagster/dagster/core/definitions/assets.py
+++ b/python_modules/dagster/dagster/core/definitions/assets.py
@@ -68,7 +68,7 @@ class AssetsDefinition(ResourceAddable):
     _group_names_by_key: Mapping[AssetKey, str]
     _selected_asset_keys: AbstractSet[AssetKey]
     _can_subset: bool
-    _metadata_by_asset_key: Mapping[AssetKey, MetadataUserInput]
+    _metadata_by_key: Mapping[AssetKey, MetadataUserInput]
 
     def __init__(
         self,
@@ -82,6 +82,7 @@ class AssetsDefinition(ResourceAddable):
         can_subset: bool = False,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         group_names_by_key: Optional[Mapping[AssetKey, str]] = None,
+        metadata_by_key: Optional[Mapping[AssetKey, MetadataUserInput]] = None,
         # if adding new fields, make sure to handle them in the with_prefix_or_group
         # and from_graph methods
     ):
@@ -138,10 +139,14 @@ class AssetsDefinition(ResourceAddable):
             self._selected_asset_keys = all_asset_keys
         self._can_subset = can_subset
 
-        self._metadata_by_asset_key = {
-            asset_key: node_def.resolve_output_to_origin(output_name, None)[0].metadata
-            for output_name, asset_key in keys_by_output_name.items()
-        }
+        self._metadata_by_key = check.opt_dict_param(
+            metadata_by_key, "metadata_by_key", key_type=AssetKey, value_type=dict
+        )
+        for output_name, asset_key in keys_by_output_name.items():
+            self._metadata_by_key[asset_key] = merge_dicts(
+                node_def.resolve_output_to_origin(output_name, None)[0].metadata,
+                self._metadata_by_key.get(asset_key, {}),
+            )
 
     def __call__(self, *args, **kwargs):
         from dagster.core.definitions.decorators.solid_decorator import DecoratedSolidFunction
@@ -182,6 +187,7 @@ class AssetsDefinition(ResourceAddable):
         group_name: Optional[str] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
+        metadata_by_output_name: Optional[Mapping[str, MetadataUserInput]] = None,
     ) -> "AssetsDefinition":
         """
         Constructs an AssetsDefinition from a GraphDefinition.
@@ -213,6 +219,10 @@ class AssetsDefinition(ResourceAddable):
                 If no entry is provided for a particular asset dependency, the partition mapping defaults
                 to the default partition mapping for the partitions definition, which is typically maps
                 partition keys to the same partition keys in upstream assets.
+            metadata_by_output_name (Optional[Mapping[str, MetadataUserInput]]): Defines metadata to
+                be associated with each of the output assets for this node. Keys are names of the
+                outputs, and values are dictionaries of metadata to be associated with the related
+                asset.
         """
         return AssetsDefinition._from_node(
             graph_def,
@@ -223,6 +233,7 @@ class AssetsDefinition(ResourceAddable):
             group_name,
             resource_defs,
             partition_mappings,
+            metadata_by_output_name,
         )
 
     @staticmethod
@@ -234,6 +245,7 @@ class AssetsDefinition(ResourceAddable):
         partitions_def: Optional[PartitionsDefinition] = None,
         group_name: Optional[str] = None,
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
+        metadata_by_output_name: Optional[Mapping[str, MetadataUserInput]] = None,
     ) -> "AssetsDefinition":
         """
         Constructs an AssetsDefinition from an OpDefinition.
@@ -261,6 +273,10 @@ class AssetsDefinition(ResourceAddable):
                 If no entry is provided for a particular asset dependency, the partition mapping defaults
                 to the default partition mapping for the partitions definition, which is typically maps
                 partition keys to the same partition keys in upstream assets.
+            metadata_by_output_name (Optional[Mapping[str, MetadataUserInput]]): Defines metadata to
+                be associated with each of the output assets for this node. Keys are names of the
+                outputs, and values are dictionaries of metadata to be associated with the related
+                asset.
         """
         return AssetsDefinition._from_node(
             op_def,
@@ -270,6 +286,7 @@ class AssetsDefinition(ResourceAddable):
             partitions_def,
             group_name,
             partition_mappings=partition_mappings,
+            metadata_by_output_name=metadata_by_output_name,
         )
 
     @staticmethod
@@ -282,6 +299,7 @@ class AssetsDefinition(ResourceAddable):
         group_name: Optional[str] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
+        metadata_by_output_name: Optional[Mapping[str, MetadataUserInput]] = None,
     ) -> "AssetsDefinition":
         from .graph_definition import GraphDefinition
 
@@ -341,6 +359,12 @@ class AssetsDefinition(ResourceAddable):
                 for input_name, partition_mapping in partition_mappings.items()
             }
             if partition_mappings
+            else None,
+            metadata_by_key={
+                keys_by_output_name[output_name]: metadata
+                for output_name, metadata in metadata_by_output_name.items()
+            }
+            if metadata_by_output_name
             else None,
         )
 
@@ -439,8 +463,8 @@ class AssetsDefinition(ResourceAddable):
         return self._partitions_def
 
     @property
-    def metadata_by_asset_key(self):
-        return self._metadata_by_asset_key
+    def metadata_by_key(self):
+        return self._metadata_by_key
 
     def get_partition_mapping(self, in_asset_key: AssetKey) -> PartitionMapping:
         if self._partitions_def is None:

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -7,7 +7,7 @@ for that.
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from datetime import datetime
-from typing import Dict, List, Mapping, NamedTuple, Optional, Sequence, Set, Tuple, Union
+from typing import Dict, List, Mapping, NamedTuple, Optional, Sequence, Set, Tuple, Union, cast
 
 from dagster import StaticPartitionsDefinition
 from dagster import _check as check
@@ -24,7 +24,7 @@ from dagster.core.definitions import (
 from dagster.core.definitions.asset_layer import AssetOutputInfo
 from dagster.core.definitions.dependency import NodeOutputHandle
 from dagster.core.definitions.events import AssetKey
-from dagster.core.definitions.metadata import MetadataEntry
+from dagster.core.definitions.metadata import MetadataEntry, MetadataUserInput, normalize_metadata
 from dagster.core.definitions.mode import DEFAULT_MODE_NAME
 from dagster.core.definitions.partition import PartitionScheduleDefinition, ScheduleType
 from dagster.core.definitions.schedule_definition import DefaultScheduleStatus
@@ -801,6 +801,7 @@ def external_asset_graph_from_defs(
         AssetKey, List[Tuple[NodeOutputHandle, PipelineDefinition]]
     ] = defaultdict(list)
     asset_info_by_asset_key: Dict[AssetKey, AssetOutputInfo] = dict()
+    metadata_by_asset_key: Dict[AssetKey, MetadataUserInput] = dict()
 
     deps: Dict[AssetKey, Dict[AssetKey, ExternalAssetDependency]] = defaultdict(dict)
     dep_by: Dict[AssetKey, Dict[AssetKey, ExternalAssetDependedBy]] = defaultdict(dict)
@@ -810,6 +811,7 @@ def external_asset_graph_from_defs(
 
     for pipeline_def in pipelines:
         asset_info_by_node_output = pipeline_def.asset_layer.asset_info_by_node_output_handle
+
         for node_output_handle, asset_info in asset_info_by_node_output.items():
             if not asset_info.is_required:
                 continue
@@ -825,6 +827,7 @@ def external_asset_graph_from_defs(
             all_upstream_asset_keys.update(upstream_asset_keys)
             node_defs_by_asset_key[output_key].append((node_output_handle, pipeline_def))
             asset_info_by_asset_key[output_key] = asset_info
+
             for upstream_key in upstream_asset_keys:
                 deps[output_key][upstream_key] = ExternalAssetDependency(
                     upstream_asset_key=upstream_key
@@ -833,6 +836,8 @@ def external_asset_graph_from_defs(
                     downstream_asset_key=output_key
                 )
 
+        for assets_def in pipeline_def.asset_layer.assets_defs_by_key.values():
+            metadata_by_asset_key.update(assets_def.metadata_by_key)
         group_names.update(pipeline_def.asset_layer.group_names_by_assets())
 
     asset_keys_without_definitions = all_upstream_asset_keys.difference(
@@ -875,6 +880,15 @@ def external_asset_graph_from_defs(
         output_def = node_def.output_def_named(node_output_handle.output_name)
 
         asset_info = asset_info_by_asset_key[asset_key]
+
+        asset_metadata_entries = (
+            cast(
+                Sequence,
+                normalize_metadata(metadata=metadata_by_asset_key[asset_key], metadata_entries=[]),
+            )
+            if asset_key in metadata_by_asset_key
+            else cast(Sequence, output_def.metadata_entries)
+        )
 
         job_names = [job_def.name for _, job_def in node_tuple_list]
 
@@ -924,7 +938,7 @@ def external_asset_graph_from_defs(
                 partitions_def_data=partitions_def_data,
                 output_name=output_def.name,
                 output_description=output_def.description,
-                metadata_entries=output_def.metadata_entries,
+                metadata_entries=asset_metadata_entries,
                 # assets defined by Out(asset_key="k") do not have any group
                 # name specified we default to DEFAULT_GROUP_NAME here to ensure
                 # such assets are part of the default group

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -677,6 +677,74 @@ def test_used_source_asset():
     ]
 
 
+def test_graph_output_metadata():
+    from dagster.core.definitions.metadata import normalize_metadata
+
+    metadata = {"foo": 1, "bar": "baz"}
+
+    @op
+    def add_one(i):
+        return i + 1
+
+    @graph
+    def three(zero):
+        return add_one(add_one(add_one(zero)))
+
+    @asset
+    def zero():
+        return 0
+
+    three_asset = AssetsDefinition.from_graph(three, metadata_by_output_name={"result": metadata})
+
+    assets_job = build_assets_job("assets_job", [zero, three_asset])
+
+    external_asset_nodes = external_asset_graph_from_defs([assets_job], source_assets_by_key={})
+
+    # sort so that test is deterministic
+    sorted_nodes = sorted(
+        [
+            node._replace(
+                dependencies=sorted(node.dependencies, key=lambda d: d.upstream_asset_key),
+                depended_by=sorted(node.depended_by, key=lambda d: d.downstream_asset_key),
+                op_names=sorted(node.op_names),
+            )
+            for node in external_asset_nodes
+        ],
+        key=lambda n: n.asset_key,
+    )
+
+    assert sorted_nodes == [
+        ExternalAssetNode(
+            asset_key=AssetKey(["three"]),
+            dependencies=[ExternalAssetDependency(AssetKey(["zero"]))],
+            depended_by=[],
+            op_name="three",
+            node_definition_name="add_one",
+            graph_name="three",
+            op_names=["three.add_one", "three.add_one_2", "three.add_one_3"],
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="result",
+            metadata_entries=normalize_metadata(metadata, []),
+            group_name=DEFAULT_GROUP_NAME,
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey(["zero"]),
+            dependencies=[],
+            depended_by=[ExternalAssetDependedBy(AssetKey(["three"]))],
+            op_name="zero",
+            node_definition_name="zero",
+            graph_name=None,
+            op_names=["zero"],
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="result",
+            metadata_entries=[],
+            group_name=DEFAULT_GROUP_NAME,
+        ),
+    ]
+
+
 def test_nasty_nested_graph_asset():
     @op
     def add_one(i):


### PR DESCRIPTION
### Summary & Motivation

resolves: https://github.com/dagster-io/dagster/issues/8819

adds together explicit metadata added in the from_graph/from_op invocation with metadata sourced from the output definition


### How I Tested These Changes
