### PR TITLE
[graphql] status code based on errors

### DIFF
--- a/python_modules/dagit/dagit/graphql.py
+++ b/python_modules/dagit/dagit/graphql.py
@@ -4,8 +4,9 @@ from enum import Enum
 from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple, Union, cast
 
 from dagit.templates.playground import TEMPLATE
+from dagster_graphql.implementation.utils import ErrorCapture
 from graphene import Schema
-from graphql.error import GraphQLError
+from graphql.error import GraphQLError, GraphQLLocatedError
 from graphql.error import format_error as format_graphql_error
 from graphql.execution import ExecutionResult
 from rx import Observable
@@ -49,23 +50,23 @@ class GraphQLServer(ABC):
 
     @abstractmethod
     def build_graphql_schema(self) -> Schema:
-        raise NotImplementedError()
+        ...
 
     @abstractmethod
     def build_graphql_middleware(self) -> list:
-        raise NotImplementedError()
+        ...
 
     @abstractmethod
     def build_middleware(self) -> List[Middleware]:
-        raise NotImplementedError()
+        ...
 
     @abstractmethod
     def build_routes(self) -> List[BaseRoute]:
-        raise NotImplementedError()
+        ...
 
     @abstractmethod
     def make_request_context(self, conn: HTTPConnection):
-        raise NotImplementedError()
+        ...
 
     def handle_graphql_errors(self, errors):
         return [format_graphql_error(err) for err in errors]
@@ -126,16 +127,22 @@ class GraphQLServer(ABC):
                     status_code=status.HTTP_400_BAD_REQUEST,
                 )
 
-        result = await self.execute_graphql_request(request, query, variables, operation_name)
+        captured_errors: List[Exception] = []
+        with ErrorCapture.watch(captured_errors.append):
+            result = await self.execute_graphql_request(request, query, variables, operation_name)
 
         response_data = {"data": result.data}
-        status_code = status.HTTP_200_OK
 
         if result.errors:
             response_data["errors"] = self.handle_graphql_errors(result.errors)
-            status_code = status.HTTP_400_BAD_REQUEST
 
-        return JSONResponse(response_data, status_code=status_code)
+        return JSONResponse(
+            response_data,
+            status_code=self._determine_status_code(
+                resolver_errors=result.errors,
+                captured_errors=captured_errors,
+            ),
+        )
 
     async def graphql_ws_endpoint(self, websocket: WebSocket):
         """
@@ -255,6 +262,33 @@ class GraphQLServer(ABC):
             middleware=self.build_middleware(),
             **kwargs,
         )
+
+    def _determine_status_code(
+        self,
+        resolver_errors: Optional[List[Exception]],
+        captured_errors: List[Exception],
+    ) -> int:
+        server_error = False
+        user_error = False
+
+        if resolver_errors:
+            for error in resolver_errors:
+                if isinstance(error, GraphQLLocatedError):
+                    server_error = True
+                else:
+                    # syntax error, invalid query, etc
+                    user_error = True
+
+        if captured_errors:
+            server_error = True
+
+        if server_error:
+            return status.HTTP_500_INTERNAL_SERVER_ERROR
+
+        if user_error:
+            return status.HTTP_400_BAD_REQUEST
+
+        return status.HTTP_200_OK
 
 
 async def _handle_async_results(results: AsyncGenerator, operation_id: str, websocket: WebSocket):

--- a/python_modules/dagit/dagit_tests/webserver/test_app.py
+++ b/python_modules/dagit/dagit_tests/webserver/test_app.py
@@ -168,6 +168,13 @@ def test_graphql_post(test_client: TestClient):
     assert response.status_code == 200, response.text
     assert response.json() == {"data": {"__typename": "DagitQuery"}}
 
+    # non existent field
+    response = test_client.post(
+        "/graphql",
+        params={"query": "{__invalid}"},
+    )
+    assert response.status_code == 400, response.text
+
 
 def test_graphql_ws_error(test_client: TestClient):
     # wtf pylint

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -94,12 +94,10 @@ def stop_sensor(graphene_info, instigator_origin_id, instigator_selector_id):
         for repository in repository_location.get_repositories().values()
         for sensor in repository.get_external_sensors()
     }
-    instance.stop_sensor(
-        instigator_origin_id, instigator_selector_id, external_sensors.get(instigator_origin_id)
-    )
-    state = graphene_info.context.instance.get_instigator_state(
+    state = instance.stop_sensor(
         instigator_origin_id,
         instigator_selector_id,
+        external_sensors.get(instigator_origin_id),
     )
     return GrapheneStopSensorMutationResult(state)
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -1,5 +1,7 @@
 import sys
-from typing import Mapping, NamedTuple, Optional, Sequence, cast
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Callable, Mapping, NamedTuple, Optional, Sequence, cast
 
 from graphql.execution.base import ResolveInfo
 
@@ -30,6 +32,10 @@ def assert_permission(graphene_info: ResolveInfo, permission: str) -> None:
         raise UserFacingGraphQLError(GrapheneUnauthorizedError())
 
 
+def _noop(_):
+    pass
+
+
 class ErrorCapture:
     @staticmethod
     def default_on_exception(exc_info):
@@ -38,17 +44,32 @@ class ErrorCapture:
         # Transform exception in to PythonError to present to user
         return GraphenePythonError(serializable_error_info_from_exc_info(exc_info))
 
+    # global behavior for how to handle unexpected exceptions
     on_exception = default_on_exception
+
+    # context var for observing unexpected exceptions
+    observer: ContextVar[Callable[[Exception], None]] = ContextVar(
+        "error_capture_observer", default=_noop
+    )
+
+    @staticmethod
+    @contextmanager
+    def watch(fn: Callable[[Exception], None]):
+        token = ErrorCapture.observer.set(fn)
+        try:
+            yield
+        finally:
+            ErrorCapture.observer.reset(token)
 
 
 def capture_error(fn):
     def _fn(*args, **kwargs):
-
         try:
             return fn(*args, **kwargs)
         except UserFacingGraphQLError as de_exception:
             return de_exception.error
-        except Exception:
+        except Exception as exc:
+            ErrorCapture.observer.get()(exc)
             return ErrorCapture.on_exception(sys.exc_info())
 
     return _fn

--- a/python_modules/dagster/dagster/core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/base.py
@@ -38,7 +38,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
         """
 
     @abc.abstractmethod
-    def add_instigator_state(self, state: InstigatorState):
+    def add_instigator_state(self, state: InstigatorState) -> InstigatorState:
         """Add an instigator state to storage.
 
         Args:
@@ -46,7 +46,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
         """
 
     @abc.abstractmethod
-    def update_instigator_state(self, state: InstigatorState):
+    def update_instigator_state(self, state: InstigatorState) -> InstigatorState:
         """Update an instigator state in storage.
 
         Args:

--- a/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
@@ -120,7 +120,7 @@ class SqlScheduleStorage(ScheduleStorage):
                 )
             )
 
-    def add_instigator_state(self, state):
+    def add_instigator_state(self, state) -> InstigatorState:
         check.inst_param(state, "state", InstigatorState)
         with self.connect() as conn:
             try:
@@ -144,7 +144,7 @@ class SqlScheduleStorage(ScheduleStorage):
 
         return state
 
-    def update_instigator_state(self, state):
+    def update_instigator_state(self, state) -> InstigatorState:
         check.inst_param(state, "state", InstigatorState)
         if not self.get_instigator_state(state.instigator_origin_id, state.selector_id):
             raise DagsterInvariantViolationError(
@@ -169,6 +169,8 @@ class SqlScheduleStorage(ScheduleStorage):
             )
             if self._has_instigators_table(conn):
                 self._add_or_update_instigators_table(conn, state)
+
+        return state
 
     def delete_instigator_state(self, origin_id, selector_id):
         check.str_param(origin_id, "origin_id")


### PR DESCRIPTION
### Summary & Motivation

* instead of assuming errors returned by the `ExecutionResult` are bad queries (`400`), attempt to discern resolver errors which we now classify as `500` from syntax/query errors which should continue to `400`
* when `ErrorCapture` occurs and produces a `PythonError`, classify those requests as `500` since ideally that condition indicates an unexpected server error has occurred 
* update the Apollo `ErrorLink` to resolve requests even on `500` if graphql data is present 

* also includes a small fix to the sensor stop mutation which now producing `500` s was causing issues in tests / dagit. 

### How I Tested These Changes

BK here and internal
trigger ErrorCaptrue to generate `PythonError` payloads and ensure the front end continues to display the modal showing the error. 
