### PR TITLE
[bug] fix input loading regression

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -599,7 +599,7 @@ class AssetLayer:
 
     @property
     def has_assets_defs(self) -> bool:
-        return len(self.assets_defs_by_key) != 0
+        return len(self.assets_defs_by_key) > 0
 
     def assets_def_for_asset(self, asset_key: AssetKey) -> "AssetsDefinition":
         return self._assets_defs_by_key[asset_key]

--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -472,13 +472,11 @@ class AssetLayer:
     def from_graph(graph_def: GraphDefinition) -> "AssetLayer":
         """Scrape asset info off of InputDefinition/OutputDefinition instances"""
         check.inst_param(graph_def, "graph_def", GraphDefinition)
-        _, asset_by_output, asset_deps, io_manager_by_asset = _asset_mappings_for_node(
+        asset_by_input, asset_by_output, asset_deps, io_manager_by_asset = _asset_mappings_for_node(
             graph_def, None
         )
         return AssetLayer(
-            # we ignore InputDef<>AssetKey mappings in the AssetLayer to avoid
-            # changing input loading behavior for non-SDA JobDefinitions.
-            asset_keys_by_node_input_handle={},
+            asset_keys_by_node_input_handle=asset_by_input,
             asset_info_by_node_output_handle=asset_by_output,
             asset_deps=asset_deps,
             io_manager_keys_by_asset_key=io_manager_by_asset,
@@ -598,6 +596,10 @@ class AssetLayer:
     @property
     def assets_defs_by_key(self) -> Mapping[AssetKey, "AssetsDefinition"]:
         return self._assets_defs_by_key
+
+    @property
+    def has_assets_defs(self) -> bool:
+        return len(self.assets_defs_by_key) != 0
 
     def assets_def_for_asset(self, asset_key: AssetKey) -> "AssetsDefinition":
         return self._assets_defs_by_key[asset_key]

--- a/python_modules/dagster/dagster/core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/core/definitions/asset_layer.py
@@ -472,11 +472,13 @@ class AssetLayer:
     def from_graph(graph_def: GraphDefinition) -> "AssetLayer":
         """Scrape asset info off of InputDefinition/OutputDefinition instances"""
         check.inst_param(graph_def, "graph_def", GraphDefinition)
-        asset_by_input, asset_by_output, asset_deps, io_manager_by_asset = _asset_mappings_for_node(
+        _, asset_by_output, asset_deps, io_manager_by_asset = _asset_mappings_for_node(
             graph_def, None
         )
         return AssetLayer(
-            asset_keys_by_node_input_handle=asset_by_input,
+            # we ignore InputDef<>AssetKey mappings in the AssetLayer to avoid
+            # changing input loading behavior for non-SDA JobDefinitions.
+            asset_keys_by_node_input_handle={},
             asset_info_by_node_output_handle=asset_by_output,
             asset_deps=asset_deps,
             io_manager_keys_by_asset_key=io_manager_by_asset,

--- a/python_modules/dagster/dagster/core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/core/definitions/run_config.py
@@ -208,7 +208,11 @@ def get_inputs_field(
         has_upstream = input_has_upstream(dependency_structure, inp_handle, solid, name)
         if inp.input_manager_key:
             input_field = get_input_manager_input_field(solid, inp, resource_defs)
-        elif asset_layer.asset_key_for_input(handle, name) and not has_upstream:
+        elif (
+            asset_layer.has_assets_defs
+            and asset_layer.asset_key_for_input(handle, name)
+            and not has_upstream
+        ):
             input_field = None
         elif name in direct_inputs and not has_upstream:
             input_field = None

--- a/python_modules/dagster/dagster/core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/core/definitions/run_config.py
@@ -209,6 +209,7 @@ def get_inputs_field(
         if inp.input_manager_key:
             input_field = get_input_manager_input_field(solid, inp, resource_defs)
         elif (
+            # if you have asset definitions, input will be loaded from the source asset
             asset_layer.has_assets_defs
             and asset_layer.asset_key_for_input(handle, name)
             and not has_upstream

--- a/python_modules/dagster/dagster/core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/plan.py
@@ -482,7 +482,9 @@ def get_step_input_source(
     ):
         if input_def.root_manager_key or input_def.input_manager_key:
             return FromRootInputManager(solid_handle=handle, input_name=input_name)
-        elif asset_layer.asset_key_for_input(handle, input_handle.input_name):
+        elif asset_layer.has_assets_defs and asset_layer.asset_key_for_input(
+            handle, input_handle.input_name
+        ):
             return FromSourceAsset(solid_handle=handle, input_name=input_name)
 
     if dependency_structure.has_direct_dep(input_handle):

--- a/python_modules/dagster/dagster/core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/plan.py
@@ -482,6 +482,7 @@ def get_step_input_source(
     ):
         if input_def.root_manager_key or input_def.input_manager_key:
             return FromRootInputManager(solid_handle=handle, input_name=input_name)
+        # can only load from source asset if assets defs are available
         elif asset_layer.has_assets_defs and asset_layer.asset_key_for_input(
             handle, input_handle.input_name
         ):

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
@@ -5,6 +5,7 @@ from typing import List
 import pytest
 
 from dagster import (
+    AssetKey,
     ConfigMapping,
     DynamicOut,
     DynamicOutput,
@@ -207,6 +208,39 @@ def test_unsatisfied_input_use_root_input_manager():
     assert result.output_for_node("end") == 4
 
     # test to ensure that if start is not being executed its input config is still allowed (and ignored)
+    subset_result = full_job.execute_in_process(
+        run_config={
+            "ops": {"end": {"inputs": {"x": 1}}},
+        },
+        op_selection=["end"],
+    )
+    assert subset_result.success
+    assert subset_result.output_for_node("end") == 1
+
+
+def test_unsatisfied_input_with_asset_key_use_config():
+    @op(ins={"x": In(asset_key=AssetKey("foo"))})
+    def start(_, x: int):
+        return x
+
+    @op(ins={"x": In(asset_key=AssetKey("bar"))})
+    def end(_, x: int):
+        return x
+
+    @graph
+    def testing_io():
+        end(start())
+
+    full_job = testing_io.to_job()
+    result = full_job.execute_in_process(
+        run_config={
+            "ops": {"start": {"inputs": {"x": 4}}},
+        },
+    )
+    assert result.success
+    assert result.output_for_node("end") == 4
+
+    # test to ensure that if start is not being executed its input config is used
     subset_result = full_job.execute_in_process(
         run_config={
             "ops": {"end": {"inputs": {"x": 1}}},


### PR DESCRIPTION
### Summary & Motivation

If the following were both true:

- An `In()` of an op had an `asset_key` argument set
- That `In()` was unconnected, and intended to be loaded using a DagsterTypeLoader, e.g.:

```python
run_config={"ops": {"foo": {"inputs": {"bar": 1}}}}
```

Then you would experience an error. This is because of this line: https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/core/definitions/run_config.py#L211.

Because this input was technically mapped to an asset key, this line would evaluate to True, causing the input config schema to be None, rather than the config schema specified by the type loader.

The feature that line corresponds to is purely designed for software defined assets, which cannot be used with dagster type loaders. This change breaks any mapping of InputDefinition to AssetKey in the AssetLayer for non-SDA use cases. All instances of this mapping being used (as far as I could tell) are similarly designed around SDAs, and so this seems to be a safe change.

The equivalent asset_info_for_output_handle does not have any similar issues (as far as I can tell), so I left it in, alongside all of the other asset information we scrape out.

### How I Tested These Changes

New test failed before, succeeds now.
