### PR TITLE
[1.0] DagsterPipelineRunMetadataValue -> DagsterRunMetadataValue

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -4,10 +4,10 @@ from dagster_graphql.schema.table import GrapheneTable, GrapheneTableSchema
 
 import dagster._check as check
 import dagster.seven as seven
-from dagster.core.definitions.metadata import (
+from dagster import (
     BoolMetadataValue,
     DagsterAssetMetadataValue,
-    DagsterRunMetadataValue,
+    DagsterPipelineRunMetadataValue,
     FloatMetadataValue,
     IntMetadataValue,
     JsonMetadataValue,
@@ -115,7 +115,7 @@ def iterate_metadata_entries(metadata_entries):
                 description=metadata_entry.description,
                 boolValue=metadata_entry.entry_data.value,
             )
-        elif isinstance(metadata_entry.entry_data, DagsterRunMetadataValue):
+        elif isinstance(metadata_entry.entry_data, DagsterPipelineRunMetadataValue):
             yield GraphenePipelineRunMetadataEntry(
                 label=metadata_entry.label,
                 description=metadata_entry.description,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -7,7 +7,7 @@ import dagster.seven as seven
 from dagster.core.definitions.metadata import (
     BoolMetadataValue,
     DagsterAssetMetadataValue,
-    DagsterPipelineRunMetadataValue,
+    DagsterRunMetadataValue,
     FloatMetadataValue,
     IntMetadataValue,
     JsonMetadataValue,
@@ -115,7 +115,7 @@ def iterate_metadata_entries(metadata_entries):
                 description=metadata_entry.description,
                 boolValue=metadata_entry.entry_data.value,
             )
-        elif isinstance(metadata_entry.entry_data, DagsterPipelineRunMetadataValue):
+        elif isinstance(metadata_entry.entry_data, DagsterRunMetadataValue):
             yield GraphenePipelineRunMetadataEntry(
                 label=metadata_entry.label,
                 description=metadata_entry.description,

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -356,7 +356,7 @@ _DEPRECATED_RENAMED = {
     "FloatMetadataEntryData": (FloatMetadataValue, "1.0.0"),
     "IntMetadataEntryData": (IntMetadataValue, "1.0.0"),
     "DagsterPipelineRunMetadataEntryData": (
-        DagsterPipelineRunMetadataValue,
+        DagsterRunMetadataValue,
         "1.0.0",
     ),
     "DagsterAssetMetadataEntryData": (

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -34,6 +34,7 @@ from dagster.core.definitions import (
     ConfigMapping,
     DagsterAssetMetadataValue,
     DagsterPipelineRunMetadataValue,
+    DagsterRunMetadataValue,
     DailyPartitionsDefinition,
     DefaultScheduleStatus,
     DefaultSensorStatus,
@@ -312,9 +313,6 @@ if typing.TYPE_CHECKING:
     # pylint:disable=reimported
     from dagster.core.definitions import AssetGroup
     from dagster.core.definitions import DagsterAssetMetadataValue as DagsterAssetMetadataEntryData
-    from dagster.core.definitions import (
-        DagsterPipelineRunMetadataValue as DagsterPipelineRunMetadataEntryData,
-    )
     from dagster.core.definitions import FloatMetadataValue as FloatMetadataEntryData
     from dagster.core.definitions import IntMetadataValue as IntMetadataEntryData
     from dagster.core.definitions import JsonMetadataValue as JsonMetadataEntryData
@@ -410,6 +408,7 @@ __all__ = [
     "AssetsDefinition",
     "DagsterAssetMetadataValue",
     "DagsterPipelineRunMetadataValue",
+    "DagsterRunMetadataValue",
     "TableColumn",
     "TableColumnConstraints",
     "TableConstraints",

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -312,6 +312,9 @@ if typing.TYPE_CHECKING:
     # pylint:disable=reimported
     from dagster.core.definitions import AssetGroup
     from dagster.core.definitions import DagsterAssetMetadataValue as DagsterAssetMetadataEntryData
+    from dagster.core.definitions import (
+        DagsterRunMetadataValue as DagsterPipelineRunMetadataEntryData,
+    )
     from dagster.core.definitions import DagsterRunMetadataValue as DagsterPipelineRunMetadataValue
     from dagster.core.definitions import FloatMetadataValue as FloatMetadataEntryData
     from dagster.core.definitions import IntMetadataValue as IntMetadataEntryData

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -33,7 +33,7 @@ from dagster.core.definitions import (
     CompositeSolidDefinition,
     ConfigMapping,
     DagsterAssetMetadataValue,
-    DagsterPipelineRunMetadataValue,
+    DagsterRunMetadataValue,
     DagsterRunMetadataValue,
     DailyPartitionsDefinition,
     DefaultScheduleStatus,
@@ -319,6 +319,7 @@ if typing.TYPE_CHECKING:
     from dagster.core.definitions import MarkdownMetadataValue as MarkdownMetadataEntryData
     from dagster.core.definitions import MetadataEntry as EventMetadataEntry
     from dagster.core.definitions import MetadataValue as EventMetadata
+    from dagster.core.definitions import DagsterRunMetadataValue as DagsterPipelineRunMetadataValue
     from dagster.core.definitions import PathMetadataValue as PathMetadataEntryData
     from dagster.core.definitions import (
         PythonArtifactMetadataValue as PythonArtifactMetadataEntryData,
@@ -365,6 +366,7 @@ _DEPRECATED_RENAMED = {
         TableSchemaMetadataValue,
         "1.0.0",
     ),
+    "DagsterPipelineRunMetadataValue": (DagsterRunMetadataValue, "1.0.0"),
 }
 
 
@@ -407,7 +409,7 @@ __all__ = [
     "AssetSensorDefinition",
     "AssetsDefinition",
     "DagsterAssetMetadataValue",
-    "DagsterPipelineRunMetadataValue",
+    "DagsterRunMetadataValue",
     "DagsterRunMetadataValue",
     "TableColumn",
     "TableColumnConstraints",

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -34,7 +34,6 @@ from dagster.core.definitions import (
     ConfigMapping,
     DagsterAssetMetadataValue,
     DagsterRunMetadataValue,
-    DagsterRunMetadataValue,
     DailyPartitionsDefinition,
     DefaultScheduleStatus,
     DefaultSensorStatus,
@@ -313,13 +312,13 @@ if typing.TYPE_CHECKING:
     # pylint:disable=reimported
     from dagster.core.definitions import AssetGroup
     from dagster.core.definitions import DagsterAssetMetadataValue as DagsterAssetMetadataEntryData
+    from dagster.core.definitions import DagsterRunMetadataValue as DagsterPipelineRunMetadataValue
     from dagster.core.definitions import FloatMetadataValue as FloatMetadataEntryData
     from dagster.core.definitions import IntMetadataValue as IntMetadataEntryData
     from dagster.core.definitions import JsonMetadataValue as JsonMetadataEntryData
     from dagster.core.definitions import MarkdownMetadataValue as MarkdownMetadataEntryData
     from dagster.core.definitions import MetadataEntry as EventMetadataEntry
     from dagster.core.definitions import MetadataValue as EventMetadata
-    from dagster.core.definitions import DagsterRunMetadataValue as DagsterPipelineRunMetadataValue
     from dagster.core.definitions import PathMetadataValue as PathMetadataEntryData
     from dagster.core.definitions import (
         PythonArtifactMetadataValue as PythonArtifactMetadataEntryData,
@@ -409,7 +408,6 @@ __all__ = [
     "AssetSensorDefinition",
     "AssetsDefinition",
     "DagsterAssetMetadataValue",
-    "DagsterRunMetadataValue",
     "DagsterRunMetadataValue",
     "TableColumn",
     "TableColumnConstraints",

--- a/python_modules/dagster/dagster/core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/__init__.py
@@ -76,7 +76,7 @@ from .materialize import materialize, materialize_to_memory
 from .metadata import (
     BoolMetadataValue,
     DagsterAssetMetadataValue,
-    DagsterPipelineRunMetadataValue,
+    DagsterRunMetadataValue,
     FloatMetadataValue,
     IntMetadataValue,
     JsonMetadataValue,

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -714,29 +714,37 @@ class BoolMetadataValue(
 
 
 @whitelist_for_serdes(storage_name="DagsterPipelineRunMetadataEntryData")
-class DagsterPipelineRunMetadataValue(
+class DagsterRunMetadataValue(
     NamedTuple(
-        "_DagsterPipelineRunMetadataValue",
+        "_DagsterRunMetadataValue",
         [
             ("run_id", str),
         ],
     ),
     MetadataValue,
 ):
-    """Representation of a dagster pipeline run.
+    """Representation of a dagster run.
 
     Args:
-        run_id (str): The pipeline run id
+        run_id (str): The run id
     """
 
     def __new__(cls, run_id: str):
-        return super(DagsterPipelineRunMetadataValue, cls).__new__(
-            cls, check.str_param(run_id, "run_id")
-        )
+        return super(DagsterRunMetadataValue, cls).__new__(cls, check.str_param(run_id, "run_id"))
 
     @property
     def value(self) -> str:
         return self.run_id
+
+
+class DagsterPipelineRunMetadataValue(DagsterRunMetadataValue):
+    def __new__(cls, run_id: str):
+        deprecation_warning(
+            "DagsterPipelineRunMetadataValue", "1.1.0", "Use DagsterRunMetadataValue instead."
+        )
+        return super(DagsterPipelineRunMetadataValue, cls).__new__(
+            cls, check.str_param(run_id, "run_id")
+        )
 
 
 @whitelist_for_serdes(storage_name="DagsterAssetMetadataEntryData")

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -382,12 +382,12 @@ class MetadataValue(ABC):
         return BoolMetadataValue(value)
 
     @staticmethod
-    def pipeline_run(run_id: str) -> "DagsterPipelineRunMetadataValue":
+    def pipeline_run(run_id: str) -> "DagsterRunMetadataValue":
         check.str_param(run_id, "run_id")
-        return DagsterPipelineRunMetadataValue(run_id)
+        return DagsterRunMetadataValue(run_id)
 
     @staticmethod
-    def dagster_run(run_id: str) -> "DagsterPipelineRunMetadataValue":
+    def dagster_run(run_id: str) -> "DagsterRunMetadataValue":
         """Static constructor for a metadata value wrapping a reference to a Dagster run.
 
         Args:
@@ -1154,7 +1154,7 @@ class MetadataEntry(
     @deprecated_metadata_entry_constructor
     def pipeline_run(run_id: str, label: str, description: Optional[str] = None) -> "MetadataEntry":
         check.str_param(run_id, "run_id")
-        return MetadataEntry(label, description, DagsterPipelineRunMetadataValue(run_id))
+        return MetadataEntry(label, description, DagsterRunMetadataValue(run_id))
 
     @staticmethod
     @deprecated_metadata_entry_constructor

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -737,16 +737,6 @@ class DagsterRunMetadataValue(
         return self.run_id
 
 
-class DagsterPipelineRunMetadataValue(DagsterRunMetadataValue):
-    def __new__(cls, run_id: str):
-        deprecation_warning(
-            "DagsterPipelineRunMetadataValue", "1.1.0", "Use DagsterRunMetadataValue instead."
-        )
-        return super(DagsterPipelineRunMetadataValue, cls).__new__(
-            cls, check.str_param(run_id, "run_id")
-        )
-
-
 @whitelist_for_serdes(storage_name="DagsterAssetMetadataEntryData")
 class DagsterAssetMetadataValue(
     NamedTuple("_DagsterAssetMetadataValue", [("asset_key", "AssetKey")]), MetadataValue

--- a/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
@@ -10,7 +10,7 @@ from dagster.core.definitions.events import Output
 from dagster.core.definitions.input import InputDefinition
 from dagster.core.definitions.metadata import (
     DagsterAssetMetadataValue,
-    DagsterPipelineRunMetadataValue,
+    DagsterRunMetadataValue,
     FloatMetadataValue,
     IntMetadataValue,
     JsonMetadataValue,
@@ -54,8 +54,12 @@ METADATA_DEPRECATIONS = {
     "FloatMetadataEntryData": ("FloatMetadataValue", FloatMetadataValue),
     "IntMetadataEntryData": ("IntMetadataValue", IntMetadataValue),
     "DagsterPipelineRunMetadataEntryData": (
-        "DagsterPipelineRunMetadataValue",
-        DagsterPipelineRunMetadataValue,
+        "DagsterRunMetadataValue",
+        DagsterRunMetadataValue,
+    ),
+    "DagsterPipelineRunMetadataValue": (
+        "DagsterRunMetadataValue",
+        DagsterRunMetadataValue,
     ),
     "DagsterAssetMetadataEntryData": ("DagsterAssetMetadataValue", DagsterAssetMetadataValue),
     "TableMetadataEntryData": ("TableMetadataValue", TableMetadataValue),


### PR DESCRIPTION
Add DagsterRunMetadataValue, throw 1.1.0 deprecation warning for DagsterPipelineRunMetadata.

Also follows through on removal of DagsterPipelineRunMetadataEntry, which is telegraphed for 1.0. Therefore, this cannot land until 1.0.
