### PR TITLE
add securityContext to dagit init-user-deployment initContainers

### DIFF
--- a/helm/dagster/templates/helpers/_deployment-dagit.tpl
+++ b/helm/dagster/templates/helpers/_deployment-dagit.tpl
@@ -56,6 +56,8 @@ spec:
         - name: "init-user-deployment-{{- $deployment.name -}}"
           image: {{ include "dagster.externalImage.name" $.Values.busybox.image | quote }}
           command: ['sh', '-c', "until nslookup {{ $deployment.name -}}; do echo waiting for user service; sleep 2; done"]
+          securityContext:
+            {{- toYaml .Values.dagit.securityContext | nindent 12 }}
         {{- end }}
         {{- end }}
       containers:


### PR DESCRIPTION
### Summary & Motivation
Reuse `.Values.dagit.securityContext` for the `init-user-deployment...` `initContainer` for the dagit deployment. This allows to specify the `securityContext` to satisfy the restricted Pod Security Standard. 

Otherwise the pod creation is blocked due to PodSecurity violations:
```shell
Error creating: pods "sherloq-dagster-dagit-66cf7c4c5d-vm24x" is forbidden: violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "init-user-deployment-hello-world" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "init-user-deployment-hello-world" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "init-user-deployment-hello-world" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "init-user-deployment-hello-world" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost"
```

### How I Tested These Changes
Activate pod security standards (profile restricted) for the desired namespace and specify `.Values.dagit.securityContext` as follows: 
```yaml
securityContext:
  allowPrivilegeEscalation: false
  runAsNonRoot: true
  runAsUser: 1000
  privileged: false
  capabilities:
    drop:
      - ALL
  seccompProfile:
    type: RuntimeDefault
```
