### PR TITLE
add the ability to specify postgresql password key inside kubernetes secret

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -50,7 +50,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagsterUserDeployments.postgresql.secretName" $ }}
-                  key: postgresql-password
+                  key: {{ $.Values.postgresqlSecretKeyRefKey }}
             {{- $includeConfigInLaunchedRuns := $deployment.includeConfigInLaunchedRuns | default (dict "enabled" true) }}
             {{- if $includeConfigInLaunchedRuns.enabled }}
             # uses the auto_envvar_prefix of the dagster cli to set the --container-context arg

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -7,6 +7,7 @@ global:
 
 dagsterHome: "/opt/dagster/dagster_home"
 postgresqlSecretName: "dagster-postgresql-secret"
+postgresqlSecretKeyRefKey: postgresql-password
 celeryConfigSecretName: "dagster-celery-config-secret"
 
 ####################################################################################################
@@ -147,3 +148,4 @@ rbacEnabled: true
 # Extra Manifests: (Optional) Create additional k8s resources within this chart
 ####################################################################################################
 extraManifests: []
+

--- a/helm/dagster/schema/schema/charts/dagster/subschema/postgresql.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/postgresql.py
@@ -15,6 +15,7 @@ class PostgreSQL(BaseModel):
     postgresqlHost: str
     postgresqlUsername: str
     postgresqlPassword: str
+    postgresqlSecretKeyRefKey: str
     postgresqlDatabase: str
     postgresqlParams: dict
     postgresqlScheme: Optional[str]

--- a/helm/dagster/templates/deployment-celery-queues.yaml
+++ b/helm/dagster/templates/deployment-celery-queues.yaml
@@ -66,7 +66,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagster.postgresql.secretName" $ | quote }}
-                  key: postgresql-password
+                  key: {{ .Values.postgresql.postgresqlSecretKeyRefKey }}
           envFrom:
             - configMapRef:
                 name: {{ template "dagster.fullname" $ }}-celery-worker-env

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -77,7 +77,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagster.postgresql.secretName" $ | quote }}
-                  key: postgresql-password
+                  key: {{ .Values.postgresql.postgresqlSecretKeyRefKey }}
             - name: DAGSTER_DAEMON_HEARTBEAT_TOLERANCE
               value: "{{ .Values.dagsterDaemon.heartbeatTolerance }}"
           envFrom:

--- a/helm/dagster/templates/helpers/_deployment-dagit.tpl
+++ b/helm/dagster/templates/helpers/_deployment-dagit.tpl
@@ -74,7 +74,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagster.postgresql.secretName" . | quote }}
-                  key: postgresql-password
+                  key: {{ .Values.postgresql.postgresqlSecretKeyRefKey }}
           envFrom:
             - configMapRef:
                 name: {{ template "dagster.fullname" . }}-dagit-env

--- a/helm/dagster/templates/job-instance-migrate.yaml
+++ b/helm/dagster/templates/job-instance-migrate.yaml
@@ -24,7 +24,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagster.postgresql.secretName" . | quote }}
-                  key: postgresql-password
+                  key: {{ .Values.postgresql.postgresqlSecretKeyRefKey }}
           envFrom:
             - configMapRef:
                 name: {{ template "dagster.fullname" . }}-dagit-env

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -667,6 +667,10 @@
                     "title": "Postgresqlpassword",
                     "type": "string"
                 },
+                "postgresqlSecretKeyRefKey": {
+                    "title": "Postgresqlsecretkeyrefkey",
+                    "type": "string"
+                },
                 "postgresqlDatabase": {
                     "title": "Postgresqldatabase",
                     "type": "string"

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -683,6 +683,11 @@ postgresql:
   # https://github.com/helm/charts/issues/12836#issuecomment-524552358
   postgresqlPassword: test
 
+  # Used by dagit to refrence postgres password from postgresql secret
+  # New bitnami charts use postgres as key, currently used one uses 
+  # postgresql-password as key.
+  postgresqlSecretKeyRefKey: postgresql-password
+
   postgresqlDatabase: test
 
   # set postgresql parameter keywords for the connection string.


### PR DESCRIPTION
### Summary & Motivation
To satisfy kubernetes pod security standards (restricted) we have to use a newer postgres chart. The new bitnami postgres chart splits passwords to ``postgres-password`` for the ``postgres``-User password and ``password`` for the user password. 

To be able to update we have to specify the key for the ``secretRefKey.key`` value.

### How I Tested These Changes
- Install this charts as is and it should still work. 
- Install a newer bitnami/postgres chart and specify the alternative ``postgresqlSecretRefKey.key=password``