### PR TITLE
Fix ScheduleRootQuery typo

### DIFF
--- a/js_modules/dagit/packages/core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleRoot.tsx
@@ -159,7 +159,7 @@ const SCHEDULE_ROOT_QUERY = gql`
       ...InstanceHealthFragment
       daemonHealth {
         id
-        daemonStatus(daemonType: "SCHEDULE") {
+        daemonStatus(daemonType: "SCHEDULER") {
           id
           healthy
         }


### PR DESCRIPTION
I believe the new daemon heartbeat backend exposed an old typo in the schedule gql:

SCHEDULE instead of SCHEDULER meant that we were returning a 'not required' status for the scheduler: https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/daemon/controller.py#L374-L375

For cloud we don't bother with 'required', since the set of daemons is constant, so we return no heartbeats for this query: https://github.com/dagster-io/internal/blob/master/dagster-cloud/python_modules/dagster-cloud-backend/dagster_cloud_backend/instance.py#L326-L330

Resulting in the key error here: https://app.datadoghq.com/apm/trace/899156492898095091?colorBy=service&env=cloud-prod-eks&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=6017938836252937910&spanViewType=errors&timeHint=1657893322059.613