### PR TITLE
Error when @repository-decorated function has arguments

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/repository_decorator.py
@@ -2,6 +2,7 @@ from functools import update_wrapper
 from typing import Any, Callable, List, Mapping, Optional, Union, overload
 
 import dagster._check as check
+from dagster.core.decorator_utils import get_function_params
 from dagster.core.errors import DagsterInvalidDefinitionError
 
 from ..executor_definition import ExecutorDefinition
@@ -277,6 +278,7 @@ def repository(
     """
     if callable(name):
         check.invariant(description is None)
+        check.invariant(len(get_function_params(name)) == 0)
 
         return _Repository()(name)
 

--- a/python_modules/dagster/dagster_tests/general_tests/test_repository.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_repository.py
@@ -11,8 +11,10 @@ from dagster import (
     repository,
     resource,
 )
+from dagster._check import CheckError
 from dagster.legacy import solid
 from dagster.utils import file_relative_path
+import pytest
 
 
 def define_empty_pipeline():
@@ -116,3 +118,11 @@ def test_repository_construction():
 @repository
 def empty_repository():
     return []
+
+
+def test_invalid_repository():
+    with pytest.raises(CheckError):
+
+        @repository
+        def invalid_repository(invalid_arg: str):
+            return []

--- a/python_modules/dagster/dagster_tests/general_tests/test_repository.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_repository.py
@@ -2,6 +2,8 @@
 Repository of test pipelines
 """
 
+import pytest
+
 from dagster import (
     Int,
     ModeDefinition,
@@ -14,7 +16,6 @@ from dagster import (
 from dagster._check import CheckError
 from dagster.legacy import solid
 from dagster.utils import file_relative_path
-import pytest
 
 
 def define_empty_pipeline():
@@ -124,5 +125,5 @@ def test_invalid_repository():
     with pytest.raises(CheckError):
 
         @repository
-        def invalid_repository(invalid_arg: str):
+        def invalid_repository(_invalid_arg: str):
             return []


### PR DESCRIPTION
### Summary & Motivation
Resolving https://github.com/dagster-io/dagster/issues/8849

### How I Tested These Changes
- Debugged and tested locally
- Unit test for `CheckError` trigger on invalid decorated func
