### PR TITLE
[docs] Fix broken examples for loading dbt models from a dbt project

### DIFF
--- a/docs/content/integrations/dbt.mdx
+++ b/docs/content/integrations/dbt.mdx
@@ -33,7 +33,9 @@ These similarities make it natural to interact with dbt models as SDAs. Dagster 
 For smaller dbt projects, where compilation time is not a concern, the simplest way to load your dbt assets into Dagster is the following:
 
 ```python startafter=start_load_assets_from_dbt_project endbefore=end_load_assets_from_dbt_project file=/integrations/dbt/dbt.py dedent=4
-No match for startAfter value "start_load_assets_from_dbt_project"
+from dagster_dbt import load_assets_from_dbt_project
+
+dbt_assets = load_assets_from_dbt_project(project_dir="path/to/dbt/project")
 ```
 
 The `load_assets_from_dbt_project` function:
@@ -45,7 +47,13 @@ The `load_assets_from_dbt_project` function:
 For larger projects, the overhead involved with recompiling the entire project may be a concern. In these cases, you can load dbt models from an existing dbt `manifest.json` file:
 
 ```python startafter=start_load_assets_from_dbt_manifest endbefore=end_load_assets_from_dbt_manifest file=/integrations/dbt/dbt.py dedent=4
-No match for startAfter value "start_load_assets_from_dbt_manifest"
+import json
+
+from dagster_dbt import load_assets_from_dbt_manifest
+
+dbt_assets = load_assets_from_dbt_manifest(
+    json.load("path/to/dbt/manifest.json", encoding="utf8"),
+)
 ```
 
 **Note:** if you make any changes to your dbt project that change the structure of the project (such as changing the dependencies of a model or adding a new one), you'll need to regenerate your manifest file for those changes to be reflected in Dagster.

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -2,15 +2,15 @@
 
 
 def scope_load_assets_from_dbt_project():
-    # start_marker_load_assets_from_dbt_project
+    # start_load_assets_from_dbt_project
     from dagster_dbt import load_assets_from_dbt_project
 
     dbt_assets = load_assets_from_dbt_project(project_dir="path/to/dbt/project")
-    # end_marker_load_assets_from_dbt_project
+    # end_load_assets_from_dbt_project
 
 
 def scope_load_assets_from_dbt_manifest():
-    # start_marker_load_assets_from_dbt_manifest
+    # start_load_assets_from_dbt_manifest
     import json
 
     from dagster_dbt import load_assets_from_dbt_manifest
@@ -18,7 +18,7 @@ def scope_load_assets_from_dbt_manifest():
     dbt_assets = load_assets_from_dbt_manifest(
         json.load("path/to/dbt/manifest.json", encoding="utf8"),
     )
-    # end_marker_load_assets_from_dbt_manifest
+    # end_load_assets_from_dbt_manifest
 
 
 def scope_dbt_cli_resource_config():


### PR DESCRIPTION
### Summary & Motivation
I noticed that the dbt docs for loading a dbt model from a dbt project both display an error message rather than the desired code block. 
![Screen Shot 2022-07-16 at 11 14 25 AM](https://user-images.githubusercontent.com/1664578/179367232-b9409909-9c14-4a69-91a1-41a01ea53924.png)

### How I Tested These Changes
After making the fix, I ran `make snapshot` and then `make dev` for viewing the changes locally. 
![Screen Shot 2022-07-16 at 11 14 57 AM](https://user-images.githubusercontent.com/1664578/179367250-44b058f2-4798-49b5-9e59-5e662089a892.png)

