### PR TITLE
Fix garbled sentence in ops.mdx

### DIFF
--- a/docs/content/concepts/ops-jobs-graphs/ops.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/ops.mdx
@@ -5,7 +5,7 @@ description: Ops are the core unit of computation in Dagster and contain the log
 
 # Ops
 
-Ops are are core unit of computation in Dagster.
+Ops are the core unit of computation in Dagster.
 
 An individual op should perform relatively simple tasks, such as:
 


### PR DESCRIPTION
"Ops are are core unit of computation in Dagster." --> "Ops are the core unit of computation in Dagster."

