### PR TITLE
[dagster-dbt] fix tagged source asset loading

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -165,14 +165,13 @@ def _get_deps(dbt_nodes, selected_unique_ids, asset_resource_types):
     for unique_id in selected_unique_ids:
         node_info = dbt_nodes[unique_id]
         node_resource_type = node_info["resource_type"]
-        node_parent_unique_ids = node_info["depends_on"]["nodes"]
 
-        # skip non-asset resources, such as tests
+        # skip non-asset resources, such as tests and sources
         if node_resource_type not in asset_resource_types:
             continue
 
         asset_deps[unique_id] = set()
-        for parent_unique_id in node_parent_unique_ids:
+        for parent_unique_id in node_info["depends_on"]["nodes"]:
             parent_node_info = dbt_nodes[parent_unique_id]
             parent_resource_type = parent_node_info["resource_type"]
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_python_test_project/models/bot_labeled_events.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_python_test_project/models/bot_labeled_events.sql
@@ -1,3 +1,4 @@
+{{ config(tags=["events"]) }}
 select blu.is_bot, e.* from
 {{ source("dagster", "bot_labeled_users") }} blu join {{ ref("cleaned_events") }} e
 on blu.user_id = e.user_id

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_python_test_project/models/cleaned_events.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_python_test_project/models/cleaned_events.sql
@@ -1,1 +1,2 @@
+{{ config(tags=["events"]) }}
 SELECT * from {{ source('raw_data', 'events') }}

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_python_test_project/models/sources.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_python_test_project/models/sources.yml
@@ -4,6 +4,7 @@ sources:
   - name: raw_data
     tables:
       - name: events
+        tags: ["events"]
       - name: users
 
   - name: dagster

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -1,4 +1,5 @@
 import json
+import os
 from unittest.mock import MagicMock
 
 import psycopg2
@@ -648,6 +649,24 @@ def test_source_key_prefix(
     }
 
     assert dbt_assets[0].keys_by_output_name["cleaned_users"] == AssetKey(["dbt", "cleaned_users"])
+
+
+def test_source_tag_selection(
+    conn_string, test_python_project_dir, dbt_python_config_dir
+):  # pylint: disable=unused-argument
+    dbt_assets = load_assets_from_dbt_project(
+        test_python_project_dir, dbt_python_config_dir, select="tag:events"
+    )
+
+    assert len(dbt_assets[0].keys) == 2
+
+    manifest_path = os.path.join(test_python_project_dir, "target", "manifest.json")
+    with open(manifest_path, "r", encoding="utf8") as f:
+        manifest_json = json.load(f)
+
+    dbt_assets = load_assets_from_dbt_manifest(manifest_json, select="tag:events")
+
+    assert len(dbt_assets[0].keys) == 2
 
 
 def test_python_interleaving(


### PR DESCRIPTION
### Summary & Motivation

When source assets are given tags, and a tag-based selection string is used when using load_assets_from_manifest_json, sources are included as selected_unique_ids. this is fine (we filter them out later), but these nodes don't have a "depends_on" field, which we look for before doing that filtering, causing an error.

This PR changes that order of operations to filter out non-asset nodes (which will not have the "depends_on" field) earlier.

### How I Tested These Changes

unit test failed, not it succeeds