### PR TITLE
[bug] Fix issue where 'invalid' asset metadata resulted in an error

### DIFF
--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -884,7 +884,11 @@ def external_asset_graph_from_defs(
         asset_metadata_entries = (
             cast(
                 Sequence,
-                normalize_metadata(metadata=metadata_by_asset_key[asset_key], metadata_entries=[]),
+                normalize_metadata(
+                    metadata=metadata_by_asset_key[asset_key],
+                    metadata_entries=[],
+                    allow_invalid=True,
+                ),
             )
             if asset_key in metadata_by_asset_key
             else cast(Sequence, output_def.metadata_entries)


### PR DESCRIPTION
### Summary & Motivation

Fixes: https://github.com/dagster-io/dagster/issues/8944

The basic issue was that, in the old world, output/input metadata for assets was normalized with the allow_invalid flag set to True. With the new method, which allows asset metadata to be sourced directly from the AssetsDefinition object, this flag was set to False, leading to errors when users upgraded to 0.15.6

This sets the allow_invalid flag to True in all cases, and adds somewhat better test coverage as well.

### How I Tested These Changes

Tests failed, now they succeed.
