### PR TITLE
[dagit] Adjust shift-selection behavior in asset graphs

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -192,15 +192,22 @@ export const AssetGraphExplorerWithData: React.FC<
       let nextOpsNameSelection = token;
 
       if (e.shiftKey || e.metaKey) {
-        const existing = explorerPath.opNames[0].split(',');
-        const added =
-          e.shiftKey && lastSelectedNode && node
-            ? opsInRange({graph: assetGraphData, from: lastSelectedNode, to: node})
-            : [token];
+        let tokensToAdd = [token];
+        if (e.shiftKey && lastSelectedNode && node) {
+          const tokensInRange = opsInRange({
+            graph: assetGraphData,
+            from: lastSelectedNode,
+            to: node,
+          });
+          if (tokensInRange.length) {
+            tokensToAdd = tokensInRange;
+          }
+        }
 
+        const existing = explorerPath.opNames[0].split(',');
         nextOpsNameSelection = (existing.includes(token)
           ? without(existing, token)
-          : uniq([...existing, ...added])
+          : uniq([...existing, ...tokensToAdd])
         ).join(',');
       }
 


### PR DESCRIPTION
### Summary & Motivation

This is a small change Josh, Sandy and I discussed in Slack. If you select one node in an asset graph and shift-select to another node, we try to select all the nodes in the graph between them. If they're not connected in the graph, shift-selecting previously did nothing.  This PR changes the behavior so that in the latter case, we fall back to a "cmd-click" behavior and still select the item you clicked.


### How I Tested These Changes
