### PR TITLE
[1.0] Get rid of pipeline/solid in backcompat tests

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
@@ -85,7 +85,7 @@ def backcompat_extra_cmds(_, factor: str) -> List[str]:
     return [
         f"export EARLIEST_TESTED_RELEASE={EARLIEST_TESTED_RELEASE}",
         "pushd integration_tests/test_suites/backcompat-test-suite/dagit_service",
-        f"./build.sh {dagit_version} {user_code_version}",
+        f"./build.sh {dagit_version} {user_code_version} {_extract_major_version(user_code_version)}",
         "docker-compose up -d --remove-orphans",  # clean up in hooks/pre-exit
         *network_buildkite_container("dagit_service_network"),
         *connect_sibling_docker_container(
@@ -95,6 +95,13 @@ def backcompat_extra_cmds(_, factor: str) -> List[str]:
         ),
         "popd",
     ]
+
+
+def _extract_major_version(release):
+    """Returns major version if 0.x.x release, returns 'current_branch' if master."""
+    if release == "current_branch":
+        return release
+    return release.split(".")[0]
 
 
 # ########################

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/Dockerfile_user_code_legacy_release
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/Dockerfile_user_code_legacy_release
@@ -1,0 +1,23 @@
+FROM python:3.8-slim
+
+ARG USER_CODE_BACKCOMPAT_VERSION
+
+COPY pins.txt pins.txt
+
+RUN pip install \
+    -r pins.txt \
+    dagster=="${USER_CODE_BACKCOMPAT_VERSION}" \
+    dagster-postgres=="${USER_CODE_BACKCOMPAT_VERSION}" \
+    dagster-docker=="${USER_CODE_BACKCOMPAT_VERSION}"
+
+WORKDIR /opt/dagster/app
+
+COPY legacy_repo.py /opt/dagster/app
+
+# Run dagster gRPC server on port 8090
+
+EXPOSE 8090
+
+# CMD allows this to be overridden from run launchers or executors that want
+# to run other commands against your repository
+CMD ["dagster", "api", "grpc", "-h", "0.0.0.0", "-p", "8090", "-f", "legacy_repo.py"]

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/build.sh
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/build.sh
@@ -10,15 +10,10 @@ else
 fi
 
 if [ "$USER_CODE_BACKCOMPAT_VERSION" = "current_branch" ]; then
-    echo "asdfCURRENT_BRANCH REPO"
     export USER_CODE_DOCKERFILE="./Dockerfile_user_code_source"
 elif [ "$USER_CODE_MAJOR_VERSION" = "0" ]; then # If the dagster version is 0.x.x, then use the legacy dockerfile, which will test pipeline code.
-    echo "$USER_CODE_MAJOR_VERSION"
-    echo "asdfLEGACY REPO"
     export USER_CODE_DOCKERFILE="./Dockerfile_user_code_legacy_release"
 else
-    echo "$USER_CODE_MAJOR_VERSION"
-    echo "asdfMODERN REPO"
     export USER_CODE_DOCKERFILE="./Dockerfile_user_code_release"
 fi
 

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/build.sh
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 DAGIT_BACKCOMPAT_VERSION=$1
 USER_CODE_BACKCOMPAT_VERSION=$2
+USER_CODE_MAJOR_VERSION=$3
 
 if [ "$DAGIT_BACKCOMPAT_VERSION" = "current_branch" ]; then
     export DAGIT_DOCKERFILE="./Dockerfile_dagit_source"
@@ -10,10 +11,11 @@ fi
 
 if [ "$USER_CODE_BACKCOMPAT_VERSION" = "current_branch" ]; then
     export USER_CODE_DOCKERFILE="./Dockerfile_user_code_source"
+elif [ $USER_CODE_MAJOR_VERSION = "0" ]; then # If the dagster version is 0.x.x, then use the legacy dockerfile, which will test pipeline code.
+    export USER_CODE_DOCKERFILE="./Dockerfile_user_code_legacy_release"
 else
     export USER_CODE_DOCKERFILE="./Dockerfile_user_code_release"
 fi
-
 
 ROOT=$(git rev-parse --show-toplevel)
 BASE_DIR="${ROOT}/integration_tests/test_suites/backcompat-test-suite/dagit_service"

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/build.sh
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/build.sh
@@ -10,10 +10,15 @@ else
 fi
 
 if [ "$USER_CODE_BACKCOMPAT_VERSION" = "current_branch" ]; then
+    echo "asdfCURRENT_BRANCH REPO"
     export USER_CODE_DOCKERFILE="./Dockerfile_user_code_source"
 elif [ "$USER_CODE_MAJOR_VERSION" = "0" ]; then # If the dagster version is 0.x.x, then use the legacy dockerfile, which will test pipeline code.
+    echo "$USER_CODE_MAJOR_VERSION"
+    echo "asdfLEGACY REPO"
     export USER_CODE_DOCKERFILE="./Dockerfile_user_code_legacy_release"
 else
+    echo "$USER_CODE_MAJOR_VERSION"
+    echo "asdfMODERN REPO"
     export USER_CODE_DOCKERFILE="./Dockerfile_user_code_release"
 fi
 

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/build.sh
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/build.sh
@@ -11,7 +11,7 @@ fi
 
 if [ "$USER_CODE_BACKCOMPAT_VERSION" = "current_branch" ]; then
     export USER_CODE_DOCKERFILE="./Dockerfile_user_code_source"
-elif [ $USER_CODE_MAJOR_VERSION = "0" ]; then # If the dagster version is 0.x.x, then use the legacy dockerfile, which will test pipeline code.
+elif [ "$USER_CODE_MAJOR_VERSION" = "0" ]; then # If the dagster version is 0.x.x, then use the legacy dockerfile, which will test pipeline code.
     export USER_CODE_DOCKERFILE="./Dockerfile_user_code_legacy_release"
 else
     export USER_CODE_DOCKERFILE="./Dockerfile_user_code_release"

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/legacy_repo.py
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/legacy_repo.py
@@ -1,0 +1,40 @@
+# pylint: skip-file
+from dagster import graph, op, pipeline, repository, solid
+
+
+@solid
+def my_solid():
+    return 5
+
+
+@solid
+def ingest_solid(x):
+    return x + 5
+
+
+@pipeline
+def the_pipeline():
+    ingest_solid(my_solid())
+
+
+@op
+def my_op():
+    return 5
+
+
+@op
+def ingest(x):
+    return x + 5
+
+
+@graph
+def basic():
+    ingest(my_op())
+
+
+the_job = basic.to_job(name="the_job")
+
+
+@repository
+def basic_repo():
+    return [the_job, the_pipeline]

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/repo.py
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/repo.py
@@ -1,19 +1,4 @@
-from dagster import graph, op, pipeline, repository, solid
-
-
-@solid
-def my_solid():
-    return 5
-
-
-@solid
-def ingest_solid(x):
-    return x + 5
-
-
-@pipeline
-def the_pipeline():
-    ingest_solid(my_solid())
+from dagster import graph, op, repository
 
 
 @op
@@ -36,4 +21,4 @@ the_job = basic.to_job(name="the_job")
 
 @repository
 def basic_repo():
-    return [the_job, the_pipeline]
+    return [the_job]

--- a/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
+++ b/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
@@ -177,14 +177,6 @@ def graphql_client(release_test_map, retrying_requests):
         yield DagsterGraphQLClient(dagit_host, port_number=3000)
 
 
-def test_backcompat_deployed_pipeline(graphql_client):
-    assert_runs_and_exists(graphql_client, "the_pipeline")
-
-
-def test_backcompat_deployed_pipeline_subset(graphql_client):
-    assert_runs_and_exists(graphql_client, "the_pipeline", subset_selection=["my_solid"])
-
-
 def test_backcompat_deployed_job(graphql_client):
     assert_runs_and_exists(graphql_client, "the_job")
 

--- a/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
+++ b/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
@@ -136,7 +136,7 @@ def docker_service_up(docker_compose_file, build_args=None):
 
     try:
         subprocess.check_output(["docker-compose", "-f", docker_compose_file, "stop"])
-        subprocess.check_output(["docker-compose", "-f", docker_compose_file, "rm", "-f"])
+        # subprocess.check_output(["docker-compose", "-f", docker_compose_file, "rm", "-f"])
     except subprocess.CalledProcessError:
         pass
 
@@ -170,11 +170,23 @@ def graphql_client(release_test_map, retrying_requests):
 
     with docker_service_up(
         os.path.join(os.getcwd(), "dagit_service", "docker-compose.yml"),
-        build_args=[dagit_version, user_code_version],
+        build_args=[dagit_version, user_code_version, extract_major_version(user_code_version)],
     ):
         result = retrying_requests.get(f"http://{dagit_host}:3000/dagit_info")
         assert result.json().get("dagit_version")
         yield DagsterGraphQLClient(dagit_host, port_number=3000)
+
+
+def test_backcompat_deployed_pipeline(graphql_client, release_test_map):
+    # Only run this test on backcompat versions
+    if is_0_release(release_test_map["user_code"]):
+        assert_runs_and_exists(graphql_client, "the_pipeline")
+
+
+def test_backcompat_deployed_pipeline_subset(graphql_client, release_test_map):
+    # Only run this test on backcompat versions
+    if is_0_release(release_test_map["user_code"]):
+        assert_runs_and_exists(graphql_client, "the_pipeline", subset_selection=["my_solid"])
 
 
 def test_backcompat_deployed_job(graphql_client):
@@ -201,3 +213,17 @@ def assert_runs_and_exists(client: DagsterGraphQLClient, name, subset_selection=
     )
     assert len(locations) == 1
     assert locations[0].pipeline_name == name
+
+
+def is_0_release(release):
+    """Returns true if 0.x.x release of dagster, false otherwise"""
+    if release == "current_branch":
+        return False
+    return release.split(".")[0] == "0"
+
+
+def extract_major_version(release):
+    """Returns major version if 0.x.x release, returns 'current_branch' if master."""
+    if release == "current_branch":
+        return False
+    return release.split(".")[0]

--- a/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
+++ b/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
@@ -225,5 +225,5 @@ def is_0_release(release):
 def extract_major_version(release):
     """Returns major version if 0.x.x release, returns 'current_branch' if master."""
     if release == "current_branch":
-        return False
+        return release
     return release.split(".")[0]

--- a/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
+++ b/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
@@ -136,7 +136,7 @@ def docker_service_up(docker_compose_file, build_args=None):
 
     try:
         subprocess.check_output(["docker-compose", "-f", docker_compose_file, "stop"])
-        # subprocess.check_output(["docker-compose", "-f", docker_compose_file, "rm", "-f"])
+        subprocess.check_output(["docker-compose", "-f", docker_compose_file, "rm", "-f"])
     except subprocess.CalledProcessError:
         pass
 


### PR DESCRIPTION
Given that they are no longer supported in 1.0