### PR TITLE
[dagit] Send assetSelection, stepSelection tag from the launchpad

### DIFF
--- a/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import {getJSONForKey, useStateWithStorage} from '../hooks/useStateWithStorage';
 import {LaunchpadSessionPartitionSetsFragment} from '../launchpad/types/LaunchpadSessionPartitionSetsFragment';
 import {LaunchpadSessionPipelineFragment} from '../launchpad/types/LaunchpadSessionPipelineFragment';
+import {AssetKeyInput} from '../types/globalTypes';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
 
@@ -37,6 +38,7 @@ export interface IExecutionSession {
   base: SessionBase | null;
   mode: string | null;
   needsRefresh: boolean;
+  assetSelection: {assetKey: AssetKeyInput; opNames: string[]}[] | null;
   solidSelection: string[] | null;
   solidSelectionQuery: string | null;
   flattenGraphs: boolean;
@@ -88,6 +90,7 @@ export const createSingleSession = (initial: IExecutionSessionChanges = {}, key?
     mode: null,
     base: null,
     needsRefresh: false,
+    assetSelection: null,
     solidSelection: null,
     solidSelectionQuery: '*',
     flattenGraphs: false,

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -263,8 +263,9 @@ async function stateForLaunchingAssets(
       jobName,
       repoAddress,
       sessionPresets: {
-        solidSelection: assetOpNames,
-        solidSelectionQuery: assetOpNames.map((name) => `"${name}"`).join(' '),
+        flattenGraphs: true,
+        assetSelection: assets.map((a) => ({assetKey: a.assetKey, opNames: a.opNames})),
+        solidSelectionQuery: assetOpNames.map((name) => `"${name}"`).join(', '),
       },
     };
   }
@@ -291,7 +292,7 @@ export function executionParamsForAssetJob(
         },
       ],
     },
-    runConfigData: {},
+    runConfigData: '{}',
     selector: {
       repositoryLocationName: repoAddress.location,
       repositoryName: repoAddress.name,

--- a/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
@@ -26,6 +26,7 @@ import {
   ConfigEditorRunConfigSchemaFragment_allConfigTypes_CompositeConfigType,
 } from '../configeditor/types/ConfigEditorRunConfigSchemaFragment';
 
+import {LaunchpadType} from './LaunchpadRoot';
 import {
   RunPreviewValidationFragment,
   RunPreviewValidationFragment_RunConfigValidationInvalid_errors,
@@ -202,6 +203,7 @@ const ScaffoldConfigButton = ({
 interface RunPreviewProps {
   validation: RunPreviewValidationFragment | null;
   document: any | null;
+  launchpadType: LaunchpadType;
 
   runConfigSchema?: ConfigEditorRunConfigSchemaFragment;
   onHighlightPath: (path: string[]) => void;
@@ -215,6 +217,7 @@ export const RunPreview: React.FC<RunPreviewProps> = (props) => {
     document,
     validation,
     onHighlightPath,
+    launchpadType,
     onRemoveExtraPaths,
     onScaffoldMissingConfig,
     solidSelection,
@@ -424,7 +427,7 @@ export const RunPreview: React.FC<RunPreviewProps> = (props) => {
               )}
             </RuntimeAndResourcesSection>
             <Section>
-              <SectionTitle>Ops</SectionTitle>
+              <SectionTitle>{launchpadType === 'asset' ? 'Assets (Ops)' : 'Ops'}</SectionTitle>
               <ItemSet>
                 {itemsIn(
                   [hasOps ? 'ops' : 'solids'],


### PR DESCRIPTION
### Summary & Motivation

This PR makes several changes noted in this thread:
https://elementl-workspace.slack.com/archives/C03CCE471E0/p1658179015802579

- If you shift-click the "Materialize" button and open the launchpad for a set of assets:

   + The execute button sends the `assetSelection`, not a `solidSelection`
   
   + The "op subset" input is disabled, since changing your subset could yield a set for which there is no assetSelection. (cc @sryza is this ok?)
   
   + The "step selection" tag is passed with the op names corresponding to your asset selection.
   
   + The "Run Preview" has an "Assets (Ops)" section instead of labeling your assets "Ops"

![image](https://user-images.githubusercontent.com/1037212/179841676-c55148f2-0329-411a-bb45-8ecbcea47ccb.png)

### How I Tested These Changes
