### PR TITLE
[dagit] Fix “Related Assets” tag for asset jobs, hide Launchpad

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/JobMetadata.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/JobMetadata.test.tsx
@@ -5,7 +5,7 @@ import * as Flags from '../app/Flags';
 import {TestProvider} from '../testing/TestProvider';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
-import {JobMetadata} from './JobMetadata';
+import {JobMetadata, useJobNavMetadata} from './JobMetadata';
 
 jest.mock('../app/Flags');
 
@@ -69,10 +69,17 @@ describe('JobMetadata', () => {
     }),
   };
 
+  const JobMetadataContainer = () => {
+    const metadata = useJobNavMetadata(REPO_ADDRESS, PIPELINE_NAME);
+    return (
+      <JobMetadata metadata={metadata} pipelineName={PIPELINE_NAME} repoAddress={REPO_ADDRESS} />
+    );
+  };
+
   const renderWithMocks = (mocks?: any) => {
     render(
       <TestProvider apolloProps={{mocks: mocks ? [defaultMocks, mocks] : defaultMocks}}>
-        <JobMetadata pipelineName={PIPELINE_NAME} repoAddress={REPO_ADDRESS} />
+        <JobMetadataContainer />
       </TestProvider>,
     );
   };

--- a/js_modules/dagit/packages/core/src/nav/types/JobMetadataQuery.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/JobMetadataQuery.ts
@@ -63,6 +63,17 @@ export interface JobMetadataQuery_pipelineOrError_Pipeline {
 
 export type JobMetadataQuery_pipelineOrError = JobMetadataQuery_pipelineOrError_PipelineNotFoundError | JobMetadataQuery_pipelineOrError_Pipeline;
 
+export interface JobMetadataQuery_assetNodes_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface JobMetadataQuery_assetNodes {
+  __typename: "AssetNode";
+  id: string;
+  assetKey: JobMetadataQuery_assetNodes_assetKey;
+}
+
 export interface JobMetadataQuery_pipelineRunsOrError_InvalidPipelineRunsFilterError {
   __typename: "InvalidPipelineRunsFilterError" | "PythonError";
 }
@@ -98,6 +109,7 @@ export type JobMetadataQuery_pipelineRunsOrError = JobMetadataQuery_pipelineRuns
 
 export interface JobMetadataQuery {
   pipelineOrError: JobMetadataQuery_pipelineOrError;
+  assetNodes: JobMetadataQuery_assetNodes[];
   pipelineRunsOrError: JobMetadataQuery_pipelineRunsOrError;
 }
 

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineRoot.test.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineRoot.test.tsx
@@ -48,6 +48,9 @@ describe('PipelineRoot', () => {
       pipelines: () => [...new Array(1)],
       assetGroups: () => [...new Array(0)],
     }),
+    DagitQuery: () => ({
+      assetNodes: () => [], // standard job, not an asset job
+    }),
   };
 
   const apolloProps = {mocks};


### PR DESCRIPTION
### Summary & Motivation

This PR hides the "Launchpad" tab for asset jobs, and switches the "Related Assets" tag shown in the job / pipeline nav to reflect the actual assetNodes of the job, rather than the assets run in the last 5 jobs (the implementation when it appears on op jobs.)

This required a bit of a refactor because the app actually doesn't /know/ if the job is an asset job until it loads the ops and sees that they have assetNodes defined. I don't think we want to load `isAssetJob` for every job instance-wide (the way we do `isJob`) because the graphql resolver seems expensive.

The downside of hiding this tab based on async-loaded data is that the Launchpad tab appears a moment after the others do for normal op jobs. I'm not sure of a good workaround for this. We could make it less noticeable by putting the Launchpad tab at the end of the tab list. 

Video of the change here: https://www.loom.com/share/52115dbb64b54a88a67f3c665040209e

### How I Tested These Changes
