### PR TITLE
move imports to use dagster._legacy

### DIFF
--- a/examples/dbt_example/dbt_example/pipelines.py
+++ b/examples/dbt_example/dbt_example/pipelines.py
@@ -1,0 +1,103 @@
+from dagster_dbt import dbt_cli_resource
+from dagster_slack import slack_resource
+
+from dagster import file_relative_path, fs_io_manager
+from dagster._legacy import ModeDefinition, PresetDefinition, pipeline
+
+from .resources import mock_slack_resource, postgres
+from .solids import (
+    analyze_cereals,
+    download_file,
+    load_cereals_from_csv,
+    post_plot_to_slack,
+    run_cereals_models,
+    test_cereals_models,
+)
+
+CEREALS_DATASET_URL = "https://gist.githubusercontent.com/mgasner/bd2c0f66dff4a9f01855cfa6870b1fce/raw/2de62a57fb08da7c58d6480c987077cf91c783a1/cereal.csv"
+
+DBT_PROJECT_DIR = file_relative_path(__file__, "../dbt_example_project")
+
+# start_pipeline_marker_0
+@pipeline(
+    mode_defs=[
+        ModeDefinition(
+            name="prod",
+            resource_defs={
+                "db": postgres,
+                "slack": slack_resource,
+                "io_manager": fs_io_manager,
+                "dbt": dbt_cli_resource.configured(
+                    {"project_dir": DBT_PROJECT_DIR, "profiles_dir": DBT_PROJECT_DIR}
+                ),
+            },
+        ),
+        ModeDefinition(
+            name="dev",
+            resource_defs={
+                "db": postgres,
+                "slack": mock_slack_resource,
+                "io_manager": fs_io_manager,
+                "dbt": dbt_cli_resource.configured(
+                    {"project_dir": DBT_PROJECT_DIR, "profiles_dir": DBT_PROJECT_DIR}
+                ),
+            },
+        ),
+    ],
+    preset_defs=[
+        PresetDefinition(
+            name="dev",
+            run_config={
+                "solids": {
+                    "download_file": {
+                        "config": {
+                            "url": CEREALS_DATASET_URL,
+                            "target_path": "cereals.csv",
+                        }
+                    },
+                    "post_plot_to_slack": {"config": {"channels": ["foo_channel"]}},
+                },
+                "resources": {
+                    "db": {
+                        "config": {
+                            "db_url": "postgresql://dbt_example:dbt_example@localhost:5432/dbt_example"
+                        }
+                    },
+                    "slack": {"config": {"token": "nonce"}},
+                },
+            },
+            mode="dev",
+        ),
+        PresetDefinition(
+            name="prod",
+            run_config={
+                "solids": {
+                    "download_file": {
+                        "config": {
+                            "url": CEREALS_DATASET_URL,
+                            "target_path": "cereals.csv",
+                        }
+                    },
+                    "post_plot_to_slack": {"config": {"channels": ["foo_channel"]}},
+                },
+                "resources": {
+                    "db": {
+                        "config": {
+                            "db_url": "postgresql://dbt_example:dbt_example@localhost:5432/dbt_example"
+                        }
+                    },
+                    "slack": {"config": {"token": "nonce"}},
+                },
+            },
+            mode="prod",
+        ),
+    ],
+)
+def dbt_example_pipeline():
+    loaded = load_cereals_from_csv(download_file())
+    run_results = run_cereals_models(after=loaded)
+    test_cereals_models(after=run_results)
+    post_plot_to_slack(analyze_cereals(run_results))
+
+
+# end_pipeline_marker_0

--- a/examples/dbt_example/dbt_example/solids.py
+++ b/examples/dbt_example/dbt_example/solids.py
@@ -1,0 +1,56 @@
+import pandas
+import requests
+from dagster_dbt.cli.types import DbtCliOutput
+from dagstermill import define_dagstermill_solid
+
+from dagster import Array, Nothing
+from dagster._legacy import InputDefinition, OutputDefinition, solid
+from dagster._utils import file_relative_path
+
+CEREAL_DATASET_URL = "https://gist.githubusercontent.com/mgasner/bd2c0f66dff4a9f01855cfa6870b1fce/raw/2de62a57fb08da7c58d6480c987077cf91c783a1/cereal.csv"
+
+
+@solid(config_schema={"url": str, "target_path": str})
+def download_file(context) -> str:
+
+    url = context.solid_config["url"]
+    target_path = context.solid_config["target_path"]
+
+    with open(target_path, "w", encoding="utf8") as fd:
+        fd.write(requests.get(url).text)
+
+    return target_path
+
+
+@solid(required_resource_keys={"db"})
+def load_cereals_from_csv(context, csv_file_path):
+    cereals_df = pandas.read_csv(csv_file_path)
+    with context.resources.db.connect() as conn:
+        conn.execute("drop table if exists cereals cascade")
+        cereals_df.to_sql(name="cereals", con=conn)
+
+
+@solid(config_schema={"channels": Array(str)}, required_resource_keys={"slack"})
+def post_plot_to_slack(context, plot_path):
+    context.resources.slack.files_upload(
+        channels=",".join(context.solid_config["channels"]), file=plot_path
+    )
+
+
+@solid(required_resource_keys={"dbt"}, input_defs=[InputDefinition("after", Nothing)])
+def run_cereals_models(context) -> DbtCliOutput:
+    return context.resources.dbt.run()
+
+
+@solid(required_resource_keys={"dbt"}, input_defs=[InputDefinition("after", Nothing)])
+def test_cereals_models(context) -> DbtCliOutput:
+    return context.resources.dbt.test()
+
+
+analyze_cereals = define_dagstermill_solid(
+    "analyze_cereals",
+    file_relative_path(__file__, "notebooks/Analyze_Cereals.ipynb"),
+    input_defs=[InputDefinition("run_results", dagster_type=DbtCliOutput)],
+    output_defs=[OutputDefinition(str)],
+    required_resource_keys={"db"},
+)

--- a/examples/dbt_example/dbt_example_tests/test_pipeline.py
+++ b/examples/dbt_example/dbt_example_tests/test_pipeline.py
@@ -1,4 +1,5 @@
 import tempfile
+
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.test_utils import instance_for_test
 from dagster._legacy import execute_pipeline

--- a/examples/dbt_example/dbt_example_tests/test_pipeline.py
+++ b/examples/dbt_example/dbt_example_tests/test_pipeline.py
@@ -1,0 +1,51 @@
+import tempfile
+from dagster._core.definitions.reconstruct import ReconstructablePipeline
+from dagster._core.test_utils import instance_for_test
+from dagster._legacy import execute_pipeline
+
+CEREALS_DATASET_URL = "https://gist.githubusercontent.com/mgasner/bd2c0f66dff4a9f01855cfa6870b1fce/raw/2de62a57fb08da7c58d6480c987077cf91c783a1/cereal.csv"
+
+
+def test_pipeline(pg_hostname, postgres):  # pylint: disable=unused-argument
+    reconstructable_pipeline = ReconstructablePipeline.for_module(
+        "dbt_example", "dbt_example_pipeline"
+    )
+    assert set([solid.name for solid in reconstructable_pipeline.get_definition().solids]) == {
+        "download_file",
+        "load_cereals_from_csv",
+        "run_cereals_models",
+        "test_cereals_models",
+        "analyze_cereals",
+        "post_plot_to_slack",
+    }
+    with instance_for_test() as instance:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            res = execute_pipeline(
+                ReconstructablePipeline.for_module("dbt_example", "dbt_example_pipeline"),
+                instance=instance,
+                mode="dev",
+                run_config={
+                    "solids": {
+                        "download_file": {
+                            "config": {
+                                "url": CEREALS_DATASET_URL,
+                                "target_path": "cereals.csv",
+                            }
+                        },
+                        "post_plot_to_slack": {"config": {"channels": ["foo_channel"]}},
+                    },
+                    "resources": {
+                        "db": {
+                            "config": {
+                                "db_url": (
+                                    f"postgresql://dbt_example:dbt_example@{pg_hostname}"
+                                    ":5432/dbt_example"
+                                )
+                            }
+                        },
+                        "slack": {"config": {"token": "nonce"}},
+                        "io_manager": {"config": {"base_dir": temp_dir}},
+                    },
+                },
+            )
+            assert res.success

--- a/examples/docs_snippets/docs_snippets/concepts/assets/from_package_name.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/from_package_name.py
@@ -1,4 +1,4 @@
-from dagster import AssetGroup
+from dagster._legacy import AssetGroup
 
 asset_group = AssetGroup.from_package_name(
     "docs_snippets.concepts.assets.package_with_assets"

--- a/examples/docs_snippets/docs_snippets/concepts/dagit/graphql/client_example.py
+++ b/examples/docs_snippets/docs_snippets/concepts/dagit/graphql/client_example.py
@@ -96,7 +96,9 @@ from dagster_graphql import (
     ShutdownRepositoryLocationStatus,
 )
 
-shutdown_info: ShutdownRepositoryLocationInfo = client.shutdown_repository_location(REPO_NAME)
+shutdown_info: ShutdownRepositoryLocationInfo = client.shutdown_repository_location(
+    REPO_NAME
+)
 if shutdown_info.status == ShutdownRepositoryLocationStatus.SUCCESS:
     do_something_on_success()
 else:

--- a/examples/docs_snippets/docs_snippets/concepts/dagit/graphql/client_example.py
+++ b/examples/docs_snippets/docs_snippets/concepts/dagit/graphql/client_example.py
@@ -96,9 +96,7 @@ from dagster_graphql import (
     ShutdownRepositoryLocationStatus,
 )
 
-shutdown_info: ShutdownRepositoryLocationInfo = client.shutdown_repository_location(
-    REPO_NAME
-)
+shutdown_info: ShutdownRepositoryLocationInfo = client.shutdown_repository_location(REPO_NAME)
 if shutdown_info.status == ShutdownRepositoryLocationStatus.SUCCESS:
     do_something_on_success()
 else:

--- a/examples/docs_snippets/docs_snippets/concepts/repositories_workspaces/lazy_repository_definition.py
+++ b/examples/docs_snippets/docs_snippets/concepts/repositories_workspaces/lazy_repository_definition.py
@@ -2,8 +2,8 @@
 
 import datetime
 
-from dagster import InputDefinition, RunRequest, daily_schedule, job, repository, sensor
-from dagster._legacy import pipeline, solid
+from dagster import RunRequest, daily_schedule, job, repository, sensor
+from dagster._legacy import InputDefinition, pipeline, solid
 
 
 @solid

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_materialization_io_managers.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_materialization_io_managers.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
-from dagster import ModeDefinition, execute_pipeline, io_manager
-from dagster._legacy import pipeline, solid
+from dagster import io_manager
+from dagster._legacy import ModeDefinition, execute_pipeline, pipeline, solid
 from docs_snippets.concepts.assets.materialization_io_managers import (
     PandasCsvIOManager,
     PandasCsvIOManagerWithAsset,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_non_argument_deps.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_non_argument_deps.py
@@ -1,8 +1,8 @@
+from dagster._legacy import AssetGroup
 from docs_snippets.concepts.assets.non_argument_deps import (
     downstream_asset,
     upstream_asset,
 )
-from dagster._legacy import AssetGroup
 
 
 def test_non_argument_deps():

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_non_argument_deps.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_non_argument_deps.py
@@ -1,8 +1,8 @@
-from dagster import AssetGroup
 from docs_snippets.concepts.assets.non_argument_deps import (
     downstream_asset,
     upstream_asset,
 )
+from dagster._legacy import AssetGroup
 
 
 def test_non_argument_deps():

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/ops_jobs_graphs_tests/test_job_execution.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/ops_jobs_graphs_tests/test_job_execution.py
@@ -1,11 +1,12 @@
 import yaml
+
+from dagster._legacy import execute_pipeline
 from docs_snippets.concepts.ops_jobs_graphs.job_execution import (
     execute_subset,
     forkserver_job,
     ip_yaml,
     my_job,
 )
-from dagster._legacy import execute_pipeline
 
 
 def test_execute_my_job():

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/ops_jobs_graphs_tests/test_job_execution.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/ops_jobs_graphs_tests/test_job_execution.py
@@ -1,12 +1,11 @@
 import yaml
-
-from dagster import execute_pipeline
 from docs_snippets.concepts.ops_jobs_graphs.job_execution import (
     execute_subset,
     forkserver_job,
     ip_yaml,
     my_job,
 )
+from dagster._legacy import execute_pipeline
 
 
 def test_execute_my_job():

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/asset_tutorial_tests/test_cereal.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/asset_tutorial_tests/test_cereal.py
@@ -1,6 +1,6 @@
+from dagster._legacy import AssetGroup
 from docs_snippets.guides.dagster.asset_tutorial import cereal
 from docs_snippets.intro_tutorial.test_util import patch_cereal_requests
-from dagster._legacy import AssetGroup
 
 
 @patch_cereal_requests

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/asset_tutorial_tests/test_cereal.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/asset_tutorial_tests/test_cereal.py
@@ -1,6 +1,6 @@
-from dagster import AssetGroup
 from docs_snippets.guides.dagster.asset_tutorial import cereal
 from docs_snippets.intro_tutorial.test_util import patch_cereal_requests
+from dagster._legacy import AssetGroup
 
 
 @patch_cereal_requests

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/asset_tutorial_tests/test_serial_asset_graph.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/asset_tutorial_tests/test_serial_asset_graph.py
@@ -1,6 +1,6 @@
+from dagster._legacy import AssetGroup
 from docs_snippets.guides.dagster.asset_tutorial import serial_asset_graph
 from docs_snippets.intro_tutorial.test_util import patch_cereal_requests
-from dagster._legacy import AssetGroup
 
 
 @patch_cereal_requests

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/asset_tutorial_tests/test_serial_asset_graph.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/asset_tutorial_tests/test_serial_asset_graph.py
@@ -1,6 +1,6 @@
-from dagster import AssetGroup
 from docs_snippets.guides.dagster.asset_tutorial import serial_asset_graph
 from docs_snippets.intro_tutorial.test_util import patch_cereal_requests
+from dagster._legacy import AssetGroup
 
 
 @patch_cereal_requests

--- a/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_type_guide.py
+++ b/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_type_guide.py
@@ -7,18 +7,21 @@ from dagster import (
     AssetMaterialization,
     DagsterType,
     DagsterTypeCheckDidNotPass,
-    InputDefinition,
     Nothing,
-    OutputDefinition,
     PythonObjectDagsterType,
     dagster_type_loader,
     dagster_type_materializer,
-    execute_pipeline,
     execute_solid,
     make_python_type_usable_as_dagster_type,
     usable_as_dagster_type,
 )
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 from dagster._utils import safe_tempfile_path
 
 

--- a/examples/docs_snippets/docs_snippets_tests/legacy_tests/data_science_tests/test_pipelines.py
+++ b/examples/docs_snippets/docs_snippets_tests/legacy_tests/data_science_tests/test_pipelines.py
@@ -2,11 +2,12 @@ import tempfile
 
 import pytest
 
-from dagster import execute_pipeline, file_relative_path
+from dagster import file_relative_path
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.test_utils import instance_for_test
 from dagster._utils import pushd
 from dagster._utils.yaml_utils import load_yaml_from_path
+from dagster._legacy import execute_pipeline
 
 
 @pytest.mark.parametrize(

--- a/examples/docs_snippets/docs_snippets_tests/legacy_tests/data_science_tests/test_pipelines.py
+++ b/examples/docs_snippets/docs_snippets_tests/legacy_tests/data_science_tests/test_pipelines.py
@@ -5,9 +5,9 @@ import pytest
 from dagster import file_relative_path
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.test_utils import instance_for_test
+from dagster._legacy import execute_pipeline
 from dagster._utils import pushd
 from dagster._utils.yaml_utils import load_yaml_from_path
-from dagster._legacy import execute_pipeline
 
 
 @pytest.mark.parametrize(

--- a/examples/memoized_development/memoized_development/repo.py
+++ b/examples/memoized_development/memoized_development/repo.py
@@ -1,0 +1,27 @@
+# start_mypipeline
+from memoized_development.solids.dog import emit_dog
+from memoized_development.solids.sentence import emit_sentence
+from memoized_development.solids.tree import emit_tree
+
+from dagster import repository
+from dagster._core.storage.memoizable_io_manager import versioned_filesystem_io_manager
+from dagster._core.storage.tags import MEMOIZED_RUN_TAG
+from dagster._legacy import ModeDefinition, pipeline
+
+
+@pipeline(
+    mode_defs=[
+        ModeDefinition("memoized", resource_defs={"io_manager": versioned_filesystem_io_manager}),
+    ],
+    tags={MEMOIZED_RUN_TAG: "true"},
+)
+def my_pipeline():
+    return emit_sentence(emit_dog(), emit_tree())
+
+
+# end_mypipeline
+
+
+@repository
+def memoized_development():
+    return [my_pipeline]

--- a/examples/memoized_development/memoized_development/solids/sentence.py
+++ b/examples/memoized_development/memoized_development/solids/sentence.py
@@ -1,0 +1,10 @@
+from memoized_development.solids.solid_utils import get_hash_for_file
+from dagster._legacy import InputDefinition, solid
+
+
+@solid(
+    version=get_hash_for_file(__file__),
+    input_defs=[InputDefinition("dog_breed"), InputDefinition("tree_species")],
+)
+def emit_sentence(dog_breed, tree_species):
+    return f"{dog_breed} is a breed of dog, while {tree_species} is a species of tree."

--- a/examples/memoized_development/memoized_development/solids/sentence.py
+++ b/examples/memoized_development/memoized_development/solids/sentence.py
@@ -1,4 +1,5 @@
 from memoized_development.solids.solid_utils import get_hash_for_file
+
 from dagster._legacy import InputDefinition, solid
 
 

--- a/examples/memoized_development/tests/test_memoized_development.py
+++ b/examples/memoized_development/tests/test_memoized_development.py
@@ -1,6 +1,7 @@
 import tempfile
 
 from memoized_development.repo import my_pipeline
+
 from dagster._core.test_utils import instance_for_test
 from dagster._legacy import execute_pipeline
 

--- a/examples/memoized_development/tests/test_memoized_development.py
+++ b/examples/memoized_development/tests/test_memoized_development.py
@@ -1,0 +1,22 @@
+import tempfile
+
+from memoized_development.repo import my_pipeline
+from dagster._core.test_utils import instance_for_test
+from dagster._legacy import execute_pipeline
+
+
+def test_memoized_development():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with instance_for_test(temp_dir=temp_dir) as instance:
+            result = execute_pipeline(
+                my_pipeline,
+                run_config={
+                    "solids": {
+                        "emit_dog": {"config": {"dog_breed": "poodle"}},
+                        "emit_tree": {"config": {"tree_species": "weeping_willow"}},
+                    },
+                    "resources": {"io_manager": {"config": {"base_dir": temp_dir}}},
+                },
+                instance=instance,
+            )
+            assert result.success

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/repo.py
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/repo.py
@@ -1,4 +1,5 @@
-from dagster import graph, op, pipeline, repository, solid
+from dagster import graph, op, repository
+from dagster._legacy import pipeline, solid
 
 
 @solid

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/repo.py
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/repo.py
@@ -1,5 +1,4 @@
-from dagster import graph, op, repository
-from dagster._legacy import pipeline, solid
+from dagster import graph, op, pipeline, repository, solid
 
 
 @solid

--- a/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
+++ b/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
@@ -10,17 +10,15 @@ from dagster._core.snap import snapshot_from_execution_plan
 from dagster._core.storage.pipeline_run import RunsFilter
 from dagster._core.storage.tags import MAX_RETRIES_TAG, RETRY_STRATEGY_TAG
 from dagster._core.test_utils import create_run_for_test, instance_for_test
+from dagster._legacy import PipelineRunStatus
 from dagster.daemon.auto_run_reexecution.auto_run_reexecution import (
     consume_new_runs_for_automatic_reexecution,
     filter_runs_to_should_retry,
     get_reexecution_strategy,
 )
-from dagster.daemon.auto_run_reexecution.event_log_consumer import (
-    EventLogConsumerDaemon,
-)
+from dagster.daemon.auto_run_reexecution.event_log_consumer import EventLogConsumerDaemon
 
 from .utils import foo, get_foo_pipeline_handle
-from dagster._legacy import PipelineRunStatus
 
 
 def create_run(instance, **kwargs):

--- a/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
+++ b/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
@@ -2,7 +2,7 @@
 import logging
 import time
 
-from dagster import DagsterEvent, DagsterEventType, EventLogEntry, PipelineRunStatus
+from dagster import DagsterEvent, DagsterEventType, EventLogEntry
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.instance import DagsterInstance
@@ -15,9 +15,12 @@ from dagster.daemon.auto_run_reexecution.auto_run_reexecution import (
     filter_runs_to_should_retry,
     get_reexecution_strategy,
 )
-from dagster.daemon.auto_run_reexecution.event_log_consumer import EventLogConsumerDaemon
+from dagster.daemon.auto_run_reexecution.event_log_consumer import (
+    EventLogConsumerDaemon,
+)
 
 from .utils import foo, get_foo_pipeline_handle
+from dagster._legacy import PipelineRunStatus
 
 
 def create_run(instance, **kwargs):

--- a/python_modules/automation/automation/docker/images/k8s-example/build_cache/example_project/example_repo/repo.py
+++ b/python_modules/automation/automation/docker/images/k8s-example/build_cache/example_project/example_repo/repo.py
@@ -4,15 +4,15 @@ from collections import Counter
 from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
 from dagster_celery_k8s import celery_k8s_job_executor
 
-from dagster import (
+from dagster import file_relative_path, repository
+from dagster._legacy import (
     InputDefinition,
     ModeDefinition,
     PresetDefinition,
     default_executors,
-    file_relative_path,
-    repository,
+    pipeline,
+    solid,
 )
-from dagster._legacy import pipeline, solid
 
 
 @solid(input_defs=[InputDefinition("word", str)], config_schema={"factor": int})

--- a/python_modules/dagit/dagit_tests/override_pipeline.py
+++ b/python_modules/dagit/dagit_tests/override_pipeline.py
@@ -1,5 +1,5 @@
-from dagster import InputDefinition, Int, OutputDefinition, lambda_solid, repository
-from dagster._legacy import pipeline
+from dagster import Int, repository
+from dagster._legacy import InputDefinition, OutputDefinition, lambda_solid, pipeline
 
 
 @lambda_solid(input_defs=[InputDefinition("num", Int)], output_def=OutputDefinition(Int))

--- a/python_modules/dagit/dagit_tests/pipeline.py
+++ b/python_modules/dagit/dagit_tests/pipeline.py
@@ -1,6 +1,6 @@
-from dagster import InputDefinition, Int, OutputDefinition, daily_schedule, lambda_solid, repository
+from dagster import Int, daily_schedule, repository
 from dagster._core.test_utils import today_at_midnight
-from dagster._legacy import pipeline
+from dagster._legacy import InputDefinition, OutputDefinition, lambda_solid, pipeline
 
 
 @lambda_solid(input_defs=[InputDefinition("num", Int)], output_def=OutputDefinition(Int))

--- a/python_modules/dagit/dagit_tests/stress/dag_gen.py
+++ b/python_modules/dagit/dagit_tests/stress/dag_gen.py
@@ -1,16 +1,14 @@
 import random
 from collections import defaultdict
 
-from dagster import (
-    DependencyDefinition,
-    Field,
+from dagster import DependencyDefinition, Field, Output
+from dagster import _check as check
+from dagster._legacy import (
     InputDefinition,
-    Output,
     OutputDefinition,
     PipelineDefinition,
     SolidDefinition,
 )
-from dagster import _check as check
 
 
 def generate_solid(solid_id, num_inputs, num_outputs, num_cfg):

--- a/python_modules/dagit/dagit_tests/stress/dag_gen.py
+++ b/python_modules/dagit/dagit_tests/stress/dag_gen.py
@@ -3,12 +3,7 @@ from collections import defaultdict
 
 from dagster import DependencyDefinition, Field, Output
 from dagster import _check as check
-from dagster._legacy import (
-    InputDefinition,
-    OutputDefinition,
-    PipelineDefinition,
-    SolidDefinition,
-)
+from dagster._legacy import InputDefinition, OutputDefinition, PipelineDefinition, SolidDefinition
 
 
 def generate_solid(solid_id, num_inputs, num_outputs, num_cfg):

--- a/python_modules/dagit/dagit_tests/test_debug_cli.py
+++ b/python_modules/dagit/dagit_tests/test_debug_cli.py
@@ -3,6 +3,7 @@ from os import path
 import uvicorn
 from click.testing import CliRunner
 from dagit.debug import dagit_debug_command
+
 from dagster._cli.debug import export_command
 from dagster._core.test_utils import instance_for_test
 from dagster._legacy import execute_pipeline, lambda_solid, pipeline

--- a/python_modules/dagit/dagit_tests/test_debug_cli.py
+++ b/python_modules/dagit/dagit_tests/test_debug_cli.py
@@ -3,11 +3,9 @@ from os import path
 import uvicorn
 from click.testing import CliRunner
 from dagit.debug import dagit_debug_command
-
-from dagster import execute_pipeline, lambda_solid
 from dagster._cli.debug import export_command
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline
+from dagster._legacy import execute_pipeline, lambda_solid, pipeline
 
 
 @lambda_solid

--- a/python_modules/dagit/dagit_tests/test_subscriptions.py
+++ b/python_modules/dagit/dagit_tests/test_subscriptions.py
@@ -6,6 +6,7 @@ import objgraph
 from dagit.graphql import GraphQLWS
 from dagit.webserver import DagitWebserver
 from starlette.testclient import TestClient
+
 from dagster._core.test_utils import environ, instance_for_test
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import WorkspaceFileTarget

--- a/python_modules/dagit/dagit_tests/test_subscriptions.py
+++ b/python_modules/dagit/dagit_tests/test_subscriptions.py
@@ -6,12 +6,10 @@ import objgraph
 from dagit.graphql import GraphQLWS
 from dagit.webserver import DagitWebserver
 from starlette.testclient import TestClient
-
-from dagster import execute_pipeline
 from dagster._core.test_utils import environ, instance_for_test
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import WorkspaceFileTarget
-from dagster._legacy import pipeline, solid
+from dagster._legacy import execute_pipeline, pipeline, solid
 from dagster._utils import file_relative_path
 
 EVENT_LOG_SUBSCRIPTION = """

--- a/python_modules/dagit/dagit_tests/toy/bar_repo.py
+++ b/python_modules/dagit/dagit_tests/toy/bar_repo.py
@@ -1,7 +1,7 @@
 import string
 
-from dagster import PartitionSetDefinition, ScheduleDefinition, lambda_solid, repository
-from dagster._legacy import pipeline
+from dagster import PartitionSetDefinition, ScheduleDefinition, repository
+from dagster._legacy import lambda_solid, pipeline
 
 
 @lambda_solid

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -1,15 +1,6 @@
 from collections import defaultdict
 from enum import Enum
-from typing import (
-    TYPE_CHECKING,
-    Dict,
-    Iterable,
-    KeysView,
-    List,
-    Mapping,
-    Optional,
-    cast,
-)
+from typing import TYPE_CHECKING, Dict, Iterable, KeysView, List, Mapping, Optional, cast
 
 from dagster_graphql.implementation.fetch_assets import get_asset_nodes_by_asset_key
 from graphql.execution.base import ResolveInfo
@@ -24,11 +15,11 @@ from dagster._core.host_representation import PipelineSelector
 from dagster._core.storage.event_log.base import AssetRecord
 from dagster._core.storage.pipeline_run import RunRecord, RunsFilter
 from dagster._core.storage.tags import TagType, get_tag_type
+from dagster._legacy import PipelineDefinition, PipelineRunStatus
 
 from .events import from_event_record
 from .external import ensure_valid_config, get_external_pipeline_or_raise
 from .utils import UserFacingGraphQLError, capture_error
-from dagster._legacy import PipelineDefinition, PipelineRunStatus
 
 if TYPE_CHECKING:
     from ..schema.asset_graph import GrapheneAssetNode

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -1,11 +1,20 @@
 from collections import defaultdict
 from enum import Enum
-from typing import TYPE_CHECKING, Dict, Iterable, KeysView, List, Mapping, Optional, cast
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Iterable,
+    KeysView,
+    List,
+    Mapping,
+    Optional,
+    cast,
+)
 
 from dagster_graphql.implementation.fetch_assets import get_asset_nodes_by_asset_key
 from graphql.execution.base import ResolveInfo
 
-from dagster import AssetKey, PipelineDefinition, PipelineRunStatus
+from dagster import AssetKey
 from dagster import _check as check
 from dagster._config import validate_config
 from dagster._core.definitions import create_run_config_schema
@@ -19,6 +28,7 @@ from dagster._core.storage.tags import TagType, get_tag_type
 from .events import from_event_record
 from .external import ensure_valid_config, get_external_pipeline_or_raise
 from .utils import UserFacingGraphQLError, capture_error
+from dagster._legacy import PipelineDefinition, PipelineRunStatus
 
 if TYPE_CHECKING:
     from ..schema.asset_graph import GrapheneAssetNode
@@ -261,9 +271,10 @@ def get_assets_latest_info(graphene_info, step_keys_by_asset: Mapping[AssetKey, 
                 in_progress_records.append(run_record)
             run_records_by_run_id[run_record.pipeline_run.run_id] = run_record
 
-    in_progress_run_ids_by_asset, unstarted_run_ids_by_asset = _get_in_progress_runs_for_assets(
-        graphene_info, in_progress_records, step_keys_by_asset
-    )
+    (
+        in_progress_run_ids_by_asset,
+        unstarted_run_ids_by_asset,
+    ) = _get_in_progress_runs_for_assets(graphene_info, in_progress_records, step_keys_by_asset)
 
     return [
         GrapheneAssetLatestInfo(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/sleepy.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/sleepy.py
@@ -4,13 +4,7 @@ from time import sleep
 
 from dagster import Field, Int, List, Output
 from dagster._core.test_utils import default_mode_def_for_test
-from dagster._legacy import (
-    InputDefinition,
-    OutputDefinition,
-    PresetDefinition,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, OutputDefinition, PresetDefinition, pipeline, solid
 
 
 @solid(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/sleepy.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/sleepy.py
@@ -2,13 +2,20 @@
 
 from time import sleep
 
-from dagster import Field, InputDefinition, Int, List, Output, OutputDefinition, PresetDefinition
+from dagster import Field, Int, List, Output
 from dagster._core.test_utils import default_mode_def_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    PresetDefinition,
+    pipeline,
+    solid,
+)
 
 
 @solid(
-    input_defs=[InputDefinition("units", List[Int])], output_defs=[OutputDefinition(Int, "total")]
+    input_defs=[InputDefinition("units", List[Int])],
+    output_defs=[OutputDefinition(Int, "total")],
 )
 def sleeper(context, units):
     tot = 0

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/cross_repo_asset_deps.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/cross_repo_asset_deps.py
@@ -1,5 +1,6 @@
 # pylint: disable=redefined-outer-name
-from dagster import AssetGroup, AssetKey, SourceAsset, asset, repository
+from dagster import AssetKey, SourceAsset, asset, repository
+from dagster._legacy import AssetGroup
 
 
 @asset

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/setup.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/setup.py
@@ -19,7 +19,6 @@ from dagster_graphql.test.utils import (
 
 from dagster import (
     Any,
-    AssetGroup,
     AssetKey,
     AssetMaterialization,
     AssetObservation,
@@ -29,7 +28,6 @@ from dagster import (
     DefaultScheduleStatus,
     DefaultSensorStatus,
     DynamicOutput,
-    DynamicOutputDefinition,
     Enum,
     EnumValue,
     ExpectationResult,
@@ -37,19 +35,14 @@ from dagster import (
     HourlyPartitionsDefinition,
     IOManager,
     IOManagerDefinition,
-    InputDefinition,
     Int,
     Map,
-    Materialization,
     MetadataEntry,
-    ModeDefinition,
     Noneable,
     Nothing,
     Output,
-    OutputDefinition,
     Partition,
     PartitionSetDefinition,
-    PresetDefinition,
     PythonObjectDagsterType,
     ScheduleDefinition,
     ScheduleEvaluationContext,
@@ -67,15 +60,12 @@ from dagster import (
 from dagster import _check as check
 from dagster import (
     asset,
-    build_assets_job,
-    composite_solid,
     dagster_type_loader,
     dagster_type_materializer,
     daily_schedule,
     graph,
     hourly_schedule,
     job,
-    lambda_solid,
     logger,
     monthly_schedule,
     op,
@@ -96,7 +86,20 @@ from dagster._core.storage.tags import RESUME_RETRY_TAG
 from dagster._core.test_utils import default_mode_def_for_test, today_at_midnight
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import PythonFileTarget
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    AssetGroup,
+    DynamicOutputDefinition,
+    InputDefinition,
+    Materialization,
+    ModeDefinition,
+    OutputDefinition,
+    PresetDefinition,
+    build_assets_job,
+    composite_solid,
+    lambda_solid,
+    pipeline,
+    solid,
+)
 from dagster._seven import get_system_temp_directory
 from dagster._utils import file_relative_path, segfault
 
@@ -713,7 +716,8 @@ def materialization_pipeline():
                 MetadataEntry("json", value={"is_dope": True}),
                 MetadataEntry("python class", value=MetadataValue.python_artifact(MetadataEntry)),
                 MetadataEntry(
-                    "python function", value=MetadataValue.python_artifact(file_relative_path)
+                    "python function",
+                    value=MetadataValue.python_artifact(file_relative_path),
                 ),
                 MetadataEntry("float", value=1.2),
                 MetadataEntry("int", value=1),
@@ -776,7 +780,10 @@ def retry_config_resource(context):
 @pipeline(
     mode_defs=[
         ModeDefinition(
-            resource_defs={"io_manager": fs_io_manager, "retry_count": retry_config_resource}
+            resource_defs={
+                "io_manager": fs_io_manager,
+                "retry_count": retry_config_resource,
+            }
         )
     ]
 )
@@ -856,7 +863,11 @@ def will_fail(context, num):  # pylint: disable=unused-argument
 @pipeline(
     mode_defs=[
         ModeDefinition(
-            resource_defs={"a": resource_a, "b": resource_b, "io_manager": fs_io_manager}
+            resource_defs={
+                "a": resource_a,
+                "b": resource_b,
+                "io_manager": fs_io_manager,
+            }
         )
     ]
 )
@@ -965,7 +976,10 @@ def retry_multi_input_early_terminate_pipeline():
         return one
 
     @lambda_solid(
-        input_defs=[InputDefinition("input_one", Int), InputDefinition("input_two", Int)],
+        input_defs=[
+            InputDefinition("input_one", Int),
+            InputDefinition("input_two", Int),
+        ],
         output_def=OutputDefinition(Int),
     )
     def sum_inputs(input_one, input_two):
@@ -1320,7 +1334,10 @@ def chained_failure_pipeline():
     @lambda_solid
     def conditionally_fail(_):
         if os.path.isfile(
-            os.path.join(get_system_temp_directory(), "chained_failure_pipeline_conditionally_fail")
+            os.path.join(
+                get_system_temp_directory(),
+                "chained_failure_pipeline_conditionally_fail",
+            )
         ):
             raise Exception("blah")
 
@@ -1347,7 +1364,8 @@ def backcompat_materialization_pipeline():
                 MetadataEntry("json", value={"is_dope": True}),
                 MetadataEntry("python class", value=MetadataValue.python_artifact(MetadataEntry)),
                 MetadataEntry(
-                    "python function", value=MetadataValue.python_artifact(file_relative_path)
+                    "python function",
+                    value=MetadataValue.python_artifact(file_relative_path),
                 ),
                 MetadataEntry("float", value=1.2),
                 MetadataEntry("int", value=1),
@@ -1399,7 +1417,9 @@ dummy_source_asset = SourceAsset(key=AssetKey("dummy_source_asset"))
 
 
 @asset
-def first_asset(dummy_source_asset):  # pylint: disable=redefined-outer-name,unused-argument
+def first_asset(
+    dummy_source_asset,
+):  # pylint: disable=redefined-outer-name,unused-argument
     return 1
 
 
@@ -1416,7 +1436,9 @@ def hanging_asset(context, first_asset):  # pylint: disable=redefined-outer-name
 
 
 @asset
-def never_runs_asset(hanging_asset):  # pylint: disable=redefined-outer-name,unused-argument
+def never_runs_asset(
+    hanging_asset,
+):  # pylint: disable=redefined-outer-name,unused-argument
     pass
 
 
@@ -1553,7 +1575,9 @@ def asset_yields_observation():
 
 
 observation_job = build_assets_job(
-    "observation_job", assets=[asset_yields_observation], executor_def=in_process_executor
+    "observation_job",
+    assets=[asset_yields_observation],
+    executor_def=in_process_executor,
 )
 
 
@@ -1673,7 +1697,13 @@ def ungrouped_asset_5():
 # For now the only way to add assets to repositories is via AssetGroup
 # When AssetGroup is removed, these assets should be added directly to repository_with_named_groups
 named_groups_job = AssetGroup(
-    [grouped_asset_1, grouped_asset_2, ungrouped_asset_3, grouped_asset_4, ungrouped_asset_5]
+    [
+        grouped_asset_1,
+        grouped_asset_2,
+        ungrouped_asset_3,
+        grouped_asset_4,
+        ungrouped_asset_5,
+    ]
 ).build_job("named_groups_job")
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_api_backcompat.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_api_backcompat.py
@@ -1,9 +1,6 @@
 import time
 
-from dagster_graphql.test.utils import (
-    define_out_of_process_context,
-    execute_dagster_graphql,
-)
+from dagster_graphql.test.utils import define_out_of_process_context, execute_dagster_graphql
 
 from dagster import repository
 from dagster._core.storage.pipeline_run import PipelineRunStatus

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_api_backcompat.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_api_backcompat.py
@@ -1,11 +1,14 @@
 import time
 
-from dagster_graphql.test.utils import define_out_of_process_context, execute_dagster_graphql
+from dagster_graphql.test.utils import (
+    define_out_of_process_context,
+    execute_dagster_graphql,
+)
 
-from dagster import PresetDefinition, repository
+from dagster import repository
 from dagster._core.storage.pipeline_run import PipelineRunStatus
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import PresetDefinition, pipeline, solid
 
 RUNS_QUERY = """
 query RunsQuery {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -12,7 +12,7 @@ from dagster_graphql.test.utils import (
     infer_repository_selector,
 )
 
-from dagster import AssetKey, DagsterEventType, PipelineRunStatus
+from dagster import AssetKey, DagsterEventType
 from dagster._core.test_utils import poll_for_finished_run
 from dagster._utils import safe_tempfile_path
 
@@ -21,6 +21,7 @@ from .graphql_context_test_suite import (
     AllRepositoryGraphQLContextTestMatrix,
     ExecutingGraphQLContextTestMatrix,
 )
+from dagster._legacy import PipelineRunStatus
 
 GET_ASSET_KEY_QUERY = """
     query AssetKeyQuery {
@@ -317,7 +318,13 @@ def _create_run(
     result = execute_dagster_graphql(
         graphql_context,
         LAUNCH_PIPELINE_EXECUTION_MUTATION,
-        variables={"executionParams": {"selector": selector, "mode": mode, "stepKeys": step_keys}},
+        variables={
+            "executionParams": {
+                "selector": selector,
+                "mode": mode,
+                "stepKeys": step_keys,
+            }
+        },
     )
     assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
     run_id = result.data["launchPipelineExecution"]["run"]["runId"]
@@ -352,7 +359,9 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
     def test_get_asset_key_materialization(self, graphql_context, snapshot):
         _create_run(graphql_context, "single_asset_pipeline")
         result = execute_dagster_graphql(
-            graphql_context, GET_ASSET_MATERIALIZATION, variables={"assetKey": {"path": ["a"]}}
+            graphql_context,
+            GET_ASSET_MATERIALIZATION,
+            variables={"assetKey": {"path": ["a"]}},
         )
         assert result.data
         snapshot.assert_match(result.data)
@@ -509,7 +518,10 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         result = execute_dagster_graphql(
             graphql_context,
             GET_ASSET_NODES_FROM_KEYS,
-            variables={"pipelineSelector": selector, "assetKeys": [{"path": ["asset_one"]}]},
+            variables={
+                "pipelineSelector": selector,
+                "assetKeys": [{"path": ["asset_one"]}],
+            },
         )
 
         assert result.data
@@ -814,7 +826,9 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
 
         # Confirm that asset selection is respected
         run_id = _create_run(
-            graphql_context, "failure_assets_job", asset_selection=[{"path": ["asset_3"]}]
+            graphql_context,
+            "failure_assets_job",
+            asset_selection=[{"path": ["asset_3"]}],
         )
 
         result = execute_dagster_graphql(
@@ -870,7 +884,9 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
 
         # Execute subselection with assets foo and foo_bar
         run_id = _create_run(
-            graphql_context, "foo_job", asset_selection=[{"path": ["foo"]}, {"path": ["foo_bar"]}]
+            graphql_context,
+            "foo_job",
+            asset_selection=[{"path": ["foo"]}, {"path": ["foo_bar"]}],
         )
         run = graphql_context.instance.get_run_by_id(run_id)
         assert run.is_finished
@@ -886,14 +902,20 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         run_id = _create_run(
             graphql_context,
             "foo_job",
-            asset_selection=[{"path": ["foo"]}, {"path": ["bar"]}, {"path": ["foo_bar"]}],
+            asset_selection=[
+                {"path": ["foo"]},
+                {"path": ["bar"]},
+                {"path": ["foo_bar"]},
+            ],
         )
         run = graphql_context.instance.get_run_by_id(run_id)
         assert run.is_finished
 
         # Generate materializations with subselection of foo and baz
         run_id = _create_run(
-            graphql_context, "foo_job", asset_selection=[{"path": ["foo"]}, {"path": ["baz"]}]
+            graphql_context,
+            "foo_job",
+            asset_selection=[{"path": ["foo"]}, {"path": ["baz"]}],
         )
         run = graphql_context.instance.get_run_by_id(run_id)
         assert run.is_finished
@@ -1118,7 +1140,9 @@ class TestCrossRepoAssetDependedBy(AllRepositoryGraphQLContextTestMatrix):
             "repositoryName": repository.name,
         }
         result = execute_dagster_graphql(
-            graphql_context, CROSS_REPO_ASSET_GRAPH, variables={"repositorySelector": selector}
+            graphql_context,
+            CROSS_REPO_ASSET_GRAPH,
+            variables={"repositorySelector": selector},
         )
         asset_nodes = result.data["assetNodes"]
         upstream_asset = [
@@ -1126,7 +1150,10 @@ class TestCrossRepoAssetDependedBy(AllRepositoryGraphQLContextTestMatrix):
             for node in asset_nodes
             if node["id"] == 'cross_asset_repos.upstream_assets_repository.["upstream_asset"]'
         ][0]
-        dependent_asset_keys = [{"path": ["downstream_asset1"]}, {"path": ["downstream_asset2"]}]
+        dependent_asset_keys = [
+            {"path": ["downstream_asset1"]},
+            {"path": ["downstream_asset2"]},
+        ]
 
         result_dependent_keys = sorted(
             upstream_asset["dependedByKeys"], key=lambda node: node.get("path")[0]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -14,6 +14,7 @@ from dagster_graphql.test.utils import (
 
 from dagster import AssetKey, DagsterEventType
 from dagster._core.test_utils import poll_for_finished_run
+from dagster._legacy import PipelineRunStatus
 from dagster._utils import safe_tempfile_path
 
 # from .graphql_context_test_suite import GraphQLContextVariant, make_graphql_context_test_suite
@@ -21,7 +22,6 @@ from .graphql_context_test_suite import (
     AllRepositoryGraphQLContextTestMatrix,
     ExecutingGraphQLContextTestMatrix,
 )
-from dagster._legacy import PipelineRunStatus
 
 GET_ASSET_KEY_QUERY = """
     query AssetKeyQuery {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_context.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_context.py
@@ -4,15 +4,10 @@ from contextlib import ExitStack
 from unittest import mock
 
 import pytest
-from dagster_graphql.test.utils import (
-    define_out_of_process_workspace,
-    main_repo_location_name,
-)
+from dagster_graphql.test.utils import define_out_of_process_workspace, main_repo_location_name
 
 from dagster import repository
-from dagster._core.host_representation.repository_location import (
-    GrpcServerRepositoryLocation,
-)
+from dagster._core.host_representation.repository_location import GrpcServerRepositoryLocation
 from dagster._core.test_utils import instance_for_test
 from dagster._legacy import lambda_solid, pipeline
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_context.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_context.py
@@ -4,12 +4,17 @@ from contextlib import ExitStack
 from unittest import mock
 
 import pytest
-from dagster_graphql.test.utils import define_out_of_process_workspace, main_repo_location_name
+from dagster_graphql.test.utils import (
+    define_out_of_process_workspace,
+    main_repo_location_name,
+)
 
-from dagster import lambda_solid, repository
-from dagster._core.host_representation.repository_location import GrpcServerRepositoryLocation
+from dagster import repository
+from dagster._core.host_representation.repository_location import (
+    GrpcServerRepositoryLocation,
+)
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline
+from dagster._legacy import lambda_solid, pipeline
 
 
 def get_repo():

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_execute_pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_execute_pipeline.py
@@ -9,8 +9,10 @@ from dagster_graphql.client.query import (
 )
 from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_selector
 from graphql import parse
+
 from dagster._core.storage.pipeline_run import RunsFilter
 from dagster._core.test_utils import wait_for_runs_to_finish
+from dagster._legacy import PipelineRunStatus
 from dagster._utils import file_relative_path
 from dagster._utils.test import get_temp_file_name
 
@@ -25,7 +27,6 @@ from .utils import (
     step_did_succeed,
     sync_execute_get_run_log_data,
 )
-from dagster._legacy import PipelineRunStatus
 
 STEP_FAILURE_EVENTS_QUERY = """
 query pipelineRunEvents($runId: ID!) {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_execute_pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_execute_pipeline.py
@@ -9,8 +9,6 @@ from dagster_graphql.client.query import (
 )
 from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_selector
 from graphql import parse
-
-from dagster import PipelineRunStatus
 from dagster._core.storage.pipeline_run import RunsFilter
 from dagster._core.test_utils import wait_for_runs_to_finish
 from dagster._utils import file_relative_path
@@ -27,6 +25,7 @@ from .utils import (
     step_did_succeed,
     sync_execute_get_run_log_data,
 )
+from dagster._legacy import PipelineRunStatus
 
 STEP_FAILURE_EVENTS_QUERY = """
 query pipelineRunEvents($runId: ID!) {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_misc.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_misc.py
@@ -7,17 +7,19 @@ from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_s
 from dagster import (
     AssetMaterialization,
     DependencyDefinition,
-    InputDefinition,
-    OutputDefinition,
-    PipelineDefinition,
     PythonObjectDagsterType,
-    SolidDefinition,
     dagster_type_loader,
     dagster_type_materializer,
     repository,
 )
 
 from .production_query import PRODUCTION_QUERY
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    PipelineDefinition,
+    SolidDefinition,
+)
 
 
 @dagster_type_loader(str)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_misc.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_misc.py
@@ -12,14 +12,9 @@ from dagster import (
     dagster_type_materializer,
     repository,
 )
+from dagster._legacy import InputDefinition, OutputDefinition, PipelineDefinition, SolidDefinition
 
 from .production_query import PRODUCTION_QUERY
-from dagster._legacy import (
-    InputDefinition,
-    OutputDefinition,
-    PipelineDefinition,
-    SolidDefinition,
-)
 
 
 @dagster_type_loader(str)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -7,14 +7,13 @@ from dagster_graphql.test.utils import (
     execute_dagster_graphql_and_finish_runs,
     infer_repository_selector,
 )
-
-from dagster import PipelineRun, PipelineRunStatus
 from dagster._core.execution.backfill import BulkActionStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._core.test_utils import create_run_for_test
 from dagster._seven import get_system_temp_directory
 
 from .graphql_context_test_suite import ExecutingGraphQLContextTestMatrix
+from dagster._legacy import PipelineRun, PipelineRunStatus
 
 PARTITION_PROGRESS_QUERY = """
   query PartitionProgressQuery($backfillId: String!) {
@@ -96,7 +95,10 @@ def _seed_runs(graphql_context, partition_runs: List[Tuple[str, PipelineRunStatu
         create_run_for_test(
             instance=graphql_context.instance,
             status=status,
-            tags={**PipelineRun.tags_for_backfill_id(backfill_id), PARTITION_NAME_TAG: partition},
+            tags={
+                **PipelineRun.tags_for_backfill_id(backfill_id),
+                PARTITION_NAME_TAG: partition,
+            },
         )
 
 
@@ -142,7 +144,9 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
 
         result = execute_dagster_graphql(
-            graphql_context, PARTITION_PROGRESS_QUERY, variables={"backfillId": backfill_id}
+            graphql_context,
+            PARTITION_PROGRESS_QUERY,
+            variables={"backfillId": backfill_id},
         )
 
         assert not result.errors
@@ -211,7 +215,9 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
 
         result = execute_dagster_graphql(
-            graphql_context, PARTITION_PROGRESS_QUERY, variables={"backfillId": backfill_id}
+            graphql_context,
+            PARTITION_PROGRESS_QUERY,
+            variables={"backfillId": backfill_id},
         )
 
         assert not result.errors
@@ -244,7 +250,9 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
 
         result = execute_dagster_graphql(
-            graphql_context, PARTITION_PROGRESS_QUERY, variables={"backfillId": backfill_id}
+            graphql_context,
+            PARTITION_PROGRESS_QUERY,
+            variables={"backfillId": backfill_id},
         )
 
         assert not result.errors
@@ -255,13 +263,17 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert len(result.data["partitionBackfillOrError"]["partitionNames"]) == 2
 
         result = execute_dagster_graphql(
-            graphql_context, CANCEL_BACKFILL_MUTATION, variables={"backfillId": backfill_id}
+            graphql_context,
+            CANCEL_BACKFILL_MUTATION,
+            variables={"backfillId": backfill_id},
         )
         assert result.data
         assert result.data["cancelPartitionBackfill"]["__typename"] == "CancelBackfillSuccess"
 
         result = execute_dagster_graphql(
-            graphql_context, PARTITION_PROGRESS_QUERY, variables={"backfillId": backfill_id}
+            graphql_context,
+            PARTITION_PROGRESS_QUERY,
+            variables={"backfillId": backfill_id},
         )
         assert not result.errors
         assert result.data
@@ -291,7 +303,9 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
 
         result = execute_dagster_graphql(
-            graphql_context, PARTITION_PROGRESS_QUERY, variables={"backfillId": backfill_id}
+            graphql_context,
+            PARTITION_PROGRESS_QUERY,
+            variables={"backfillId": backfill_id},
         )
 
         assert not result.errors
@@ -306,13 +320,17 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         graphql_context.instance.update_backfill(backfill.with_status(BulkActionStatus.FAILED))
 
         result = execute_dagster_graphql(
-            graphql_context, RESUME_BACKFILL_MUTATION, variables={"backfillId": backfill_id}
+            graphql_context,
+            RESUME_BACKFILL_MUTATION,
+            variables={"backfillId": backfill_id},
         )
         assert result.data
         assert result.data["resumePartitionBackfill"]["__typename"] == "ResumeBackfillSuccess"
 
         result = execute_dagster_graphql(
-            graphql_context, PARTITION_PROGRESS_QUERY, variables={"backfillId": backfill_id}
+            graphql_context,
+            PARTITION_PROGRESS_QUERY,
+            variables={"backfillId": backfill_id},
         )
         assert not result.errors
         assert result.data
@@ -356,7 +374,9 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         )
 
         result = execute_dagster_graphql(
-            graphql_context, PARTITION_PROGRESS_QUERY, variables={"backfillId": backfill_id}
+            graphql_context,
+            PARTITION_PROGRESS_QUERY,
+            variables={"backfillId": backfill_id},
         )
 
         assert not result.errors
@@ -381,7 +401,9 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         graphql_context.instance.update_backfill(backfill.with_status(BulkActionStatus.COMPLETED))
 
         result = execute_dagster_graphql(
-            graphql_context, PARTITION_PROGRESS_QUERY, variables={"backfillId": backfill_id}
+            graphql_context,
+            PARTITION_PROGRESS_QUERY,
+            variables={"backfillId": backfill_id},
         )
         assert result.data["partitionBackfillOrError"]["status"] == "COMPLETED"
         assert result.data["partitionBackfillOrError"]["backfillStatus"] == "IN_PROGRESS"
@@ -422,7 +444,9 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         )
 
         result = execute_dagster_graphql(
-            graphql_context, PARTITION_PROGRESS_QUERY, variables={"backfillId": backfill_id}
+            graphql_context,
+            PARTITION_PROGRESS_QUERY,
+            variables={"backfillId": backfill_id},
         )
 
         assert not result.errors
@@ -478,7 +502,9 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         )
 
         result = execute_dagster_graphql(
-            graphql_context, PARTITION_PROGRESS_QUERY, variables={"backfillId": backfill_id}
+            graphql_context,
+            PARTITION_PROGRESS_QUERY,
+            variables={"backfillId": backfill_id},
         )
 
         assert not result.errors
@@ -550,7 +576,9 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
 
         result = execute_dagster_graphql(
-            graphql_context, PARTITION_PROGRESS_QUERY, variables={"backfillId": backfill_id}
+            graphql_context,
+            PARTITION_PROGRESS_QUERY,
+            variables={"backfillId": backfill_id},
         )
         assert not result.errors
         assert result.data
@@ -583,7 +611,9 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
 
         result = execute_dagster_graphql(
-            graphql_context, PARTITION_PROGRESS_QUERY, variables={"backfillId": backfill_id}
+            graphql_context,
+            PARTITION_PROGRESS_QUERY,
+            variables={"backfillId": backfill_id},
         )
 
         assert not result.errors

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -7,13 +7,14 @@ from dagster_graphql.test.utils import (
     execute_dagster_graphql_and_finish_runs,
     infer_repository_selector,
 )
+
 from dagster._core.execution.backfill import BulkActionStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._core.test_utils import create_run_for_test
+from dagster._legacy import PipelineRun, PipelineRunStatus
 from dagster._seven import get_system_temp_directory
 
 from .graphql_context_test_suite import ExecutingGraphQLContextTestMatrix
-from dagster._legacy import PipelineRun, PipelineRunStatus
 
 PARTITION_PROGRESS_QUERY = """
   query PartitionProgressQuery($backfillId: String!) {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_pipeline_snapshot.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_pipeline_snapshot.py
@@ -1,18 +1,19 @@
 from unittest import mock
 
 import pytest
-from dagster_graphql.implementation.fetch_pipelines import _get_pipeline_snapshot_from_instance
+from dagster_graphql.implementation.fetch_pipelines import (
+    _get_pipeline_snapshot_from_instance,
+)
 from dagster_graphql.implementation.utils import UserFacingGraphQLError
 from dagster_graphql.test.utils import (
     execute_dagster_graphql,
     main_repo_location_name,
     main_repo_name,
 )
-
-from dagster import execute_pipeline
 from dagster._seven import json
 
 from .setup import noop_pipeline
+from dagster._legacy import execute_pipeline
 
 SNAPSHOT_OR_ERROR_QUERY_BY_SNAPSHOT_ID = """
 query PipelineSnapshotQueryBySnapshotID($snapshotId: String!) {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_pipeline_snapshot.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_pipeline_snapshot.py
@@ -1,19 +1,18 @@
 from unittest import mock
 
 import pytest
-from dagster_graphql.implementation.fetch_pipelines import (
-    _get_pipeline_snapshot_from_instance,
-)
+from dagster_graphql.implementation.fetch_pipelines import _get_pipeline_snapshot_from_instance
 from dagster_graphql.implementation.utils import UserFacingGraphQLError
 from dagster_graphql.test.utils import (
     execute_dagster_graphql,
     main_repo_location_name,
     main_repo_name,
 )
+
+from dagster._legacy import execute_pipeline
 from dagster._seven import json
 
 from .setup import noop_pipeline
-from dagster._legacy import execute_pipeline
 
 SNAPSHOT_OR_ERROR_QUERY_BY_SNAPSHOT_ID = """
 query PipelineSnapshotQueryBySnapshotID($snapshotId: String!) {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_cancellation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_cancellation.py
@@ -5,16 +5,14 @@ from typing import Any
 import pytest
 from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
 from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_selector
+
 from dagster._core.definitions.reconstruct import ReconstructableRepository
 from dagster._core.storage.pipeline_run import PipelineRunStatus
 from dagster._grpc.types import CancelExecutionRequest
+from dagster._legacy import execute_pipeline
 from dagster._utils import file_relative_path, safe_tempfile_path
 
-from .graphql_context_test_suite import (
-    GraphQLContextVariant,
-    make_graphql_context_test_suite,
-)
-from dagster._legacy import execute_pipeline
+from .graphql_context_test_suite import GraphQLContextVariant, make_graphql_context_test_suite
 
 RUN_CANCELLATION_QUERY = """
 mutation($runId: String!, $terminatePolicy: TerminateRunPolicy) {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_cancellation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_cancellation.py
@@ -5,14 +5,16 @@ from typing import Any
 import pytest
 from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
 from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_selector
-
-from dagster import execute_pipeline
 from dagster._core.definitions.reconstruct import ReconstructableRepository
 from dagster._core.storage.pipeline_run import PipelineRunStatus
 from dagster._grpc.types import CancelExecutionRequest
 from dagster._utils import file_relative_path, safe_tempfile_path
 
-from .graphql_context_test_suite import GraphQLContextVariant, make_graphql_context_test_suite
+from .graphql_context_test_suite import (
+    GraphQLContextVariant,
+    make_graphql_context_test_suite,
+)
+from dagster._legacy import execute_pipeline
 
 RUN_CANCELLATION_QUERY = """
 mutation($runId: String!, $terminatePolicy: TerminateRunPolicy) {
@@ -129,7 +131,10 @@ class TestQueuedRunTermination(QueuedRunCoordinatorTestSuite):
             result = execute_dagster_graphql(
                 graphql_context,
                 RUN_CANCELLATION_QUERY,
-                variables={"runId": run_id, "terminatePolicy": "MARK_AS_CANCELED_IMMEDIATELY"},
+                variables={
+                    "runId": run_id,
+                    "terminatePolicy": "MARK_AS_CANCELED_IMMEDIATELY",
+                },
             )
             assert result.data["terminatePipelineExecution"]["__typename"] == "TerminateRunSuccess"
 
@@ -212,7 +217,10 @@ class TestRunVariantTermination(RunTerminationTestSuite):
             result = execute_dagster_graphql(
                 graphql_context,
                 RUN_CANCELLATION_QUERY,
-                variables={"runId": run_id, "terminatePolicy": "MARK_AS_CANCELED_IMMEDIATELY"},
+                variables={
+                    "runId": run_id,
+                    "terminatePolicy": "MARK_AS_CANCELED_IMMEDIATELY",
+                },
             )
             assert result.data["terminatePipelineExecution"]["__typename"] == "TerminateRunSuccess"
 
@@ -273,7 +281,10 @@ class TestRunVariantTermination(RunTerminationTestSuite):
             result = execute_dagster_graphql(
                 graphql_context,
                 RUN_CANCELLATION_QUERY,
-                variables={"runId": run_id, "terminatePolicy": "MARK_AS_CANCELED_IMMEDIATELY"},
+                variables={
+                    "runId": run_id,
+                    "terminatePolicy": "MARK_AS_CANCELED_IMMEDIATELY",
+                },
             )
 
             assert result.data["terminatePipelineExecution"]["__typename"] == "TerminateRunSuccess"
@@ -305,7 +316,9 @@ class TestRunVariantTermination(RunTerminationTestSuite):
         time.sleep(0.05)  # guarantee execution finish
 
         result = execute_dagster_graphql(
-            graphql_context, RUN_CANCELLATION_QUERY, variables={"runId": pipeline_result.run_id}
+            graphql_context,
+            RUN_CANCELLATION_QUERY,
+            variables={"runId": pipeline_result.run_id},
         )
 
         assert result.data["terminatePipelineExecution"]["__typename"] == "TerminateRunFailure"
@@ -359,6 +372,8 @@ class TestRunVariantTermination(RunTerminationTestSuite):
                 time.sleep(0.1)
 
             result = execute_dagster_graphql(
-                graphql_context, BACKCOMPAT_LEGACY_TERMINATE_PIPELINE, variables={"runId": run_id}
+                graphql_context,
+                BACKCOMPAT_LEGACY_TERMINATE_PIPELINE,
+                variables={"runId": run_id},
             )
             assert result.data["terminatePipelineExecution"]["run"]["runId"] == run_id

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -11,21 +11,13 @@ from dagster_graphql_tests.graphql.graphql_context_test_suite import (
     ExecutingGraphQLContextTestMatrix,
 )
 
-from dagster import (
-    AssetMaterialization,
-    Output,
-    execute_pipeline,
-    job,
-    lambda_solid,
-    op,
-    repository,
-)
+from dagster import AssetMaterialization, Output, job, op, repository
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
 from dagster._core.execution.api import execute_run
 from dagster._core.storage.pipeline_run import PipelineRunStatus
 from dagster._core.storage.tags import PARENT_RUN_ID_TAG, ROOT_RUN_ID_TAG
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline
+from dagster._legacy import execute_pipeline, lambda_solid, pipeline
 from dagster._utils import Counter, traced_counter
 
 RUNS_QUERY = """
@@ -634,7 +626,9 @@ def test_filtered_runs():
         ).run_id
         with define_out_of_process_context(__file__, "get_repo_at_time_1", instance) as context:
             result = execute_dagster_graphql(
-                context, FILTERED_RUN_QUERY, variables={"filter": {"runIds": [run_id_1]}}
+                context,
+                FILTERED_RUN_QUERY,
+                variables={"filter": {"runIds": [run_id_1]}},
             )
             assert result.data
             run_ids = [run["runId"] for run in result.data["pipelineRunsOrError"]["results"]]
@@ -653,7 +647,9 @@ def test_filtered_runs():
 
             # test multiple run ids
             result = execute_dagster_graphql(
-                context, FILTERED_RUN_QUERY, variables={"filter": {"runIds": [run_id_1, run_id_2]}}
+                context,
+                FILTERED_RUN_QUERY,
+                variables={"filter": {"runIds": [run_id_1, run_id_2]}},
             )
             assert result.data
             run_ids = [run["runId"] for run in result.data["pipelineRunsOrError"]["results"]]
@@ -672,7 +668,9 @@ def test_filtered_runs_status():
         ).run_id
         with define_out_of_process_context(__file__, "get_repo_at_time_1", instance) as context:
             result = execute_dagster_graphql(
-                context, FILTERED_RUN_QUERY, variables={"filter": {"statuses": ["FAILURE"]}}
+                context,
+                FILTERED_RUN_QUERY,
+                variables={"filter": {"statuses": ["FAILURE"]}},
             )
             assert result.data
             run_ids = [run["runId"] for run in result.data["pipelineRunsOrError"]["results"]]
@@ -710,10 +708,14 @@ def test_filtered_runs_multiple_filters():
         repo = get_repo_at_time_1()
 
         started_run_with_tags = instance.create_run_for_pipeline(
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.STARTED, tags={"foo": "bar"}
+            repo.get_pipeline("foo_pipeline"),
+            status=PipelineRunStatus.STARTED,
+            tags={"foo": "bar"},
         )
         failed_run_with_tags = instance.create_run_for_pipeline(
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.FAILURE, tags={"foo": "bar"}
+            repo.get_pipeline("foo_pipeline"),
+            status=PipelineRunStatus.FAILURE,
+            tags={"foo": "bar"},
         )
         started_run_without_tags = instance.create_run_for_pipeline(
             repo.get_pipeline("foo_pipeline"),
@@ -726,7 +728,10 @@ def test_filtered_runs_multiple_filters():
                 context,
                 FILTERED_RUN_QUERY,
                 variables={
-                    "filter": {"statuses": ["STARTED"], "tags": [{"key": "foo", "value": "bar"}]}
+                    "filter": {
+                        "statuses": ["STARTED"],
+                        "tags": [{"key": "foo", "value": "bar"}],
+                    }
                 },
             )
             assert result.data
@@ -748,7 +753,9 @@ def test_filtered_runs_count():
         ).run_id
         with define_out_of_process_context(__file__, "get_repo_at_time_1", instance) as context:
             result = execute_dagster_graphql(
-                context, FILTERED_RUN_COUNT_QUERY, variables={"filter": {"statuses": ["FAILURE"]}}
+                context,
+                FILTERED_RUN_COUNT_QUERY,
+                variables={"filter": {"statuses": ["FAILURE"]}},
             )
             assert result.data
             count = result.data["pipelineRunsOrError"]["count"]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/test_cli_repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/test_cli_repo.py
@@ -1,11 +1,5 @@
 from dagster import Int, ScheduleDefinition, repository
-from dagster._legacy import (
-    InputDefinition,
-    OutputDefinition,
-    lambda_solid,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, OutputDefinition, lambda_solid, pipeline, solid
 
 
 @lambda_solid(input_defs=[InputDefinition("num", Int)], output_def=OutputDefinition(Int))

--- a/python_modules/dagster-graphql/dagster_graphql_tests/test_cli_repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/test_cli_repo.py
@@ -1,12 +1,11 @@
-from dagster import (
+from dagster import Int, ScheduleDefinition, repository
+from dagster._legacy import (
     InputDefinition,
-    Int,
     OutputDefinition,
-    ScheduleDefinition,
     lambda_solid,
-    repository,
+    pipeline,
+    solid,
 )
-from dagster._legacy import pipeline, solid
 
 
 @lambda_solid(input_defs=[InputDefinition("num", Int)], output_def=OutputDefinition(Int))

--- a/python_modules/dagster-test/dagster_test/dagster_core_docker_buildkite/test_pipelines/repo.py
+++ b/python_modules/dagster-test/dagster_test/dagster_core_docker_buildkite/test_pipelines/repo.py
@@ -1,16 +1,19 @@
 import string
 
 from dagster import (
-    InputDefinition,
     Int,
-    OutputDefinition,
     PartitionSetDefinition,
     ScheduleDefinition,
-    lambda_solid,
     repository,
     usable_as_dagster_type,
 )
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    lambda_solid,
+    pipeline,
+    solid,
+)
 
 
 @lambda_solid

--- a/python_modules/dagster-test/dagster_test/dagster_core_docker_buildkite/test_pipelines/repo.py
+++ b/python_modules/dagster-test/dagster_test/dagster_core_docker_buildkite/test_pipelines/repo.py
@@ -7,13 +7,7 @@ from dagster import (
     repository,
     usable_as_dagster_type,
 )
-from dagster._legacy import (
-    InputDefinition,
-    OutputDefinition,
-    lambda_solid,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, OutputDefinition, lambda_solid, pipeline, solid
 
 
 @lambda_solid

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/big_honkin_asset_graph.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/big_honkin_asset_graph.py
@@ -1,8 +1,9 @@
 import random
 from typing import List
 
-from dagster import AssetGroup, AssetKey, asset
+from dagster import AssetKey, asset
 from dagster._core.definitions.assets import AssetsDefinition
+from dagster._legacy import AssetGroup
 
 N_ASSETS = 1000
 

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/cross_repo_assets.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/cross_repo_assets.py
@@ -1,5 +1,6 @@
 # pylint: disable=redefined-outer-name
-from dagster import AssetGroup, AssetKey, SourceAsset, asset
+from dagster import AssetKey, SourceAsset, asset
+from dagster._legacy import AssetGroup
 
 
 @asset

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/graph_backed_assets.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/graph_backed_assets.py
@@ -1,4 +1,5 @@
-from dagster import AssetGroup, AssetsDefinition, graph, op
+from dagster import AssetsDefinition, graph, op
+from dagster._legacy import AssetGroup
 
 
 @op

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/long_asset_keys.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/long_asset_keys.py
@@ -1,5 +1,6 @@
 # pylint: disable=redefined-outer-name
-from dagster import AssetGroup, AssetIn, asset
+from dagster import AssetIn, asset
+from dagster._legacy import AssetGroup
 
 namespace1 = ["s3", "superdomain_1", "subdomain_1", "subsubdomain_1"]
 

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/partitioned_assets.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/partitioned_assets.py
@@ -1,12 +1,7 @@
 # pylint: disable=redefined-outer-name
 from datetime import datetime
 
-from dagster import (
-    DailyPartitionsDefinition,
-    HourlyPartitionsDefinition,
-    MetadataValue,
-    asset,
-)
+from dagster import DailyPartitionsDefinition, HourlyPartitionsDefinition, MetadataValue, asset
 from dagster._legacy import AssetGroup
 
 daily_partitions_def = DailyPartitionsDefinition(start_date="2020-01-01")

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/partitioned_assets.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/partitioned_assets.py
@@ -2,12 +2,12 @@
 from datetime import datetime
 
 from dagster import (
-    AssetGroup,
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
     MetadataValue,
     asset,
 )
+from dagster._legacy import AssetGroup
 
 daily_partitions_def = DailyPartitionsDefinition(start_date="2020-01-01")
 
@@ -22,7 +22,9 @@ def upstream_daily_partitioned_asset():
 
 
 @asset(
-    metadata={"owner": "alice@example.com"}, compute_kind="sql", partitions_def=daily_partitions_def
+    metadata={"owner": "alice@example.com"},
+    compute_kind="sql",
+    partitions_def=daily_partitions_def,
 )
 def downstream_daily_partitioned_asset(upstream_daily_partitioned_asset):
     assert upstream_daily_partitioned_asset is None

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/software_defined_assets.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/software_defined_assets.py
@@ -1,7 +1,8 @@
 # pylint: disable=redefined-outer-name
 import time
 
-from dagster import AssetGroup, AssetKey, IOManager, IOManagerDefinition, SourceAsset, asset
+from dagster import AssetKey, IOManager, IOManagerDefinition, SourceAsset, asset
+from dagster._legacy import AssetGroup
 
 sfo_q2_weather_sample = SourceAsset(key=AssetKey("sfo_q2_weather_sample"))
 

--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
@@ -16,28 +16,31 @@ from dagster import (
     Bool,
     Field,
     In,
-    InputDefinition,
     Int,
     IntSource,
     List,
-    ModeDefinition,
     Output,
-    OutputDefinition,
     RetryRequested,
     String,
     VersionStrategy,
-    default_executors,
     file_relative_path,
     fs_io_manager,
     job,
-    lambda_solid,
     op,
     repository,
     resource,
 )
 from dagster._core.definitions.decorators import daily_schedule, schedule
 from dagster._core.test_utils import nesting_composite_pipeline
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    default_executors,
+    lambda_solid,
+    pipeline,
+    solid,
+)
 from dagster._utils import merge_dicts, segfault
 from dagster._utils.yaml_utils import merge_yamls
 
@@ -405,7 +408,10 @@ def define_long_running_pipeline_celery():
 
 def define_large_pipeline_celery():
     return nesting_composite_pipeline(
-        depth=1, num_children=6, mode_defs=celery_mode_defs(), name="large_pipeline_celery"
+        depth=1,
+        num_children=6,
+        mode_defs=celery_mode_defs(),
+        name="large_pipeline_celery",
     )
 
 

--- a/python_modules/dagster-test/dagster_test/toys/asset_lineage.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_lineage.py
@@ -11,15 +11,13 @@ from dagster import (
     Field,
     MetadataEntry,
     MetadataValue,
-    ModeDefinition,
     Output,
-    OutputDefinition,
     Partition,
     PartitionSetDefinition,
 )
 from dagster._core.storage.fs_io_manager import PickledObjectFilesystemIOManager
 from dagster._core.storage.io_manager import io_manager
-from dagster._legacy import pipeline, solid
+from dagster._legacy import ModeDefinition, OutputDefinition, pipeline, solid
 
 
 def get_date_partitions():
@@ -76,7 +74,9 @@ class MyDatabaseIOManager(PickledObjectFilesystemIOManager):
         super().handle_output(context, obj)
         # can pretend this actually came from a library call
         yield MetadataEntry(
-            label="num rows written to db", description=None, entry_data=MetadataValue.int(len(obj))
+            label="num rows written to db",
+            description=None,
+            entry_data=MetadataValue.int(len(obj)),
         )
 
     def get_output_asset_key(self, context):
@@ -122,10 +122,14 @@ def download_data(_):
 @solid(
     output_defs=[
         OutputDefinition(
-            name="reviews", io_manager_key="my_db_io_manager", metadata={"table_name": "reviews"}
+            name="reviews",
+            io_manager_key="my_db_io_manager",
+            metadata={"table_name": "reviews"},
         ),
         OutputDefinition(
-            name="comments", io_manager_key="my_db_io_manager", metadata={"table_name": "comments"}
+            name="comments",
+            io_manager_key="my_db_io_manager",
+            metadata={"table_name": "comments"},
         ),
     ]
 )

--- a/python_modules/dagster-test/dagster_test/toys/branches.py
+++ b/python_modules/dagster-test/dagster_test/toys/branches.py
@@ -1,13 +1,7 @@
 from time import sleep
 
 from dagster import Field, Int, Output, fs_io_manager
-from dagster._legacy import (
-    ModeDefinition,
-    OutputDefinition,
-    PresetDefinition,
-    pipeline,
-    solid,
-)
+from dagster._legacy import ModeDefinition, OutputDefinition, PresetDefinition, pipeline, solid
 
 
 @solid(

--- a/python_modules/dagster-test/dagster_test/toys/branches.py
+++ b/python_modules/dagster-test/dagster_test/toys/branches.py
@@ -1,15 +1,13 @@
 from time import sleep
 
-from dagster import (
-    Field,
-    Int,
+from dagster import Field, Int, Output, fs_io_manager
+from dagster._legacy import (
     ModeDefinition,
-    Output,
     OutputDefinition,
     PresetDefinition,
-    fs_io_manager,
+    pipeline,
+    solid,
 )
-from dagster._legacy import pipeline, solid
 
 
 @solid(

--- a/python_modules/dagster-test/dagster_test/toys/composition.py
+++ b/python_modules/dagster-test/dagster_test/toys/composition.py
@@ -1,11 +1,5 @@
 from dagster import Float, Int, List
-from dagster._legacy import (
-    InputDefinition,
-    OutputDefinition,
-    composite_solid,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, OutputDefinition, composite_solid, pipeline, solid
 
 
 @solid(output_defs=[OutputDefinition(Int)])

--- a/python_modules/dagster-test/dagster_test/toys/composition.py
+++ b/python_modules/dagster-test/dagster_test/toys/composition.py
@@ -1,5 +1,11 @@
-from dagster import Float, InputDefinition, Int, List, OutputDefinition, composite_solid
-from dagster._legacy import pipeline, solid
+from dagster import Float, Int, List
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    composite_solid,
+    pipeline,
+    solid,
+)
 
 
 @solid(output_defs=[OutputDefinition(Int)])
@@ -7,7 +13,10 @@ def emit_one(_):
     return 1
 
 
-@solid(input_defs=[InputDefinition("numbers", List[Int])], output_defs=[OutputDefinition(Int)])
+@solid(
+    input_defs=[InputDefinition("numbers", List[Int])],
+    output_defs=[OutputDefinition(Int)],
+)
 def add(_, numbers):
     return sum(numbers)
 

--- a/python_modules/dagster-test/dagster_test/toys/error_monster.py
+++ b/python_modules/dagster-test/dagster_test/toys/error_monster.py
@@ -2,18 +2,21 @@ from dagster import (
     Failure,
     Field,
     IOManager,
-    InputDefinition,
     Int,
-    ModeDefinition,
-    OutputDefinition,
-    PresetDefinition,
     ResourceDefinition,
     RetryRequested,
     String,
-    execute_pipeline,
     io_manager,
 )
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    PresetDefinition,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 from dagster._utils import segfault
 
 

--- a/python_modules/dagster-test/dagster_test/toys/graph_job_repos.py
+++ b/python_modules/dagster-test/dagster_test/toys/graph_job_repos.py
@@ -1,16 +1,7 @@
 from typing import Any, Optional, Set
 
-from dagster import (
-    InputDefinition,
-    ResourceDefinition,
-    SkipReason,
-    SolidDefinition,
-    graph,
-    repository,
-    schedule,
-    sensor,
-)
-from dagster._legacy import solid
+from dagster import ResourceDefinition, SkipReason, graph, repository, schedule, sensor
+from dagster._legacy import InputDefinition, SolidDefinition, solid
 
 
 def make_solid(
@@ -75,7 +66,8 @@ crm_ingest_dev = crm_ingest.to_job(resource_defs={"crm": ResourceDefinition.none
 
 @schedule(
     job=crm_ingest.to_job(
-        name="crm_ingest_instance1", resource_defs={"crm": ResourceDefinition.none_resource()}
+        name="crm_ingest_instance1",
+        resource_defs={"crm": ResourceDefinition.none_resource()},
     ),
     cron_schedule="0 0 * * *",
 )
@@ -85,7 +77,8 @@ def crm_ingest_instance1_schedule(_):
 
 @schedule(
     job=crm_ingest.to_job(
-        name="crm_ingest_instance2", resource_defs={"crm": ResourceDefinition.none_resource()}
+        name="crm_ingest_instance2",
+        resource_defs={"crm": ResourceDefinition.none_resource()},
     ),
     cron_schedule="0 0 * * *",
 )

--- a/python_modules/dagster-test/dagster_test/toys/hammer.py
+++ b/python_modules/dagster-test/dagster_test/toys/hammer.py
@@ -1,9 +1,15 @@
 import random
 import time
 
-from dagster import Field, InputDefinition, ModeDefinition, Output, OutputDefinition, fs_io_manager
+from dagster import Field, Output, fs_io_manager
 from dagster._core.definitions.executor_definition import default_executors
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    pipeline,
+    solid,
+)
 
 
 def get_executor_defs():
@@ -79,7 +85,8 @@ def reducer(_, in_1, in_2, in_3, in_4):
     # Needed for Dask tests which use this pipeline
     mode_defs=[
         ModeDefinition(
-            resource_defs={"io_manager": fs_io_manager}, executor_defs=get_executor_defs()
+            resource_defs={"io_manager": fs_io_manager},
+            executor_defs=get_executor_defs(),
         )
     ]
 )

--- a/python_modules/dagster-test/dagster_test/toys/hammer.py
+++ b/python_modules/dagster-test/dagster_test/toys/hammer.py
@@ -3,13 +3,7 @@ import time
 
 from dagster import Field, Output, fs_io_manager
 from dagster._core.definitions.executor_definition import default_executors
-from dagster._legacy import (
-    InputDefinition,
-    ModeDefinition,
-    OutputDefinition,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, ModeDefinition, OutputDefinition, pipeline, solid
 
 
 def get_executor_defs():

--- a/python_modules/dagster-test/dagster_test/toys/log_spew.py
+++ b/python_modules/dagster-test/dagster_test/toys/log_spew.py
@@ -1,13 +1,7 @@
 import time
 
 from dagster import Output, fs_io_manager
-from dagster._legacy import (
-    InputDefinition,
-    ModeDefinition,
-    OutputDefinition,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, ModeDefinition, OutputDefinition, pipeline, solid
 
 
 def nonce_solid(name, n_inputs, n_outputs):

--- a/python_modules/dagster-test/dagster_test/toys/log_spew.py
+++ b/python_modules/dagster-test/dagster_test/toys/log_spew.py
@@ -1,7 +1,13 @@
 import time
 
-from dagster import InputDefinition, ModeDefinition, Output, OutputDefinition, fs_io_manager
-from dagster._legacy import pipeline, solid
+from dagster import Output, fs_io_manager
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    pipeline,
+    solid,
+)
 
 
 def nonce_solid(name, n_inputs, n_outputs):

--- a/python_modules/dagster-test/dagster_test/toys/longitudinal.py
+++ b/python_modules/dagster-test/dagster_test/toys/longitudinal.py
@@ -4,13 +4,7 @@ from datetime import datetime
 from random import random
 
 from dagster import AssetMaterialization, Nothing, fs_io_manager
-from dagster._legacy import (
-    InputDefinition,
-    ModeDefinition,
-    OutputDefinition,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, ModeDefinition, OutputDefinition, pipeline, solid
 from dagster._utils.partitions import DEFAULT_DATE_FORMAT
 
 TRAFFIC_CONSTANTS = {

--- a/python_modules/dagster-test/dagster_test/toys/longitudinal.py
+++ b/python_modules/dagster-test/dagster_test/toys/longitudinal.py
@@ -3,15 +3,14 @@ import time
 from datetime import datetime
 from random import random
 
-from dagster import (
-    AssetMaterialization,
+from dagster import AssetMaterialization, Nothing, fs_io_manager
+from dagster._legacy import (
     InputDefinition,
     ModeDefinition,
-    Nothing,
     OutputDefinition,
-    fs_io_manager,
+    pipeline,
+    solid,
 )
-from dagster._legacy import pipeline, solid
 from dagster._utils.partitions import DEFAULT_DATE_FORMAT
 
 TRAFFIC_CONSTANTS = {

--- a/python_modules/dagster-test/dagster_test/toys/many_events.py
+++ b/python_modules/dagster-test/dagster_test/toys/many_events.py
@@ -7,13 +7,7 @@ from dagster import (
     file_relative_path,
     fs_io_manager,
 )
-from dagster._legacy import (
-    InputDefinition,
-    ModeDefinition,
-    OutputDefinition,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, ModeDefinition, OutputDefinition, pipeline, solid
 
 MARKDOWN_EXAMPLE = "markdown_example.md"
 

--- a/python_modules/dagster-test/dagster_test/toys/many_events.py
+++ b/python_modules/dagster-test/dagster_test/toys/many_events.py
@@ -1,16 +1,19 @@
 from dagster import (
     AssetMaterialization,
     ExpectationResult,
-    InputDefinition,
     MetadataValue,
-    ModeDefinition,
     Nothing,
     Output,
-    OutputDefinition,
     file_relative_path,
     fs_io_manager,
 )
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    pipeline,
+    solid,
+)
 
 MARKDOWN_EXAMPLE = "markdown_example.md"
 
@@ -140,8 +143,18 @@ def check_users_and_groups_one_fails_one_succeeds(_context):
         metadata={
             "table_summary": {
                 "columns": {
-                    "name": {"nulls": 0, "empty": 0, "values": 123, "average_length": 3.394893},
-                    "time_created": {"nulls": 1, "empty": 2, "values": 120, "average": 1231283},
+                    "name": {
+                        "nulls": 0,
+                        "empty": 0,
+                        "values": 123,
+                        "average_length": 3.394893,
+                    },
+                    "time_created": {
+                        "nulls": 1,
+                        "empty": 2,
+                        "values": 120,
+                        "average": 1231283,
+                    },
                 }
             },
         },
@@ -154,8 +167,18 @@ def check_users_and_groups_one_fails_one_succeeds(_context):
         metadata={
             "table_summary": {
                 "columns": {
-                    "name": {"nulls": 1, "empty": 0, "values": 122, "average_length": 3.394893},
-                    "time_created": {"nulls": 1, "empty": 2, "values": 120, "average": 1231283},
+                    "name": {
+                        "nulls": 1,
+                        "empty": 0,
+                        "values": 122,
+                        "average_length": 3.394893,
+                    },
+                    "time_created": {
+                        "nulls": 1,
+                        "empty": 2,
+                        "values": 120,
+                        "average": 1231283,
+                    },
                 }
             }
         },

--- a/python_modules/dagster-test/dagster_test/toys/pyspark_assets/pyspark_assets_pipeline.py
+++ b/python_modules/dagster-test/dagster_test/toys/pyspark_assets/pyspark_assets_pipeline.py
@@ -4,8 +4,14 @@ from pyspark.sql import SparkSession, Window
 from pyspark.sql.functions import col, concat, lit
 from pyspark.sql.functions import max as pyspark_max
 
-from dagster import Field, InputDefinition, ModeDefinition, String, execute_pipeline, resource
-from dagster._legacy import pipeline, solid
+from dagster import Field, String, resource
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 def create_spark_session():

--- a/python_modules/dagster-test/dagster_test/toys/pyspark_assets/pyspark_assets_pipeline.py
+++ b/python_modules/dagster-test/dagster_test/toys/pyspark_assets/pyspark_assets_pipeline.py
@@ -5,13 +5,7 @@ from pyspark.sql.functions import col, concat, lit
 from pyspark.sql.functions import max as pyspark_max
 
 from dagster import Field, String, resource
-from dagster._legacy import (
-    InputDefinition,
-    ModeDefinition,
-    execute_pipeline,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, ModeDefinition, execute_pipeline, pipeline, solid
 
 
 def create_spark_session():

--- a/python_modules/dagster-test/dagster_test/toys/resources.py
+++ b/python_modules/dagster-test/dagster_test/toys/resources.py
@@ -1,13 +1,5 @@
-from dagster import (
-    Field,
-    Int,
-    ModeDefinition,
-    execute_pipeline,
-    fs_io_manager,
-    reconstructable,
-    resource,
-)
-from dagster._legacy import pipeline, solid
+from dagster import Field, Int, fs_io_manager, reconstructable, resource
+from dagster._legacy import ModeDefinition, execute_pipeline, pipeline, solid
 from dagster._utils import merge_dicts
 
 

--- a/python_modules/dagster-test/dagster_test/toys/retries.py
+++ b/python_modules/dagster-test/dagster_test/toys/retries.py
@@ -1,7 +1,7 @@
 import time
 
-from dagster import PresetDefinition, RetryRequested, lambda_solid
-from dagster._legacy import pipeline, solid
+from dagster import RetryRequested
+from dagster._legacy import PresetDefinition, lambda_solid, pipeline, solid
 
 
 @lambda_solid

--- a/python_modules/dagster-test/dagster_test/toys/sensors.py
+++ b/python_modules/dagster-test/dagster_test/toys/sensors.py
@@ -4,7 +4,8 @@ from slack_sdk.web.client import WebClient
 
 from dagster import AssetKey, PipelineFailureSensorContext, RunRequest, SkipReason
 from dagster import _check as check
-from dagster import asset_sensor, pipeline_failure_sensor, sensor
+from dagster import asset_sensor, sensor
+from dagster._legacy import pipeline_failure_sensor
 
 
 def get_directory_files(directory_name, since=None):
@@ -55,7 +56,12 @@ def get_toys_sensors():
                 run_key="{}:{}".format(filename, str(mtime)),
                 run_config={
                     "solids": {
-                        "read_file": {"config": {"directory": directory_name, "filename": filename}}
+                        "read_file": {
+                            "config": {
+                                "directory": directory_name,
+                                "filename": filename,
+                            }
+                        }
                     }
                 },
             )
@@ -114,7 +120,10 @@ def get_toys_sensors():
             run_config={
                 "solids": {
                     "read_materialization": {
-                        "config": {"asset_key": ["model"], "pipeline": asset_event.pipeline_name}
+                        "config": {
+                            "asset_key": ["model"],
+                            "pipeline": asset_event.pipeline_name,
+                        }
                     }
                 }
             },

--- a/python_modules/dagster-test/dagster_test/toys/sleepy.py
+++ b/python_modules/dagster-test/dagster_test/toys/sleepy.py
@@ -2,8 +2,8 @@
 from time import sleep
 from typing import Iterator, List
 
-from dagster import Field, Output, OutputDefinition, graph
-from dagster._legacy import solid
+from dagster import Field, Output, graph
+from dagster._legacy import OutputDefinition, solid
 
 
 @solid

--- a/python_modules/dagster-test/dagster_test/toys/unreliable.py
+++ b/python_modules/dagster-test/dagster_test/toys/unreliable.py
@@ -1,7 +1,7 @@
 from random import random
 
-from dagster import Field, ModeDefinition, fs_io_manager
-from dagster._legacy import pipeline, solid
+from dagster import Field, fs_io_manager
+from dagster._legacy import ModeDefinition, pipeline, solid
 
 DEFAULT_EXCEPTION_RATE = 0.3
 

--- a/python_modules/dagster-test/dagster_test_tests/test_toys.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_toys.py
@@ -5,10 +5,15 @@ from dagster_test.toys.dynamic import dynamic_pipeline
 from dagster_test.toys.error_monster import error_monster
 from dagster_test.toys.hammer import hammer_pipeline
 from dagster_test.toys.log_spew import log_spew
-from dagster_test.toys.longitudinal import IntentionalRandomFailure, longitudinal_pipeline
+from dagster_test.toys.longitudinal import (
+    IntentionalRandomFailure,
+    longitudinal_pipeline,
+)
 from dagster_test.toys.many_events import many_events
 from dagster_test.toys.notebooks import hello_world_notebook_pipeline
-from dagster_test.toys.pyspark_assets.pyspark_assets_pipeline import pyspark_assets_pipeline
+from dagster_test.toys.pyspark_assets.pyspark_assets_pipeline import (
+    pyspark_assets_pipeline,
+)
 from dagster_test.toys.repo import toys_repository
 from dagster_test.toys.resources import resource_pipeline
 from dagster_test.toys.retries import retry_pipeline
@@ -19,12 +24,12 @@ from dagster import (
     DagsterInvariantViolationError,
     DagsterResourceFunctionError,
     DagsterTypeCheckDidNotPass,
-    execute_pipeline,
     reconstructable,
 )
 from dagster._core.test_utils import instance_for_test
 from dagster._utils import file_relative_path
 from dagster._utils.temp_file import get_temp_dir
+from dagster._legacy import execute_pipeline
 
 
 def test_repo():
@@ -110,7 +115,8 @@ def test_pyspark_assets_pipeline():
                 "source_data_dir": {
                     "config": {
                         "dir": file_relative_path(
-                            __file__, "../dagster_test/toys/pyspark_assets/asset_pipeline_files"
+                            __file__,
+                            "../dagster_test/toys/pyspark_assets/asset_pipeline_files",
                         ),
                     }
                 },

--- a/python_modules/dagster-test/dagster_test_tests/test_toys.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_toys.py
@@ -5,15 +5,10 @@ from dagster_test.toys.dynamic import dynamic_pipeline
 from dagster_test.toys.error_monster import error_monster
 from dagster_test.toys.hammer import hammer_pipeline
 from dagster_test.toys.log_spew import log_spew
-from dagster_test.toys.longitudinal import (
-    IntentionalRandomFailure,
-    longitudinal_pipeline,
-)
+from dagster_test.toys.longitudinal import IntentionalRandomFailure, longitudinal_pipeline
 from dagster_test.toys.many_events import many_events
 from dagster_test.toys.notebooks import hello_world_notebook_pipeline
-from dagster_test.toys.pyspark_assets.pyspark_assets_pipeline import (
-    pyspark_assets_pipeline,
-)
+from dagster_test.toys.pyspark_assets.pyspark_assets_pipeline import pyspark_assets_pipeline
 from dagster_test.toys.repo import toys_repository
 from dagster_test.toys.resources import resource_pipeline
 from dagster_test.toys.retries import retry_pipeline
@@ -27,9 +22,9 @@ from dagster import (
     reconstructable,
 )
 from dagster._core.test_utils import instance_for_test
+from dagster._legacy import execute_pipeline
 from dagster._utils import file_relative_path
 from dagster._utils.temp_file import get_temp_dir
-from dagster._legacy import execute_pipeline
 
 
 def test_repo():

--- a/python_modules/dagster/dagster/_cli/config_scaffolder.py
+++ b/python_modules/dagster/dagster/_cli/config_scaffolder.py
@@ -1,13 +1,14 @@
 from typing import Optional
-
-from dagster import PipelineDefinition
 from dagster import _check as check
 from dagster._config import ConfigType, ConfigTypeKind
 from dagster._core.definitions import create_run_config_schema
+from dagster._legacy import PipelineDefinition
 
 
 def scaffold_pipeline_config(
-    pipeline_def: PipelineDefinition, skip_non_required: bool = True, mode: Optional[str] = None
+    pipeline_def: PipelineDefinition,
+    skip_non_required: bool = True,
+    mode: Optional[str] = None,
 ):
     check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
     check.bool_param(skip_non_required, "skip_non_required")

--- a/python_modules/dagster/dagster/_cli/config_scaffolder.py
+++ b/python_modules/dagster/dagster/_cli/config_scaffolder.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 from dagster import _check as check
 from dagster._config import ConfigType, ConfigTypeKind
 from dagster._core.definitions import create_run_config_schema

--- a/python_modules/dagster/dagster/_cli/pipeline.py
+++ b/python_modules/dagster/dagster/_cli/pipeline.py
@@ -9,9 +9,7 @@ import pendulum
 from tabulate import tabulate
 
 import dagster._check as check
-from dagster import PipelineDefinition
 from dagster import __version__ as dagster_version
-from dagster import execute_pipeline
 from dagster._cli.workspace.cli_target import (
     WORKSPACE_TARGET_WARNING,
     get_external_pipeline_or_job_from_external_repo,
@@ -27,7 +25,10 @@ from dagster._cli.workspace.cli_target import (
     repository_target_argument,
 )
 from dagster._core.definitions.pipeline_base import IPipeline
-from dagster._core.errors import DagsterBackfillFailedError, DagsterInvariantViolationError
+from dagster._core.errors import (
+    DagsterBackfillFailedError,
+    DagsterInvariantViolationError,
+)
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.backfill import (
     BulkActionStatus,
@@ -40,7 +41,9 @@ from dagster._core.host_representation import (
     RepositoryHandle,
     RepositoryLocation,
 )
-from dagster._core.host_representation.external_data import ExternalPartitionSetExecutionParamData
+from dagster._core.host_representation.external_data import (
+    ExternalPartitionSetExecutionParamData,
+)
 from dagster._core.host_representation.selector import PipelineSelector
 from dagster._core.instance import DagsterInstance
 from dagster._core.snap import PipelineSnapshot, SolidInvocationSnap
@@ -48,7 +51,11 @@ from dagster._core.storage.tags import MEMOIZED_RUN_TAG
 from dagster._core.telemetry import log_external_repo_stats, telemetry_wrapper
 from dagster._core.utils import make_new_backfill_id
 from dagster._seven import IS_WINDOWS, JSONDecodeError, json
-from dagster._utils import DEFAULT_WORKSPACE_YAML_FILENAME, load_yaml_from_glob_list, merge_dicts
+from dagster._utils import (
+    DEFAULT_WORKSPACE_YAML_FILENAME,
+    load_yaml_from_glob_list,
+    merge_dicts,
+)
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.hosted_user_process import recon_pipeline_from_origin
 from dagster._utils.indenting_printer import IndentingPrinter
@@ -57,6 +64,7 @@ from dagster._utils.yaml_utils import dump_run_config_yaml
 
 from .config_scaffolder import scaffold_pipeline_config
 from .utils import get_instance_for_service
+from dagster._legacy import PipelineDefinition, execute_pipeline
 
 
 @click.group(name="pipeline")
@@ -281,7 +289,9 @@ def print_solid_or_op(
     "preset_defs.",
 )
 @click.option(
-    "--mode", type=click.STRING, help="The name of the mode in which to execute the pipeline."
+    "--mode",
+    type=click.STRING,
+    help="The name of the mode in which to execute the pipeline.",
 )
 def pipeline_list_versions_command(**kwargs):
     with DagsterInstance.get() as instance:
@@ -322,7 +332,8 @@ def add_step_to_table(memoized_plan):
         table.append(
             [
                 "{key}.{output}".format(
-                    key=step_output_handle.step_key, output=step_output_handle.output_name
+                    key=step_output_handle.step_key,
+                    output=step_output_handle.output_name,
                 ),
                 version,
                 "stored"
@@ -351,10 +362,14 @@ def add_step_to_table(memoized_plan):
     "preset_defs.",
 )
 @click.option(
-    "--mode", type=click.STRING, help="The name of the mode in which to execute the pipeline."
+    "--mode",
+    type=click.STRING,
+    help="The name of the mode in which to execute the pipeline.",
 )
 @click.option(
-    "--tags", type=click.STRING, help="JSON string of tags to use for this pipeline/job run"
+    "--tags",
+    type=click.STRING,
+    help="JSON string of tags to use for this pipeline/job run",
 )
 @click.option(
     "-s",
@@ -379,7 +394,9 @@ def pipeline_execute_command(**kwargs):
 
 @telemetry_wrapper
 def execute_execute_command(
-    instance: DagsterInstance, kwargs: Dict[str, object], using_job_op_graph_apis: bool = False
+    instance: DagsterInstance,
+    kwargs: Dict[str, object],
+    using_job_op_graph_apis: bool = False,
 ):
     check.inst_param(instance, "instance", DagsterInstance)
 
@@ -618,7 +635,9 @@ def do_execute_command(
     "preset_defs.",
 )
 @click.option(
-    "--mode", type=click.STRING, help="The name of the mode in which to execute the pipeline."
+    "--mode",
+    type=click.STRING,
+    help="The name of the mode in which to execute the pipeline.",
 )
 @click.option("--tags", type=click.STRING, help="JSON string of tags to use for this pipeline run")
 @click.option(
@@ -636,7 +655,11 @@ def do_execute_command(
         '   ancestors, "other_solid_a" itself, and "other_solid_b" and its direct child solids'
     ),
 )
-@click.option("--run-id", type=click.STRING, help="The ID to give to the launched pipeline/job run")
+@click.option(
+    "--run-id",
+    type=click.STRING,
+    help="The ID to give to the launched pipeline/job run",
+)
 def pipeline_launch_command(**kwargs):
     with DagsterInstance.get() as instance:
         return execute_launch_command(instance, kwargs)
@@ -644,7 +667,9 @@ def pipeline_launch_command(**kwargs):
 
 @telemetry_wrapper
 def execute_launch_command(
-    instance: DagsterInstance, kwargs: Dict[str, str], using_job_op_graph_apis: bool = False
+    instance: DagsterInstance,
+    kwargs: Dict[str, str],
+    using_job_op_graph_apis: bool = False,
 ):
     preset = cast(Optional[str], kwargs.get("preset"))
     mode = cast(Optional[str], kwargs.get("mode"))
@@ -714,7 +739,9 @@ def execute_scaffold_command(cli_args, print_fn, using_job_op_graph_apis=False):
 
 
 def do_scaffold_command(
-    pipeline_def: PipelineDefinition, printer: Callable[..., Any], skip_non_required: bool
+    pipeline_def: PipelineDefinition,
+    printer: Callable[..., Any],
+    skip_non_required: bool,
 ):
     check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
     check.callable_param(printer, "printer")
@@ -885,7 +912,9 @@ def validate_partition_slice(partition_names, name, value):
     ),
 )
 @click.option(
-    "--tags", type=click.STRING, help="JSON string of tags to use for this pipeline/job run"
+    "--tags",
+    type=click.STRING,
+    help="JSON string of tags to use for this pipeline/job run",
 )
 @click.option("--noprompt", is_flag=True)
 def pipeline_backfill_command(**kwargs):
@@ -897,12 +926,22 @@ def execute_backfill_command(cli_args, print_fn, instance, using_graph_job_op_ap
     with get_workspace_from_kwargs(instance, version=dagster_version, kwargs=cli_args) as workspace:
         repo_location = get_repository_location_from_workspace(workspace, cli_args.get("location"))
         _execute_backfill_command_at_location(
-            cli_args, print_fn, instance, workspace, repo_location, using_graph_job_op_apis
+            cli_args,
+            print_fn,
+            instance,
+            workspace,
+            repo_location,
+            using_graph_job_op_apis,
         )
 
 
 def _execute_backfill_command_at_location(
-    cli_args, print_fn, instance, workspace, repo_location, using_graph_job_op_apis=False
+    cli_args,
+    print_fn,
+    instance,
+    workspace,
+    repo_location,
+    using_graph_job_op_apis=False,
 ):
     external_repo = get_external_repository_from_repo_location(
         repo_location, cli_args.get("repository")

--- a/python_modules/dagster/dagster/_cli/pipeline.py
+++ b/python_modules/dagster/dagster/_cli/pipeline.py
@@ -25,10 +25,7 @@ from dagster._cli.workspace.cli_target import (
     repository_target_argument,
 )
 from dagster._core.definitions.pipeline_base import IPipeline
-from dagster._core.errors import (
-    DagsterBackfillFailedError,
-    DagsterInvariantViolationError,
-)
+from dagster._core.errors import DagsterBackfillFailedError, DagsterInvariantViolationError
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.backfill import (
     BulkActionStatus,
@@ -41,21 +38,16 @@ from dagster._core.host_representation import (
     RepositoryHandle,
     RepositoryLocation,
 )
-from dagster._core.host_representation.external_data import (
-    ExternalPartitionSetExecutionParamData,
-)
+from dagster._core.host_representation.external_data import ExternalPartitionSetExecutionParamData
 from dagster._core.host_representation.selector import PipelineSelector
 from dagster._core.instance import DagsterInstance
 from dagster._core.snap import PipelineSnapshot, SolidInvocationSnap
 from dagster._core.storage.tags import MEMOIZED_RUN_TAG
 from dagster._core.telemetry import log_external_repo_stats, telemetry_wrapper
 from dagster._core.utils import make_new_backfill_id
+from dagster._legacy import PipelineDefinition, execute_pipeline
 from dagster._seven import IS_WINDOWS, JSONDecodeError, json
-from dagster._utils import (
-    DEFAULT_WORKSPACE_YAML_FILENAME,
-    load_yaml_from_glob_list,
-    merge_dicts,
-)
+from dagster._utils import DEFAULT_WORKSPACE_YAML_FILENAME, load_yaml_from_glob_list, merge_dicts
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.hosted_user_process import recon_pipeline_from_origin
 from dagster._utils.indenting_printer import IndentingPrinter
@@ -64,7 +56,6 @@ from dagster._utils.yaml_utils import dump_run_config_yaml
 
 from .config_scaffolder import scaffold_pipeline_config
 from .utils import get_instance_for_service
-from dagster._legacy import PipelineDefinition, execute_pipeline
 
 
 @click.group(name="pipeline")

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -5,9 +5,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union
 import dagster._check as check
 from dagster._core.utils import coerce_valid_log_level, make_new_run_id
 from dagster._utils.log import get_dagster_logger
+from dagster._legacy import PipelineRun
 
 if TYPE_CHECKING:
-    from dagster import DagsterInstance, PipelineRun
+    from dagster import DagsterInstance
     from dagster._core.events import DagsterEvent
 
 DAGSTER_META_KEY = "dagster_meta"
@@ -40,7 +41,9 @@ class DagsterMessageProps(
                 log_message_id, "log_message_id", default=make_new_run_id()
             ),
             log_timestamp=check.opt_str_param(
-                log_timestamp, "log_timestamp", default=datetime.datetime.utcnow().isoformat()
+                log_timestamp,
+                "log_timestamp",
+                default=datetime.datetime.utcnow().isoformat(),
             ),
             dagster_event=dagster_event,
         )
@@ -209,7 +212,10 @@ class DagsterLogHandler(logging.Handler):
         This function figures out what the original `extra` values of the log call were by
         comparing the set of attributes in the received record to those of a default record.
         """
-        ref_attrs = list(logging.makeLogRecord({}).__dict__.keys()) + ["message", "asctime"]
+        ref_attrs = list(logging.makeLogRecord({}).__dict__.keys()) + [
+            "message",
+            "asctime",
+        ]
         return {k: v for k, v in record.__dict__.items() if k not in ref_attrs}
 
     def _convert_record(self, record: logging.LogRecord) -> logging.LogRecord:

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -5,11 +5,11 @@ from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union
 import dagster._check as check
 from dagster._core.utils import coerce_valid_log_level, make_new_run_id
 from dagster._utils.log import get_dagster_logger
-from dagster._legacy import PipelineRun
 
 if TYPE_CHECKING:
     from dagster import DagsterInstance
     from dagster._core.events import DagsterEvent
+    from dagster._legacy import PipelineRun
 
 DAGSTER_META_KEY = "dagster_meta"
 

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -23,11 +23,7 @@ from dagster._core.host_representation.origin import (
 from dagster._core.instance import DagsterInstance
 from dagster._core.launcher import RunLauncher
 from dagster._core.run_coordinator import RunCoordinator, SubmitRunContext
-from dagster._core.storage.pipeline_run import (
-    PipelineRun,
-    PipelineRunStatus,
-    RunsFilter,
-)
+from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus, RunsFilter
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import WorkspaceLoadTarget
 from dagster._daemon.controller import create_daemon_grpc_server_registry

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -12,9 +12,9 @@ from contextlib import ExitStack, contextmanager
 import pendulum
 import yaml
 
-from dagster import ModeDefinition, Shape
+from dagster import Shape
 from dagster import _check as check
-from dagster import composite_solid, fs_io_manager
+from dagster import fs_io_manager
 from dagster._config import Array, Field
 from dagster._core.host_representation.origin import (
     ExternalPipelineOrigin,
@@ -23,12 +23,16 @@ from dagster._core.host_representation.origin import (
 from dagster._core.instance import DagsterInstance
 from dagster._core.launcher import RunLauncher
 from dagster._core.run_coordinator import RunCoordinator, SubmitRunContext
-from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus, RunsFilter
+from dagster._core.storage.pipeline_run import (
+    PipelineRun,
+    PipelineRunStatus,
+    RunsFilter,
+)
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import WorkspaceLoadTarget
 from dagster._daemon.controller import create_daemon_grpc_server_registry
 from dagster._daemon.workspace import DaemonWorkspace
-from dagster._legacy import pipeline, solid
+from dagster._legacy import ModeDefinition, composite_solid, pipeline, solid
 from dagster._serdes import ConfigurableClass
 from dagster._seven.compat.pendulum import create_pendulum_time, mock_pendulum_timezone
 from dagster._utils import Counter, merge_dicts, traced, traced_counter
@@ -246,7 +250,11 @@ def poll_for_finished_run(instance, run_id=None, timeout=20, run_tags=None):
     filters = RunsFilter(
         run_ids=[run_id] if run_id else None,
         tags=run_tags,
-        statuses=[PipelineRunStatus.SUCCESS, PipelineRunStatus.FAILURE, PipelineRunStatus.CANCELED],
+        statuses=[
+            PipelineRunStatus.SUCCESS,
+            PipelineRunStatus.FAILURE,
+            PipelineRunStatus.CANCELED,
+        ],
     )
 
     while True:

--- a/python_modules/dagster/dagster/_core/utility_solids.py
+++ b/python_modules/dagster/dagster/_core/utility_solids.py
@@ -1,6 +1,6 @@
 from dagster import Output
 from dagster import _check as check
-from dagster._legacy import (
+from dagster._core.definitions import (
     InputDefinition,
     OutputDefinition,
     SolidDefinition,

--- a/python_modules/dagster/dagster/_core/utility_solids.py
+++ b/python_modules/dagster/dagster/_core/utility_solids.py
@@ -1,6 +1,11 @@
-from dagster import InputDefinition, Output, OutputDefinition, SolidDefinition
+from dagster import Output
 from dagster import _check as check
-from dagster import lambda_solid
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    SolidDefinition,
+    lambda_solid,
+)
 
 
 def _compute_fn(context, inputs):
@@ -34,7 +39,10 @@ def create_root_solid(name):
     inp = InputDefinition(input_name)
 
     return SolidDefinition(
-        name=name, input_defs=[inp], compute_fn=_compute_fn, output_defs=[OutputDefinition()]
+        name=name,
+        input_defs=[inp],
+        compute_fn=_compute_fn,
+        output_defs=[OutputDefinition()],
     )
 
 
@@ -42,7 +50,10 @@ def create_solid_with_deps(name, *solid_deps):
     inputs = [InputDefinition(solid_dep.name) for solid_dep in solid_deps]
 
     return SolidDefinition(
-        name=name, input_defs=inputs, compute_fn=_compute_fn, output_defs=[OutputDefinition()]
+        name=name,
+        input_defs=inputs,
+        compute_fn=_compute_fn,
+        output_defs=[OutputDefinition()],
     )
 
 

--- a/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
+++ b/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
@@ -6,11 +6,11 @@ from dagster import (
     DagsterInvariantViolationError,
     GraphDefinition,
     JobDefinition,
-    PipelineDefinition,
     RepositoryDefinition,
 )
 from dagster._core.code_pointer import load_python_file, load_python_module
 from dagster._core.definitions import AssetGroup
+from dagster._legacy import PipelineDefinition
 
 LOAD_ALL_ASSETS = "<<LOAD_ALL_ASSETS>>"
 

--- a/python_modules/dagster/dagster/_legacy/__init__.py
+++ b/python_modules/dagster/dagster/_legacy/__init__.py
@@ -1,1 +1,33 @@
-from dagster._core.definitions import pipeline, solid
+from dagster._core.definitions import (
+    AssetGroup,
+    CompositeSolidDefinition,
+    DynamicOutputDefinition,
+    InputDefinition,
+    Materialization,
+    ModeDefinition,
+    OutputDefinition,
+    PipelineDefinition,
+    PresetDefinition,
+    SolidDefinition,
+    SolidInvocation,
+    build_assets_job,
+    composite_solid,
+    default_executors,
+    lambda_solid,
+    pipeline,
+    pipeline_failure_sensor,
+    solid,
+)
+from dagster._core.execution.api import (
+    execute_pipeline,
+    execute_pipeline_iterator,
+    reexecute_pipeline,
+)
+from dagster._core.execution.context.invocation import build_solid_context
+from dagster._core.execution.results import (
+    CompositeSolidExecutionResult,
+    PipelineExecutionResult,
+    SolidExecutionResult,
+)
+from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus
+from dagster._utils.test import execute_solid, execute_solid_within_pipeline

--- a/python_modules/dagster/dagster/_utils/test/__init__.py
+++ b/python_modules/dagster/dagster/_utils/test/__init__.py
@@ -4,21 +4,27 @@ import tempfile
 import uuid
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, AbstractSet, Any, Dict, Generator, Optional, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Any,
+    Dict,
+    Generator,
+    Optional,
+    Union,
+    overload,
+)
 
 # top-level include is dangerous in terms of incurring circular deps
 from dagster import (
     DagsterInvariantViolationError,
     DependencyDefinition,
     Failure,
-    ModeDefinition,
     NodeInvocation,
-    PipelineDefinition,
     RepositoryDefinition,
     TypeCheck,
 )
 from dagster import _check as check
-from dagster import execute_pipeline, lambda_solid
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
 from dagster._core.definitions.resource_definition import ScopedResourcesBuilder
@@ -38,7 +44,10 @@ from dagster._core.execution.context_creation_pipeline import (
 )
 from dagster._core.instance import DagsterInstance
 from dagster._core.scheduler import Scheduler
-from dagster._core.scheduler.scheduler import DagsterScheduleDoesNotExist, DagsterSchedulerError
+from dagster._core.scheduler.scheduler import (
+    DagsterScheduleDoesNotExist,
+    DagsterSchedulerError,
+)
 from dagster._core.snap import snapshot_from_execution_plan
 from dagster._core.storage.file_manager import LocalFileManager
 from dagster._core.storage.pipeline_run import PipelineRun
@@ -57,9 +66,18 @@ from ..temp_file import (
     get_temp_file_names,
 )
 from ..typing_api import is_typing_type
+from dagster._legacy import (
+    ModeDefinition,
+    PipelineDefinition,
+    execute_pipeline,
+    lambda_solid,
+)
 
 if TYPE_CHECKING:
-    from dagster._core.execution.results import CompositeSolidExecutionResult, SolidExecutionResult
+    from dagster._core.execution.results import (
+        CompositeSolidExecutionResult,
+        SolidExecutionResult,
+    )
 
 
 def create_test_pipeline_execution_context(
@@ -77,7 +95,11 @@ def create_test_pipeline_execution_context(
     instance = DagsterInstance.ephemeral()
     execution_plan = create_execution_plan(pipeline=pipeline_def, run_config=run_config)
     creation_data = create_context_creation_data(
-        InMemoryPipeline(pipeline_def), execution_plan, run_config, pipeline_run, instance
+        InMemoryPipeline(pipeline_def),
+        execution_plan,
+        run_config,
+        pipeline_run,
+        instance,
     )
     log_manager = create_log_manager(creation_data)
     scoped_resources_builder = ScopedResourcesBuilder()

--- a/python_modules/dagster/dagster/_utils/test/__init__.py
+++ b/python_modules/dagster/dagster/_utils/test/__init__.py
@@ -4,16 +4,7 @@ import tempfile
 import uuid
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import (
-    TYPE_CHECKING,
-    AbstractSet,
-    Any,
-    Dict,
-    Generator,
-    Optional,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, AbstractSet, Any, Dict, Generator, Optional, Union, overload
 
 # top-level include is dangerous in terms of incurring circular deps
 from dagster import (
@@ -25,6 +16,7 @@ from dagster import (
     TypeCheck,
 )
 from dagster import _check as check
+from dagster._core.definitions import ModeDefinition, PipelineDefinition, lambda_solid
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
 from dagster._core.definitions.resource_definition import ScopedResourcesBuilder
@@ -33,7 +25,11 @@ from dagster._core.definitions.solid_definition import (
     NodeDefinition,
     SolidDefinition,
 )
-from dagster._core.execution.api import create_execution_plan, scoped_pipeline_context
+from dagster._core.execution.api import (
+    create_execution_plan,
+    execute_pipeline,
+    scoped_pipeline_context,
+)
 from dagster._core.execution.context.system import PlanExecutionContext
 from dagster._core.execution.context_creation_pipeline import (
     create_context_creation_data,
@@ -44,10 +40,7 @@ from dagster._core.execution.context_creation_pipeline import (
 )
 from dagster._core.instance import DagsterInstance
 from dagster._core.scheduler import Scheduler
-from dagster._core.scheduler.scheduler import (
-    DagsterScheduleDoesNotExist,
-    DagsterSchedulerError,
-)
+from dagster._core.scheduler.scheduler import DagsterScheduleDoesNotExist, DagsterSchedulerError
 from dagster._core.snap import snapshot_from_execution_plan
 from dagster._core.storage.file_manager import LocalFileManager
 from dagster._core.storage.pipeline_run import PipelineRun
@@ -66,18 +59,9 @@ from ..temp_file import (
     get_temp_file_names,
 )
 from ..typing_api import is_typing_type
-from dagster._legacy import (
-    ModeDefinition,
-    PipelineDefinition,
-    execute_pipeline,
-    lambda_solid,
-)
 
 if TYPE_CHECKING:
-    from dagster._core.execution.results import (
-        CompositeSolidExecutionResult,
-        SolidExecutionResult,
-    )
+    from dagster._core.execution.results import CompositeSolidExecutionResult, SolidExecutionResult
 
 
 def create_test_pipeline_execution_context(

--- a/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
+++ b/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
@@ -12,13 +12,7 @@ from dagster._core.definitions.decorators.sensor_decorator import sensor
 from dagster._core.definitions.sensor_definition import RunRequest
 from dagster._core.errors import DagsterError
 from dagster._core.test_utils import default_mode_def_for_test
-from dagster._legacy import (
-    InputDefinition,
-    OutputDefinition,
-    lambda_solid,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, OutputDefinition, lambda_solid, pipeline, solid
 
 
 @lambda_solid

--- a/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
+++ b/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
@@ -1,12 +1,9 @@
 import string
 
 from dagster import (
-    InputDefinition,
     Int,
-    OutputDefinition,
     PartitionSetDefinition,
     ScheduleDefinition,
-    lambda_solid,
     op,
     repository,
     usable_as_dagster_type,
@@ -15,7 +12,13 @@ from dagster._core.definitions.decorators.sensor_decorator import sensor
 from dagster._core.definitions.sensor_definition import RunRequest
 from dagster._core.errors import DagsterError
 from dagster._core.test_utils import default_mode_def_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    lambda_solid,
+    pipeline,
+    solid,
+)
 
 
 @lambda_solid

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -3,8 +3,10 @@ from contextlib import contextmanager
 
 import pytest
 
-from dagster import lambda_solid, repository
-from dagster._api.snapshot_repository import sync_get_streaming_external_repositories_data_grpc
+from dagster import repository
+from dagster._api.snapshot_repository import (
+    sync_get_streaming_external_repositories_data_grpc,
+)
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.host_representation import (
     ExternalRepositoryData,
@@ -12,7 +14,7 @@ from dagster._core.host_representation import (
 )
 from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._legacy import pipeline
+from dagster._legacy import lambda_solid, pipeline
 
 from .utils import get_bar_repo_repository_location
 
@@ -37,7 +39,8 @@ def test_streaming_external_repositories_error(instance):
         assert repository_location.repository_names == {"does_not_exist"}
 
         with pytest.raises(
-            DagsterUserCodeProcessError, match='Could not find a repository called "does_not_exist"'
+            DagsterUserCodeProcessError,
+            match='Could not find a repository called "does_not_exist"',
         ):
             sync_get_streaming_external_repositories_data_grpc(
                 repository_location.client, repository_location

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -4,9 +4,7 @@ from contextlib import contextmanager
 import pytest
 
 from dagster import repository
-from dagster._api.snapshot_repository import (
-    sync_get_streaming_external_repositories_data_grpc,
-)
+from dagster._api.snapshot_repository import sync_get_streaming_external_repositories_data_grpc
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.host_representation import (
     ExternalRepositoryData,

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/extra_repo.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/extra_repo.py
@@ -1,5 +1,5 @@
-from dagster import job, lambda_solid, repository
-from dagster._legacy import pipeline
+from dagster import job, repository
+from dagster._legacy import lambda_solid, pipeline
 
 
 @lambda_solid

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -9,19 +9,15 @@ import pytest
 from click.testing import CliRunner
 
 from dagster import (
-    ModeDefinition,
     Out,
     Output,
     Partition,
     PartitionSetDefinition,
-    PresetDefinition,
     ScheduleDefinition,
     String,
-    execute_pipeline,
     graph,
     in_process_executor,
     job,
-    lambda_solid,
     op,
     repository,
 )
@@ -30,14 +26,24 @@ from dagster._cli.job import job_execute_command
 from dagster._cli.pipeline import pipeline_execute_command
 from dagster._cli.run import run_delete_command, run_list_command, run_wipe_command
 from dagster._core.definitions.decorators.sensor_decorator import sensor
-from dagster._core.definitions.partition import PartitionedConfig, StaticPartitionsDefinition
+from dagster._core.definitions.partition import (
+    PartitionedConfig,
+    StaticPartitionsDefinition,
+)
 from dagster._core.definitions.sensor_definition import RunRequest
 from dagster._core.storage.memoizable_io_manager import versioned_filesystem_io_manager
 from dagster._core.storage.tags import MEMOIZED_RUN_TAG
 from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.server import GrpcServerProcess
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    ModeDefinition,
+    PresetDefinition,
+    execute_pipeline,
+    lambda_solid,
+    pipeline,
+    solid,
+)
 from dagster._utils import file_relative_path, merge_dicts
 from dagster.version import __version__
 
@@ -83,7 +89,8 @@ def qux():
 
 qux_job = qux.to_job(
     config=PartitionedConfig(
-        partitions_def=StaticPartitionsDefinition(["abc"]), run_config_for_partition_fn=lambda _: {}
+        partitions_def=StaticPartitionsDefinition(["abc"]),
+        run_config_for_partition_fn=lambda _: {},
     ),
     tags={"foo": "bar"},
     executor_def=in_process_executor,
@@ -574,7 +581,14 @@ def valid_external_pipeline_target_args():
 
 def valid_pipeline_python_origin_target_cli_args():
     return [
-        ["-f", file_relative_path(__file__, "test_cli_commands.py"), "-a", "bar", "-p", "foo"],
+        [
+            "-f",
+            file_relative_path(__file__, "test_cli_commands.py"),
+            "-a",
+            "bar",
+            "-p",
+            "foo",
+        ],
         [
             "-f",
             file_relative_path(__file__, "test_cli_commands.py"),
@@ -593,7 +607,12 @@ def valid_pipeline_python_origin_target_cli_args():
             "-p",
             "foo",
         ],
-        ["-m", "dagster_tests.cli_tests.command_tests.test_cli_commands", "-a", "foo_pipeline"],
+        [
+            "-m",
+            "dagster_tests.cli_tests.command_tests.test_cli_commands",
+            "-a",
+            "foo_pipeline",
+        ],
         [
             "-f",
             file_relative_path(__file__, "test_cli_commands.py"),
@@ -613,7 +632,14 @@ def valid_pipeline_python_origin_target_cli_args():
 
 def valid_job_python_origin_target_cli_args():
     return [
-        ["-f", file_relative_path(__file__, "test_cli_commands.py"), "-a", "bar", "-j", "qux"],
+        [
+            "-f",
+            file_relative_path(__file__, "test_cli_commands.py"),
+            "-a",
+            "bar",
+            "-j",
+            "qux",
+        ],
         [
             "-f",
             file_relative_path(__file__, "test_cli_commands.py"),
@@ -836,7 +862,8 @@ def test_run_list_limit():
 
 def runner_pipeline_or_job_execute(runner, cli_args, using_job_op_graph_apis=False):
     result = runner.invoke(
-        job_execute_command if using_job_op_graph_apis else pipeline_execute_command, cli_args
+        job_execute_command if using_job_op_graph_apis else pipeline_execute_command,
+        cli_args,
     )
     if result.exit_code != 0:
         # CliRunner captures stdout so printing it out here

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -26,10 +26,7 @@ from dagster._cli.job import job_execute_command
 from dagster._cli.pipeline import pipeline_execute_command
 from dagster._cli.run import run_delete_command, run_list_command, run_wipe_command
 from dagster._core.definitions.decorators.sensor_decorator import sensor
-from dagster._core.definitions.partition import (
-    PartitionedConfig,
-    StaticPartitionsDefinition,
-)
+from dagster._core.definitions.partition import PartitionedConfig, StaticPartitionsDefinition
 from dagster._core.definitions.sensor_definition import RunRequest
 from dagster._core.storage.memoizable_io_manager import versioned_filesystem_io_manager
 from dagster._core.storage.tags import MEMOIZED_RUN_TAG

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
@@ -1,11 +1,13 @@
 import click
 import pytest
 from click.testing import CliRunner
+
 from dagster._cli.job import job_launch_command
 from dagster._cli.pipeline import execute_launch_command, pipeline_launch_command
 from dagster._core.errors import DagsterRunAlreadyExists
 from dagster._core.storage.pipeline_run import PipelineRunStatus
 from dagster._core.test_utils import new_cwd
+from dagster._legacy import execute_pipeline
 from dagster._utils import file_relative_path
 
 from .test_cli_commands import (
@@ -18,7 +20,6 @@ from .test_cli_commands import (
     valid_external_job_target_cli_args,
     valid_external_pipeline_target_cli_args_with_preset,
 )
-from dagster._legacy import execute_pipeline
 
 
 def run_launch(kwargs, instance, expected_count=None):

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
@@ -1,8 +1,6 @@
 import click
 import pytest
 from click.testing import CliRunner
-
-from dagster import execute_pipeline
 from dagster._cli.job import job_launch_command
 from dagster._cli.pipeline import execute_launch_command, pipeline_launch_command
 from dagster._core.errors import DagsterRunAlreadyExists
@@ -20,6 +18,7 @@ from .test_cli_commands import (
     valid_external_job_target_cli_args,
     valid_external_pipeline_target_cli_args_with_preset,
 )
+from dagster._legacy import execute_pipeline
 
 
 def run_launch(kwargs, instance, expected_count=None):

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_memoized_development_cli.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_memoized_development_cli.py
@@ -4,13 +4,12 @@ import tempfile
 from io import BytesIO
 
 import yaml
-
-from dagster import execute_pipeline
 from dagster._cli.pipeline import execute_list_versions_command
 from dagster._core.test_utils import instance_for_test
 from dagster._utils import file_relative_path
 
 from ...execution_tests.memoized_dev_loop_pipeline import asset_pipeline
+from dagster._legacy import execute_pipeline
 
 
 class Capturing(list):

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_memoized_development_cli.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_memoized_development_cli.py
@@ -4,12 +4,13 @@ import tempfile
 from io import BytesIO
 
 import yaml
+
 from dagster._cli.pipeline import execute_list_versions_command
 from dagster._core.test_utils import instance_for_test
+from dagster._legacy import execute_pipeline
 from dagster._utils import file_relative_path
 
 from ...execution_tests.memoized_dev_loop_pipeline import asset_pipeline
-from dagster._legacy import execute_pipeline
 
 
 class Capturing(list):

--- a/python_modules/dagster/dagster_tests/cli_tests/test_asset_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_asset_commands.py
@@ -1,10 +1,10 @@
 import pytest
 from click.testing import CliRunner
 
-from dagster import AssetKey, AssetMaterialization, Output, execute_pipeline
+from dagster import AssetKey, AssetMaterialization, Output
 from dagster._cli.asset import asset_wipe_command
 from dagster._core.instance import DagsterInstance
-from dagster._legacy import pipeline, solid
+from dagster._legacy import execute_pipeline, pipeline, solid
 from dagster._seven import json
 
 

--- a/python_modules/dagster/dagster_tests/cli_tests/test_config_scaffolder.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_config_scaffolder.py
@@ -1,15 +1,9 @@
-from dagster import (
-    Int,
-    ModeDefinition,
-    PipelineDefinition,
-    ResourceDefinition,
-    SolidDefinition,
-    String,
-)
+from dagster import Int, ResourceDefinition, String
 from dagster import _check as check
 from dagster._cli.config_scaffolder import scaffold_pipeline_config, scaffold_type
 from dagster._config import config_type
 from dagster._core.definitions import create_run_config_schema
+from dagster._legacy import ModeDefinition, PipelineDefinition, SolidDefinition
 
 
 def fail_me():

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_composite_descent.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_composite_descent.py
@@ -6,17 +6,20 @@ from dagster import (
     Enum,
     EnumValue,
     Field,
-    InputDefinition,
     Output,
     String,
-    composite_solid,
     configured,
-    execute_pipeline,
-    lambda_solid,
     mem_io_manager,
 )
 from dagster._core.system_config.composite_descent import composite_descent
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    composite_solid,
+    execute_pipeline,
+    lambda_solid,
+    pipeline,
+    solid,
+)
 
 
 def test_single_level_pipeline():
@@ -104,7 +107,9 @@ def test_single_layer_pipeline_hardcoded_config_mapping():
         return_int_hardcode_wrap()
 
     solid_config_dict = composite_descent(
-        return_int_hardcode_wrap_pipeline, {}, resource_defs={"io_manager": mem_io_manager}
+        return_int_hardcode_wrap_pipeline,
+        {},
+        resource_defs={"io_manager": mem_io_manager},
     )
 
     assert solid_config_dict["return_int_hardcode_wrap.return_int"].config == 35
@@ -154,7 +159,8 @@ def test_mix_layer_computed_mapping():
             return {"layer_three_wrap": {"config": {"number": cfg["number"] + 1}}}
 
     @composite_solid(
-        config_schema={"number": int, "inject_error": bool}, config_fn=_layer_two_double_wrap_cfg_fn
+        config_schema={"number": int, "inject_error": bool},
+        config_fn=_layer_two_double_wrap_cfg_fn,
     )
     def layer_two_double_wrap():
         layer_three_wrap()
@@ -243,7 +249,8 @@ def test_nested_input_via_config_mapping():
         return num + 1
 
     @composite_solid(
-        config_schema={}, config_fn=lambda _cfg: {"add_one": {"inputs": {"num": {"value": 2}}}}
+        config_schema={},
+        config_fn=lambda _cfg: {"add_one": {"inputs": {"num": {"value": 2}}}},
     )
     def wrap_add_one():
         add_one()
@@ -268,7 +275,8 @@ def test_double_nested_input_via_config_mapping():
         return num
 
     @composite_solid(
-        config_fn=lambda _: {"number": {"inputs": {"num": {"value": 4}}}}, config_schema={}
+        config_fn=lambda _: {"number": {"inputs": {"num": {"value": 4}}}},
+        config_schema={},
     )
     def wrap_solid():  # pylint: disable=unused-variable
         return number()
@@ -299,8 +307,14 @@ def test_double_nested_input_via_config_mapping():
 
 def test_provide_one_of_two_inputs_via_config():
     @solid(
-        config_schema={"config_field_a": Field(String), "config_field_b": Field(String)},
-        input_defs=[InputDefinition("input_a", String), InputDefinition("input_b", String)],
+        config_schema={
+            "config_field_a": Field(String),
+            "config_field_b": Field(String),
+        },
+        input_defs=[
+            InputDefinition("input_a", String),
+            InputDefinition("input_b", String),
+        ],
     )
     def basic(context, input_a, input_b):
         res = ".".join(
@@ -324,7 +338,10 @@ def test_provide_one_of_two_inputs_via_config():
                 "inputs": {"input_b": {"value": "set_input_b"}},
             }
         },
-        config_schema={"config_field_a": Field(String), "config_field_b": Field(String)},
+        config_schema={
+            "config_field_a": Field(String),
+            "config_field_b": Field(String),
+        },
     )
     def wrap_all_config_one_input(input_a):
         return basic(input_a)
@@ -600,7 +617,8 @@ def test_single_level_pipeline_with_complex_configured_solid_within_composite():
         introduce_wrapper()
 
     result = execute_pipeline(
-        introduce_pipeline, {"solids": {"introduce_wrapper": {"config": {"num_as_str": "20"}}}}
+        introduce_pipeline,
+        {"solids": {"introduce_wrapper": {"config": {"num_as_str": "20"}}}},
     )
 
     assert result.success
@@ -745,7 +763,8 @@ def test_configured_composite_solid_with_inputs():
         return_int_composite_x()
 
     result = execute_pipeline(
-        test_pipeline, {"solids": {"return_int_composite": {"inputs": {"x": 6, "y": 4}}}}
+        test_pipeline,
+        {"solids": {"return_int_composite": {"inputs": {"x": 6, "y": 4}}}},
     )
 
     assert result.success

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_config_mappings.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_config_mappings.py
@@ -7,16 +7,19 @@ from dagster import (
     DagsterInvalidConfigError,
     DagsterInvalidDefinitionError,
     Field,
-    InputDefinition,
     Int,
     Output,
     String,
+    graph,
+)
+from dagster._legacy import (
+    InputDefinition,
     composite_solid,
     execute_pipeline,
-    graph,
     lambda_solid,
+    pipeline,
+    solid,
 )
-from dagster._legacy import pipeline, solid
 
 
 # have to use "pipe" solid since "result_for_solid" doesnt work with composite mappings
@@ -324,7 +327,8 @@ def test_nested_with_inputs():
         pipe(outer_wrap())
 
     result = execute_pipeline(
-        config_mapping_pipeline, {"solids": {"outer_wrap": {"config": {"outer_first": "foo"}}}}
+        config_mapping_pipeline,
+        {"solids": {"outer_wrap": {"config": {"outer_first": "foo"}}}},
     )
 
     assert result.success
@@ -333,8 +337,14 @@ def test_nested_with_inputs():
 
 def test_wrap_none_config_and_inputs():
     @solid(
-        config_schema={"config_field_a": Field(String), "config_field_b": Field(String)},
-        input_defs=[InputDefinition("input_a", String), InputDefinition("input_b", String)],
+        config_schema={
+            "config_field_a": Field(String),
+            "config_field_b": Field(String),
+        },
+        input_defs=[
+            InputDefinition("input_a", String),
+            InputDefinition("input_b", String),
+        ],
     )
     def basic(context, input_a, input_b):
         res = ".".join(
@@ -444,8 +454,14 @@ def test_wrap_none_config_and_inputs():
 
 def test_wrap_all_config_no_inputs():
     @solid(
-        config_schema={"config_field_a": Field(String), "config_field_b": Field(String)},
-        input_defs=[InputDefinition("input_a", String), InputDefinition("input_b", String)],
+        config_schema={
+            "config_field_a": Field(String),
+            "config_field_b": Field(String),
+        },
+        input_defs=[
+            InputDefinition("input_a", String),
+            InputDefinition("input_b", String),
+        ],
     )
     def basic(context, input_a, input_b):
         res = ".".join(
@@ -459,7 +475,10 @@ def test_wrap_all_config_no_inputs():
         yield Output(res)
 
     @composite_solid(
-        input_defs=[InputDefinition("input_a", String), InputDefinition("input_b", String)],
+        input_defs=[
+            InputDefinition("input_a", String),
+            InputDefinition("input_b", String),
+        ],
         config_fn=lambda cfg: {
             "basic": {
                 "config": {
@@ -468,7 +487,10 @@ def test_wrap_all_config_no_inputs():
                 }
             }
         },
-        config_schema={"config_field_a": Field(String), "config_field_b": Field(String)},
+        config_schema={
+            "config_field_a": Field(String),
+            "config_field_b": Field(String),
+        },
     )
     def wrap_all_config_no_inputs(input_a, input_b):
         return basic(input_a, input_b)
@@ -482,7 +504,10 @@ def test_wrap_all_config_no_inputs():
         {
             "solids": {
                 "wrap_all_config_no_inputs": {
-                    "config": {"config_field_a": "override_a", "config_field_b": "override_b"},
+                    "config": {
+                        "config_field_a": "override_a",
+                        "config_field_b": "override_b",
+                    },
                     "inputs": {
                         "input_a": {"value": "set_input_a"},
                         "input_b": {"value": "set_input_b"},
@@ -503,7 +528,10 @@ def test_wrap_all_config_no_inputs():
             {
                 "solids": {
                     "wrap_all_config_no_inputs": {
-                        "config": {"config_field_a": 1234, "config_field_b": "override_b"},
+                        "config": {
+                            "config_field_a": 1234,
+                            "config_field_b": "override_b",
+                        },
                         "inputs": {
                             "input_a": {"value": "set_input_a"},
                             "input_b": {"value": "set_input_b"},
@@ -524,8 +552,14 @@ def test_wrap_all_config_no_inputs():
             {
                 "solids": {
                     "wrap_all_config_no_inputs": {
-                        "config": {"config_field_a": "override_a", "config_field_b": "override_b"},
-                        "inputs": {"input_a": {"value": 1234}, "input_b": {"value": "set_input_b"}},
+                        "config": {
+                            "config_field_a": "override_a",
+                            "config_field_b": "override_b",
+                        },
+                        "inputs": {
+                            "input_a": {"value": 1234},
+                            "input_b": {"value": "set_input_b"},
+                        },
                     }
                 }
             },
@@ -539,8 +573,14 @@ def test_wrap_all_config_no_inputs():
 
 def test_wrap_all_config_one_input():
     @solid(
-        config_schema={"config_field_a": Field(String), "config_field_b": Field(String)},
-        input_defs=[InputDefinition("input_a", String), InputDefinition("input_b", String)],
+        config_schema={
+            "config_field_a": Field(String),
+            "config_field_b": Field(String),
+        },
+        input_defs=[
+            InputDefinition("input_a", String),
+            InputDefinition("input_b", String),
+        ],
     )
     def basic(context, input_a, input_b):
         res = ".".join(
@@ -564,7 +604,10 @@ def test_wrap_all_config_one_input():
                 "inputs": {"input_b": {"value": "set_input_b"}},
             }
         },
-        config_schema={"config_field_a": Field(String), "config_field_b": Field(String)},
+        config_schema={
+            "config_field_a": Field(String),
+            "config_field_b": Field(String),
+        },
     )
     def wrap_all_config_one_input(input_a):
         return basic(input_a)
@@ -578,7 +621,10 @@ def test_wrap_all_config_one_input():
         {
             "solids": {
                 "wrap_all_config_one_input": {
-                    "config": {"config_field_a": "override_a", "config_field_b": "override_b"},
+                    "config": {
+                        "config_field_a": "override_a",
+                        "config_field_b": "override_b",
+                    },
                     "inputs": {"input_a": {"value": "set_input_a"}},
                 }
             }
@@ -596,7 +642,10 @@ def test_wrap_all_config_one_input():
             {
                 "solids": {
                     "wrap_all_config_one_input": {
-                        "config": {"config_field_a": 1234, "config_field_b": "override_b"},
+                        "config": {
+                            "config_field_a": 1234,
+                            "config_field_b": "override_b",
+                        },
                         "inputs": {"input_a": {"value": "set_input_a"}},
                     }
                 }
@@ -614,7 +663,10 @@ def test_wrap_all_config_one_input():
             {
                 "solids": {
                     "wrap_all_config_one_input": {
-                        "config": {"config_field_a": "override_a", "config_field_b": "override_b"},
+                        "config": {
+                            "config_field_a": "override_a",
+                            "config_field_b": "override_b",
+                        },
                         "inputs": {"input_a": {"value": 1234}},
                     }
                 }
@@ -629,8 +681,14 @@ def test_wrap_all_config_one_input():
 
 def test_wrap_all_config_and_inputs():
     @solid(
-        config_schema={"config_field_a": Field(String), "config_field_b": Field(String)},
-        input_defs=[InputDefinition("input_a", String), InputDefinition("input_b", String)],
+        config_schema={
+            "config_field_a": Field(String),
+            "config_field_b": Field(String),
+        },
+        input_defs=[
+            InputDefinition("input_a", String),
+            InputDefinition("input_b", String),
+        ],
     )
     def basic(context, input_a, input_b):
         res = ".".join(
@@ -656,7 +714,10 @@ def test_wrap_all_config_and_inputs():
                 },
             }
         },
-        config_schema={"config_field_a": Field(String), "config_field_b": Field(String)},
+        config_schema={
+            "config_field_a": Field(String),
+            "config_field_b": Field(String),
+        },
     )
     def wrap_all():
         return basic()
@@ -670,7 +731,10 @@ def test_wrap_all_config_and_inputs():
         {
             "solids": {
                 "wrap_all": {
-                    "config": {"config_field_a": "override_a", "config_field_b": "override_b"}
+                    "config": {
+                        "config_field_a": "override_a",
+                        "config_field_b": "override_b",
+                    }
                 }
             }
         },
@@ -714,7 +778,8 @@ def test_empty_config():
     # Testing that this definition does *not* raise
     # See: https://github.com/dagster-io/dagster/issues/1606
     @composite_solid(
-        config_fn=lambda _: {"scalar_config_solid": {"config": "an input"}}, config_schema={}
+        config_fn=lambda _: {"scalar_config_solid": {"config": "an input"}},
+        config_schema={},
     )
     def wrap_solid():  # pylint: disable=unused-variable
         return scalar_config_solid()
@@ -732,7 +797,8 @@ def test_empty_config():
 
 def test_nested_empty_config():
     @composite_solid(
-        config_fn=lambda _: {"scalar_config_solid": {"config": "an input"}}, config_schema={}
+        config_fn=lambda _: {"scalar_config_solid": {"config": "an input"}},
+        config_schema={},
     )
     def wrap_solid():  # pylint: disable=unused-variable
         return scalar_config_solid()
@@ -758,7 +824,8 @@ def test_nested_empty_config_input():
         return num
 
     @composite_solid(
-        config_fn=lambda _: {"number": {"inputs": {"num": {"value": 4}}}}, config_schema={}
+        config_fn=lambda _: {"number": {"inputs": {"num": {"value": 4}}}},
+        config_schema={},
     )
     def wrap_solid():  # pylint: disable=unused-variable
         return number()

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_enums.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_enums.py
@@ -9,12 +9,10 @@ from dagster import (
     EnumValue,
     Field,
     Int,
-    PipelineDefinition,
-    execute_pipeline,
 )
 from dagster._config import Enum as ConfigEnum
 from dagster._config.validate import validate_config
-from dagster._legacy import pipeline, solid
+from dagster._legacy import PipelineDefinition, execute_pipeline, pipeline, solid
 
 
 def define_test_enum_type():

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_schema.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_schema.py
@@ -1,9 +1,9 @@
 import pytest
 
-from dagster import Field, composite_solid
+from dagster import Field
 from dagster._check import CheckError
 from dagster._config import ConfigAnyInstance
-from dagster._legacy import solid
+from dagster._legacy import composite_solid, solid
 
 
 def test_solid_field_backcompat():
@@ -66,7 +66,8 @@ def test_composite_field_backwards_compat():
         composite_with_int.config_schema.default_value_as_json_str  # pylint: disable=pointless-statement
 
     @composite_solid(
-        config_schema=Field(int, default_value=2, description="bar"), config_fn=lambda _: 4
+        config_schema=Field(int, default_value=2, description="bar"),
+        config_fn=lambda _: 4,
     )
     def composite_kitchen_sink():
         noop()

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_type_system.py
@@ -15,16 +15,12 @@ from dagster import (
     Float,
     Int,
     List,
-    ModeDefinition,
     Noneable,
     Permissive,
-    PipelineDefinition,
     ResourceDefinition,
     Set,
     String,
     Tuple,
-    composite_solid,
-    execute_pipeline,
     execute_solid,
 )
 from dagster._check import ParameterCheckError
@@ -36,7 +32,14 @@ from dagster._config import (
     process_config,
     validate_config,
 )
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    ModeDefinition,
+    PipelineDefinition,
+    composite_solid,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 def test_noop_config():
@@ -172,7 +175,10 @@ def test_single_required_string_field_config_type():
         _validate(_single_required_string_config_dict(), {"extra": "yup"})
 
     with pytest.raises(AssertionError):
-        _validate(_single_required_string_config_dict(), {"string_field": "yupup", "extra": "yup"})
+        _validate(
+            _single_required_string_config_dict(),
+            {"string_field": "yupup", "extra": "yup"},
+        )
 
     with pytest.raises(AssertionError):
         _validate(_single_required_string_config_dict(), {"string_field": 1})
@@ -187,7 +193,8 @@ def test_undefined_field_error():
         ),
     ):
         _validate(
-            _single_required_string_config_dict(), {"string_field": "value", "extra": "extra"}
+            _single_required_string_config_dict(),
+            {"string_field": "value", "extra": "extra"},
         )
 
 
@@ -214,7 +221,10 @@ def test_multiple_required_fields_failing():
         _validate(_multiple_required_fields_config_dict(), {"field_one": "yup"})
 
     with pytest.raises(AssertionError):
-        _validate(_multiple_required_fields_config_dict(), {"field_one": "yup", "extra": "yup"})
+        _validate(
+            _multiple_required_fields_config_dict(),
+            {"field_one": "yup", "extra": "yup"},
+        )
 
     with pytest.raises(AssertionError):
         _validate(
@@ -224,7 +234,8 @@ def test_multiple_required_fields_failing():
 
     with pytest.raises(AssertionError):
         _validate(
-            _multiple_required_fields_config_dict(), {"field_one": "value_one", "field_two": 2}
+            _multiple_required_fields_config_dict(),
+            {"field_one": "value_one", "field_two": 2},
         )
 
 
@@ -255,7 +266,8 @@ def test_single_optional_field_passing_with_default():
     }
 
     assert _validate(
-        _single_optional_string_field_config_dict_with_default(), {"optional_field": "override"}
+        _single_optional_string_field_config_dict_with_default(),
+        {"optional_field": "override"},
     ) == {"optional_field": "override"}
 
 
@@ -469,7 +481,8 @@ def test_mixed_args_passing():
     ) == {"optional_arg": "value_one", "required_arg": "value_two"}
 
     assert _validate(
-        _mixed_required_optional_string_config_dict_with_default(), {"required_arg": "value_two"}
+        _mixed_required_optional_string_config_dict_with_default(),
+        {"required_arg": "value_two"},
     ) == {"optional_arg": "some_default", "required_arg": "value_two"}
 
     assert _validate(
@@ -581,7 +594,8 @@ def test_config_defaults():
         addition_composite_solid()
 
     result = execute_pipeline(
-        addition_pipeline, {"solids": {"addition_composite_solid": {"config": {"c": 3}}}}
+        addition_pipeline,
+        {"solids": {"addition_composite_solid": {"config": {"c": 3}}}},
     )
 
     assert result.success
@@ -676,7 +690,10 @@ def test_wrong_resources():
         name="pipeline_test_multiple_context",
         mode_defs=[
             ModeDefinition(
-                resource_defs={"resource_one": dummy_resource(), "resource_two": dummy_resource()}
+                resource_defs={
+                    "resource_one": dummy_resource(),
+                    "resource_two": dummy_resource(),
+                }
             )
         ],
         solid_defs=[],
@@ -814,7 +831,10 @@ def test_root_extra_field():
     with pytest.raises(DagsterInvalidConfigError) as pe_info:
         execute_pipeline(
             pipeline_def,
-            run_config={"solids": {"required_int_solid": {"config": 948594}}, "nope": None},
+            run_config={
+                "solids": {"required_int_solid": {"config": 948594}},
+                "nope": None,
+            },
         )
 
     pe = pe_info.value
@@ -835,7 +855,8 @@ def test_deeper_path():
 
     with pytest.raises(DagsterInvalidConfigError) as pe_info:
         execute_pipeline(
-            pipeline_def, run_config={"solids": {"required_int_solid": {"config": "asdf"}}}
+            pipeline_def,
+            run_config={"solids": {"required_int_solid": {"config": "asdf"}}},
         )
 
     pe = pe_info.value
@@ -857,7 +878,8 @@ def test_working_list_path():
         required_list_int_solid()
 
     result = execute_pipeline(
-        pipeline_def, run_config={"solids": {"required_list_int_solid": {"config": [1, 2]}}}
+        pipeline_def,
+        run_config={"solids": {"required_list_int_solid": {"config": [1, 2]}}},
     )
 
     assert result.success

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_type_printer.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_type_printer.py
@@ -1,4 +1,4 @@
-from dagster import Field, Int, Map, Noneable, PipelineDefinition, ScalarUnion, String
+from dagster import Field, Int, Map, Noneable, ScalarUnion, String
 from dagster._config import (
     config_schema_snapshot_from_config_type,
     get_recursive_type_keys,
@@ -6,7 +6,7 @@ from dagster._config import (
     resolve_to_config_type,
     snap_from_config_type,
 )
-from dagster._legacy import solid
+from dagster._legacy import PipelineDefinition, solid
 
 
 def assert_inner_types(parent_type, *dagster_types):

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_description_inference.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_description_inference.py
@@ -1,5 +1,5 @@
-from dagster import composite_solid, graph, job, op, resource
-from dagster._legacy import solid
+from dagster import graph, job, op, resource
+from dagster._legacy import composite_solid, solid
 
 
 def test_description_inference():

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -17,11 +17,9 @@ from dagster import (
     DynamicOutput,
     ExpectationResult,
     In,
-    Materialization,
     Nothing,
     Out,
     Output,
-    SolidDefinition,
     build_op_context,
     graph,
     job,
@@ -31,7 +29,7 @@ from dagster import (
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.test_utils import instance_for_test
 from dagster._core.types.dagster_type import Int, String
-from dagster._legacy import solid
+from dagster._legacy import Materialization, SolidDefinition, solid
 
 
 def some_fn(a):
@@ -130,7 +128,10 @@ def test_out():
 
     assert my_op.outs == {
         "result": Out(
-            metadata={"x": 1}, dagster_type=Int, is_required=True, io_manager_key="io_manager"
+            metadata={"x": 1},
+            dagster_type=Int,
+            is_required=True,
+            io_manager_key="io_manager",
         )
     }
     assert my_op.output_defs[0].metadata == {"x": 1}
@@ -155,10 +156,16 @@ def test_multi_out():
 
     assert my_op.outs == {
         "a": Out(
-            metadata={"x": 1}, dagster_type=Int, is_required=True, io_manager_key="io_manager"
+            metadata={"x": 1},
+            dagster_type=Int,
+            is_required=True,
+            io_manager_key="io_manager",
         ),
         "b": Out(
-            metadata={"y": 2}, dagster_type=String, is_required=True, io_manager_key="io_manager"
+            metadata={"y": 2},
+            dagster_type=String,
+            is_required=True,
+            io_manager_key="io_manager",
         ),
     }
     assert my_op.output_defs[0].metadata == {"x": 1}
@@ -199,7 +206,12 @@ def test_multi_out_yields():
 
 
 def test_multi_out_optional():
-    @op(out={"a": Out(metadata={"x": 1}, is_required=False), "b": Out(metadata={"y": 2})})
+    @op(
+        out={
+            "a": Out(metadata={"x": 1}, is_required=False),
+            "b": Out(metadata={"y": 2}),
+        }
+    )
     def my_op():
         yield Output(output_name="b", value=2)
 
@@ -969,7 +981,10 @@ def test_generic_output_name_mismatch():
 def test_generic_dynamic_output():
     @op
     def basic() -> List[DynamicOutput[int]]:
-        return [DynamicOutput(mapping_key="1", value=1), DynamicOutput(mapping_key="2", value=2)]
+        return [
+            DynamicOutput(mapping_key="1", value=1),
+            DynamicOutput(mapping_key="2", value=2),
+        ]
 
     result = execute_op_in_graph(basic)
     assert result.success
@@ -985,7 +1000,10 @@ def test_generic_dynamic_output():
 def test_generic_dynamic_output_type_mismatch():
     @op
     def basic() -> List[DynamicOutput[int]]:
-        return [DynamicOutput(mapping_key="1", value=1), DynamicOutput(mapping_key="2", value="2")]
+        return [
+            DynamicOutput(mapping_key="1", value=1),
+            DynamicOutput(mapping_key="2", value="2"),
+        ]
 
     with pytest.raises(
         DagsterTypeCheckDidNotPass,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_solid.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_solid.py
@@ -8,19 +8,22 @@ from dagster import (
     DagsterInvariantViolationError,
     DependencyDefinition,
     Field,
-    InputDefinition,
     Output,
+    execute_solid,
+    graph,
+    op,
+)
+from dagster._core.utility_solids import define_stub_solid
+from dagster._legacy import (
+    InputDefinition,
     OutputDefinition,
     PipelineDefinition,
     composite_solid,
     execute_pipeline,
-    execute_solid,
-    graph,
     lambda_solid,
-    op,
+    pipeline,
+    solid,
 )
-from dagster._core.utility_solids import define_stub_solid
-from dagster._legacy import pipeline, solid
 
 # This file tests a lot of parameter name stuff, so these warnings are spurious
 # pylint: disable=unused-variable, unused-argument, redefined-outer-name
@@ -192,7 +195,8 @@ def test_lambda_solid_with_underscore_input():
 
 def test_lambda_solid_definition_errors():
     with pytest.raises(
-        DagsterInvalidDefinitionError, match=re.escape("positional vararg parameter '*args'")
+        DagsterInvalidDefinitionError,
+        match=re.escape("positional vararg parameter '*args'"),
     ):
 
         @lambda_solid(input_defs=[InputDefinition(name="foo")])
@@ -202,7 +206,8 @@ def test_lambda_solid_definition_errors():
 
 def test_solid_definition_errors():
     with pytest.raises(
-        DagsterInvalidDefinitionError, match=re.escape("positional vararg parameter '*args'")
+        DagsterInvalidDefinitionError,
+        match=re.escape("positional vararg parameter '*args'"),
     ):
 
         @solid(input_defs=[InputDefinition(name="foo")], output_defs=[OutputDefinition()])
@@ -248,12 +253,14 @@ def test_wrong_argument_to_pipeline():
         pass
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match="You have passed a lambda or function non_solid_func"
+        DagsterInvalidDefinitionError,
+        match="You have passed a lambda or function non_solid_func",
     ):
         PipelineDefinition(solid_defs=[non_solid_func], name="test")
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match="You have passed a lambda or function <lambda>"
+        DagsterInvalidDefinitionError,
+        match="You have passed a lambda or function <lambda>",
     ):
         PipelineDefinition(solid_defs=[lambda x: x], name="test")
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_autoalias.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_autoalias.py
@@ -1,5 +1,4 @@
-from dagster import composite_solid, execute_pipeline
-from dagster._legacy import pipeline, solid
+from dagster._legacy import composite_solid, execute_pipeline, pipeline, solid
 
 
 @solid

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composition.py
@@ -3,15 +3,9 @@ import warnings
 import pytest
 
 from dagster import DependencyDefinition, Int, Nothing, Output
-from dagster._core.definitions.decorators.hook_decorator import (
-    event_list_hook,
-    success_hook,
-)
+from dagster._core.definitions.decorators.hook_decorator import event_list_hook, success_hook
 from dagster._core.definitions.events import DynamicOutput, HookExecutionResult
-from dagster._core.errors import (
-    DagsterInvalidDefinitionError,
-    DagsterInvariantViolationError,
-)
+from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._core.execution.api import create_execution_plan
 from dagster._legacy import (
     InputDefinition,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composition.py
@@ -2,24 +2,28 @@ import warnings
 
 import pytest
 
-from dagster import (
-    DependencyDefinition,
+from dagster import DependencyDefinition, Int, Nothing, Output
+from dagster._core.definitions.decorators.hook_decorator import (
+    event_list_hook,
+    success_hook,
+)
+from dagster._core.definitions.events import DynamicOutput, HookExecutionResult
+from dagster._core.errors import (
+    DagsterInvalidDefinitionError,
+    DagsterInvariantViolationError,
+)
+from dagster._core.execution.api import create_execution_plan
+from dagster._legacy import (
     InputDefinition,
-    Int,
-    Nothing,
-    Output,
     OutputDefinition,
     PipelineDefinition,
     SolidDefinition,
     composite_solid,
     execute_pipeline,
     lambda_solid,
+    pipeline,
+    solid,
 )
-from dagster._core.definitions.decorators.hook_decorator import event_list_hook, success_hook
-from dagster._core.definitions.events import DynamicOutput, HookExecutionResult
-from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
-from dagster._core.execution.api import create_execution_plan
-from dagster._legacy import pipeline, solid
 
 
 def builder(graph):
@@ -236,7 +240,12 @@ def test_basic_aliasing_with_dsl():
 
 
 def test_diamond_graph():
-    @solid(output_defs=[OutputDefinition(name="value_one"), OutputDefinition(name="value_two")])
+    @solid(
+        output_defs=[
+            OutputDefinition(name="value_one"),
+            OutputDefinition(name="value_two"),
+        ]
+    )
     def emit_values(_context):
         yield Output(1, "value_one")
         yield Output(2, "value_two")
@@ -248,7 +257,10 @@ def test_diamond_graph():
     @composite_solid
     def diamond():
         value_one, value_two = emit_values()
-        subtract(num_one=add_one(num=value_one), num_two=add_one.alias("renamed")(num=value_two))
+        subtract(
+            num_one=add_one(num=value_one),
+            num_two=add_one.alias("renamed")(num=value_two),
+        )
 
     result = execute_pipeline(PipelineDefinition(solid_defs=[diamond], name="test"))
 
@@ -257,13 +269,15 @@ def test_diamond_graph():
 
 def test_mapping():
     @lambda_solid(
-        input_defs=[InputDefinition("num_in", Int)], output_def=OutputDefinition(Int, "num_out")
+        input_defs=[InputDefinition("num_in", Int)],
+        output_def=OutputDefinition(Int, "num_out"),
     )
     def double(num_in):
         return num_in * 2
 
     @composite_solid(
-        input_defs=[InputDefinition("num_in", Int)], output_defs=[OutputDefinition(Int, "num_out")]
+        input_defs=[InputDefinition("num_in", Int)],
+        output_defs=[OutputDefinition(Int, "num_out")],
     )
     def composed_inout(num_in):
         return double(num_in=num_in)
@@ -489,7 +503,11 @@ def test_mapping_args_ordering():
         {
             "solids": {
                 "swizzle_2": {
-                    "inputs": {"a": {"value": "a"}, "b": {"value": "b"}, "c": {"value": "c"}}
+                    "inputs": {
+                        "a": {"value": "a"},
+                        "b": {"value": "b"},
+                        "c": {"value": "c"},
+                    }
                 }
             }
         },
@@ -820,7 +838,8 @@ def test_uninvoked_aliased_solid_fails():
 
 def test_alias_on_invoked_solid_fails():
     with pytest.raises(
-        DagsterInvariantViolationError, match=r".*Consider checking the location of parentheses."
+        DagsterInvariantViolationError,
+        match=r".*Consider checking the location of parentheses.",
     ):
 
         @pipeline
@@ -836,7 +855,8 @@ def test_warn_on_pipeline_return():
         pass
 
     with pytest.warns(
-        UserWarning, match="You have returned a value out of a @pipeline-decorated function. "
+        UserWarning,
+        match="You have returned a value out of a @pipeline-decorated function. ",
     ):
 
         @pipeline

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
@@ -7,15 +7,17 @@ from dagster import (
     DagsterInvalidDefinitionError,
     DependencyDefinition,
     Field,
-    InputDefinition,
-    OutputDefinition,
-    PipelineDefinition,
     ResourceDefinition,
-    SolidDefinition,
 )
 from dagster._check import ParameterCheckError
 from dagster._core.utility_solids import define_stub_solid
-from dagster._legacy import solid
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    PipelineDefinition,
+    SolidDefinition,
+    solid,
+)
 
 
 def solid_a_b_list():
@@ -56,7 +58,8 @@ def test_circular_dep():
 
 def test_from_solid_not_there():
     with pytest.raises(
-        DagsterInvalidDefinitionError, match='node "NOTTHERE" in dependency dictionary not found'
+        DagsterInvalidDefinitionError,
+        match='node "NOTTHERE" in dependency dictionary not found',
     ):
         PipelineDefinition(
             solid_defs=solid_a_b_list(),
@@ -71,7 +74,8 @@ def test_from_solid_not_there():
 
 def test_from_non_existant_input():
     with pytest.raises(
-        DagsterInvalidDefinitionError, match='solid "B" does not have input "not_an_input"'
+        DagsterInvalidDefinitionError,
+        match='solid "B" does not have input "not_an_input"',
     ):
         PipelineDefinition(
             solid_defs=solid_a_b_list(),
@@ -118,7 +122,9 @@ def test_one_layer_off_dependencies():
         match="Received a IDependencyDefinition one layer too high under key B",
     ):
         PipelineDefinition(
-            solid_defs=solid_a_b_list(), name="test", dependencies={"B": DependencyDefinition("A")}
+            solid_defs=solid_a_b_list(),
+            name="test",
+            dependencies={"B": DependencyDefinition("A")},
         )
 
 
@@ -136,7 +142,8 @@ def test_malformed_dependencies():
 
 def test_list_dependencies():
     with pytest.raises(
-        DagsterInvalidDefinitionError, match='The expected type for "dependencies" is Dict'
+        DagsterInvalidDefinitionError,
+        match='The expected type for "dependencies" is Dict',
     ):
         PipelineDefinition(solid_defs=solid_a_b_list(), name="test", dependencies=[])
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions.py
@@ -2,23 +2,22 @@ import json
 
 import pytest
 
-from dagster import (
-    Any,
-    AssetKey,
-    CompositeSolidDefinition,
-    DependencyDefinition,
-    InputDefinition,
-    Int,
-    NodeInvocation,
-    OutputDefinition,
-    PipelineDefinition,
-    String,
-    lambda_solid,
+from dagster import Any, AssetKey, DependencyDefinition, Int, NodeInvocation, String
+from dagster._core.definitions import (
+    AssetMaterialization,
+    Node,
+    create_run_config_schema,
 )
-from dagster._core.definitions import AssetMaterialization, Node, create_run_config_schema
 from dagster._core.definitions.dependency import NodeHandle, SolidOutputHandle
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster._legacy import solid
+from dagster._legacy import (
+    CompositeSolidDefinition,
+    InputDefinition,
+    OutputDefinition,
+    PipelineDefinition,
+    lambda_solid,
+    solid,
+)
 
 
 def test_deps_equal():

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions.py
@@ -3,11 +3,7 @@ import json
 import pytest
 
 from dagster import Any, AssetKey, DependencyDefinition, Int, NodeInvocation, String
-from dagster._core.definitions import (
-    AssetMaterialization,
-    Node,
-    create_run_config_schema,
-)
+from dagster._core.definitions import AssetMaterialization, Node, create_run_config_schema
 from dagster._core.definitions.dependency import NodeHandle, SolidOutputHandle
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._legacy import (

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_executor_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_executor_definition.py
@@ -4,12 +4,7 @@ import pytest
 
 from dagster import ExecutorRequirement
 from dagster import _check as check
-from dagster import (
-    fs_io_manager,
-    in_process_executor,
-    multiprocess_executor,
-    reconstructable,
-)
+from dagster import fs_io_manager, in_process_executor, multiprocess_executor, reconstructable
 from dagster._core.definitions.executor_definition import executor
 from dagster._core.errors import (
     DagsterInvalidConfigError,
@@ -19,13 +14,7 @@ from dagster._core.errors import (
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.retries import RetryMode
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import (
-    ModeDefinition,
-    PipelineDefinition,
-    execute_pipeline,
-    pipeline,
-    solid,
-)
+from dagster._legacy import ModeDefinition, PipelineDefinition, execute_pipeline, pipeline, solid
 
 
 def assert_pipeline_runs_with_executor(executor_defs, execution_config, instance=None):

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_executor_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_executor_definition.py
@@ -2,10 +2,9 @@ from os import path
 
 import pytest
 
-from dagster import ExecutorRequirement, ModeDefinition, PipelineDefinition
+from dagster import ExecutorRequirement
 from dagster import _check as check
 from dagster import (
-    execute_pipeline,
     fs_io_manager,
     in_process_executor,
     multiprocess_executor,
@@ -20,7 +19,13 @@ from dagster._core.errors import (
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.retries import RetryMode
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    ModeDefinition,
+    PipelineDefinition,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 def assert_pipeline_runs_with_executor(executor_defs, execution_config, instance=None):
@@ -80,7 +85,8 @@ def test_in_process_executor_dict_config():
         )
 
     assert_pipeline_runs_with_executor(
-        [test_executor], {"test_executor": {"config": {"value": "secret testing value!!"}}}
+        [test_executor],
+        {"test_executor": {"config": {"value": "secret testing value!!"}}},
     )
 
 
@@ -103,7 +109,8 @@ def test_in_process_executor_with_requirement():
 
     with pytest.raises(DagsterUnmetExecutorRequirementsError):
         assert_pipeline_runs_with_executor(
-            [test_executor], {"test_executor": {"config": {"value": "secret testing value!!"}}}
+            [test_executor],
+            {"test_executor": {"config": {"value": "secret testing value!!"}}},
         )
 
     with instance_for_test() as instance:
@@ -138,7 +145,9 @@ def test_in_process_executor_dict_config_configured():
 
     with instance_for_test() as instance:
         assert_pipeline_runs_with_executor(
-            [test_executor_configured], {"configured_test_executor": None}, instance=instance
+            [test_executor_configured],
+            {"configured_test_executor": None},
+            instance=instance,
         )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_inference.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_inference.py
@@ -1,5 +1,4 @@
-from dagster import lambda_solid
-from dagster._legacy import solid
+from dagster._legacy import lambda_solid, solid
 
 
 def test_single_input():

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_input_defaults.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_input_defaults.py
@@ -2,18 +2,14 @@ from typing import Optional
 
 import pytest
 
-from dagster import (
-    DagsterInvalidDefinitionError,
+from dagster import DagsterInvalidDefinitionError, Nothing, execute_solid, job, op
+from dagster._legacy import (
     InputDefinition,
-    Nothing,
     composite_solid,
     execute_pipeline,
-    execute_solid,
-    job,
     lambda_solid,
-    op,
+    pipeline,
 )
-from dagster._legacy import pipeline
 
 
 def test_none():

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_logger_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_logger_definition.py
@@ -1,17 +1,8 @@
 import logging
 
-from dagster import (
-    Enum,
-    EnumValue,
-    Field,
-    Int,
-    ModeDefinition,
-    configured,
-    execute_pipeline,
-    logger,
-)
+from dagster import Enum, EnumValue, Field, Int, configured, logger
 from dagster._core.utils import coerce_valid_log_level
-from dagster._legacy import pipeline
+from dagster._legacy import ModeDefinition, execute_pipeline, pipeline
 
 
 def assert_pipeline_runs_with_logger(logger_def, logger_config):

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_pipeline.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_pipeline.py
@@ -3,17 +3,20 @@ import pytest
 from dagster import (
     DagsterInvalidDefinitionError,
     DependencyDefinition,
-    InputDefinition,
     Int,
     Output,
+    usable_as_dagster_type,
+)
+from dagster._legacy import (
+    InputDefinition,
     OutputDefinition,
     PipelineDefinition,
     composite_solid,
     execute_pipeline,
     lambda_solid,
-    usable_as_dagster_type,
+    pipeline,
+    solid,
 )
-from dagster._legacy import pipeline, solid
 
 
 def builder(graph):
@@ -98,7 +101,12 @@ def test_basic_aliasing_with_dsl():
 
 
 def test_diamond_graph():
-    @solid(output_defs=[OutputDefinition(name="value_one"), OutputDefinition(name="value_two")])
+    @solid(
+        output_defs=[
+            OutputDefinition(name="value_one"),
+            OutputDefinition(name="value_two"),
+        ]
+    )
     def emit_values(_context):
         yield Output(1, "value_one")
         yield Output(2, "value_two")
@@ -110,7 +118,10 @@ def test_diamond_graph():
     @pipeline
     def diamond_pipeline():
         value_one, value_two = emit_values()
-        subtract(num_one=add_one(num=value_one), num_two=add_one.alias("renamed")(num=value_two))
+        subtract(
+            num_one=add_one(num=value_one),
+            num_two=add_one.alias("renamed")(num=value_two),
+        )
 
     result = execute_pipeline(diamond_pipeline)
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_preset_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_preset_definition.py
@@ -7,13 +7,17 @@ from dagster import (
     DagsterInstance,
     DagsterInvalidDefinitionError,
     DagsterInvariantViolationError,
+)
+from dagster import _check as check
+from dagster._legacy import (
     ModeDefinition,
     PipelineDefinition,
     PresetDefinition,
+    execute_pipeline,
+    lambda_solid,
+    pipeline,
+    solid,
 )
-from dagster import _check as check
-from dagster import execute_pipeline, lambda_solid
-from dagster._legacy import pipeline, solid
 from dagster._utils import file_relative_path
 
 
@@ -53,7 +57,8 @@ def test_presets():
                 solid_selection=["can_fail"],
             ),
             PresetDefinition.from_files(
-                "failing_2", config_files=[file_relative_path(__file__, "pass_env.yaml")]
+                "failing_2",
+                config_files=[file_relative_path(__file__, "pass_env.yaml")],
             ),
             PresetDefinition(
                 "subset",
@@ -169,7 +174,8 @@ final: "result"
         "final": "result",
     }
     with pytest.raises(
-        DagsterInvariantViolationError, match="Encountered error attempting to parse yaml"
+        DagsterInvariantViolationError,
+        match="Encountered error attempting to parse yaml",
     ):
         PresetDefinition.from_yaml_strings("failing", ["--- `"])
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_reconstructable.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_reconstructable.py
@@ -4,7 +4,7 @@ import types
 
 import pytest
 
-from dagster import DagsterInvariantViolationError, PipelineDefinition, lambda_solid
+from dagster import DagsterInvariantViolationError
 from dagster._core.code_pointer import FileCodePointer
 from dagster._core.definitions.reconstruct import reconstructable
 from dagster._core.origin import (
@@ -13,7 +13,7 @@ from dagster._core.origin import (
     RepositoryPythonOrigin,
 )
 from dagster._core.snap import PipelineSnapshot, create_pipeline_snapshot_id
-from dagster._legacy import pipeline
+from dagster._legacy import PipelineDefinition, lambda_solid, pipeline
 from dagster._utils import file_relative_path
 from dagster._utils.hosted_user_process import recon_pipeline_from_origin
 
@@ -59,7 +59,8 @@ def test_decorator():
 
 def test_lambda():
     with pytest.raises(
-        DagsterInvariantViolationError, match="Reconstructable target can not be a lambda"
+        DagsterInvariantViolationError,
+        match="Reconstructable target can not be a lambda",
     ):
         reconstructable(lambda_version)
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -5,7 +5,6 @@ from typing import Sequence
 import pytest
 
 from dagster import (
-    AssetGroup,
     AssetKey,
     AssetsDefinition,
     DagsterInvalidDefinitionError,
@@ -13,10 +12,8 @@ from dagster import (
     DailyPartitionsDefinition,
     IOManager,
     JobDefinition,
-    PipelineDefinition,
     ResourceDefinition,
     SensorDefinition,
-    SolidDefinition,
     SourceAsset,
     asset,
     build_schedule_from_partitioned_job,
@@ -28,7 +25,6 @@ from dagster import (
     in_process_executor,
     io_manager,
     job,
-    lambda_solid,
     logger,
     op,
     repository,
@@ -41,9 +37,19 @@ from dagster._core.definitions.executor_definition import (
     default_executors,
     multi_or_in_process_executor,
 )
-from dagster._core.definitions.partition import PartitionedConfig, StaticPartitionsDefinition
+from dagster._core.definitions.partition import (
+    PartitionedConfig,
+    StaticPartitionsDefinition,
+)
 from dagster._core.errors import DagsterInvalidSubsetError
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    AssetGroup,
+    PipelineDefinition,
+    SolidDefinition,
+    lambda_solid,
+    pipeline,
+    solid,
+)
 from dagster._loggers import default_loggers
 
 # pylint: disable=comparison-with-callable
@@ -673,7 +679,8 @@ def test_list_dupe_graph():
         pass
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match="Duplicate job definition found for graph 'foo'"
+        DagsterInvalidDefinitionError,
+        match="Duplicate job definition found for graph 'foo'",
     ):
 
         @repository
@@ -925,7 +932,11 @@ def test_source_asset_unsatisfied_resource_transitive():
         @repository
         def the_repo():
             return [
-                SourceAsset("foo", io_manager_def=the_manager, resource_defs={"foo": foo_resource})
+                SourceAsset(
+                    "foo",
+                    io_manager_def=the_manager,
+                    resource_defs={"foo": foo_resource},
+                )
             ]
 
 
@@ -1157,7 +1168,11 @@ def test_duplicate_job_target_valid():
 
     @repository
     def the_repo_dupe_job_valid():
-        return [the_job, _create_schedule_from_target(the_job), _create_sensor_from_target(the_job)]
+        return [
+            the_job,
+            _create_schedule_from_target(the_job),
+            _create_sensor_from_target(the_job),
+        ]
 
 
 def test_duplicate_job_target_invalid():
@@ -1448,7 +1463,8 @@ def test_default_executor_config():
         # The config provided to the_job matches in_process_executor, but not the default executor.
         return [
             define_asset_job(
-                "the_job", config={"execution": {"config": {"retries": {"enabled": {}}}}}
+                "the_job",
+                config={"execution": {"config": {"retries": {"enabled": {}}}}},
             ),
             some_asset,
         ]

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -37,10 +37,7 @@ from dagster._core.definitions.executor_definition import (
     default_executors,
     multi_or_in_process_executor,
 )
-from dagster._core.definitions.partition import (
-    PartitionedConfig,
-    StaticPartitionsDefinition,
-)
+from dagster._core.definitions.partition import PartitionedConfig, StaticPartitionsDefinition
 from dagster._core.errors import DagsterInvalidSubsetError
 from dagster._legacy import (
     AssetGroup,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_solid_io.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_solid_io.py
@@ -5,12 +5,7 @@ import pytest
 
 from dagster import AssetKey, DynamicOutput, Output
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster._legacy import (
-    DynamicOutputDefinition,
-    InputDefinition,
-    OutputDefinition,
-    solid,
-)
+from dagster._legacy import DynamicOutputDefinition, InputDefinition, OutputDefinition, solid
 
 
 def test_flex_inputs():

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_solid_io.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_solid_io.py
@@ -3,16 +3,14 @@ from typing import Generator, Iterable, Iterator
 
 import pytest
 
-from dagster import (
-    AssetKey,
-    DynamicOutput,
+from dagster import AssetKey, DynamicOutput, Output
+from dagster._core.errors import DagsterInvalidDefinitionError
+from dagster._legacy import (
     DynamicOutputDefinition,
     InputDefinition,
-    Output,
     OutputDefinition,
+    solid,
 )
-from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster._legacy import solid
 
 
 def test_flex_inputs():

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
@@ -1,14 +1,14 @@
 import pytest
 
 import dagster._check as check
-from dagster import OpExecutionContext, execute_pipeline, job, op
+from dagster import OpExecutionContext, job, op
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.pipeline_definition import PipelineDefinition
 from dagster._core.definitions.solid_definition import SolidDefinition
 from dagster._core.execution.context.compute import SolidExecutionContext
 from dagster._core.storage.pipeline_run import DagsterRun, PipelineRun
-from dagster._legacy import pipeline, solid
+from dagster._legacy import execute_pipeline, pipeline, solid
 
 
 def test_op_execution_context():

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -13,7 +13,6 @@ from dagster import (
     Enum,
     Field,
     In,
-    InputDefinition,
     Nothing,
     Out,
     Permissive,
@@ -32,7 +31,10 @@ from dagster._core.definitions.partition import (
     StaticPartitionsDefinition,
 )
 from dagster._core.definitions.pipeline_definition import PipelineSubsetDefinition
-from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition, TimeWindow
+from dagster._core.definitions.time_window_partitions import (
+    DailyPartitionsDefinition,
+    TimeWindow,
+)
 from dagster._core.errors import (
     DagsterConfigMappingFunctionError,
     DagsterInvalidConfigError,
@@ -40,6 +42,7 @@ from dagster._core.errors import (
 )
 from dagster._core.test_utils import instance_for_test
 from dagster._loggers import json_console_logger
+from dagster._legacy import InputDefinition
 
 
 def get_ops():
@@ -569,7 +572,9 @@ def test_enum_config_mapping():
         config_schema=Shape(
             {
                 "my_field": Field(
-                    Enum.from_python_enum(TestEnum), is_required=False, default_value="TWO"
+                    Enum.from_python_enum(TestEnum),
+                    is_required=False,
+                    default_value="TWO",
                 )
             }
         ),
@@ -972,7 +977,8 @@ def test_job_non_default_logger_config():
         pass
 
     your_job = your_graph.to_job(
-        logger_defs={"json": json_console_logger}, config={"loggers": {"json": {"config": {}}}}
+        logger_defs={"json": json_console_logger},
+        config={"loggers": {"json": {"config": {}}}},
     )
 
     result = your_job.execute_in_process()

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -31,18 +31,15 @@ from dagster._core.definitions.partition import (
     StaticPartitionsDefinition,
 )
 from dagster._core.definitions.pipeline_definition import PipelineSubsetDefinition
-from dagster._core.definitions.time_window_partitions import (
-    DailyPartitionsDefinition,
-    TimeWindow,
-)
+from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition, TimeWindow
 from dagster._core.errors import (
     DagsterConfigMappingFunctionError,
     DagsterInvalidConfigError,
     DagsterInvalidDefinitionError,
 )
 from dagster._core.test_utils import instance_for_test
-from dagster._loggers import json_console_logger
 from dagster._legacy import InputDefinition
+from dagster._loggers import json_console_logger
 
 
 def get_ops():

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
@@ -6,27 +6,13 @@ import pytest
 from dagster import DagsterEventType, NodeInvocation
 from dagster import _check as check
 from dagster import build_hook_context, graph, job, op, reconstructable, resource
-from dagster._core.definitions import (
-    NodeHandle,
-    PresetDefinition,
-    failure_hook,
-    success_hook,
-)
+from dagster._core.definitions import NodeHandle, PresetDefinition, failure_hook, success_hook
 from dagster._core.definitions.decorators.hook_decorator import event_list_hook
 from dagster._core.definitions.events import HookExecutionResult
 from dagster._core.definitions.policy import RetryPolicy
-from dagster._core.errors import (
-    DagsterExecutionInterruptedError,
-    DagsterInvalidDefinitionError,
-)
+from dagster._core.errors import DagsterExecutionInterruptedError, DagsterInvalidDefinitionError
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import (
-    ModeDefinition,
-    PipelineDefinition,
-    execute_pipeline,
-    pipeline,
-    solid,
-)
+from dagster._legacy import ModeDefinition, PipelineDefinition, execute_pipeline, pipeline, solid
 
 
 class SomeUserException(Exception):

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
@@ -3,16 +3,30 @@ from unittest import mock
 
 import pytest
 
-from dagster import DagsterEventType, ModeDefinition, NodeInvocation, PipelineDefinition
+from dagster import DagsterEventType, NodeInvocation
 from dagster import _check as check
-from dagster import build_hook_context, execute_pipeline, graph, job, op, reconstructable, resource
-from dagster._core.definitions import NodeHandle, PresetDefinition, failure_hook, success_hook
+from dagster import build_hook_context, graph, job, op, reconstructable, resource
+from dagster._core.definitions import (
+    NodeHandle,
+    PresetDefinition,
+    failure_hook,
+    success_hook,
+)
 from dagster._core.definitions.decorators.hook_decorator import event_list_hook
 from dagster._core.definitions.events import HookExecutionResult
 from dagster._core.definitions.policy import RetryPolicy
-from dagster._core.errors import DagsterExecutionInterruptedError, DagsterInvalidDefinitionError
+from dagster._core.errors import (
+    DagsterExecutionInterruptedError,
+    DagsterInvalidDefinitionError,
+)
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    ModeDefinition,
+    PipelineDefinition,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 class SomeUserException(Exception):
@@ -79,7 +93,10 @@ def test_hook_user_error():
     assert result.success
 
     hook_errored_events = list(
-        filter(lambda event: event.event_type == DagsterEventType.HOOK_ERRORED, result.event_list)
+        filter(
+            lambda event: event.event_type == DagsterEventType.HOOK_ERRORED,
+            result.event_list,
+        )
     )
     assert len(hook_errored_events) == 1
     assert hook_errored_events[0].solid_handle.name == "a_solid_with_hook"

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_run.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_run.py
@@ -2,25 +2,20 @@ from collections import defaultdict
 
 import pytest
 
-from dagster import (
-    DynamicOutput,
-    DynamicOutputDefinition,
-    Int,
-    ModeDefinition,
-    Output,
-    OutputDefinition,
-    composite_solid,
-    execute_pipeline,
-    graph,
-    job,
-    op,
-    resource,
-)
+from dagster import DynamicOutput, Int, Output, graph, job, op, resource
 from dagster._core.definitions import failure_hook, success_hook
 from dagster._core.definitions.decorators.hook_decorator import event_list_hook
 from dagster._core.definitions.events import Failure, HookExecutionResult
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    DynamicOutputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    composite_solid,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 class SomeUserException(Exception):
@@ -482,7 +477,11 @@ def test_hook_decorate_pipeline_def():
     result = execute_pipeline(a_pipeline, raise_on_error=False)
     assert not result.success
     # a generic hook runs on all solids
-    assert called_hook_to_solids["hook_a_generic"] == {"solid_a", "solid_b", "failed_solid"}
+    assert called_hook_to_solids["hook_a_generic"] == {
+        "solid_a",
+        "solid_b",
+        "failed_solid",
+    }
     # a success hook runs on all succeeded solids
     assert called_hook_to_solids["hook_b_success"] == {"solid_a", "solid_b"}
     # a failure hook runs on all failed solids
@@ -529,7 +528,11 @@ def test_hook_on_pipeline_def_and_solid_instance():
     result = execute_pipeline(a_pipeline, raise_on_error=False)
     assert not result.success
     # a generic hook runs on all solids
-    assert called_hook_to_solids["hook_a_generic"] == {"solid_a", "solid_b", "failed_solid"}
+    assert called_hook_to_solids["hook_a_generic"] == {
+        "solid_a",
+        "solid_b",
+        "failed_solid",
+    }
     # a success hook runs on "solid_a"
     assert called_hook_to_solids["hook_b_success"] == {"solid_a"}
     # a failure hook runs on "failed_solid"

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
@@ -2,14 +2,14 @@ import sys
 
 import pytest
 
-from dagster import file_relative_path, lambda_solid, repository
+from dagster import file_relative_path, repository
 from dagster._core.definitions.repository_definition import RepositoryData
 from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace import WorkspaceProcessContext
 from dagster._core.workspace.load_target import GrpcServerTarget
 from dagster._grpc.server import GrpcServerProcess
-from dagster._legacy import pipeline
+from dagster._legacy import lambda_solid, pipeline
 
 
 def define_do_something(num_calls):

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -3,10 +3,7 @@ import re
 import pytest
 import yaml
 from dagster_tests.api_tests.utils import get_bar_workspace
-
-from dagster import PipelineDefinition
 from dagster import _check as check
-from dagster import execute_pipeline
 from dagster._check import CheckError
 from dagster._config import Field
 from dagster._core.errors import (
@@ -25,7 +22,7 @@ from dagster._core.snap import (
     snapshot_from_execution_plan,
 )
 from dagster._core.test_utils import create_run_for_test, environ, instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import PipelineDefinition, execute_pipeline, pipeline, solid
 from dagster._serdes import ConfigurableClass
 from dagster._serdes.config_class import ConfigurableClassData
 
@@ -337,7 +334,12 @@ def test_invalid_configurable_module():
         ),
     ):
         with instance_for_test(
-            overrides={"run_launcher": {"module": "made_up_module", "class": "MadeUpRunLauncher"}}
+            overrides={
+                "run_launcher": {
+                    "module": "made_up_module",
+                    "class": "MadeUpRunLauncher",
+                }
+            }
         ):
             pass
 
@@ -380,7 +382,10 @@ class TestInstanceSubclass(DagsterInstance):
 
     @classmethod
     def config_schema(cls):
-        return {"foo": Field(str, is_required=True), "baz": Field(str, is_required=False)}
+        return {
+            "foo": Field(str, is_required=True),
+            "baz": Field(str, is_required=False),
+        }
 
     @staticmethod
     def config_defaults(base_dir):

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -3,6 +3,7 @@ import re
 import pytest
 import yaml
 from dagster_tests.api_tests.utils import get_bar_workspace
+
 from dagster import _check as check
 from dagster._check import CheckError
 from dagster._config import Field

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from dagster import DagsterInstance, execute_pipeline, job, op, reconstructable, repository
+from dagster import DagsterInstance, job, op, reconstructable, repository
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.storage.pipeline_run import PipelineRunStatus
 from dagster._core.storage.tags import RESUME_RETRY_TAG
@@ -15,6 +15,7 @@ from dagster._core.test_utils import (
 )
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import PythonFileTarget
+from dagster._legacy import execute_pipeline
 
 CONDITIONAL_FAIL_ENV = "DAGSTER_CONDIIONAL_FAIL"
 

--- a/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_default_run_launcher.py
@@ -11,7 +11,6 @@ import pytest
 from dagster import (
     DagsterEventType,
     DefaultRunLauncher,
-    ModeDefinition,
     _seven,
     file_relative_path,
     fs_io_manager,
@@ -33,7 +32,7 @@ from dagster._core.workspace.load_target import GrpcServerTarget, PythonFileTarg
 from dagster._grpc.client import DagsterGrpcClient
 from dagster._grpc.server import GrpcServerProcess
 from dagster._grpc.types import CancelExecutionRequest
-from dagster._legacy import pipeline, solid
+from dagster._legacy import ModeDefinition, pipeline, solid
 
 default_mode_def = ModeDefinition(resource_defs={"io_manager": fs_io_manager})
 
@@ -699,7 +698,10 @@ def test_engine_events(get_workspace, run_config):  # pylint: disable=redefined-
             assert finished_pipeline_run.status == PipelineRunStatus.SUCCESS
 
             poll_for_event(
-                instance, run_id, event_type="ENGINE_EVENT", message="Process for run exited"
+                instance,
+                run_id,
+                event_type="ENGINE_EVENT",
+                message="Process for run exited",
             )
             event_records = instance.all_logs(run_id)
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
@@ -2,28 +2,34 @@ import pytest
 
 from dagster import (
     AssetMaterialization,
-    CompositeSolidDefinition,
     DagsterInstance,
     DagsterType,
     DagsterUnknownResourceError,
-    InputDefinition,
-    ModeDefinition,
-    OutputDefinition,
     ResourceDefinition,
     String,
-    composite_solid,
     dagster_type_loader,
     dagster_type_materializer,
-    execute_pipeline,
     resource,
     usable_as_dagster_type,
 )
 from dagster._core.definitions.configurable import configured
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
-from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidSubsetError
+from dagster._core.errors import (
+    DagsterInvalidDefinitionError,
+    DagsterInvalidSubsetError,
+)
 from dagster._core.execution.api import create_execution_plan, execute_run
 from dagster._core.types.dagster_type import create_any_type
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    CompositeSolidDefinition,
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    composite_solid,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 def get_resource_init_pipeline(resources_initted):
@@ -353,7 +359,9 @@ def test_execution_plan_subset_with_aliases():
     )
 
     result = execute_run(
-        InMemoryPipeline(selective_init_test_pipeline_with_alias), pipeline_run, instance
+        InMemoryPipeline(selective_init_test_pipeline_with_alias),
+        pipeline_run,
+        instance,
     )
 
     assert result.success
@@ -661,7 +669,8 @@ def test_loader_missing_resource_fails():
         return "A"
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match="required by the loader on type 'CustomType'"
+        DagsterInvalidDefinitionError,
+        match="required by the loader on type 'CustomType'",
     ):
 
         @pipeline
@@ -682,7 +691,8 @@ def test_materialize_missing_resource_fails():
         return "A"
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match="required by the materializer on type 'CustomType'"
+        DagsterInvalidDefinitionError,
+        match="required by the materializer on type 'CustomType'",
     ):
 
         @pipeline

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
@@ -14,10 +14,7 @@ from dagster import (
 )
 from dagster._core.definitions.configurable import configured
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
-from dagster._core.errors import (
-    DagsterInvalidDefinitionError,
-    DagsterInvalidSubsetError,
-)
+from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidSubsetError
 from dagster._core.execution.api import create_execution_plan, execute_run
 from dagster._core.types.dagster_type import create_any_type
 from dagster._legacy import (

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
@@ -11,14 +11,10 @@ from dagster import (
     EnumValue,
     Field,
     Int,
-    ModeDefinition,
-    PipelineDefinition,
     ResourceDefinition,
     String,
     build_op_context,
     configured,
-    execute_pipeline,
-    execute_pipeline_iterator,
     fs_io_manager,
     graph,
     job,
@@ -29,18 +25,28 @@ from dagster import (
 from dagster._core.definitions import pipeline
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
 from dagster._core.definitions.resource_definition import make_values_resource
-from dagster._core.errors import DagsterConfigMappingFunctionError, DagsterInvalidDefinitionError
+from dagster._core.errors import (
+    DagsterConfigMappingFunctionError,
+    DagsterInvalidDefinitionError,
+)
 from dagster._core.events.log import EventLogEntry, construct_event_logger
 from dagster._core.execution.api import create_execution_plan, execute_plan, execute_run
 from dagster._core.instance import DagsterInstance
 from dagster._core.test_utils import instance_for_test
 from dagster._core.utils import coerce_valid_log_level
-from dagster._legacy import solid
+from dagster._legacy import (
+    ModeDefinition,
+    PipelineDefinition,
+    execute_pipeline,
+    execute_pipeline_iterator,
+    solid,
+)
 
 
 def define_string_resource():
     return ResourceDefinition(
-        config_schema=String, resource_fn=lambda init_context: init_context.resource_config
+        config_schema=String,
+        resource_fn=lambda init_context: init_context.resource_config,
     )
 
 
@@ -123,7 +129,10 @@ def test_resource_with_dependencies():
         solid_defs=[dep_solid],
         mode_defs=[
             ModeDefinition(
-                resource_defs={"foo_resource": foo_resource, "bar_resource": bar_resource}
+                resource_defs={
+                    "foo_resource": foo_resource,
+                    "bar_resource": bar_resource,
+                }
             )
         ],
     )
@@ -163,7 +172,10 @@ def test_resource_cyclic_dependencies():
             solid_defs=[dep_solid],
             mode_defs=[
                 ModeDefinition(
-                    resource_defs={"foo_resource": foo_resource, "bar_resource": bar_resource}
+                    resource_defs={
+                        "foo_resource": foo_resource,
+                        "bar_resource": bar_resource,
+                    }
                 )
             ],
         )
@@ -227,7 +239,12 @@ def test_yield_multiple_resources():
 
     result = execute_pipeline(
         pipeline_def,
-        {"resources": {"string_one": {"config": "foo"}, "string_two": {"config": "bar"}}},
+        {
+            "resources": {
+                "string_one": {"config": "foo"},
+                "string_two": {"config": "bar"},
+            }
+        },
     )
 
     assert result.success
@@ -273,7 +290,12 @@ def test_resource_decorator():
 
     result = execute_pipeline(
         pipeline_def,
-        {"resources": {"string_one": {"config": "foo"}, "string_two": {"config": "bar"}}},
+        {
+            "resources": {
+                "string_one": {"config": "foo"},
+                "string_two": {"config": "bar"},
+            }
+        },
     )
 
     assert result.success
@@ -327,7 +349,12 @@ def test_mixed_multiple_resources():
 
     result = execute_pipeline(
         pipeline_def,
-        {"resources": {"returned_string": {"config": "foo"}, "yielded_string": {"config": "bar"}}},
+        {
+            "resources": {
+                "returned_string": {"config": "foo"},
+                "yielded_string": {"config": "bar"},
+            }
+        },
     )
 
     assert result.success
@@ -946,7 +973,11 @@ def define_resource_teardown_failure_pipeline():
         solid_defs=[resource_solid],
         mode_defs=[
             ModeDefinition(
-                resource_defs={"a": resource_a, "b": resource_b, "io_manager": fs_io_manager}
+                resource_defs={
+                    "a": resource_a,
+                    "b": resource_b,
+                    "io_manager": fs_io_manager,
+                }
             )
         ],
     )
@@ -1202,7 +1233,11 @@ def test_resource_op_subset():
 
     assert nested.get_job_def_for_subset_selection(["foo_op"]).get_required_resource_defs_for_mode(
         "default"
-    ).keys() == {"foo", "bar", "io_manager"}
+    ).keys() == {
+        "foo",
+        "bar",
+        "io_manager",
+    }
 
     assert nested.get_job_def_for_subset_selection(["bar_op"]).get_required_resource_defs_for_mode(
         "default"
@@ -1279,7 +1314,11 @@ def test_context_manager_resource():
     with build_op_context(resources={"cm": cm_resource}) as context:
         basic(context)
 
-    assert event_list == ["foo", "compute", "finally"]  # Ensures that we teardown after compute
+    assert event_list == [
+        "foo",
+        "compute",
+        "finally",
+    ]  # Ensures that we teardown after compute
 
     with pytest.raises(
         DagsterInvariantViolationError,

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
@@ -25,10 +25,7 @@ from dagster import (
 from dagster._core.definitions import pipeline
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
 from dagster._core.definitions.resource_definition import make_values_resource
-from dagster._core.errors import (
-    DagsterConfigMappingFunctionError,
-    DagsterInvalidDefinitionError,
-)
+from dagster._core.errors import DagsterConfigMappingFunctionError, DagsterInvalidDefinitionError
 from dagster._core.events.log import EventLogEntry, construct_event_logger
 from dagster._core.execution.api import create_execution_plan, execute_plan, execute_run
 from dagster._core.instance import DagsterInstance

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/config_schema_tests/test_builtin_schemas.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/config_schema_tests/test_builtin_schemas.py
@@ -5,17 +5,19 @@ from dagster import (
     Bool,
     DagsterInvalidConfigError,
     Float,
-    InputDefinition,
     Int,
     List,
     Optional,
+    String,
+)
+from dagster._utils.test import get_temp_file_name
+from dagster._legacy import (
+    InputDefinition,
     OutputDefinition,
     PipelineDefinition,
-    String,
     execute_pipeline,
     lambda_solid,
 )
-from dagster._utils.test import get_temp_file_name
 
 
 def _execute_pipeline_with_subset(pipeline, run_config, solid_selection):

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/config_schema_tests/test_builtin_schemas.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/config_schema_tests/test_builtin_schemas.py
@@ -1,16 +1,6 @@
 import pytest
 
-from dagster import (
-    Any,
-    Bool,
-    DagsterInvalidConfigError,
-    Float,
-    Int,
-    List,
-    Optional,
-    String,
-)
-from dagster._utils.test import get_temp_file_name
+from dagster import Any, Bool, DagsterInvalidConfigError, Float, Int, List, Optional, String
 from dagster._legacy import (
     InputDefinition,
     OutputDefinition,
@@ -18,6 +8,7 @@ from dagster._legacy import (
     execute_pipeline,
     lambda_solid,
 )
+from dagster._utils.test import get_temp_file_name
 
 
 def _execute_pipeline_with_subset(pipeline, run_config, solid_selection):

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_dict.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_dict.py
@@ -6,12 +6,10 @@ from dagster import (
     DagsterInvalidDefinitionError,
     DagsterTypeCheckDidNotPass,
     Dict,
-    InputDefinition,
-    OutputDefinition,
     execute_solid,
-    lambda_solid,
     usable_as_dagster_type,
 )
+from dagster._legacy import InputDefinition, OutputDefinition, lambda_solid
 
 
 def test_basic_python_dictionary_output():
@@ -92,7 +90,8 @@ def test_basic_typing_dictionary_output():
 
 def test_basic_typing_dictionary_input():
     @lambda_solid(
-        input_defs=[InputDefinition("data", typing.Dict)], output_def=OutputDefinition(str)
+        input_defs=[InputDefinition("data", typing.Dict)],
+        output_def=OutputDefinition(str),
     )
     def input_dict(data):
         return data["key"]

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_set.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_set.py
@@ -2,16 +2,10 @@ import typing
 
 import pytest
 
-from dagster import (
-    DagsterTypeCheckDidNotPass,
-    InputDefinition,
-    Optional,
-    OutputDefinition,
-    execute_solid,
-    lambda_solid,
-)
+from dagster import DagsterTypeCheckDidNotPass, Optional, execute_solid
 from dagster._core.types.dagster_type import resolve_dagster_type
 from dagster._core.types.python_set import create_typed_runtime_set
+from dagster._legacy import InputDefinition, OutputDefinition, lambda_solid
 
 
 def test_vanilla_set_output():

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_tuple.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_tuple.py
@@ -2,14 +2,9 @@ from typing import Tuple
 
 import pytest
 
-from dagster import (
-    DagsterTypeCheckDidNotPass,
-    InputDefinition,
-    OutputDefinition,
-    execute_solid,
-    lambda_solid,
-)
+from dagster import DagsterTypeCheckDidNotPass, execute_solid
 from dagster._core.types.python_tuple import create_typed_tuple
+from dagster._legacy import InputDefinition, OutputDefinition, lambda_solid
 
 
 def test_vanilla_tuple_output():
@@ -34,7 +29,10 @@ def test_vanilla_tuple_input():
     def take_tuple(tt):
         return tt
 
-    assert execute_solid(take_tuple, input_values={"tt": (2, 3)}).output_value() == (2, 3)
+    assert execute_solid(take_tuple, input_values={"tt": (2, 3)}).output_value() == (
+        2,
+        3,
+    )
 
 
 def test_vanilla_tuple_input_fail():
@@ -68,7 +66,10 @@ def test_open_typing_tuple_input():
     def take_tuple(tt):
         return tt
 
-    assert execute_solid(take_tuple, input_values={"tt": (2, 3)}).output_value() == (2, 3)
+    assert execute_solid(take_tuple, input_values={"tt": (2, 3)}).output_value() == (
+        2,
+        3,
+    )
 
 
 def test_open_typing_tuple_input_fail():
@@ -155,7 +156,10 @@ def test_closed_typing_tuple_input():
     def take_tuple(tt):
         return tt
 
-    assert execute_solid(take_tuple, input_values={"tt": (2, 3)}).output_value() == (2, 3)
+    assert execute_solid(take_tuple, input_values={"tt": (2, 3)}).output_value() == (
+        2,
+        3,
+    )
 
 
 def test_closed_typing_tuple_input_fail():

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_runtime_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_runtime_types.py
@@ -6,17 +6,13 @@ from dagster import (
     DagsterInvalidDefinitionError,
     Dict,
     Float,
-    InputDefinition,
     Int,
     List,
     Nothing,
     Optional,
-    OutputDefinition,
-    PipelineDefinition,
     Set,
     String,
     Tuple,
-    lambda_solid,
 )
 from dagster._core.types.dagster_type import (
     ALL_RUNTIME_BUILTINS,
@@ -24,7 +20,13 @@ from dagster._core.types.dagster_type import (
     DagsterTypeKind,
     resolve_dagster_type,
 )
-from dagster._legacy import pipeline
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    PipelineDefinition,
+    lambda_solid,
+    pipeline,
+)
 
 
 def inner_type_key_set(dagster_type):

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_type_examples_py2.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_type_examples_py2.py
@@ -3,17 +3,15 @@ from dagster import (
     Bool,
     Dict,
     Float,
-    InputDefinition,
     Int,
     List,
     Optional,
-    OutputDefinition,
     Set,
     String,
     Tuple,
     execute_solid,
 )
-from dagster._legacy import solid
+from dagster._legacy import InputDefinition, OutputDefinition, solid
 
 
 @solid(
@@ -57,7 +55,10 @@ def div_2_py_2(_, x):
 
 
 @solid(
-    input_defs=[InputDefinition("x", dagster_type=String), InputDefinition("y", dagster_type=str)],
+    input_defs=[
+        InputDefinition("x", dagster_type=String),
+        InputDefinition("y", dagster_type=str),
+    ],
     output_defs=[OutputDefinition(dagster_type=str)],
 )
 def concat_py_2(_, x, y):
@@ -84,7 +85,8 @@ def concat_list_py2(_, xs):
 
 
 @solid(
-    input_defs=[InputDefinition("spec", dagster_type=Dict)], output_defs=[OutputDefinition(String)]
+    input_defs=[InputDefinition("spec", dagster_type=Dict)],
+    output_defs=[OutputDefinition(String)],
 )
 def repeat_py2(_, spec):
     return spec["word"] * spec["times"]

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_type_examples_py2.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_type_examples_py2.py
@@ -1,16 +1,4 @@
-from dagster import (
-    Any,
-    Bool,
-    Dict,
-    Float,
-    Int,
-    List,
-    Optional,
-    Set,
-    String,
-    Tuple,
-    execute_solid,
-)
+from dagster import Any, Bool, Dict, Float, Int, List, Optional, Set, String, Tuple, execute_solid
 from dagster._legacy import InputDefinition, OutputDefinition, solid
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_typed_list.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_typed_list.py
@@ -2,13 +2,8 @@ import typing
 
 import pytest
 
-from dagster import (
-    DagsterTypeCheckDidNotPass,
-    InputDefinition,
-    OutputDefinition,
-    execute_solid,
-    lambda_solid,
-)
+from dagster import DagsterTypeCheckDidNotPass, execute_solid
+from dagster._legacy import InputDefinition, OutputDefinition, lambda_solid
 
 
 def test_basic_list_output_pass():

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_typed_python_dict.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_typed_python_dict.py
@@ -1,13 +1,7 @@
 import pytest
 
-from dagster import (
-    DagsterTypeCheckDidNotPass,
-    Dict,
-    InputDefinition,
-    OutputDefinition,
-    execute_solid,
-    lambda_solid,
-)
+from dagster import DagsterTypeCheckDidNotPass, Dict, execute_solid
+from dagster._legacy import InputDefinition, OutputDefinition, lambda_solid
 
 
 def test_typed_python_dict():

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -9,19 +9,14 @@ from dagster import (
     DagsterInvariantViolationError,
     DagsterTypeCheckDidNotPass,
     Failure,
-    InputDefinition,
     Int,
     List,
     MetadataEntry,
-    ModeDefinition,
     Optional,
-    OutputDefinition,
     String,
     Tuple,
     TypeCheck,
     check_dagster_type,
-    execute_pipeline,
-    lambda_solid,
     make_python_type_usable_as_dagster_type,
     resource,
 )
@@ -32,7 +27,15 @@ from dagster._core.types.dagster_type import (
     PythonObjectDagsterType,
     resolve_dagster_type,
 )
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    execute_pipeline,
+    lambda_solid,
+    pipeline,
+    solid,
+)
 
 
 class BarObj:
@@ -588,7 +591,10 @@ def test_contextual_type_check():
         return TypeCheck(success=context.resources.foo.check(value))
 
     custom = DagsterType(
-        key="custom", name="custom", type_check_fn=fancy_type_check, required_resource_keys={"foo"}
+        key="custom",
+        name="custom",
+        type_check_fn=fancy_type_check,
+        required_resource_keys={"foo"},
     )
 
     @resource

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_execute.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_execute.py
@@ -5,20 +5,13 @@ import pytest
 from dagster import reexecute_pipeline_iterator
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
-from dagster._core.errors import (
-    DagsterExecutionStepNotFoundError,
-    DagsterInvalidSubsetError,
-)
+from dagster._core.errors import DagsterExecutionStepNotFoundError, DagsterInvalidSubsetError
 from dagster._core.execution.api import create_execution_plan, execute_run
 from dagster._core.instance import DagsterInstance
 from dagster._core.test_utils import instance_for_test, step_output_event_filter
+from dagster._legacy import execute_pipeline, execute_pipeline_iterator, reexecute_pipeline
 
 from .test_subset_selector import asset_selection_job, foo_pipeline
-from dagster._legacy import (
-    execute_pipeline,
-    execute_pipeline_iterator,
-    reexecute_pipeline,
-)
 
 
 def test_subset_for_execution():

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_execute.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_execute.py
@@ -2,20 +2,23 @@ import re
 
 import pytest
 
-from dagster import (
-    execute_pipeline,
-    execute_pipeline_iterator,
-    reexecute_pipeline,
-    reexecute_pipeline_iterator,
-)
+from dagster import reexecute_pipeline_iterator
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
-from dagster._core.errors import DagsterExecutionStepNotFoundError, DagsterInvalidSubsetError
+from dagster._core.errors import (
+    DagsterExecutionStepNotFoundError,
+    DagsterInvalidSubsetError,
+)
 from dagster._core.execution.api import create_execution_plan, execute_run
 from dagster._core.instance import DagsterInstance
 from dagster._core.test_utils import instance_for_test, step_output_event_filter
 
 from .test_subset_selector import asset_selection_job, foo_pipeline
+from dagster._legacy import (
+    execute_pipeline,
+    execute_pipeline_iterator,
+    reexecute_pipeline,
+)
 
 
 def test_subset_for_execution():

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
@@ -1,8 +1,11 @@
 import pytest
 
-from dagster import AssetGroup, InputDefinition, asset, lambda_solid
+from dagster import asset
 from dagster._core.definitions.executor_definition import execute_in_process_executor
-from dagster._core.errors import DagsterExecutionStepNotFoundError, DagsterInvalidSubsetError
+from dagster._core.errors import (
+    DagsterExecutionStepNotFoundError,
+    DagsterInvalidSubsetError,
+)
 from dagster._core.selector.subset_selector import (
     MAX_NUM,
     Traverser,
@@ -13,7 +16,7 @@ from dagster._core.selector.subset_selector import (
     parse_step_selection,
 )
 from dagster._core.test_utils import default_mode_def_for_test
-from dagster._legacy import pipeline
+from dagster._legacy import AssetGroup, InputDefinition, lambda_solid, pipeline
 
 
 @lambda_solid
@@ -115,7 +118,12 @@ def test_parse_solid_selection_single():
 
     solid_selection_both = parse_solid_selection(foo_pipeline, ["*add_nums+"])
     assert len(solid_selection_both) == 4
-    assert set(solid_selection_both) == {"return_one", "return_two", "add_nums", "multiply_two"}
+    assert set(solid_selection_both) == {
+        "return_one",
+        "return_two",
+        "add_nums",
+        "multiply_two",
+    }
 
 
 def test_parse_solid_selection_multi():
@@ -123,13 +131,21 @@ def test_parse_solid_selection_multi():
         foo_pipeline, ["return_one", "add_nums+"]
     )
     assert len(solid_selection_multi_disjoint) == 3
-    assert set(solid_selection_multi_disjoint) == {"return_one", "add_nums", "multiply_two"}
+    assert set(solid_selection_multi_disjoint) == {
+        "return_one",
+        "add_nums",
+        "multiply_two",
+    }
 
     solid_selection_multi_overlap = parse_solid_selection(
         foo_pipeline, ["*add_nums", "return_one+"]
     )
     assert len(solid_selection_multi_overlap) == 3
-    assert set(solid_selection_multi_overlap) == {"return_one", "return_two", "add_nums"}
+    assert set(solid_selection_multi_overlap) == {
+        "return_one",
+        "return_two",
+        "add_nums",
+    }
 
     with pytest.raises(
         DagsterInvalidSubsetError,

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
@@ -2,10 +2,7 @@ import pytest
 
 from dagster import asset
 from dagster._core.definitions.executor_definition import execute_in_process_executor
-from dagster._core.errors import (
-    DagsterExecutionStepNotFoundError,
-    DagsterInvalidSubsetError,
-)
+from dagster._core.errors import DagsterExecutionStepNotFoundError, DagsterInvalidSubsetError
 from dagster._core.selector.subset_selector import (
     MAX_NUM,
     Traverser,

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_active_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_active_data.py
@@ -1,11 +1,11 @@
 from datetime import datetime
 
-from dagster import ModeDefinition, PresetDefinition, daily_schedule, repository
+from dagster import daily_schedule, repository
 from dagster._core.host_representation import (
     external_pipeline_data_from_def,
     external_repository_data_from_def,
 )
-from dagster._legacy import pipeline, solid
+from dagster._legacy import ModeDefinition, PresetDefinition, pipeline, solid
 from dagster._serdes import serialize_pp
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_composite_solid_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_composite_solid_def_snap.py
@@ -4,10 +4,7 @@ from dagster._core.snap import (
     build_composite_solid_def_snap,
 )
 from dagster._legacy import composite_solid, solid
-from dagster._serdes import (
-    deserialize_json_to_dagster_namedtuple,
-    serialize_dagster_namedtuple,
-)
+from dagster._serdes import deserialize_json_to_dagster_namedtuple, serialize_dagster_namedtuple
 
 
 def test_noop_comp_solid_definition():

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_composite_solid_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_composite_solid_def_snap.py
@@ -1,11 +1,13 @@
-from dagster import composite_solid
 from dagster._core.snap import (
     CompositeSolidDefSnap,
     DependencyStructureIndex,
     build_composite_solid_def_snap,
 )
-from dagster._legacy import solid
-from dagster._serdes import deserialize_json_to_dagster_namedtuple, serialize_dagster_namedtuple
+from dagster._legacy import composite_solid, solid
+from dagster._serdes import (
+    deserialize_json_to_dagster_namedtuple,
+    serialize_dagster_namedtuple,
+)
 
 
 def test_noop_comp_solid_definition():

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
@@ -3,7 +3,6 @@ from dagster import (
     Enum,
     EnumValue,
     Field,
-    ModeDefinition,
     Noneable,
     ScalarUnion,
     Selector,
@@ -16,7 +15,7 @@ from dagster._core.snap import (
     build_config_schema_snapshot,
     snap_from_config_type,
 )
-from dagster._legacy import pipeline, solid
+from dagster._legacy import ModeDefinition, pipeline, solid
 from dagster._serdes import (
     deserialize_json_to_dagster_namedtuple,
     deserialize_value,

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
@@ -1,14 +1,4 @@
-from dagster import (
-    Array,
-    Enum,
-    EnumValue,
-    Field,
-    Noneable,
-    ScalarUnion,
-    Selector,
-    Shape,
-    resource,
-)
+from dagster import Array, Enum, EnumValue, Field, Noneable, ScalarUnion, Selector, Shape, resource
 from dagster._config import ConfigTypeKind, Map, resolve_to_config_type
 from dagster._core.snap import (
     ConfigEnumValueSnap,

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_dagster_type_namespace_snapshot.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_dagster_type_namespace_snapshot.py
@@ -1,7 +1,7 @@
-from dagster import Dict, InputDefinition, List, OutputDefinition, Set, Tuple
+from dagster import Dict, List, Set, Tuple
 from dagster._core.snap import build_dagster_type_namespace_snapshot
 from dagster._core.types.dagster_type import ALL_RUNTIME_BUILTINS, create_string_type
-from dagster._legacy import pipeline, solid
+from dagster._legacy import InputDefinition, OutputDefinition, pipeline, solid
 
 
 def test_simple_pipeline_input_dagster_type_namespace():

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_execution_plan.py
@@ -1,12 +1,6 @@
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.snap import create_pipeline_snapshot_id, snapshot_from_execution_plan
-from dagster._legacy import (
-    InputDefinition,
-    OutputDefinition,
-    composite_solid,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, OutputDefinition, composite_solid, pipeline, solid
 from dagster._serdes import serialize_pp
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_execution_plan.py
@@ -1,7 +1,12 @@
-from dagster import InputDefinition, OutputDefinition, composite_solid
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.snap import create_pipeline_snapshot_id, snapshot_from_execution_plan
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    composite_solid,
+    pipeline,
+    solid,
+)
 from dagster._serdes import serialize_pp
 
 
@@ -19,7 +24,8 @@ def test_create_noop_execution_plan(snapshot):
     snapshot.assert_match(
         serialize_pp(
             snapshot_from_execution_plan(
-                execution_plan, create_pipeline_snapshot_id(noop_pipeline.get_pipeline_snapshot())
+                execution_plan,
+                create_pipeline_snapshot_id(noop_pipeline.get_pipeline_snapshot()),
             )
         )
     )
@@ -43,7 +49,8 @@ def test_create_execution_plan_with_dep(snapshot):
     snapshot.assert_match(
         serialize_pp(
             snapshot_from_execution_plan(
-                execution_plan, create_pipeline_snapshot_id(noop_pipeline.get_pipeline_snapshot())
+                execution_plan,
+                create_pipeline_snapshot_id(noop_pipeline.get_pipeline_snapshot()),
             )
         )
     )
@@ -82,7 +89,8 @@ def test_create_with_composite(snapshot):
     snapshot.assert_match(
         serialize_pp(
             snapshot_from_execution_plan(
-                execution_plan, create_pipeline_snapshot_id(do_comps.get_pipeline_snapshot())
+                execution_plan,
+                create_pipeline_snapshot_id(do_comps.get_pipeline_snapshot()),
             )
         )
     )
@@ -102,7 +110,8 @@ def test_create_noop_execution_plan_with_tags(snapshot):
     snapshot.assert_match(
         serialize_pp(
             snapshot_from_execution_plan(
-                execution_plan, create_pipeline_snapshot_id(noop_pipeline.get_pipeline_snapshot())
+                execution_plan,
+                create_pipeline_snapshot_id(noop_pipeline.get_pipeline_snapshot()),
             )
         )
     )

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_mode_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_mode_def_snap.py
@@ -1,10 +1,7 @@
 from dagster import logger, resource
 from dagster._core.snap import PipelineSnapshot
 from dagster._legacy import ModeDefinition, pipeline
-from dagster._serdes import (
-    deserialize_json_to_dagster_namedtuple,
-    serialize_dagster_namedtuple,
-)
+from dagster._serdes import deserialize_json_to_dagster_namedtuple, serialize_dagster_namedtuple
 
 
 def test_mode_snap(snapshot):

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_mode_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_mode_def_snap.py
@@ -1,7 +1,10 @@
-from dagster import ModeDefinition, logger, resource
+from dagster import logger, resource
 from dagster._core.snap import PipelineSnapshot
-from dagster._legacy import pipeline
-from dagster._serdes import deserialize_json_to_dagster_namedtuple, serialize_dagster_namedtuple
+from dagster._legacy import ModeDefinition, pipeline
+from dagster._serdes import (
+    deserialize_json_to_dagster_namedtuple,
+    serialize_dagster_namedtuple,
+)
 
 
 def test_mode_snap(snapshot):
@@ -30,7 +33,10 @@ def test_mode_snap(snapshot):
                     "some_resource": a_resource,
                     "no_config_resource": no_config_resource,
                 },
-                logger_defs={"some_logger": a_logger, "no_config_logger": no_config_logger},
+                logger_defs={
+                    "some_logger": a_logger,
+                    "no_config_logger": no_config_logger,
+                },
             )
         ]
     )

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
@@ -2,16 +2,7 @@ import itertools
 
 import pytest
 
-from dagster import (
-    Field,
-    InputDefinition,
-    Map,
-    Nothing,
-    OutputDefinition,
-    Permissive,
-    Selector,
-    Shape,
-)
+from dagster import Field, Map, Nothing, Permissive, Selector, Shape
 from dagster._config import Array, Bool, Enum, EnumValue, Float, Int, Noneable, String
 from dagster._core.snap import (
     DependencyStructureIndex,
@@ -25,7 +16,7 @@ from dagster._core.snap.dep_snapshot import (
     OutputHandleSnap,
     build_dep_structure_snapshot_from_icontains_solids,
 )
-from dagster._legacy import pipeline, solid
+from dagster._legacy import InputDefinition, OutputDefinition, pipeline, solid
 from dagster._serdes import (
     deserialize_json_to_dagster_namedtuple,
     serialize_dagster_namedtuple,
@@ -211,7 +202,10 @@ def test_basic_fan_in(snapshot):
     @pipeline
     def fan_in_test():
         take_nothings(
-            [return_nothing.alias("nothing_one")(), return_nothing.alias("nothing_two")()]
+            [
+                return_nothing.alias("nothing_one")(),
+                return_nothing.alias("nothing_two")(),
+            ]
         )
 
     dep_structure_snapshot = build_dep_structure_snapshot_from_icontains_solids(fan_in_test.graph)
@@ -280,7 +274,8 @@ def test_deserialize_solid_def_snaps_default_field():
     assert not recevied_config_type.fields["foo"].is_required
     assert recevied_config_type.fields["foo"].default_value == "hello"
     _dict_has_stable_hashes(
-        recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
+        recevied_config_type,
+        pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key,
     )
 
 
@@ -325,7 +320,8 @@ def test_deserialize_solid_def_snaps_strict_shape():
     assert isinstance(recevied_config_type.fields["bar"].config_type, String)
     assert not recevied_config_type.fields["foo"].is_required
     _dict_has_stable_hashes(
-        recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
+        recevied_config_type,
+        pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key,
     )
 
 
@@ -345,7 +341,8 @@ def test_deserialize_solid_def_snaps_selector():
     assert isinstance(recevied_config_type.fields["foo"].config_type, String)
     assert isinstance(recevied_config_type.fields["bar"].config_type, Int)
     _dict_has_stable_hashes(
-        recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
+        recevied_config_type,
+        pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key,
     )
 
 
@@ -364,7 +361,8 @@ def test_deserialize_solid_def_snaps_permissive():
     assert isinstance(recevied_config_type, Permissive)
     assert isinstance(recevied_config_type.fields["foo"].config_type, String)
     _dict_has_stable_hashes(
-        recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
+        recevied_config_type,
+        pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key,
     )
 
 
@@ -383,7 +381,8 @@ def test_deserialize_solid_def_snaps_array():
     assert isinstance(recevied_config_type, Array)
     assert isinstance(recevied_config_type.inner_type, String)
     _array_has_stable_hashes(
-        recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
+        recevied_config_type,
+        pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key,
     )
 
 
@@ -403,7 +402,8 @@ def test_deserialize_solid_def_snaps_map():
     assert isinstance(recevied_config_type.key_type, String)
     assert isinstance(recevied_config_type.inner_type, String)
     _map_has_stable_hashes(
-        recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
+        recevied_config_type,
+        pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key,
     )
 
 
@@ -424,7 +424,8 @@ def test_deserialize_solid_def_snaps_map_with_name():
     assert isinstance(recevied_config_type.inner_type, Float)
     assert recevied_config_type.given_name == "title"
     _map_has_stable_hashes(
-        recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
+        recevied_config_type,
+        pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key,
     )
 
 
@@ -458,7 +459,11 @@ def test_deserialize_solid_def_snaps_multi_type_config(snapshot):
                                 "corge": Field(
                                     Enum(
                                         "RGB",
-                                        [EnumValue("red"), EnumValue("green"), EnumValue("blue")],
+                                        [
+                                            EnumValue("red"),
+                                            EnumValue("green"),
+                                            EnumValue("blue"),
+                                        ],
                                     )
                                 ),
                             },
@@ -480,7 +485,8 @@ def test_deserialize_solid_def_snaps_multi_type_config(snapshot):
     recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
     snapshot.assert_match(serialize_pp(snap_from_config_type(recevied_config_type)))
     _dict_has_stable_hashes(
-        recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
+        recevied_config_type,
+        pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key,
     )
 
 
@@ -499,7 +505,8 @@ def test_multi_type_config_array_dict_fields(dict_config_type, snapshot):
     recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
     snapshot.assert_match(serialize_pp(snap_from_config_type(recevied_config_type)))
     _array_has_stable_hashes(
-        recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
+        recevied_config_type,
+        pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key,
     )
 
 
@@ -517,7 +524,8 @@ def test_multi_type_config_array_map(snapshot):
     recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
     snapshot.assert_match(serialize_pp(snap_from_config_type(recevied_config_type)))
     _array_has_stable_hashes(
-        recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
+        recevied_config_type,
+        pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key,
     )
 
 
@@ -541,5 +549,6 @@ def test_multi_type_config_nested_dicts(nested_dict_types, snapshot):
     recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
     snapshot.assert_match(serialize_pp(snap_from_config_type(recevied_config_type)))
     _dict_has_stable_hashes(
-        recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
+        recevied_config_type,
+        pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key,
     )

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_solid_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_solid_def_snap.py
@@ -1,9 +1,6 @@
 from dagster._core.snap.solid import build_core_solid_def_snap
 from dagster._legacy import InputDefinition, OutputDefinition, solid
-from dagster._serdes import (
-    deserialize_json_to_dagster_namedtuple,
-    serialize_dagster_namedtuple,
-)
+from dagster._serdes import deserialize_json_to_dagster_namedtuple, serialize_dagster_namedtuple
 
 
 def test_basic_solid_definition():

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_solid_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_solid_def_snap.py
@@ -1,7 +1,9 @@
-from dagster import InputDefinition, OutputDefinition
 from dagster._core.snap.solid import build_core_solid_def_snap
-from dagster._legacy import solid
-from dagster._serdes import deserialize_json_to_dagster_namedtuple, serialize_dagster_namedtuple
+from dagster._legacy import InputDefinition, OutputDefinition, solid
+from dagster._serdes import (
+    deserialize_json_to_dagster_namedtuple,
+    serialize_dagster_namedtuple,
+)
 
 
 def test_basic_solid_definition():
@@ -27,7 +29,10 @@ def test_solid_definition_kitchen_sink():
         output_defs=[
             OutputDefinition(name="output_one", dagster_type=str),
             OutputDefinition(
-                name="output_two", dagster_type=int, description="desc2", is_required=False
+                name="output_two",
+                dagster_type=int,
+                description="desc2",
+                is_required=False,
             ),
         ],
         config_schema={"foo": int},
@@ -45,7 +50,10 @@ def test_solid_definition_kitchen_sink():
     assert kitchen_sink_solid_snap
     assert kitchen_sink_solid_snap.name == "kitchen_sink_solid"
     assert len(kitchen_sink_solid_snap.input_def_snaps) == 2
-    assert [inp.name for inp in kitchen_sink_solid_snap.input_def_snaps] == ["arg_one", "arg_two"]
+    assert [inp.name for inp in kitchen_sink_solid_snap.input_def_snaps] == [
+        "arg_one",
+        "arg_two",
+    ]
     assert [inp.dagster_type_key for inp in kitchen_sink_solid_snap.input_def_snaps] == [
         "String",
         "Int",
@@ -66,7 +74,10 @@ def test_solid_definition_kitchen_sink():
     assert kitchen_sink_solid_snap.get_output_snap("output_two").description == "desc2"
     assert kitchen_sink_solid_snap.get_output_snap("output_two").is_required is False
 
-    assert kitchen_sink_solid_snap.required_resource_keys == ["a_resource", "b_resource"]
+    assert kitchen_sink_solid_snap.required_resource_keys == [
+        "a_resource",
+        "b_resource",
+    ]
     assert kitchen_sink_solid_snap.tags == {"a_tag": "yup"}
     assert kitchen_sink_solid.positional_inputs == ["arg_two", "arg_one"]
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_asset_events.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_asset_events.py
@@ -4,16 +4,11 @@ from dagster import (
     AssetKey,
     AssetObservation,
     In,
-    InputDefinition,
-    ModeDefinition,
     Out,
     Output,
-    OutputDefinition,
     StaticPartitionsDefinition,
     asset,
-    build_assets_job,
     build_input_context,
-    execute_pipeline,
     io_manager,
     job,
     op,
@@ -24,7 +19,15 @@ from dagster._core.definitions.events import AssetLineageInfo
 from dagster._core.definitions.metadata import MetadataEntry, PartitionMetadataEntry
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.storage.io_manager import IOManager
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    build_assets_job,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 def n_asset_keys(path, n):
@@ -86,7 +89,9 @@ def test_output_definition_multiple_partition_materialization():
     @solid(
         output_defs=[
             OutputDefinition(
-                name="output1", asset_key=AssetKey("table1"), asset_partitions=set(["0", "1", "2"])
+                name="output1",
+                asset_key=AssetKey("table1"),
+                asset_partitions=set(["0", "1", "2"]),
             )
         ]
     )
@@ -266,7 +271,10 @@ def test_io_manager_single_partition_add_input_metadata():
 
     assert observations[0].step_key == "asset_2"
     assert get_observation(observations[0]) == AssetObservation(
-        asset_key="asset_1", metadata={"foo": "bar"}, description="hello world", partition="a"
+        asset_key="asset_1",
+        metadata={"foo": "bar"},
+        description="hello world",
+        partition="a",
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_asset_lineage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_asset_lineage.py
@@ -1,21 +1,19 @@
 import pytest
 
-from dagster import (
-    AssetKey,
-    DynamicOutput,
-    DynamicOutputDefinition,
-    InputDefinition,
-    ModeDefinition,
-    Output,
-    OutputDefinition,
-    execute_pipeline,
-    io_manager,
-)
+from dagster import AssetKey, DynamicOutput, Output, io_manager
 from dagster._core.definitions.events import AssetLineageInfo
 from dagster._core.definitions.metadata import MetadataEntry, PartitionMetadataEntry
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.storage.io_manager import IOManager
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    DynamicOutputDefinition,
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 def n_asset_keys(path, n):
@@ -157,7 +155,9 @@ def test_input_definition_multiple_partition_lineage():
         input_defs=[
             # here, only take 1 of the asset keys specified by the output
             InputDefinition(
-                name="_input1", asset_key=AssetKey("table1"), asset_partitions=set(["0"])
+                name="_input1",
+                asset_key=AssetKey("table1"),
+                asset_partitions=set(["0"]),
             )
         ],
         output_defs=[OutputDefinition(name="output2", asset_key=lambda _: AssetKey("table2"))],

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_io_manager.py
@@ -9,22 +9,26 @@ from dagster import (
     AssetsDefinition,
     DailyPartitionsDefinition,
     MetadataValue,
-    ModeDefinition,
     Out,
     Output,
     StaticPartitionsDefinition,
-    execute_pipeline,
     graph,
     op,
 )
-from dagster._core.definitions import AssetGroup, AssetIn, asset, build_assets_job, multi_asset
+from dagster._core.definitions import (
+    AssetGroup,
+    AssetIn,
+    asset,
+    build_assets_job,
+    multi_asset,
+)
 from dagster._core.definitions.version_strategy import VersionStrategy
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.fs_io_manager import fs_io_manager
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import ModeDefinition, execute_pipeline, pipeline, solid
 
 
 def define_pipeline(io_manager):
@@ -246,7 +250,8 @@ def test_fs_io_manager_partitioned():
     with tempfile.TemporaryDirectory() as tmpdir_path:
         io_manager_def = fs_io_manager.configured({"base_dir": tmpdir_path})
         job_def = get_assets_job(
-            io_manager_def, partitions_def=DailyPartitionsDefinition(start_date="2020-02-01")
+            io_manager_def,
+            partitions_def=DailyPartitionsDefinition(start_date="2020-02-01"),
         )
 
         result = job_def.execute_in_process(partition_key="2020-05-03")
@@ -296,7 +301,8 @@ def test_fs_io_manager_partitioned_multi_asset():
             return 2
 
         group = AssetGroup(
-            [upstream_asset, downstream_asset], resource_defs={"io_manager": io_manager_def}
+            [upstream_asset, downstream_asset],
+            resource_defs={"io_manager": io_manager_def},
         )
 
         job = group.build_job(name="TheJob")
@@ -334,7 +340,9 @@ def test_fs_io_manager_partitioned_graph_backed_asset():
         )
 
         job_def = build_assets_job(
-            name="a", assets=[one, four_asset], resource_defs={"io_manager": io_manager_def}
+            name="a",
+            assets=[one, four_asset],
+            resource_defs={"io_manager": io_manager_def},
         )
 
         result = job_def.execute_in_process(partition_key="A")

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_io_manager.py
@@ -15,13 +15,7 @@ from dagster import (
     graph,
     op,
 )
-from dagster._core.definitions import (
-    AssetGroup,
-    AssetIn,
-    asset,
-    build_assets_job,
-    multi_asset,
-)
+from dagster._core.definitions import AssetGroup, AssetIn, asset, build_assets_job, multi_asset
 from dagster._core.definitions.version_strategy import VersionStrategy
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.api import create_execution_plan

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_input_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_input_manager.py
@@ -7,15 +7,10 @@ from dagster import (
     DagsterInvalidDefinitionError,
     IOManager,
     In,
-    InputDefinition,
     InputManager,
     MetadataEntry,
-    ModeDefinition,
-    OutputDefinition,
     PythonObjectDagsterType,
     RootInputManagerDefinition,
-    composite_solid,
-    execute_pipeline,
     execute_solid,
     input_manager,
     io_manager,
@@ -27,7 +22,15 @@ from dagster import (
 from dagster._core.definitions.events import Failure, RetryRequested
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.instance import InstanceRef
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    composite_solid,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 
 ### input manager tests
 
@@ -63,7 +66,12 @@ def test_input_manager_override():
     def second_op(an_input):
         assert an_input == 4
 
-    @job(resource_defs={"io_manager": my_io_manager, "my_input_manager": my_input_manager})
+    @job(
+        resource_defs={
+            "io_manager": my_io_manager,
+            "my_input_manager": my_input_manager,
+        }
+    )
     def check_input_managers():
         out = first_op()
         second_op(out)
@@ -102,7 +110,12 @@ def test_input_manager_root_input():
     def second_op(an_input):
         assert an_input == 4
 
-    @job(resource_defs={"io_manager": my_io_manager, "my_input_manager": my_input_manager})
+    @job(
+        resource_defs={
+            "io_manager": my_io_manager,
+            "my_input_manager": my_input_manager,
+        }
+    )
     def check_input_managers():
         first_op()
         second_op()
@@ -142,7 +155,8 @@ def test_root_input_and_input_managers():
         @op(
             ins={
                 "an_input": In(
-                    input_manager_key="my_input_manager", root_manager_key="my_root_manager"
+                    input_manager_key="my_input_manager",
+                    root_manager_key="my_root_manager",
                 )
             }
         )
@@ -181,7 +195,12 @@ def test_input_manager_calls_super():
     def second_op(an_input):
         assert an_input == 6
 
-    @job(resource_defs={"io_manager": my_io_manager, "my_input_manager": my_input_manager})
+    @job(
+        resource_defs={
+            "io_manager": my_io_manager,
+            "my_input_manager": my_input_manager,
+        }
+    )
     def check_input_managers():
         out = first_op()
         second_op(out)
@@ -220,7 +239,12 @@ def test_input_config():
     def second_op(an_input):
         assert an_input == 6
 
-    @job(resource_defs={"io_manager": my_io_manager, "my_input_manager": my_input_manager})
+    @job(
+        resource_defs={
+            "io_manager": my_io_manager,
+            "my_input_manager": my_input_manager,
+        }
+    )
     def check_input_managers():
         out = first_op()
         second_op(out)
@@ -268,7 +292,12 @@ def test_input_manager_decorator():
     def second_op(an_input):
         assert an_input == 4
 
-    @job(resource_defs={"io_manager": my_io_manager, "my_input_manager": my_input_manager})
+    @job(
+        resource_defs={
+            "io_manager": my_io_manager,
+            "my_input_manager": my_input_manager,
+        }
+    )
     def check_input_managers():
         out = first_op()
         second_op(out)
@@ -300,7 +329,12 @@ def test_input_manager_w_function():
     def second_op(an_input):
         assert an_input == 4
 
-    @job(resource_defs={"io_manager": my_io_manager, "my_input_manager": my_input_manager})
+    @job(
+        resource_defs={
+            "io_manager": my_io_manager,
+            "my_input_manager": my_input_manager,
+        }
+    )
     def check_input_managers():
         out = first_op()
         second_op(out)
@@ -339,7 +373,12 @@ def test_input_manager_class():
     def second_op(an_input):
         assert an_input == 4
 
-    @job(resource_defs={"io_manager": my_io_manager, "my_input_manager": my_input_manager})
+    @job(
+        resource_defs={
+            "io_manager": my_io_manager,
+            "my_input_manager": my_input_manager,
+        }
+    )
     def check_input_managers():
         out = first_op()
         second_op(out)
@@ -360,7 +399,9 @@ def test_validate_inputs():
     @solid(
         input_defs=[
             InputDefinition(
-                "input1", dagster_type=PythonObjectDagsterType(int), root_manager_key="my_loader"
+                "input1",
+                dagster_type=PythonObjectDagsterType(int),
+                root_manager_key="my_loader",
             )
         ]
     )
@@ -599,7 +640,8 @@ def test_input_manager_resource_config():
         return source_solid(source_solid())
 
     result = execute_pipeline(
-        basic_pipeline, run_config={"resources": {"emit_dog": {"config": {"dog": "poodle"}}}}
+        basic_pipeline,
+        run_config={"resources": {"emit_dog": {"config": {"dog": "poodle"}}}},
     )
 
     assert result.success
@@ -686,7 +728,8 @@ def test_no_root_manager_composite():
         return data
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match="Root input manager cannot be set on a composite solid"
+        DagsterInvalidDefinitionError,
+        match="Root input manager cannot be set on a composite solid",
     ):
 
         @composite_solid(

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_io_manager.py
@@ -16,19 +16,13 @@ from dagster import (
     Field,
     IOManagerDefinition,
     In,
-    InputDefinition,
     MetadataEntry,
-    ModeDefinition,
     Out,
-    OutputDefinition,
     build_input_context,
     build_output_context,
-    composite_solid,
-    execute_pipeline,
     graph,
     job,
     op,
-    reexecute_pipeline,
     resource,
 )
 from dagster._check import CheckError
@@ -42,7 +36,16 @@ from dagster._core.storage.io_manager import IOManager, io_manager
 from dagster._core.storage.mem_io_manager import InMemoryIOManager, mem_io_manager
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    composite_solid,
+    execute_pipeline,
+    reexecute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 def test_io_manager_with_config():

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_io_manager.py
@@ -42,8 +42,8 @@ from dagster._legacy import (
     OutputDefinition,
     composite_solid,
     execute_pipeline,
-    reexecute_pipeline,
     pipeline,
+    reexecute_pipeline,
     solid,
 )
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_io_manager_composites.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_io_manager_composites.py
@@ -1,17 +1,16 @@
 import pytest
 
-from dagster import (
-    DagsterInvalidDefinitionError,
-    DagsterType,
+from dagster import DagsterInvalidDefinitionError, DagsterType, root_input_manager
+from dagster._core.storage.io_manager import IOManager, io_manager
+from dagster._legacy import (
     InputDefinition,
     ModeDefinition,
     OutputDefinition,
     composite_solid,
     execute_pipeline,
-    root_input_manager,
+    pipeline,
+    solid,
 )
-from dagster._core.storage.io_manager import IOManager, io_manager
-from dagster._legacy import pipeline, solid
 
 
 def named_io_manager(storage_dict, name):
@@ -49,7 +48,8 @@ def test_composite_solid_output():
 
     # Error on io_manager_key on composite
     with pytest.raises(
-        DagsterInvalidDefinitionError, match="IO manager cannot be set on a composite solid"
+        DagsterInvalidDefinitionError,
+        match="IO manager cannot be set on a composite solid",
     ):
 
         @composite_solid(output_defs=[OutputDefinition(io_manager_key="outer_manager")])

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_io_manager_multiprocess.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_io_manager_multiprocess.py
@@ -1,8 +1,8 @@
 import tempfile
 
-from dagster import ModeDefinition, execute_pipeline, fs_io_manager, reconstructable
+from dagster import fs_io_manager, reconstructable
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import ModeDefinition, execute_pipeline, pipeline, solid
 
 
 @solid

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_local_file_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_local_file_manager.py
@@ -2,11 +2,11 @@ import os
 import tempfile
 from contextlib import contextmanager
 
-from dagster import LocalFileHandle, ModeDefinition, execute_pipeline
+from dagster import LocalFileHandle
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.file_manager import LocalFileManager, local_file_manager
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import ModeDefinition, execute_pipeline, pipeline, solid
 from dagster._utils.temp_file import get_temp_file_handle_with_data
 
 
@@ -65,7 +65,8 @@ def test_basic_file_manager_execute():
     with tempfile.TemporaryDirectory() as temp_dir:
 
         result = execute_pipeline(
-            pipe, run_config={"resources": {"file_manager": {"config": {"base_dir": temp_dir}}}}
+            pipe,
+            run_config={"resources": {"file_manager": {"config": {"base_dir": temp_dir}}}},
         )
         assert result.success
         assert called["yup"]

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_local_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_local_instance.py
@@ -5,16 +5,8 @@ import types
 import pytest
 import yaml
 
-from dagster import (
-    DagsterEventType,
-    DagsterInvalidConfigError,
-    InputDefinition,
-    Output,
-    OutputDefinition,
-    PipelineRun,
-)
+from dagster import DagsterEventType, DagsterInvalidConfigError, Output
 from dagster import _check as check
-from dagster import execute_pipeline
 from dagster._core.definitions.events import RetryRequested
 from dagster._core.execution.stats import StepEventStatus
 from dagster._core.instance import DagsterInstance, InstanceRef, InstanceType
@@ -26,7 +18,14 @@ from dagster._core.storage.pipeline_run import PipelineRunStatus
 from dagster._core.storage.root import LocalArtifactStorage
 from dagster._core.storage.runs import SqliteRunStorage
 from dagster._core.test_utils import environ
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    PipelineRun,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 def test_fs_stores():
@@ -75,7 +74,8 @@ def test_init_compute_log_with_bad_config():
         with open(os.path.join(tmpdir_path, "dagster.yaml"), "w", encoding="utf8") as fd:
             yaml.dump({"compute_logs": {"garbage": "flargh"}}, fd, default_flow_style=False)
         with pytest.raises(
-            DagsterInvalidConfigError, match='Received unexpected config entry "garbage"'
+            DagsterInvalidConfigError,
+            match='Received unexpected config entry "garbage"',
         ):
             DagsterInstance.from_ref(InstanceRef.from_dir(tmpdir_path))
 
@@ -83,7 +83,8 @@ def test_init_compute_log_with_bad_config():
 def test_init_compute_log_with_bad_config_override():
     with tempfile.TemporaryDirectory() as tmpdir_path:
         with pytest.raises(
-            DagsterInvalidConfigError, match='Received unexpected config entry "garbage"'
+            DagsterInvalidConfigError,
+            match='Received unexpected config entry "garbage"',
         ):
             DagsterInstance.from_ref(
                 InstanceRef.from_dir(tmpdir_path, overrides={"compute_logs": {"garbage": "flargh"}})
@@ -172,7 +173,10 @@ def test_run_step_stats():
             context.log.info("succeed")
             return "yay"
 
-        @solid(input_defs=[InputDefinition("_input", str)], output_defs=[OutputDefinition(str)])
+        @solid(
+            input_defs=[InputDefinition("_input", str)],
+            output_defs=[OutputDefinition(str)],
+        )
         def should_fail(context, _input):
             context.log.info("fail")
             raise Exception("booo")
@@ -216,7 +220,10 @@ def test_run_step_stats_with_retries():
 
             yield Output("yay")
 
-        @solid(input_defs=[InputDefinition("_input", str)], output_defs=[OutputDefinition(str)])
+        @solid(
+            input_defs=[InputDefinition("_input", str)],
+            output_defs=[OutputDefinition(str)],
+        )
         def should_retry(context, _input):
             raise RetryRequested(max_retries=3)
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_memoizable_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_memoizable_io_manager.py
@@ -2,12 +2,10 @@ import os
 from tempfile import TemporaryDirectory
 
 from dagster import (
-    ModeDefinition,
     ResourceDefinition,
     build_init_resource_context,
     build_input_context,
     build_output_context,
-    execute_pipeline,
     io_manager,
 )
 from dagster._core.storage.memoizable_io_manager import (
@@ -17,7 +15,7 @@ from dagster._core.storage.memoizable_io_manager import (
 )
 from dagster._core.storage.tags import MEMOIZED_RUN_TAG
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import ModeDefinition, execute_pipeline, pipeline, solid
 
 
 def test_versioned_pickled_object_filesystem_io_manager():

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -48,9 +48,7 @@ from dagster._core.storage.event_log.migration import (
     EVENT_LOG_DATA_MIGRATIONS,
     migrate_asset_key_data,
 )
-from dagster._core.storage.event_log.sqlite.sqlite_event_log import (
-    SqliteEventLogStorage,
-)
+from dagster._core.storage.event_log.sqlite.sqlite_event_log import SqliteEventLogStorage
 from dagster._core.test_utils import create_run_for_test, instance_for_test
 from dagster._core.utils import make_new_run_id
 from dagster._legacy import (

--- a/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
@@ -16,11 +16,7 @@ from dagster._core.definitions.run_config import (
     RunConfigSchemaCreationData,
     define_solid_dictionary_cls,
 )
-from dagster._core.system_config.objects import (
-    ResolvedRunConfig,
-    ResourceConfig,
-    SolidConfig,
-)
+from dagster._core.system_config.objects import ResolvedRunConfig, ResourceConfig, SolidConfig
 from dagster._legacy import (
     InputDefinition,
     ModeDefinition,

--- a/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
@@ -4,18 +4,11 @@ from dagster import (
     Any,
     DependencyDefinition,
     Field,
-    InputDefinition,
     Int,
-    ModeDefinition,
     NodeInvocation,
-    OutputDefinition,
-    PipelineDefinition,
     ResourceDefinition,
     Shape,
-    SolidDefinition,
     String,
-    execute_pipeline,
-    lambda_solid,
 )
 from dagster._config import ConfigTypeKind, process_config
 from dagster._core.definitions import create_run_config_schema
@@ -23,8 +16,22 @@ from dagster._core.definitions.run_config import (
     RunConfigSchemaCreationData,
     define_solid_dictionary_cls,
 )
-from dagster._core.system_config.objects import ResolvedRunConfig, ResourceConfig, SolidConfig
-from dagster._legacy import pipeline, solid
+from dagster._core.system_config.objects import (
+    ResolvedRunConfig,
+    ResourceConfig,
+    SolidConfig,
+)
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    PipelineDefinition,
+    SolidDefinition,
+    execute_pipeline,
+    lambda_solid,
+    pipeline,
+    solid,
+)
 from dagster._loggers import default_loggers
 
 
@@ -83,7 +90,10 @@ def test_all_types_provided():
 
 def test_provided_default_on_resources_config():
     @solid(
-        name="some_solid", input_defs=[], output_defs=[], required_resource_keys={"some_resource"}
+        name="some_solid",
+        input_defs=[],
+        output_defs=[],
+        required_resource_keys={"some_resource"},
     )
     def some_solid(_):
         return None
@@ -146,7 +156,10 @@ def test_solid_dictionary_type():
     env_obj = ResolvedRunConfig.build(
         pipeline_def,
         {
-            "solids": {"int_config_solid": {"config": 1}, "string_config_solid": {"config": "bar"}},
+            "solids": {
+                "int_config_solid": {"config": 1},
+                "string_config_solid": {"config": "bar"},
+            },
         },
     )
 
@@ -258,7 +271,10 @@ def test_whole_environment():
                 compute_fn=lambda *args: None,
             ),
             SolidDefinition(
-                name="no_config_solid", input_defs=[], output_defs=[], compute_fn=lambda *args: None
+                name="no_config_solid",
+                input_defs=[],
+                output_defs=[],
+                compute_fn=lambda *args: None,
             ),
         ],
     )
@@ -276,7 +292,10 @@ def test_whole_environment():
         "int_config_solid": SolidConfig.from_dict({"config": 123}),
         "no_config_solid": SolidConfig.from_dict({}),
     }
-    assert env.resources == {"test_resource": ResourceConfig(1), "io_manager": ResourceConfig(None)}
+    assert env.resources == {
+        "test_resource": ResourceConfig(1),
+        "io_manager": ResourceConfig(None),
+    }
 
 
 def test_solid_config_error():
@@ -440,7 +459,8 @@ def test_optional_solid_with_optional_subfield():
             SolidDefinition(
                 name="int_config_solid",
                 config_schema=Field(
-                    {"optional_field": Field(String, is_required=False)}, is_required=False
+                    {"optional_field": Field(String, is_required=False)},
+                    is_required=False,
                 ),
                 input_defs=[],
                 output_defs=[],

--- a/python_modules/dagster/dagster_tests/core_tests/test_asset_events.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_asset_events.py
@@ -5,12 +5,12 @@ from dagster import (
     Out,
     Output,
     asset,
-    build_assets_job,
     job,
     multi_asset,
     op,
 )
 from dagster._core.test_utils import instance_for_test
+from dagster._legacy import build_assets_job
 
 
 def test_asset_materialization_planned_event_yielded():
@@ -78,7 +78,8 @@ def test_multi_asset_asset_materialization_planned_events():
         result = assets_job.execute_in_process(instance=instance)
         records = instance.get_event_records(
             EventRecordsFilter(
-                DagsterEventType.ASSET_MATERIALIZATION_PLANNED, AssetKey("my_asset_name")
+                DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+                AssetKey("my_asset_name"),
             )
         )
         assert result.run_id == records[0].event_log_entry.run_id

--- a/python_modules/dagster/dagster_tests/core_tests/test_compute_only_pipeline.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_compute_only_pipeline.py
@@ -1,5 +1,4 @@
-from dagster import execute_pipeline
-from dagster._legacy import pipeline, solid
+from dagster._legacy import execute_pipeline, pipeline, solid
 
 
 def _set_key_value(ddict, key, value):

--- a/python_modules/dagster/dagster_tests/core_tests/test_configured.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_configured.py
@@ -1,5 +1,5 @@
-from dagster import ModeDefinition, execute_pipeline, resource
-from dagster._legacy import pipeline, solid
+from dagster import resource
+from dagster._legacy import ModeDefinition, execute_pipeline, pipeline, solid
 
 
 def test_configured_solids_and_resources():

--- a/python_modules/dagster/dagster_tests/core_tests/test_event_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_event_logging.py
@@ -1,10 +1,16 @@
 import logging
 from collections import defaultdict
 
-from dagster import DagsterEvent, ModeDefinition, PipelineDefinition, execute_pipeline, lambda_solid
+from dagster import DagsterEvent
 from dagster._core.events import DagsterEventType
 from dagster._core.events.log import EventLogEntry, construct_event_logger
-from dagster._legacy import pipeline
+from dagster._legacy import (
+    ModeDefinition,
+    PipelineDefinition,
+    execute_pipeline,
+    lambda_solid,
+    pipeline,
+)
 from dagster._loggers import colored_console_logger
 from dagster._serdes import deserialize_as
 
@@ -25,7 +31,10 @@ def single_dagster_event(events, event_type):
 
 def define_event_logging_pipeline(name, solids, event_callback, deps=None):
     return PipelineDefinition(
-        name=name, solid_defs=solids, description=deps, mode_defs=[mode_def(event_callback)]
+        name=name,
+        solid_defs=solids,
+        description=deps,
+        mode_defs=[mode_def(event_callback)],
     )
 
 
@@ -67,7 +76,9 @@ def test_single_solid_pipeline_success():
             events[record.dagster_event.event_type].append(record)
 
     pipeline_def = PipelineDefinition(
-        name="single_solid_pipeline", solid_defs=[solid_one], mode_defs=[mode_def(_event_callback)]
+        name="single_solid_pipeline",
+        solid_defs=[solid_one],
+        mode_defs=[mode_def(_event_callback)],
     )
 
     result = execute_pipeline(pipeline_def, {"loggers": {"callback": {}}})
@@ -102,7 +113,9 @@ def test_single_solid_pipeline_failure():
             events[record.dagster_event.event_type].append(record)
 
     pipeline_def = PipelineDefinition(
-        name="single_solid_pipeline", solid_defs=[solid_one], mode_defs=[mode_def(_event_callback)]
+        name="single_solid_pipeline",
+        solid_defs=[solid_one],
+        mode_defs=[mode_def(_event_callback)],
     )
 
     result = execute_pipeline(pipeline_def, {"loggers": {"callback": {}}}, raise_on_error=False)

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -8,11 +8,7 @@ from dagster import (
     DagsterEventType,
     DagsterExecutionStepNotFoundError,
     DependencyDefinition,
-    InputDefinition,
     Int,
-    OutputDefinition,
-    PipelineDefinition,
-    lambda_solid,
     reconstructable,
 )
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
@@ -21,6 +17,12 @@ from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.instance import DagsterInstance
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    PipelineDefinition,
+    lambda_solid,
+)
 
 
 def define_inty_pipeline(using_file_system=False):
@@ -136,7 +138,12 @@ def test_using_file_system_for_subplan_multiprocessing():
 
         assert get_step_output(return_one_step_events, "return_one")
         with open(
-            os.path.join(instance.storage_directory(), pipeline_run.run_id, "return_one", "result"),
+            os.path.join(
+                instance.storage_directory(),
+                pipeline_run.run_id,
+                "return_one",
+                "result",
+            ),
             "rb",
         ) as read_obj:
             assert pickle.load(read_obj) == 1

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -17,12 +17,7 @@ from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.instance import DagsterInstance
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
-from dagster._legacy import (
-    InputDefinition,
-    OutputDefinition,
-    PipelineDefinition,
-    lambda_solid,
-)
+from dagster._legacy import InputDefinition, OutputDefinition, PipelineDefinition, lambda_solid
 
 
 def define_inty_pipeline(using_file_system=False):

--- a/python_modules/dagster/dagster_tests/core_tests/test_input_injection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_input_injection.py
@@ -3,15 +3,17 @@ import pytest
 from dagster import (
     DagsterInvalidConfigError,
     DependencyDefinition,
-    InputDefinition,
     List,
     NodeInvocation,
+    String,
+)
+from dagster._legacy import (
+    InputDefinition,
     OutputDefinition,
     PipelineDefinition,
-    String,
     execute_pipeline,
+    solid,
 )
-from dagster._legacy import solid
 
 
 def test_string_from_inputs():
@@ -27,7 +29,8 @@ def test_string_from_inputs():
     )
 
     result = execute_pipeline(
-        pipeline, {"solids": {"str_as_input": {"inputs": {"string_input": {"value": "foo"}}}}}
+        pipeline,
+        {"solids": {"str_as_input": {"inputs": {"string_input": {"value": "foo"}}}}},
     )
 
     assert result.success
@@ -49,7 +52,8 @@ def test_string_from_aliased_inputs():
     )
 
     result = execute_pipeline(
-        pipeline, {"solids": {"aliased": {"inputs": {"string_input": {"value": "foo"}}}}}
+        pipeline,
+        {"solids": {"aliased": {"inputs": {"string_input": {"value": "foo"}}}}},
     )
 
     assert result.success

--- a/python_modules/dagster/dagster_tests/core_tests/test_input_injection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_input_injection.py
@@ -1,12 +1,6 @@
 import pytest
 
-from dagster import (
-    DagsterInvalidConfigError,
-    DependencyDefinition,
-    List,
-    NodeInvocation,
-    String,
-)
+from dagster import DagsterInvalidConfigError, DependencyDefinition, List, NodeInvocation, String
 from dagster._legacy import (
     InputDefinition,
     OutputDefinition,

--- a/python_modules/dagster/dagster_tests/core_tests/test_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_logging.py
@@ -6,9 +6,9 @@ from contextlib import contextmanager
 
 import pytest
 
-from dagster import DagsterInvalidConfigError, ModeDefinition, PipelineRun
+from dagster import DagsterInvalidConfigError
 from dagster import _check as check
-from dagster import execute_pipeline, execute_solid, resource
+from dagster import execute_solid, resource
 from dagster._core.definitions import NodeHandle
 from dagster._core.events import DagsterEvent
 from dagster._core.execution.context.logger import InitLoggerContext
@@ -16,7 +16,13 @@ from dagster._core.execution.plan.objects import StepFailureData
 from dagster._core.execution.plan.outputs import StepOutputHandle
 from dagster._core.log_manager import DagsterLogManager
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    ModeDefinition,
+    PipelineRun,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 from dagster._loggers import colored_console_logger, json_console_logger
 from dagster._utils.error import SerializableErrorInfo
 
@@ -72,7 +78,8 @@ def test_logging_basic():
     with _setup_logger("test") as (captured_results, logger):
 
         dl = DagsterLogManager.create(
-            loggers=[logger], pipeline_run=PipelineRun(pipeline_name="system", run_id="123")
+            loggers=[logger],
+            pipeline_run=PipelineRun(pipeline_name="system", run_id="123"),
         )
         dl.debug("test")
         dl.info("test")
@@ -87,7 +94,8 @@ def test_logging_custom_log_levels():
     with _setup_logger("test", {"FOO": 3}) as (_captured_results, logger):
 
         dl = DagsterLogManager.create(
-            loggers=[logger], pipeline_run=PipelineRun(pipeline_name="system", run_id="123")
+            loggers=[logger],
+            pipeline_run=PipelineRun(pipeline_name="system", run_id="123"),
         )
         with pytest.raises(AttributeError):
             dl.foo("test")  # pylint: disable=no-member
@@ -97,7 +105,8 @@ def test_logging_integer_log_levels():
     with _setup_logger("test", {"FOO": 3}) as (_captured_results, logger):
 
         dl = DagsterLogManager.create(
-            loggers=[logger], pipeline_run=PipelineRun(pipeline_name="system", run_id="123")
+            loggers=[logger],
+            pipeline_run=PipelineRun(pipeline_name="system", run_id="123"),
         )
         dl.log(3, "test")  # pylint: disable=no-member
 
@@ -106,7 +115,8 @@ def test_logging_bad_custom_log_levels():
     with _setup_logger("test") as (_, logger):
 
         dl = DagsterLogManager.create(
-            loggers=[logger], pipeline_run=PipelineRun(pipeline_name="system", run_id="123")
+            loggers=[logger],
+            pipeline_run=PipelineRun(pipeline_name="system", run_id="123"),
         )
         with pytest.raises(check.CheckError):
             dl.log(level="test", msg="foobar")
@@ -139,7 +149,8 @@ def test_multiline_logging_complex():
     with _setup_logger(DAGSTER_DEFAULT_LOGGER) as (captured_results, logger):
 
         dl = DagsterLogManager.create(
-            loggers=[logger], pipeline_run=PipelineRun(run_id="123", pipeline_name="error_monster")
+            loggers=[logger],
+            pipeline_run=PipelineRun(run_id="123", pipeline_name="error_monster"),
         )
         dl.log_dagster_event(logging.INFO, msg, dagster_event)
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_logging.py
@@ -16,13 +16,7 @@ from dagster._core.execution.plan.objects import StepFailureData
 from dagster._core.execution.plan.outputs import StepOutputHandle
 from dagster._core.log_manager import DagsterLogManager
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import (
-    ModeDefinition,
-    PipelineRun,
-    execute_pipeline,
-    pipeline,
-    solid,
-)
+from dagster._legacy import ModeDefinition, PipelineRun, execute_pipeline, pipeline, solid
 from dagster._loggers import colored_console_logger, json_console_logger
 from dagster._utils.error import SerializableErrorInfo
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
@@ -1,5 +1,5 @@
-from dagster import NodeInvocation, PipelineDefinition, execute_pipeline
-from dagster._legacy import solid
+from dagster import NodeInvocation
+from dagster._legacy import PipelineDefinition, execute_pipeline, solid
 
 
 def test_solid_instance_tags():

--- a/python_modules/dagster/dagster_tests/core_tests/test_mode_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_mode_definitions.py
@@ -12,16 +12,19 @@ from dagster import (
     DagsterInvalidDefinitionError,
     DagsterInvariantViolationError,
     Field,
-    ModeDefinition,
-    PipelineDefinition,
     String,
-    execute_pipeline,
     logger,
     resource,
 )
 from dagster._check import CheckError
 from dagster._core.utils import coerce_valid_log_level
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    ModeDefinition,
+    PipelineDefinition,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 from dagster._utils.test import execute_solids_within_pipeline
 
 
@@ -56,7 +59,8 @@ def test_mode_from_resources():
         return context.resources.three
 
     @pipeline(
-        name="takesamode", mode_defs=[ModeDefinition.from_resources({"three": 3}, name="three")]
+        name="takesamode",
+        mode_defs=[ModeDefinition.from_resources({"three": 3}, name="three")],
     )
     def pipeline_def():
         ret_three()
@@ -91,7 +95,9 @@ def test_wrong_single_mode():
 def test_mode_double_default_name():
     with pytest.raises(DagsterInvalidDefinitionError) as ide:
         PipelineDefinition(
-            name="double_default", solid_defs=[], mode_defs=[ModeDefinition(), ModeDefinition()]
+            name="double_default",
+            solid_defs=[],
+            mode_defs=[ModeDefinition(), ModeDefinition()],
         )
 
     assert (
@@ -283,7 +289,8 @@ def define_multi_mode_with_loggers_pipeline():
             mode_defs=[
                 ModeDefinition(name="foo_mode", logger_defs={"foo": foo_logger}),
                 ModeDefinition(
-                    name="foo_bar_mode", logger_defs={"foo": foo_logger, "bar": bar_logger}
+                    name="foo_bar_mode",
+                    logger_defs={"foo": foo_logger, "bar": bar_logger},
                 ),
             ],
         ),

--- a/python_modules/dagster/dagster_tests/core_tests/test_mode_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_mode_definitions.py
@@ -18,13 +18,7 @@ from dagster import (
 )
 from dagster._check import CheckError
 from dagster._core.utils import coerce_valid_log_level
-from dagster._legacy import (
-    ModeDefinition,
-    PipelineDefinition,
-    execute_pipeline,
-    pipeline,
-    solid,
-)
+from dagster._legacy import ModeDefinition, PipelineDefinition, execute_pipeline, pipeline, solid
 from dagster._utils.test import execute_solids_within_pipeline
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_multi_dependency.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_multi_dependency.py
@@ -4,20 +4,23 @@ from dagster import (
     Any,
     DagsterInvalidDefinitionError,
     DependencyDefinition,
-    InputDefinition,
     Int,
     List,
     MultiDependencyDefinition,
     Nothing,
+)
+from dagster._core.definitions.composition import MappedInputPlaceholder
+from dagster._core.definitions.solid_definition import CompositeSolidDefinition
+from dagster._legacy import (
+    InputDefinition,
     OutputDefinition,
     PipelineDefinition,
     composite_solid,
     execute_pipeline,
     lambda_solid,
+    pipeline,
+    solid,
 )
-from dagster._core.definitions.composition import MappedInputPlaceholder
-from dagster._core.definitions.solid_definition import CompositeSolidDefinition
-from dagster._legacy import pipeline, solid
 
 
 def test_simple_values():

--- a/python_modules/dagster/dagster_tests/core_tests/test_multiple_outputs.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_multiple_outputs.py
@@ -11,13 +11,7 @@ from dagster import (
     reconstructable,
 )
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
-from dagster._legacy import (
-    InputDefinition,
-    OutputDefinition,
-    execute_pipeline,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, OutputDefinition, execute_pipeline, pipeline, solid
 
 
 def test_multiple_outputs():

--- a/python_modules/dagster/dagster_tests/core_tests/test_multiple_outputs.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_multiple_outputs.py
@@ -6,22 +6,28 @@ from dagster import (
     Any,
     DagsterInvariantViolationError,
     DagsterStepOutputNotFoundError,
-    InputDefinition,
     Output,
-    OutputDefinition,
-    execute_pipeline,
     execute_solid,
     reconstructable,
 )
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 def test_multiple_outputs():
     @solid(
         name="multiple_outputs",
         input_defs=[],
-        output_defs=[OutputDefinition(name="output_one"), OutputDefinition(name="output_two")],
+        output_defs=[
+            OutputDefinition(name="output_one"),
+            OutputDefinition(name="output_two"),
+        ],
     )
     def multiple_outputs(_):
         yield Output(output_name="output_one", value="foo")
@@ -47,7 +53,9 @@ def test_multiple_outputs():
 
 def test_wrong_multiple_output():
     @solid(
-        name="multiple_outputs", input_defs=[], output_defs=[OutputDefinition(name="output_one")]
+        name="multiple_outputs",
+        input_defs=[],
+        output_defs=[OutputDefinition(name="output_one")],
     )
     def multiple_outputs(_):
         yield Output(output_name="mismatch", value="foo")
@@ -64,7 +72,9 @@ def test_multiple_outputs_of_same_name_disallowed():
     # make this illegal until it is supported
 
     @solid(
-        name="multiple_outputs", input_defs=[], output_defs=[OutputDefinition(name="output_one")]
+        name="multiple_outputs",
+        input_defs=[],
+        output_defs=[OutputDefinition(name="output_one")],
     )
     def multiple_outputs(_):
         yield Output(output_name="output_one", value="foo")
@@ -90,7 +100,11 @@ def define_multi_out():
     def multiple_outputs(_):
         yield Output(output_name="output_one", value="foo")
 
-    @solid(name="downstream_one", input_defs=[InputDefinition("some_input")], output_defs=[])
+    @solid(
+        name="downstream_one",
+        input_defs=[InputDefinition("some_input")],
+        output_defs=[],
+    )
     def downstream_one(_, some_input):
         del some_input
 
@@ -175,7 +189,10 @@ def test_missing_non_optional_output_fails():
     @solid(
         name="multiple_outputs",
         input_defs=[],
-        output_defs=[OutputDefinition(name="output_one"), OutputDefinition(name="output_two")],
+        output_defs=[
+            OutputDefinition(name="output_one"),
+            OutputDefinition(name="output_two"),
+        ],
     )
     def multiple_outputs(_):
         yield Output(output_name="output_one", value="foo")
@@ -189,7 +206,10 @@ def test_missing_non_optional_output_fails():
 
 
 def test_warning_for_conditional_output(capsys):
-    @solid(config_schema={"return": bool}, output_defs=[OutputDefinition(Any, is_required=False)])
+    @solid(
+        config_schema={"return": bool},
+        output_defs=[OutputDefinition(Any, is_required=False)],
+    )
     def maybe(context):
         if context.solid_config["return"]:
             return 3

--- a/python_modules/dagster/dagster_tests/core_tests/test_naming_collisions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_naming_collisions.py
@@ -1,7 +1,6 @@
-from dagster import Field, Output, OutputDefinition, String
+from dagster import Field, Output, String
 from dagster import _check as check
-from dagster import execute_pipeline
-from dagster._legacy import pipeline, solid
+from dagster._legacy import OutputDefinition, execute_pipeline, pipeline, solid
 
 
 def define_pass_value_solid(name, description=None):

--- a/python_modules/dagster/dagster_tests/core_tests/test_nothing_dependencies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_nothing_dependencies.py
@@ -7,7 +7,6 @@ from dagster import (
     DagsterInvalidDefinitionError,
     DagsterTypeCheckDidNotPass,
     DependencyDefinition,
-    InputDefinition,
     Int,
     List,
     MultiDependencyDefinition,
@@ -15,13 +14,16 @@ from dagster import (
     Nothing,
     Optional,
     Output,
+)
+from dagster._core.execution.api import create_execution_plan
+from dagster._legacy import (
+    InputDefinition,
     OutputDefinition,
     PipelineDefinition,
     execute_pipeline,
     lambda_solid,
+    solid,
 )
-from dagster._core.execution.api import create_execution_plan
-from dagster._legacy import solid
 
 
 def _define_nothing_dep_pipeline():
@@ -43,7 +45,10 @@ def _define_nothing_dep_pipeline():
         return 1
 
     @lambda_solid(
-        input_defs=[InputDefinition("on_complete", Nothing), InputDefinition("num", Int)],
+        input_defs=[
+            InputDefinition("on_complete", Nothing),
+            InputDefinition("num", Int),
+        ],
         output_def=OutputDefinition(Int),
     )
     def add_value(num):
@@ -241,7 +246,8 @@ def test_valid_nothing_fns():
         yield AssetMaterialization.file("/path/to/nowhere")
 
     pipeline = PipelineDefinition(
-        name="fn_test", solid_defs=[just_pass, just_pass2, ret_none, yield_none, yield_stuff]
+        name="fn_test",
+        solid_defs=[just_pass, just_pass2, ret_none, yield_none, yield_stuff],
     )
     result = execute_pipeline(pipeline)
     assert result.success

--- a/python_modules/dagster/dagster_tests/core_tests/test_output_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_output_definition.py
@@ -1,4 +1,4 @@
-from dagster import OutputDefinition
+from dagster._legacy import OutputDefinition
 
 
 def test_output_definition():

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
@@ -6,16 +6,21 @@ from dagster import (
     DagsterInvariantViolationError,
     DagsterTypeCheckDidNotPass,
     DependencyDefinition,
-    InputDefinition,
     MetadataEntry,
     Output,
+)
+from dagster import _check as check
+from dagster import execute_solid
+from dagster._legacy import (
+    InputDefinition,
     OutputDefinition,
     PipelineDefinition,
     SolidDefinition,
+    execute_pipeline,
+    lambda_solid,
+    pipeline,
+    solid,
 )
-from dagster import _check as check
-from dagster import execute_pipeline, execute_solid, lambda_solid
-from dagster._legacy import pipeline, solid
 
 
 def create_root_success_solid(name):

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -20,10 +20,7 @@ from dagster import reconstructable
 from dagster._core.definitions import Node
 from dagster._core.definitions.dependency import DependencyStructure
 from dagster._core.definitions.graph_definition import _create_adjacency_lists
-from dagster._core.errors import (
-    DagsterExecutionStepNotFoundError,
-    DagsterInvariantViolationError,
-)
+from dagster._core.errors import DagsterExecutionStepNotFoundError, DagsterInvariantViolationError
 from dagster._core.execution.results import SolidExecutionResult
 from dagster._core.instance import DagsterInstance
 from dagster._core.test_utils import (
@@ -45,8 +42,8 @@ from dagster._legacy import (
     PipelineDefinition,
     execute_pipeline,
     execute_pipeline_iterator,
-    reexecute_pipeline,
     pipeline,
+    reexecute_pipeline,
     solid,
 )
 from dagster._utils.test import execute_solid_within_pipeline

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_init.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_init.py
@@ -1,9 +1,11 @@
 import pytest
 
-from dagster import DagsterInstance, ModeDefinition, PipelineDefinition, resource
+from dagster import DagsterInstance, resource
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
 from dagster._core.execution.api import create_execution_plan
-from dagster._core.execution.context_creation_pipeline import PlanExecutionContextManager
+from dagster._core.execution.context_creation_pipeline import (
+    PlanExecutionContextManager,
+)
 from dagster._core.execution.resources_init import (
     resource_initialization_event_generator,
     resource_initialization_manager,
@@ -12,7 +14,7 @@ from dagster._core.execution.resources_init import (
 from dagster._core.execution.retries import RetryMode
 from dagster._core.log_manager import DagsterLogManager
 from dagster._core.system_config.objects import ResolvedRunConfig
-from dagster._legacy import solid
+from dagster._legacy import ModeDefinition, PipelineDefinition, solid
 
 
 def test_generator_exit():

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_init.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_init.py
@@ -3,9 +3,7 @@ import pytest
 from dagster import DagsterInstance, resource
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
 from dagster._core.execution.api import create_execution_plan
-from dagster._core.execution.context_creation_pipeline import (
-    PlanExecutionContextManager,
-)
+from dagster._core.execution.context_creation_pipeline import PlanExecutionContextManager
 from dagster._core.execution.resources_init import (
     resource_initialization_event_generator,
     resource_initialization_manager,

--- a/python_modules/dagster/dagster_tests/core_tests/test_presets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_presets.py
@@ -1,8 +1,7 @@
-from dagster_tests.general_tests.test_repository import (
-    define_multi_mode_with_resources_pipeline,
-)
-from dagster._utils import file_relative_path
+from dagster_tests.general_tests.test_repository import define_multi_mode_with_resources_pipeline
+
 from dagster._legacy import PresetDefinition
+from dagster._utils import file_relative_path
 
 
 def test_preset_yaml_roundtrip():

--- a/python_modules/dagster/dagster_tests/core_tests/test_presets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_presets.py
@@ -1,7 +1,8 @@
-from dagster_tests.general_tests.test_repository import define_multi_mode_with_resources_pipeline
-
-from dagster import PresetDefinition
+from dagster_tests.general_tests.test_repository import (
+    define_multi_mode_with_resources_pipeline,
+)
 from dagster._utils import file_relative_path
+from dagster._legacy import PresetDefinition
 
 
 def test_preset_yaml_roundtrip():

--- a/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
@@ -5,9 +5,9 @@ import logging
 import mock
 import pytest
 
-from dagster import ModeDefinition, execute_pipeline, get_dagster_logger, reconstructable, resource
+from dagster import get_dagster_logger, reconstructable, resource
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import ModeDefinition, execute_pipeline, pipeline, solid
 
 
 def _reset_logging():
@@ -371,7 +371,10 @@ def test_execution_logging(managed_loggers, run_config, reset_logging):
 def test_failure_logging(managed_loggers, reset_logging):
     with instance_for_test(
         overrides={
-            "python_logs": {"managed_python_loggers": managed_loggers, "python_log_level": "INFO"}
+            "python_logs": {
+                "managed_python_loggers": managed_loggers,
+                "python_log_level": "INFO",
+            }
         }
     ) as instance:
         result = execute_pipeline(

--- a/python_modules/dagster/dagster_tests/core_tests/test_resolve_versions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_resolve_versions.py
@@ -9,14 +9,10 @@ from dagster import (
     IOManagerDefinition,
     In,
     Int,
-    ModeDefinition,
     Output,
-    OutputDefinition,
     SourceHashVersionStrategy,
     String,
-    composite_solid,
     dagster_type_loader,
-    execute_pipeline,
     fs_io_manager,
     graph,
     io_manager,
@@ -31,12 +27,22 @@ from dagster._core.definitions import InputDefinition
 from dagster._core.definitions.version_strategy import VersionStrategy
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.plan.outputs import StepOutputHandle
-from dagster._core.execution.resolve_versions import join_and_hash, resolve_config_version
+from dagster._core.execution.resolve_versions import (
+    join_and_hash,
+    resolve_config_version,
+)
 from dagster._core.storage.memoizable_io_manager import MemoizableIOManager
 from dagster._core.storage.tags import MEMOIZED_RUN_TAG
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    ModeDefinition,
+    OutputDefinition,
+    composite_solid,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 class VersionedInMemoryIOManager(MemoizableIOManager):
@@ -172,11 +178,18 @@ def test_memoized_plan_memoized_results():
         step_output_handle = StepOutputHandle("versioned_solid_no_input", "result")
         step_output_version = plan.get_version_for_step_output_handle(step_output_handle)
         manager.values[
-            (step_output_handle.step_key, step_output_handle.output_name, step_output_version)
+            (
+                step_output_handle.step_key,
+                step_output_handle.output_name,
+                step_output_version,
+            )
         ] = 4
 
         memoized_plan = plan.build_memoized_plan(
-            versioned_pipeline, resolved_run_config, instance=None, selected_step_keys=None
+            versioned_pipeline,
+            resolved_run_config,
+            instance=None,
+            selected_step_keys=None,
         )
 
         assert memoized_plan.step_keys_to_execute == ["versioned_solid_takes_input"]
@@ -466,7 +479,11 @@ def test_memoized_inner_solid():
         # Affix value to expected version for step output.
         step_output_version = unmemoized_plan.get_version_for_step_output_handle(step_output_handle)
         mgr.values[
-            (step_output_handle.step_key, step_output_handle.output_name, step_output_version)
+            (
+                step_output_handle.step_key,
+                step_output_handle.output_name,
+                step_output_version,
+            )
         ] = 4
         memoized_plan = unmemoized_plan.build_memoized_plan(
             wrap_pipeline,
@@ -584,7 +601,9 @@ def test_memoized_plan_disable_memoization():
         assert len(memoized_plan.step_keys_to_execute) == 0
 
         unmemoized_again = create_execution_plan(
-            my_pipeline, instance_ref=instance.get_ref(), tags={MEMOIZED_RUN_TAG: "false"}
+            my_pipeline,
+            instance_ref=instance.get_ref(),
+            tags={MEMOIZED_RUN_TAG: "false"},
         )
         assert len(unmemoized_again.step_keys_to_execute) == 1
 
@@ -594,7 +613,10 @@ def test_memoized_plan_root_input_manager():
     def my_input_manager():
         return 5
 
-    @solid(input_defs=[InputDefinition("x", root_manager_key="my_input_manager")], version="foo")
+    @solid(
+        input_defs=[InputDefinition("x", root_manager_key="my_input_manager")],
+        version="foo",
+    )
     def my_solid_takes_input(x):
         return x
 
@@ -629,7 +651,10 @@ def test_memoized_plan_root_input_manager_input_config():
     def my_input_manager():
         return 5
 
-    @solid(input_defs=[InputDefinition("x", root_manager_key="my_input_manager")], version="foo")
+    @solid(
+        input_defs=[InputDefinition("x", root_manager_key="my_input_manager")],
+        version="foo",
+    )
     def my_solid_takes_input(x):
         return x
 
@@ -684,7 +709,10 @@ def test_memoized_plan_root_input_manager_resource_config():
     def my_input_manager():
         return 5
 
-    @solid(input_defs=[InputDefinition("x", root_manager_key="my_input_manager")], version="foo")
+    @solid(
+        input_defs=[InputDefinition("x", root_manager_key="my_input_manager")],
+        version="foo",
+    )
     def my_solid_takes_input(x):
         return x
 
@@ -819,7 +847,8 @@ def test_bad_version_str(graph_for_test, strategy):
         )
 
         with pytest.raises(
-            DagsterInvariantViolationError, match=f"'{bad_str}' is not a valid version string."
+            DagsterInvariantViolationError,
+            match=f"'{bad_str}' is not a valid version string.",
         ):
             create_execution_plan(my_job, instance_ref=instance.get_ref())
 
@@ -933,7 +962,10 @@ def test_source_hash_with_root_input_manager():
     def the_op(x):
         return x + 1
 
-    @job(version_strategy=SourceHashVersionStrategy(), resource_defs={"manager": my_input_manager})
+    @job(
+        version_strategy=SourceHashVersionStrategy(),
+        resource_defs={"manager": my_input_manager},
+    )
     def call_the_op():
         the_op()
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_resolve_versions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_resolve_versions.py
@@ -27,10 +27,7 @@ from dagster._core.definitions import InputDefinition
 from dagster._core.definitions.version_strategy import VersionStrategy
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.plan.outputs import StepOutputHandle
-from dagster._core.execution.resolve_versions import (
-    join_and_hash,
-    resolve_config_version,
-)
+from dagster._core.execution.resolve_versions import join_and_hash, resolve_config_version
 from dagster._core.storage.memoizable_io_manager import MemoizableIOManager
 from dagster._core.storage.tags import MEMOIZED_RUN_TAG
 from dagster._core.system_config.objects import ResolvedRunConfig

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_aliases.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_aliases.py
@@ -1,15 +1,13 @@
 from collections import defaultdict
 
-from dagster import (
-    DependencyDefinition,
+from dagster import DependencyDefinition, Int, NodeInvocation
+from dagster._legacy import (
     InputDefinition,
-    Int,
-    NodeInvocation,
     PipelineDefinition,
     execute_pipeline,
     lambda_solid,
+    solid,
 )
-from dagster._legacy import solid
 
 
 def test_aliased_solids():
@@ -36,7 +34,12 @@ def test_aliased_solids():
     result = execute_pipeline(pipeline)
     assert result.success
     solid_result = result.result_for_solid("third")
-    assert solid_result.output_value() == ["first", "not_first", "not_first", "not_first"]
+    assert solid_result.output_value() == [
+        "first",
+        "not_first",
+        "not_first",
+        "not_first",
+    ]
 
 
 def test_only_aliased_solids():

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_arguments.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_arguments.py
@@ -1,9 +1,9 @@
 # pylint: disable=unused-argument
 import pytest
 
-from dagster import InputDefinition, execute_solid, lambda_solid
+from dagster import execute_solid
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster._legacy import solid
+from dagster._legacy import InputDefinition, lambda_solid, solid
 
 
 def test_solid_input_arguments():

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
@@ -9,23 +9,17 @@ from dagster import (
     AssetObservation,
     DynamicOut,
     DynamicOutput,
-    DynamicOutputDefinition,
     ExpectationResult,
     Failure,
     Field,
     In,
-    InputDefinition,
-    Materialization,
     Noneable,
     Nothing,
     Out,
     Output,
-    OutputDefinition,
     RetryRequested,
     Selector,
     build_op_context,
-    build_solid_context,
-    composite_solid,
     execute_solid,
     op,
     resource,
@@ -40,7 +34,16 @@ from dagster._core.errors import (
     DagsterStepOutputNotFoundError,
     DagsterTypeCheckDidNotPass,
 )
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    DynamicOutputDefinition,
+    InputDefinition,
+    Materialization,
+    OutputDefinition,
+    build_solid_context,
+    composite_solid,
+    pipeline,
+    solid,
+)
 
 
 def test_solid_invocation_no_arg():
@@ -793,7 +796,13 @@ def test_solid_invocation_nothing_deps():
     # Ensure that not providing nothing dependency also works.
     assert nothing_dep() == 5
 
-    @solid(input_defs=[InputDefinition("x"), InputDefinition("y", Nothing), InputDefinition("z")])
+    @solid(
+        input_defs=[
+            InputDefinition("x"),
+            InputDefinition("y", Nothing),
+            InputDefinition("z"),
+        ]
+    )
     def sandwiched_nothing_dep(x, z):
         return x + z
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_with_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_with_config.py
@@ -1,16 +1,14 @@
 import pytest
 
-from dagster import (
-    DagsterInvalidConfigError,
-    Field,
+from dagster import DagsterInvalidConfigError, Field, String, root_input_manager
+from dagster._legacy import (
     InputDefinition,
     ModeDefinition,
-    String,
     composite_solid,
     execute_pipeline,
-    root_input_manager,
+    pipeline,
+    solid,
 )
-from dagster._legacy import pipeline, solid
 
 
 def test_basic_solid_with_config():
@@ -30,7 +28,8 @@ def test_basic_solid_with_config():
         solid_with_context()
 
     execute_pipeline(
-        pipeline_def, {"solids": {"solid_with_context": {"config": {"some_config": "foo"}}}}
+        pipeline_def,
+        {"solids": {"solid_with_context": {"config": {"some_config": "foo"}}}},
     )
 
     assert "yep" in did_get
@@ -56,7 +55,8 @@ def test_config_arg_mismatch():
 
     with pytest.raises(DagsterInvalidConfigError):
         execute_pipeline(
-            pipeline_def, {"solids": {"solid_with_context": {"config": {"some_config": 1}}}}
+            pipeline_def,
+            {"solids": {"solid_with_context": {"config": {"some_config": 1}}}},
         )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_stdout.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_stdout.py
@@ -8,20 +8,18 @@ import time
 
 import pytest
 
-from dagster import (
-    DagsterEventType,
-    InputDefinition,
-    ModeDefinition,
-    execute_pipeline,
-    fs_io_manager,
-    reconstructable,
-    resource,
-)
+from dagster import DagsterEventType, fs_io_manager, reconstructable, resource
 from dagster._core.execution.compute_logs import should_disable_io_stream_redirect
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.test_utils import create_run_for_test, instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 from dagster._utils import ensure_dir, touch_file
 
 HELLO_SOLID = "HELLO SOLID"
@@ -360,7 +358,8 @@ def test_multi():
 
             for step_key in step_keys:
                 process = ctx.Process(
-                    target=execute_inner, args=(step_key, pipeline_run, instance.get_ref())
+                    target=execute_inner,
+                    args=(step_key, pipeline_run, instance.get_ref()),
                 )
                 process.start()
                 process.join()

--- a/python_modules/dagster/dagster_tests/core_tests/test_stdout.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_stdout.py
@@ -13,13 +13,7 @@ from dagster._core.execution.compute_logs import should_disable_io_stream_redire
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.test_utils import create_run_for_test, instance_for_test
-from dagster._legacy import (
-    InputDefinition,
-    ModeDefinition,
-    execute_pipeline,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, ModeDefinition, execute_pipeline, pipeline, solid
 from dagster._utils import ensure_dir, touch_file
 
 HELLO_SOLID = "HELLO SOLID"

--- a/python_modules/dagster/dagster_tests/core_tests/test_user_code_boundary.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_user_code_boundary.py
@@ -1,16 +1,19 @@
 from dagster import (
-    InputDefinition,
-    ModeDefinition,
-    OutputDefinition,
     String,
     dagster_type_loader,
     dagster_type_materializer,
-    execute_pipeline,
     resource,
     usable_as_dagster_type,
 )
 from dagster._core.types.dagster_type import create_any_type
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 class UserError(Exception):

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -11,7 +11,6 @@ import pytest
 from dagster import (
     Any,
     Field,
-    ModeDefinition,
     daily_partitioned_config,
     fs_io_manager,
     graph,
@@ -25,7 +24,11 @@ from dagster._core.host_representation import (
     InProcessRepositoryLocationOrigin,
 )
 from dagster._core.storage.pipeline_run import PipelineRunStatus, RunsFilter
-from dagster._core.storage.tags import BACKFILL_ID_TAG, PARTITION_NAME_TAG, PARTITION_SET_TAG
+from dagster._core.storage.tags import (
+    BACKFILL_ID_TAG,
+    PARTITION_NAME_TAG,
+    PARTITION_SET_TAG,
+)
 from dagster._core.test_utils import (
     create_test_daemon_workspace,
     instance_for_test,
@@ -37,7 +40,7 @@ from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.load_target import PythonFileTarget
 from dagster._daemon import get_default_daemon_logger
 from dagster._daemon.backfill import execute_backfill_iteration
-from dagster._legacy import pipeline, solid
+from dagster._legacy import ModeDefinition, pipeline, solid
 from dagster._seven import IS_WINDOWS, get_system_temp_directory
 from dagster._utils import touch_file
 from dagster._utils.error import SerializableErrorInfo

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -8,14 +8,7 @@ from contextlib import contextmanager
 import pendulum
 import pytest
 
-from dagster import (
-    Any,
-    Field,
-    daily_partitioned_config,
-    fs_io_manager,
-    graph,
-    repository,
-)
+from dagster import Any, Field, daily_partitioned_config, fs_io_manager, graph, repository
 from dagster._core.definitions import Partition, PartitionSetDefinition
 from dagster._core.execution.api import execute_pipeline
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
@@ -24,11 +17,7 @@ from dagster._core.host_representation import (
     InProcessRepositoryLocationOrigin,
 )
 from dagster._core.storage.pipeline_run import PipelineRunStatus, RunsFilter
-from dagster._core.storage.tags import (
-    BACKFILL_ID_TAG,
-    PARTITION_NAME_TAG,
-    PARTITION_SET_TAG,
-)
+from dagster._core.storage.tags import BACKFILL_ID_TAG, PARTITION_NAME_TAG, PARTITION_SET_TAG
 from dagster._core.test_utils import (
     create_test_daemon_workspace,
     instance_for_test,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -23,24 +23,13 @@ from dagster import (
 from dagster._core.definitions.decorators.sensor_decorator import asset_sensor, sensor
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.run_status_sensor_definition import run_status_sensor
-from dagster._core.definitions.sensor_definition import (
-    DefaultSensorStatus,
-    RunRequest,
-    SkipReason,
-)
+from dagster._core.definitions.sensor_definition import DefaultSensorStatus, RunRequest, SkipReason
 from dagster._core.events import DagsterEvent, DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.api import execute_pipeline
-from dagster._core.host_representation import (
-    ExternalInstigatorOrigin,
-    ExternalRepositoryOrigin,
-)
+from dagster._core.host_representation import ExternalInstigatorOrigin, ExternalRepositoryOrigin
 from dagster._core.instance import DagsterInstance
-from dagster._core.scheduler.instigation import (
-    InstigatorState,
-    InstigatorStatus,
-    TickStatus,
-)
+from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus, TickStatus
 from dagster._core.storage.event_log.base import EventRecordsFilter
 from dagster._core.storage.pipeline_run import PipelineRunStatus
 from dagster._core.test_utils import (
@@ -52,11 +41,8 @@ from dagster._core.test_utils import (
 )
 from dagster._core.workspace.load_target import PythonFileTarget
 from dagster._daemon import get_default_daemon_logger
-from dagster._daemon.sensor import (
-    execute_sensor_iteration,
-    execute_sensor_iteration_loop,
-)
-from dagster._legacy import pipeline_failure_sensor, pipeline, solid
+from dagster._daemon.sensor import execute_sensor_iteration, execute_sensor_iteration_loop
+from dagster._legacy import pipeline, pipeline_failure_sensor, solid
 from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
 
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -17,20 +17,30 @@ from dagster import (
     Field,
     Output,
     graph,
-    pipeline_failure_sensor,
     repository,
     run_failure_sensor,
 )
 from dagster._core.definitions.decorators.sensor_decorator import asset_sensor, sensor
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.run_status_sensor_definition import run_status_sensor
-from dagster._core.definitions.sensor_definition import DefaultSensorStatus, RunRequest, SkipReason
+from dagster._core.definitions.sensor_definition import (
+    DefaultSensorStatus,
+    RunRequest,
+    SkipReason,
+)
 from dagster._core.events import DagsterEvent, DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.api import execute_pipeline
-from dagster._core.host_representation import ExternalInstigatorOrigin, ExternalRepositoryOrigin
+from dagster._core.host_representation import (
+    ExternalInstigatorOrigin,
+    ExternalRepositoryOrigin,
+)
 from dagster._core.instance import DagsterInstance
-from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus, TickStatus
+from dagster._core.scheduler.instigation import (
+    InstigatorState,
+    InstigatorStatus,
+    TickStatus,
+)
 from dagster._core.storage.event_log.base import EventRecordsFilter
 from dagster._core.storage.pipeline_run import PipelineRunStatus
 from dagster._core.test_utils import (
@@ -42,8 +52,11 @@ from dagster._core.test_utils import (
 )
 from dagster._core.workspace.load_target import PythonFileTarget
 from dagster._daemon import get_default_daemon_logger
-from dagster._daemon.sensor import execute_sensor_iteration, execute_sensor_iteration_loop
-from dagster._legacy import pipeline, solid
+from dagster._daemon.sensor import (
+    execute_sensor_iteration,
+    execute_sensor_iteration_loop,
+)
+from dagster._legacy import pipeline_failure_sensor, pipeline, solid
 from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
 
 
@@ -2287,7 +2300,8 @@ def test_status_in_code_sensor(executor):
                 assert (
                     len(
                         instance.get_ticks(
-                            never_running_origin.get_id(), not_running_sensor.selector_id
+                            never_running_origin.get_id(),
+                            not_running_sensor.selector_id,
                         )
                     )
                     == 0
@@ -2319,7 +2333,8 @@ def test_status_in_code_sensor(executor):
                 assert (
                     len(
                         instance.get_ticks(
-                            never_running_origin.get_id(), not_running_sensor.selector_id
+                            never_running_origin.get_id(),
+                            not_running_sensor.selector_id,
                         )
                     )
                     == 0
@@ -2351,7 +2366,8 @@ def test_status_in_code_sensor(executor):
                 assert (
                     len(
                         instance.get_ticks(
-                            never_running_origin.get_id(), not_running_sensor.selector_id
+                            never_running_origin.get_id(),
+                            not_running_sensor.selector_id,
                         )
                     )
                     == 0

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_dsl.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_dsl.py
@@ -1,15 +1,14 @@
 import pytest
 
-from dagster import (
-    Any,
-    DagsterInvalidDefinitionError,
-    DynamicOutput,
+from dagster import Any, DagsterInvalidDefinitionError, DynamicOutput
+from dagster._legacy import (
     DynamicOutputDefinition,
     OutputDefinition,
     composite_solid,
     execute_pipeline,
+    pipeline,
+    solid,
 )
-from dagster._legacy import pipeline, solid
 
 
 @solid(output_defs=[DynamicOutputDefinition()])
@@ -88,7 +87,10 @@ def test_mapping_multi():
 
 def test_composite_multi_out():
     @composite_solid(
-        output_defs=[OutputDefinition(Any, "one"), DynamicOutputDefinition(Any, "numbers")]
+        output_defs=[
+            OutputDefinition(Any, "one"),
+            DynamicOutputDefinition(Any, "numbers"),
+        ]
     )
     def multi_out():
         one = emit_one()

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_dynamic_execution.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_dynamic_execution.py
@@ -1,24 +1,19 @@
 import pytest
 
-from dagster import (
-    DynamicOut,
-    DynamicOutput,
-    DynamicOutputDefinition,
-    Field,
-    InputDefinition,
-    Output,
-    OutputDefinition,
-    composite_solid,
-    execute_pipeline,
-    job,
-    op,
-    reconstructable,
-)
+from dagster import DynamicOut, DynamicOutput, Field, Output, job, op, reconstructable
 from dagster._core.errors import DagsterExecutionStepNotFoundError
 from dagster._core.execution.api import create_execution_plan, reexecute_pipeline
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    DynamicOutputDefinition,
+    InputDefinition,
+    OutputDefinition,
+    composite_solid,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 from dagster._utils import merge_dicts
 
 
@@ -176,7 +171,11 @@ def test_composite_wrapping():
 
     result = execute_pipeline(shallow)
     assert result.success
-    assert result.result_for_solid("do_multiple_steps").output_value() == {"0": 0, "1": 1, "2": 2}
+    assert result.result_for_solid("do_multiple_steps").output_value() == {
+        "0": 0,
+        "1": 1,
+        "2": 2,
+    }
 
     @composite_solid(input_defs=[InputDefinition("x", int)], output_defs=[OutputDefinition(int)])
     def inner(x):

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_dynamic_output.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_dynamic_output.py
@@ -7,10 +7,7 @@ import pytest
 from dagster import (
     DynamicOut,
     DynamicOutput,
-    DynamicOutputDefinition,
     Out,
-    build_solid_context,
-    execute_pipeline,
     execute_solid,
     graph,
     job,
@@ -19,9 +16,18 @@ from dagster import (
 )
 from dagster._core.definitions.events import Output
 from dagster._core.definitions.output import OutputDefinition
-from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
+from dagster._core.errors import (
+    DagsterInvalidDefinitionError,
+    DagsterInvariantViolationError,
+)
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    DynamicOutputDefinition,
+    build_solid_context,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 def test_basic():

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_dynamic_output.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_dynamic_output.py
@@ -4,22 +4,10 @@ from typing import NamedTuple
 import objgraph
 import pytest
 
-from dagster import (
-    DynamicOut,
-    DynamicOutput,
-    Out,
-    execute_solid,
-    graph,
-    job,
-    op,
-    reconstructable,
-)
+from dagster import DynamicOut, DynamicOutput, Out, execute_solid, graph, job, op, reconstructable
 from dagster._core.definitions.events import Output
 from dagster._core.definitions.output import OutputDefinition
-from dagster._core.errors import (
-    DagsterInvalidDefinitionError,
-    DagsterInvariantViolationError,
-)
+from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._core.test_utils import instance_for_test
 from dagster._legacy import (
     DynamicOutputDefinition,

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_not_allowed.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_not_allowed.py
@@ -1,13 +1,13 @@
 import pytest
 
-from dagster import (
-    DagsterInvalidDefinitionError,
-    DynamicOutput,
+from dagster import DagsterInvalidDefinitionError, DynamicOutput
+from dagster._legacy import (
     DynamicOutputDefinition,
     OutputDefinition,
     composite_solid,
+    pipeline,
+    solid,
 )
-from dagster._legacy import pipeline, solid
 
 
 @solid(output_defs=[DynamicOutputDefinition()])

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_reexecute.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_reexecute.py
@@ -5,16 +5,13 @@ import pytest
 from dagster import DynamicOutput, fs_io_manager, job, op, reconstructable
 from dagster._core.definitions.events import Output
 from dagster._core.definitions.output import DynamicOut, Out
-from dagster._core.errors import (
-    DagsterExecutionStepNotFoundError,
-    DagsterInvariantViolationError,
-)
+from dagster._core.errors import DagsterExecutionStepNotFoundError, DagsterInvariantViolationError
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
 from dagster._legacy import (
     DynamicOutputDefinition,
     execute_pipeline,
-    reexecute_pipeline,
     pipeline,
+    reexecute_pipeline,
     solid,
 )
 

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_reexecute.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_reexecute.py
@@ -2,21 +2,21 @@ from typing import List
 
 import pytest
 
-from dagster import (
-    DynamicOutput,
-    DynamicOutputDefinition,
-    execute_pipeline,
-    fs_io_manager,
-    job,
-    op,
-    reconstructable,
-    reexecute_pipeline,
-)
+from dagster import DynamicOutput, fs_io_manager, job, op, reconstructable
 from dagster._core.definitions.events import Output
 from dagster._core.definitions.output import DynamicOut, Out
-from dagster._core.errors import DagsterExecutionStepNotFoundError, DagsterInvariantViolationError
+from dagster._core.errors import (
+    DagsterExecutionStepNotFoundError,
+    DagsterInvariantViolationError,
+)
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    DynamicOutputDefinition,
+    execute_pipeline,
+    reexecute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 @solid

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
@@ -4,15 +4,7 @@ import time
 
 import pytest
 
-from dagster import (
-    Failure,
-    Field,
-    MetadataEntry,
-    Nothing,
-    Output,
-    String,
-    reconstructable,
-)
+from dagster import Failure, Field, MetadataEntry, Nothing, Output, String, reconstructable
 from dagster._core.errors import DagsterUnmetExecutorRequirementsError
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.compute_log_manager import ComputeIOType

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
@@ -7,22 +7,25 @@ import pytest
 from dagster import (
     Failure,
     Field,
-    InputDefinition,
     MetadataEntry,
     Nothing,
     Output,
-    OutputDefinition,
-    PresetDefinition,
     String,
-    execute_pipeline,
-    lambda_solid,
     reconstructable,
 )
 from dagster._core.errors import DagsterUnmetExecutorRequirementsError
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    PresetDefinition,
+    execute_pipeline,
+    lambda_solid,
+    pipeline,
+    solid,
+)
 from dagster._utils import safe_tempfile_path, segfault
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_priorities.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_priorities.py
@@ -1,6 +1,6 @@
-from dagster import execute_pipeline, reconstructable
+from dagster import reconstructable
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import execute_pipeline, pipeline, solid
 
 
 @solid(tags={"dagster/priority": "-1"})

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan.py
@@ -1,8 +1,7 @@
 import pytest
 
-from dagster import DagsterInstance, Int, Output, OutputDefinition
+from dagster import DagsterInstance, Int, Output
 from dagster import _check as check
-from dagster import composite_solid, execute_pipeline, lambda_solid
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
 from dagster._core.errors import (
     DagsterInvalidConfigError,
@@ -15,7 +14,14 @@ from dagster._core.execution.plan.plan import should_skip_step
 from dagster._core.execution.retries import RetryMode
 from dagster._core.storage.pipeline_run import PipelineRun
 from dagster._core.utils import make_new_run_id
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    OutputDefinition,
+    composite_solid,
+    execute_pipeline,
+    lambda_solid,
+    pipeline,
+    solid,
+)
 
 
 def define_diamond_pipeline():

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan_composite.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan_composite.py
@@ -1,8 +1,8 @@
-from dagster import Field, Int, String, composite_solid
+from dagster import Field, Int, String
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
 from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.instance import DagsterInstance
-from dagster._legacy import pipeline, solid
+from dagster._legacy import composite_solid, pipeline, solid
 
 
 @solid(config_schema={"foo": Field(String)})
@@ -45,7 +45,10 @@ def test_execution_plan_for_composite_solid():
     run_config = {
         "solids": {
             "composite_with_nested_config_solid": {
-                "solids": {"node_a": {"config": {"foo": "baz"}}, "node_b": {"config": {"bar": 3}}}
+                "solids": {
+                    "node_a": {"config": {"foo": "baz"}},
+                    "node_b": {"config": {"bar": 3}},
+                }
             }
         }
     }
@@ -93,7 +96,8 @@ def test_execution_plan_for_composite_solid_with_config_mapping():
     )
     instance = DagsterInstance.ephemeral()
     pipeline_run = instance.create_run_for_pipeline(
-        pipeline_def=composite_pipeline_with_config_mapping, execution_plan=execution_plan
+        pipeline_def=composite_pipeline_with_config_mapping,
+        execution_plan=execution_plan,
     )
 
     events = execute_plan(

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan_reexecution.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan_reexecution.py
@@ -4,18 +4,12 @@ import pickle
 import pytest
 
 import dagster._check as check
-from dagster import (
-    DependencyDefinition,
-    InputDefinition,
-    Int,
-    OutputDefinition,
-    PipelineDefinition,
-    execute_pipeline,
-    lambda_solid,
-    reexecute_pipeline,
-)
+from dagster import DependencyDefinition, Int
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
-from dagster._core.errors import DagsterExecutionStepNotFoundError, DagsterInvariantViolationError
+from dagster._core.errors import (
+    DagsterExecutionStepNotFoundError,
+    DagsterInvariantViolationError,
+)
 from dagster._core.events import get_step_output_event
 from dagster._core.execution.api import execute_plan
 from dagster._core.execution.plan.plan import ExecutionPlan
@@ -23,6 +17,14 @@ from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.instance import DagsterInstance
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.test_utils import default_mode_def_for_test
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    PipelineDefinition,
+    execute_pipeline,
+    lambda_solid,
+    reexecute_pipeline,
+)
 
 
 def define_addy_pipeline(using_file_system=False):
@@ -206,12 +208,18 @@ def test_pipeline_step_key_subset_execution():
     assert step_events
     assert not os.path.exists(
         os.path.join(
-            instance.storage_directory(), pipeline_reexecution_result.run_id, "add_one", "result"
+            instance.storage_directory(),
+            pipeline_reexecution_result.run_id,
+            "add_one",
+            "result",
         )
     )
     with open(
         os.path.join(
-            instance.storage_directory(), pipeline_reexecution_result.run_id, "add_two", "result"
+            instance.storage_directory(),
+            pipeline_reexecution_result.run_id,
+            "add_two",
+            "result",
         ),
         "rb",
     ) as read_obj:

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan_reexecution.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan_reexecution.py
@@ -6,10 +6,7 @@ import pytest
 import dagster._check as check
 from dagster import DependencyDefinition, Int
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
-from dagster._core.errors import (
-    DagsterExecutionStepNotFoundError,
-    DagsterInvariantViolationError,
-)
+from dagster._core.errors import DagsterExecutionStepNotFoundError, DagsterInvariantViolationError
 from dagster._core.events import get_step_output_event
 from dagster._core.execution.api import execute_plan
 from dagster._core.execution.plan.plan import ExecutionPlan

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan_subset.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan_subset.py
@@ -1,16 +1,14 @@
-from dagster import (
-    DependencyDefinition,
-    InputDefinition,
-    Int,
-    Output,
-    OutputDefinition,
-    PipelineDefinition,
-    lambda_solid,
-)
+from dagster import DependencyDefinition, Int, Output
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
 from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.instance import DagsterInstance
-from dagster._legacy import solid
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    PipelineDefinition,
+    lambda_solid,
+    solid,
+)
 
 
 def define_two_int_pipeline():
@@ -48,7 +46,10 @@ def test_execution_plan_simple_two_steps():
     assert execution_plan.get_step_by_key("add_one")
 
     events = execute_plan(
-        execution_plan, InMemoryPipeline(pipeline_def), pipeline_run=pipeline_run, instance=instance
+        execution_plan,
+        InMemoryPipeline(pipeline_def),
+        pipeline_run=pipeline_run,
+        instance=instance,
     )
     step_starts = find_events(events, event_type="STEP_START")
     assert len(step_starts) == 2
@@ -79,7 +80,10 @@ def test_execution_plan_two_outputs():
         pipeline_def=pipeline_def, execution_plan=execution_plan
     )
     events = execute_plan(
-        execution_plan, InMemoryPipeline(pipeline_def), pipeline_run=pipeline_run, instance=instance
+        execution_plan,
+        InMemoryPipeline(pipeline_def),
+        pipeline_run=pipeline_run,
+        instance=instance,
     )
 
     output_events = find_events(events, event_type="STEP_OUTPUT")
@@ -105,7 +109,10 @@ def test_reentrant_execute_plan():
         pipeline_def=pipeline_def, tags={"foo": "bar"}, execution_plan=execution_plan
     )
     step_events = execute_plan(
-        execution_plan, InMemoryPipeline(pipeline_def), pipeline_run=pipeline_run, instance=instance
+        execution_plan,
+        InMemoryPipeline(pipeline_def),
+        pipeline_run=pipeline_run,
+        instance=instance,
     )
 
     assert called["yup"]

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
@@ -25,9 +25,7 @@ from dagster import (
 from dagster._core.definitions.no_step_launcher import no_step_launcher
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import create_execution_plan
-from dagster._core.execution.context_creation_pipeline import (
-    PlanExecutionContextManager,
-)
+from dagster._core.execution.context_creation_pipeline import PlanExecutionContextManager
 from dagster._core.execution.plan.external_step import (
     LocalExternalStepLauncher,
     local_external_step_launcher,
@@ -43,8 +41,8 @@ from dagster._legacy import (
     ModeDefinition,
     execute_pipeline,
     execute_pipeline_iterator,
-    reexecute_pipeline,
     pipeline,
+    reexecute_pipeline,
     solid,
 )
 from dagster._utils import safe_tempfile_path, send_interrupt

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
@@ -12,24 +12,22 @@ from dagster import (
     Failure,
     Field,
     MetadataEntry,
-    ModeDefinition,
     ResourceDefinition,
     RetryPolicy,
     RetryRequested,
     String,
-    execute_pipeline,
-    execute_pipeline_iterator,
     fs_io_manager,
     job,
     op,
     reconstructable,
-    reexecute_pipeline,
     resource,
 )
 from dagster._core.definitions.no_step_launcher import no_step_launcher
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import create_execution_plan
-from dagster._core.execution.context_creation_pipeline import PlanExecutionContextManager
+from dagster._core.execution.context_creation_pipeline import (
+    PlanExecutionContextManager,
+)
 from dagster._core.execution.plan.external_step import (
     LocalExternalStepLauncher,
     local_external_step_launcher,
@@ -41,7 +39,14 @@ from dagster._core.execution.retries import RetryMode
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.pipeline_run import PipelineRun
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    ModeDefinition,
+    execute_pipeline,
+    execute_pipeline_iterator,
+    reexecute_pipeline,
+    pipeline,
+    solid,
+)
 from dagster._utils import safe_tempfile_path, send_interrupt
 from dagster._utils.merger import deep_merge_dicts, merge_dicts
 
@@ -212,7 +217,10 @@ def define_basic_job_last_launched():
 
 
 def define_basic_pipeline():
-    @solid(required_resource_keys=set(["first_step_launcher"]), config_schema={"a": Field(str)})
+    @solid(
+        required_resource_keys=set(["first_step_launcher"]),
+        config_schema={"a": Field(str)},
+    )
     def return_two(_):
         return 2
 

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_host_run_worker.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_host_run_worker.py
@@ -1,6 +1,6 @@
 import os
 
-from dagster import ModeDefinition, executor, fs_io_manager, reconstructable, resource
+from dagster import executor, fs_io_manager, reconstructable, resource
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.host_mode import execute_run_host_mode
@@ -8,7 +8,7 @@ from dagster._core.execution.retries import RetryMode
 from dagster._core.executor.multiprocess import MultiprocessExecutor
 from dagster._core.storage.pipeline_run import PipelineRunStatus
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import ModeDefinition, pipeline, solid
 
 
 @resource
@@ -35,10 +35,12 @@ def solid_that_uses_adder_resource(context, number):
 @pipeline(
     mode_defs=[
         ModeDefinition(
-            name="add_one", resource_defs={"adder": add_one_resource, "io_manager": fs_io_manager}
+            name="add_one",
+            resource_defs={"adder": add_one_resource, "io_manager": fs_io_manager},
         ),
         ModeDefinition(
-            name="add_two", resource_defs={"adder": add_two_resource, "io_manager": fs_io_manager}
+            name="add_two",
+            resource_defs={"adder": add_two_resource, "io_manager": fs_io_manager},
         ),
     ]
 )

--- a/python_modules/dagster/dagster_tests/execution_tests/memoized_dev_loop_pipeline.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/memoized_dev_loop_pipeline.py
@@ -1,12 +1,6 @@
 from dagster import Field, String, repository
 from dagster._core.storage.memoizable_io_manager import versioned_filesystem_io_manager
-from dagster._legacy import (
-    InputDefinition,
-    ModeDefinition,
-    OutputDefinition,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, ModeDefinition, OutputDefinition, pipeline, solid
 
 
 @solid(

--- a/python_modules/dagster/dagster_tests/execution_tests/memoized_dev_loop_pipeline.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/memoized_dev_loop_pipeline.py
@@ -1,6 +1,12 @@
-from dagster import Field, InputDefinition, ModeDefinition, OutputDefinition, String, repository
+from dagster import Field, String, repository
 from dagster._core.storage.memoizable_io_manager import versioned_filesystem_io_manager
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    pipeline,
+    solid,
+)
 
 
 @solid(

--- a/python_modules/dagster/dagster_tests/execution_tests/test_api_iterators.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_api_iterators.py
@@ -1,6 +1,4 @@
 import pytest
-
-from dagster import ModeDefinition, PipelineDefinition
 from dagster import _check as check
 from dagster import resource
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
@@ -15,7 +13,7 @@ from dagster._core.execution.api import (
 )
 from dagster._core.storage.pipeline_run import PipelineRunStatus
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import solid
+from dagster._legacy import ModeDefinition, PipelineDefinition, solid
 
 
 @resource
@@ -146,7 +144,9 @@ def test_execute_run_iterator():
         ) as run_monitoring_instance:
             event = next(
                 execute_run_iterator(
-                    InMemoryPipeline(pipeline_def), pipeline_run, instance=run_monitoring_instance
+                    InMemoryPipeline(pipeline_def),
+                    pipeline_run,
+                    instance=run_monitoring_instance,
                 )
             )
             assert (

--- a/python_modules/dagster/dagster_tests/execution_tests/test_api_iterators.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_api_iterators.py
@@ -1,4 +1,5 @@
 import pytest
+
 from dagster import _check as check
 from dagster import resource
 from dagster._core.definitions.pipeline_base import InMemoryPipeline

--- a/python_modules/dagster/dagster_tests/execution_tests/test_expectations.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_expectations.py
@@ -1,13 +1,7 @@
 import pytest
 
-from dagster import (
-    DagsterEventType,
-    DagsterInvariantViolationError,
-    ExpectationResult,
-    PipelineDefinition,
-    execute_pipeline,
-)
-from dagster._legacy import solid
+from dagster import DagsterEventType, DagsterInvariantViolationError, ExpectationResult
+from dagster._legacy import PipelineDefinition, execute_pipeline, solid
 
 
 def expt_results_for_compute_step(result, solid_name):
@@ -25,7 +19,8 @@ def test_successful_expectation_in_compute_step():
         yield ExpectationResult(success=True, description="This is always true.")
 
     pipeline_def = PipelineDefinition(
-        name="success_expectation_in_compute_pipeline", solid_defs=[success_expectation_solid]
+        name="success_expectation_in_compute_pipeline",
+        solid_defs=[success_expectation_solid],
     )
 
     result = execute_pipeline(pipeline_def)
@@ -47,7 +42,8 @@ def test_failed_expectation_in_compute_step():
         yield ExpectationResult(success=False, description="This is always false.")
 
     pipeline_def = PipelineDefinition(
-        name="failure_expectation_in_compute_pipeline", solid_defs=[failure_expectation_solid]
+        name="failure_expectation_in_compute_pipeline",
+        solid_defs=[failure_expectation_solid],
     )
 
     result = execute_pipeline(pipeline_def)
@@ -68,7 +64,8 @@ def test_return_expectation_failure():
         return ExpectationResult(success=True, description="This is always true.")
 
     pipeline_def = PipelineDefinition(
-        name="success_expectation_in_compute_pipeline", solid_defs=[return_expectation_failure]
+        name="success_expectation_in_compute_pipeline",
+        solid_defs=[return_expectation_failure],
     )
 
     with pytest.raises(

--- a/python_modules/dagster/dagster_tests/execution_tests/test_failure.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_failure.py
@@ -1,5 +1,5 @@
-from dagster import Failure, MetadataEntry, execute_pipeline, lambda_solid
-from dagster._legacy import pipeline
+from dagster import Failure, MetadataEntry
+from dagster._legacy import execute_pipeline, lambda_solid, pipeline
 
 
 def test_failure():

--- a/python_modules/dagster/dagster_tests/execution_tests/test_input_values_from_intermediates.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_input_values_from_intermediates.py
@@ -1,5 +1,5 @@
-from dagster import InputDefinition, List, Optional, execute_pipeline, lambda_solid
-from dagster._legacy import pipeline
+from dagster import List, Optional
+from dagster._legacy import InputDefinition, execute_pipeline, lambda_solid, pipeline
 
 
 def test_from_intermediates_from_multiple_outputs():

--- a/python_modules/dagster/dagster_tests/execution_tests/test_interrupt.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_interrupt.py
@@ -10,20 +10,26 @@ from dagster import (
     DagsterEventType,
     Failure,
     Field,
-    ModeDefinition,
     RetryPolicy,
     String,
     _seven,
-    execute_pipeline,
-    execute_pipeline_iterator,
     job,
     op,
     reconstructable,
     resource,
 )
-from dagster._core.errors import DagsterExecutionInterruptedError, raise_execution_interrupts
+from dagster._core.errors import (
+    DagsterExecutionInterruptedError,
+    raise_execution_interrupts,
+)
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    ModeDefinition,
+    execute_pipeline,
+    execute_pipeline_iterator,
+    pipeline,
+    solid,
+)
 from dagster._utils import safe_tempfile_path, send_interrupt
 from dagster._utils.interrupts import capture_interrupts, check_captured_interrupt
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_interrupt.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_interrupt.py
@@ -18,10 +18,7 @@ from dagster import (
     reconstructable,
     resource,
 )
-from dagster._core.errors import (
-    DagsterExecutionInterruptedError,
-    raise_execution_interrupts,
-)
+from dagster._core.errors import DagsterExecutionInterruptedError, raise_execution_interrupts
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
 from dagster._legacy import (
     ModeDefinition,

--- a/python_modules/dagster/dagster_tests/execution_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_job.py
@@ -7,7 +7,6 @@ from dagster import (
     DagsterInvariantViolationError,
     Field,
     StringSource,
-    execute_pipeline,
     graph,
     job,
     op,
@@ -16,6 +15,7 @@ from dagster import (
 )
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._core.test_utils import environ, instance_for_test
+from dagster._legacy import execute_pipeline
 
 
 def define_the_job():

--- a/python_modules/dagster/dagster_tests/execution_tests/test_markers.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_markers.py
@@ -1,7 +1,7 @@
-from dagster import execute_pipeline, lambda_solid, reconstructable
+from dagster import reconstructable
 from dagster._core.events import MARKER_EVENTS
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
-from dagster._legacy import pipeline
+from dagster._legacy import execute_pipeline, lambda_solid, pipeline
 
 
 def define_pipeline():
@@ -34,12 +34,14 @@ def test_multiproc_markers():
             if dagster_event and dagster_event.event_type in MARKER_EVENTS:
                 if dagster_event.engine_event_data.marker_start:
                     key = "{step}.{marker}".format(
-                        step=event.step_key, marker=dagster_event.engine_event_data.marker_start
+                        step=event.step_key,
+                        marker=dagster_event.engine_event_data.marker_start,
                     )
                     start_markers[key] = event.timestamp
                 if dagster_event.engine_event_data.marker_end:
                     key = "{step}.{marker}".format(
-                        step=event.step_key, marker=dagster_event.engine_event_data.marker_end
+                        step=event.step_key,
+                        marker=dagster_event.engine_event_data.marker_end,
                     )
                     end_markers[key] = event.timestamp
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_memoized_dev_loop.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_memoized_dev_loop.py
@@ -7,10 +7,8 @@ from dagster import (
     DynamicOut,
     DynamicOutput,
     In,
-    execute_pipeline,
     graph,
     op,
-    reexecute_pipeline,
     resource,
     root_input_manager,
 )
@@ -21,11 +19,16 @@ from dagster._core.storage.tags import MEMOIZED_RUN_TAG
 from dagster._core.test_utils import instance_for_test
 
 from .memoized_dev_loop_pipeline import asset_pipeline
+from dagster._legacy import execute_pipeline, reexecute_pipeline
 
 
 def get_step_keys_to_execute(pipeline, run_config, mode, instance):
     return create_execution_plan(
-        pipeline, run_config, mode, instance_ref=instance.get_ref(), tags={MEMOIZED_RUN_TAG: "true"}
+        pipeline,
+        run_config,
+        mode,
+        instance_ref=instance.get_ref(),
+        tags={MEMOIZED_RUN_TAG: "true"},
     ).step_keys_to_execute
 
 
@@ -179,7 +182,9 @@ def test_memoization_with_step_selection():
 
             assert (
                 create_execution_plan(
-                    my_job, instance_ref=instance.get_ref(), step_keys_to_execute=["op1"]
+                    my_job,
+                    instance_ref=instance.get_ref(),
+                    step_keys_to_execute=["op1"],
                 ).step_keys_to_execute
                 == []
             )
@@ -238,7 +243,9 @@ def test_memoization_with_default_strategy_overriden():
             # Ensure that after switching memoization tag off, that the plan recognizes every step
             # should be run.
             unmemoized_plan = create_execution_plan(
-                my_job, instance_ref=instance.get_ref(), tags={MEMOIZED_RUN_TAG: "false"}
+                my_job,
+                instance_ref=instance.get_ref(),
+                tags={MEMOIZED_RUN_TAG: "false"},
             )
             assert len(unmemoized_plan.step_keys_to_execute) == 1
 
@@ -311,7 +318,9 @@ def test_version_strategy_depends_from_context():
             # Ensure that after switching memoization tag off, that the plan recognizes every step
             # should be run.
             unmemoized_plan = create_execution_plan(
-                my_job, instance_ref=instance.get_ref(), tags={MEMOIZED_RUN_TAG: "false"}
+                my_job,
+                instance_ref=instance.get_ref(),
+                tags={MEMOIZED_RUN_TAG: "false"},
             )
             assert len(unmemoized_plan.step_keys_to_execute) == 1
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_memoized_dev_loop.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_memoized_dev_loop.py
@@ -17,9 +17,9 @@ from dagster._core.execution.api import create_execution_plan
 from dagster._core.storage.memoizable_io_manager import versioned_filesystem_io_manager
 from dagster._core.storage.tags import MEMOIZED_RUN_TAG
 from dagster._core.test_utils import instance_for_test
+from dagster._legacy import execute_pipeline, reexecute_pipeline
 
 from .memoized_dev_loop_pipeline import asset_pipeline
-from dagster._legacy import execute_pipeline, reexecute_pipeline
 
 
 def get_step_keys_to_execute(pipeline, run_config, mode, instance):

--- a/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
@@ -14,7 +14,6 @@ from dagster import (
     PythonArtifactMetadataValue,
     TextMetadataValue,
     UrlMetadataValue,
-    execute_pipeline,
 )
 from dagster._check import CheckError
 from dagster._core.definitions.metadata import (
@@ -29,7 +28,7 @@ from dagster._core.definitions.metadata.table import (
     TableRecord,
     TableSchema,
 )
-from dagster._legacy import pipeline, solid
+from dagster._legacy import execute_pipeline, pipeline, solid
 from dagster._utils import frozendict
 
 
@@ -217,7 +216,12 @@ def test_table_metadata_value_schema_inference():
 bad_values = frozendict(
     {
         "table_schema": {"columns": False, "constraints": False},
-        "table_column": {"name": False, "type": False, "description": False, "constraints": False},
+        "table_column": {
+            "name": False,
+            "type": False,
+            "description": False,
+            "constraints": False,
+        },
         "table_constraints": {"other": False},
         "table_column_constraints": {
             "nullable": "foo",

--- a/python_modules/dagster/dagster_tests/execution_tests/test_modes.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_modes.py
@@ -1,7 +1,7 @@
 import pytest
 
-from dagster import DagsterInvariantViolationError, ModeDefinition, execute_pipeline, resource
-from dagster._legacy import pipeline, solid
+from dagster import DagsterInvariantViolationError, resource
+from dagster._legacy import ModeDefinition, execute_pipeline, pipeline, solid
 
 
 @resource

--- a/python_modules/dagster/dagster_tests/execution_tests/test_retries.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_retries.py
@@ -33,8 +33,8 @@ from dagster._legacy import (
     execute_pipeline,
     execute_pipeline_iterator,
     lambda_solid,
-    reexecute_pipeline,
     pipeline,
+    reexecute_pipeline,
     solid,
 )
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_retries.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_retries.py
@@ -12,18 +12,12 @@ from dagster import (
     Failure,
     Jitter,
     Output,
-    OutputDefinition,
-    PipelineRun,
     RetryPolicy,
     RetryRequested,
-    execute_pipeline,
-    execute_pipeline_iterator,
     graph,
     job,
-    lambda_solid,
     op,
     reconstructable,
-    reexecute_pipeline,
     success_hook,
 )
 from dagster._core.definitions.events import HookExecutionResult
@@ -33,7 +27,16 @@ from dagster._core.events import DagsterEvent
 from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.execution.retries import RetryMode
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    OutputDefinition,
+    PipelineRun,
+    execute_pipeline,
+    execute_pipeline_iterator,
+    lambda_solid,
+    reexecute_pipeline,
+    pipeline,
+    solid,
+)
 
 executors = pytest.mark.parametrize(
     "environment",

--- a/python_modules/dagster/dagster_tests/execution_tests/test_timing.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_timing.py
@@ -3,8 +3,8 @@ import time
 
 import pytest
 
-from dagster import Output, PipelineDefinition, execute_pipeline
-from dagster._legacy import solid
+from dagster import Output
+from dagster._legacy import PipelineDefinition, execute_pipeline, solid
 
 
 @pytest.mark.skipif(

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -14,7 +14,7 @@ import sqlalchemy as db
 
 from dagster import AssetKey, AssetMaterialization, Output
 from dagster import _check as check
-from dagster import execute_pipeline, file_relative_path, job
+from dagster import file_relative_path, job
 from dagster._cli.debug import DebugRunPayload
 from dagster._core.definitions.dependency import NodeHandle
 from dagster._core.events import DagsterEvent
@@ -27,7 +27,7 @@ from dagster._core.storage.event_log.sql_event_log import SqlEventLogStorage
 from dagster._core.storage.migration.utils import upgrading_instance
 from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import REPOSITORY_LABEL_TAG
-from dagster._legacy import pipeline, solid
+from dagster._legacy import execute_pipeline, pipeline, solid
 from dagster._serdes import DefaultNamedTupleSerializer, create_snapshot_id
 from dagster._serdes.serdes import (
     WhitelistMap,
@@ -628,7 +628,10 @@ def test_external_job_origin_instigator_origin():
 
         @_whitelist_for_serdes(legacy_env)
         class ExternalRepositoryOrigin(
-            namedtuple("_ExternalRepositoryOrigin", "repository_location_origin repository_name")
+            namedtuple(
+                "_ExternalRepositoryOrigin",
+                "repository_location_origin repository_name",
+            )
         ):
             def get_id(self):
                 return create_snapshot_id(self)
@@ -824,7 +827,11 @@ def test_jobs_selector_id_migration():
     src_dir = file_relative_path(__file__, "snapshot_0_14_6_post_schema_pre_data_migration/sqlite")
 
     from dagster._core.storage.schedules.migration import SCHEDULE_JOBS_SELECTOR_ID
-    from dagster._core.storage.schedules.schema import InstigatorsTable, JobTable, JobTickTable
+    from dagster._core.storage.schedules.schema import (
+        InstigatorsTable,
+        JobTable,
+        JobTickTable,
+    )
 
     with copy_directory(src_dir) as test_dir:
         db_path = os.path.join(test_dir, "schedules", "schedules.db")

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -827,11 +827,7 @@ def test_jobs_selector_id_migration():
     src_dir = file_relative_path(__file__, "snapshot_0_14_6_post_schema_pre_data_migration/sqlite")
 
     from dagster._core.storage.schedules.migration import SCHEDULE_JOBS_SELECTOR_ID
-    from dagster._core.storage.schedules.schema import (
-        InstigatorsTable,
-        JobTable,
-        JobTickTable,
-    )
+    from dagster._core.storage.schedules.schema import InstigatorsTable, JobTable, JobTickTable
 
     with copy_directory(src_dir) as test_dir:
         db_path = os.path.join(test_dir, "schedules", "schedules.db")

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_execution_plan_snapshot.py
@@ -1,15 +1,6 @@
 import os
 
-from dagster import (
-    DynamicOutput,
-    DynamicOutputDefinition,
-    InputDefinition,
-    List,
-    ModeDefinition,
-    Output,
-    OutputDefinition,
-    fs_io_manager,
-)
+from dagster import DynamicOutput, List, Output, fs_io_manager
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
 from dagster._core.execution.api import create_execution_plan, execute_run
 from dagster._core.execution.plan.inputs import (
@@ -28,7 +19,14 @@ from dagster._core.instance.ref import InstanceRef
 from dagster._core.snap.execution_plan_snapshot import snapshot_from_execution_plan
 from dagster._core.storage.pipeline_run import PipelineRunStatus
 from dagster._core.storage.root_input_manager import root_input_manager
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    DynamicOutputDefinition,
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    pipeline,
+    solid,
+)
 from dagster._utils import file_relative_path
 from dagster._utils.test import copy_directory
 

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/grpc_repo.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/grpc_repo.py
@@ -10,13 +10,7 @@ from dagster import (
     sensor,
     usable_as_dagster_type,
 )
-from dagster._legacy import (
-    InputDefinition,
-    OutputDefinition,
-    lambda_solid,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, OutputDefinition, lambda_solid, pipeline, solid
 
 
 @lambda_solid

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/grpc_repo.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/grpc_repo.py
@@ -2,18 +2,21 @@ import string
 import time
 
 from dagster import (
-    InputDefinition,
     Int,
-    OutputDefinition,
     PartitionSetDefinition,
     ScheduleDefinition,
     SkipReason,
-    lambda_solid,
     repository,
     sensor,
     usable_as_dagster_type,
 )
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    lambda_solid,
+    pipeline,
+    solid,
+)
 
 
 @lambda_solid

--- a/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
+++ b/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
@@ -527,9 +527,7 @@ def test_same_name_different_modules():
     class MyClass:
         pass
 
-    from dagster_tests.general_tests.py3_tests.other_module import (
-        MyClass as OtherModuleMyClass,
-    )
+    from dagster_tests.general_tests.py3_tests.other_module import MyClass as OtherModuleMyClass
 
     @solid
     def my_solid(_) -> MyClass:

--- a/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
+++ b/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
@@ -6,19 +6,22 @@ from dagster import (
     DagsterInvalidDefinitionError,
     DagsterType,
     In,
-    InputDefinition,
     Int,
-    composite_solid,
-    execute_pipeline,
     execute_solid,
-    lambda_solid,
     make_python_type_usable_as_dagster_type,
     op,
     usable_as_dagster_type,
 )
 from dagster._core.definitions.inference import infer_input_props, infer_output_props
 from dagster._core.types.dagster_type import DagsterTypeKind
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    composite_solid,
+    execute_pipeline,
+    lambda_solid,
+    pipeline,
+    solid,
+)
 
 
 def test_infer_solid_description_from_docstring():
@@ -148,7 +151,14 @@ def test_kitchen_sink():
 
     @lambda_solid
     def sink(
-        n: int, f: float, b: bool, s: str, x: Any, o: Optional[str], l: List[str], c: Custom
+        n: int,
+        f: float,
+        b: bool,
+        s: str,
+        x: Any,
+        o: Optional[str],
+        l: List[str],
+        c: Custom,
     ):  # pylint: disable=unused-argument
         pass
 
@@ -517,7 +527,9 @@ def test_same_name_different_modules():
     class MyClass:
         pass
 
-    from dagster_tests.general_tests.py3_tests.other_module import MyClass as OtherModuleMyClass
+    from dagster_tests.general_tests.py3_tests.other_module import (
+        MyClass as OtherModuleMyClass,
+    )
 
     @solid
     def my_solid(_) -> MyClass:

--- a/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_type_examples_py3.py
+++ b/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_type_examples_py3.py
@@ -16,7 +16,6 @@ from dagster import (
     Dict,
     Field,
     Float,
-    InputDefinition,
     Int,
     List,
     Nothing,
@@ -28,8 +27,8 @@ from dagster import (
     Tuple,
 )
 from dagster import _check as check
-from dagster import execute_pipeline, execute_solid
-from dagster._legacy import pipeline, solid
+from dagster import execute_solid
+from dagster._legacy import InputDefinition, execute_pipeline, pipeline, solid
 
 
 @solid
@@ -233,7 +232,13 @@ def test_set_solid_configable_input():
         run_config={
             "solids": {
                 "set_solid": {
-                    "inputs": {"set_input": [{"value": "foo"}, {"value": "bar"}, {"value": "baz"}]}
+                    "inputs": {
+                        "set_input": [
+                            {"value": "foo"},
+                            {"value": "bar"},
+                            {"value": "baz"},
+                        ]
+                    }
                 }
             }
         },
@@ -396,7 +401,9 @@ def test_add_n():
 
 def test_div_y():
     res = execute_solid(
-        div_y, input_values={"x": 3.0}, run_config={"solids": {"div_y": {"config": 2.0}}}
+        div_y,
+        input_values={"x": 3.0},
+        run_config={"solids": {"div_y": {"config": 2.0}}},
     )
     assert res.output_value() == 1.5
 

--- a/python_modules/dagster/dagster_tests/general_tests/test_repository.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_repository.py
@@ -4,17 +4,9 @@ Repository of test pipelines
 
 import pytest
 
-from dagster import (
-    Int,
-    ModeDefinition,
-    PipelineDefinition,
-    PresetDefinition,
-    fs_io_manager,
-    repository,
-    resource,
-)
+from dagster import Int, fs_io_manager, repository, resource
 from dagster._check import CheckError
-from dagster._legacy import solid
+from dagster._legacy import ModeDefinition, PipelineDefinition, PresetDefinition, solid
 from dagster._utils import file_relative_path
 
 
@@ -28,7 +20,9 @@ def define_single_mode_pipeline():
         return 2
 
     return PipelineDefinition(
-        name="single_mode", solid_defs=[return_two], mode_defs=[ModeDefinition(name="the_mode")]
+        name="single_mode",
+        solid_defs=[return_two],
+        mode_defs=[ModeDefinition(name="the_mode")],
     )
 
 
@@ -71,7 +65,8 @@ def define_multi_mode_with_resources_pipeline():
         solid_defs=[apply_to_three],
         mode_defs=[
             ModeDefinition(
-                name="add_mode", resource_defs={"op": adder_resource, "io_manager": fs_io_manager}
+                name="add_mode",
+                resource_defs={"op": adder_resource, "io_manager": fs_io_manager},
             ),
             ModeDefinition(name="mult_mode", resource_defs={"op": multer_resource}),
             ModeDefinition(
@@ -86,7 +81,8 @@ def define_multi_mode_with_resources_pipeline():
                 mode="add_mode",
                 config_files=[
                     file_relative_path(
-                        __file__, "../environments/multi_mode_with_resources/add_mode.yaml"
+                        __file__,
+                        "../environments/multi_mode_with_resources/add_mode.yaml",
                     )
                 ],
             ),

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_json_logging.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_json_logging.py
@@ -1,10 +1,12 @@
 import json
 import logging
-
-from dagster import PipelineDefinition
 from dagster._core.execution.context.logger import InitLoggerContext
 from dagster._utils.log import define_json_file_logger
-from dagster._utils.test import create_test_pipeline_execution_context, get_temp_file_name
+from dagster._utils.test import (
+    create_test_pipeline_execution_context,
+    get_temp_file_name,
+)
+from dagster._legacy import PipelineDefinition
 
 
 def setup_json_file_logger(tf_name, name="foo", level=logging.DEBUG):

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_json_logging.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_json_logging.py
@@ -1,12 +1,10 @@
 import json
 import logging
+
 from dagster._core.execution.context.logger import InitLoggerContext
-from dagster._utils.log import define_json_file_logger
-from dagster._utils.test import (
-    create_test_pipeline_execution_context,
-    get_temp_file_name,
-)
 from dagster._legacy import PipelineDefinition
+from dagster._utils.log import define_json_file_logger
+from dagster._utils.test import create_test_pipeline_execution_context, get_temp_file_name
 
 
 def setup_json_file_logger(tf_name, name="foo", level=logging.DEBUG):

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_single_handler.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_single_handler.py
@@ -1,9 +1,8 @@
 import logging
-
-from dagster import PipelineDefinition
 from dagster._core.execution.context.logger import InitLoggerContext
 from dagster._core.log_manager import DagsterLogManager
 from dagster._utils.log import construct_single_handler_logger
+from dagster._legacy import PipelineDefinition
 
 
 class LogTestHandler(logging.Handler):

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_single_handler.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_single_handler.py
@@ -1,8 +1,9 @@
 import logging
+
 from dagster._core.execution.context.logger import InitLoggerContext
 from dagster._core.log_manager import DagsterLogManager
-from dagster._utils.log import construct_single_handler_logger
 from dagster._legacy import PipelineDefinition
+from dagster._utils.log import construct_single_handler_logger
 
 
 class LogTestHandler(logging.Handler):

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_solid_isolation.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_solid_isolation.py
@@ -2,13 +2,7 @@ import re
 
 import pytest
 
-from dagster import (
-    DagsterInvariantViolationError,
-    DagsterTypeCheckDidNotPass,
-    Field,
-    Int,
-    resource,
-)
+from dagster import DagsterInvariantViolationError, DagsterTypeCheckDidNotPass, Field, Int, resource
 from dagster._core.test_utils import nesting_composite_pipeline
 from dagster._core.utility_solids import (
     create_root_solid,

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_solid_isolation.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_solid_isolation.py
@@ -6,12 +6,7 @@ from dagster import (
     DagsterInvariantViolationError,
     DagsterTypeCheckDidNotPass,
     Field,
-    InputDefinition,
     Int,
-    ModeDefinition,
-    OutputDefinition,
-    composite_solid,
-    lambda_solid,
     resource,
 )
 from dagster._core.test_utils import nesting_composite_pipeline
@@ -21,7 +16,14 @@ from dagster._core.utility_solids import (
     define_stub_solid,
     input_set,
 )
-from dagster._legacy import solid
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    composite_solid,
+    lambda_solid,
+    solid,
+)
 from dagster._utils.test import execute_solid
 
 
@@ -70,7 +72,8 @@ def test_single_solid_with_config():
         ran["check_config_for_two"] = True
 
     result = execute_solid(
-        check_config_for_two, run_config={"solids": {"check_config_for_two": {"config": 2}}}
+        check_config_for_two,
+        run_config={"solids": {"check_config_for_two": {"config": 2}}},
     )
 
     assert result.success
@@ -99,7 +102,8 @@ def test_single_solid_with_context_config():
     assert ran["count"] == 1
 
     result = execute_solid(
-        check_context_config_for_two, mode_def=ModeDefinition(resource_defs={"num": num_resource})
+        check_context_config_for_two,
+        mode_def=ModeDefinition(resource_defs={"num": num_resource}),
     )
 
     assert result.success

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -7,11 +7,11 @@ from dagster import (
     MetadataEntry,
     TableColumn,
     TableSchema,
-    build_assets_job,
     build_init_resource_context,
 )
 
 from .utils import get_sample_connection_json, get_sample_job_json
+from dagster._legacy import build_assets_job
 
 
 @responses.activate

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -2,16 +2,10 @@ import pytest
 import responses
 from dagster_airbyte import airbyte_resource, build_airbyte_assets
 
-from dagster import (
-    AssetKey,
-    MetadataEntry,
-    TableColumn,
-    TableSchema,
-    build_init_resource_context,
-)
+from dagster import AssetKey, MetadataEntry, TableColumn, TableSchema, build_init_resource_context
+from dagster._legacy import build_assets_job
 
 from .utils import get_sample_connection_json, get_sample_job_json
-from dagster._legacy import build_assets_job
 
 
 @responses.activate

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -16,18 +16,23 @@ from dagster_airflow.patch_airflow_example_dag import patch_airflow_example_dag
 from dagster import (
     DagsterInvariantViolationError,
     DependencyDefinition,
-    InputDefinition,
     MultiDependencyDefinition,
     Nothing,
-    OutputDefinition,
-    PipelineDefinition,
-    SolidDefinition,
 )
 from dagster import _check as check
 from dagster import repository
 from dagster._core.definitions.utils import VALID_NAME_REGEX, validate_tags
-from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR, IS_AIRFLOW_INGEST_PIPELINE_STR
-from dagster._legacy import solid
+from dagster._core.instance import (
+    AIRFLOW_EXECUTION_DATE_STR,
+    IS_AIRFLOW_INGEST_PIPELINE_STR,
+)
+from dagster._legacy import (
+    InputDefinition,
+    OutputDefinition,
+    PipelineDefinition,
+    SolidDefinition,
+    solid,
+)
 
 
 class DagsterAirflowError(Exception):
@@ -52,7 +57,10 @@ def contains_duplicate_task_names(dag_bag, refresh_from_airflow_db):
 
 
 def make_dagster_repo_from_airflow_dag_bag(
-    dag_bag, repo_name, refresh_from_airflow_db=False, use_airflow_template_context=False
+    dag_bag,
+    repo_name,
+    refresh_from_airflow_db=False,
+    use_airflow_template_context=False,
 ):
     """Construct a Dagster repository corresponding to Airflow DAGs in DagBag.
 
@@ -97,7 +105,9 @@ def make_dagster_repo_from_airflow_dag_bag(
         if not use_unique_id:
             pipeline_defs.append(
                 make_dagster_pipeline_from_airflow_dag(
-                    dag=dag, tags=None, use_airflow_template_context=use_airflow_template_context
+                    dag=dag,
+                    tags=None,
+                    use_airflow_template_context=use_airflow_template_context,
                 )
             )
         else:
@@ -333,7 +343,12 @@ def _get_pipeline_definition_args(dag, use_airflow_template_context, unique_id=N
 
 
 def _traverse_airflow_dag(
-    task, seen_tasks, pipeline_dependencies, solid_defs, use_airflow_template_context, unique_id
+    task,
+    seen_tasks,
+    pipeline_dependencies,
+    solid_defs,
+    use_airflow_template_context,
+    unique_id,
 ):
     check.inst_param(task, "task", BaseOperator)
     check.list_param(seen_tasks, "seen_tasks", BaseOperator)

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -22,10 +22,7 @@ from dagster import (
 from dagster import _check as check
 from dagster import repository
 from dagster._core.definitions.utils import VALID_NAME_REGEX, validate_tags
-from dagster._core.instance import (
-    AIRFLOW_EXECUTION_DATE_STR,
-    IS_AIRFLOW_INGEST_PIPELINE_STR,
-)
+from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR, IS_AIRFLOW_INGEST_PIPELINE_STR
 from dagster._legacy import (
     InputDefinition,
     OutputDefinition,

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_load_dag_bag.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_load_dag_bag.py
@@ -7,6 +7,7 @@ from dagster_airflow.dagster_pipeline_factory import (
     make_dagster_repo_from_airflow_example_dags,
 )
 from dagster_airflow_tests.marks import requires_airflow_db
+
 from dagster._legacy import execute_pipeline
 
 COMPLEX_DAG_FILE_CONTENTS = '''#

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_load_dag_bag.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_load_dag_bag.py
@@ -7,8 +7,7 @@ from dagster_airflow.dagster_pipeline_factory import (
     make_dagster_repo_from_airflow_example_dags,
 )
 from dagster_airflow_tests.marks import requires_airflow_db
-
-from dagster import execute_pipeline
+from dagster._legacy import execute_pipeline
 
 COMPLEX_DAG_FILE_CONTENTS = '''#
 # Licensed to the Apache Software Foundation (ASF) under one
@@ -336,7 +335,10 @@ test_make_repo_inputs = [
     ([("complex.py", COMPLEX_DAG_FILE_CONTENTS)], None, ["airflow_example_complex"]),
     ([("bash.py", BASH_DAG_FILE_CONTENTS)], None, ["airflow_example_bash_operator"]),
     (
-        [("complex.py", COMPLEX_DAG_FILE_CONTENTS), ("bash.py", BASH_DAG_FILE_CONTENTS)],
+        [
+            ("complex.py", COMPLEX_DAG_FILE_CONTENTS),
+            ("bash.py", BASH_DAG_FILE_CONTENTS),
+        ],
         None,
         ["airflow_example_complex", "airflow_example_bash_operator"],
     ),

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_solid_execution.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_solid_execution.py
@@ -8,16 +8,14 @@ from airflow.models.dag import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.dates import days_ago
-from dagster_airflow.dagster_pipeline_factory import (
-    make_dagster_pipeline_from_airflow_dag,
-)
+from dagster_airflow.dagster_pipeline_factory import make_dagster_pipeline_from_airflow_dag
 
 from dagster import DagsterEventType
 from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR
 from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.test_utils import instance_for_test
-from dagster._seven import get_current_datetime_in_utc
 from dagster._legacy import execute_pipeline
+from dagster._seven import get_current_datetime_in_utc
 
 default_args = {
     "owner": "dagster",

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_solid_execution.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_solid_execution.py
@@ -8,13 +8,16 @@ from airflow.models.dag import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.dates import days_ago
-from dagster_airflow.dagster_pipeline_factory import make_dagster_pipeline_from_airflow_dag
+from dagster_airflow.dagster_pipeline_factory import (
+    make_dagster_pipeline_from_airflow_dag,
+)
 
-from dagster import DagsterEventType, execute_pipeline
+from dagster import DagsterEventType
 from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR
 from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.test_utils import instance_for_test
 from dagster._seven import get_current_datetime_in_utc
+from dagster._legacy import execute_pipeline
 
 default_args = {
     "owner": "dagster",
@@ -231,7 +234,14 @@ def test_template_task_dag():
 
 
 def intercept_spark_submit(*args, **kwargs):
-    if args[0] == ["spark-submit", "--master", "", "--name", "airflow-spark", "some_path.py"]:
+    if args[0] == [
+        "spark-submit",
+        "--master",
+        "",
+        "--name",
+        "airflow-spark",
+        "some_path.py",
+    ]:
         m = mock.MagicMock()
         m.stdout.readline.return_value = ""
         m.wait.return_value = 0

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_tags.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_tags.py
@@ -4,16 +4,14 @@ import os
 from airflow.models.dag import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.utils.dates import days_ago
-from dagster_airflow.dagster_pipeline_factory import (
-    make_dagster_pipeline_from_airflow_dag,
-)
+from dagster_airflow.dagster_pipeline_factory import make_dagster_pipeline_from_airflow_dag
 
 from dagster import DagsterEventType
 from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR
 from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.test_utils import instance_for_test
-from dagster._seven import get_current_datetime_in_utc
 from dagster._legacy import execute_pipeline
+from dagster._seven import get_current_datetime_in_utc
 
 default_args = {
     "owner": "dagster",

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_tags.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_tags.py
@@ -4,13 +4,16 @@ import os
 from airflow.models.dag import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.utils.dates import days_ago
-from dagster_airflow.dagster_pipeline_factory import make_dagster_pipeline_from_airflow_dag
+from dagster_airflow.dagster_pipeline_factory import (
+    make_dagster_pipeline_from_airflow_dag,
+)
 
-from dagster import DagsterEventType, execute_pipeline
+from dagster import DagsterEventType
 from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR
 from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.test_utils import instance_for_test
 from dagster._seven import get_current_datetime_in_utc
+from dagster._legacy import execute_pipeline
 
 default_args = {
     "owner": "dagster",
@@ -96,7 +99,8 @@ def test_pipeline_tags():
         # When mode is default and tags are set, run with tags
         result = execute_pipeline(
             pipeline=make_dagster_pipeline_from_airflow_dag(
-                dag=dag, tags={AIRFLOW_EXECUTION_DATE_STR: EXECUTION_DATE_MINUS_WEEK_FMT}
+                dag=dag,
+                tags={AIRFLOW_EXECUTION_DATE_STR: EXECUTION_DATE_MINUS_WEEK_FMT},
             ),
             instance=instance,
         )

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecr_tests/test_resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecr_tests/test_resources.py
@@ -1,7 +1,7 @@
 from dagster_aws.ecr import fake_ecr_public_resource
 
-from dagster import ModeDefinition, execute_solid
-from dagster._legacy import solid
+from dagster import execute_solid
+from dagster._legacy import ModeDefinition, solid
 
 
 def test_ecr_public_get_login_password():

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/emr_tests/test_pyspark.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/emr_tests/test_pyspark.py
@@ -5,24 +5,28 @@ from unittest import mock
 
 import pytest
 from dagster_aws.emr import EmrError, EmrJobRunner
-from dagster_aws.emr.pyspark_step_launcher import EmrPySparkStepLauncher, emr_pyspark_step_launcher
+from dagster_aws.emr.pyspark_step_launcher import (
+    EmrPySparkStepLauncher,
+    emr_pyspark_step_launcher,
+)
 from dagster_aws.s3 import s3_resource
 from dagster_pyspark import DataFrame, pyspark_resource
 from moto import mock_emr
 from pyspark.sql import Row
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
-from dagster import (
+from dagster import reconstructable
+from dagster._core.definitions.no_step_launcher import no_step_launcher
+from dagster._core.errors import DagsterSubprocessError
+from dagster._core.test_utils import instance_for_test
+from dagster._legacy import (
     InputDefinition,
     ModeDefinition,
     OutputDefinition,
     execute_pipeline,
-    reconstructable,
+    pipeline,
+    solid,
 )
-from dagster._core.definitions.no_step_launcher import no_step_launcher
-from dagster._core.errors import DagsterSubprocessError
-from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
 from dagster._utils.merger import deep_merge_dicts
 from dagster._utils.test import create_test_pipeline_execution_context
 
@@ -44,7 +48,11 @@ BASE_EMR_PYSPARK_STEP_LAUNCHER_CONFIG = {
 )
 def make_df_solid(context):
     schema = StructType([StructField("name", StringType()), StructField("age", IntegerType())])
-    rows = [Row(name="John", age=19), Row(name="Jennifer", age=29), Row(name="Henry", age=50)]
+    rows = [
+        Row(name="John", age=19),
+        Row(name="Jennifer", age=29),
+        Row(name="Henry", age=50),
+    ]
     return context.resources.pyspark.spark_session.createDataFrame(rows, schema)
 
 
@@ -71,7 +79,10 @@ MODE_DEFS = [
     ),
     ModeDefinition(
         "local",
-        resource_defs={"pyspark_step_launcher": no_step_launcher, "pyspark": pyspark_resource},
+        resource_defs={
+            "pyspark_step_launcher": no_step_launcher,
+            "pyspark": pyspark_resource,
+        },
     ),
 ]
 
@@ -149,7 +160,10 @@ def test_pyspark_emr(mock_is_emr_step_complete, mock_read_events, mock_s3_bucket
                 "pyspark_step_launcher": {
                     "config": deep_merge_dicts(
                         BASE_EMR_PYSPARK_STEP_LAUNCHER_CONFIG,
-                        {"cluster_id": cluster_id, "staging_bucket": mock_s3_bucket.name},
+                        {
+                            "cluster_id": cluster_id,
+                            "staging_bucket": mock_s3_bucket.name,
+                        },
                     ),
                 }
             },
@@ -175,14 +189,17 @@ def sync_code():
     ]
     if (
         subprocess.call(
-            " ".join(sync_code_command), stdout=sys.stdout, stderr=sys.stderr, shell=True
+            " ".join(sync_code_command),
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            shell=True,
         )
         != 0
     ):
         raise DagsterSubprocessError("Failed to sync code to EMR")
 
     # Install dagster packages on remote node
-    remote_install_dagster_packages_command = ["sudo", "python3", "-m", "pip", "install"] + [
+    remote_install_dagster_packages_command = ["sudo", "python3", "-m", "pip", "install",] + [
         token
         for package_subpath in ["dagster", "libraries/dagster-pyspark"]
         for token in ["-e", "/home/hadoop/dagster/python_modules/" + package_subpath]

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/emr_tests/test_pyspark.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/emr_tests/test_pyspark.py
@@ -5,10 +5,7 @@ from unittest import mock
 
 import pytest
 from dagster_aws.emr import EmrError, EmrJobRunner
-from dagster_aws.emr.pyspark_step_launcher import (
-    EmrPySparkStepLauncher,
-    emr_pyspark_step_launcher,
-)
+from dagster_aws.emr.pyspark_step_launcher import EmrPySparkStepLauncher, emr_pyspark_step_launcher
 from dagster_aws.s3 import s3_resource
 from dagster_pyspark import DataFrame, pyspark_resource
 from moto import mock_emr

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/redshift_tests/test_resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/redshift_tests/test_resources.py
@@ -5,10 +5,14 @@ from unittest import mock
 import boto3
 import psycopg2
 import pytest
-from dagster_aws.redshift import FakeRedshiftResource, fake_redshift_resource, redshift_resource
+from dagster_aws.redshift import (
+    FakeRedshiftResource,
+    fake_redshift_resource,
+    redshift_resource,
+)
 
-from dagster import ModeDefinition, execute_solid
-from dagster._legacy import solid
+from dagster import execute_solid
+from dagster._legacy import ModeDefinition, solid
 
 REDSHIFT_ENV = {
     "resources": {

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/redshift_tests/test_resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/redshift_tests/test_resources.py
@@ -5,11 +5,7 @@ from unittest import mock
 import boto3
 import psycopg2
 import pytest
-from dagster_aws.redshift import (
-    FakeRedshiftResource,
-    fake_redshift_resource,
-    redshift_resource,
-)
+from dagster_aws.redshift import FakeRedshiftResource, fake_redshift_resource, redshift_resource
 
 from dagster import execute_solid
 from dagster._legacy import ModeDefinition, solid

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
@@ -11,7 +11,6 @@ from dagster import (
     StaticPartitionsDefinition,
     VersionStrategy,
     asset,
-    build_assets_job,
     graph,
     job,
     op,
@@ -19,6 +18,7 @@ from dagster import (
 )
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.test_utils import instance_for_test
+from dagster._legacy import build_assets_job
 
 
 @resource

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
@@ -8,17 +8,15 @@ from dagster_azure.adls2 import (
     adls2_file_manager,
 )
 
-from dagster import (
+from dagster import ResourceDefinition, build_op_context, configured, op
+from dagster._legacy import (
     InputDefinition,
     ModeDefinition,
     OutputDefinition,
-    ResourceDefinition,
-    build_op_context,
-    configured,
     execute_pipeline,
-    op,
+    pipeline,
+    solid,
 )
-from dagster._legacy import pipeline, solid
 
 # For deps
 
@@ -100,7 +98,10 @@ def create_adls2_key(run_id, step_key, output_name):
 def test_depends_on_adls2_resource_file_manager(storage_account, file_system):
     bar_bytes = b"bar"
 
-    @solid(output_defs=[OutputDefinition(ADLS2FileHandle)], required_resource_keys={"file_manager"})
+    @solid(
+        output_defs=[OutputDefinition(ADLS2FileHandle)],
+        required_resource_keys={"file_manager"},
+    )
     def emit_file(context):
         return context.resources.file_manager.write_data(bar_bytes)
 

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
@@ -4,10 +4,7 @@ import pytest
 from azure.storage.filedatalake import DataLakeLeaseClient
 from dagster_azure.adls2 import create_adls2_client
 from dagster_azure.adls2.fake_adls2_resource import fake_adls2_resource
-from dagster_azure.adls2.io_manager import (
-    PickledObjectADLS2IOManager,
-    adls2_pickle_io_manager,
-)
+from dagster_azure.adls2.io_manager import PickledObjectADLS2IOManager, adls2_pickle_io_manager
 from dagster_azure.adls2.resources import adls2_resource
 from dagster_azure.blob import create_blob_client
 

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
@@ -4,22 +4,20 @@ import pytest
 from azure.storage.filedatalake import DataLakeLeaseClient
 from dagster_azure.adls2 import create_adls2_client
 from dagster_azure.adls2.fake_adls2_resource import fake_adls2_resource
-from dagster_azure.adls2.io_manager import PickledObjectADLS2IOManager, adls2_pickle_io_manager
+from dagster_azure.adls2.io_manager import (
+    PickledObjectADLS2IOManager,
+    adls2_pickle_io_manager,
+)
 from dagster_azure.adls2.resources import adls2_resource
 from dagster_azure.blob import create_blob_client
 
 from dagster import (
-    AssetGroup,
     AssetIn,
     AssetKey,
     DagsterInstance,
     DynamicOutput,
-    DynamicOutputDefinition,
     GraphOut,
-    InputDefinition,
     Int,
-    OutputDefinition,
-    PipelineRun,
     asset,
     build_input_context,
     build_output_context,
@@ -34,6 +32,13 @@ from dagster._core.execution.api import execute_plan
 from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.utils import make_new_run_id
+from dagster._legacy import (
+    AssetGroup,
+    DynamicOutputDefinition,
+    InputDefinition,
+    OutputDefinition,
+    PipelineRun,
+)
 
 
 def fake_io_manager_factory(io_manager):
@@ -85,7 +90,10 @@ def test_adls2_pickle_io_manager_deletes_recursively(storage_account, file_syste
         "resources": {
             "io_manager": {"config": {"adls2_file_system": file_system}},
             "adls2": {
-                "config": {"storage_account": storage_account, "credential": {"key": credential}}
+                "config": {
+                    "storage_account": storage_account,
+                    "credential": {"key": credential},
+                }
             },
         }
     }
@@ -148,7 +156,10 @@ def test_adls2_pickle_io_manager_execution(storage_account, file_system, credent
         "resources": {
             "io_manager": {"config": {"adls2_file_system": file_system}},
             "adls2": {
-                "config": {"storage_account": storage_account, "credential": {"key": credential}}
+                "config": {
+                    "storage_account": storage_account,
+                    "credential": {"key": credential},
+                }
             },
         }
     }
@@ -242,7 +253,8 @@ def test_asset_io_manager(storage_account, file_system, credential):
         return asset3 + 1
 
     @asset(
-        name=f"downstream_{_id}", ins={"upstream": AssetIn(asset_key=AssetKey([f"upstream_{_id}"]))}
+        name=f"downstream_{_id}",
+        ins={"upstream": AssetIn(asset_key=AssetKey([f"upstream_{_id}"]))},
     )
     def downstream(upstream):
         assert upstream == 7
@@ -258,7 +270,10 @@ def test_asset_io_manager(storage_account, file_system, credential):
         "resources": {
             "io_manager": {"config": {"adls2_file_system": file_system}},
             "adls2": {
-                "config": {"storage_account": storage_account, "credential": {"key": credential}}
+                "config": {
+                    "storage_account": storage_account,
+                    "credential": {"key": credential},
+                }
             },
         }
     }

--- a/python_modules/libraries/dagster-celery-docker/dagster_celery_docker_tests/test_execute_docker.py
+++ b/python_modules/libraries/dagster-celery-docker/dagster_celery_docker_tests/test_execute_docker.py
@@ -11,11 +11,10 @@ from dagster_test.test_project import (
     get_test_project_environments_path,
     get_test_project_recon_pipeline,
 )
-
-from dagster import execute_pipeline
 from dagster._utils import merge_dicts
 from dagster._utils.test.postgres_instance import postgres_instance_for_test
 from dagster._utils.yaml_utils import merge_yamls
+from dagster._legacy import execute_pipeline
 
 IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 

--- a/python_modules/libraries/dagster-celery-docker/dagster_celery_docker_tests/test_execute_docker.py
+++ b/python_modules/libraries/dagster-celery-docker/dagster_celery_docker_tests/test_execute_docker.py
@@ -11,10 +11,11 @@ from dagster_test.test_project import (
     get_test_project_environments_path,
     get_test_project_recon_pipeline,
 )
+
+from dagster._legacy import execute_pipeline
 from dagster._utils import merge_dicts
 from dagster._utils.test.postgres_instance import postgres_instance_for_test
 from dagster._utils.yaml_utils import merge_yamls
-from dagster._legacy import execute_pipeline
 
 IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/repo.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/repo.py
@@ -2,20 +2,17 @@ import time
 
 from dagster_celery import celery_executor
 
-from dagster import (
-    InputDefinition,
-    Int,
-    ModeDefinition,
-    Output,
-    OutputDefinition,
-    RetryRequested,
-    VersionStrategy,
-    default_executors,
-    fs_io_manager,
-    lambda_solid,
-)
+from dagster import Int, Output, RetryRequested, VersionStrategy, fs_io_manager
 from dagster._core.test_utils import nesting_composite_pipeline
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    default_executors,
+    lambda_solid,
+    pipeline,
+    solid,
+)
 
 celery_mode_defs = [
     ModeDefinition(

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_execute.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_execute.py
@@ -7,9 +7,17 @@ from unittest import mock
 
 import pytest
 from dagster_celery_tests.repo import COMPOSITE_DEPTH
+
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.errors import DagsterSubprocessError
 from dagster._core.events import DagsterEventType
+from dagster._legacy import (
+    CompositeSolidExecutionResult,
+    PipelineExecutionResult,
+    SolidExecutionResult,
+    execute_pipeline,
+    execute_pipeline_iterator,
+)
 from dagster._utils import send_interrupt
 
 from .utils import (  # isort:skip
@@ -17,13 +25,6 @@ from .utils import (  # isort:skip
     execute_pipeline_on_celery,
     events_of_type,
     REPO_FILE,
-)
-from dagster._legacy import (
-    CompositeSolidExecutionResult,
-    PipelineExecutionResult,
-    SolidExecutionResult,
-    execute_pipeline,
-    execute_pipeline_iterator,
 )
 
 

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_execute.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_execute.py
@@ -7,14 +7,6 @@ from unittest import mock
 
 import pytest
 from dagster_celery_tests.repo import COMPOSITE_DEPTH
-
-from dagster import (
-    CompositeSolidExecutionResult,
-    PipelineExecutionResult,
-    SolidExecutionResult,
-    execute_pipeline,
-    execute_pipeline_iterator,
-)
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.errors import DagsterSubprocessError
 from dagster._core.events import DagsterEventType
@@ -25,6 +17,13 @@ from .utils import (  # isort:skip
     execute_pipeline_on_celery,
     events_of_type,
     REPO_FILE,
+)
+from dagster._legacy import (
+    CompositeSolidExecutionResult,
+    PipelineExecutionResult,
+    SolidExecutionResult,
+    execute_pipeline,
+    execute_pipeline_iterator,
 )
 
 
@@ -169,12 +168,14 @@ def test_execute_eagerly_on_celery(instance):
             if dagster_event and dagster_event.is_engine_event:
                 if dagster_event.engine_event_data.marker_start:
                     key = "{step}.{marker}".format(
-                        step=event.step_key, marker=dagster_event.engine_event_data.marker_start
+                        step=event.step_key,
+                        marker=dagster_event.engine_event_data.marker_start,
                     )
                     start_markers[key] = event.timestamp
                 if dagster_event.engine_event_data.marker_end:
                     key = "{step}.{marker}".format(
-                        step=event.step_key, marker=dagster_event.engine_event_data.marker_end
+                        step=event.step_key,
+                        marker=dagster_event.engine_event_data.marker_end,
                     )
                     end_markers[key] = event.timestamp
 

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_priority.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_priority.py
@@ -7,12 +7,11 @@ from collections import OrderedDict
 
 from dagster_celery import celery_executor
 from dagster_celery.tags import DAGSTER_CELERY_RUN_PRIORITY_TAG
-
-from dagster import ModeDefinition, default_executors
 from dagster._core.storage.pipeline_run import RunsFilter
 from dagster._core.test_utils import instance_for_test
 
 from .utils import execute_eagerly_on_celery, execute_on_thread, start_celery_worker
+from dagster._legacy import ModeDefinition, default_executors
 
 celery_mode_defs = [ModeDefinition(executor_defs=default_executors + [celery_executor])]
 
@@ -45,7 +44,10 @@ def test_run_priority_pipeline(rabbitmq):
             low_thread = threading.Thread(
                 target=execute_on_thread,
                 args=("low_pipeline", low_done, instance.get_ref()),
-                kwargs={"tempdir": tempdir, "tags": {DAGSTER_CELERY_RUN_PRIORITY_TAG: "-3"}},
+                kwargs={
+                    "tempdir": tempdir,
+                    "tags": {DAGSTER_CELERY_RUN_PRIORITY_TAG: "-3"},
+                },
             )
             low_thread.daemon = True
             low_thread.start()
@@ -56,7 +58,10 @@ def test_run_priority_pipeline(rabbitmq):
             hi_thread = threading.Thread(
                 target=execute_on_thread,
                 args=("hi_pipeline", hi_done, instance.get_ref()),
-                kwargs={"tempdir": tempdir, "tags": {DAGSTER_CELERY_RUN_PRIORITY_TAG: "3"}},
+                kwargs={
+                    "tempdir": tempdir,
+                    "tags": {DAGSTER_CELERY_RUN_PRIORITY_TAG: "3"},
+                },
             )
             hi_thread.daemon = True
             hi_thread.start()

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_priority.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_priority.py
@@ -7,11 +7,12 @@ from collections import OrderedDict
 
 from dagster_celery import celery_executor
 from dagster_celery.tags import DAGSTER_CELERY_RUN_PRIORITY_TAG
+
 from dagster._core.storage.pipeline_run import RunsFilter
 from dagster._core.test_utils import instance_for_test
+from dagster._legacy import ModeDefinition, default_executors
 
 from .utils import execute_eagerly_on_celery, execute_on_thread, start_celery_worker
-from dagster._legacy import ModeDefinition, default_executors
 
 celery_mode_defs = [ModeDefinition(executor_defs=default_executors + [celery_executor])]
 

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_queues.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_queues.py
@@ -2,11 +2,10 @@ import threading
 import time
 
 from dagster_celery import celery_executor
-
-from dagster import ModeDefinition, default_executors
 from dagster._core.test_utils import instance_for_test
 
 from .utils import execute_on_thread, start_celery_worker
+from dagster._legacy import ModeDefinition, default_executors
 
 celery_mode_defs = [ModeDefinition(executor_defs=default_executors + [celery_executor])]
 
@@ -17,7 +16,8 @@ def test_multiqueue(rabbitmq):  # pylint: disable=unused-argument
         done = threading.Event()
         with start_celery_worker():
             execute_thread = threading.Thread(
-                target=execute_on_thread, args=("multiqueue_pipeline", done, instance.get_ref())
+                target=execute_on_thread,
+                args=("multiqueue_pipeline", done, instance.get_ref()),
             )
             execute_thread.daemon = True
             execute_thread.start()

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_queues.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_queues.py
@@ -2,10 +2,11 @@ import threading
 import time
 
 from dagster_celery import celery_executor
+
 from dagster._core.test_utils import instance_for_test
+from dagster._legacy import ModeDefinition, default_executors
 
 from .utils import execute_on_thread, start_celery_worker
-from dagster._legacy import ModeDefinition, default_executors
 
 celery_mode_defs = [ModeDefinition(executor_defs=default_executors + [celery_executor])]
 

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/utils.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/utils.py
@@ -3,11 +3,10 @@ import signal
 import subprocess
 import tempfile
 from contextlib import contextmanager
-
-from dagster import execute_pipeline
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.instance import DagsterInstance
 from dagster._core.test_utils import instance_for_test
+from dagster._legacy import execute_pipeline
 
 BUILDKITE = os.getenv("BUILDKITE")
 

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/utils.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/utils.py
@@ -3,6 +3,7 @@ import signal
 import subprocess
 import tempfile
 from contextlib import contextmanager
+
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.instance import DagsterInstance
 from dagster._core.test_utils import instance_for_test

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_data_frame.py
@@ -5,8 +5,8 @@ from dagster_dask.data_frame import DataFrameReadTypes, DataFrameToTypes
 from dagster_dask.utils import DataFrameUtilities
 from dask.dataframe.utils import assert_eq
 
-from dagster import InputDefinition, execute_solid, file_relative_path
-from dagster._legacy import solid
+from dagster import execute_solid, file_relative_path
+from dagster._legacy import InputDefinition, solid
 
 
 def create_dask_df():

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_execute.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_execute.py
@@ -10,11 +10,7 @@ from dask.distributed import Scheduler, Worker
 
 from dagster import (
     DagsterUnmetExecutorRequirementsError,
-    InputDefinition,
-    ModeDefinition,
     VersionStrategy,
-    execute_pipeline,
-    execute_pipeline_iterator,
     file_relative_path,
     fs_io_manager,
     job,
@@ -25,7 +21,14 @@ from dagster._core.definitions.executor_definition import default_executors
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.events import DagsterEventType
 from dagster._core.test_utils import instance_for_test, nesting_composite_pipeline
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    execute_pipeline,
+    execute_pipeline_iterator,
+    pipeline,
+    solid,
+)
 from dagster._utils import send_interrupt
 
 

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_resources.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_resources.py
@@ -1,9 +1,15 @@
 from dagster_dask import dask_resource
 from dask.distributed import Client
 
-from dagster import Dict, ModeDefinition, Output, OutputDefinition, execute_pipeline
+from dagster import Dict, Output
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    ModeDefinition,
+    OutputDefinition,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 @solid(

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_resources.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_resources.py
@@ -3,13 +3,7 @@ from dask.distributed import Client
 
 from dagster import Dict, Output
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import (
-    ModeDefinition,
-    OutputDefinition,
-    execute_pipeline,
-    pipeline,
-    solid,
-)
+from dagster._legacy import ModeDefinition, OutputDefinition, execute_pipeline, pipeline, solid
 
 
 @solid(

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
@@ -1,8 +1,8 @@
 import dask.dataframe as dd
 from dagster_dask import DataFrame
 
-from dagster import InputDefinition, execute_solid, file_relative_path
-from dagster._legacy import solid
+from dagster import execute_solid, file_relative_path
+from dagster._legacy import InputDefinition, solid
 
 
 @solid(input_defs=[InputDefinition(dagster_type=DataFrame, name="input_df")])

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/solids.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/solids.py
@@ -1,7 +1,7 @@
-from dagster import Field, InputDefinition, Nothing, OutputDefinition, Permissive
+from dagster import Field, Nothing, Permissive
 from dagster import _check as check
 from dagster import op
-from dagster._legacy import solid
+from dagster._legacy import InputDefinition, OutputDefinition, solid
 
 from .databricks import wait_for_run_to_complete
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
@@ -15,17 +15,17 @@ from dagster_pyspark import DataFrame, pyspark_resource
 from pyspark.sql import Row
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
-from dagster import (
+from dagster import fs_io_manager, reconstructable
+from dagster._core.definitions.no_step_launcher import no_step_launcher
+from dagster._core.test_utils import instance_for_test
+from dagster._legacy import (
     InputDefinition,
     ModeDefinition,
     OutputDefinition,
     execute_pipeline,
-    fs_io_manager,
-    reconstructable,
+    pipeline,
+    solid,
 )
-from dagster._core.definitions.no_step_launcher import no_step_launcher
-from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
 from dagster._utils.merger import deep_merge_dicts
 
 S3_BUCKET = "dagster-databricks-tests"
@@ -78,7 +78,11 @@ BASE_DATABRICKS_PYSPARK_STEP_LAUNCHER_CONFIG: Dict[str, object] = {
 )
 def make_df_solid(context):
     schema = StructType([StructField("name", StringType()), StructField("age", IntegerType())])
-    rows = [Row(name="John", age=19), Row(name="Jennifer", age=29), Row(name="Henry", age=50)]
+    rows = [
+        Row(name="John", age=19),
+        Row(name="Jennifer", age=29),
+        Row(name="Henry", age=50),
+    ]
     return context.resources.pyspark.spark_session.createDataFrame(rows, schema)
 
 
@@ -123,7 +127,10 @@ MODE_DEFS = [
     ),
     ModeDefinition(
         "local",
-        resource_defs={"pyspark_step_launcher": no_step_launcher, "pyspark": pyspark_resource},
+        resource_defs={
+            "pyspark_step_launcher": no_step_launcher,
+            "pyspark": pyspark_resource,
+        },
     ),
 ]
 
@@ -189,7 +196,9 @@ def test_pyspark_databricks(
 
     with instance_for_test() as instance:
         result = execute_pipeline(
-            pipeline=reconstructable(define_do_nothing_pipe), mode="local", instance=instance
+            pipeline=reconstructable(define_do_nothing_pipe),
+            mode="local",
+            instance=instance,
         )
         mock_get_step_events.return_value = [
             event
@@ -277,7 +286,10 @@ def test_do_it_live_databricks_s3():
             "resources": {
                 "pyspark_step_launcher": {"config": BASE_DATABRICKS_PYSPARK_STEP_LAUNCHER_CONFIG},
                 "io_manager": {
-                    "config": {"s3_bucket": "elementl-databricks", "s3_prefix": "dagster-test"}
+                    "config": {
+                        "s3_bucket": "elementl-databricks",
+                        "s3_prefix": "dagster-test",
+                    }
                 },
             },
         },

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_solids.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_solids.py
@@ -8,10 +8,8 @@ from dagster_databricks import (
 )
 from dagster_databricks.databricks import DatabricksRunState
 from dagster_databricks.solids import create_ui_url
-from dagster_databricks.types import (
-    DatabricksRunLifeCycleState,
-    DatabricksRunResultState,
-)
+from dagster_databricks.types import DatabricksRunLifeCycleState, DatabricksRunResultState
+
 from dagster._legacy import ModeDefinition, execute_pipeline, pipeline
 
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_solids.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_solids.py
@@ -8,10 +8,11 @@ from dagster_databricks import (
 )
 from dagster_databricks.databricks import DatabricksRunState
 from dagster_databricks.solids import create_ui_url
-from dagster_databricks.types import DatabricksRunLifeCycleState, DatabricksRunResultState
-
-from dagster import ModeDefinition, execute_pipeline
-from dagster._legacy import pipeline
+from dagster_databricks.types import (
+    DatabricksRunLifeCycleState,
+    DatabricksRunResultState,
+)
+from dagster._legacy import ModeDefinition, execute_pipeline, pipeline
 
 
 @pytest.mark.parametrize("job_creator", [create_databricks_job_solid, create_databricks_job_op])

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/solids.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/solids.py
@@ -1,17 +1,7 @@
-from dagster import (
-    Array,
-    Bool,
-    InputDefinition,
-    Noneable,
-    Nothing,
-    Output,
-    OutputDefinition,
-    Permissive,
-    StringSource,
-)
+from dagster import Array, Bool, Noneable, Nothing, Output, Permissive, StringSource
 from dagster._annotations import experimental
 from dagster._config.field import Field
-from dagster._legacy import solid
+from dagster._legacy import InputDefinition, OutputDefinition, solid
 
 from ..utils import generate_materializations
 from .constants import (
@@ -22,7 +12,10 @@ from .constants import (
 from .types import DbtCliOutput
 from .utils import execute_cli
 
-CLI_CONFIG_SCHEMA = {**CLI_COMMON_FLAGS_CONFIG_SCHEMA, **CLI_COMMON_OPTIONS_CONFIG_SCHEMA}
+CLI_CONFIG_SCHEMA = {
+    **CLI_COMMON_FLAGS_CONFIG_SCHEMA,
+    **CLI_COMMON_OPTIONS_CONFIG_SCHEMA,
+}
 CLI_COMMON_FLAGS = set(CLI_COMMON_FLAGS_CONFIG_SCHEMA.keys())
 
 
@@ -107,7 +100,8 @@ def dbt_cli_run(context):
         context.solid_config["dbt_executable"],
         command="run",
         flags_dict=passthrough_flags_only(
-            context.solid_config, ("threads", "models", "exclude", "full-refresh", "fail-fast")
+            context.solid_config,
+            ("threads", "models", "exclude", "full-refresh", "fail-fast"),
         ),
         log=context.log,
         warn_error=context.solid_config["warn-error"],
@@ -191,7 +185,8 @@ def dbt_cli_test(context):
         context.solid_config["dbt_executable"],
         command="test",
         flags_dict=passthrough_flags_only(
-            context.solid_config, ("data", "schema", "fail-fast", "threads", "models", "exclude")
+            context.solid_config,
+            ("data", "schema", "fail-fast", "threads", "models", "exclude"),
         ),
         log=context.log,
         warn_error=context.solid_config["warn-error"],

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/solids.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/solids.py
@@ -11,19 +11,17 @@ from dagster import (
     DagsterInvalidDefinitionError,
     Failure,
     Field,
-    InputDefinition,
     Int,
     Noneable,
     Nothing,
     Output,
-    OutputDefinition,
     Permissive,
     RetryRequested,
     String,
 )
 from dagster import _check as check
 from dagster._core.execution.context.compute import SolidExecutionContext
-from dagster._legacy import solid
+from dagster._legacy import InputDefinition, OutputDefinition, solid
 
 from ..errors import DagsterDbtRpcUnexpectedPollOutputError
 from .types import DbtRpcOutput
@@ -31,7 +29,9 @@ from .utils import log_rpc, raise_for_rpc_error
 
 
 def _poll_rpc(
-    context: SolidExecutionContext, request_token: str, should_yield_materializations: bool = True
+    context: SolidExecutionContext,
+    request_token: str,
+    should_yield_materializations: bool = True,
 ):
     """Polls the dbt RPC server for the status of a request until the state is ``success``."""
     from ..utils import generate_materializations
@@ -46,7 +46,9 @@ def _poll_rpc(
         # Poll for the dbt RPC request.
         context.log.debug(f"RequestToken: {request_token}")
         out = context.resources.dbt_rpc.poll(
-            request_token=request_token, logs=context.solid_config["logs"], logs_start=logs_start
+            request_token=request_token,
+            logs=context.solid_config["logs"],
+            logs_start=logs_start,
         )
         raise_for_rpc_error(context, out.response)
 
@@ -876,7 +878,9 @@ def create_dbt_rpc_run_sql_solid(
         output_defs=[
             output_def
             or OutputDefinition(
-                name="df", description="The results of the SQL query.", dagster_type=DataFrame
+                name="df",
+                description="The results of the SQL query.",
+                dagster_type=DataFrame,
             )
         ],
         config_schema={

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources.py
@@ -1,9 +1,7 @@
 import json
 
 from dagster_dbt import dbt_cli_resource
-
-from dagster import build_solid_context
-from dagster._legacy import solid
+from dagster._legacy import build_solid_context, solid
 
 
 def get_dbt_resource(project_dir, profiles_dir, **kwargs):

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources.py
@@ -1,6 +1,7 @@
 import json
 
 from dagster_dbt import dbt_cli_resource
+
 from dagster._legacy import build_solid_context, solid
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
@@ -9,8 +9,8 @@ from dagster_dbt import (
     local_dbt_rpc_resource,
 )
 
-from dagster import ModeDefinition, execute_solid
-from dagster._legacy import solid
+from dagster import execute_solid
+from dagster._legacy import ModeDefinition, solid
 
 
 def test_url(client):
@@ -164,7 +164,9 @@ def test_dbt_rpc_resource_status(
     assert isinstance(result.output_value("result"), DbtRpcOutput)
 
 
-def test_dbt_rpc_resource_is_not_waiting(dbt_rpc_server):  # pylint: disable=unused-argument
+def test_dbt_rpc_resource_is_not_waiting(
+    dbt_rpc_server,
+):  # pylint: disable=unused-argument
     @solid(required_resource_keys={"dbt_rpc"})
     def cli_solid(context):
         assert isinstance(context.resources.dbt_rpc, DbtRpcResource)
@@ -187,7 +189,9 @@ def test_dbt_rpc_resource_is_not_waiting(dbt_rpc_server):  # pylint: disable=unu
     assert "request_token" in response
 
 
-def test_dbt_rpc_sync_resource_is_waiting(dbt_rpc_server):  # pylint: disable=unused-argument
+def test_dbt_rpc_sync_resource_is_waiting(
+    dbt_rpc_server,
+):  # pylint: disable=unused-argument
     @solid(required_resource_keys={"dbt_rpc"})
     def cli_solid(context):
         assert isinstance(context.resources.dbt_rpc, DbtRpcSyncResource)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_solids_i.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_solids_i.py
@@ -12,17 +12,13 @@ from dagster_dbt import (
 )
 from mock import MagicMock
 
-from dagster import (
-    AssetKey,
-    DagsterInstance,
+from dagster import AssetKey, DagsterInstance, configured, execute_solid, resource
+from dagster._legacy import (
     ModeDefinition,
     PipelineDefinition,
     SolidDefinition,
     SolidExecutionResult,
-    configured,
     execute_pipeline,
-    execute_solid,
-    resource,
 )
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_solids_ii.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_solids_ii.py
@@ -18,7 +18,8 @@ from dagster_dbt import (
     dbt_rpc_test_and_wait,
 )
 
-from dagster import ModeDefinition, execute_solid
+from dagster import execute_solid
+from dagster._legacy import ModeDefinition
 
 
 def test_dbt_rpc_snapshot(rsps):

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -5,12 +5,17 @@ from unittest.mock import MagicMock
 import psycopg2
 import pytest
 from dagster_dbt import dbt_cli_resource
-from dagster_dbt.asset_defs import load_assets_from_dbt_manifest, load_assets_from_dbt_project
-from dagster_dbt.errors import DagsterDbtCliFatalRuntimeError, DagsterDbtCliHandledRuntimeError
+from dagster_dbt.asset_defs import (
+    load_assets_from_dbt_manifest,
+    load_assets_from_dbt_project,
+)
+from dagster_dbt.errors import (
+    DagsterDbtCliFatalRuntimeError,
+    DagsterDbtCliHandledRuntimeError,
+)
 from dagster_dbt.types import DbtOutput
 
 from dagster import (
-    AssetGroup,
     AssetIn,
     AssetKey,
     IOManager,
@@ -22,6 +27,7 @@ from dagster import (
 )
 from dagster._core.definitions import build_assets_job
 from dagster._utils import file_relative_path
+from dagster._legacy import AssetGroup
 
 
 @pytest.mark.parametrize(
@@ -485,7 +491,10 @@ def test_node_info_to_asset_key(
         ),
         ("*hanger2", "hanger2,subdir_schema/least_caloric,sort_by_calories"),
         (
-            ["cold_schema/sort_cold_cereals_by_calories", "subdir_schema/least_caloric"],
+            [
+                "cold_schema/sort_cold_cereals_by_calories",
+                "subdir_schema/least_caloric",
+            ],
             "cold_schema/sort_cold_cereals_by_calories,subdir_schema/least_caloric",
         ),
     ],
@@ -619,7 +628,10 @@ def test_dbt_selects(
 
 @pytest.mark.parametrize(
     "select,error_match",
-    [("tag:nonexist", "No dbt models match"), ("asjdlhalskujh:z", "not a valid method name")],
+    [
+        ("tag:nonexist", "No dbt models match"),
+        ("asjdlhalskujh:z", "not a valid method name"),
+    ],
 )
 def test_static_select_invalid_selection(select, error_match):
     manifest_path = file_relative_path(__file__, "sample_manifest.json")
@@ -634,7 +646,10 @@ def test_source_key_prefix(
     conn_string, test_python_project_dir, dbt_python_config_dir
 ):  # pylint: disable=unused-argument
     dbt_assets = load_assets_from_dbt_project(
-        test_python_project_dir, dbt_python_config_dir, key_prefix="dbt", source_key_prefix="source"
+        test_python_project_dir,
+        dbt_python_config_dir,
+        key_prefix="dbt",
+        source_key_prefix="source",
     )
     assert dbt_assets[0].keys_by_input_name == {
         "source_dagster_dbt_python_test_project_dagster_bot_labeled_users": AssetKey(
@@ -691,7 +706,8 @@ def test_python_interleaving(
                         f'CREATE TABLE IF NOT EXISTS "test-python-schema"."{table}" (user_id integer, is_bot bool)'
                     )
                     cur.executemany(
-                        f'INSERT INTO "test-python-schema"."{table}"' + " VALUES(%s,%s)", obj
+                        f'INSERT INTO "test-python-schema"."{table}"' + " VALUES(%s,%s)",
+                        obj,
                     )
                     conn.commit()
                     cur.close()
@@ -729,7 +745,10 @@ def test_python_interleaving(
         resource_defs={
             "io_manager": test_io_manager,
             "dbt": dbt_cli_resource.configured(
-                {"project_dir": test_python_project_dir, "profiles_dir": dbt_python_config_dir}
+                {
+                    "project_dir": test_python_project_dir,
+                    "profiles_dir": dbt_python_config_dir,
+                }
             ),
         },
     ).build_job("interleave_job")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -5,14 +5,8 @@ from unittest.mock import MagicMock
 import psycopg2
 import pytest
 from dagster_dbt import dbt_cli_resource
-from dagster_dbt.asset_defs import (
-    load_assets_from_dbt_manifest,
-    load_assets_from_dbt_project,
-)
-from dagster_dbt.errors import (
-    DagsterDbtCliFatalRuntimeError,
-    DagsterDbtCliHandledRuntimeError,
-)
+from dagster_dbt.asset_defs import load_assets_from_dbt_manifest, load_assets_from_dbt_project
+from dagster_dbt.errors import DagsterDbtCliFatalRuntimeError, DagsterDbtCliHandledRuntimeError
 from dagster_dbt.types import DbtOutput
 
 from dagster import (
@@ -26,8 +20,8 @@ from dagster import (
     repository,
 )
 from dagster._core.definitions import build_assets_job
-from dagster._utils import file_relative_path
 from dagster._legacy import AssetGroup
+from dagster._utils import file_relative_path
 
 
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
@@ -4,7 +4,7 @@ from dagster_fivetran import fivetran_resource
 from dagster_fivetran.asset_defs import build_fivetran_assets
 from dagster_fivetran.resources import FIVETRAN_API_BASE, FIVETRAN_CONNECTOR_PATH
 
-from dagster import AssetKey, DagsterStepOutputNotFoundError, build_assets_job
+from dagster import AssetKey, DagsterStepOutputNotFoundError
 
 from .utils import (
     DEFAULT_CONNECTOR_ID,
@@ -13,6 +13,7 @@ from .utils import (
     get_sample_sync_response,
     get_sample_update_response,
 )
+from dagster._legacy import build_assets_job
 
 
 def test_fivetran_asset_keys():

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
@@ -5,6 +5,7 @@ from dagster_fivetran.asset_defs import build_fivetran_assets
 from dagster_fivetran.resources import FIVETRAN_API_BASE, FIVETRAN_CONNECTOR_PATH
 
 from dagster import AssetKey, DagsterStepOutputNotFoundError
+from dagster._legacy import build_assets_job
 
 from .utils import (
     DEFAULT_CONNECTOR_ID,
@@ -13,7 +14,6 @@ from .utils import (
     get_sample_sync_response,
     get_sample_update_response,
 )
-from dagster._legacy import build_assets_job
 
 
 def test_fivetran_asset_keys():

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/ops.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/ops.py
@@ -4,10 +4,10 @@ from dagster_pandas import DataFrame
 from google.cloud.bigquery.job import LoadJobConfig, QueryJobConfig
 from google.cloud.bigquery.table import EncryptionConfiguration, TimePartitioning
 
-from dagster import InputDefinition, List, Nothing, OutputDefinition
+from dagster import List, Nothing
 from dagster import _check as check
 from dagster import op
-from dagster._legacy import solid
+from dagster._legacy import InputDefinition, OutputDefinition, solid
 
 from .configs import (
     define_bigquery_create_dataset_config,

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_ops.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_ops.py
@@ -20,17 +20,10 @@ from dagster_pandas import DataFrame
 from google.cloud import bigquery  # type: ignore
 from google.cloud.exceptions import NotFound
 
-from dagster import (
-    DagsterExecutionStepExecutionError,
-    InputDefinition,
-    List,
-    Nothing,
-    OutputDefinition,
-    job,
-    op,
-)
+from dagster import DagsterExecutionStepExecutionError, List, Nothing, job, op
 from dagster._config import process_config, validate_config
 from dagster._core.definitions import create_run_config_schema
+from dagster._legacy import InputDefinition, OutputDefinition
 
 
 def dataset_exists(name):
@@ -209,7 +202,10 @@ def test_pd_df_load():
     query_op = bq_op_for_queries(["SELECT num1, num2 FROM %s" % table]).alias("query_op")
     delete_op = bq_delete_dataset.alias("delete_op")
 
-    @op(input_defs=[InputDefinition("success", Nothing)], output_defs=[OutputDefinition(DataFrame)])
+    @op(
+        input_defs=[InputDefinition("success", Nothing)],
+        output_defs=[OutputDefinition(DataFrame)],
+    )
     def return_df(_context):  # pylint: disable=unused-argument
         return test_df
 
@@ -277,7 +273,10 @@ def test_gcs_load():
     ).alias("query_op")
     delete_op = bq_delete_dataset.alias("delete_op")
 
-    @op(input_defs=[InputDefinition("success", Nothing)], output_defs=[OutputDefinition(List[str])])
+    @op(
+        input_defs=[InputDefinition("success", Nothing)],
+        output_defs=[OutputDefinition(List[str])],
+    )
     def return_gcs_uri(_context):  # pylint: disable=unused-argument
         return ["gs://cloud-samples-data/bigquery/us-states/us-states.csv"]
 
@@ -307,6 +306,9 @@ def test_gcs_load():
     assert result.success
 
     values = result.output_for_node("query_op")
-    assert values[0].to_dict() == {"string_field_0": {0: "Alabama"}, "string_field_1": {0: "AL"}}
+    assert values[0].to_dict() == {
+        "string_field_0": {0: "Alabama"},
+        "string_field_1": {0: "AL"},
+    }
 
     assert not dataset_exists(dataset)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_io_manager.py
@@ -4,7 +4,6 @@ from dagster_gcp.gcs.resources import gcs_resource
 from google.cloud import storage  # type: ignore
 
 from dagster import (
-    AssetGroup,
     AssetsDefinition,
     DagsterInstance,
     DynamicOut,
@@ -14,7 +13,6 @@ from dagster import (
     In,
     Int,
     Out,
-    PipelineRun,
     ResourceDefinition,
     StaticPartitionsDefinition,
     asset,
@@ -32,6 +30,7 @@ from dagster._core.execution.plan.outputs import StepOutputHandle
 from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.utils import make_new_run_id
+from dagster._legacy import AssetGroup, PipelineRun
 
 
 @resource

--- a/python_modules/libraries/dagster-ge/dagster_ge/factory.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge/factory.py
@@ -5,14 +5,7 @@ from dagster_pandas import DataFrame
 from great_expectations.render.renderer import ValidationResultsPageRenderer
 from great_expectations.render.view import DefaultMarkdownPageView
 
-from dagster import (
-    ExpectationResult,
-    MetadataEntry,
-    MetadataValue,
-    Noneable,
-    Output,
-    StringSource,
-)
+from dagster import ExpectationResult, MetadataEntry, MetadataValue, Noneable, Output, StringSource
 from dagster import _check as check
 from dagster import op, resource
 from dagster._legacy import InputDefinition, OutputDefinition, solid

--- a/python_modules/libraries/dagster-ge/dagster_ge/factory.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge/factory.py
@@ -7,17 +7,15 @@ from great_expectations.render.view import DefaultMarkdownPageView
 
 from dagster import (
     ExpectationResult,
-    InputDefinition,
     MetadataEntry,
     MetadataValue,
     Noneable,
     Output,
-    OutputDefinition,
     StringSource,
 )
 from dagster import _check as check
 from dagster import op, resource
-from dagster._legacy import solid
+from dagster._legacy import InputDefinition, OutputDefinition, solid
 
 try:
     # ge < v0.13.0

--- a/python_modules/libraries/dagster-ge/dagster_ge_tests/test_basic_integ.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge_tests/test_basic_integ.py
@@ -10,9 +10,15 @@ from dagster_pyspark import DataFrame as DagsterPySparkDataFrame
 from dagster_pyspark import pyspark_resource
 from pandas import read_csv
 
-from dagster import InputDefinition, ModeDefinition, Output, execute_pipeline, reconstructable
+from dagster import Output, reconstructable
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 from dagster._utils import file_relative_path
 
 
@@ -65,7 +71,11 @@ def hello_world_pandas_pipeline_v3():
 @pipeline(
     mode_defs=[
         ModeDefinition(
-            "basic", resource_defs={"ge_data_context": ge_data_context, "pyspark": pyspark_resource}
+            "basic",
+            resource_defs={
+                "ge_data_context": ge_data_context,
+                "pyspark": pyspark_resource,
+            },
         )
     ],
 )

--- a/python_modules/libraries/dagster-ge/dagster_ge_tests/test_basic_integ.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge_tests/test_basic_integ.py
@@ -12,13 +12,7 @@ from pandas import read_csv
 
 from dagster import Output, reconstructable
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import (
-    InputDefinition,
-    ModeDefinition,
-    execute_pipeline,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, ModeDefinition, execute_pipeline, pipeline, solid
 from dagster._utils import file_relative_path
 
 

--- a/python_modules/libraries/dagster-github/dagster_github_tests/test_resources.py
+++ b/python_modules/libraries/dagster-github/dagster_github_tests/test_resources.py
@@ -8,8 +8,8 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from dagster_github import github_resource
 from dagster_github.resources import GithubResource
 
-from dagster import ModeDefinition, execute_solid
-from dagster._legacy import solid
+from dagster import execute_solid
+from dagster._legacy import ModeDefinition, solid
 
 FAKE_PRIVATE_RSA_KEY = (
     rsa.generate_private_key(public_exponent=65537, key_size=1024, backend=default_backend())

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
@@ -6,21 +6,21 @@ import pytest
 from dagster_k8s.container_context import K8sContainerContext
 from dagster_k8s.executor import K8sStepHandler, k8s_job_executor
 from dagster_k8s.job import UserDefinedDagsterK8sConfig
-
-from dagster import PipelineDefinition, execute_pipeline
 from dagster._core.definitions.mode import ModeDefinition
 from dagster._core.definitions.reconstruct import reconstructable
 from dagster._core.errors import DagsterUnmetExecutorRequirementsError
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.context.system import PlanData, PlanOrchestrationContext
-from dagster._core.execution.context_creation_pipeline import create_context_free_log_manager
+from dagster._core.execution.context_creation_pipeline import (
+    create_context_free_log_manager,
+)
 from dagster._core.execution.retries import RetryMode
 from dagster._core.executor.init import InitExecutorContext
 from dagster._core.executor.step_delegating.step_handler.base import StepHandlerContext
 from dagster._core.storage.fs_io_manager import fs_io_manager
 from dagster._core.test_utils import create_run_for_test, environ, instance_for_test
 from dagster._grpc.types import ExecuteStepArgs
-from dagster._legacy import solid
+from dagster._legacy import PipelineDefinition, execute_pipeline, solid
 
 
 def _get_pipeline(name, solid_tags=None):
@@ -33,7 +33,8 @@ def _get_pipeline(name, solid_tags=None):
         solid_defs=[foo],
         mode_defs=[
             ModeDefinition(
-                executor_defs=[k8s_job_executor], resource_defs={"io_manager": fs_io_manager}
+                executor_defs=[k8s_job_executor],
+                resource_defs={"io_manager": fs_io_manager},
             )
         ],
     )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
@@ -6,14 +6,13 @@ import pytest
 from dagster_k8s.container_context import K8sContainerContext
 from dagster_k8s.executor import K8sStepHandler, k8s_job_executor
 from dagster_k8s.job import UserDefinedDagsterK8sConfig
+
 from dagster._core.definitions.mode import ModeDefinition
 from dagster._core.definitions.reconstruct import reconstructable
 from dagster._core.errors import DagsterUnmetExecutorRequirementsError
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.context.system import PlanData, PlanOrchestrationContext
-from dagster._core.execution.context_creation_pipeline import (
-    create_context_free_log_manager,
-)
+from dagster._core.execution.context_creation_pipeline import create_context_free_log_manager
 from dagster._core.execution.retries import RetryMode
 from dagster._core.executor.init import InitExecutorContext
 from dagster._core.executor.step_delegating.step_handler.base import StepHandlerContext

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_resource_tags.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_resource_tags.py
@@ -6,11 +6,11 @@ from dagster_k8s.job import (
     get_user_defined_k8s_config,
 )
 
-from dagster import DynamicOutput, DynamicOutputDefinition
+from dagster import DynamicOutput
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.plan.state import KnownExecutionState
-from dagster._legacy import pipeline, solid
+from dagster._legacy import DynamicOutputDefinition, pipeline, solid
 
 
 # CPU units are millicpu
@@ -202,7 +202,8 @@ def test_bad_user_defined_k8s_config_tags():
         pass
 
     with pytest.raises(
-        DagsterInvalidConfigError, match='Received unexpected config entry "other" at the root'
+        DagsterInvalidConfigError,
+        match='Received unexpected config entry "other" at the root',
     ):
         get_user_defined_k8s_config(my_pipeline.tags)
 

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_hooks.py
@@ -1,9 +1,18 @@
 from unittest.mock import Mock
 
-from dagster_mlflow.hooks import _cleanup_on_success, end_mlflow_run_on_pipeline_finished
+from dagster_mlflow.hooks import (
+    _cleanup_on_success,
+    end_mlflow_run_on_pipeline_finished,
+)
 
-from dagster import InputDefinition, ModeDefinition, Nothing, ResourceDefinition, execute_pipeline
-from dagster._legacy import pipeline, solid
+from dagster import Nothing, ResourceDefinition
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    execute_pipeline,
+    pipeline,
+    solid,
+)
 
 
 def test_cleanup_on_success():

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_hooks.py
@@ -1,18 +1,9 @@
 from unittest.mock import Mock
 
-from dagster_mlflow.hooks import (
-    _cleanup_on_success,
-    end_mlflow_run_on_pipeline_finished,
-)
+from dagster_mlflow.hooks import _cleanup_on_success, end_mlflow_run_on_pipeline_finished
 
 from dagster import Nothing, ResourceDefinition
-from dagster._legacy import (
-    InputDefinition,
-    ModeDefinition,
-    execute_pipeline,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, ModeDefinition, execute_pipeline, pipeline, solid
 
 
 def test_cleanup_on_success():

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
@@ -14,9 +14,7 @@ import mlflow
 import pandas as pd
 import pytest
 from dagster_mlflow.resources import MlFlow, mlflow_tracking
-
-from dagster import ModeDefinition, execute_pipeline
-from dagster._legacy import pipeline, solid
+from dagster._legacy import ModeDefinition, execute_pipeline, pipeline, solid
 
 
 @pytest.fixture
@@ -191,7 +189,10 @@ def test_start_run(mock_start_run, context):
 @patch("mlflow.end_run")
 @pytest.mark.parametrize("any_error", [KeyboardInterrupt(), OSError(), RuntimeError(), None])
 def test_cleanup_on_error(
-    mock_mlflow_end_run, any_error, context, cleanup_mlflow_runs  # pylint: disable=unused-argument
+    mock_mlflow_end_run,
+    any_error,
+    context,
+    cleanup_mlflow_runs,  # pylint: disable=unused-argument
 ):
     with patch.object(MlFlow, "_setup"):
         # Given: a context  passed into the __init__ for MlFlow

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
@@ -14,6 +14,7 @@ import mlflow
 import pandas as pd
 import pytest
 from dagster_mlflow.resources import MlFlow, mlflow_tracking
+
 from dagster._legacy import ModeDefinition, execute_pipeline, pipeline, solid
 
 

--- a/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_hooks.py
@@ -1,6 +1,7 @@
 from dagster_msteams.hooks import teams_on_failure, teams_on_success
 from dagster_msteams.resources import msteams_resource
 from mock import patch
+
 from dagster._legacy import ModeDefinition, execute_pipeline, pipeline, solid
 
 

--- a/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_hooks.py
@@ -1,9 +1,7 @@
 from dagster_msteams.hooks import teams_on_failure, teams_on_success
 from dagster_msteams.resources import msteams_resource
 from mock import patch
-
-from dagster import ModeDefinition, execute_pipeline
-from dagster._legacy import pipeline, solid
+from dagster._legacy import ModeDefinition, execute_pipeline, pipeline, solid
 
 
 class SomeUserException(Exception):

--- a/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_resources.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_resources.py
@@ -3,8 +3,8 @@ import json
 from dagster_msteams import msteams_resource
 from mock import patch
 
-from dagster import ModeDefinition, execute_solid
-from dagster._legacy import solid
+from dagster import execute_solid
+from dagster._legacy import ModeDefinition, solid
 
 
 @patch("dagster_msteams.client.TeamsClient.post_message")
@@ -26,7 +26,10 @@ def test_msteams_resource(mock_teams_post_message, json_message, teams_client):
         run_config={
             "resources": {
                 "msteams": {
-                    "config": {"hook_url": "https://some_url_here/", "https_proxy": "some_proxy"}
+                    "config": {
+                        "hook_url": "https://some_url_here/",
+                        "https_proxy": "some_proxy",
+                    }
                 }
             }
         },

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/examples/__init__.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/examples/__init__.py
@@ -1,8 +1,6 @@
 from dagster import (
     In,
-    InputDefinition,
     Out,
-    OutputDefinition,
     config_from_files,
     file_relative_path,
     fs_io_manager,
@@ -12,7 +10,13 @@ from dagster import (
 )
 
 from ..data_frame import DataFrame
-from .pandas_hello_world.ops import always_fails_op, papermill_pandas_hello_world, sum_op, sum_sq_op
+from .pandas_hello_world.ops import (
+    always_fails_op,
+    papermill_pandas_hello_world,
+    sum_op,
+    sum_sq_op,
+)
+from dagster._legacy import InputDefinition, OutputDefinition
 
 
 @graph

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/examples/__init__.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/examples/__init__.py
@@ -8,15 +8,10 @@ from dagster import (
     in_process_executor,
     repository,
 )
+from dagster._legacy import InputDefinition, OutputDefinition
 
 from ..data_frame import DataFrame
-from .pandas_hello_world.ops import (
-    always_fails_op,
-    papermill_pandas_hello_world,
-    sum_op,
-    sum_sq_op,
-)
-from dagster._legacy import InputDefinition, OutputDefinition
+from .pandas_hello_world.ops import always_fails_op, papermill_pandas_hello_world, sum_op, sum_sq_op
 
 
 @graph

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/examples/pandas_hello_world/ops.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/examples/pandas_hello_world/ops.py
@@ -2,9 +2,9 @@ import dagster_pandas as dagster_pd
 import dagstermill
 
 from dagster import In, Out, file_relative_path, op
+from dagster._legacy import InputDefinition, OutputDefinition
 
 from ...data_frame import DataFrame
-from dagster._legacy import InputDefinition, OutputDefinition
 
 
 @op(

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/examples/pandas_hello_world/ops.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/examples/pandas_hello_world/ops.py
@@ -1,9 +1,10 @@
 import dagster_pandas as dagster_pd
 import dagstermill
 
-from dagster import In, InputDefinition, Out, OutputDefinition, file_relative_path, op
+from dagster import In, Out, file_relative_path, op
 
 from ...data_frame import DataFrame
+from dagster._legacy import InputDefinition, OutputDefinition
 
 
 @op(

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/pandas_hello_world/test_pandas_hello_world.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/pandas_hello_world/test_pandas_hello_world.py
@@ -1,9 +1,10 @@
 import os
+
 from dagster._cli.pipeline import do_execute_command
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.test_utils import instance_for_test
-from dagster._utils import file_relative_path
 from dagster._legacy import execute_pipeline
+from dagster._utils import file_relative_path
 
 
 def test_execute_pipeline():

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/pandas_hello_world/test_pandas_hello_world.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/pandas_hello_world/test_pandas_hello_world.py
@@ -1,10 +1,9 @@
 import os
-
-from dagster import execute_pipeline
 from dagster._cli.pipeline import do_execute_command
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.test_utils import instance_for_test
 from dagster._utils import file_relative_path
+from dagster._legacy import execute_pipeline
 
 
 def test_execute_pipeline():
@@ -53,7 +52,8 @@ def test_cli_execute():
                 instance=instance,
                 config=[
                     file_relative_path(
-                        __file__, "../../dagster_pandas/examples/pandas_hello_world/*.yaml"
+                        __file__,
+                        "../../dagster_pandas/examples/pandas_hello_world/*.yaml",
                     )
                 ],
             )
@@ -80,7 +80,8 @@ def test_cli_execute_failure():
                 instance=instance,
                 config=[
                     file_relative_path(
-                        __file__, "../../dagster_pandas/examples/pandas_hello_world/*.yaml"
+                        __file__,
+                        "../../dagster_pandas/examples/pandas_hello_world/*.yaml",
                     )
                 ],
             )

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_dagstermill_pandas_solids.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_dagstermill_pandas_solids.py
@@ -1,11 +1,10 @@
 import tempfile
 
 import pandas as pd
-
-from dagster import execute_pipeline
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.test_utils import instance_for_test
 from dagster._utils import file_relative_path
+from dagster._legacy import execute_pipeline
 
 
 def test_papermill_pandas_hello_world_pipeline():

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_dagstermill_pandas_solids.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_dagstermill_pandas_solids.py
@@ -1,10 +1,11 @@
 import tempfile
 
 import pandas as pd
+
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.test_utils import instance_for_test
-from dagster._utils import file_relative_path
 from dagster._legacy import execute_pipeline
+from dagster._utils import file_relative_path
 
 
 def test_papermill_pandas_hello_world_pipeline():

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -14,7 +14,6 @@ from dagster import (
     AssetMaterialization,
     AssetObservation,
     Output,
-    execute_pipeline,
     job,
     op,
     reconstructable,
@@ -23,7 +22,7 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster._core.storage.pipeline_run import RunsFilter
 from dagster._core.storage.tags import PARTITION_NAME_TAG, PARTITION_SET_TAG
-from dagster._legacy import pipeline, solid
+from dagster._legacy import execute_pipeline, pipeline, solid
 from dagster._utils import file_relative_path
 
 
@@ -164,7 +163,10 @@ def test_0_9_22_postgres_pre_run_partition(hostname, conn_string):
         def simple_pipeline():
             simple_solid()
 
-        tags = {PARTITION_NAME_TAG: "my_partition", PARTITION_SET_TAG: "my_partition_set"}
+        tags = {
+            PARTITION_NAME_TAG: "my_partition",
+            PARTITION_SET_TAG: "my_partition_set",
+        }
 
         with pytest.raises(
             (db.exc.OperationalError, db.exc.ProgrammingError, db.exc.StatementError)
@@ -244,7 +246,11 @@ def test_0_11_0_add_asset_details(hostname, conn_string):
         with DagsterInstance.from_config(tempdir) as instance:
             storage = instance._event_storage
             with pytest.raises(
-                (db.exc.OperationalError, db.exc.ProgrammingError, db.exc.StatementError)
+                (
+                    db.exc.OperationalError,
+                    db.exc.ProgrammingError,
+                    db.exc.StatementError,
+                )
             ):
                 storage.all_asset_keys()
             instance.upgrade()
@@ -521,13 +527,18 @@ def test_instigators_table_backcompat(hostname, conn_string):
 
 def test_jobs_selector_id_migration(hostname, conn_string):
     from dagster._core.storage.schedules.migration import SCHEDULE_JOBS_SELECTOR_ID
-    from dagster._core.storage.schedules.schema import InstigatorsTable, JobTable, JobTickTable
+    from dagster._core.storage.schedules.schema import (
+        InstigatorsTable,
+        JobTable,
+        JobTickTable,
+    )
 
     _reconstruct_from_file(
         hostname,
         conn_string,
         file_relative_path(
-            __file__, "snapshot_0_14_6_post_schema_pre_data_migration/postgres/pg_dump.txt"
+            __file__,
+            "snapshot_0_14_6_post_schema_pre_data_migration/postgres/pg_dump.txt",
         ),
     )
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -527,11 +527,7 @@ def test_instigators_table_backcompat(hostname, conn_string):
 
 def test_jobs_selector_id_migration(hostname, conn_string):
     from dagster._core.storage.schedules.migration import SCHEDULE_JOBS_SELECTOR_ID
-    from dagster._core.storage.schedules.schema import (
-        InstigatorsTable,
-        JobTable,
-        JobTickTable,
-    )
+    from dagster._core.storage.schedules.schema import InstigatorsTable, JobTable, JobTickTable
 
     _reconstruct_from_file(
         hostname,

--- a/python_modules/libraries/dagster-prometheus/dagster_prometheus_tests/test_resources.py
+++ b/python_modules/libraries/dagster-prometheus/dagster_prometheus_tests/test_resources.py
@@ -3,8 +3,8 @@ import time
 from dagster_prometheus import prometheus_resource
 from prometheus_client import Counter, Enum, Gauge, Histogram, Info, Summary
 
-from dagster import ModeDefinition, execute_solid
-from dagster._legacy import solid
+from dagster import execute_solid
+from dagster._legacy import ModeDefinition, solid
 
 EPS = 0.001
 ENV = {"resources": {"prometheus": {"config": {"gateway": "localhost:9091"}}}}

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark_tests/test_resources.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark_tests/test_resources.py
@@ -1,7 +1,8 @@
 from dagster_pyspark.resources import pyspark_resource
 
-from dagster import execute_pipeline, job, multiprocess_executor, op, reconstructable
+from dagster import job, multiprocess_executor, op, reconstructable
 from dagster._core.test_utils import instance_for_test
+from dagster._legacy import execute_pipeline
 
 
 def assert_pipeline_runs_with_resource(resource_def):

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark_tests/test_types.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark_tests/test_types.py
@@ -5,14 +5,8 @@ from dagster_pyspark import DataFrame as DagsterPySparkDataFrame
 from dagster_pyspark import pyspark_resource
 from pyspark.sql import Row, SparkSession
 
-from dagster import (
-    InputDefinition,
-    ModeDefinition,
-    OutputDefinition,
-    execute_solid,
-    file_relative_path,
-)
-from dagster._legacy import solid
+from dagster import execute_solid, file_relative_path
+from dagster._legacy import InputDefinition, ModeDefinition, OutputDefinition, solid
 from dagster._utils import dict_without_keys
 from dagster._utils.test import get_temp_dir
 

--- a/python_modules/libraries/dagster-shell/dagster_shell/solids.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell/solids.py
@@ -1,19 +1,9 @@
 import os
 
-from dagster import (
-    Enum,
-    EnumValue,
-    Failure,
-    Field,
-    InputDefinition,
-    Noneable,
-    Nothing,
-    OutputDefinition,
-    Permissive,
-)
+from dagster import Enum, EnumValue, Failure, Field, Noneable, Nothing, Permissive
 from dagster import _check as check
 from dagster import op
-from dagster._legacy import solid
+from dagster._legacy import InputDefinition, OutputDefinition, solid
 
 from .utils import execute, execute_script_file
 

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_examples.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_examples.py
@@ -1,4 +1,4 @@
-from dagster import execute_pipeline
+from dagster._legacy import execute_pipeline
 
 
 def test_example_shell_command_solid():

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_solids.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_solids.py
@@ -10,7 +10,8 @@ from dagster_shell import (
     shell_solid,
 )
 
-from dagster import Failure, OutputDefinition, composite_solid, execute_solid, job, op
+from dagster import Failure, execute_solid, job, op
+from dagster._legacy import OutputDefinition, composite_solid
 
 
 @pytest.mark.parametrize("factory", [create_shell_command_solid, create_shell_command_op])
@@ -90,7 +91,12 @@ def test_shell_command_stream_logs(factory):
         solid,
         run_config={
             "solids": {
-                "foobar": {"config": {"output_logging": "STREAM", "env": {"MY_ENV_VAR": "foobar"}}}
+                "foobar": {
+                    "config": {
+                        "output_logging": "STREAM",
+                        "env": {"MY_ENV_VAR": "foobar"},
+                    }
+                }
             }
         },
     )
@@ -122,7 +128,9 @@ def test_shell_script_solid_no_config_composite(factory):
     solid = factory(os.path.join(script_dir, "test.sh"), name="foobar")
 
     @composite_solid(
-        config_schema={}, config_fn=lambda cfg: {}, output_defs=[OutputDefinition(str, "result")]
+        config_schema={},
+        config_fn=lambda cfg: {},
+        output_defs=[OutputDefinition(str, "result")],
     )
     def composite():
         return solid()
@@ -162,7 +170,9 @@ def test_shell_script_solid_run_time_config_composite(factory, monkeypatch):
     solid = factory(os.path.join(script_dir, "test.sh"), name="foobar")
 
     @composite_solid(
-        config_schema={}, config_fn=lambda cfg: {}, output_defs=[OutputDefinition(str, "result")]
+        config_schema={},
+        config_fn=lambda cfg: {},
+        output_defs=[OutputDefinition(str, "result")],
     )
     def composite():
         return solid()

--- a/python_modules/libraries/dagster-slack/dagster_slack_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack_tests/test_hooks.py
@@ -1,9 +1,7 @@
 from dagster_slack import slack_resource
 from dagster_slack.hooks import slack_on_failure, slack_on_success
 from mock import patch
-
-from dagster import ModeDefinition, execute_pipeline
-from dagster._legacy import pipeline, solid
+from dagster._legacy import ModeDefinition, execute_pipeline, pipeline, solid
 
 
 class SomeUserException(Exception):

--- a/python_modules/libraries/dagster-slack/dagster_slack_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack_tests/test_hooks.py
@@ -1,6 +1,7 @@
 from dagster_slack import slack_resource
 from dagster_slack.hooks import slack_on_failure, slack_on_success
 from mock import patch
+
 from dagster._legacy import ModeDefinition, execute_pipeline, pipeline, solid
 
 

--- a/python_modules/libraries/dagster-slack/dagster_slack_tests/test_resources.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack_tests/test_resources.py
@@ -3,8 +3,8 @@ import json
 from dagster_slack import slack_resource
 from mock import patch
 
-from dagster import ModeDefinition, execute_solid
-from dagster._legacy import solid
+from dagster import execute_solid
+from dagster._legacy import ModeDefinition, solid
 
 
 @patch("slack_sdk.WebClient.api_call")

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/solids.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/solids.py
@@ -1,7 +1,7 @@
-from dagster import InputDefinition, Nothing
+from dagster import Nothing
 from dagster import _check as check
 from dagster import op
-from dagster._legacy import solid
+from dagster._legacy import InputDefinition, solid
 
 
 def _core_create_snowflake_command(dagster_decorator, decorator_name, sql, parameters=None):

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
@@ -2,9 +2,9 @@ from unittest import mock
 
 from dagster_snowflake import snowflake_resource
 
-from dagster import ModeDefinition, execute_solid
+from dagster import execute_solid
 from dagster._core.test_utils import environ
-from dagster._legacy import solid
+from dagster._legacy import ModeDefinition, solid
 
 from .utils import create_mock_connector
 

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_solids.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_solids.py
@@ -2,9 +2,10 @@ from unittest import mock
 
 from dagster_snowflake import snowflake_resource, snowflake_solid_for_query
 
-from dagster import ModeDefinition, execute_solid
+from dagster import execute_solid
 
 from .utils import create_mock_connector
+from dagster._legacy import ModeDefinition
 
 
 @mock.patch("snowflake.connector.connect", new_callable=create_mock_connector)

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_solids.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_solids.py
@@ -3,9 +3,9 @@ from unittest import mock
 from dagster_snowflake import snowflake_resource, snowflake_solid_for_query
 
 from dagster import execute_solid
+from dagster._legacy import ModeDefinition
 
 from .utils import create_mock_connector
-from dagster._legacy import ModeDefinition
 
 
 @mock.patch("snowflake.connector.connect", new_callable=create_mock_connector)

--- a/python_modules/libraries/dagster-spark/dagster_spark/ops.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark/ops.py
@@ -1,7 +1,7 @@
-from dagster import InputDefinition, Nothing, OutputDefinition
+from dagster import Nothing
 from dagster import _check as check
 from dagster import op
-from dagster._legacy import solid
+from dagster._legacy import InputDefinition, OutputDefinition, solid
 
 from .configs import define_spark_config
 

--- a/python_modules/libraries/dagster-spark/dagster_spark_tests/test_error.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark_tests/test_error.py
@@ -5,8 +5,8 @@ import yaml
 from dagster_spark import create_spark_solid, spark_resource
 
 from dagster import execute_solid
-from dagster._utils import file_relative_path
 from dagster._legacy import ModeDefinition
+from dagster._utils import file_relative_path
 
 CONFIG_FILE = """
 solids:

--- a/python_modules/libraries/dagster-spark/dagster_spark_tests/test_error.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark_tests/test_error.py
@@ -4,8 +4,9 @@ import uuid
 import yaml
 from dagster_spark import create_spark_solid, spark_resource
 
-from dagster import ModeDefinition, execute_solid
+from dagster import execute_solid
 from dagster._utils import file_relative_path
+from dagster._legacy import ModeDefinition
 
 CONFIG_FILE = """
 solids:

--- a/python_modules/libraries/dagster-spark/dagster_spark_tests/test_ops.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark_tests/test_ops.py
@@ -6,8 +6,8 @@ import pytest
 import yaml
 from dagster_spark import create_spark_op, create_spark_solid, spark_resource
 
-from dagster import ModeDefinition, execute_pipeline, job
-from dagster._legacy import pipeline
+from dagster import job
+from dagster._legacy import ModeDefinition, execute_pipeline, pipeline
 
 CONFIG = """
 solids:

--- a/python_modules/libraries/dagster-ssh/dagster_ssh_tests/test_resources.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh_tests/test_resources.py
@@ -8,8 +8,8 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from dagster_ssh.resources import SSHResource, key_from_str
 from dagster_ssh.resources import ssh_resource as sshresource
 
-from dagster import Field, ModeDefinition, execute_solid
-from dagster._legacy import solid
+from dagster import Field, execute_solid
+from dagster._legacy import ModeDefinition, solid
 from dagster._seven import get_system_temp_directory
 
 

--- a/python_modules/libraries/dagster-twilio/dagster_twilio_tests/test_resources.py
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio_tests/test_resources.py
@@ -4,8 +4,8 @@ import pytest
 from dagster_twilio import twilio_resource
 from twilio.base.exceptions import TwilioRestException
 
-from dagster import ModeDefinition, execute_solid
-from dagster._legacy import solid
+from dagster import execute_solid
+from dagster._legacy import ModeDefinition, solid
 
 
 def test_twilio_resource():

--- a/python_modules/libraries/dagstermill/dagstermill/context.py
+++ b/python_modules/libraries/dagstermill/dagstermill/context.py
@@ -1,11 +1,9 @@
 from typing import Any, Dict, Mapping, Optional, Set, cast
+
 from dagster import _check as check
 from dagster._core.definitions.dependency import Node, NodeHandle
 from dagster._core.execution.context.compute import AbstractComputeExecutionContext
-from dagster._core.execution.context.system import (
-    PlanExecutionContext,
-    StepExecutionContext,
-)
+from dagster._core.execution.context.system import PlanExecutionContext, StepExecutionContext
 from dagster._core.log_manager import DagsterLogManager
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._legacy import PipelineDefinition, PipelineRun, SolidDefinition

--- a/python_modules/libraries/dagstermill/dagstermill/context.py
+++ b/python_modules/libraries/dagstermill/dagstermill/context.py
@@ -1,12 +1,14 @@
 from typing import Any, Dict, Mapping, Optional, Set, cast
-
-from dagster import PipelineDefinition, PipelineRun, SolidDefinition
 from dagster import _check as check
 from dagster._core.definitions.dependency import Node, NodeHandle
 from dagster._core.execution.context.compute import AbstractComputeExecutionContext
-from dagster._core.execution.context.system import PlanExecutionContext, StepExecutionContext
+from dagster._core.execution.context.system import (
+    PlanExecutionContext,
+    StepExecutionContext,
+)
 from dagster._core.log_manager import DagsterLogManager
 from dagster._core.system_config.objects import ResolvedRunConfig
+from dagster._legacy import PipelineDefinition, PipelineRun, SolidDefinition
 
 
 class DagstermillExecutionContext(AbstractComputeExecutionContext):

--- a/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
+++ b/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
@@ -8,15 +8,11 @@ from dagstermill.io_managers import local_output_notebook_io_manager
 from dagster import (
     Field,
     FileHandle,
-    InputDefinition,
     Int,
     List,
-    ModeDefinition,
     Out,
-    OutputDefinition,
     ResourceDefinition,
     String,
-    composite_solid,
     fs_io_manager,
     job,
     repository,
@@ -24,7 +20,14 @@ from dagster import (
 )
 from dagster._core.definitions.utils import DEFAULT_OUTPUT
 from dagster._core.storage.file_manager import local_file_manager
-from dagster._legacy import pipeline, solid
+from dagster._legacy import (
+    InputDefinition,
+    ModeDefinition,
+    OutputDefinition,
+    composite_solid,
+    pipeline,
+    solid,
+)
 from dagster._utils import PICKLE_PROTOCOL, file_relative_path
 
 try:
@@ -427,7 +430,9 @@ def bad_kernel_pipeline():
 
 
 reimport = test_nb_solid(
-    "reimport", input_defs=[InputDefinition("l", List[int])], output_defs=[OutputDefinition(int)]
+    "reimport",
+    input_defs=[InputDefinition("l", List[int])],
+    output_defs=[OutputDefinition(int)],
 )
 
 

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -14,11 +14,7 @@ from papermill.iorw import load_notebook_node, write_ipynb
 from dagster import In, OpDefinition, Out, Output
 from dagster import _check as check
 from dagster import _seven
-from dagster._core.definitions.events import (
-    AssetMaterialization,
-    Failure,
-    RetryRequested,
-)
+from dagster._core.definitions.events import AssetMaterialization, Failure, RetryRequested
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.definitions.utils import validate_tags
@@ -27,6 +23,7 @@ from dagster._core.execution.context.input import build_input_context
 from dagster._core.execution.context.system import StepExecutionContext
 from dagster._core.execution.plan.outputs import StepOutputHandle
 from dagster._core.storage.file_manager import FileHandle
+from dagster._legacy import InputDefinition, OutputDefinition, SolidDefinition
 from dagster._serdes import pack_value
 from dagster._seven import get_system_temp_directory
 from dagster._utils import mkdir_p, safe_tempfile_path
@@ -37,7 +34,6 @@ from .compat import ExecutionError
 from .engine import DagstermillEngine
 from .errors import DagstermillError
 from .translator import DagsterTranslator
-from dagster._legacy import InputDefinition, OutputDefinition, SolidDefinition
 
 
 # https://github.com/nteract/papermill/blob/17d4bbb3960c30c263bca835e48baf34322a3530/papermill/parameterize.py

--- a/python_modules/libraries/dagstermill/dagstermill/manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill/manager.py
@@ -21,6 +21,7 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.storage.pipeline_run import DagsterRun, PipelineRunStatus
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.utils import make_new_run_id
+from dagster._legacy import Materialization, ModeDefinition, PipelineDefinition, SolidDefinition
 from dagster._loggers import colored_console_logger
 from dagster._serdes import unpack_value
 from dagster._utils import EventGenerationManager, ensure_gen
@@ -28,12 +29,6 @@ from dagster._utils import EventGenerationManager, ensure_gen
 from .context import DagstermillExecutionContext, DagstermillRuntimeExecutionContext
 from .errors import DagstermillError
 from .serialize import PICKLE_PROTOCOL
-from dagster._legacy import (
-    Materialization,
-    ModeDefinition,
-    PipelineDefinition,
-    SolidDefinition,
-)
 
 
 class DagstermillResourceEventGenerationManager(EventGenerationManager):

--- a/python_modules/libraries/dagstermill/dagstermill/manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill/manager.py
@@ -2,16 +2,7 @@ import os
 import pickle
 import uuid
 
-from dagster import (
-    AssetMaterialization,
-    ExpectationResult,
-    Failure,
-    Materialization,
-    ModeDefinition,
-    PipelineDefinition,
-    SolidDefinition,
-    TypeCheck,
-)
+from dagster import AssetMaterialization, ExpectationResult, Failure, TypeCheck
 from dagster import _check as check
 from dagster._core.definitions.dependency import NodeHandle
 from dagster._core.definitions.events import RetryRequested
@@ -37,6 +28,12 @@ from dagster._utils import EventGenerationManager, ensure_gen
 from .context import DagstermillExecutionContext, DagstermillRuntimeExecutionContext
 from .errors import DagstermillError
 from .serialize import PICKLE_PROTOCOL
+from dagster._legacy import (
+    Materialization,
+    ModeDefinition,
+    PipelineDefinition,
+    SolidDefinition,
+)
 
 
 class DagstermillResourceEventGenerationManager(EventGenerationManager):

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_context.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_context.py
@@ -1,8 +1,7 @@
 from dagstermill.manager import MANAGER_FOR_NOTEBOOK_INSTANCE
-
-from dagster import SolidDefinition
 from dagster._core.definitions.dependency import Node
 from dagster._core.system_config.objects import ResolvedRunConfig
+from dagster._legacy import SolidDefinition
 
 BARE_OUT_OF_PIPELINE_CONTEXT = MANAGER_FOR_NOTEBOOK_INSTANCE.get_context()
 

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_context.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_context.py
@@ -1,4 +1,5 @@
 from dagstermill.manager import MANAGER_FOR_NOTEBOOK_INSTANCE
+
 from dagster._core.definitions.dependency import Node
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._legacy import SolidDefinition

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_logging.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_logging.py
@@ -5,11 +5,11 @@ import os
 from dagstermill.examples.repository import hello_logging
 from dagstermill.io_managers import local_output_notebook_io_manager
 
-from dagster import ModeDefinition, String
+from dagster import String
 from dagster import _seven as seven
-from dagster import execute_pipeline, logger, reconstructable
+from dagster import logger, reconstructable
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline
+from dagster._legacy import ModeDefinition, execute_pipeline, pipeline
 from dagster._utils import safe_tempfile_path
 
 
@@ -30,7 +30,8 @@ class LogTestFileHandler(logging.Handler):
 def test_file_logger(init_context):
     klass = logging.getLoggerClass()
     logger_ = klass(
-        init_context.logger_config["name"], level=init_context.logger_config["log_level"]
+        init_context.logger_config["name"],
+        level=init_context.logger_config["log_level"],
     )
     handler = LogTestFileHandler(init_context.logger_config["file_path"])
     logger_.addHandler(handler)

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_manager.py
@@ -10,7 +10,7 @@ import pytest
 from dagstermill import DagstermillError
 from dagstermill.manager import Manager
 
-from dagster import AssetMaterialization, ModeDefinition, ResourceDefinition
+from dagster import AssetMaterialization, ResourceDefinition
 from dagster import _check as check
 from dagster._core.definitions.dependency import NodeHandle
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
@@ -19,6 +19,7 @@ from dagster._core.test_utils import instance_for_test
 from dagster._core.utils import make_new_run_id
 from dagster._serdes import pack_value
 from dagster._utils import safe_tempfile_path
+from dagster._legacy import ModeDefinition
 
 
 @contextlib.contextmanager
@@ -100,7 +101,8 @@ def test_out_of_pipeline_manager_yield_complex_result():
 def test_in_pipeline_manager_yield_bad_result():
     with in_pipeline_manager() as manager:
         with pytest.raises(
-            DagstermillError, match="Solid hello_world does not have output named result"
+            DagstermillError,
+            match="Solid hello_world does not have output named result",
         ):
             assert manager.yield_result("foo") == "foo"
 
@@ -134,7 +136,8 @@ def test_in_pipeline_manager_bad_solid():
 def test_in_pipeline_manager_bad_yield_result():
     with in_pipeline_manager() as manager:
         with pytest.raises(
-            DagstermillError, match="Solid hello_world does not have output named result"
+            DagstermillError,
+            match="Solid hello_world does not have output named result",
         ):
             manager.yield_result("foo")
 

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_manager.py
@@ -17,9 +17,9 @@ from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus
 from dagster._core.test_utils import instance_for_test
 from dagster._core.utils import make_new_run_id
+from dagster._legacy import ModeDefinition
 from dagster._serdes import pack_value
 from dagster._utils import safe_tempfile_path
-from dagster._legacy import ModeDefinition
 
 
 @contextlib.contextmanager

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_solids.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_solids.py
@@ -10,13 +10,11 @@ from dagstermill import DagstermillError, define_dagstermill_solid
 from dagstermill.compat import ExecutionError
 from jupyter_client.kernelspec import NoSuchKernel
 from nbconvert.preprocessors import ExecutePreprocessor
-
-from dagster import execute_pipeline
 from dagster._check import CheckError
 from dagster._core.definitions.metadata import PathMetadataValue
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import pipeline
+from dagster._legacy import execute_pipeline, pipeline
 from dagster._utils import file_relative_path, safe_tempfile_path
 
 DAGSTER_PANDAS_PRESENT = importlib.util.find_spec("dagster_pandas") is not None
@@ -138,7 +136,8 @@ def test_reexecute_result_notebook():
         return nb
 
     with exec_for_test(
-        "hello_world_pipeline", {"loggers": {"console": {"config": {"log_level": "ERROR"}}}}
+        "hello_world_pipeline",
+        {"loggers": {"console": {"config": {"log_level": "ERROR"}}}},
     ) as result:
         assert result.success
 
@@ -188,7 +187,8 @@ def test_add_pipeline():
 @pytest.mark.notebook_test
 def test_double_add_pipeline():
     with exec_for_test(
-        "double_add_pipeline", {"loggers": {"console": {"config": {"log_level": "ERROR"}}}}
+        "double_add_pipeline",
+        {"loggers": {"console": {"config": {"log_level": "ERROR"}}}},
     ) as result:
         assert result.success
         assert result.result_for_solid("add_two_numbers_1").output_value() == 3
@@ -277,7 +277,8 @@ def test_error_notebook():
 )
 def test_tutorial_pipeline():
     with exec_for_test(
-        "tutorial_pipeline", {"loggers": {"console": {"config": {"log_level": "DEBUG"}}}}
+        "tutorial_pipeline",
+        {"loggers": {"console": {"config": {"log_level": "DEBUG"}}}},
     ) as result:
         assert result.success
 

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_solids.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_solids.py
@@ -10,6 +10,7 @@ from dagstermill import DagstermillError, define_dagstermill_solid
 from dagstermill.compat import ExecutionError
 from jupyter_client.kernelspec import NoSuchKernel
 from nbconvert.preprocessors import ExecutePreprocessor
+
 from dagster._check import CheckError
 from dagster._core.definitions.metadata import PathMetadataValue
 from dagster._core.definitions.reconstruct import ReconstructablePipeline


### PR DESCRIPTION
Moves a bunch of imports to use dagster._legacy. I performed this using a codemod tool called libCST. The code can be found here: https://github.com/dpeng817/codemods.