### PR TITLE
[docs] - Fix bad link to graphs core topic in apidocs.mdx

### DIFF
--- a/docs/content/_apidocs.mdx
+++ b/docs/content/_apidocs.mdx
@@ -18,7 +18,7 @@ APIs from the core `dagster` package, divided roughly by topic:
 
 - [Ops](/\_apidocs/ops) APIs to define or decorate functions as ops, declare their inputs and outputs, compose ops with each other, as well as the datatypes that op execution can return or yield.
 
-- [Graphs](/\_apidocs/ops) APIs to define a logical structure of ops.
+- [Graphs](/\_apidocs/graphs) APIs to define a logical structure of ops.
 
 - [Resources](/\_apidocs/resources) APIs to define resources which can provide specific implementations of certain functionality within a job.
 


### PR DESCRIPTION
### Summary & Motivation

Fix bad link to graphs core topic in apidocs.mdx.

Previously:

```
- [Graphs](/\_apidocs/ops) APIs to define a logical structure of ops.
```

Now:

```
- [Graphs](/\_apidocs/graphs) APIs to define a logical structure of ops.
```

### How I Tested These Changes

The link to `_apidocs/graphs` works.
