### PR TITLE
In the run worker, check the run status one more time after loading the pipeline definition

### DIFF
--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -88,7 +88,17 @@ def core_execute_run(
         )
         yield from _report_run_failed_if_not_finished(instance, pipeline_run.run_id)
         raise
+
+    # Reload the run to verify that its status didn't change while the pipeline was loaded
+    pipeline_run = instance.get_run_by_id(pipeline_run.run_id)
+    check.inst(
+        pipeline_run,
+        PipelineRun,
+        f"Pipeline run with id '{pipeline_run.run_id}' was deleted after the run worker started.",
+    )
+
     try:
+        pipeline_run = instance.get_run_by_id(pipeline_run.run_id)
         yield from execute_run_iterator(
             recon_pipeline, pipeline_run, instance, resume_from_failure=resume_from_failure
         )


### PR DESCRIPTION
Summary:
This would account for the following race condition that a user reported;
- run worker monitoring is set up
- monitoring kicks in while the code is being loaded
- we blithely continue on, without checking if the run status is correc

The downside is one more  DB call on each run, but this is a pretty quick DB and/or API call I think?

Test Plan:
Testing the specific race condition reported here is tricky but can be done manually pretty easily by having a job that takes 3 minutes to load its repo, then marking it as failure in that period. Existing tests should also pass

### Summary & Motivation

### How I Tested These Changes
