### PR TITLE
Keyword-only args for decorators and associated defs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -78,6 +78,7 @@ class AssetsDefinition(ResourceAddable):
 
     def __init__(
         self,
+        *,
         keys_by_input_name: Mapping[str, AssetKey],
         keys_by_output_name: Mapping[str, AssetKey],
         node_def: NodeDefinition,
@@ -187,6 +188,7 @@ class AssetsDefinition(ResourceAddable):
     @staticmethod
     def from_graph(
         graph_def: "GraphDefinition",
+        *,
         keys_by_input_name: Optional[Mapping[str, AssetKey]] = None,
         keys_by_output_name: Optional[Mapping[str, AssetKey]] = None,
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
@@ -255,6 +257,7 @@ class AssetsDefinition(ResourceAddable):
     @staticmethod
     def from_op(
         op_def: OpDefinition,
+        *,
         keys_by_input_name: Optional[Mapping[str, AssetKey]] = None,
         keys_by_output_name: Optional[Mapping[str, AssetKey]] = None,
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
@@ -314,6 +317,7 @@ class AssetsDefinition(ResourceAddable):
     @staticmethod
     def _from_node(
         node_def: Union[OpDefinition, "GraphDefinition"],
+        *,
         keys_by_input_name: Optional[Mapping[str, AssetKey]] = None,
         keys_by_output_name: Optional[Mapping[str, AssetKey]] = None,
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -241,15 +241,15 @@ class AssetsDefinition(ResourceAddable):
         if resource_defs is not None:
             experimental_arg_warning("resource_defs", "AssetsDefinition.from_graph")
         return AssetsDefinition._from_node(
-            graph_def,
-            keys_by_input_name,
-            keys_by_output_name,
-            internal_asset_deps,
-            partitions_def,
-            group_name,
-            resource_defs,
-            partition_mappings,
-            metadata_by_output_name,
+            node_def=graph_def,
+            keys_by_input_name=keys_by_input_name,
+            keys_by_output_name=keys_by_output_name,
+            internal_asset_deps=internal_asset_deps,
+            partitions_def=partitions_def,
+            group_name=group_name,
+            resource_defs=resource_defs,
+            partition_mappings=partition_mappings,
+            metadata_by_output_name=metadata_by_output_name,
             key_prefix=key_prefix,
         )
 
@@ -303,12 +303,12 @@ class AssetsDefinition(ResourceAddable):
                 asset.
         """
         return AssetsDefinition._from_node(
-            op_def,
-            keys_by_input_name,
-            keys_by_output_name,
-            internal_asset_deps,
-            partitions_def,
-            group_name,
+            node_def=op_def,
+            keys_by_input_name=keys_by_input_name,
+            keys_by_output_name=keys_by_output_name,
+            internal_asset_deps=internal_asset_deps,
+            partitions_def=partitions_def,
+            group_name=group_name,
             partition_mappings=partition_mappings,
             metadata_by_output_name=metadata_by_output_name,
             key_prefix=key_prefix,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -41,13 +41,14 @@ from ..utils import DEFAULT_IO_MANAGER_KEY, NoValueSentinel
 
 @overload
 def asset(
-    name: Callable[..., Any],
+    compute_fn: Callable,
 ) -> AssetsDefinition:
     ...
 
 
 @overload
 def asset(
+    *,
     name: Optional[str] = ...,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     ins: Optional[Mapping[str, AssetIn]] = ...,
@@ -69,7 +70,9 @@ def asset(
 
 
 def asset(
-    name: Optional[Union[Callable[..., Any], Optional[str]]] = None,
+    compute_fn: Optional[Callable] = None,
+    *,
+    name: Optional[str] = None,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     ins: Optional[Mapping[str, AssetIn]] = None,
     non_argument_deps: Optional[Union[Set[AssetKey], Set[str]]] = None,
@@ -145,8 +148,8 @@ def asset(
             def my_asset(my_upstream_asset: int) -> int:
                 return my_upstream_asset + 1
     """
-    if callable(name):
-        return _Asset()(name)
+    if compute_fn is not None:
+        return _Asset()(compute_fn)
 
     def inner(fn: Callable[..., Any]) -> AssetsDefinition:
         check.invariant(
@@ -286,6 +289,7 @@ class _Asset:
 
 
 def multi_asset(
+    *,
     outs: Mapping[str, AssetOut],
     name: Optional[str] = None,
     ins: Optional[Mapping[str, AssetIn]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/config_mapping_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/config_mapping_decorator.py
@@ -36,7 +36,7 @@ def config_mapping(
 
 @overload
 def config_mapping(
-    config_fn: None = ...,
+    *,
     config_schema: UserConfigSchema = ...,
     receive_processed_config_values: Optional[bool] = ...,
 ) -> Union[_ConfigMapping, ConfigMapping]:
@@ -45,6 +45,7 @@ def config_mapping(
 
 def config_mapping(
     config_fn: Optional[Callable[..., Any]] = None,
+    *,
     config_schema: Optional[UserConfigSchema] = None,
     receive_processed_config_values: Optional[bool] = None,
 ) -> Union[ConfigMapping, _ConfigMapping]:
@@ -84,7 +85,7 @@ def config_mapping(
 
     """
     # This case is for when decorator is used bare, without arguments. e.g. @config_mapping versus @config_mapping()
-    if callable(config_fn):
+    if config_fn is not None:
         check.invariant(config_schema is None)
         check.invariant(receive_processed_config_values is None)
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/graph_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/graph_decorator.py
@@ -102,12 +102,13 @@ class _Graph:
 
 
 @overload
-def graph(name: Callable[..., Any]) -> GraphDefinition:
+def graph(compose_fn: Callable) -> GraphDefinition:
     ...
 
 
 @overload
 def graph(
+    *,
     name: Optional[str] = ...,
     description: Optional[str] = ...,
     input_defs: Optional[List[InputDefinition]] = ...,
@@ -121,7 +122,9 @@ def graph(
 
 
 def graph(
-    name: Optional[Union[Callable[..., Any], str]] = None,
+    compose_fn: Optional[Callable] = None,
+    *,
+    name: Optional[str] = None,
     description: Optional[str] = None,
     input_defs: Optional[List[InputDefinition]] = None,
     output_defs: Optional[List[OutputDefinition]] = None,
@@ -172,9 +175,9 @@ def graph(
             `json.loads(json.dumps(value)) == value`.  These tag values may be overwritten by tag
             values provided at invocation time.
     """
-    if callable(name):
+    if compose_fn is not None:
         check.invariant(description is None)
-        return _Graph()(name)
+        return _Graph()(compose_fn)
 
     config_mapping = None
     # Case 1: a dictionary of config is provided, convert to config mapping.

--- a/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
@@ -116,12 +116,13 @@ class _Job:
 
 
 @overload
-def job(name: Callable[..., Any]) -> JobDefinition:
+def job(compose_fn: Callable[..., Any]) -> JobDefinition:
     ...
 
 
 @overload
 def job(
+    *,
     name: Optional[str] = ...,
     description: Optional[str] = ...,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = ...,
@@ -140,7 +141,9 @@ def job(
 
 
 def job(
-    name: Optional[Union[Callable[..., Any], str]] = None,
+    compose_fn: Optional[Callable[..., Any]] = None,
+    *,
+    name: Optional[str] = None,
     description: Optional[str] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     config: Optional[Union[ConfigMapping, Dict[str, Any], "PartitionedConfig"]] = None,
@@ -209,9 +212,9 @@ def job(
             A dictionary that maps python objects to the top-level inputs of a job.
 
     """
-    if callable(name):
+    if compose_fn is not None:
         check.invariant(description is None)
-        return _Job()(name)
+        return _Job()(compose_fn)
 
     return _Job(
         name=name,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -83,12 +83,13 @@ class _Op:
 
 
 @overload
-def op(name: Callable[..., Any]) -> "OpDefinition":
+def op(compute_fn: Callable[..., Any]) -> "OpDefinition":
     ...
 
 
 @overload
 def op(
+    *,
     name: Optional[str] = ...,
     description: Optional[str] = ...,
     ins: Optional[Dict[str, In]] = ...,
@@ -103,7 +104,9 @@ def op(
 
 
 def op(
-    name: Optional[Union[Callable[..., Any], str]] = None,
+    compute_fn: Optional[Callable] = None,
+    *,
+    name: Optional[str] = None,
     description: Optional[str] = None,
     ins: Optional[Dict[str, In]] = None,
     out: Optional[Union[Out, Mapping[str, Out]]] = None,
@@ -183,15 +186,14 @@ def op(
                 return 'cool', 4
     """
 
-    # This case is for when decorator is used bare, without arguments. e.g. @op versus @op()
-    if callable(name):
+    if compute_fn is not None:
         check.invariant(description is None)
         check.invariant(config_schema is None)
         check.invariant(required_resource_keys is None)
         check.invariant(tags is None)
         check.invariant(version is None)
 
-        return _Op()(name)
+        return _Op()(compute_fn)
 
     return _Op(
         name=name,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -1,5 +1,5 @@
 from functools import update_wrapper
-from typing import Any, Callable, List, Mapping, Optional, Sequence, Union, overload
+from typing import Any, Callable, List, Mapping, Optional, Union, overload
 
 import dagster._check as check
 from dagster._core.decorator_utils import get_function_params

--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -1,5 +1,5 @@
 from functools import update_wrapper
-from typing import Any, Callable, List, Mapping, Optional, Union, overload
+from typing import Any, Callable, List, Mapping, Optional, Sequence, Union, overload
 
 import dagster._check as check
 from dagster._core.decorator_utils import get_function_params
@@ -130,12 +130,13 @@ class _Repository:
 
 
 @overload
-def repository(name: Callable[..., Any]) -> RepositoryDefinition:
+def repository(definitions_fn: Callable[..., Any]) -> RepositoryDefinition:
     ...
 
 
 @overload
 def repository(
+    *,
     name: Optional[str] = ...,
     description: Optional[str] = ...,
     default_executor_def: Optional[ExecutorDefinition] = ...,
@@ -145,7 +146,9 @@ def repository(
 
 
 def repository(
-    name: Optional[Union[str, Callable[..., Any]]] = None,
+    definitions_fn: Optional[Callable[..., Any]] = None,
+    *,
+    name: Optional[str] = None,
     description: Optional[str] = None,
     default_executor_def: Optional[ExecutorDefinition] = None,
     default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
@@ -274,11 +277,11 @@ def repository(
             return ComplexRepositoryData('some_directory')
 
     """
-    if callable(name):
+    if definitions_fn is not None:
         check.invariant(description is None)
-        check.invariant(len(get_function_params(name)) == 0)
+        check.invariant(len(get_function_params(definitions_fn)) == 0)
 
-        return _Repository()(name)
+        return _Repository()(definitions_fn)
 
     return _Repository(
         name=name,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -48,8 +48,8 @@ if TYPE_CHECKING:
 
 
 def schedule(
-    *,
     cron_schedule: str,
+    *,
     job_name: Optional[str] = None,
     name: Optional[str] = None,
     tags: Optional[Dict[str, str]] = None,
@@ -186,8 +186,8 @@ def schedule(
 
 
 def monthly_schedule(
-    *,
     pipeline_name: Optional[str],
+    *,
     start_date: datetime.datetime,
     name: Optional[str] = None,
     execution_day_of_month: int = 1,
@@ -348,8 +348,8 @@ def my_schedule_definition(_):
 
 
 def weekly_schedule(
-    *,
     pipeline_name: Optional[str],
+    *,
     start_date: datetime.datetime,
     name: Optional[str] = None,
     execution_day_of_week: int = 0,
@@ -505,8 +505,8 @@ def my_schedule_definition(_):
 
 
 def daily_schedule(
-    *,
     pipeline_name: Optional[str],
+    *,
     start_date: datetime.datetime,
     name: Optional[str] = None,
     execution_time: datetime.time = datetime.time(0, 0),
@@ -649,8 +649,8 @@ def my_schedule_definition(_):
 
 
 def hourly_schedule(
-    *,
     pipeline_name: Optional[str],
+    *,
     start_date: datetime.datetime,
     name: Optional[str] = None,
     execution_time: datetime.time = datetime.time(0, 0),

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 
 
 def schedule(
+    *,
     cron_schedule: str,
     job_name: Optional[str] = None,
     name: Optional[str] = None,
@@ -185,6 +186,7 @@ def schedule(
 
 
 def monthly_schedule(
+    *,
     pipeline_name: Optional[str],
     start_date: datetime.datetime,
     name: Optional[str] = None,
@@ -346,6 +348,7 @@ def my_schedule_definition(_):
 
 
 def weekly_schedule(
+    *,
     pipeline_name: Optional[str],
     start_date: datetime.datetime,
     name: Optional[str] = None,
@@ -502,6 +505,7 @@ def my_schedule_definition(_):
 
 
 def daily_schedule(
+    *,
     pipeline_name: Optional[str],
     start_date: datetime.datetime,
     name: Optional[str] = None,
@@ -645,6 +649,7 @@ def my_schedule_definition(_):
 
 
 def hourly_schedule(
+    *,
     pipeline_name: Optional[str],
     start_date: datetime.datetime,
     name: Optional[str] = None,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -23,12 +23,8 @@ if TYPE_CHECKING:
 
 
 def sensor(
-<<<<<<< HEAD
-    job_name: Optional[str] = None,
-=======
     *,
-    pipeline_name: Optional[str] = None,
->>>>>>> 35daf5ae9a (keyword-only args for decs and defs)
+    job_name: Optional[str] = None,
     name: Optional[str] = None,
     minimum_interval_seconds: Optional[int] = None,
     description: Optional[str] = None,
@@ -85,8 +81,8 @@ def sensor(
 
 
 def asset_sensor(
-    *,
     asset_key: AssetKey,
+    *,
     job_name: Optional[str] = None,
     name: Optional[str] = None,
     minimum_interval_seconds: Optional[int] = None,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -23,7 +23,12 @@ if TYPE_CHECKING:
 
 
 def sensor(
+<<<<<<< HEAD
     job_name: Optional[str] = None,
+=======
+    *,
+    pipeline_name: Optional[str] = None,
+>>>>>>> 35daf5ae9a (keyword-only args for decs and defs)
     name: Optional[str] = None,
     minimum_interval_seconds: Optional[int] = None,
     description: Optional[str] = None,
@@ -80,6 +85,7 @@ def sensor(
 
 
 def asset_sensor(
+    *,
     asset_key: AssetKey,
     job_name: Optional[str] = None,
     name: Optional[str] = None,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -23,8 +23,8 @@ if TYPE_CHECKING:
 
 
 def sensor(
-    *,
     job_name: Optional[str] = None,
+    *,
     name: Optional[str] = None,
     minimum_interval_seconds: Optional[int] = None,
     description: Optional[str] = None,

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -184,6 +184,7 @@ class GraphDefinition(NodeDefinition):
 
     def __init__(
         self,
+        *,
         name: str,
         description: Optional[str] = None,
         node_defs: Optional[Sequence[NodeDefinition]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -184,8 +184,8 @@ class GraphDefinition(NodeDefinition):
 
     def __init__(
         self,
-        *,
         name: str,
+        *,
         description: Optional[str] = None,
         node_defs: Optional[Sequence[NodeDefinition]] = None,
         dependencies: Optional[

--- a/python_modules/dagster/dagster/_core/definitions/hook_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/hook_definition.py
@@ -33,6 +33,7 @@ class HookDefinition(
 
     def __new__(
         cls,
+        *,
         name: str,
         hook_fn: Callable[..., Any],
         required_resource_keys: Optional[AbstractSet[str]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -83,6 +83,7 @@ class JobDefinition(PipelineDefinition):
 
     def __init__(
         self,
+        *,
         graph_def: GraphDefinition,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         executor_def: Optional[ExecutorDefinition] = None,

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition.py
@@ -1123,8 +1123,8 @@ class RepositoryDefinition:
 
     def __init__(
         self,
-        *,
         name,
+        *,
         repository_data,
         description=None,
     ):

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition.py
@@ -1123,6 +1123,7 @@ class RepositoryDefinition:
 
     def __init__(
         self,
+        *,
         name,
         repository_data,
         description=None,

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -241,6 +241,7 @@ class ScheduleDefinition:
 
     def __init__(
         self,
+        *,
         name: Optional[str] = None,
         cron_schedule: Optional[str] = None,
         job_name: Optional[str] = None,

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -241,8 +241,8 @@ class ScheduleDefinition:
 
     def __init__(
         self,
-        *,
         name: Optional[str] = None,
+        *,
         cron_schedule: Optional[str] = None,
         job_name: Optional[str] = None,
         run_config: Optional[Any] = None,

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -201,6 +201,7 @@ class SensorDefinition:
 
     def __init__(
         self,
+        *,
         name: Optional[str] = None,
         evaluation_fn: Optional[RawSensorEvaluationFunction] = None,
         job_name: Optional[str] = None,

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -201,8 +201,8 @@ class SensorDefinition:
 
     def __init__(
         self,
-        *,
         name: Optional[str] = None,
+        *,
         evaluation_fn: Optional[RawSensorEvaluationFunction] = None,
         job_name: Optional[str] = None,
         minimum_interval_seconds: Optional[int] = None,


### PR DESCRIPTION
### Summary & Motivation

This PR adds bare asterisks to enforce keyword-only args for decorators and their associated definitions.

This is a pattern that we may want to apply in many places in the codebase in the for 1.0. The main reason is that it provides us greater flexibility to change/add to function signatures going forward. Without enforcing keyword-only arguments, it is technically possible for a user to call e.g. `@op` like this:

```python
@op(
  "my_op",
  op_description,
  op_ins,
  op_outs,
  op_config_schema,
  ...
)
def my_op():
    ...
```

This means adding a new argument anywhere but the end of the arglist is technically a breaking change. With keyword-only args order no longer matters and we have more flexibility in adding to the signature.

A bonus is that our API docs become a bit less confusing since the first arg of a decorator no longer needs to do double-duty as a decorated function and a decorator parameter.

There are likely several places where the first one or two decorator params are frequently used positionally-- in those cases we should consider moving the bare asterisk behind these. We probably also need to look at every public API signature.

However, to get started here I went with a high-priority subset of the API (decorators in `dagster.core.definitions.decorators` except solid/pipeline ones that are going away) and their associated definition classes. 

I also used the simplest possible strategy of:

- Making all decorator params keyword only.
- Making all underlying `XDefinition` constructor params keyword-only.

We can discuss individual cases where we may want to deviate from this in the comments.

Note also that this PR just changes the signatures, not all the internal callsites (so there will be test failures). When we finalize our decision I can create another PR to change the internal callsites and stack this PR on top of that one.

### How I Tested These Changes

Existing BK suite, nothing changed yet.
