### PR TITLE
Fix JobDefinition constructor

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -16,8 +16,8 @@ from .config import ConfigMapping
 from .dependency import DependencyDefinition, IDependencyDefinition, NodeHandle, NodeInvocation
 from .events import AssetKey
 from .executor_definition import ExecutorDefinition
-from .graph_definition import GraphDefinition, default_job_io_manager
-from .job_definition import JobDefinition
+from .graph_definition import GraphDefinition
+from .job_definition import JobDefinition, default_job_io_manager
 from .partition import PartitionedConfig, PartitionsDefinition
 from .resolved_asset_deps import ResolvedAssetDependencies
 from .resource_definition import ResourceDefinition

--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -646,7 +646,7 @@ class PendingNodeInvocation:
             tags=self.tags,
             hook_defs=self.hook_defs,
             op_retry_policy=self.retry_policy,
-            _input_values=input_values,
+            input_values=input_values,
         )
 
         return core_execute_in_process(

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -581,23 +581,6 @@ class GraphDefinition(NodeDefinition):
             JobDefinition
         """
         from .job_definition import JobDefinition
-        from .partition import PartitionedConfig, PartitionsDefinition
-
-        job_name = check_valid_name(name or self.name)
-
-        tags = check.opt_dict_param(tags, "tags", key_type=str)
-        executor_def_specified = executor_def is not None
-        logger_defs_specified = logger_defs is not None
-        metadata_entries = check.opt_sequence_param(_metadata_entries, "_metadata_entries")
-
-        executor_def = check.opt_inst_param(
-            executor_def, "executor_def", ExecutorDefinition, default=multi_or_in_process_executor
-        )
-        input_values = check.opt_mapping_param(input_values, "input_values")
-
-        hooks = check.opt_set_param(hooks, "hooks", of_type=HookDefinition)
-        op_retry_policy = check.opt_inst_param(op_retry_policy, "op_retry_policy", RetryPolicy)
-        op_selection = check.opt_list_param(op_selection, "op_selection", of_type=str)
 
         return JobDefinition(
             name=name,
@@ -616,9 +599,7 @@ class GraphDefinition(NodeDefinition):
             asset_layer=asset_layer,
             input_values=input_values,
             _subset_selection_data=_asset_selection_data,
-            _executor_def_specified=executor_def_specified,
-            _logger_defs_specified=logger_defs_specified,
-            _metadata_entries=metadata_entries,
+            _metadata_entries=_metadata_entries,
         ).get_job_def_for_subset_selection(op_selection)
 
     def coerce_to_job(self):

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -20,7 +20,9 @@ from typing import (
 from toposort import CircularDependencyError, toposort_flatten
 
 import dagster._check as check
-from dagster._config import ConfigType, Field, Shape, validate_config
+from dagster._config import Field, Shape
+from dagster._config.config_type import ConfigType
+from dagster._config.validate import validate_config
 from dagster._core.definitions.config import ConfigMapping
 from dagster._core.definitions.definition_config_schema import IDefinitionConfigSchema
 from dagster._core.definitions.policy import RetryPolicy
@@ -28,7 +30,6 @@ from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.utils import check_valid_name
 from dagster._core.errors import DagsterInvalidConfigError, DagsterInvalidDefinitionError
 from dagster._core.selector.subset_selector import AssetSelectionData
-from dagster._core.storage.io_manager import io_manager
 from dagster._core.types.dagster_type import (
     DagsterType,
     DagsterTypeKind,
@@ -602,50 +603,9 @@ class GraphDefinition(NodeDefinition):
         )
         input_values = check.opt_mapping_param(input_values, "input_values")
 
-        if resource_defs and DEFAULT_IO_MANAGER_KEY in resource_defs:
-            resource_defs_with_defaults = resource_defs
-        else:
-            resource_defs_with_defaults = merge_dicts(
-                {DEFAULT_IO_MANAGER_KEY: default_job_io_manager}, resource_defs or {}
-            )
-
         hooks = check.opt_set_param(hooks, "hooks", of_type=HookDefinition)
         op_retry_policy = check.opt_inst_param(op_retry_policy, "op_retry_policy", RetryPolicy)
         op_selection = check.opt_list_param(op_selection, "op_selection", of_type=str)
-        presets = []
-        config_mapping = None
-        partitioned_config = None
-
-        if partitions_def:
-            check.inst_param(partitions_def, "partitions_def", PartitionsDefinition)
-            if isinstance(config, (ConfigMapping, PartitionedConfig)):
-                check.failed(
-                    "Can't supply a ConfigMapping or PartitionedConfig for 'config' when 'partitions_def' is supplied."
-                )
-            hardcoded_config = config if config else {}
-            partitioned_config = PartitionedConfig(partitions_def, lambda _: hardcoded_config)
-
-        if isinstance(config, ConfigMapping):
-            config_mapping = config
-        elif isinstance(config, PartitionedConfig):
-            partitioned_config = config
-        elif isinstance(config, dict):
-            presets = [PresetDefinition(name="default", run_config=config)]
-            # Using config mapping here is a trick to make it so that the preset will be used even
-            # when no config is supplied for the job.
-            config_mapping = _config_mapping_with_default_value(
-                self._get_config_schema(
-                    resource_defs_with_defaults, executor_def, logger_defs, asset_layer
-                ),
-                config,
-                job_name,
-                self.name,
-            )
-        elif config is not None:
-            check.failed(
-                f"config param must be a ConfigMapping, a PartitionedConfig, or a dictionary, but "
-                f"is an object of type {type(config)}"
-            )
 
         return JobDefinition(
             name=job_name,
@@ -654,9 +614,8 @@ class GraphDefinition(NodeDefinition):
             resource_defs=resource_defs_with_defaults,
             logger_defs=logger_defs,
             executor_def=executor_def,
-            config_mapping=config_mapping,
-            partitioned_config=partitioned_config,
-            preset_defs=presets,
+            config=config,
+            partitions_def=partitions_def,
             tags=tags,
             metadata=metadata,
             hook_defs=hooks,
@@ -1118,13 +1077,3 @@ def _config_mapping_with_default_value(
     return ConfigMapping(
         config_fn=config_fn, config_schema=config_schema, receive_processed_config_values=False
     )
-
-
-@io_manager(
-    description="Built-in filesystem IO manager that stores and retrieves values using pickling."
-)
-def default_job_io_manager(init_context: "InitResourceContext"):
-    from dagster._core.storage.fs_io_manager import PickledObjectFilesystemIOManager
-
-    instance = check.not_none(init_context.instance)
-    return PickledObjectFilesystemIOManager(base_dir=instance.storage_directory())

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -46,14 +46,9 @@ from dagster._core.selector.subset_selector import (
     OpSelectionData,
     parse_op_selection,
 )
-<<<<<<< HEAD:python_modules/dagster/dagster/_core/definitions/job_definition.py
-from dagster._core.utils import str_format_set
-from dagster._utils import merge_dicts
-=======
 from dagster._core.storage.io_manager import io_manager
 from dagster._core.utils import str_format_set
-from dagster.utils import merge_dicts
->>>>>>> refactor JobDefinition creation:python_modules/dagster/dagster/core/definitions/job_definition.py
+from dagster._utils import merge_dicts
 
 from .asset_layer import AssetLayer, build_asset_selection_job
 from .config import ConfigMapping
@@ -73,16 +68,10 @@ from .utils import DEFAULT_IO_MANAGER_KEY
 from .version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
-<<<<<<< HEAD:python_modules/dagster/dagster/_core/definitions/job_definition.py
-    from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
-    from dagster._core.instance import DagsterInstance
-    from dagster._core.snap import PipelineSnapshot
-=======
     from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
     from dagster._core.execution.resources_init import InitResourceContext
     from dagster._core.instance import DagsterInstance
     from dagster._core.snap import PipelineSnapshot
->>>>>>> refactor JobDefinition creation:python_modules/dagster/dagster/core/definitions/job_definition.py
 
 
 class JobDefinition(PipelineDefinition):
@@ -114,7 +103,7 @@ class JobDefinition(PipelineDefinition):
         _logger_defs_specified: Optional[bool] = None,
         _preset_defs: Optional[Sequence[PresetDefinition]] = None,
     ):
-        from dagster.loggers import default_loggers
+        from dagster._loggers import default_loggers
 
         check.inst_param(graph_def, "graph_def", GraphDefinition)
         resource_defs = check.opt_mapping_param(
@@ -126,12 +115,12 @@ class JobDefinition(PipelineDefinition):
         # it directly. Once JobDefinition no longer subclasses
         # PipelineDefinition, we can change the default executor to be set
         # elsewhere to avoid the need for this check.
-        _executor_def_specified = (
+        self._executor_def_specified = (
             _executor_def_specified
             if _executor_def_specified is not None
             else executor_def is not None
         )
-        _logger_defs_specified = (
+        self._logger_defs_specified = (
             _logger_defs_specified
             if _logger_defs_specified is not None
             else logger_defs is not None
@@ -216,15 +205,13 @@ class JobDefinition(PipelineDefinition):
 
         # Exists for backcompat - JobDefinition is implemented as a single-mode pipeline.
         mode_def = ModeDefinition(
-            resource_defs=resource_defs,
+            resource_defs=resource_defs_with_defaults,
             logger_defs=logger_defs,
             executor_defs=[executor_def] if executor_def else None,
             _config_mapping=config_mapping,
             _partitioned_config=partitioned_config,
         )
 
-        self._executor_def_specified = _executor_def_specified
-        self._logger_defs_specified = _logger_defs_specified
         self._cached_partition_set: Optional["PartitionSetDefinition"] = None
         self._subset_selection_data = _subset_selection_data
         self.input_values = input_values

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -192,7 +192,7 @@ class JobDefinition(PipelineDefinition):
             # when no config is supplied for the job.
             config_mapping = _config_mapping_with_default_value(
                 get_run_config_schema_for_job(
-                    graph_def, resource_defs_with_defaults, executor_def, logger_defs
+                    graph_def, resource_defs_with_defaults, executor_def, logger_defs, asset_layer
                 ),
                 config,
                 name,
@@ -852,6 +852,7 @@ def get_run_config_schema_for_job(
     resource_defs: Mapping[str, ResourceDefinition],
     executor_def: "ExecutorDefinition",
     logger_defs: Mapping[str, LoggerDefinition],
+    asset_layer: Optional[AssetLayer],
 ) -> ConfigType:
     return (
         JobDefinition(
@@ -860,6 +861,7 @@ def get_run_config_schema_for_job(
             resource_defs=resource_defs,
             executor_def=executor_def,
             logger_defs=logger_defs,
+            asset_layer=asset_layer,
         )
         .get_run_config_schema("default")
         .run_config_schema_type

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -780,7 +780,7 @@ def test_log_metadata_asset_materialization():
 
     result = execute_op_in_graph(the_op)
     materialization = result.asset_materializations_for_node("the_op")[0]
-    assert len(materialization.metadata_entries) == 1
+    assert len(materialization.metadata_entries) == 2
     assert materialization.metadata_entries[0].label == "bar"
     assert materialization.metadata_entries[0].entry_data.text == "baz"
 

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -492,7 +492,7 @@ def test_to_job_incomplete_default_config():
     def my_graph():
         my_op()
 
-    default_config_error = "Error in config when building job 'my_job' from graph 'my_graph' "
+    default_config_error = "Error in config when building job 'my_job' "
     invalid_default_error = "Invalid default_value for Field."
     invalid_configs = [
         (


### PR DESCRIPTION
JobDefinition previously utilized presets in its top-level API due to how config mapping was processed. This pushes a lot of the config/resource processing code down into the JobDefinition. 
This also fixes a bug where the default executor/io manager if constructing a JobDefinition from the constructor would be the defaults from the pipeline, because the job-level defaults were previously resolved in the `to_job` call.