### PR TITLE
Thread config during asset selection

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/core/definitions/assets_job.py
@@ -131,10 +131,10 @@ def build_assets_job(
             partitions_def=partitions_def,
             asset_layer=asset_layer,
             _asset_selection_data=_asset_selection_data,
-            _metadata_entries=original_job._metadata_entries,
+            _metadata_entries=original_job._metadata_entries,  # pylint: disable=protected-access
             logger_defs=original_job.get_mode_definition().loggers,
             hooks=original_job.hook_defs,
-            op_retry_policy=original_job._solid_retry_policy,
+            op_retry_policy=original_job._solid_retry_policy,  # pylint: disable=protected-access
             version_strategy=original_job.version_strategy,
         )
 

--- a/python_modules/dagster/dagster/core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/core/definitions/assets_job.py
@@ -121,6 +121,23 @@ def build_assets_job(
 
     all_resource_defs = get_all_resource_defs(assets, resolved_source_assets, resource_defs)
 
+    if _asset_selection_data:
+        original_job = _asset_selection_data.parent_job_def
+        return graph.to_job(
+            resource_defs=all_resource_defs,
+            config=config,
+            tags=tags,
+            executor_def=executor_def,
+            partitions_def=partitions_def,
+            asset_layer=asset_layer,
+            _asset_selection_data=_asset_selection_data,
+            _metadata_entries=original_job._metadata_entries,
+            logger_defs=original_job.get_mode_definition().loggers,
+            hooks=original_job.hook_defs,
+            op_retry_policy=original_job._solid_retry_policy,
+            version_strategy=original_job.version_strategy,
+        )
+
     return graph.to_job(
         resource_defs=all_resource_defs,
         config=config,

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -49,7 +49,7 @@ from .dependency import (
 from .hook_definition import HookDefinition
 from .input import FanInInputPointer, InputDefinition, InputMapping, InputPointer
 from .logger_definition import LoggerDefinition
-from .metadata import RawMetadataValue
+from .metadata import RawMetadataValue, MetadataEntry, PartitionMetadataEntry
 from .node_definition import NodeDefinition
 from .output import OutputDefinition, OutputMapping
 from .preset import PresetDefinition
@@ -527,7 +527,7 @@ class GraphDefinition(NodeDefinition):
         asset_layer: Optional["AssetLayer"] = None,
         input_values: Optional[Mapping[str, object]] = None,
         _asset_selection_data: Optional[AssetSelectionData] = None,
-        _executor_def_specified: bool = False,
+        _metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
     ) -> "JobDefinition":
         """
         Make this graph in to an executable Job by providing remaining components required for execution.
@@ -597,6 +597,8 @@ class GraphDefinition(NodeDefinition):
         tags = check.opt_dict_param(tags, "tags", key_type=str)
         executor_def_specified = executor_def is not None
         logger_defs_specified = logger_defs is not None
+        metadata_entries = check.opt_sequence_param(_metadata_entries, "_metadata_entries")
+
         executor_def = check.opt_inst_param(
             executor_def, "executor_def", ExecutorDefinition, default=multi_or_in_process_executor
         )
@@ -665,6 +667,7 @@ class GraphDefinition(NodeDefinition):
             _subset_selection_data=_asset_selection_data,
             _executor_def_specified=executor_def_specified,
             _logger_defs_specified=logger_defs_specified,
+            _metadata_entries=metadata_entries,
         ).get_job_def_for_subset_selection(op_selection)
 
     def coerce_to_job(self):

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -49,7 +49,7 @@ from .dependency import (
 from .hook_definition import HookDefinition
 from .input import FanInInputPointer, InputDefinition, InputMapping, InputPointer
 from .logger_definition import LoggerDefinition
-from .metadata import RawMetadataValue, MetadataEntry, PartitionMetadataEntry
+from .metadata import MetadataEntry, PartitionMetadataEntry, RawMetadataValue
 from .node_definition import NodeDefinition
 from .output import OutputDefinition, OutputMapping
 from .preset import PresetDefinition

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -303,6 +303,12 @@ class JobDefinition(PipelineDefinition):
             else None
         )
 
+    @property
+    def is_subset_pipeline(self) -> bool:
+        if self._subset_selection_data:
+            return True
+        return False
+
     def get_job_def_for_subset_selection(
         self,
         op_selection: Optional[Sequence[str]] = None,
@@ -359,6 +365,7 @@ class JobDefinition(PipelineDefinition):
             tags=self.tags,
             asset_selection=asset_selection,
             asset_selection_data=asset_selection_data,
+            config=self.config_mapping,
         )
         return new_job
 

--- a/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
@@ -796,7 +796,7 @@ def _create_run_config_schema(
     mode_definition: ModeDefinition,
     required_resources: AbstractSet[str],
 ) -> "RunConfigSchema":
-    from .job_definition import get_direct_input_values_from_job
+    from .job_definition import JobDefinition, get_direct_input_values_from_job
     from .run_config import (
         RunConfigSchemaCreationData,
         construct_config_type_dictionary,
@@ -807,12 +807,12 @@ def _create_run_config_schema(
     # When executing with a subset pipeline, include the missing solids
     # from the original pipeline as ignored to allow execution with
     # run config that is valid for the original
-    if pipeline_def.is_job and pipeline_def.is_subset_pipeline:
-        if pipeline_def.op_selection_data:
+    if isinstance(pipeline_def, JobDefinition) and pipeline_def.is_subset_pipeline:
+        if isinstance(pipeline_def.graph, SubselectedGraphDefinition):  # op selection provided
             ignored_solids = pipeline_def.graph.get_top_level_omitted_nodes()
         elif pipeline_def.asset_selection_data:
             parent_job = pipeline_def
-            while parent_job.is_subset_pipeline:
+            while parent_job.asset_selection_data:
                 parent_job = parent_job.asset_selection_data.parent_job_def
 
             selected_solids = pipeline_def.graph.solids

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -18,13 +18,13 @@ from dagster import (
     Output,
     ResourceDefinition,
     StaticPartitionsDefinition,
+    define_asset_job,
     graph,
     io_manager,
     materialize_to_memory,
     multi_asset,
     op,
     resource,
-    define_asset_job,
 )
 from dagster.config.source import StringSource
 from dagster.core.definitions import AssetGroup, AssetIn, SourceAsset, asset, build_assets_job
@@ -1329,20 +1329,20 @@ def test_job_preserved_with_asset_subset():
     asset_one = AssetsDefinition.from_op(one)
 
     @asset(config_schema={"bar": int})
-    def two(context, one):
+    def two(context, one):  # pylint: disable=unused-argument
         assert context.op_config["bar"] == 2
 
     @asset(config_schema={"baz": int})
-    def three(context, two):
+    def three(context, two):  # pylint: disable=unused-argument
         assert context.op_config["baz"] == 3
 
     foo_job = define_asset_job(
         "foo_job",
         config={
-            'ops': {
-                'one': {'config': {'foo': 1}},
-                'two': {'config': {'bar': 2}},
-                'three': {'config': {'baz': 3}},
+            "ops": {
+                "one": {"config": {"foo": 1}},
+                "two": {"config": {"bar": 2}},
+                "three": {"config": {"baz": 3}},
             }
         },
         description="my cool job",
@@ -1351,7 +1351,7 @@ def test_job_preserved_with_asset_subset():
 
     result = foo_job.execute_in_process(asset_selection=[AssetKey("one")])
     assert result.success
-    assert result.dagster_run.tags == {'yay': '1'}
+    assert result.dagster_run.tags == {"yay": "1"}
 
 
 def test_raise_error_on_incomplete_graph_asset_subset():

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -24,6 +24,7 @@ from dagster import (
     multi_asset,
     op,
     resource,
+    define_asset_job,
 )
 from dagster.config.source import StringSource
 from dagster.core.definitions import AssetGroup, AssetIn, SourceAsset, asset, build_assets_job
@@ -1316,6 +1317,41 @@ def test_subset_of_build_assets_job():
                 instance=instance,
                 asset_selection=[AssetKey("unconnected")],
             )
+
+
+def test_job_preserved_with_asset_subset():
+    # Assert that default config is used for asset subset
+
+    @op(config_schema={"foo": int})
+    def one(context):
+        assert context.op_config["foo"] == 1
+
+    asset_one = AssetsDefinition.from_op(one)
+
+    @asset(config_schema={"bar": int})
+    def two(context, one):
+        assert context.op_config["bar"] == 2
+
+    @asset(config_schema={"baz": int})
+    def three(context, two):
+        assert context.op_config["baz"] == 3
+
+    foo_job = define_asset_job(
+        "foo_job",
+        config={
+            'ops': {
+                'one': {'config': {'foo': 1}},
+                'two': {'config': {'bar': 2}},
+                'three': {'config': {'baz': 3}},
+            }
+        },
+        description="my cool job",
+        tags={"yay": 1},
+    ).resolve([asset_one, two, three], [])
+
+    result = foo_job.execute_in_process(asset_selection=[AssetKey("one")])
+    assert result.success
+    assert result.dagster_run.tags == {'yay': '1'}
 
 
 def test_raise_error_on_incomplete_graph_asset_subset():


### PR DESCRIPTION
Reported by a user ([link](https://elementl-workspace.slack.com/archives/C03CCE471E0/p1658179015802579))

Default config that is provided in `define_asset_job` is not threaded through when an asset selection occurs. This PR amends this behavior by passing in this default config.

Other fields were also missing (e.g. metadata, loggers, etc.) which don't currently affect users because there's currently no way to specify these fields on asset jobs. This PR threads these fields to the subsetted job so that these fields will be respected should they exist in the future.

Additionally, if default config is provided for an asset that is not part of the asset selection, this PR ignores the config for these de-selected assets. This is existing behavior for op/solid selection.