### PR TITLE
Bug fix with run status sensors that return run requests

### DIFF
--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/repo.py
@@ -41,9 +41,11 @@ from dagster_test.graph_job_op_toys.retries import retry_job
 from dagster_test.graph_job_op_toys.run_status_sensors import (
     fails_job,
     fails_sensor,
+    multi_run_request_success_sensor,
     status_job,
     succeeds_job,
     succeeds_sensor,
+    success_sensor_with_pipeline_run_reaction,
 )
 from dagster_test.graph_job_op_toys.sleepy import sleepy_job
 from dagster_test.graph_job_op_toys.software_defined_assets import software_defined_assets
@@ -104,6 +106,8 @@ def toys_repository():
             fails_sensor,
             status_job,
             df_stats_job,
+            multi_run_request_success_sensor,
+            success_sensor_with_pipeline_run_reaction,
         ]
         + get_toys_schedules()
         + get_toys_sensors()

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/repo.py
@@ -41,11 +41,13 @@ from dagster_test.graph_job_op_toys.retries import retry_job
 from dagster_test.graph_job_op_toys.run_status_sensors import (
     fails_job,
     fails_sensor,
-    multi_run_request_success_sensor,
+    return_multi_run_request_success_sensor,
+    return_run_request_succeeds_sensor,
     status_job,
     succeeds_job,
-    succeeds_sensor,
     success_sensor_with_pipeline_run_reaction,
+    yield_multi_run_request_success_sensor,
+    yield_run_request_succeeds_sensor,
 )
 from dagster_test.graph_job_op_toys.sleepy import sleepy_job
 from dagster_test.graph_job_op_toys.software_defined_assets import software_defined_assets
@@ -101,12 +103,14 @@ def toys_repository():
             software_defined_assets,
             with_metadata,
             succeeds_job,
-            succeeds_sensor,
+            return_run_request_succeeds_sensor,
+            yield_run_request_succeeds_sensor,
             fails_job,
             fails_sensor,
             status_job,
             df_stats_job,
-            multi_run_request_success_sensor,
+            yield_multi_run_request_success_sensor,
+            return_multi_run_request_success_sensor,
             success_sensor_with_pipeline_run_reaction,
         ]
         + get_toys_schedules()

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/run_status_sensors.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/run_status_sensors.py
@@ -43,9 +43,31 @@ def status_job():
 
 
 @run_status_sensor(pipeline_run_status=DagsterRunStatus.SUCCESS, request_job=status_job)
-def succeeds_sensor(context):
+def yield_run_request_succeeds_sensor(context):
+    """
+    We recommend returning RunRequests, but it's possible to yield, so this is here to test it
+    """
     if context.dagster_run.pipeline_name != status_job.name:
         yield RunRequest(
+            run_key=None,
+            run_config={
+                "ops": {
+                    "status_printer": {
+                        "config": {
+                            "message": f"{context.dagster_run.pipeline_name} job succeeded!!!"
+                        }
+                    }
+                }
+            },
+        )
+    else:
+        yield SkipReason("Don't report status of status_job.")
+
+
+@run_status_sensor(pipeline_run_status=DagsterRunStatus.SUCCESS, request_job=status_job)
+def return_run_request_succeeds_sensor(context):
+    if context.dagster_run.pipeline_name != status_job.name:
+        return RunRequest(
             run_key=None,
             run_config={
                 "ops": {
@@ -84,7 +106,7 @@ def success_sensor_with_pipeline_run_reaction(context):
 
 
 @run_status_sensor(pipeline_run_status=DagsterRunStatus.SUCCESS, request_job=status_job)
-def multi_run_request_success_sensor(context):
+def yield_multi_run_request_success_sensor(context):
     if context.dagster_run.pipeline_name != status_job.name:
         for _ in range(3):
             yield RunRequest(
@@ -99,5 +121,31 @@ def multi_run_request_success_sensor(context):
                     }
                 },
             )
+    else:
+        return SkipReason("Don't report status of status_job.")
+
+
+@run_status_sensor(pipeline_run_status=DagsterRunStatus.SUCCESS, request_job=status_job)
+def return_multi_run_request_success_sensor(context):
+    """
+    Also test returning a list of run requests
+    """
+    if context.dagster_run.pipeline_name != status_job.name:
+        reqs = []
+        for _ in range(3):
+            r = RunRequest(
+                run_key=str(time()),
+                run_config={
+                    "ops": {
+                        "status_printer": {
+                            "config": {
+                                "message": f"{context.dagster_run.pipeline_name} job succeeded!!!"
+                            }
+                        }
+                    }
+                },
+            )
+            reqs.append(r)
+        return reqs
     else:
         return SkipReason("Don't report status of status_job.")

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/run_status_sensors.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/run_status_sensors.py
@@ -1,3 +1,5 @@
+from time import time
+
 from dagster import (
     DagsterRunStatus,
     RunRequest,
@@ -7,6 +9,7 @@ from dagster import (
     run_failure_sensor,
     run_status_sensor,
 )
+from dagster.core.definitions.run_request import PipelineRunReaction
 
 
 @op
@@ -42,7 +45,7 @@ def status_job():
 @run_status_sensor(pipeline_run_status=DagsterRunStatus.SUCCESS, request_job=status_job)
 def succeeds_sensor(context):
     if context.dagster_run.pipeline_name != status_job.name:
-        return RunRequest(
+        yield RunRequest(
             run_key=None,
             run_config={
                 "ops": {
@@ -70,3 +73,31 @@ def fails_sensor(context):
             }
         },
     )
+
+
+@run_status_sensor(
+    pipeline_run_status=DagsterRunStatus.SUCCESS,
+)
+def success_sensor_with_pipeline_run_reaction(context):
+    """Some users do this, so here's a way to test it out"""
+    return PipelineRunReaction(context.dagster_run)
+
+
+@run_status_sensor(pipeline_run_status=DagsterRunStatus.SUCCESS, request_job=status_job)
+def multi_run_request_success_sensor(context):
+    if context.dagster_run.pipeline_name != status_job.name:
+        for _ in range(3):
+            yield RunRequest(
+                run_key=str(time()),
+                run_config={
+                    "ops": {
+                        "status_printer": {
+                            "config": {
+                                "message": f"{context.dagster_run.pipeline_name} job succeeded!!!"
+                            }
+                        }
+                    }
+                },
+            )
+    else:
+        return SkipReason("Don't report status of status_job.")


### PR DESCRIPTION
### Summary & Motivation
User reported bug when a run status sensor returned a PipelineRunReaction causes a check failure. This happened with returning RunRequests as well because instead of returning a RunRequest (or pipeline run reaction, etc), the individual attributes of the run request named tuple were returned. 

I have no idea how this got through testing (i tested the exact case that replicates the bug a bunch of times when originally developing this feature) so, if possible, i'd like to add some kind of integration test that can check for this in the future. However, i'm not sure where such tests exist in the code base if they do exist. lmk if there's somewhere i can look 


### How I Tested These Changes
