### PR TITLE
Make ALERT_SUCCESS event grey instead of green

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/LogsRowStructuredContent.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRowStructuredContent.tsx
@@ -175,7 +175,7 @@ export const LogsRowStructuredContent: React.FC<IStructuredContentProps> = ({nod
     case 'AlertStartEvent':
       return <DefaultContent eventType={eventType} message={node.message} />;
     case 'AlertSuccessEvent':
-      return <DefaultContent eventType={eventType} message={node.message} eventIntent="success" />;
+      return <DefaultContent eventType={eventType} message={node.message} />;
     case 'AlertFailureEvent':
       return <DefaultContent eventType={eventType} message={node.message} eventIntent="warning" />;
     case 'ResourceInitFailureEvent':


### PR DESCRIPTION
I find green 'ALERT_SUCCESS' to look too much like a `RUN_SUCCESS` at a glance, change it to grey

<img width="150" alt="Screen Shot 2022-07-21 at 2 57 59 PM" src="https://user-images.githubusercontent.com/22018973/180294825-fe17a250-7635-4361-97e0-6f5d77fc4d5c.png">
 