### PR TITLE
Add public/deprecated annotation decorators

### DIFF
--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -1,21 +1,113 @@
-from typing import Callable, TypeVar
+import inspect
+from functools import wraps
+from typing import Callable, Type, TypeVar, cast
+
+import dagster._check as check
+from dagster.utils.backcompat import (
+    experimental_class_warning,
+    experimental_decorator_warning,
+    experimental_fn_warning,
+)
 
 T_Callable = TypeVar("T_Callable", bound=Callable)
 
+##### PUBLIC
 
-def public(fn: T_Callable) -> T_Callable:
-    setattr(fn, "_public", True)
-    return fn
+
+def public(obj: T_Callable) -> T_Callable:
+    """
+    Mark a method on a public class as public. This distinguishes the method from "internal"
+    methods, which are methods that are public in the Python sense of being non-underscored, but
+    not intended for user access. Only `public` methods of a class are rendered in the docs.
+    """
+    check.callable_param(obj, "obj")
+    setattr(obj, "_public", True)
+    return obj
 
 
 def is_public(fn: Callable) -> bool:
+    check.callable_param(fn, "fn")
     return hasattr(fn, "_public") and getattr(fn, "_public")
 
 
-def deprecated(fn: T_Callable) -> T_Callable:
-    setattr(fn, "_deprecated", True)
-    return fn
+##### DEPRECATED
+
+
+def deprecated(obj: T_Callable) -> T_Callable:
+    """
+    Mark a class/method/function as deprecated. This appends some metadata to tee fucntion that
+    causes it to be rendered with a "deprecated" tag in the docs.
+
+    Note that this decorator does not add any warnings-- they should be added separately.
+    """
+    check.callable_param(obj, "obj")
+    setattr(obj, "_deprecated", True)
+    return obj
 
 
 def is_deprecated(fn: Callable) -> bool:
+    check.callable_param(fn, "fn")
     return hasattr(fn, "_deprecated") and getattr(fn, "_deprecated")
+
+
+##### EXPERIMENTAL
+
+
+def experimental(obj: T_Callable, *, decorator: bool = False) -> T_Callable:
+    """
+    Mark a class/method/function as experimental. This appends some metadata to the function that
+    causes it to be rendered with an "experimental" tag in the docs.
+
+    Also triggers an "experimental" warning whenever the passed callable is called. If the argument
+    is a class, this means the warning will be emitted when the class is instantiated.
+
+    Usage:
+
+        .. code-block:: python
+
+            @experimental
+            def my_experimental_function(my_arg):
+                do_stuff()
+
+            @experimental
+            class MyExperimentalClass:
+                pass
+    """
+    check.callable_param(obj, "fn")
+    setattr(obj, "_experimental", True)
+
+    if inspect.isfunction(obj):
+
+        warning_fn = experimental_decorator_warning if decorator else experimental_fn_warning
+
+        @wraps(obj)
+        def inner(*args, **kwargs):
+            warning_fn(obj.__name__, stacklevel=3)
+            return obj(*args, **kwargs)
+
+        return cast(T_Callable, inner)
+
+    elif inspect.isclass(obj):
+
+        undecorated_init = obj.__init__
+
+        def __init__(self, *args, **kwargs):
+            experimental_class_warning(obj.__name__, stacklevel=3)
+            # Tuples must be handled differently, because the undecorated_init does not take any
+            # arguments-- they're assigned in __new__.
+            if issubclass(cast(Type, obj), tuple):
+                undecorated_init(self)
+            else:
+                undecorated_init(self, *args, **kwargs)
+
+        obj.__init__ = __init__
+
+        return cast(T_Callable, obj)
+
+    else:
+        check.failed("obj must be a function or a class")
+
+
+def is_experimental(obj: Callable) -> bool:
+    check.callable_param(obj, "obj")
+    return hasattr(obj, "_experimental") and getattr(obj, "_experimental")

--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -4,7 +4,7 @@ T_Callable = TypeVar("T_Callable", bound=Callable)
 
 
 def public(fn: T_Callable) -> T_Callable:
-    fn._public = True  # pylint: disable = protected-access
+    setattr(fn, "_public", True)
     return fn
 
 
@@ -13,7 +13,7 @@ def is_public(fn: Callable) -> bool:
 
 
 def deprecated(fn: T_Callable) -> T_Callable:
-    fn._deprecated = True  # pylint: disable = protected-access
+    setattr(fn, "_deprecated", True)
     return fn
 
 

--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -1,0 +1,21 @@
+from typing import Callable, TypeVar
+
+T_Callable = TypeVar("T_Callable", bound=Callable)
+
+
+def public(fn: T_Callable) -> T_Callable:
+    fn._public = True  # pylint: disable = protected-access
+    return fn
+
+
+def is_public(fn: Callable) -> bool:
+    return hasattr(fn, "_public") and getattr(fn, "_public")
+
+
+def deprecated(fn: T_Callable) -> T_Callable:
+    fn._deprecated = True  # pylint: disable = protected-access
+    return fn
+
+
+def is_deprecated(fn: Callable) -> bool:
+    return hasattr(fn, "_deprecated") and getattr(fn, "_deprecated")

--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -21,13 +21,13 @@ def public(obj: T_Callable) -> T_Callable:
     not intended for user access. Only `public` methods of a class are rendered in the docs.
     """
     check.callable_param(obj, "obj")
-    setattr(obj, "_public", True)
+    setattr(obj, "_is_public", True)
     return obj
 
 
 def is_public(fn: Callable) -> bool:
     check.callable_param(fn, "fn")
-    return hasattr(fn, "_public") and getattr(fn, "_public")
+    return hasattr(fn, "_is_public") and getattr(fn, "_is_public")
 
 
 ##### DEPRECATED
@@ -41,13 +41,13 @@ def deprecated(obj: T_Callable) -> T_Callable:
     Note that this decorator does not add any warnings-- they should be added separately.
     """
     check.callable_param(obj, "obj")
-    setattr(obj, "_deprecated", True)
+    setattr(obj, "_is_deprecated", True)
     return obj
 
 
 def is_deprecated(fn: Callable) -> bool:
     check.callable_param(fn, "fn")
-    return hasattr(fn, "_deprecated") and getattr(fn, "_deprecated")
+    return hasattr(fn, "_is_deprecated") and getattr(fn, "_is_deprecated")
 
 
 ##### EXPERIMENTAL
@@ -74,7 +74,7 @@ def experimental(obj: T_Callable, *, decorator: bool = False) -> T_Callable:
                 pass
     """
     check.callable_param(obj, "fn")
-    setattr(obj, "_experimental", True)
+    setattr(obj, "_is_experimental", True)
 
     if inspect.isfunction(obj):
 
@@ -110,4 +110,4 @@ def experimental(obj: T_Callable, *, decorator: bool = False) -> T_Callable:
 
 def is_experimental(obj: Callable) -> bool:
     check.callable_param(obj, "obj")
-    return hasattr(obj, "_experimental") and getattr(obj, "_experimental")
+    return hasattr(obj, "_is_experimental") and getattr(obj, "_is_experimental")

--- a/python_modules/dagster/dagster/cli/new_project.py
+++ b/python_modules/dagster/dagster/cli/new_project.py
@@ -2,8 +2,8 @@ import os
 
 import click
 
+from dagster._annotations import experimental
 from dagster.generate import generate_new_project
-from dagster.utils.backcompat import experimental
 
 
 @click.command(name="new-project")

--- a/python_modules/dagster/dagster/core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/core/definitions/assets_job.py
@@ -4,11 +4,11 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, 
 from toposort import CircularDependencyError, toposort
 
 import dagster._check as check
+from dagster._annotations import experimental
 from dagster.core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.selector.subset_selector import AssetSelectionData
 from dagster.utils import merge_dicts
-from dagster.utils.backcompat import experimental
 
 from .asset_layer import AssetLayer
 from .assets import AssetsDefinition

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -18,12 +18,12 @@ from typing import (
 
 import dagster._check as check
 import dagster.seven as seven
+from dagster._annotations import experimental
 from dagster.core.errors import DagsterInvalidMetadata
 from dagster.serdes import whitelist_for_serdes
 from dagster.utils.backcompat import (
     canonicalize_backcompat_args,
     deprecation_warning,
-    experimental,
     experimental_class_warning,
 )
 

--- a/python_modules/dagster/dagster/core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/table.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict, List, NamedTuple, Optional, Type, Union, cast
 
 import dagster._check as check
+from dagster._annotations import experimental
 from dagster.serdes.serdes import DefaultNamedTupleSerializer, whitelist_for_serdes
-from dagster.utils.backcompat import experimental
 
 # ########################
 # ##### TABLE RECORD

--- a/python_modules/dagster/dagster/core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/core/definitions/partition_mapping.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
 from typing import Optional
 
+from dagster._annotations import experimental
 from dagster.core.definitions.partition import PartitionsDefinition
 from dagster.core.definitions.partition_key_range import PartitionKeyRange
-from dagster.utils.backcompat import experimental
 
 
 @experimental

--- a/python_modules/dagster/dagster/core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/core/definitions/reconstruct.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, FrozenSet, List, NamedTuple, Option
 
 import dagster._check as check
 import dagster.seven as seven
+from dagster._annotations import experimental
 from dagster.core.code_pointer import (
     CodePointer,
     CustomPointer,
@@ -22,7 +23,6 @@ from dagster.core.origin import (
 from dagster.core.selector import parse_solid_selection
 from dagster.serdes import pack_value, unpack_value, whitelist_for_serdes
 from dagster.utils import frozenlist, make_readonly_value
-from dagster.utils.backcompat import experimental
 
 from .events import AssetKey
 from .pipeline_base import IPipeline

--- a/python_modules/dagster/dagster/core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/core/storage/fs_io_manager.py
@@ -3,6 +3,7 @@ import pickle
 from typing import Union
 
 import dagster._check as check
+from dagster._annotations import experimental
 from dagster.config import Field
 from dagster.config.source import StringSource
 from dagster.core.definitions.events import AssetKey, AssetMaterialization
@@ -13,7 +14,6 @@ from dagster.core.execution.context.output import OutputContext
 from dagster.core.storage.io_manager import IOManager, io_manager
 from dagster.core.storage.memoizable_io_manager import MemoizableIOManager
 from dagster.utils import PICKLE_PROTOCOL, mkdir_p
-from dagster.utils.backcompat import experimental
 
 
 @io_manager(

--- a/python_modules/dagster/dagster/core/storage/memoizable_io_manager.py
+++ b/python_modules/dagster/dagster/core/storage/memoizable_io_manager.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 from typing import Union
 
 import dagster._check as check
+from dagster._annotations import experimental
 from dagster.config import Field
 from dagster.config.source import StringSource
 from dagster.core.errors import DagsterInvariantViolationError
@@ -11,7 +12,6 @@ from dagster.core.execution.context.input import InputContext
 from dagster.core.execution.context.output import OutputContext
 from dagster.core.storage.io_manager import IOManager, io_manager
 from dagster.utils import PICKLE_PROTOCOL, mkdir_p
-from dagster.utils.backcompat import experimental
 
 
 class MemoizableIOManager(IOManager):

--- a/python_modules/dagster/dagster/core/storage/root_input_manager.py
+++ b/python_modules/dagster/dagster/core/storage/root_input_manager.py
@@ -2,13 +2,14 @@ from abc import abstractmethod
 from functools import update_wrapper
 
 import dagster._check as check
+from dagster._annotations import experimental
 from dagster.core.definitions.config import is_callable_valid_config_arg
 from dagster.core.definitions.definition_config_schema import (
     convert_user_facing_definition_config_schema,
 )
 from dagster.core.definitions.resource_definition import ResourceDefinition, is_context_provided
 from dagster.core.storage.input_manager import IInputManagerDefinition, InputManager
-from dagster.utils.backcompat import deprecation_warning, experimental
+from dagster.utils.backcompat import deprecation_warning
 
 
 class RootInputManagerDefinition(ResourceDefinition, IInputManagerDefinition):

--- a/python_modules/dagster/dagster_tests/execution_tests/test_solid_iterators.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_solid_iterators.py
@@ -1,6 +1,6 @@
 from dagster import AssetMaterialization, Output, execute_solid
+from dagster._annotations import experimental
 from dagster._legacy import solid
-from dagster.utils.backcompat import experimental
 
 
 def test_generator_return_solid():

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_backcompat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_backcompat.py
@@ -4,14 +4,12 @@ from typing import NamedTuple
 import pytest
 from dagster_tests.general_tests.utils_tests.utils import assert_no_warnings
 
+from dagster._annotations import experimental
 from dagster._check import CheckError
 from dagster.utils.backcompat import (
     ExperimentalWarning,
     canonicalize_backcompat_args,
-    experimental,
     experimental_arg_warning,
-    experimental_class_warning,
-    experimental_fn_warning,
 )
 
 
@@ -67,8 +65,9 @@ def test_backcompat_both_set():
 
 
 def test_experimental_fn_warning():
+    @experimental
     def my_experimental_function():
-        experimental_fn_warning("my_experimental_function")
+        pass
 
     with pytest.warns(
         ExperimentalWarning,
@@ -81,9 +80,10 @@ def test_experimental_fn_warning():
 
 
 def test_experimental_class_warning():
+    @experimental
     class MyExperimentalClass:
         def __init__(self):
-            experimental_class_warning("MyExperimentalClass")
+            pass
 
     with pytest.warns(
         ExperimentalWarning,
@@ -95,38 +95,7 @@ def test_experimental_class_warning():
     assert warning[0].filename.endswith("test_backcompat.py")
 
 
-def test_experimental_arg_warning():
-    def stable_function(_stable_arg, _experimental_arg):
-        experimental_arg_warning("experimental_arg", "stable_function")
-
-    with pytest.warns(
-        ExperimentalWarning,
-        match='"experimental_arg" is an experimental argument to function "stable_function". '
-        "It may break in future versions, even between dot releases. ",
-    ) as warning:
-        stable_function(1, 2)
-
-    assert warning[0].filename.endswith("test_backcompat.py")
-
-
-def test_experimental_decorator_function():
-    @experimental
-    def my_experimental_function(arg):
-        return arg
-
-    assert my_experimental_function.__name__ == "my_experimental_function"
-
-    with pytest.warns(
-        ExperimentalWarning,
-        match='"my_experimental_function" is an experimental function. It may break in future'
-        " versions, even between dot releases. ",
-    ) as warning:
-        assert my_experimental_function(5) == 5
-
-    assert warning[0].filename.endswith("test_backcompat.py")
-
-
-def test_experimental_decorator_class():
+def test_experimental_class_with_methods():
     @experimental
     class ExperimentalClass:
         def __init__(self, salutation="hello"):
@@ -178,3 +147,17 @@ def test_experimental_decorator_class():
         match='"ExperimentalNamedTupleClass" is an experimental class. It may break in future versions, even between dot releases.',
     ):
         assert ExperimentalNamedTupleClass(salutation="howdy").salutation == "howdy"
+
+
+def test_experimental_arg_warning():
+    def stable_function(_stable_arg, _experimental_arg):
+        experimental_arg_warning("experimental_arg", "stable_function")
+
+    with pytest.warns(
+        ExperimentalWarning,
+        match='"experimental_arg" is an experimental argument to function "stable_function". '
+        "It may break in future versions, even between dot releases. ",
+    ) as warning:
+        stable_function(1, 2)
+
+    assert warning[0].filename.endswith("test_backcompat.py")

--- a/python_modules/dagster/dagster_tests/test_annotations.py
+++ b/python_modules/dagster/dagster_tests/test_annotations.py
@@ -1,4 +1,11 @@
-from dagster._annotations import deprecated, is_deprecated, is_public, public
+from dagster._annotations import (
+    deprecated,
+    experimental,
+    is_deprecated,
+    is_experimental,
+    is_public,
+    public,
+)
 
 
 def test_public_annotation():
@@ -17,3 +24,12 @@ def test_deprecated():
             pass
 
     assert is_deprecated(Foo.bar)
+
+
+def test_experimental():
+    class Foo:
+        @experimental
+        def bar(self):
+            pass
+
+    assert is_experimental(Foo.bar)

--- a/python_modules/dagster/dagster_tests/test_annotations.py
+++ b/python_modules/dagster/dagster_tests/test_annotations.py
@@ -1,0 +1,19 @@
+from dagster._annotations import deprecated, is_deprecated, is_public, public
+
+
+def test_public_annotation():
+    class Foo:
+        @public
+        def bar(self):
+            pass
+
+    assert is_public(Foo.bar)
+
+
+def test_deprecated():
+    class Foo:
+        @deprecated
+        def bar(self):
+            pass
+
+    assert is_deprecated(Foo.bar)

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -4,8 +4,8 @@ from dagster_airbyte.utils import generate_materializations
 
 from dagster import AssetKey, Out, Output
 from dagster import _check as check
+from dagster._annotations import experimental
 from dagster.core.definitions import AssetsDefinition, multi_asset
-from dagster.utils.backcompat import experimental
 
 
 @experimental

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/solids.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/solids.py
@@ -9,9 +9,9 @@ from dagster import (
     Permissive,
     StringSource,
 )
+from dagster._annotations import experimental
 from dagster._legacy import solid
 from dagster.config.field import Field
-from dagster.utils.backcompat import experimental
 
 from ..utils import generate_materializations
 from .constants import (

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
@@ -5,6 +5,7 @@ from dagster_docker.utils import DOCKER_CONFIG_SCHEMA, validate_docker_config, v
 
 import dagster._check as check
 from dagster import executor
+from dagster._annotations import experimental
 from dagster.core.definitions.executor_definition import multiple_process_executor_requirements
 from dagster.core.events import DagsterEvent, EngineEventData, MetadataEntry
 from dagster.core.execution.retries import RetryMode, get_retries_config
@@ -20,7 +21,6 @@ from dagster.core.origin import PipelinePythonOrigin
 from dagster.core.utils import parse_env_var
 from dagster.serdes.utils import hash_str
 from dagster.utils import merge_dicts
-from dagster.utils.backcompat import experimental
 
 from .container_context import DockerContainerContext
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -6,7 +6,7 @@ from dagster_fivetran.utils import generate_materializations
 from dagster import AssetKey, AssetsDefinition, Out, Output
 from dagster import _check as check
 from dagster import multi_asset
-from dagster.utils.backcompat import experimental
+from dagster._annotations import experimental
 
 
 @experimental

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -3,8 +3,8 @@ import time
 import kubernetes
 
 from dagster import Field, In, Noneable, Nothing, Permissive, StringSource, op
+from dagster._annotations import experimental
 from dagster.utils import merge_dicts
-from dagster.utils.backcompat import experimental
 
 from ..container_context import K8sContainerContext
 from ..job import (

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
@@ -17,12 +17,12 @@ from dagster import (
 )
 from dagster import _check as check
 from dagster import dagster_type_loader, dagster_type_materializer
+from dagster._annotations import experimental
 from dagster._check import CheckError
 from dagster.config.field_utils import Selector
 from dagster.core.definitions.metadata import normalize_metadata
 from dagster.core.errors import DagsterInvalidMetadata
 from dagster.utils import dict_without_keys
-from dagster.utils.backcompat import experimental
 
 CONSTRAINT_BLACKLIST = {ColumnDTypeFnConstraint, ColumnDTypeInSetConstraint}
 


### PR DESCRIPTION
### Summary & Motivation

This adds `@public` and `@deprecated` annotations to a new submodule. We can use these for marking the public API.

I also moved the `@experimental` decorator in here, added the same kind of tag as used for public/deprecated, and deleted `@experimental_decorator` (folded its functionality into `@experimental`), and deleted some outdated experimental tests (we should be using the decorator and not calling the class/fn warning methods manually).

I paired the decorators with `is_public`, `is_deprecated`, and `is_experimental` predicates, which should give us freedom to easily change the implementation if we want to later.

### How I Tested These Changes

Added unit tests.
