### PR TITLE
create a top-level "env_vars" key in container context

### DIFF
--- a/python_modules/dagster/dagster/core/container_context/__init__.py
+++ b/python_modules/dagster/dagster/core/container_context/__init__.py
@@ -1,0 +1,1 @@
+from .config import SHARED_CONTAINER_CONTEXT_SCHEMA, process_shared_container_context_config

--- a/python_modules/dagster/dagster/core/container_context/config.py
+++ b/python_modules/dagster/dagster/core/container_context/config.py
@@ -1,0 +1,34 @@
+from typing import Any, Dict, Optional, cast
+
+from dagster import Field, Permissive
+from dagster.config.validate import process_config
+from dagster.core.errors import DagsterInvalidConfigError
+
+SHARED_CONTAINER_CONTEXT_SCHEMA = Permissive(
+    {
+        "env_vars": Field(
+            [str],
+            is_required=False,
+            description="The list of environment variables names to include in the container. "
+            "Each can be of the form KEY=VALUE or just KEY (in which case the value will be pulled "
+            "from the local environment)",
+        ),
+    }
+)
+
+
+# Process fields shared by container contexts in all environments (docker / k8s / ecs etc.)
+def process_shared_container_context_config(
+    container_context_config: Optional[Dict[str, Any]]
+) -> Dict[str, Any]:
+    shared_container_context = process_config(
+        SHARED_CONTAINER_CONTEXT_SCHEMA, container_context_config or {}
+    )
+    if not shared_container_context.success:
+        raise DagsterInvalidConfigError(
+            "Errors while parsing container context",
+            shared_container_context.errors,
+            container_context_config,
+        )
+
+    return cast(Dict[str, Any], shared_container_context.value)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -266,6 +266,7 @@ def other_configured_secret(secrets_manager):
 @pytest.fixture
 def container_context_config(configured_secret):
     return {
+        "env_vars": ["SHARED_KEY=SHARED_VAL"],
         "ecs": {
             "secrets": [
                 {
@@ -275,13 +276,14 @@ def container_context_config(configured_secret):
             ],
             "secrets_tags": ["dagster"],
             "env_vars": ["FOO_ENV_VAR=BAR_VALUE"],
-        }
+        },
     }
 
 
 @pytest.fixture
 def other_container_context_config(other_configured_secret):
     return {
+        "env_vars": ["SHARED_OTHER_KEY=SHARED_OTHER_VAL"],
         "ecs": {
             "secrets": [
                 {
@@ -291,7 +293,7 @@ def other_container_context_config(other_configured_secret):
             ],
             "secrets_tags": ["other_secret_tag"],
             "env_vars": ["OTHER_FOO_ENV_VAR"],
-        }
+        },
     }
 
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_container_context.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_container_context.py
@@ -48,7 +48,10 @@ def test_merge(
         {"name": "HELLO", "valueFrom": configured_secret.arn + "/hello"},
     ]
     assert secrets_container_context.secrets_tags == ["dagster"]
-    assert secrets_container_context.get_environment_dict() == {"FOO_ENV_VAR": "BAR_VALUE"}
+    assert secrets_container_context.get_environment_dict() == {
+        "FOO_ENV_VAR": "BAR_VALUE",
+        "SHARED_KEY": "SHARED_VAL",
+    }
 
     assert other_secrets_container_context.secrets == [
         {"name": "GOODBYE", "valueFrom": other_configured_secret.arn + "/goodbye"},
@@ -62,7 +65,8 @@ def test_merge(
 
     with environ({"OTHER_FOO_ENV_VAR": "OTHER_BAR_VALUE"}):
         assert other_secrets_container_context.get_environment_dict() == {
-            "OTHER_FOO_ENV_VAR": "OTHER_BAR_VALUE"
+            "OTHER_FOO_ENV_VAR": "OTHER_BAR_VALUE",
+            "SHARED_OTHER_KEY": "SHARED_OTHER_VAL",
         }
 
     merged = other_secrets_container_context.merge(secrets_container_context)
@@ -83,6 +87,8 @@ def test_merge(
         assert merged.get_environment_dict() == {
             "FOO_ENV_VAR": "BAR_VALUE",
             "OTHER_FOO_ENV_VAR": "OTHER_BAR_VALUE",
+            "SHARED_KEY": "SHARED_VAL",
+            "SHARED_OTHER_KEY": "SHARED_OTHER_VAL",
         }
 
     assert (

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_container_context.py
@@ -10,6 +10,9 @@ from dagster.utils import make_readonly_value
 @pytest.fixture
 def container_context_config():
     return {
+        "env_vars": [
+            "SHARED_KEY=SHARED_VAL",
+        ],
         "k8s": {
             "image_pull_policy": "Always",
             "image_pull_secrets": [{"name": "my_secret"}],
@@ -33,13 +36,16 @@ def container_context_config():
                 "requests": {"memory": "64Mi", "cpu": "250m"},
                 "limits": {"memory": "128Mi", "cpu": "500m"},
             },
-        }
+        },
     }
 
 
 @pytest.fixture
 def other_container_context_config():
     return {
+        "env_vars": [
+            "SHARED_OTHER_KEY=SHARED_OTHER_VAL",
+        ],
         "k8s": {
             "image_pull_policy": "Never",
             "image_pull_secrets": [{"name": "your_secret"}],
@@ -62,7 +68,7 @@ def other_container_context_config():
             "resources": {
                 "limits": {"memory": "64Mi", "cpu": "250m"},
             },
-        }
+        },
     }
 
 
@@ -156,7 +162,13 @@ def test_merge(empty_container_context, container_context, other_container_conte
     assert container_context.service_account_name == "my_service_account"
     assert container_context.env_config_maps == ["my_config_map"]
     assert container_context.env_secrets == ["my_secret"]
-    assert container_context.env_vars == ["MY_ENV_VAR"]
+    _check_same_sorted(
+        container_context.env_vars,
+        [
+            "MY_ENV_VAR",
+            "SHARED_KEY=SHARED_VAL",
+        ],
+    )
     assert container_context.volume_mounts == [
         {
             "mount_path": "my_mount_path",
@@ -204,6 +216,8 @@ def test_merge(empty_container_context, container_context, other_container_conte
         [
             "YOUR_ENV_VAR",
             "MY_ENV_VAR",
+            "SHARED_OTHER_KEY=SHARED_OTHER_VAL",
+            "SHARED_KEY=SHARED_VAL",
         ],
     )
     _check_same_sorted(


### PR DESCRIPTION
Summary;
Allows you to have a top-level set of contaienr context config that isn't specific to a particular environment. env_vars is the first entry.

### Summary & Motivation

### How I Tested These Changes
