### PR TITLE
stop relying on legacy APIs in some integrations

### DIFF
--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -16,20 +16,16 @@ from dagster_airflow.patch_airflow_example_dag import patch_airflow_example_dag
 from dagster import (
     DagsterInvariantViolationError,
     DependencyDefinition,
+    In,
     MultiDependencyDefinition,
     Nothing,
+    Out,
 )
 from dagster import _check as check
-from dagster import repository
+from dagster import op, repository
 from dagster._core.definitions.utils import VALID_NAME_REGEX, validate_tags
 from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR, IS_AIRFLOW_INGEST_PIPELINE_STR
-from dagster._legacy import (
-    InputDefinition,
-    OutputDefinition,
-    PipelineDefinition,
-    SolidDefinition,
-    solid,
-)
+from dagster._legacy import PipelineDefinition, SolidDefinition
 
 
 class DagsterAirflowError(Exception):
@@ -411,10 +407,10 @@ def make_dagster_solid_from_airflow_task(task, use_airflow_template_context, uni
     check.bool_param(use_airflow_template_context, "use_airflow_template_context")
     unique_id = check.opt_int_param(unique_id, "unique_id")
 
-    @solid(
+    @op(
         name=normalized_name(task.task_id, unique_id),
-        input_defs=[InputDefinition("airflow_task_ready", Nothing)],
-        output_defs=[OutputDefinition(Nothing, "airflow_task_complete")],
+        ins={"airflow_task_ready": In(Nothing)},
+        out={"airflow_task_complete": Out(Nothing)},
     )
     def _solid(context):  # pylint: disable=unused-argument
         if AIRFLOW_EXECUTION_DATE_STR not in context.pipeline_run.tags:

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/solids.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/solids.py
@@ -60,7 +60,6 @@ def create_databricks_job_op(
                 }
             )
     """
-
     check.str_param(name, "name")
     check.opt_str_param(description, "description")
     check.int_param(num_inputs, "num_inputs")

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/ops.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/ops.py
@@ -1,5 +1,4 @@
 from dagster import Bool, Field, Int, op
-from dagster._legacy import solid
 from dagster._seven import json
 
 from .configs import define_dataproc_submit_job_config
@@ -53,7 +52,7 @@ def _dataproc_compute(context):
         context.resources.dataproc.wait_for_job(job_id, wait_timeout=job_timeout)
 
 
-@solid(required_resource_keys={"dataproc"}, config_schema=DATAPROC_CONFIG_SCHEMA)
+@op(required_resource_keys={"dataproc"}, config_schema=DATAPROC_CONFIG_SCHEMA)
 def dataproc_solid(context):
     return _dataproc_compute(context)
 

--- a/python_modules/libraries/dagster-ge/dagster_ge/factory.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge/factory.py
@@ -5,10 +5,18 @@ from dagster_pandas import DataFrame
 from great_expectations.render.renderer import ValidationResultsPageRenderer
 from great_expectations.render.view import DefaultMarkdownPageView
 
-from dagster import ExpectationResult, MetadataEntry, MetadataValue, Noneable, Output, StringSource
+from dagster import (
+    ExpectationResult,
+    In,
+    MetadataEntry,
+    MetadataValue,
+    Noneable,
+    Out,
+    Output,
+    StringSource,
+)
 from dagster import _check as check
 from dagster import op, resource
-from dagster._legacy import InputDefinition, OutputDefinition, solid
 
 try:
     # ge < v0.13.0
@@ -43,18 +51,16 @@ def core_ge_validation_factory(
 
     @dagster_decorator(
         name=name,
-        input_defs=[InputDefinition("dataset", input_dagster_type)],
-        output_defs=[
-            OutputDefinition(
-                dagster_type=dict,
-                description=f"""
+        ins={"dataset": In(input_dagster_type)},
+        out=Out(
+            dagster_type=dict,
+            description=f"""
         This {decorator_name} yields an expectationResult with a structured dict of metadata from
         the GE suite, as well as the full result in case a user wants to process it differently.
         The structured dict contains both summary stats from the suite as well as expectation by
         expectation results/details.
         """,
-            )
-        ],
+        ),
         required_resource_keys={"ge_data_context"},
         tags={"kind": "ge"},
     )
@@ -103,46 +109,6 @@ def core_ge_validation_factory(
     return _ge_validation_fn
 
 
-def ge_validation_solid_factory(
-    name,
-    datasource_name,
-    suite_name,
-    validation_operator_name=None,
-    input_dagster_type=DataFrame,
-    batch_kwargs=None,
-):
-    """Generates solids for interacting with GE.
-
-    Args:
-        name (str): the name of the solid
-        datasource_name (str): the name of your DataSource, see your great_expectations.yml
-        suite_name (str): the name of your expectation suite, see your great_expectations.yml
-        validation_operator_name (Optional[str]): what validation operator to run  -- defaults to None,
-                    which generates an ephemeral validator.
-                    If you want to save data docs, use 'action_list_operator'.
-                    See https://docs.greatexpectations.io/en/latest/reference/core_concepts/validation_operators_and_actions.html
-        input_dagster_type (DagsterType): the Dagster type used to type check the input to the
-                    solid. Defaults to `dagster_pandas.DataFrame`.
-        batch_kwargs (Optional[dict]): overrides the `batch_kwargs` parameter when calling the
-                    `ge_data_context`'s `get_batch` method. Defaults to `{"dataset": dataset}`,
-                    where `dataset` is the input to the generated solid.
-    Returns:
-        A solid that takes in a set of data and yields both an expectation with relevant metadata
-        and an output with all the metadata (for user processing)
-    """
-
-    return core_ge_validation_factory(
-        solid,
-        "solid",
-        name,
-        datasource_name,
-        suite_name,
-        validation_operator_name,
-        input_dagster_type,
-        batch_kwargs,
-    )
-
-
 def ge_validation_op_factory(
     name,
     datasource_name,
@@ -167,13 +133,13 @@ def ge_validation_op_factory(
             `ge_data_context`'s `get_batch` method. Defaults to `{"dataset": dataset}`, where
             `dataset` is the input to the generated op.
     Returns:
-        A solid that takes in a set of data and yields both an expectation with relevant metadata
+        An op that takes in a set of data and yields both an expectation with relevant metadata
         and an output with all the metadata (for user processing)
     """
 
     return core_ge_validation_factory(
-        solid,
-        "solid",
+        op,
+        "op",
         name,
         datasource_name,
         suite_name,
@@ -204,18 +170,16 @@ def core_ge_validation_factory_v3(
 
     @dagster_decorator(
         name=name,
-        input_defs=[InputDefinition("dataset", input_dagster_type)],
-        output_defs=[
-            OutputDefinition(
-                dagster_type=dict,
-                description=f"""
+        ins={"dataset": In(input_dagster_type)},
+        out=Out(
+            dagster_type=dict,
+            description=f"""
         This {decorator_name} yields an ExpectationResult with a structured dict of metadata from
         the GE suite, as well as the full result in case a user wants to process it differently.
         The structured dict contains both summary stats from the suite as well as expectation by
         expectation results/details.
         """,
-            )
-        ],
+        ),
         required_resource_keys={"ge_data_context"},
         tags={"kind": "ge"},
     )
@@ -252,68 +216,6 @@ def core_ge_validation_factory_v3(
         yield Output(results.to_json_dict())
 
     return _ge_validation_fn
-
-
-def ge_validation_solid_factory_v3(
-    name,
-    datasource_name,
-    data_connector_name,
-    data_asset_name,
-    suite_name,
-    batch_identifiers: dict,
-    input_dagster_type=DataFrame,
-    runtime_method_type="batch_data",
-    extra_kwargs=None,
-):
-    """Generates solids for interacting with GE (v3 API)
-
-    Args:
-        name (str): the name of the solid
-        datasource_name (str): the name of your DataSource, see your great_expectations.yml
-        data_connector_name (str): the name of the data connector for this datasource. This should
-            point to a RuntimeDataConnector. For information on how to set this up, see:
-            https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/how_to_create_a_batch_of_data_from_an_in_memory_spark_or_pandas_dataframe
-        data_asset_name (str): the name of the data asset that this solid will be validating.
-        suite_name (str): the name of your expectation suite, see your great_expectations.yml
-        batch_identifier_fn (dict): A dicitonary of batch identifiers to uniquely identify this
-            batch of data. To learn more about batch identifiers, see:
-            https://docs.greatexpectations.io/docs/reference/datasources#batches.
-        input_dagster_type (DagsterType): the Dagster type used to type check the input to the
-                    solid. Defaults to `dagster_pandas.DataFrame`.
-        runtime_method_type (str): how GE should interperet the solid input. One of ("batch_data",
-            "path", "query"). Defaults to "batch_data", which will interperet the input as an in-memory
-            object.
-        extra_kwargs (Optional[dict]): adds extra kwargs to the invocation of `ge_data_context`'s
-                    `get_validator` method. If not set, input will be:
-                        {
-                            "datasource_name": datasource_name,
-                            "data_connector_name": data_connector_name,
-                            "data_asset_name": data_asset_name,
-                            "runtime_parameters": {
-                               "<runtime_method_type>": <solid input>
-                            },
-                            "batch_identifiers": batch_identifiers,
-                            "expectation_suite_name": suite_name,
-                        }
-
-    Returns:
-        A solid that takes in a set of data and yields both an expectation with relevant metadata
-        and an output with all the metadata (for user processing)
-
-    """
-    return core_ge_validation_factory_v3(
-        solid,
-        "solid",
-        name,
-        datasource_name,
-        data_connector_name,
-        data_asset_name,
-        suite_name,
-        batch_identifiers,
-        input_dagster_type,
-        runtime_method_type,
-        extra_kwargs,
-    )
 
 
 def ge_validation_op_factory_v3(

--- a/python_modules/libraries/dagster-ge/dagster_ge_tests/test_basic_integ.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge_tests/test_basic_integ.py
@@ -3,8 +3,8 @@
 import pytest
 from dagster_ge.factory import (
     ge_data_context,
-    ge_validation_solid_factory,
-    ge_validation_solid_factory_v3,
+    ge_validation_op_factory,
+    ge_validation_op_factory_v3,
 )
 from dagster_pyspark import DataFrame as DagsterPySparkDataFrame
 from dagster_pyspark import pyspark_resource
@@ -40,9 +40,7 @@ def reyielder(_context, res):
 )
 def hello_world_pandas_pipeline_v2():
     return reyielder(
-        ge_validation_solid_factory("ge_validation_solid", "getest", "basic.warning")(
-            pandas_yielder()
-        )
+        ge_validation_op_factory("ge_validation_solid", "getest", "basic.warning")(pandas_yielder())
     )
 
 
@@ -51,7 +49,7 @@ def hello_world_pandas_pipeline_v2():
 )
 def hello_world_pandas_pipeline_v3():
     return reyielder(
-        ge_validation_solid_factory_v3(
+        ge_validation_op_factory_v3(
             name="ge_validation_solid",
             datasource_name="getest",
             data_connector_name="my_runtime_data_connector",
@@ -74,7 +72,7 @@ def hello_world_pandas_pipeline_v3():
     ],
 )
 def hello_world_pyspark_pipeline():
-    validate = ge_validation_solid_factory(
+    validate = ge_validation_op_factory(
         "ge_validation_solid",
         "getestspark",
         "basic.warning",


### PR DESCRIPTION
### Summary & Motivation

This is by no means comprehensive - just a set of changes I made to get a feel for it.

I think it's fine if some error messages say "op" instead of solid for legacy APIs for the next couple releases.

### How I Tested These Changes
