### PR TITLE
Fix OpDefinition constructor

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/op_decorator.py
@@ -90,9 +90,9 @@ class _Op:
             )
 
         outs: Optional[Mapping[str, Out]] = None
-        if self.out and isinstance(self.out, Out):
+        if self.out is not None and isinstance(self.out, Out):
             outs = {DEFAULT_OUTPUT: self.out}
-        elif self.out:
+        elif self.out is not None:
             outs = check.mapping_param(self.out, "out", key_type=str, value_type=Out)
 
         op_def = OpDefinition(

--- a/python_modules/dagster/dagster/core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/op_decorator.py
@@ -18,16 +18,10 @@ from dagster.config.config_schema import UserConfigSchema
 from dagster.core.decorator_utils import format_docstring_for_description
 
 from ....seven.typing import get_origin
-from ...errors import DagsterInvariantViolationError
-from ..inference import InferredOutputProps, infer_output_props
 from ..input import In, InputDefinition
 from ..output import Out, OutputDefinition
 from ..policy import RetryPolicy
-from .solid_decorator import (
-    DecoratedSolidFunction,
-    NoContextDecoratedSolidFunction,
-    resolve_checked_solid_fn_inputs,
-)
+from .solid_decorator import DecoratedSolidFunction, NoContextDecoratedSolidFunction
 
 if TYPE_CHECKING:
     from ..op_definition import OpDefinition
@@ -75,40 +69,8 @@ class _Op:
     def __call__(self, fn: Callable[..., Any]) -> "OpDefinition":
         from ..op_definition import OpDefinition
 
-        if self.input_defs is not None and self.ins is not None:
-            check.failed("Values cannot be provided for both the 'input_defs' and 'ins' arguments")
-
-        if self.output_defs is not None and self.out is not None:
-            check.failed("Values cannot be provided for both the 'output_defs' and 'out' arguments")
-
-        inferred_out = infer_output_props(fn)
-
-        if self.ins is not None:
-            input_defs = [
-                inp.to_definition(name)
-                for name, inp in sorted(self.ins.items(), key=lambda input: input[0])
-            ]  # sort so that input definition order is deterministic
-        else:
-            input_defs = check.opt_list_param(
-                self.input_defs, "input_defs", of_type=InputDefinition
-            )
-
-        output_defs_from_out = _resolve_output_defs_from_outs(
-            inferred_out=inferred_out, out=self.out
-        )
-        resolved_output_defs = (
-            output_defs_from_out if output_defs_from_out is not None else self.output_defs
-        )
-
         if not self.name:
             self.name = fn.__name__
-
-        if resolved_output_defs is None:
-            resolved_output_defs = [OutputDefinition.create_from_inferred(infer_output_props(fn))]
-        elif len(resolved_output_defs) == 1:
-            resolved_output_defs = [
-                resolved_output_defs[0].combine_with_inferred(infer_output_props(fn))
-            ]
 
         compute_fn = (
             DecoratedSolidFunction(decorated_fn=fn)
@@ -116,18 +78,10 @@ class _Op:
             else NoContextDecoratedSolidFunction(decorated_fn=fn)
         )
 
-        resolved_input_defs = resolve_checked_solid_fn_inputs(
-            decorator_name="@op",
-            fn_name=self.name,
-            compute_fn=compute_fn,
-            explicit_input_defs=input_defs,
-            exclude_nothing=True,
-        )
-
         op_def = OpDefinition(
             name=self.name,
-            input_defs=resolved_input_defs,
-            output_defs=resolved_output_defs,
+            ins=self.ins,
+            out=self.out,
             compute_fn=compute_fn,
             config_schema=self.config_schema,
             description=self.description or format_docstring_for_description(fn),
@@ -138,46 +92,6 @@ class _Op:
         )
         update_wrapper(op_def, compute_fn.decorated_fn)
         return op_def
-
-
-def _resolve_output_defs_from_outs(
-    inferred_out: InferredOutputProps, out: Optional[Union[Out, Mapping]]
-) -> Optional[List[OutputDefinition]]:
-    if out is None:
-        return None
-    if isinstance(out, Out):
-        return [out.to_definition(inferred_out.annotation, name=None)]
-    else:
-        check.mapping_param(out, "out", key_type=str, value_type=Out)
-
-        # If only a single entry has been provided to the out dict, then slurp the
-        # annotation into the entry.
-        if len(out) == 1:
-            name = list(out.keys())[0]
-            only_out = out[name]
-            return [only_out.to_definition(inferred_out.annotation, name)]
-
-        output_defs = []
-
-        # Introspection on type annotations is experimental, so checking
-        # metaclass is the best we can do.
-        if inferred_out.annotation and not get_origin(inferred_out.annotation) == tuple:
-            raise DagsterInvariantViolationError(
-                "Expected Tuple annotation for multiple outputs, but received non-tuple annotation."
-            )
-        if inferred_out.annotation and not len(inferred_out.annotation.__args__) == len(out):
-            raise DagsterInvariantViolationError(
-                "Expected Tuple annotation to have number of entries matching the "
-                f"number of outputs for more than one output. Expected {len(out)} "
-                f"outputs but annotation has {len(inferred_out.annotation.__args__)}."
-            )
-        for idx, (name, cur_out) in enumerate(out.items()):
-            annotation_type = (
-                inferred_out.annotation.__args__[idx] if inferred_out.annotation else None
-            )
-            output_defs.append(cur_out.to_definition(annotation_type, name=name))
-
-        return output_defs
 
 
 @overload

--- a/python_modules/dagster/dagster/core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/op_definition.py
@@ -1,8 +1,35 @@
-from typing import Dict
+from typing import (
+    Dict,
+    Mapping,
+    Optional,
+    Union,
+    List,
+    TYPE_CHECKING,
+    cast,
+    Callable,
+    Any,
+    AbstractSet,
+    Sequence,
+)
 
 from .input import In
 from .output import Out
 from .solid_definition import SolidDefinition
+from .output import OutputDefinition
+from .input import InputDefinition
+from ...seven.typing import get_origin
+from dagster.config.config_schema import UserConfigSchema
+from .definition_config_schema import IDefinitionConfigSchema
+
+
+import dagster._check as check
+from dagster.core.errors import DagsterInvariantViolationError
+from .inference import InferredOutputProps, infer_output_props
+from dagster.core.definitions.policy import RetryPolicy
+
+
+if TYPE_CHECKING:
+    from .decorators.solid_decorator import DecoratedSolidFunction
 
 
 class OpDefinition(SolidDefinition):
@@ -58,6 +85,98 @@ class OpDefinition(SolidDefinition):
             )
     """
 
+    def __init__(
+        self,
+        compute_fn: Union[Callable[..., Any], "DecoratedSolidFunction"],
+        name: str,
+        description: Optional[str],
+        ins: Optional[Mapping[str, In]],
+        out: Optional[Union[Out, Mapping[str, Out]]],
+        config_schema: Optional[Union[UserConfigSchema, IDefinitionConfigSchema]] = None,
+        required_resource_keys: Optional[AbstractSet[str]] = None,
+        tags: Optional[Mapping[str, Any]] = None,
+        version: Optional[str] = None,
+        retry_policy: Optional[RetryPolicy] = None,
+        input_defs: Optional[Sequence[InputDefinition]] = None,
+        output_defs: Optional[Sequence[OutputDefinition]] = None,
+    ):
+        from .decorators.solid_decorator import (
+            resolve_checked_solid_fn_inputs,
+            DecoratedSolidFunction,
+        )
+
+        self._ins = ins
+        self._out = out
+
+        if input_defs is not None and ins is not None:
+            check.failed("Values cannot be provided for both the 'input_defs' and 'ins' arguments")
+
+        if output_defs is not None and out is not None:
+            check.failed("Values cannot be provided for both the 'output_defs' and 'out' arguments")
+
+        if ins is not None:
+            input_defs = [
+                inp.to_definition(name)
+                for name, inp in sorted(ins.items(), key=lambda input: input[0])
+            ]  # sort so that input definition order is deterministic
+        else:
+            input_defs = check.opt_list_param(input_defs, "input_defs", of_type=InputDefinition)
+
+        if isinstance(compute_fn, DecoratedSolidFunction):
+            resolved_input_defs = resolve_checked_solid_fn_inputs(
+                decorator_name="@op",
+                fn_name=name,
+                compute_fn=cast(DecoratedSolidFunction, compute_fn),
+                explicit_input_defs=input_defs,
+                exclude_nothing=True,
+            )
+        else:
+            resolved_input_defs = input_defs
+
+        if isinstance(compute_fn, DecoratedSolidFunction):
+            inferred_out = infer_output_props(cast(DecoratedSolidFunction, compute_fn).decorated_fn)
+        else:
+            inferred_out = None
+
+        if out is not None:
+            resolved_output_defs: Optional[
+                Sequence[OutputDefinition]
+            ] = _resolve_output_defs_from_outs(
+                inferred_out=cast(InferredOutputProps, inferred_out), out=out
+            )
+        else:
+            resolved_output_defs = output_defs
+
+        if resolved_output_defs is None:
+            if inferred_out:
+                resolved_output_defs = [
+                    OutputDefinition.create_from_inferred(cast(InferredOutputProps, inferred_out))
+                ]
+            else:
+                raise DagsterInvariantViolationError(
+                    "Error when constructing OpDefinition: an Out must be explicitly provided when constructing an OpDefinition, but none were provided."
+                )
+        elif len(resolved_output_defs) == 1:
+            if inferred_out:
+                resolved_output_defs = [resolved_output_defs[0].combine_with_inferred(inferred_out)]
+            else:
+                raise DagsterInvariantViolationError(
+                    "Error when constructing OpDefinition: an Out must be explicitly provided when constructing an OpDefinition, but none were provided."
+                )
+
+        super(OpDefinition, self).__init__(
+            compute_fn=compute_fn,
+            name=name,
+            description=description,
+            config_schema=config_schema,
+            required_resource_keys=required_resource_keys,
+            tags=tags,
+            version=version,
+            retry_policy=retry_policy,
+            input_defs=resolved_input_defs,
+            output_defs=resolved_output_defs,
+        )
+
     @property
     def node_type_str(self) -> str:
         return "op"
@@ -73,3 +192,40 @@ class OpDefinition(SolidDefinition):
     @property
     def outs(self) -> Dict[str, Out]:
         return {output_def.name: Out.from_definition(output_def) for output_def in self.output_defs}
+
+
+def _resolve_output_defs_from_outs(
+    inferred_out: Optional[InferredOutputProps], out: Union[Out, Mapping[str, Out]]
+) -> Optional[Sequence[OutputDefinition]]:
+    annotation = inferred_out.annotation if inferred_out else None
+    if isinstance(out, Out):
+        return [out.to_definition(annotation, name=None)]
+    else:
+        check.mapping_param(out, "out", key_type=str, value_type=Out)
+
+        # If only a single entry has been provided to the out dict, then slurp the
+        # annotation into the entry.
+        if len(out) == 1:
+            name = list(out.keys())[0]
+            only_out = out[name]
+            return [only_out.to_definition(annotation, name)]
+
+        output_defs = []
+
+        # Introspection on type annotations is experimental, so checking
+        # metaclass is the best we can do.
+        if annotation and not get_origin(annotation) == tuple:
+            raise DagsterInvariantViolationError(
+                "Expected Tuple annotation for multiple outputs, but received non-tuple annotation."
+            )
+        if annotation and not len(annotation.__args__) == len(out):
+            raise DagsterInvariantViolationError(
+                "Expected Tuple annotation to have number of entries matching the "
+                f"number of outputs for more than one output. Expected {len(out)} "
+                f"outputs but annotation has {len(annotation.__args__)}."
+            )
+        for idx, (name, cur_out) in enumerate(out.items()):
+            annotation_type = annotation.__args__[idx] if annotation else None
+            output_defs.append(cur_out.to_definition(annotation_type, name=name))
+
+        return output_defs

--- a/python_modules/dagster/dagster/core/definitions/output.py
+++ b/python_modules/dagster/dagster/core/definitions/output.py
@@ -445,7 +445,9 @@ class Out(
             asset_partitions_def=output_def.asset_partitions_def,  # pylint: disable=protected-access
         )
 
-    def to_definition(self, annotation_type: type, name: Optional[str]) -> "OutputDefinition":
+    def to_definition(
+        self, annotation_type: Optional[type], name: Optional[str]
+    ) -> "OutputDefinition":
         dagster_type = (
             self.dagster_type if self.dagster_type is not NoValueSentinel else annotation_type
         )
@@ -501,7 +503,9 @@ class DynamicOut(Out):
                 summarize_directory(file_results.collect())
     """
 
-    def to_definition(self, annotation_type: type, name: Optional[str]) -> "OutputDefinition":
+    def to_definition(
+        self, annotation_type: Optional[type], name: Optional[str]
+    ) -> "OutputDefinition":
         dagster_type = (
             self.dagster_type if self.dagster_type is not NoValueSentinel else annotation_type
         )

--- a/python_modules/dagster/dagster/core/definitions/output.py
+++ b/python_modules/dagster/dagster/core/definitions/output.py
@@ -234,7 +234,9 @@ class OutputDefinition:
         return OutputMapping(self, OutputPointer(solid_name, output_name))
 
     @staticmethod
-    def create_from_inferred(inferred: InferredOutputProps) -> "OutputDefinition":
+    def create_from_inferred(inferred: Optional[InferredOutputProps]) -> "OutputDefinition":
+        if not inferred:
+            return OutputDefinition()
         if is_dynamic_output_annotation(inferred.annotation):
             return DynamicOutputDefinition(
                 dagster_type=_checked_inferred_type(inferred.annotation),
@@ -445,9 +447,7 @@ class Out(
             asset_partitions_def=output_def.asset_partitions_def,  # pylint: disable=protected-access
         )
 
-    def to_definition(
-        self, annotation_type: Optional[type], name: Optional[str]
-    ) -> "OutputDefinition":
+    def to_definition(self, annotation_type: type, name: Optional[str]) -> "OutputDefinition":
         dagster_type = (
             self.dagster_type if self.dagster_type is not NoValueSentinel else annotation_type
         )
@@ -503,9 +503,7 @@ class DynamicOut(Out):
                 summarize_directory(file_results.collect())
     """
 
-    def to_definition(
-        self, annotation_type: Optional[type], name: Optional[str]
-    ) -> "OutputDefinition":
+    def to_definition(self, annotation_type: type, name: Optional[str]) -> "OutputDefinition":
         dagster_type = (
             self.dagster_type if self.dagster_type is not NoValueSentinel else annotation_type
         )

--- a/python_modules/dagster/dagster/core/definitions/test_op_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/test_op_definition.py
@@ -1,4 +1,4 @@
-from dagster import OpDefinition, In, Out, job, Output
+from dagster import In, OpDefinition, Out, Output, job
 
 
 def test_op_def_direct():

--- a/python_modules/dagster/dagster/core/definitions/test_op_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/test_op_definition.py
@@ -1,0 +1,18 @@
+from dagster import OpDefinition, In, Out, job, Output
+
+
+def test_op_def_direct():
+    def the_op_fn(_, inputs):
+        assert inputs["x"] == 5
+        yield Output(inputs["x"] + 1, output_name="the_output")
+
+    op_def = OpDefinition(
+        the_op_fn, "the_op", ins={"x": In(dagster_type=int)}, outs={"the_output": Out(int)}
+    )
+
+    @job
+    def the_job(x):
+        op_def(x)
+
+    result = the_job.execute_in_process(input_values={"x": 5})
+    assert result.success

--- a/python_modules/dagster/dagster/core/execution/context/input.py
+++ b/python_modules/dagster/dagster/core/execution/context/input.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Sequence,
 import dagster._check as check
 from dagster.core.definitions.events import AssetKey, AssetObservation
 from dagster.core.definitions.metadata import MetadataEntry, PartitionMetadataEntry
-from dagster.core.definitions.op_definition import OpDefinition
 from dagster.core.definitions.partition_key_range import PartitionKeyRange
 from dagster.core.definitions.time_window_partitions import (
     TimeWindow,
@@ -18,6 +17,7 @@ if TYPE_CHECKING:
     from dagster.core.execution.context.system import StepExecutionContext
     from dagster.core.log_manager import DagsterLogManager
     from dagster.core.types.dagster_type import DagsterType
+    from dagster.core.definitions.op_definition import OpDefinition
 
     from .output import OutputContext
 
@@ -143,6 +143,8 @@ class InputContext:
 
     @property
     def op_def(self) -> "OpDefinition":
+        from dagster.core.definitions import OpDefinition
+
         if self._solid_def is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access op_def, "
@@ -432,7 +434,7 @@ def build_input_context(
     dagster_type: Optional["DagsterType"] = None,
     resource_config: Optional[Dict[str, Any]] = None,
     resources: Optional[Dict[str, Any]] = None,
-    op_def: Optional[OpDefinition] = None,
+    op_def: Optional["OpDefinition"] = None,
     step_context: Optional["StepExecutionContext"] = None,
 ) -> "InputContext":
     """Builds input context from provided parameters.
@@ -472,6 +474,7 @@ def build_input_context(
     from dagster.core.execution.context.system import StepExecutionContext
     from dagster.core.execution.context_creation_pipeline import initialize_console_manager
     from dagster.core.types.dagster_type import DagsterType
+    from dagster.core.definitions import OpDefinition
 
     name = check.opt_str_param(name, "name")
     metadata = check.opt_dict_param(metadata, "metadata", key_type=str)

--- a/python_modules/dagster/dagster/core/execution/context/input.py
+++ b/python_modules/dagster/dagster/core/execution/context/input.py
@@ -12,12 +12,12 @@ from dagster.core.errors import DagsterInvariantViolationError
 
 if TYPE_CHECKING:
     from dagster.core.definitions import PartitionsDefinition, SolidDefinition
+    from dagster.core.definitions.op_definition import OpDefinition
     from dagster.core.definitions.resource_definition import Resources
     from dagster.core.events import DagsterEvent
     from dagster.core.execution.context.system import StepExecutionContext
     from dagster.core.log_manager import DagsterLogManager
     from dagster.core.types.dagster_type import DagsterType
-    from dagster.core.definitions.op_definition import OpDefinition
 
     from .output import OutputContext
 
@@ -470,11 +470,11 @@ def build_input_context(
             with build_input_context(resources={"foo": context_manager_resource}) as context:
                 do_something
     """
+    from dagster.core.definitions import OpDefinition
     from dagster.core.execution.context.output import OutputContext
     from dagster.core.execution.context.system import StepExecutionContext
     from dagster.core.execution.context_creation_pipeline import initialize_console_manager
     from dagster.core.types.dagster_type import DagsterType
-    from dagster.core.definitions import OpDefinition
 
     name = check.opt_str_param(name, "name")
     metadata = check.opt_dict_param(metadata, "metadata", key_type=str)

--- a/python_modules/dagster/dagster/core/execution/context/output.py
+++ b/python_modules/dagster/dagster/core/execution/context/output.py
@@ -23,7 +23,6 @@ from dagster.core.definitions.events import (
     PartitionMetadataEntry,
 )
 from dagster.core.definitions.metadata import RawMetadataValue
-from dagster.core.definitions.op_definition import OpDefinition
 from dagster.core.definitions.partition_key_range import PartitionKeyRange
 from dagster.core.definitions.solid_definition import SolidDefinition
 from dagster.core.definitions.time_window_partitions import TimeWindow
@@ -31,6 +30,7 @@ from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.execution.plan.utils import build_resources_for_manager
 
 if TYPE_CHECKING:
+    from dagster.core.definitions.op_definition import OpDefinition
     from dagster.core.definitions import PartitionsDefinition, PipelineDefinition
     from dagster.core.definitions.resource_definition import Resources
     from dagster.core.events import DagsterEvent
@@ -233,6 +233,8 @@ class OutputContext:
 
     @property
     def op_def(self) -> "OpDefinition":
+        from dagster.core.definitions import OpDefinition
+
         if self._solid_def is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access op_def, "
@@ -753,7 +755,7 @@ def build_output_context(
     resource_config: Optional[Mapping[str, object]] = None,
     resources: Optional[Mapping[str, object]] = None,
     solid_def: Optional[SolidDefinition] = None,
-    op_def: Optional[OpDefinition] = None,
+    op_def: Optional["OpDefinition"] = None,
     asset_key: Optional[Union[AssetKey, str]] = None,
     partition_key: Optional[str] = None,
 ) -> "OutputContext":
@@ -796,6 +798,7 @@ def build_output_context(
     """
     from dagster.core.execution.context_creation_pipeline import initialize_console_manager
     from dagster.core.types.dagster_type import DagsterType
+    from dagster.core.definitions import OpDefinition
 
     step_key = check.opt_str_param(step_key, "step_key")
     name = check.opt_str_param(name, "name")

--- a/python_modules/dagster/dagster/core/execution/context/output.py
+++ b/python_modules/dagster/dagster/core/execution/context/output.py
@@ -30,8 +30,8 @@ from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.execution.plan.utils import build_resources_for_manager
 
 if TYPE_CHECKING:
-    from dagster.core.definitions.op_definition import OpDefinition
     from dagster.core.definitions import PartitionsDefinition, PipelineDefinition
+    from dagster.core.definitions.op_definition import OpDefinition
     from dagster.core.definitions.resource_definition import Resources
     from dagster.core.events import DagsterEvent
     from dagster.core.execution.context.system import StepExecutionContext
@@ -796,9 +796,9 @@ def build_output_context(
                 do_something
 
     """
+    from dagster.core.definitions import OpDefinition
     from dagster.core.execution.context_creation_pipeline import initialize_console_manager
     from dagster.core.types.dagster_type import DagsterType
-    from dagster.core.definitions import OpDefinition
 
     step_key = check.opt_str_param(step_key, "step_key")
     name = check.opt_str_param(name, "name")

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -59,6 +59,12 @@ def test_no_outs():
     result = execute_op_in_graph(the_op)
     assert result.success
 
+    @op(out={})
+    def the_out_op():
+        pass
+
+    assert len(the_op.outs) == 0
+
 
 def test_op():
     @op

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -32,8 +32,6 @@ from dagster._legacy import solid
 from dagster.core.definitions.op_definition import OpDefinition
 from dagster.core.test_utils import instance_for_test
 from dagster.core.types.dagster_type import Int, String
-from dagster.seven import funcsigs
-import inspect
 
 
 def some_fn(a):
@@ -50,6 +48,16 @@ def execute_op_in_graph(an_op, instance=None):
 
     result = my_graph.execute_in_process(instance=instance)
     return result
+
+
+def test_no_outs():
+    @op(output_defs=[])
+    def the_op():
+        pass
+
+    assert len(the_op.output_defs) == 0
+    result = execute_op_in_graph(the_op)
+    assert result.success
 
 
 def test_op():

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -32,6 +32,15 @@ from dagster._legacy import solid
 from dagster.core.definitions.op_definition import OpDefinition
 from dagster.core.test_utils import instance_for_test
 from dagster.core.types.dagster_type import Int, String
+from dagster.seven import funcsigs
+import inspect
+
+
+def some_fn(a):
+    return a
+
+
+the_lambda = lambda a: a
 
 
 def execute_op_in_graph(an_op, instance=None):


### PR DESCRIPTION
Adds ins/outs arguments to OpDefinition constructor.

A bunch of gross logic for resolving between using input_defs/output_defs and ins/outs, which will go away in a 1.0 PR. 

I intentionally named the parameter on OpDefinition `outs` rather than `out`, to match with the outs property. Given that constructing OpDefinition directly is pretty advanced, I think it's fine for us to not include the convenience stuff that we have on the decorator, since it makes the internal logic simpler.