### PR TITLE
Remove submodule imports from doc snippets

### DIFF
--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -318,7 +318,7 @@ The provided `context` argument for `handle_output` is an <PyObject module="dags
 
 IO managers interoperate smoothly with [partitions](/concepts/partitions-schedules-sensors/partitions). You can access the partition key for the current run using the `context` for both `load_input` and `handle_output`. If working with [assets](/concepts/assets/software-defined-assets), you can also access the asset-specific partition key or partition key range, though most of the time the run partition key will be equal to the asset partition key.
 
-```python literalinclude file=/concepts/io_management/custom_io_manager.py startafter=start_partitioned_marker endbefore=end_partitioned_marker
+```python file=/concepts/io_management/custom_io_manager.py startafter=start_partitioned_marker endbefore=end_partitioned_marker
 from dagster import IOManager
 
 
@@ -425,7 +425,7 @@ def my_better_job():
 
 If your ops produce Pandas DataFrames that populate tables in a data warehouse, you might write something like the following. This IO manager uses the name assigned to the output as the name of the table to write the output to.
 
-```python literalinclude file=/concepts/io_management/custom_io_manager.py startafter=start_df_marker endbefore=end_df_marker
+```python file=/concepts/io_management/custom_io_manager.py startafter=start_df_marker endbefore=end_df_marker
 from dagster import IOManager, io_manager
 
 

--- a/docs/content/concepts/ops-jobs-graphs/graphs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/graphs.mdx
@@ -318,11 +318,10 @@ ops:
 
 You can programmatically generate a GraphDefinition from this YAML:
 
-```python file=/concepts/ops_jobs_graphs/dep_dsl.py
+```python file=/concepts/ops_jobs_graphs/dep_dsl.py startafter=start
 import os
 
 from dagster import DependencyDefinition, GraphDefinition, NodeInvocation, op
-from dagster.utils.yaml_utils import load_yaml_from_path
 
 
 @op

--- a/docs/content/deployment/run-launcher.mdx
+++ b/docs/content/deployment/run-launcher.mdx
@@ -19,7 +19,7 @@ The core abstraction in the launch process is the run launcher, which is configu
 
 ## Default Run Launcher
 
-The simplest run launcher is the built-in run launcher, <PyObject module="dagster.core.launcher" object="DefaultRunLauncher" />. This run launcher spawns a new process per run on the same node as the pipeline's repository location.
+The simplest run launcher is the built-in run launcher, <PyObject object="DefaultRunLauncher" />. This run launcher spawns a new process per run on the same node as the pipeline's repository location.
 
 ## Other Run Launchers
 

--- a/docs/content/integrations/dagstermill.mdx
+++ b/docs/content/integrations/dagstermill.mdx
@@ -38,11 +38,10 @@ Like many notebooks, this example does some fairly sophisticated work, producing
 
 We can simply turn a notebook into an op using <PyObject module="dagstermill" object="define_dagstermill_op" />. Once we create an op, we can start to make its outputs more accessible.
 
-```python file=/legacy/data_science/iris_classify.py
+```python file=/legacy/data_science/iris_classify.py startafter=start
 import dagstermill as dm
 
 from dagster import job
-from dagster.utils import script_relative_path
 
 k_means_iris = dm.define_dagstermill_op(
     "k_means_iris",
@@ -95,11 +94,10 @@ The ability to express data dependencies between heterogeneous units of computat
 
 We'll illustrate this process by adding a non-notebook op to our job, which will take care of downloading the Iris data from the UCI repository. This is a somewhat contrived example; in practice, your notebook ops are more likely to rely on upstream jobs whose outputs might be handles to tables in the data warehouse or to files on S3, and your notebook will likely handle the task of fetching the data.
 
-```python literalinclude showLines emphasize-lines=2,10,16 caption=iris_classify_2.py file=/legacy/data_science/iris_classify_2.py
+```python file=/legacy/data_science/iris_classify_2.py startafter=start
 import dagstermill as dm
 
 from dagster import InputDefinition, job
-from dagster.utils import script_relative_path
 from docs_snippets.legacy.data_science.download_file import download_file
 
 k_means_iris = dm.define_dagstermill_op(
@@ -123,11 +121,10 @@ def iris_classify():
 
 We'll configure the `download_file` op with the URL to download the file from, and the local path at which to save it. This op has one output—the path to the downloaded file.
 
-```python file=/legacy/data_science/download_file.py
+```python file=/legacy/data_science/download_file.py startafter=start
 from urllib.request import urlretrieve
 
 from dagster import Field, OutputDefinition, String, op
-from dagster.utils import script_relative_path
 
 
 @op(
@@ -222,11 +219,10 @@ You can use the development context to access op config and resources, to log me
 
 For instance, suppose we want to make the number of clusters (the \_k\_ in k-means) configurable. We'll change our op definition to include a config field:
 
-```python literalinclude showLines emphasize-lines=10-12 caption=iris_classify_3.py file=/legacy/data_science/iris_classify_3.py
+```python file=/legacy/data_science/iris_classify_3.py startafter=start
 import dagstermill as dm
 
 from dagster import Field, InputDefinition, Int, job
-from dagster.utils import script_relative_path
 from docs_snippets.legacy.data_science.download_file import download_file
 
 k_means_iris = dm.define_dagstermill_op(

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/dep_dsl.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/dep_dsl.py
@@ -1,7 +1,11 @@
+from dagster.utils.yaml_utils import load_yaml_from_path
+
+# isort: split
+
+# start
 import os
 
 from dagster import DependencyDefinition, GraphDefinition, NodeInvocation, op
-from dagster.utils.yaml_utils import load_yaml_from_path
 
 
 @op

--- a/examples/docs_snippets/docs_snippets/legacy/data_science/download_file.py
+++ b/examples/docs_snippets/docs_snippets/legacy/data_science/download_file.py
@@ -1,7 +1,11 @@
+from dagster.utils import script_relative_path
+
+# isort: split
+# start
+
 from urllib.request import urlretrieve
 
 from dagster import Field, OutputDefinition, String, op
-from dagster.utils import script_relative_path
 
 
 @op(

--- a/examples/docs_snippets/docs_snippets/legacy/data_science/iris_classify.py
+++ b/examples/docs_snippets/docs_snippets/legacy/data_science/iris_classify.py
@@ -1,7 +1,11 @@
+from dagster.utils import script_relative_path
+
+# isort: split
+# start
+
 import dagstermill as dm
 
 from dagster import job
-from dagster.utils import script_relative_path
 
 k_means_iris = dm.define_dagstermill_op(
     "k_means_iris",

--- a/examples/docs_snippets/docs_snippets/legacy/data_science/iris_classify_2.py
+++ b/examples/docs_snippets/docs_snippets/legacy/data_science/iris_classify_2.py
@@ -1,7 +1,11 @@
+from dagster.utils import script_relative_path
+
+# isort: split
+# start
+
 import dagstermill as dm
 
 from dagster import InputDefinition, job
-from dagster.utils import script_relative_path
 from docs_snippets.legacy.data_science.download_file import download_file
 
 k_means_iris = dm.define_dagstermill_op(

--- a/examples/docs_snippets/docs_snippets/legacy/data_science/iris_classify_3.py
+++ b/examples/docs_snippets/docs_snippets/legacy/data_science/iris_classify_3.py
@@ -1,7 +1,11 @@
+from dagster.utils import script_relative_path
+
+# isort: split
+# start
+
 import dagstermill as dm
 
 from dagster import Field, InputDefinition, Int, job
-from dagster.utils import script_relative_path
 from docs_snippets.legacy.data_science.download_file import download_file
 
 k_means_iris = dm.define_dagstermill_op(


### PR DESCRIPTION
### Summary & Motivation

This removes all submodule imports from docs snippets. In order to do this, I had to move imports for `script_relative_path` and `load_yaml_from_path` out of the imports actually shown to the user (these come from `dagster.utils`).

While this means the snippets that use these functions are not 100% self-contained, I think it is the best option-- we don't want to export these kinds of util functions from top-level dagster and it would clutter the docs to define them inline.

### How I Tested These Changes

BK
