### PR TITLE
make asset launchpad more conservative

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import {ASSET_NODE_CONFIG_FRAGMENT, configSchemaForAssetNode} from '../assets/AssetConfig';
+import {ASSET_NODE_CONFIG_FRAGMENT} from '../assets/AssetConfig';
 import {AssetEvents} from '../assets/AssetEvents';
 import {
   AssetMetadataTable,
@@ -51,7 +51,7 @@ export const SidebarAssetInfo: React.FC<{
   const repoAddress = buildRepoAddress(asset.repository.name, asset.repository.location.name);
   const {assetMetadata, assetType} = metadataForAssetNode(asset);
   const hasAssetMetadata = assetType || assetMetadata.length > 0;
-  const assetConfigSchema = configSchemaForAssetNode(asset);
+  const assetConfigSchema = asset.configField?.configType;
 
   const OpMetadataPlugin = asset.op?.metadata && pluginForMetadata(asset.op.metadata);
 

--- a/js_modules/dagit/packages/core/src/asset-graph/types/SidebarAssetFragment.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/SidebarAssetFragment.ts
@@ -520,6 +520,7 @@ export type SidebarAssetFragment_configField_configType = SidebarAssetFragment_c
 export interface SidebarAssetFragment_configField {
   __typename: "ConfigTypeField";
   name: string;
+  isRequired: boolean;
   configType: SidebarAssetFragment_configField_configType;
 }
 

--- a/js_modules/dagit/packages/core/src/asset-graph/types/SidebarAssetQuery.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/SidebarAssetQuery.ts
@@ -526,6 +526,7 @@ export type SidebarAssetQuery_assetNodeOrError_AssetNode_configField_configType 
 export interface SidebarAssetQuery_assetNodeOrError_AssetNode_configField {
   __typename: "ConfigTypeField";
   name: string;
+  isRequired: boolean;
   configType: SidebarAssetQuery_assetNodeOrError_AssetNode_configField_configType;
 }
 

--- a/js_modules/dagit/packages/core/src/assets/AssetConfig.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetConfig.tsx
@@ -28,6 +28,7 @@ export const ASSET_NODE_CONFIG_FRAGMENT = gql`
     id
     configField {
       name
+      isRequired
       configType {
         ...ConfigTypeSchemaFragment
         recursiveConfigTypes {

--- a/js_modules/dagit/packages/core/src/assets/AssetConfig.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetConfig.tsx
@@ -1,27 +1,6 @@
 import {gql} from '@apollo/client';
 
-import {
-  SidebarAssetQuery_assetNodeOrError_AssetNode_configField as ConfigField,
-  SidebarAssetQuery_assetNodeOrError_AssetNode_configField_configType_CompositeConfigType as ConfigSchema,
-} from '../asset-graph/types/SidebarAssetQuery';
 import {CONFIG_TYPE_SCHEMA_FRAGMENT} from '../typeexplorer/ConfigTypeSchema';
-
-export interface HasConfigField {
-  configField: ConfigField | null;
-}
-
-export function configSchemaForAssetNode(obj: HasConfigField): ConfigSchema | null {
-  if (obj.configField) {
-    const configSchema = obj.configField.configType as ConfigSchema;
-    if (configSchema.fields) {
-      return configSchema.fields.length > 1 ? configSchema : null;
-    } else {
-      return null;
-    }
-  } else {
-    return null;
-  }
-}
 
 export const ASSET_NODE_CONFIG_FRAGMENT = gql`
   fragment AssetNodeConfigFragment on AssetNode {

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -19,7 +19,7 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
-import {ASSET_NODE_CONFIG_FRAGMENT, configSchemaForAssetNode} from './AssetConfig';
+import {ASSET_NODE_CONFIG_FRAGMENT} from './AssetConfig';
 import {AssetDefinedInMultipleReposNotice} from './AssetDefinedInMultipleReposNotice';
 import {
   AssetMetadataTable,
@@ -39,7 +39,7 @@ export const AssetNodeDefinition: React.FC<{
   const partitionHealthData = usePartitionHealthData([assetNode.assetKey]);
   const {assetMetadata, assetType} = metadataForAssetNode(assetNode);
 
-  const assetConfigSchema = configSchemaForAssetNode(assetNode);
+  const assetConfigSchema = assetNode.configField?.configType;
   const repoAddress = buildRepoAddress(
     assetNode.repository.name,
     assetNode.repository.location.name,

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -16,7 +16,7 @@ import {CONFIG_TYPE_SCHEMA_FRAGMENT} from '../typeexplorer/ConfigTypeSchema';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
 
-import {ASSET_NODE_CONFIG_FRAGMENT, configSchemaForAssetNode} from './AssetConfig';
+import {ASSET_NODE_CONFIG_FRAGMENT} from './AssetConfig';
 import {LaunchAssetChoosePartitionsDialog} from './LaunchAssetChoosePartitionsDialog';
 import {AssetKey} from './types';
 import {LaunchAssetExecutionAssetNodeFragment} from './types/LaunchAssetExecutionAssetNodeFragment';
@@ -226,11 +226,10 @@ async function stateForLaunchingAssets(
   const resources = pipeline.modes[0].resources.filter((r) =>
     requiredResourceKeys.includes(r.name),
   );
-  const anyResourcesHaveConfig = resources.some((r) => r.configField);
   const anyResourcesHaveRequiredConfig = resources.some((r) => r.configField?.isRequired);
 
-  const anyAssetsHaveConfig = assets.some((a) => configSchemaForAssetNode(a));
-  if ((anyAssetsHaveConfig || anyResourcesHaveRequiredConfig) && partitionDefinition) {
+  const anyAssetsHaveRequiredConfig = assets.some((a) => a.configField?.isRequired);
+  if ((anyAssetsHaveRequiredConfig || anyResourcesHaveRequiredConfig) && partitionDefinition) {
     return {
       type: 'error',
       error:
@@ -256,7 +255,7 @@ async function stateForLaunchingAssets(
       upstreamAssetKeys,
     };
   }
-  if (anyAssetsHaveConfig || anyResourcesHaveConfig || forceLaunchpad) {
+  if (anyAssetsHaveRequiredConfig || anyResourcesHaveRequiredConfig || forceLaunchpad) {
     const assetOpNames = assets.flatMap((a) => a.opNames || []);
     return {
       type: 'launchpad',

--- a/js_modules/dagit/packages/core/src/assets/types/AssetNodeConfigFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNodeConfigFragment.ts
@@ -520,6 +520,7 @@ export type AssetNodeConfigFragment_configField_configType = AssetNodeConfigFrag
 export interface AssetNodeConfigFragment_configField {
   __typename: "ConfigTypeField";
   name: string;
+  isRequired: boolean;
   configType: AssetNodeConfigFragment_configField_configType;
 }
 

--- a/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
@@ -520,6 +520,7 @@ export type AssetNodeDefinitionFragment_configField_configType = AssetNodeDefini
 export interface AssetNodeDefinitionFragment_configField {
   __typename: "ConfigTypeField";
   name: string;
+  isRequired: boolean;
   configType: AssetNodeDefinitionFragment_configField_configType;
 }
 

--- a/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
@@ -588,6 +588,7 @@ export type AssetQuery_assetOrError_Asset_definition_configField_configType = As
 export interface AssetQuery_assetOrError_Asset_definition_configField {
   __typename: "ConfigTypeField";
   name: string;
+  isRequired: boolean;
   configType: AssetQuery_assetOrError_Asset_definition_configField_configType;
 }
 

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetExecutionAssetNodeFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetExecutionAssetNodeFragment.ts
@@ -548,6 +548,7 @@ export type LaunchAssetExecutionAssetNodeFragment_configField_configType = Launc
 export interface LaunchAssetExecutionAssetNodeFragment_configField {
   __typename: "ConfigTypeField";
   name: string;
+  isRequired: boolean;
   configType: LaunchAssetExecutionAssetNodeFragment_configField_configType;
 }
 

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetLoaderQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetLoaderQuery.ts
@@ -550,6 +550,7 @@ export type LaunchAssetLoaderQuery_assetNodes_configField_configType = LaunchAss
 export interface LaunchAssetLoaderQuery_assetNodes_configField {
   __typename: "ConfigTypeField";
   name: string;
+  isRequired: boolean;
   configType: LaunchAssetLoaderQuery_assetNodes_configField_configType;
 }
 

--- a/js_modules/dagit/packages/ui/src/components/ConfigTypeSchema.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ConfigTypeSchema.tsx
@@ -36,10 +36,6 @@ function renderTypeRecursive(
           <DictBlockComment indent={innerIndent} content="One of the following:" />
         )}
         {type.fields.map((fieldData) => {
-          // TODO: temporary hack while we figure this out
-          if (fieldData.name === 'assets') {
-            return null;
-          }
           const keyDisplay = (
             <DictKey
               theme={props.theme}


### PR DESCRIPTION
### Summary & Motivation

This changes asset launchpad behavior:

- Asset launchpad only shows when materializing if no partitions AND either selected asset or assoc resource has required config.
- Asset launchpad only raises error for mixing partitions and config if config is required.

### How I Tested These Changes

Played around with the resource toy in dagster test, marking config of resource and asset required/not required and verifying expected behavior.
