### PR TITLE
[dagit] Switch to updated “segmented control” styles for ButtonGroup

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
@@ -134,7 +134,7 @@ const LineageDepthControl: React.FC<{
           inputMode="numeric"
           style={{
             width: 40,
-            marginLeft: 2,
+            marginLeft: -1,
             textAlign: 'center',
             height: 32,
             padding: 6,

--- a/js_modules/dagit/packages/ui/src/components/Button.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Button.tsx
@@ -136,7 +136,7 @@ export const JoinedButtons = styled.div`
   & > *:not(:first-child) ${StyledButton} {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
-    margin-left: 1px;
+    margin-left: -1px;
   }
 `;
 

--- a/js_modules/dagit/packages/ui/src/components/ButtonGroup.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ButtonGroup.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import {BaseButton} from './BaseButton';
-import {Box} from './Box';
+import {JoinedButtons} from './Button';
 import {Colors} from './Colors';
 import {IconName, Icon} from './Icon';
 import {Tooltip} from './Tooltip';
@@ -22,16 +22,15 @@ interface Props<T> {
 export const ButtonGroup = <T extends string | number>(props: Props<T>) => {
   const {activeItems, buttons, onClick} = props;
   return (
-    <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+    <JoinedButtons>
       {buttons.map((button) => {
         const {id, icon, label, tooltip} = button;
         const isActive = activeItems?.has(id);
         const buttonElement = (
           <BaseButton
             key={id}
-            fillColor={isActive ? Colors.Gray200 : Colors.Gray50}
+            fillColor={isActive ? Colors.Gray200 : Colors.White}
             textColor={isActive ? Colors.Gray900 : Colors.Gray700}
-            strokeColor="transparent"
             icon={
               icon ? <Icon name={icon} color={isActive ? Colors.Gray900 : Colors.Gray700} /> : null
             }
@@ -50,6 +49,6 @@ export const ButtonGroup = <T extends string | number>(props: Props<T>) => {
 
         return buttonElement;
       })}
-    </Box>
+    </JoinedButtons>
   );
 };


### PR DESCRIPTION
### Summary & Motivation

This is a small PR that updates ButtonGroup to reflect the styling we discussed on Slack last month: 
https://elementl-workspace.slack.com/archives/C03CCE471E0/p1656010228830629

The goal of this change is to bring the border styling in line with our other components and make the button group look better when it's displayed in a toolbar with other inputs / buttons.

![image](https://user-images.githubusercontent.com/1037212/180501353-32f0751f-2116-4c02-87a6-a774463e3923.png)

It also updates "JoinedButtons" so that the buttons are touching and there is no hairline gap between them.

Before:
<img width="1396" alt="image" src="https://user-images.githubusercontent.com/1037212/180501534-e80d53ec-886d-4b48-bf64-53ae754d6d86.png">

Before:
<img width="1397" alt="image" src="https://user-images.githubusercontent.com/1037212/180501556-896e7797-e595-40d4-8582-635b96263a6b.png">

After:
<img width="1394" alt="image" src="https://user-images.githubusercontent.com/1037212/180501507-79c436ce-3607-4a41-b278-60795ce8bae4.png">

After:
<img width="1397" alt="image" src="https://user-images.githubusercontent.com/1037212/180501475-a2fa9f65-885b-4f8f-b487-c81365324e84.png">



### How I Tested These Changes
