### PR TITLE
consistent sorting for container context values

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
@@ -18,7 +18,7 @@ from .models import k8s_snake_case_dict
 
 
 def _dedupe_list(values):
-    return list(set([make_readonly_value(value) for value in values]))
+    return sorted(list(set([make_readonly_value(value) for value in values])), key=hash)
 
 
 class K8sContainerContext(


### PR DESCRIPTION
Summary:
Noticed a test flake that blamed to this - we should probably make this conssitent since they end up serialized in runs

### Summary & Motivation

### How I Tested These Changes
