### PR TITLE
check dynamic permission failure reason in JS

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Permissions.tsx
+++ b/js_modules/dagit/packages/core/src/app/Permissions.tsx
@@ -21,47 +21,58 @@ export const EXPECTED_PERMISSIONS = {
   cancel_partition_backfill: true,
 };
 
+export type PermissionResult = {
+  enabled: boolean;
+  disabledReason: string;
+};
+
 export type PermissionsFromJSON = {
-  launch_pipeline_execution?: boolean;
-  launch_pipeline_reexecution?: boolean;
-  start_schedule?: boolean;
-  stop_running_schedule?: boolean;
-  edit_sensor?: boolean;
-  terminate_pipeline_execution?: boolean;
-  delete_pipeline_run?: boolean;
-  reload_repository_location?: boolean;
-  reload_workspace?: boolean;
-  wipe_assets?: boolean;
-  launch_partition_backfill?: boolean;
-  cancel_partition_backfill?: boolean;
+  launch_pipeline_execution?: PermissionResult;
+  launch_pipeline_reexecution?: PermissionResult;
+  start_schedule?: PermissionResult;
+  stop_running_schedule?: PermissionResult;
+  edit_sensor?: PermissionResult;
+  terminate_pipeline_execution?: PermissionResult;
+  delete_pipeline_run?: PermissionResult;
+  reload_repository_location?: PermissionResult;
+  reload_workspace?: PermissionResult;
+  wipe_assets?: PermissionResult;
+  launch_partition_backfill?: PermissionResult;
+  cancel_partition_backfill?: PermissionResult;
+};
+
+const DEFAULT_PERMISSIONS = {
+  enabled: false,
+  disabledReason: 'Disabled by your administrator',
 };
 
 const extractPermissions = (permissions: PermissionFragment[]) => {
   const permsMap: PermissionsFromJSON = {};
   for (const item of permissions) {
-    permsMap[item.permission] = item.value;
+    permsMap[item.permission] = {
+      enabled: item.value,
+      disabledReason: item.disabledReason || '',
+    };
   }
 
   return {
-    canLaunchPipelineExecution: !!permsMap.launch_pipeline_execution,
-    canLaunchPipelineReexecution: !!permsMap.launch_pipeline_reexecution,
-    canStartSchedule: !!permsMap.start_schedule,
-    canStopRunningSchedule: !!permsMap.stop_running_schedule,
-    canStartSensor: !!permsMap.edit_sensor,
-    canStopSensor: !!permsMap.edit_sensor,
-    canTerminatePipelineExecution: !!permsMap.terminate_pipeline_execution,
-    canDeletePipelineRun: !!permsMap.delete_pipeline_run,
-    canReloadRepositoryLocation: !!permsMap.reload_repository_location,
-    canReloadWorkspace: !!permsMap.reload_workspace,
-    canWipeAssets: !!permsMap.wipe_assets,
-    canLaunchPartitionBackfill: !!permsMap.launch_partition_backfill,
-    canCancelPartitionBackfill: !!permsMap.cancel_partition_backfill,
+    canLaunchPipelineExecution: permsMap.launch_pipeline_execution || DEFAULT_PERMISSIONS,
+    canLaunchPipelineReexecution: permsMap.launch_pipeline_reexecution || DEFAULT_PERMISSIONS,
+    canStartSchedule: permsMap.start_schedule || DEFAULT_PERMISSIONS,
+    canStopRunningSchedule: permsMap.stop_running_schedule || DEFAULT_PERMISSIONS,
+    canStartSensor: permsMap.edit_sensor || DEFAULT_PERMISSIONS,
+    canStopSensor: permsMap.edit_sensor || DEFAULT_PERMISSIONS,
+    canTerminatePipelineExecution: permsMap.terminate_pipeline_execution || DEFAULT_PERMISSIONS,
+    canDeletePipelineRun: permsMap.delete_pipeline_run || DEFAULT_PERMISSIONS,
+    canReloadRepositoryLocation: permsMap.reload_repository_location || DEFAULT_PERMISSIONS,
+    canReloadWorkspace: permsMap.reload_workspace || DEFAULT_PERMISSIONS,
+    canWipeAssets: permsMap.wipe_assets || DEFAULT_PERMISSIONS,
+    canLaunchPartitionBackfill: permsMap.launch_partition_backfill || DEFAULT_PERMISSIONS,
+    canCancelPartitionBackfill: permsMap.cancel_partition_backfill || DEFAULT_PERMISSIONS,
   };
 };
 
 export type PermissionsMap = ReturnType<typeof extractPermissions>;
-
-export const DISABLED_MESSAGE = 'Disabled by your administrator';
 
 export const PermissionsContext = React.createContext<PermissionFragment[]>([]);
 
@@ -86,5 +97,6 @@ const PERMISSIONS_QUERY = gql`
   fragment PermissionFragment on Permission {
     permission
     value
+    disabledReason
   }
 `;

--- a/js_modules/dagit/packages/core/src/app/types/PermissionFragment.ts
+++ b/js_modules/dagit/packages/core/src/app/types/PermissionFragment.ts
@@ -11,4 +11,5 @@ export interface PermissionFragment {
   __typename: "Permission";
   permission: string;
   value: boolean;
+  disabledReason: string | null;
 }

--- a/js_modules/dagit/packages/core/src/app/types/PermissionsQuery.ts
+++ b/js_modules/dagit/packages/core/src/app/types/PermissionsQuery.ts
@@ -11,6 +11,7 @@ export interface PermissionsQuery_permissions {
   __typename: "Permission";
   permission: string;
   value: boolean;
+  disabledReason: string | null;
 }
 
 export interface PermissionsQuery {

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -148,7 +148,7 @@ export const AssetTable = ({
                   isSelected={checkedPaths.has(pathStr)}
                   onToggleChecked={onToggleFactory(pathStr)}
                   onWipe={(assets: Asset[]) => setToWipe(assets.map((asset) => asset.key))}
-                  canWipe={canWipeAssets}
+                  canWipe={canWipeAssets.enabled}
                 />
               );
             })
@@ -361,7 +361,7 @@ const MoreActionsDropdown: React.FC<{
   const [showBulkWipeDialog, setShowBulkWipeDialog] = React.useState<boolean>(false);
   const {canWipeAssets} = usePermissions();
 
-  if (!canWipeAssets) {
+  if (!canWipeAssets.enabled) {
     return null;
   }
 

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -68,11 +68,11 @@ export const LaunchAssetExecutionButton: React.FC<{
     context === 'all' ? ` all${count}` : context === 'selected' ? ` selected${count}` : count
   }`;
 
-  if (!assetKeys.length || !canLaunchPipelineExecution) {
+  if (!assetKeys.length || !canLaunchPipelineExecution.enabled) {
     return (
       <Tooltip
         content={
-          !canLaunchPipelineExecution
+          !canLaunchPipelineExecution.enabled
             ? 'You do not have permission to materialize assets'
             : 'Select one or more assets to materialize.'
         }

--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
@@ -68,7 +68,7 @@ export const BackfillTable = ({
   const candidateId = terminationBackfill?.backfillId;
 
   React.useEffect(() => {
-    if (canCancelPartitionBackfill && candidateId) {
+    if (canCancelPartitionBackfill.enabled && candidateId) {
       const [backfill] = backfills.filter((backfill) => backfill.backfillId === candidateId);
       setTerminationBackfill(backfill);
     }
@@ -251,7 +251,7 @@ const BackfillRow = ({
         <Popover
           content={
             <Menu>
-              {canCancelPartitionBackfill ? (
+              {canCancelPartitionBackfill.enabled ? (
                 <>
                   {backfill.numRequested < backfill.partitionStatuses.results.length &&
                   backfill.status === BulkActionStatus.REQUESTED ? (
@@ -272,7 +272,7 @@ const BackfillRow = ({
                   ) : null}
                 </>
               ) : null}
-              {canLaunchPartitionBackfill &&
+              {canLaunchPartitionBackfill.enabled &&
               backfill.status === BulkActionStatus.FAILED &&
               backfill.partitionSet ? (
                 <MenuItem

--- a/js_modules/dagit/packages/core/src/instance/JobMenu.tsx
+++ b/js_modules/dagit/packages/core/src/instance/JobMenu.tsx
@@ -2,7 +2,7 @@ import {gql, useLazyQuery} from '@apollo/client';
 import {Button, Icon, Menu, MenuItem, Popover, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
 
-import {DISABLED_MESSAGE, usePermissions} from '../app/Permissions';
+import {usePermissions} from '../app/Permissions';
 import {canRunAllSteps, canRunFromFailure} from '../runs/RunActionButtons';
 import {RunFragments} from '../runs/RunFragments';
 import {useJobReExecution} from '../runs/useJobReExecution';
@@ -43,7 +43,7 @@ export const JobMenu = (props: Props) => {
       icon="replay"
       text="Re-execute latest run"
       onClick={() => onLaunch({type: 'all'})}
-      disabled={!canLaunchPipelineReexecution || !run || !canRunAllSteps(run)}
+      disabled={!canLaunchPipelineReexecution.enabled || !run || !canRunAllSteps(run)}
     />
   );
 
@@ -52,7 +52,7 @@ export const JobMenu = (props: Props) => {
       icon="sync_problem"
       text="Re-execute latest run from failure"
       onClick={() => onLaunch({type: 'from-failure'})}
-      disabled={!canLaunchPipelineReexecution || !run || !canRunFromFailure(run)}
+      disabled={!canLaunchPipelineReexecution.enabled || !run || !canRunFromFailure(run)}
     />
   );
 
@@ -82,17 +82,17 @@ export const JobMenu = (props: Props) => {
             icon="checklist"
             text="View all recent runs"
           />
-          {canLaunchPipelineReexecution ? (
+          {canLaunchPipelineReexecution.enabled ? (
             reExecuteAllItem
           ) : (
-            <Tooltip content={DISABLED_MESSAGE} display="block">
+            <Tooltip content={canLaunchPipelineReexecution.disabledReason} display="block">
               {reExecuteAllItem}
             </Tooltip>
           )}
-          {canLaunchPipelineReexecution ? (
+          {canLaunchPipelineReexecution.enabled ? (
             reExecuteFromFailureItem
           ) : (
-            <Tooltip content={DISABLED_MESSAGE} display="block">
+            <Tooltip content={canLaunchPipelineReexecution.disabledReason} display="block">
               {reExecuteFromFailureItem}
             </Tooltip>
           )}

--- a/js_modules/dagit/packages/core/src/instigation/Unloadable.test.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/Unloadable.test.tsx
@@ -60,7 +60,7 @@ describe('Unloadables', () => {
         render(
           <TestProvider
             apolloProps={{mocks: [defaultMocks, mocks]}}
-            permissionOverrides={{edit_sensor: true}}
+            permissionOverrides={{edit_sensor: {enabled: true, disabledReason: null}}}
           >
             <Test />
           </TestProvider>,
@@ -83,7 +83,7 @@ describe('Unloadables', () => {
         render(
           <TestProvider
             apolloProps={{mocks: [defaultMocks, mocks]}}
-            permissionOverrides={{edit_sensor: true}}
+            permissionOverrides={{edit_sensor: {enabled: true, disabledReason: null}}}
           >
             <Test />
           </TestProvider>,
@@ -106,7 +106,7 @@ describe('Unloadables', () => {
         render(
           <TestProvider
             apolloProps={{mocks: [defaultMocks, mocks]}}
-            permissionOverrides={{edit_sensor: false}}
+            permissionOverrides={{edit_sensor: {enabled: false, disabledReason: 'Nope'}}}
           >
             <Test />
           </TestProvider>,
@@ -129,7 +129,7 @@ describe('Unloadables', () => {
         render(
           <TestProvider
             apolloProps={{mocks: [defaultMocks, mocks]}}
-            permissionOverrides={{edit_sensor: false}}
+            permissionOverrides={{edit_sensor: {enabled: false, disabledReason: 'Nope'}}}
           >
             <Test />
           </TestProvider>,
@@ -168,7 +168,7 @@ describe('Unloadables', () => {
         render(
           <TestProvider
             apolloProps={{mocks: [defaultMocks, mocks]}}
-            permissionOverrides={{stop_running_schedule: true}}
+            permissionOverrides={{stop_running_schedule: {enabled: true, disabledReason: null}}}
           >
             <Test />
           </TestProvider>,
@@ -191,7 +191,7 @@ describe('Unloadables', () => {
         render(
           <TestProvider
             apolloProps={{mocks: [defaultMocks, mocks]}}
-            permissionOverrides={{start_schedule: true}}
+            permissionOverrides={{start_schedule: {enabled: true, disabledReason: null}}}
           >
             <Test />
           </TestProvider>,
@@ -214,7 +214,7 @@ describe('Unloadables', () => {
         render(
           <TestProvider
             apolloProps={{mocks: [defaultMocks, mocks]}}
-            permissionOverrides={{stop_running_schedule: false}}
+            permissionOverrides={{stop_running_schedule: {enabled: false, disabledReason: 'nope'}}}
           >
             <Test />
           </TestProvider>,
@@ -237,7 +237,7 @@ describe('Unloadables', () => {
         render(
           <TestProvider
             apolloProps={{mocks: [defaultMocks, mocks]}}
-            permissionOverrides={{start_schedule: false}}
+            permissionOverrides={{start_schedule: {enabled: false, disabledReason: 'nope'}}}
           >
             <Test />
           </TestProvider>,

--- a/js_modules/dagit/packages/core/src/instigation/Unloadable.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/Unloadable.tsx
@@ -3,7 +3,7 @@ import {Alert, Box, Checkbox, Colors, Group, Table, Subheading, Tooltip} from '@
 import * as React from 'react';
 
 import {useConfirmation} from '../app/CustomConfirmationProvider';
-import {DISABLED_MESSAGE, usePermissions} from '../app/Permissions';
+import {usePermissions} from '../app/Permissions';
 import {
   displayScheduleMutationErrors,
   STOP_SCHEDULE_MUTATION,
@@ -148,7 +148,7 @@ const SensorStateRow = ({sensorState}: {sensorState: InstigationStateFragment}) 
     }
   };
 
-  const lacksPermission = status === InstigationStatus.RUNNING && !canStopSensor;
+  const lacksPermission = status === InstigationStatus.RUNNING && !canStopSensor.enabled;
   const latestTick = ticks.length ? ticks[0] : null;
 
   const checkbox = () => {
@@ -160,7 +160,11 @@ const SensorStateRow = ({sensorState}: {sensorState: InstigationStateFragment}) 
         onChange={onChangeSwitch}
       />
     );
-    return lacksPermission ? <Tooltip content={DISABLED_MESSAGE}>{element}</Tooltip> : element;
+    return lacksPermission ? (
+      <Tooltip content={canStopSensor.disabledReason}>{element}</Tooltip>
+    ) : (
+      element
+    );
   };
 
   return (
@@ -218,7 +222,7 @@ const ScheduleStateRow: React.FC<{
     }
   };
 
-  const lacksPermission = status === InstigationStatus.RUNNING && !canStopRunningSchedule;
+  const lacksPermission = status === InstigationStatus.RUNNING && !canStopRunningSchedule.enabled;
   const checkbox = () => {
     const element = (
       <Checkbox
@@ -229,7 +233,11 @@ const ScheduleStateRow: React.FC<{
       />
     );
 
-    return lacksPermission ? <Tooltip content={DISABLED_MESSAGE}>{element}</Tooltip> : element;
+    return lacksPermission ? (
+      <Tooltip content={canStopRunningSchedule.disabledReason}>{element}</Tooltip>
+    ) : (
+      element
+    );
   };
 
   return (

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchRootExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchRootExecutionButton.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {useHistory} from 'react-router';
 
 import {IconName} from '../../../ui/src';
-import {DISABLED_MESSAGE, usePermissions} from '../app/Permissions';
+import {usePermissions} from '../app/Permissions';
 import {TelemetryAction, useTelemetryAction} from '../app/Telemetry';
 import {
   LAUNCH_PIPELINE_EXECUTION_MUTATION,
@@ -42,7 +42,7 @@ export function useLaunchWithTelemetry() {
         variables.executionParams.selector.jobName ||
         variables.executionParams.selector.pipelineName;
 
-      if (!canLaunchPipelineExecution || !jobName) {
+      if (!canLaunchPipelineExecution.enabled || !jobName) {
         return;
       }
       const metadata: {[key: string]: string | null | undefined} = {
@@ -83,8 +83,10 @@ export const LaunchRootExecutionButton: React.FC<LaunchRootExecutionButtonProps>
         onClick: onLaunch,
         icon: props.icon || 'open_in_new',
         title: props.title || 'Launch Run',
-        disabled: props.disabled || !canLaunchPipelineExecution,
-        tooltip: !canLaunchPipelineExecution ? DISABLED_MESSAGE : undefined,
+        disabled: props.disabled || !canLaunchPipelineExecution.enabled,
+        tooltip: !canLaunchPipelineExecution.enabled
+          ? canLaunchPipelineExecution.disabledReason
+          : undefined,
       }}
     />
   );

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
@@ -64,7 +64,7 @@ export const JobLaunchpad: React.FC<{repoAddress: RepoAddress}> = (props) => {
   const {pipelinePath, repoPath} = useParams<{repoPath: string; pipelinePath: string}>();
   const {canLaunchPipelineExecution} = usePermissions();
 
-  if (!canLaunchPipelineExecution) {
+  if (!canLaunchPipelineExecution.enabled) {
     return <Redirect to={`/workspace/${repoPath}/pipeline_or_job/${pipelinePath}`} />;
   }
 

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupFromRunRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupFromRunRoot.tsx
@@ -28,7 +28,7 @@ export const LaunchpadSetupFromRunRoot: React.FC<{repoAddress: RepoAddress}> = (
     runId: string;
   }>();
 
-  if (!canLaunchPipelineExecution) {
+  if (!canLaunchPipelineExecution.enabled) {
     return <Redirect to={`/workspace/${repoPath}/pipeline_or_job/${pipelinePath}`} />;
   }
   return (

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupRoot.tsx
@@ -19,7 +19,7 @@ export const LaunchpadSetupRoot: React.FC<{repoAddress: RepoAddress}> = (props) 
   const {canLaunchPipelineExecution} = usePermissions();
   const {repoPath, pipelinePath} = useParams<{repoPath: string; pipelinePath: string}>();
 
-  if (!canLaunchPipelineExecution) {
+  if (!canLaunchPipelineExecution.enabled) {
     return <Redirect to={`/workspace/${repoPath}/pipeline_or_job/${pipelinePath}`} />;
   }
   return <LaunchpadSetupAllowedRoot pipelinePath={pipelinePath} repoAddress={repoAddress} />;

--- a/js_modules/dagit/packages/core/src/nav/RepoNavItem.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepoNavItem.tsx
@@ -109,7 +109,7 @@ const SingleRepoSummary: React.FC<{repo: RepoSelectorOption; onlyRepo: boolean}>
       >
         {repoAddress.name}
       </SingleRepoNameLink>
-      {canReloadRepositoryLocation ? (
+      {canReloadRepositoryLocation.enabled ? (
         <ReloadRepositoryLocationButton location={repoAddress.location}>
           {({tryReload, reloading}) => (
             <ShortcutHandler

--- a/js_modules/dagit/packages/core/src/nav/RepoSelector.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepoSelector.tsx
@@ -111,7 +111,7 @@ export const RepoSelector: React.FC<Props> = (props) => {
                     Browse
                   </Link>
                 </td>
-                {canReloadRepositoryLocation ? (
+                {canReloadRepositoryLocation.enabled ? (
                   <td>
                     <ReloadButton repoAddress={repoAddress} />
                   </td>

--- a/js_modules/dagit/packages/core/src/nav/RepositoryLink.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepositoryLink.tsx
@@ -33,7 +33,7 @@ export const RepositoryLink: React.FC<{
       <RepositoryName to={workspacePathFromAddress(repoAddress)}>
         {repoAddressTruncated}
       </RepositoryName>
-      {canReloadRepositoryLocation && showRefresh ? (
+      {canReloadRepositoryLocation.enabled && showRefresh ? (
         <ReloadRepositoryLocationButton location={location}>
           {({tryReload, reloading}) => (
             <ReloadTooltip

--- a/js_modules/dagit/packages/core/src/partitions/PartitionView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionView.tsx
@@ -12,7 +12,7 @@ import {
 } from '@dagster-io/ui';
 import * as React from 'react';
 
-import {DISABLED_MESSAGE, usePermissions} from '../app/Permissions';
+import {usePermissions} from '../app/Permissions';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {OptionsContainer} from '../gantt/VizComponents';
 import {useViewport} from '../gantt/useViewport';
@@ -187,7 +187,7 @@ const PartitionViewContent: React.FC<{
           <Button onClick={() => setShowSteps(!showSteps)} active={showBackfillSetup}>
             {showSteps ? 'Hide per-step status' : 'Show per-step status'}
           </Button>
-          {canLaunchPartitionBackfill ? (
+          {canLaunchPartitionBackfill.enabled ? (
             <Button
               onClick={() => setShowBackfillSetup(!showBackfillSetup)}
               icon={<Icon name="add_circle" />}
@@ -196,7 +196,7 @@ const PartitionViewContent: React.FC<{
               Launch backfill...
             </Button>
           ) : (
-            <Tooltip content={DISABLED_MESSAGE}>
+            <Tooltip content={canLaunchPartitionBackfill.disabledReason}>
               <Button icon={<Icon name="add_circle" />} disabled>
                 Launch backfill...
               </Button>

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineRoot.test.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineRoot.test.tsx
@@ -101,7 +101,9 @@ describe('PipelineRoot', () => {
 
       render(
         <TestProvider
-          permissionOverrides={{launch_pipeline_execution: false}}
+          permissionOverrides={{
+            launch_pipeline_execution: {enabled: false, disabledReason: 'nope'},
+          }}
           apolloProps={apolloProps}
           routerProps={routerProps}
         >

--- a/js_modules/dagit/packages/core/src/runs/RunActionButtons.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionButtons.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import {SharedToaster} from '../app/DomUtils';
 import {filterByQuery, GraphQueryItem} from '../app/GraphQueryImpl';
-import {DISABLED_MESSAGE, usePermissions} from '../app/Permissions';
+import {usePermissions} from '../app/Permissions';
 import {LaunchButtonConfiguration, LaunchButtonDropdown} from '../launchpad/LaunchButton';
 import {buildRepoPath} from '../workspace/buildRepoAddress';
 import {useRepositoryForRun} from '../workspace/useRepositoryForRun';
@@ -220,7 +220,9 @@ export const RunActionButtons: React.FC<RunActionButtonsProps> = (props) => {
     if (pipelineError?.tooltip) {
       return pipelineError?.tooltip;
     }
-    return canLaunchPipelineReexecution ? undefined : DISABLED_MESSAGE;
+    return canLaunchPipelineReexecution.enabled
+      ? undefined
+      : canLaunchPipelineReexecution.disabledReason;
   };
 
   return (
@@ -239,7 +241,7 @@ export const RunActionButtons: React.FC<RunActionButtonsProps> = (props) => {
           }
           tooltip={tooltip()}
           icon={pipelineError?.icon}
-          disabled={pipelineError?.disabled || !canLaunchPipelineReexecution}
+          disabled={pipelineError?.disabled || !canLaunchPipelineReexecution.enabled}
         />
       </Box>
       {!doneStatuses.has(run.status) ? <CancelRunButton run={run} /> : null}

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
@@ -150,7 +150,7 @@ export const RunActionsMenu: React.FC<{
                   }}
                 />
               </Tooltip>
-              {isFinished || !canTerminatePipelineExecution ? null : (
+              {isFinished || !canTerminatePipelineExecution.enabled ? null : (
                 <MenuItem
                   icon="cancel"
                   text="Terminate"
@@ -165,7 +165,7 @@ export const RunActionsMenu: React.FC<{
               download
               href={`${rootServerURI}/download_debug/${run.runId}`}
             />
-            {canDeletePipelineRun ? (
+            {canDeletePipelineRun.enabled ? (
               <MenuItem
                 icon="delete"
                 text="Delete"
@@ -184,7 +184,7 @@ export const RunActionsMenu: React.FC<{
       >
         <Button icon={<Icon name="expand_more" />} />
       </Popover>
-      {canTerminatePipelineExecution ? (
+      {canTerminatePipelineExecution.enabled ? (
         <TerminationDialog
           isOpen={visibleDialog === 'terminate'}
           onClose={closeDialogs}
@@ -192,7 +192,7 @@ export const RunActionsMenu: React.FC<{
           selectedRuns={{[run.id]: run.canTerminate}}
         />
       ) : null}
-      {canDeletePipelineRun ? (
+      {canDeletePipelineRun.enabled ? (
         <DeletionDialog
           isOpen={visibleDialog === 'delete'}
           onClose={closeDialogs}
@@ -249,7 +249,7 @@ export const RunBulkActionsMenu: React.FC<{
     'none' | 'terminate' | 'delete' | 'reexecute-from-failure' | 'reexecute'
   >('none');
 
-  if (!canTerminatePipelineExecution && !canDeletePipelineRun) {
+  if (!canTerminatePipelineExecution.enabled && !canDeletePipelineRun.enabled) {
     return null;
   }
 
@@ -286,7 +286,7 @@ export const RunBulkActionsMenu: React.FC<{
       <Popover
         content={
           <Menu>
-            {canTerminatePipelineExecution ? (
+            {canTerminatePipelineExecution.enabled ? (
               <MenuItem
                 icon="cancel"
                 text={`Terminate ${unfinishedIDs.length} ${
@@ -298,7 +298,7 @@ export const RunBulkActionsMenu: React.FC<{
                 }}
               />
             ) : null}
-            {canDeletePipelineRun ? (
+            {canDeletePipelineRun.enabled ? (
               <MenuItem
                 icon="delete"
                 intent="danger"
@@ -309,7 +309,7 @@ export const RunBulkActionsMenu: React.FC<{
                 }}
               />
             ) : null}
-            {canLaunchPipelineReexecution ? (
+            {canLaunchPipelineReexecution.enabled ? (
               <>
                 <MenuItem
                   icon="refresh"

--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -51,7 +51,8 @@ export const RunTable = (props: RunTableProps) => {
   const [{checkedIds}, {onToggleFactory, onToggleAll}] = useSelectionReducer(allIds);
 
   const {canTerminatePipelineExecution, canDeletePipelineRun} = usePermissions();
-  const canTerminateOrDelete = canTerminatePipelineExecution || canDeletePipelineRun;
+  const canTerminateOrDelete =
+    canTerminatePipelineExecution.enabled || canDeletePipelineRun.enabled;
 
   const {options} = useRepositoryOptions();
 

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleSwitch.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleSwitch.tsx
@@ -2,7 +2,7 @@ import {gql, useMutation} from '@apollo/client';
 import {Checkbox, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
 
-import {DISABLED_MESSAGE, usePermissions} from '../app/Permissions';
+import {usePermissions} from '../app/Permissions';
 import {InstigationStatus} from '../types/globalTypes';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
@@ -61,7 +61,7 @@ export const ScheduleSwitch: React.FC<Props> = (props) => {
 
   const running = status === InstigationStatus.RUNNING;
 
-  if (canStartSchedule && canStopRunningSchedule) {
+  if (canStartSchedule.enabled && canStopRunningSchedule.enabled) {
     return (
       <Checkbox
         format="switch"
@@ -73,7 +73,8 @@ export const ScheduleSwitch: React.FC<Props> = (props) => {
     );
   }
 
-  const lacksPermission = (running && !canStopRunningSchedule) || (!running && !canStartSchedule);
+  const lacksPermission =
+    (running && !canStopRunningSchedule.enabled) || (!running && !canStartSchedule.enabled);
   const disabled = toggleOffInFlight || toggleOnInFlight || lacksPermission;
 
   const switchElement = (
@@ -86,12 +87,18 @@ export const ScheduleSwitch: React.FC<Props> = (props) => {
     />
   );
 
-  return lacksPermission ? (
-    <Tooltip content={DISABLED_MESSAGE} display="flex">
+  if (!lacksPermission) {
+    return switchElement;
+  }
+
+  const disabledReason = running
+    ? canStopRunningSchedule.disabledReason
+    : canStartSchedule.disabledReason;
+
+  return (
+    <Tooltip content={disabledReason} display="flex">
       {switchElement}
     </Tooltip>
-  ) : (
-    switchElement
   );
 };
 

--- a/js_modules/dagit/packages/core/src/sensors/SensorSwitch.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorSwitch.tsx
@@ -2,7 +2,7 @@ import {gql, useMutation} from '@apollo/client';
 import {Checkbox, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
 
-import {DISABLED_MESSAGE, usePermissions} from '../app/Permissions';
+import {usePermissions} from '../app/Permissions';
 import {InstigationStatus} from '../types/globalTypes';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
@@ -54,7 +54,7 @@ export const SensorSwitch: React.FC<Props> = (props) => {
 
   const running = status === InstigationStatus.RUNNING;
 
-  if (canStartSensor && canStopSensor) {
+  if (canStartSensor.enabled && canStopSensor.enabled) {
     return (
       <Checkbox
         format="switch"
@@ -66,7 +66,8 @@ export const SensorSwitch: React.FC<Props> = (props) => {
     );
   }
 
-  const lacksPermission = (running && !canStartSensor) || (!running && !canStopSensor);
+  const lacksPermission =
+    (running && !canStartSensor.enabled) || (!running && !canStopSensor.enabled);
   const disabled = toggleOffInFlight || toggleOnInFlight || lacksPermission;
 
   const switchElement = (
@@ -80,7 +81,10 @@ export const SensorSwitch: React.FC<Props> = (props) => {
   );
 
   return lacksPermission ? (
-    <Tooltip content={DISABLED_MESSAGE} display="flex">
+    <Tooltip
+      content={running ? canStartSensor.disabledReason : canStopSensor.disabledReason}
+      display="flex"
+    >
       {switchElement}
     </Tooltip>
   ) : (

--- a/js_modules/dagit/packages/core/src/testing/TestProvider.tsx
+++ b/js_modules/dagit/packages/core/src/testing/TestProvider.tsx
@@ -13,19 +13,24 @@ import {ApolloTestProps, ApolloTestProvider} from './ApolloTestProvider';
 
 const typeDefs = loader('../graphql/schema.graphql');
 
+const DEFAULT_PERMISSIONS = {
+  enabled: true,
+  disabledReason: '',
+};
+
 export const PERMISSIONS_ALLOW_ALL: PermissionsFromJSON = {
-  launch_pipeline_execution: true,
-  launch_pipeline_reexecution: true,
-  start_schedule: true,
-  stop_running_schedule: true,
-  edit_sensor: true,
-  terminate_pipeline_execution: true,
-  delete_pipeline_run: true,
-  reload_repository_location: true,
-  reload_workspace: true,
-  wipe_assets: true,
-  launch_partition_backfill: true,
-  cancel_partition_backfill: true,
+  launch_pipeline_execution: DEFAULT_PERMISSIONS,
+  launch_pipeline_reexecution: DEFAULT_PERMISSIONS,
+  start_schedule: DEFAULT_PERMISSIONS,
+  stop_running_schedule: DEFAULT_PERMISSIONS,
+  edit_sensor: DEFAULT_PERMISSIONS,
+  terminate_pipeline_execution: DEFAULT_PERMISSIONS,
+  delete_pipeline_run: DEFAULT_PERMISSIONS,
+  reload_repository_location: DEFAULT_PERMISSIONS,
+  reload_workspace: DEFAULT_PERMISSIONS,
+  wipe_assets: DEFAULT_PERMISSIONS,
+  launch_partition_backfill: DEFAULT_PERMISSIONS,
+  cancel_partition_backfill: DEFAULT_PERMISSIONS,
 };
 
 const testValue: AppContextValue = {
@@ -44,7 +49,7 @@ const websocketValue: WebSocketContextType = {
 interface Props {
   apolloProps?: ApolloTestProps;
   appContextProps?: Partial<AppContextValue>;
-  permissionOverrides?: {[permission: string]: boolean};
+  permissionOverrides?: {[permission: string]: {enabled: boolean; disabledReason: string | null}};
   routerProps?: MemoryRouterProps;
 }
 
@@ -53,8 +58,9 @@ export const TestProvider: React.FC<Props> = (props) => {
   const permissions: PermissionFragment[] = React.useMemo(() => {
     return Object.keys(PERMISSIONS_ALLOW_ALL).map((permission) => {
       const override = permissionOverrides ? permissionOverrides[permission] : null;
-      const value = typeof override === 'boolean' ? override : true;
-      return {__typename: 'Permission', permission, value};
+      const value = override ? override.enabled : true;
+      const disabledReason = override ? override.disabledReason : null;
+      return {__typename: 'Permission', permission, value, disabledReason};
     });
   }, [permissionOverrides]);
 

--- a/js_modules/dagit/packages/core/src/workspace/ReloadAllButton.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/ReloadAllButton.tsx
@@ -1,7 +1,7 @@
 import {Button, Dialog, DialogBody, DialogFooter, Icon, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
 
-import {DISABLED_MESSAGE, usePermissions} from '../app/Permissions';
+import {usePermissions} from '../app/Permissions';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {
   reloadFnForWorkspace,
@@ -20,9 +20,9 @@ export const ReloadAllButton: React.FC<{label?: string}> = ({label = 'Reload all
   const [isOpen, setIsOpen] = React.useState(!!error);
   React.useEffect(() => setIsOpen(!!error), [error]);
 
-  if (!canReloadWorkspace) {
+  if (!canReloadWorkspace.enabled) {
     return (
-      <Tooltip content={DISABLED_MESSAGE}>
+      <Tooltip content={canReloadWorkspace.disabledReason}>
         <Button icon={<Icon name="refresh" />} disabled intent="none">
           {label}
         </Button>

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryLocationsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryLocationsList.tsx
@@ -12,7 +12,7 @@ import {
 } from '@dagster-io/ui';
 import React from 'react';
 
-import {DISABLED_MESSAGE, usePermissions} from '../app/Permissions';
+import {usePermissions} from '../app/Permissions';
 import {Timestamp} from '../app/time/Timestamp';
 import {ReloadRepositoryLocationButton} from '../nav/ReloadRepositoryLocationButton';
 import {
@@ -91,9 +91,9 @@ const ReloadButton: React.FC<{
   const {location} = props;
   const {canReloadRepositoryLocation} = usePermissions();
 
-  if (!canReloadRepositoryLocation) {
+  if (!canReloadRepositoryLocation.enabled) {
     return (
-      <Tooltip content={DISABLED_MESSAGE}>
+      <Tooltip content={canReloadRepositoryLocation.disabledReason}>
         <ButtonLink color={Colors.Gray400}>Reload</ButtonLink>
       </Tooltip>
     );


### PR DESCRIPTION
Summary:
use the disabled reason in all the places we used to use the stock text.

Test Plan:
View all these UIs in read only mode and write only mode, verify that things are still disabled