### PR TITLE
modern_data_stack_assets example updates

### DIFF
--- a/examples/modern_data_stack_assets/modern_data_stack_assets/assets.py
+++ b/examples/modern_data_stack_assets/modern_data_stack_assets/assets.py
@@ -1,16 +1,13 @@
-from typing import Any, Tuple
-
 import numpy as np
 import pandas as pd
-from dagster_airbyte import airbyte_resource, build_airbyte_assets
-from dagster_dbt import dbt_cli_resource, load_assets_from_dbt_project
+from dagster_airbyte import build_airbyte_assets
+from dagster_dbt import load_assets_from_dbt_project
 from scipy import optimize
 
-from dagster import AssetIn, asset, load_assets_from_current_module, repository
-from dagster._core.execution.with_resources import with_resources
+from dagster import AssetIn, asset, load_assets_from_current_module, repository, with_resources
 
-from .constants import *  # pylint: disable=wildcard-import,unused-wildcard-import
-from .pandas_io_manager import numpy_io_manager, pandas_io_manager
+from .constants import AIRBYTE_CONNECTION_ID, DBT_PROJECT_DIR, model_func
+from .resources import resource_defs
 
 airbyte_assets = build_airbyte_assets(
     connection_id=AIRBYTE_CONNECTION_ID,
@@ -19,53 +16,31 @@ airbyte_assets = build_airbyte_assets(
 )
 
 dbt_assets = load_assets_from_dbt_project(
-    project_dir=DBT_PROJECT_DIR, io_manager_key="pandas_io_manager"
+    project_dir=DBT_PROJECT_DIR, io_manager_key="db_io_manager"
 )
 
 
-@asset(
-    compute_kind="python",
-    # example of using an input manager to load an asset
-    ins={"daily_order_summary": AssetIn(key_prefix="public", input_manager_key="numpy_io_manager")},
-)
-def order_forecast_model(daily_order_summary: np.ndarray) -> Any:
+@asset(compute_kind="python", ins={"daily_order_summary": AssetIn(key_prefix="public")})
+def order_forecast_model(daily_order_summary: pd.DataFrame) -> np.ndarray:
     """Model parameters that best fit the observed data"""
-    return tuple(
-        optimize.curve_fit(
-            f=model_func,
-            xdata=daily_order_summary[:, 0],
-            ydata=daily_order_summary[:, 2],
-            p0=[10, 100],
-        )[0]
-    )
+    train_set = daily_order_summary.to_numpy()
+    return optimize.curve_fit(
+        f=model_func, xdata=train_set[:, 0], ydata=train_set[:, 2], p0=[10, 100]
+    )[0]
 
 
-@asset(compute_kind="python", io_manager_key="pandas_io_manager")
+@asset(compute_kind="python", io_manager_key="db_io_manager")
 def predicted_orders(
-    daily_order_summary: pd.DataFrame, order_forecast_model: Tuple[float, float]
+    daily_order_summary: pd.DataFrame, order_forecast_model: np.ndarray
 ) -> pd.DataFrame:
     """Predicted orders for the next 30 days based on the fit paramters"""
-    a, b = order_forecast_model
+    a, b = tuple(order_forecast_model)
     start_date = daily_order_summary.order_date.max()
     future_dates = pd.date_range(start=start_date, end=start_date + pd.DateOffset(days=30))
     predicted_data = model_func(x=future_dates.astype(np.int64), a=a, b=b)
     return pd.DataFrame({"order_date": future_dates, "num_orders": predicted_data})
 
 
-# all of the resources needed for interacting with our tools
-resource_defs = {
-    "airbyte": airbyte_resource.configured(AIRBYTE_CONFIG),
-    "dbt": dbt_cli_resource.configured(DBT_CONFIG),
-    "pandas_io_manager": pandas_io_manager.configured(PANDAS_IO_CONFIG),
-    "numpy_io_manager": numpy_io_manager.configured(PANDAS_IO_CONFIG),
-}
-
-
 @repository
 def mds_repo():
-    from dagster import define_asset_job
-
-    return with_resources(
-        load_assets_from_current_module(),
-        resource_defs=resource_defs,
-    ) + [define_asset_job("all")]
+    return with_resources(load_assets_from_current_module(), resource_defs=resource_defs)

--- a/examples/modern_data_stack_assets/modern_data_stack_assets/constants.py
+++ b/examples/modern_data_stack_assets/modern_data_stack_assets/constants.py
@@ -33,7 +33,7 @@ AIRBYTE_CONFIG = {"host": "localhost", "port": "8000"}
 DBT_PROJECT_DIR = file_relative_path(__file__, "../mds_dbt")
 DBT_PROFILES_DIR = file_relative_path(__file__, "../mds_dbt/config")
 DBT_CONFIG = {"project_dir": DBT_PROJECT_DIR, "profiles_dir": DBT_PROFILES_DIR}
-PANDAS_IO_CONFIG = {
+POSTGRES_CONFIG = {
     "con_string": get_conn_string(
         username=PG_DESTINATION_CONFIG["username"],
         password=PG_DESTINATION_CONFIG["password"],

--- a/examples/modern_data_stack_assets/modern_data_stack_assets/db_io_manager.py
+++ b/examples/modern_data_stack_assets/modern_data_stack_assets/db_io_manager.py
@@ -1,12 +1,9 @@
-import numpy as np
 import pandas as pd
 
-from dagster import IOManager
-from dagster import _check as check
-from dagster import io_manager
+from dagster import IOManager, io_manager
 
 
-class PandasIOManager(IOManager):
+class DbIOManager(IOManager):
     """Sample IOManager to handle loading the contents of tables as pandas DataFrames.
 
     Does not handle cases where data is written to different schemas for different outputs, and
@@ -24,7 +21,7 @@ class PandasIOManager(IOManager):
             # dbt has already written the data to this table
             pass
         else:
-            raise check.CheckError(f"Unsupported object type {type(obj)} for PandasIOManager.")
+            raise ValueError(f"Unsupported object type {type(obj)} for DbIOManager.")
 
     def load_input(self, context) -> pd.DataFrame:
         """Load the contents of a table as a pandas DataFrame."""
@@ -33,20 +30,5 @@ class PandasIOManager(IOManager):
 
 
 @io_manager(config_schema={"con_string": str})
-def pandas_io_manager(context):
-    return PandasIOManager(context.resource_config["con_string"])
-
-
-# we use the NumpyIOManager as an input manager for an asset to load it as a numpy array rather
-# than a Pandas DataFrame (the default loading behavior for assets)
-# This is to showcase swapping out input managers
-class NumpyIOManager(PandasIOManager):
-    def load_input(self, context) -> np.ndarray:
-        model_name = context.upstream_output.asset_key.path[-1]
-        pd_df = pd.read_sql(f"SELECT * FROM {model_name}", con=self._con)
-        return pd_df.to_numpy()
-
-
-@io_manager(config_schema={"con_string": str})
-def numpy_io_manager(context):
-    return NumpyIOManager(context.resource_config["con_string"])
+def db_io_manager(context):
+    return DbIOManager(context.resource_config["con_string"])

--- a/examples/modern_data_stack_assets/modern_data_stack_assets/resources.py
+++ b/examples/modern_data_stack_assets/modern_data_stack_assets/resources.py
@@ -1,0 +1,11 @@
+from dagster_airbyte import airbyte_resource
+from dagster_dbt import dbt_cli_resource
+
+from .constants import AIRBYTE_CONFIG, DBT_CONFIG, POSTGRES_CONFIG
+from .db_io_manager import db_io_manager
+
+resource_defs = {
+    "airbyte": airbyte_resource.configured(AIRBYTE_CONFIG),
+    "dbt": dbt_cli_resource.configured(DBT_CONFIG),
+    "db_io_manager": db_io_manager.configured(POSTGRES_CONFIG),
+}


### PR DESCRIPTION
I'm working on including code and a screenshot from the MDS example on dagster.io.

This PR makes a set of changes to the MDS example that I think make it more exemplary:
- IO managers should be named for the storage systems they encapsulate, not the types they handle.
- Took out the input manager. IMO this the current example is not a realistic situation where it makes sense to define a separate input manager, because it's easy enough to just call `to_numpy` on the dataframe.
- Avoided non-top-level Dagster imports.
- Moved resources into a separate module, so human eyes don't need to process as much at once.

I loaded this up in dagit, but shamefully have not tried to run it because of all the setup steps involved. I could be convinced to do so.