### PR TITLE
Providing an empty-string group_name for assets should be avoided

### DIFF
--- a/docs/content/concepts/assets/software-defined-assets.mdx
+++ b/docs/content/concepts/assets/software-defined-assets.mdx
@@ -462,6 +462,8 @@ In Dagster, there are two ways to assign assets to groups:
 
 By default, assets that aren't assigned to a group will be placed in a group named `default`. Use Dagit to [view these assets](#viewing-asset-groups-in-dagit).
 
+Note that `group_name` if provided, should not be a blank value. Doing so will result in an error being raised.
+
 #### From assets in a sub-module
 
 **This recommended approach** constructs a group of assets from a specified module in your project. Using the `load_assets_from_package_module` function, you can import all assets in a module and apply a grouping:

--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -1492,6 +1492,15 @@ def not_implemented(desc: str) -> NoReturn:
     raise NotImplementedCheckError(f"Not implemented: {desc}")
 
 
+def valid_group_name(group_name: Optional[str]) -> bool:
+    if isinstance(group_name, str) and group_name.strip() == "":
+        raise CheckError(
+            "group_name cannot be an empty string. Consider "
+            "giving it a non-empty name or keep it None to use 'default' group name"
+        )
+    return True
+
+
 # ###################################################################################################
 # ##### ERRORS / UTILITY
 # ###################################################################################################

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -326,7 +326,7 @@ class _Asset:
             partitions_def=self.partitions_def,
             partition_mappings=partition_mappings if partition_mappings else None,
             resource_defs=self.resource_defs,
-            group_names_by_key={out_asset_key: self.group_name.strip()} if self.group_name else None,
+            group_names_by_key={out_asset_key: self.group_name} if self.group_name else None,
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -317,6 +317,8 @@ class _Asset:
                 for input_name, partition_mapping in (self.partition_mappings or {}).items()
             }
 
+        check.invalid_group_name(self.group_name)
+
         return AssetsDefinition(
             keys_by_input_name=keys_by_input_name,
             keys_by_output_name={"result": out_asset_key},
@@ -324,7 +326,7 @@ class _Asset:
             partitions_def=self.partitions_def,
             partition_mappings=partition_mappings if partition_mappings else None,
             resource_defs=self.resource_defs,
-            group_names_by_key={out_asset_key: self.group_name} if self.group_name else None,
+            group_names_by_key={out_asset_key: self.group_name.strip()} if self.group_name else None,
         )
 
 

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -1415,3 +1415,14 @@ def test_not_implemented():
 
     with pytest.raises(CheckError, match="desc argument must be a string"):
         check.not_implemented(None)  # type: ignore
+
+
+def test_valid_group_name():
+    assert check.valid_group_name("valid_name")
+    assert check.valid_group_name(None)
+
+    with pytest.raises(CheckError):
+        check.valid_group_name("")
+
+    with pytest.raises(CheckError):
+        check.valid_group_name("   ")


### PR DESCRIPTION
### Summary & Motivation

tl;dr: Providing an explicit empty-string asset `group_name` should result in an error instead of silently using the `default` group name.

More details can be found in this issue -> https://github.com/dagster-io/dagster/issues/8667

The logic behind this is that providing `group_name=""` is confusing, and probably an issue with the logic building the group name. We should explicitly provide notification to the user about that, inviting him to provide a valid group_name of use `None` for `default` value.

### Remarks

- This is going to break old assets where users were using empty-string group name values
  - Actually we silently default the name

### How I Tested These Changes

- [x] I added a new unit test to check valid group name
- [x] Added this test to the `_Asset` class

### Todo

- [x] Create a check for asset group_name not empty
- [x] Test the newly created check
- [x] Add the check in the creation of the asset (ie `_Asset` class)
- [x] Document the new condition on asset group_name
- [ ] Maybe add a more global check on the creation of the asset with empty group_name

Closes #8667 
