### PR TITLE
move KnownExecutionState regression check to test

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/state.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/state.py
@@ -101,13 +101,8 @@ class KnownExecutionState(
             key_type=str,
             value_type=dict,
         )
-        for step_key, outputs in dynamic_mappings.items():
-            for outname, mapping_keys in outputs.items():
-                check.is_list(
-                    mapping_keys,
-                    of_type=str,
-                    additional_message=f"Bad mapping_keys at {step_key}.{outname}",
-                )
+        # some old payloads (0.15.0 -> 0.15.6) were persisted with [None] mapping_keys
+        # in dynamic_mappings, so can't assert [str] here in __new__.
 
         return super(KnownExecutionState, cls).__new__(
             cls,

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan_reexecution.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan_reexecution.py
@@ -3,6 +3,7 @@ import pickle
 
 import pytest
 
+import dagster._check as check
 from dagster import (
     DependencyDefinition,
     InputDefinition,
@@ -79,13 +80,15 @@ def test_execution_plan_reexecution():
         pipeline_def,
         run_config=run_config,
     )
+    known_state = KnownExecutionState.build_for_reexecution(
+        instance,
+        instance.get_run_by_id(result.run_id),
+    )
+    _check_known_state(known_state)
     execution_plan = ExecutionPlan.build(
         InMemoryPipeline(pipeline_def),
         resolved_run_config,
-        known_state=KnownExecutionState.build_for_reexecution(
-            instance,
-            instance.get_run_by_id(result.run_id),
-        ),
+        known_state=known_state,
     )
 
     subset_plan = execution_plan.build_subset_plan(["add_two"], pipeline_def, resolved_run_config)
@@ -117,6 +120,16 @@ def test_execution_plan_reexecution():
     assert get_step_output_event(step_events, "add_two")
 
 
+def _check_known_state(known_state: KnownExecutionState):
+    for step_key, outputs in known_state.dynamic_mappings.items():
+        for outname, mapping_keys in outputs.items():
+            check.is_list(
+                mapping_keys,
+                of_type=str,
+                additional_message=f"Bad mapping_keys at {step_key}.{outname}",
+            )
+
+
 def test_execution_plan_reexecution_with_in_memory():
     pipeline_def = define_addy_pipeline()
     instance = DagsterInstance.ephemeral()
@@ -128,13 +141,16 @@ def test_execution_plan_reexecution_with_in_memory():
     ## re-execute add_two
 
     resolved_run_config = ResolvedRunConfig.build(pipeline_def, run_config=run_config)
+    known_state = KnownExecutionState.build_for_reexecution(
+        instance,
+        instance.get_run_by_id(result.run_id),
+    )
+    _check_known_state(known_state)
+
     execution_plan = ExecutionPlan.build(
         InMemoryPipeline(pipeline_def),
         resolved_run_config,
-        known_state=KnownExecutionState.build_for_reexecution(
-            instance,
-            instance.get_run_by_id(result.run_id),
-        ),
+        known_state=known_state,
     )
 
     pipeline_run = instance.create_run_for_pipeline(


### PR DESCRIPTION
since we serialized payloads with this bug, we can't validate in `__new__`

considered adding a custom serializer to sanitize old payloads, but was concerned about complexity & runtime cost of sanitizing the nested structure and opted to put the check in tests

### How I Tested These Changes

undid the bug fix and ensured the tests failed with the check moved there