### PR TITLE
[assets] Fix error that occurred when defining a subselected asset job with config.

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -634,7 +634,9 @@ class GraphDefinition(NodeDefinition):
             # Using config mapping here is a trick to make it so that the preset will be used even
             # when no config is supplied for the job.
             config_mapping = _config_mapping_with_default_value(
-                self._get_config_schema(resource_defs_with_defaults, executor_def, logger_defs),
+                self._get_config_schema(
+                    resource_defs_with_defaults, executor_def, logger_defs, asset_layer
+                ),
                 config,
                 job_name,
                 self.name,
@@ -683,6 +685,7 @@ class GraphDefinition(NodeDefinition):
         resource_defs: Optional[Mapping[str, ResourceDefinition]],
         executor_def: "ExecutorDefinition",
         logger_defs: Optional[Mapping[str, LoggerDefinition]],
+        asset_layer: Optional["AssetLayer"],
     ) -> ConfigType:
         from .job_definition import JobDefinition
 
@@ -693,6 +696,7 @@ class GraphDefinition(NodeDefinition):
                 resource_defs=resource_defs,
                 executor_def=executor_def,
                 logger_defs=logger_defs,
+                asset_layer=asset_layer,
             )
             .get_run_config_schema("default")
             .run_config_schema_type


### PR DESCRIPTION
### Summary & Motivation

Fixes: https://github.com/dagster-io/dagster/issues/9020

If you have two assets `A -> B`, and define an asset job that selects only `B`, you are left with an unconnected input for the underlying `B` op. This is fine, as we will supply that input from `A` as a source asset. However, when config was supplied to the `define_asset_job` call, errors would result, related to that unconnected input.

This was happening because inside the `GraphDefinition.to_job()` call, if a dictionary-type argument is supplied as `config`, we attempt to convert that dictionary to a ConfigMapping object. In order to do this, we create a temporary JobDefinition object and grab the config schema off of that. This JobDefinition was not being constructed with the asset layer information, and so the config schema here would be incorrect (as this asset information is necessary to generate a correct config schema).

### How I Tested These Changes

Unit tests