### PR TITLE
RFC: A way to launch runs without hitting the gRPC server, by delaying execution plan creation until the start of the run worker

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -485,7 +485,7 @@ class GrapheneRun(graphene.ObjectType):
         return from_captured_log_data(log_data)
 
     def resolve_executionPlan(self, graphene_info: ResolveInfo):
-        if not (self.dagster_run.execution_plan_snapshot_id and self.dagster_run.job_snapshot_id):
+        if not self.dagster_run.execution_plan_snapshot_id:
             return None
 
         instance = graphene_info.context.instance

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -191,6 +191,16 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
             new_tags (Dict[string, string])
         """
 
+    # @abstractmethod
+    # Need to fill in the other storage impls
+    def add_execution_plan_snapshot_to_run(self, run_id: str, execution_plan_snapshot_id: str):
+        """Add an execution plan snapshot to a run.
+
+        Args:
+            run_id (str)
+            execution_plan_snapshot_id (str)
+        """
+
     @abstractmethod
     def has_run(self, run_id: str) -> bool:
         """Check if the storage contains a run.

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -438,6 +438,24 @@ class SqlRunStorage(RunStorage):
         rows = self.fetchall(query)
         return sorted([r["key"] for r in rows])
 
+    def add_execution_plan_snapshot_to_run(self, run_id: str, execution_plan_snapshot_id: str):
+        run = self._get_run_by_id(run_id)
+        if not run:
+            raise DagsterRunNotFoundError(
+                f"Run {run_id} was not found in instance.", invalid_run_id=run_id
+            )
+        with self.connect() as conn:
+            run = run._replace(execution_plan_snapshot_id=execution_plan_snapshot_id)
+            conn.execute(
+                RunsTable.update()  # pylint: disable=no-value-for-parameter
+                .where(RunsTable.c.run_id == run_id)
+                .values(
+                    run_body=serialize_value(run),
+                    update_timestamp=pendulum.now("UTC"),
+                )
+            )
+        return run
+
     def add_run_tags(self, run_id: str, new_tags: Mapping[str, str]) -> None:
         check.str_param(run_id, "run_id")
         check.mapping_param(new_tags, "new_tags", key_type=str, value_type=str)

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -540,6 +540,7 @@ class DagsterApiServer(DagsterApiServicer):
                     container_image=self._container_image,
                     container_context=self._container_context,
                     dagster_library_versions=DagsterLibraryRegistry.get(),
+                    can_create_snapshots_in_run_worker=True,
                 )
             )
         except Exception:

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -324,6 +324,7 @@ class ListRepositoriesResponse(
             ("container_image", Optional[str]),
             ("container_context", Optional[Mapping[str, Any]]),
             ("dagster_library_versions", Optional[Mapping[str, str]]),
+            ("can_create_snapshots_in_run_worker", bool),
         ],
     )
 ):
@@ -336,6 +337,7 @@ class ListRepositoriesResponse(
         container_image: Optional[str] = None,
         container_context: Optional[Mapping] = None,
         dagster_library_versions: Optional[Mapping[str, str]] = None,
+        can_create_snapshots_in_run_worker: Optional[bool] = None,
     ):
         return super(ListRepositoriesResponse, cls).__new__(
             cls,
@@ -363,6 +365,7 @@ class ListRepositoriesResponse(
             dagster_library_versions=check.opt_nullable_mapping_param(
                 dagster_library_versions, "dagster_library_versions"
             ),
+            can_create_snapshots_in_run_worker=can_create_snapshots_in_run_worker or False,
         )
 
 


### PR DESCRIPTION
Summary:
This is a quick-and-dirty end-to-end prototype of launching runs without going through the gRPC server first. This could be useful to make dagster more serverless in various scenarios - you could spin up a server to generate metadata, then spin it down until you need to create a run, possibly much later.

There are some downsides/caveats/tradeoffs though:
- It only works if you don't have any ops or assets selected - if you do, they have to go through the gRPC server first to get the right pipeline snapshot
- You lose some pre-run launch validation - for example, beofre, if you referenced an env var that didn't actually exist in the container where the run is happening, this grpc call would fail and you'd get an error before any run objects were created. There are actually some nice things about that though - now, the failed run would trigger alerts and I think appear in the factory floor, whereas before the failure would be pretty silent and stay as a failed scheduler tick that was otherwise not surfaced anywhere.

There are a couple other smaller things we would need to figure out that i put inline. Back-compat could also be a bit tricky, you could make this a setting or something that people opt into, in both OSS and cloud.

### Summary & Motivation

### How I Tested These Changes
