### PR TITLE
Fix overriding the command to use in container_config

### DIFF
--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -156,7 +156,6 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
         job_name = get_job_name_from_run_id(run.run_id)
         pod_name = job_name
         exc_config = _get_validated_celery_k8s_executor_config(run.run_config)
-        env_vars = None
 
         job_image_from_executor_config = exc_config.get("job_image")
 
@@ -214,7 +213,6 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             pod_name=pod_name,
             component="run_worker",
             user_defined_k8s_config=user_defined_k8s_config,
-            env_vars=env_vars,
             labels={
                 "dagster/job": pipeline_origin.pipeline_name,
                 "dagster/run-id": run.run_id,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -528,8 +528,6 @@ def construct_dagster_k8s_job(
     pod_name=None,
     component=None,
     labels=None,
-    env_vars=None,
-    command=None,
 ):
     """Constructs a Kubernetes Job object for a dagster-graphql invocation.
 
@@ -538,14 +536,14 @@ def construct_dagster_k8s_job(
             Job object.
         args (List[str]): CLI arguments to use with dagster-graphql in this Job.
         job_name (str): The name of the Job. Note that this name must be <= 63 characters in length.
-        resources (Dict[str, Dict[str, str]]): The resource requirements for the container
+        user_defined_k8s_config(Optional[UserDefinedDagsterK8sConfig]): Additional k8s config in tags or Dagster config
+            to apply to the job.
         pod_name (str, optional): The name of the Pod. Note that this name must be <= 63 characters
             in length. Defaults to "<job_name>-pod".
         component (str, optional): The name of the component, used to provide the Job label
             app.kubernetes.io/component. Defaults to None.
         labels(Dict[str, str]): Additional labels to be attached to k8s jobs and pod templates.
             Long label values are may be truncated.
-        env_vars(Dict[str, str]): Additional environment variables to add to the K8s Container.
 
     Returns:
         kubernetes.client.V1Job: A Kubernetes Job object.
@@ -562,7 +560,6 @@ def construct_dagster_k8s_job(
 
     pod_name = check.opt_str_param(pod_name, "pod_name", default=job_name + "-pod")
     check.opt_str_param(component, "component")
-    check.opt_dict_param(env_vars, "env_vars", key_type=str, value_type=str)
     check.opt_dict_param(labels, "labels", key_type=str, value_type=str)
 
     check.invariant(
@@ -609,21 +606,11 @@ def construct_dagster_k8s_job(
             }
         )
 
-    additional_k8s_env_vars = []
-    if env_vars:
-        for key, value in env_vars.items():
-            additional_k8s_env_vars.append({"name": key, "value": value})
-
     container_config = copy.deepcopy(user_defined_k8s_config.container_config)
 
-    user_defined_k8s_env_vars = container_config.pop("env", [])
-    for env_var in user_defined_k8s_env_vars:
-        additional_k8s_env_vars.append(env_var)
+    user_defined_env_vars = container_config.pop("env", [])
 
-    user_defined_k8s_env_from = container_config.pop("env_from", [])
-    additional_k8s_env_from = []
-    for env_from in user_defined_k8s_env_from:
-        additional_k8s_env_from.append(env_from)
+    user_defined_env_from = container_config.pop("env_from", [])
 
     job_image = container_config.pop("image", job_config.job_image)
 
@@ -640,11 +627,10 @@ def construct_dagster_k8s_job(
         {
             "name": "dagster",
             "image": job_image,
-            "command": command,
             "args": args,
             "image_pull_policy": job_config.image_pull_policy,
-            "env": env + job_config.env + additional_k8s_env_vars,
-            "env_from": job_config.env_from_sources + additional_k8s_env_from,
+            "env": env + job_config.env + user_defined_env_vars,
+            "env_from": job_config.env_from_sources + user_defined_env_from,
             "volume_mounts": volume_mounts,
             "resources": resources,
         },

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -125,8 +125,11 @@ def k8s_job_op(context):
 
     namespace = container_context.namespace
 
+    command = config.get("command")
+
     user_defined_k8s_config = UserDefinedDagsterK8sConfig(
         job_config=config.get("job_config"),
+        container_config=({"command": command} if command else {}),
     )
 
     k8s_job_config = DagsterK8sJobConfig(
@@ -150,7 +153,6 @@ def k8s_job_op(context):
 
     job = construct_dagster_k8s_job(
         job_config=k8s_job_config,
-        command=config.get("command"),
         args=config.get("args"),
         job_name=job_name,
         pod_name=job_name,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
@@ -236,6 +236,37 @@ def test_construct_dagster_k8s_job_with_user_defined_env_camelcase():
     }
 
 
+def test_construct_dagster_k8s_job_with_user_defined_command():
+    @graph
+    def user_defined_k8s_env_tags_graph():
+        pass
+
+    user_defined_k8s_config = get_user_defined_k8s_config(
+        user_defined_k8s_env_tags_graph.to_job(
+            tags={
+                USER_DEFINED_K8S_CONFIG_KEY: {
+                    "container_config": {
+                        "command": ["echo", "hi"],
+                    }
+                }
+            }
+        ).tags
+    )
+
+    cfg = DagsterK8sJobConfig(
+        job_image="test/foo:latest",
+        dagster_home="/opt/dagster/dagster_home",
+        instance_config_map="some-instance-configmap",
+    )
+
+    job = construct_dagster_k8s_job(
+        cfg, ["foo", "bar"], "job", user_defined_k8s_config=user_defined_k8s_config
+    ).to_dict()
+
+    command = job["spec"]["template"]["spec"]["containers"][0]["command"]
+    assert command == ["echo", "hi"]
+
+
 def test_construct_dagster_k8s_job_with_user_defined_env_snake_case():
     @graph
     def user_defined_k8s_env_from_tags_graph():


### PR DESCRIPTION
Summary:
Overriding the command in container_config changed in https://github.com/dagster-io/dagster/pull/8161 - we override the passed in command to the function, even if it is empty. Instead, fall back to the user-provided container_config if it is set.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
