### PR TITLE
bring back gql pin

### DIFF
--- a/python_modules/dagster-graphql/setup.py
+++ b/python_modules/dagster-graphql/setup.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
             "graphene>=2.1.3,<3",  # compatability with graphql-ws in dagit
             "graphql-core>=2.1,<3",  # compatability with graphql-ws in dagit
             "requests",
-            "gql",
+            "gql<3",  # compatibility with graphql-core pin above
         ],
         entry_points={"console_scripts": ["dagster-graphql = dagster_graphql.cli:main"]},
     )


### PR DESCRIPTION
Summary:
Removing this pin didn't actually give us any more flexibility since our graphql-core pin still requires gql<3, but did cause problems with older versions of pip/python that aren't smart enough to resolve the resulting pins. For now I think we should just re-pin.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
