### PR TITLE
[docs] - Add article list component

### DIFF
--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -4,21 +4,6 @@
   Dagster is the data orchestration platform built for productivity.
 </p>
 
-<ArticleList>
-  <ArticleListItem
-    href="#step-1-install-dagster"
-    title="Install Dagster"
-  ></ArticleListItem>
-  <ArticleListItem
-    href="#step-2-define-assets"
-    title="Define assets"
-  ></ArticleListItem>
-  <ArticleListItem
-    href="#step-3-materialize-the-assets"
-    title="Materialize the assets"
-  ></ArticleListItem>
-</ArticleList>
-
 Get started with Dagster in just three quick steps:
 
 1. [Install Dagster](#step-1-install-dagster)

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -5,21 +5,18 @@
 </p>
 
 <ArticleList>
-    <ArticleListItem
+  <ArticleListItem
     href="#step-1-install-dagster"
     title="Install Dagster"
-    >
-    </ArticleListItem>
-    <ArticleListItem
+  ></ArticleListItem>
+  <ArticleListItem
     href="#step-2-define-assets"
     title="Define assets"
-    >
-    </ArticleListItem>
-    <ArticleListItem
+  ></ArticleListItem>
+  <ArticleListItem
     href="#step-3-materialize-the-assets"
     title="Materialize the assets"
-    >
-    </ArticleListItem>
+  ></ArticleListItem>
 </ArticleList>
 
 Get started with Dagster in just three quick steps:

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -4,6 +4,24 @@
   Dagster is the data orchestration platform built for productivity.
 </p>
 
+<ArticleList>
+    <ArticleListItem
+    href="#step-1-install-dagster"
+    title="Install Dagster"
+    >
+    </ArticleListItem>
+    <ArticleListItem
+    href="#step-2-define-assets"
+    title="Define assets"
+    >
+    </ArticleListItem>
+    <ArticleListItem
+    href="#step-3-materialize-the-assets"
+    title="Materialize the assets"
+    >
+    </ArticleListItem>
+</ArticleList>
+
 Get started with Dagster in just three quick steps:
 
 1. [Install Dagster](#step-1-install-dagster)

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -395,6 +395,11 @@ const ArticleList = ({ children }) => {
   );
 };
 
+interface ArticleListItem {
+  title: string;
+  href: string;
+}
+
 const ArticleListItem = ({ title, href = [] }) => {
   return (
       <li style={{

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -395,19 +395,14 @@ const ArticleList = ({ children }) => {
   );
 };
 
-interface ArticleListItem {
-  title: string;
-  href: string;
-}
-
-const ArticleListItem = ({ title, href = [] }) => {
+const ArticleListItem = ({ title, href }) => {
   return (
       <li style={{
         marginTop: 0,
         }}>
-        <a href={href}>
+        <Link href={href}>
           {title}
-        </a>
+        </Link>
       </li>
     );
 };

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -378,6 +378,36 @@ const Pre = ({ children, ...props }) => {
   );
 };
 
+const ArticleList = ({ children }) => {
+  return (
+    <div className="category-container">
+      <div className="category-inner-container">
+        <ul style={{ 
+          columnCount: 2,
+          columnGap: "20px",
+          padding: 0,
+          margin: 0
+        }}>
+          {children}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+const ArticleListItem = ({ title, href = [] }) => {
+  return (
+      <li style={{
+        marginTop: 0,
+        }}>
+        <a href={href}>
+          {title}
+        </a>
+      </li>
+    );
+};
+
+
 export default {
   a: ({ children, ...props }) => {
     // Skip in-page links and external links
@@ -448,4 +478,6 @@ export default {
   PlaceholderImage,
   Experimental,
   Icons,
+  ArticleList,
+  ArticleListItem,
 };


### PR DESCRIPTION
This PR adds two components: `ArticleList` and `ArticleListItem`. It's used to display columns of links/items and will be primarily used on category / section pages in the docs.

Preview of it is here, at the top of the page  - will be removed prior to merging: https://dagster-git-erin-category-list-component-elementl.vercel.app/getting-started