### PR TITLE
[dagster-dbt] fix bk

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
@@ -119,8 +119,10 @@ def execute_cli(
             except json.JSONDecodeError:
                 pass
             else:
-                message = json_line.get("message", json_line.get("msg", message))
-                log_level = json_line.get("levelname", json_line.get("level", "debug"))
+                # in rare cases, the loaded json line may be a string rather than a dictionary
+                if isinstance(message, dict):
+                    message = json_line.get("message", json_line.get("msg", message))
+                    log_level = json_line.get("levelname", json_line.get("level", "debug"))
 
         messages.append(message)
         if capture_logs:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
@@ -80,7 +80,7 @@ class DbtRpcResource(DbtResource):
         headers["User-Agent"] = self._construct_user_agent()
         headers["Content-Type"] = "application/json"
         headers["Accept"] = "application/json"
-        return headers
+        return cast(Dict[str, str], headers)
 
     def _post(self, data: Optional[str] = None) -> DbtRpcOutput:
         """Constructs and sends a POST request to the dbt RPC server.


### PR DESCRIPTION
### Summary & Motivation

https://buildkite.com/dagster/dagster/builds/33162#01823bb0-a99c-46ca-9476-e1241b89341d

mysterious mypy / json decoding errors occur in python 3.7. The cast has no behavior change, and now if a string is returned when decoding from json (instead of the expected dictionary), the entire string will be logged (rather than trying to parse out a specific field from the blob).

### How I Tested These Changes
