### PR TITLE
[1.0] Remove legacy APIs from dagster_airflow

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-airflow.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-airflow.rst
@@ -18,5 +18,3 @@ Airflow (dagster-airflow)
 .. autofunction:: make_dagster_repo_from_airflow_example_dags
 
 .. autofunction:: airflow_operator_to_op
-
-.. autofunction:: make_dagster_pipeline_from_airflow_dag

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/__init__.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/__init__.py
@@ -2,7 +2,6 @@ from dagster._core.utils import check_dagster_package_version
 
 from .dagster_job_factory import make_dagster_job_from_airflow_dag
 from .dagster_pipeline_factory import (
-    make_dagster_pipeline_from_airflow_dag,
     make_dagster_repo_from_airflow_dag_bag,
     make_dagster_repo_from_airflow_dags_path,
     make_dagster_repo_from_airflow_example_dags,
@@ -17,7 +16,6 @@ __all__ = [
     "make_airflow_dag",
     "make_airflow_dag_for_operator",
     "make_airflow_dag_containerized",
-    "make_dagster_pipeline_from_airflow_dag",
     "make_dagster_repo_from_airflow_dags_path",
     "make_dagster_repo_from_airflow_dag_bag",
     "make_dagster_job_from_airflow_dag",


### PR DESCRIPTION
Felt unnecessary to add a legacy import here, was far easier to just remove the top-level import.