### PR TITLE
[1.0] remove legacy dagster_databricks imports

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-databricks.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-databricks.rst
@@ -23,9 +23,3 @@ APIs
   :annotation: ResourceDefinition
 
 .. autoclass:: dagster_databricks.DatabricksError
-
-Legacy APIs
------------
-.. currentmodule:: dagster_databricks
-
-.. autofunction:: dagster_databricks.create_databricks_job_solid

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
@@ -17,7 +17,7 @@ from .databricks_pyspark_step_launcher import (
     databricks_pyspark_step_launcher,
 )
 from .resources import databricks_client
-from .solids import create_databricks_job_op, create_databricks_job_solid
+from .solids import create_databricks_job_op
 from .types import (
     DATABRICKS_RUN_TERMINATED_STATES,
     DatabricksRunLifeCycleState,
@@ -28,7 +28,6 @@ from .version import __version__
 check_dagster_package_version("dagster-databricks", __version__)
 
 __all__ = [
-    "create_databricks_job_solid",
     "create_databricks_job_op",
     "databricks_client",
     "DatabricksConfig",

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_solids.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_solids.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 from dagster_databricks import create_databricks_job_op, databricks_client
 from dagster_databricks.databricks import DatabricksRunState
-from dagster_databricks.solids import create_ui_url, create_databricks_job_solid
+from dagster_databricks.solids import create_databricks_job_solid, create_ui_url
 from dagster_databricks.types import DatabricksRunLifeCycleState, DatabricksRunResultState
 
 from dagster._legacy import ModeDefinition, execute_pipeline, pipeline

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_solids.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_solids.py
@@ -1,13 +1,9 @@
 from unittest import mock
 
 import pytest
-from dagster_databricks import (
-    create_databricks_job_op,
-    create_databricks_job_solid,
-    databricks_client,
-)
+from dagster_databricks import create_databricks_job_op, databricks_client
 from dagster_databricks.databricks import DatabricksRunState
-from dagster_databricks.solids import create_ui_url
+from dagster_databricks.solids import create_ui_url, create_databricks_job_solid
 from dagster_databricks.types import DatabricksRunLifeCycleState, DatabricksRunResultState
 
 from dagster._legacy import ModeDefinition, execute_pipeline, pipeline


### PR DESCRIPTION
as the title. `create_databricks_job_solid` is the only legacy import here.