### PR TITLE
[1.0] remove legacy APIs in dagster-gcp

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-gcp.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-gcp.rst
@@ -47,10 +47,3 @@ GCS
 
 .. autoconfigurable:: dagster_gcp.gcs.gcs_pickle_io_manager
   :annotation: IOManagerDefinition
-
-Legacy APIs
------------
-
-.. autofunction:: bq_solid_for_queries
-
-.. autofunction:: dataproc_solid

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/__init__.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/__init__.py
@@ -4,14 +4,13 @@ from .bigquery.ops import (
     bq_create_dataset,
     bq_delete_dataset,
     bq_op_for_queries,
-    bq_solid_for_queries,
     import_df_to_bq,
     import_file_to_bq,
     import_gcs_paths_to_bq,
 )
 from .bigquery.resources import bigquery_resource
 from .bigquery.types import BigQueryError
-from .dataproc.ops import dataproc_op, dataproc_solid
+from .dataproc.ops import dataproc_op
 from .dataproc.resources import dataproc_resource
 from .gcs import GCSFileHandle, gcs_file_manager, gcs_resource
 from .version import __version__
@@ -25,10 +24,8 @@ __all__ = [
     "bq_create_dataset",
     "bq_delete_dataset",
     "bq_op_for_queries",
-    "bq_solid_for_queries",
     "dataproc_resource",
     "dataproc_op",
-    "dataproc_solid",
     "gcs_resource",
     "gcs_file_manager",
     "import_df_to_bq",

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/solids.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/solids.py
@@ -1,4 +1,4 @@
 # pylint: disable=unused-import
 
 # Keep module for legacy backcompat
-from .ops import bq_create_dataset, bq_delete_dataset, bq_solid_for_queries
+from .ops import bq_create_dataset, bq_delete_dataset


### PR DESCRIPTION
As the title. solids-related APIs mostly.