### PR TITLE
Make op decorator usable as function

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -222,17 +222,20 @@ def op(
                 return 'cool', 4
     """
 
-    # This case is for when decorator is used bare, without arguments. e.g. @op versus @op()
     if callable(name):
-        check.invariant(input_defs is None)
-        check.invariant(output_defs is None)
-        check.invariant(description is None)
-        check.invariant(config_schema is None)
-        check.invariant(required_resource_keys is None)
-        check.invariant(tags is None)
-        check.invariant(version is None)
-
-        return _Op()(name)
+        return _Op(
+            name=None,
+            description=description,
+            input_defs=input_defs,
+            output_defs=output_defs,
+            config_schema=config_schema,
+            required_resource_keys=required_resource_keys,
+            tags=tags,
+            version=version,
+            retry_policy=retry_policy,
+            ins=ins,
+            out=out,
+        )(name)
 
     return _Op(
         name=name,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -1341,3 +1341,29 @@ def test_output_mismatch_tuple_lengths():
 
     with pytest.raises(DagsterInvariantViolationError, match="Length mismatch"):
         the_op()
+
+
+def test_use_decorator_as_function():
+    def my_fun() -> Tuple[int, str]:
+        return 1, "q"
+
+    my_op = op(
+        my_fun, description="my_op", out={"a": Out(metadata={"x": 1}), "b": Out(metadata={"y": 2})}
+    )
+    assert len(my_op.output_defs) == 2
+
+    assert my_op.outs == {
+        "a": Out(
+            metadata={"x": 1}, dagster_type=Int, is_required=True, io_manager_key="io_manager"
+        ),
+        "b": Out(
+            metadata={"y": 2}, dagster_type=String, is_required=True, io_manager_key="io_manager"
+        ),
+    }
+    assert my_op.output_defs[0].metadata == {"x": 1}
+    assert my_op.output_defs[0].name == "a"
+    assert my_op.output_defs[1].metadata == {"y": 2}
+    assert my_op.output_defs[1].name == "b"
+
+    assert my_op.description == "my_op"
+    assert my_op() == (1, "q")


### PR DESCRIPTION
### Summary & Motivation

I was trying to use existing functions with the `op` decorator, in this way:

```python
my_op = op(
    my_fun, description="my_op", out={"a": Out(metadata={"x": 1}), "b": Out(metadata={"y": 2})}
)
```

However none of the arguments are passed into the instantiation of the `_Op` object, which I changed.

This is my first PR in this codebase, and 
 - I don't know if it is a deliberate choice to not do this
 - I don't fully understand the reasoning behind the original `check.invariant()` for everything to be `None`. Please help me understand if it is okay to remove these.

### How I Tested These Changes

Ran all tests and added test case to use the decorator as a function.
