### PR TITLE
Add PUBLIC constant for NamedTuple attrs, add property/staticmethod support for @public

### DIFF
--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -1,6 +1,6 @@
 import inspect
 from functools import wraps
-from typing import Callable, Type, TypeVar, cast
+from typing import Callable, Optional, Type, TypeVar, Union, cast
 
 from typing_extensions import Annotated, Final, TypeAlias
 
@@ -11,25 +11,25 @@ from dagster._utils.backcompat import (
     experimental_fn_warning,
 )
 
-T_Callable = TypeVar("T_Callable", bound=Callable)
+T = TypeVar("T", bound=Union[Callable, property])
 
 ##### PUBLIC
 
 
-def public(obj: T_Callable) -> T_Callable:
+def public(obj: T) -> T:
     """
     Mark a method on a public class as public. This distinguishes the method from "internal"
     methods, which are methods that are public in the Python sense of being non-underscored, but
     not intended for user access. Only `public` methods of a class are rendered in the docs.
     """
-    check.callable_param(obj, "obj")
-    setattr(obj, "_is_public", True)
+    target = _get_target(obj)
+    setattr(target, "_is_public", True)
     return obj
 
 
-def is_public(fn: Callable) -> bool:
-    check.callable_param(fn, "fn")
-    return hasattr(fn, "_is_public") and getattr(fn, "_is_public")
+def is_public(obj: object, attr: Optional[str] = None) -> bool:
+    target = _get_target(obj, attr)
+    return hasattr(target, "_is_public") and getattr(target, "_is_public")
 
 
 # Use `PublicAttr` to annotate public attributes on `NamedTuple`:
@@ -49,27 +49,27 @@ PublicAttr: TypeAlias = Annotated[T, PUBLIC]
 ##### DEPRECATED
 
 
-def deprecated(obj: T_Callable) -> T_Callable:
+def deprecated(obj: T) -> T:
     """
     Mark a class/method/function as deprecated. This appends some metadata to tee fucntion that
     causes it to be rendered with a "deprecated" tag in the docs.
 
     Note that this decorator does not add any warnings-- they should be added separately.
     """
-    check.callable_param(obj, "obj")
-    setattr(obj, "_is_deprecated", True)
+    target = _get_target(obj)
+    setattr(target, "_is_deprecated", True)
     return obj
 
 
-def is_deprecated(fn: Callable) -> bool:
-    check.callable_param(fn, "fn")
-    return hasattr(fn, "_is_deprecated") and getattr(fn, "_is_deprecated")
+def is_deprecated(obj: object, attr: Optional[str] = None) -> bool:
+    target = _get_target(obj, attr)
+    return hasattr(target, "_is_deprecated") and getattr(target, "_is_deprecated")
 
 
 ##### EXPERIMENTAL
 
 
-def experimental(obj: T_Callable, *, decorator: bool = False) -> T_Callable:
+def experimental(obj: T, *, decorator: bool = False) -> T:
     """
     Mark a class/method/function as experimental. This appends some metadata to the function that
     causes it to be rendered with an "experimental" tag in the docs.
@@ -89,41 +89,54 @@ def experimental(obj: T_Callable, *, decorator: bool = False) -> T_Callable:
             class MyExperimentalClass:
                 pass
     """
-    check.callable_param(obj, "fn")
-    setattr(obj, "_is_experimental", True)
+    target = _get_target(obj)
+    setattr(target, "_is_experimental", True)
 
-    if inspect.isfunction(obj):
+    if isinstance(obj, (property, staticmethod, classmethod)):
+        # warning not currently supported for these cases
+        return obj
+
+    elif inspect.isfunction(target):
 
         warning_fn = experimental_decorator_warning if decorator else experimental_fn_warning
 
-        @wraps(obj)
+        @wraps(target)
         def inner(*args, **kwargs):
-            warning_fn(obj.__name__, stacklevel=3)
-            return obj(*args, **kwargs)
+            warning_fn(target.__name__, stacklevel=3)
+            return target(*args, **kwargs)
 
-        return cast(T_Callable, inner)
+        return cast(T, inner)
 
-    elif inspect.isclass(obj):
+    elif inspect.isclass(target):
 
-        undecorated_init = obj.__init__
+        undecorated_init = target.__init__
 
         def __init__(self, *args, **kwargs):
-            experimental_class_warning(obj.__name__, stacklevel=3)
+            experimental_class_warning(target.__name__, stacklevel=3)
             # Tuples must be handled differently, because the undecorated_init does not take any
             # arguments-- they're assigned in __new__.
-            if issubclass(cast(Type, obj), tuple):
+            if issubclass(cast(Type, target), tuple):
                 undecorated_init(self)
             else:
                 undecorated_init(self, *args, **kwargs)
 
-        obj.__init__ = __init__
+        target.__init__ = __init__
 
-        return cast(T_Callable, obj)
+        return cast(T, obj)
 
     else:
         check.failed("obj must be a function or a class")
 
 
-def is_experimental(obj: Callable) -> bool:
-    check.callable_param(obj, "obj")
-    return hasattr(obj, "_is_experimental") and getattr(obj, "_is_experimental")
+def is_experimental(obj: object, attr: Optional[str] = None) -> bool:
+    target = _get_target(obj, attr)
+    return hasattr(target, "_is_experimental") and getattr(target, "_is_experimental")
+
+
+def _get_target(obj: object, attr: Optional[str] = None):
+    lookup_obj = obj.__dict__[attr] if attr else obj
+    return lookup_obj.fget if isinstance(lookup_obj, property) else lookup_obj
+
+
+def _is_descriptor(obj: object):
+    return hasattr(obj, "__set__")

--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -1,6 +1,6 @@
 import inspect
 from functools import wraps
-from typing import Callable, Type, TypeVar, cast
+from typing import Callable, Final, Type, TypeVar, cast
 
 import dagster._check as check
 from dagster._utils.backcompat import (
@@ -28,6 +28,17 @@ def public(obj: T_Callable) -> T_Callable:
 def is_public(fn: Callable) -> bool:
     check.callable_param(fn, "fn")
     return hasattr(fn, "_is_public") and getattr(fn, "_is_public")
+
+
+# Use `PUBLIC` with `typing_extensions.Annotated` to annotate public attributes on `NamedTuple`:
+#
+# from typing_extensions import Annotated
+# from dagster._annotations import PUBLIC
+#
+# class Foo(NamedTuple("_Foo", [("bar", Annotated[int, PUBLIC])])):
+#     ...
+
+PUBLIC: Final[str] = "public"
 
 
 ##### DEPRECATED

--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -1,6 +1,8 @@
 import inspect
 from functools import wraps
-from typing import Callable, Final, Type, TypeVar, cast
+from typing import Callable, Type, TypeVar, cast
+
+from typing_extensions import Annotated, Final, TypeAlias
 
 import dagster._check as check
 from dagster._utils.backcompat import (
@@ -30,15 +32,18 @@ def is_public(fn: Callable) -> bool:
     return hasattr(fn, "_is_public") and getattr(fn, "_is_public")
 
 
-# Use `PUBLIC` with `typing_extensions.Annotated` to annotate public attributes on `NamedTuple`:
+# Use `PublicAttr` to annotate public attributes on `NamedTuple`:
 #
-# from typing_extensions import Annotated
-# from dagster._annotations import PUBLIC
+# from dagster._annotations import PublicAttr
 #
-# class Foo(NamedTuple("_Foo", [("bar", Annotated[int, PUBLIC])])):
+# class Foo(NamedTuple("_Foo", [("bar", PublicAttr(int))])):
 #     ...
 
+T = TypeVar("T")
+
 PUBLIC: Final[str] = "public"
+
+PublicAttr: TypeAlias = Annotated[T, PUBLIC]
 
 
 ##### DEPRECATED

--- a/python_modules/dagster/dagster_tests/test_annotations.py
+++ b/python_modules/dagster/dagster_tests/test_annotations.py
@@ -5,6 +5,7 @@ from typing_extensions import Annotated
 
 from dagster._annotations import (
     PUBLIC,
+    PublicAttr,
     deprecated,
     experimental,
     is_deprecated,
@@ -23,8 +24,8 @@ def test_public_annotation():
     assert is_public(Foo.bar)
 
 
-def test_public_constant_for_namedtuple():
-    class Foo(NamedTuple("_Foo", [("bar", Annotated[int, PUBLIC])])):
+def test_public_attr():
+    class Foo(NamedTuple("_Foo", [("bar", PublicAttr[int])])):
         ...
 
     hints = (

--- a/python_modules/dagster/dagster_tests/test_annotations.py
+++ b/python_modules/dagster/dagster_tests/test_annotations.py
@@ -61,7 +61,7 @@ class TestAnnotations:
         class Foo:
             @decorator
             @abstractmethod
-            def bar(cls):
+            def bar(self):
                 pass
 
         assert predicate(Foo, "bar")

--- a/python_modules/dagster/dagster_tests/test_annotations.py
+++ b/python_modules/dagster/dagster_tests/test_annotations.py
@@ -1,4 +1,10 @@
+import sys
+from typing import NamedTuple, get_type_hints
+
+from typing_extensions import Annotated
+
 from dagster._annotations import (
+    PUBLIC,
     deprecated,
     experimental,
     is_deprecated,
@@ -15,6 +21,18 @@ def test_public_annotation():
             pass
 
     assert is_public(Foo.bar)
+
+
+def test_public_constant_for_namedtuple():
+    class Foo(NamedTuple("_Foo", [("bar", Annotated[int, PUBLIC])])):
+        ...
+
+    hints = (
+        get_type_hints(Foo, include_extras=True)
+        if sys.version_info >= (3, 9)
+        else get_type_hints(Foo)
+    )
+    assert hints["bar"] == Annotated[int, PUBLIC]
 
 
 def test_deprecated():


### PR DESCRIPTION
### Summary & Motivation

This adds a `PUBLIC` constant that we can use to mark whether `NamedTuple` attrs are public:

```
# Use `PUBLIC` with `typing_extensions.Annotated to annotate public attributes on `NamedTuple`:
#
# from typing_extensions import Annotated
# from dagster._annotations import PUBLIC
#
# class Foo(NamedTuple("_Foo", [("bar", Annotated[int, PUBLIC])])):
#     ...
```

See [thread](https://elementl-workspace.slack.com/archives/C03MMSAQKU7/p1658861914489869) for context.

### How I Tested These Changes

Unit test.
