### PR TITLE
fixups to explicit asset dependency example on SDA concept page

### DIFF
--- a/docs/content/concepts/assets/software-defined-assets.mdx
+++ b/docs/content/concepts/assets/software-defined-assets.mdx
@@ -101,20 +101,17 @@ In this case, `ins={"upstream": AssetIn("upstream_asset")}` declares that the co
 Asset keys can also be provided to <PyObject object="AssetIn" /> to explicitly identify the asset. For example:
 
 ```python file=/concepts/assets/explicit_asset_dependency_asset_keys.py
-from dagster import AssetIn, AssetKey, asset
-
-# One way of providing explicit asset keys:
+from dagster import AssetIn, asset
 
 
-@asset(ins={"upstream": AssetIn(asset_key="upstream_asset")})
+# If the upstream key has a single segment, you can specify it with a string:
+@asset(ins={"upstream": AssetIn(key="upstream_asset")})
 def downstream_asset(upstream):
     return upstream + [4]
 
 
-# Another way:
-
-
-@asset(ins={"upstream": AssetIn(asset_key=AssetKey("upstream_asset"))})
+# If it has multiple segments, you can provide a list:
+@asset(ins={"upstream": AssetIn(key=["some_db_schema", "upstream_asset"])})
 def another_downstream_asset(upstream):
     return upstream + [10]
 ```

--- a/examples/docs_snippets/docs_snippets/concepts/assets/explicit_asset_dependency_asset_keys.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/explicit_asset_dependency_asset_keys.py
@@ -1,16 +1,13 @@
-from dagster import AssetIn, AssetKey, asset
-
-# One way of providing explicit asset keys:
+from dagster import AssetIn, asset
 
 
-@asset(ins={"upstream": AssetIn(asset_key="upstream_asset")})
+# If the upstream key has a single segment, you can specify it with a string:
+@asset(ins={"upstream": AssetIn(key="upstream_asset")})
 def downstream_asset(upstream):
     return upstream + [4]
 
 
-# Another way:
-
-
-@asset(ins={"upstream": AssetIn(asset_key=AssetKey("upstream_asset"))})
+# If it has multiple segments, you can provide a list:
+@asset(ins={"upstream": AssetIn(key=["some_db_schema", "upstream_asset"])})
 def another_downstream_asset(upstream):
     return upstream + [10]


### PR DESCRIPTION
- Avoid deprecated asset_key argument on AssetIn
- Give guidance on when to use the offered options

### Summary & Motivation

### How I Tested These Changes
