### PR TITLE
#9014 Increase user-deployments readinessProbe timeout

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -114,7 +114,7 @@ deployments:
       # exec:
       #   command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]
       periodSeconds: 20
-      timeoutSeconds: 3
+      timeoutSeconds: 10
       successThreshold: 1
       failureThreshold: 3
 

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -147,7 +147,7 @@ dagit:
       path: "/dagit_info"
       port: 80
     periodSeconds: 20
-    timeoutSeconds: 3
+    timeoutSeconds: 10
     successThreshold: 1
     failureThreshold: 3
 


### PR DESCRIPTION
### Summary & Motivation
As discussion at https://github.com/dagster-io/dagster/issues/9014 .
Increase the `timeoutSeconds` of readinessProbe for user-deployment example to make sure the deployment will be checked by the right way.
