### PR TITLE
handle old ExternalTimeWindowPartitionsDefinitionData

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -482,9 +482,9 @@ class ExternalTimeWindowPartitionsDefinitionData(
         timezone: Optional[str],
         fmt: str,
         end_offset: int,
-        minute_offset: int,
-        hour_offset: int,
-        day_offset: Optional[int],
+        minute_offset: int = 0,
+        hour_offset: int = 0,
+        day_offset: Optional[int] = None,
     ):
         return super(ExternalTimeWindowPartitionsDefinitionData, cls).__new__(
             cls,


### PR DESCRIPTION
need to default to load older values

### How I Tested These Changes

bk