### PR TITLE
Dask parquet filters predicates need to be wrapped in tuples

### DIFF
--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -415,7 +415,6 @@ def dataframe_loader(_context, config):
 
 
 def _innermost_list2tuple(data):
-
     def converted(x):
         if not any(isinstance(a, list) for a in x):
             return tuple(x)


### PR DESCRIPTION
### Summary & Motivation

Filters passed to read_parquet are to be of the type `Union[List[Tuple[str, str, Any]], List[List[Tuple[str, str, Any]]]]`. Prior to Dask version 2022.4.2, the code was lenient and permitted the tuple to actually be a list. Version 2022.4.2 included [PR8846](https://github.com/dask/dask/pull/8846) which changed how filters were handled. In `dask/dataframe/io/parquet/arrow.py` in `_construct_collection_plan()`, the method `flatten` is now called on the filters, and this will flatten all lists except tuples. If the predicate is wrapped in a list and not a tuple, then a `ValueError: too many values to unpack (expected 3)` occurs with the `flatten` method. Therefore, Dask from 2022.4.2 is no longer lenient in the aforementioned way.

When a pipeline's configuration in YAML is converted to an object, if a parquet filter is defined the predicates will be wrapped in a list as YAML doesn't have a concept of a tuple. This MR adds code to parse through the list of filters and convert the innermost lists wrapping predicate triples to tuples.

### How I Tested These Changes

In a local project focused only on this problem, I isolated the problem, wrote some test cases, and developed the submitted method. I'm currently patching the an older version of Dagster that we are using with this method which is being used in production.
