### PR TITLE
[dagster-dbt] better dbt logs and errors

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
@@ -120,7 +120,7 @@ def execute_cli(
                 pass
             else:
                 # in rare cases, the loaded json line may be a string rather than a dictionary
-                if isinstance(message, dict):
+                if isinstance(json_line, dict):
                     message = json_line.get("message", json_line.get("msg", message))
                     log_level = json_line.get("levelname", json_line.get("level", "debug"))
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
@@ -63,7 +63,12 @@ class DagsterDbtCliFatalRuntimeError(DagsterDbtCliRuntimeError):
     """Represents a fatal error in the dbt CLI (return code 2)."""
 
     def __init__(self, logs: Sequence[Mapping[str, Any]], raw_output: str, messages: Sequence[str]):
-        super().__init__("Fatal error in the dbt CLI (return code 2)", logs, raw_output, messages)
+        super().__init__(
+            "Fatal error in the dbt CLI (return code 2): " + " ".join(messages),
+            logs,
+            raw_output,
+            messages,
+        )
 
 
 class DagsterDbtRpcUnexpectedPollOutputError(DagsterDbtError):


### PR DESCRIPTION
### Summary & Motivation

Two things:

1.  if load_assets_from_dbt_project fails, it used to only show up as a pretty unhelpful error in the Dagster UI ("dbt exited with return code 2"). The full error would be visible in the console, but in many situations, it's not easy to access those console logs (e.g. non-local dagster deployments). Now, the dbt logs will be included in that error. They'll look a bit ugly (as newlines are erased in the UI), but at the very least it'll give users a sense of what went wrong.

2. I added tests to make sure we don't regress to emitting json-formatted logs to the console (rather than parsing the message out of the json log lines). This can happen when bugs are introduced on our side, or when dbt happens to update formatting on theirs. I introduced a bug in the last release that was uncaught, but now this test will catch that and similar issues.

### How I Tested These Changes
