### PR TITLE
Fix docstrings for context objects

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -76,11 +76,12 @@ class DefaultScheduleStatus(Enum):
 
 
 class ScheduleEvaluationContext:
-    """Schedule-specific execution context.
+    """The context object available as the first argument various functions defined on a :py:class:`dagster.ScheduleDefinition`.
 
-    An instance of this class is made available as the first argument to various ScheduleDefinition
-    functions. It is passed as the first argument to ``run_config_fn``, ``tags_fn``,
+    A `ScheduleEvaluationContext` object is passed as the first argument to ``run_config_fn``, ``tags_fn``,
     and ``should_execute``.
+
+    Users should not instantiate this object directly. To construct a `ScheduleEvaluationContext` for testing purposes, use :py:func:`dagster.build_schedule_context`.
 
     Attributes:
         instance_ref (Optional[InstanceRef]): The serialized instance configured to run the schedule
@@ -89,6 +90,17 @@ class ScheduleEvaluationContext:
             from both the actual execution time and the time at which the run config is computed.
             Not available in all schedulers - currently only set in deployments using
             DagsterDaemonScheduler.
+
+    Example:
+
+    .. code-block:: python
+
+        from dagster import schedule, ScheduleEvaluationContext
+
+        @schedule
+        def the_schedule(context: ScheduleEvaluationContext):
+            ...
+
     """
 
     __slots__ = ["_instance_ref", "_scheduled_execution_time", "_exit_stack", "_instance"]

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -49,10 +49,11 @@ DEFAULT_SENSOR_DAEMON_INTERVAL = 30
 
 
 class SensorEvaluationContext:
-    """Sensor execution context.
+    """The context object available as the argument to the evaluation function of a :py:class:`dagster.SensorDefinition`.
 
-    An instance of this class is made available as the first argument to the evaluation function
-    on SensorDefinition.
+    Users should not instantiate this object directly. To construct a
+    `SensorEvaluationContext` for testing purposes, use :py:func:`dagster.
+    build_sensor_context`.
 
     Attributes:
         instance_ref (Optional[InstanceRef]): The serialized instance configured to run the schedule
@@ -64,6 +65,17 @@ class SensorEvaluationContext:
         repository_name (Optional[str]): The name of the repository that the sensor belongs to.
         instance (Optional[DagsterInstance]): The deserialized instance can also be passed in
             directly (primarily useful in testing contexts).
+
+    Example:
+
+    .. code-block:: python
+
+        from dagster import sensor, SensorEvaluationContext
+
+        @sensor
+        def the_sensor(context: SensorEvaluationContext):
+            ...
+
     """
 
     def __init__(

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -549,4 +549,22 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
 
 
 class OpExecutionContext(SolidExecutionContext):
-    pass
+    """The ``context`` object that can be made available as the first argument to an op's compute
+    function.
+
+    The context object provides system information such as resources, config,
+    and logging to an op's compute function. Users should not instantiate this
+    object directly. To construct an `OpExecutionContext` for testing
+    purposes, use :py:func:`dagster.build_op_context`.
+
+    Example:
+
+    .. code-block:: python
+
+        from dagster import op
+
+        @op
+        def hello_world(context: OpExecutionContext):
+            context.log.info("Hello, world!")
+
+    """

--- a/python_modules/dagster/dagster/_core/execution/context/init.py
+++ b/python_modules/dagster/dagster/_core/execution/context/init.py
@@ -14,7 +14,9 @@ from dagster._core.storage.pipeline_run import PipelineRun
 
 
 class InitResourceContext:
-    """Resource-specific initialization context.
+    """The context object available as the argument to the initialization function of a :py:class:`dagster.ResourceDefinition`.
+
+    Users should not instantiate this object directly. To construct an `InitResourceContext` for testing purposes, use :py:func:`dagster.build_init_resource_context`.
 
     Attributes:
         resource_config (Any): The configuration data provided by the run config. The schema
@@ -31,6 +33,16 @@ class InitResourceContext:
             outside of execution context, this will be None.
         pipeline_run (Optional[PipelineRun]): (legacy) The dagster run to use. When initializing resources
             outside of execution context, this will be None.
+
+    Example:
+
+    .. code-block:: python
+
+        from dagster import resource, InitResourceContext
+
+        @resource
+        def the_resource(init_context: InitResourceContext):
+            init_context.log.info("Hello, world!")
 
     """
 

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -26,6 +26,10 @@ class InputContext:
     """
     The ``context`` object available to the load_input method of :py:class:`RootInputManager`.
 
+    Users should not instantiate this object directly. In order to construct
+    an `InputContext` for testing an IO Manager's `load_input` method, use
+    :py:func:`dagster.build_input_context`.
+
     Attributes:
         name (Optional[str]): The name of the input that we're loading.
         pipeline_name (Optional[str]): The name of the pipeline.
@@ -43,6 +47,17 @@ class InputContext:
             input manager. If using the :py:func:`@root_input_manager` decorator, these resources
             correspond to those requested with the `required_resource_keys` parameter.
         op_def (Optional[OpDefinition]): The definition of the op that's loading the input.
+
+    Example:
+
+    .. code-block:: python
+
+        from dagster import IOManager, InputContext
+
+        class MyIOManager(IOManager):
+            def load_input(self, context: InputContext):
+                ...
+
     """
 
     def __init__(

--- a/python_modules/dagster/dagster/_core/execution/context/logger.py
+++ b/python_modules/dagster/dagster/_core/execution/context/logger.py
@@ -10,12 +10,11 @@ from .output import RUN_ID_PLACEHOLDER
 
 
 class InitLoggerContext:
-    """Logger-specific initialization context.
+    """The context object available as the argument to the initialization function of a :py:class:`dagster.LoggerDefinition`.
 
-    An instance of this class is made available as the first argument to the ``logger_fn`` decorated
-    by :py:func:`@logger <logger>` or set on a :py:class:`LoggerDefinition`.
-
-    Users should not instantiate this class.
+    Users should not instantiate this object directly. To construct an
+    `InitLoggerContext` for testing purposes, use :py:func:`dagster.
+    build_init_logger_context`.
 
     Attributes:
         logger_config (Any): The configuration data provided by the run config. The
@@ -23,6 +22,17 @@ class InitLoggerContext:
         pipeline_def (Optional[PipelineDefinition]): The pipeline/job definition currently being executed.
         logger_def (Optional[LoggerDefinition]): The logger definition for the logger being constructed.
         run_id (str): The ID for this run of the pipeline.
+
+    Example:
+
+    .. code-block:: python
+
+        from dagster import logger, InitLoggerContext
+
+        @logger
+        def hello_world(init_context: InitLoggerContext):
+            ...
+
     """
 
     def __init__(

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -45,6 +45,45 @@ RUN_ID_PLACEHOLDER = "__EPHEMERAL_RUN_ID"
 
 
 class OutputContext:
+    """
+    The context object that is available to the `handle_output` method of an :py:class:`IOManager`.
+
+    Users should not instantiate this object directly. To construct an
+    `OutputContext` for testing an IO Manager's `handle_output` method, use
+    :py:func:`dagster.build_output_context`.
+
+    Attributes:
+        step_key (Optional[str]): The step_key for the compute step that produced the output.
+        name (Optional[str]): The name of the output that produced the output.
+        pipeline_name (Optional[str]): The name of the pipeline definition.
+        run_id (Optional[str]): The id of the run that produced the output.
+        metadata (Optional[Mapping[str, RawMetadataValue]]): A dict of the metadata that is assigned to the
+            OutputDefinition that produced the output.
+        mapping_key (Optional[str]): The key that identifies a unique mapped output. None for regular outputs.
+        config (Optional[Any]): The configuration for the output.
+        solid_def (Optional[SolidDefinition]): The definition of the solid that produced the output.
+        dagster_type (Optional[DagsterType]): The type of this output.
+        log (Optional[DagsterLogManager]): The log manager to use for this output.
+        version (Optional[str]): (Experimental) The version of the output.
+        resource_config (Optional[Mapping[str, Any]]): The config associated with the resource that
+            initializes the RootInputManager.
+        resources (Optional[Resources]): The resources required by the output manager, specified by the
+            `required_resource_keys` parameter.
+        op_def (Optional[OpDefinition]): The definition of the op that produced the output.
+        asset_info: Optional[AssetOutputInfo]: (Experimental) Asset info corresponding to the
+            output.
+
+    Example:
+
+    .. code-block:: python
+
+        from dagster import IOManager, OutputContext
+
+        class MyIOManager(IOManager):
+            def handle_output(self, context: OutputContext, obj):
+                ...
+
+    """
 
     _step_key: Optional[str]
     _name: Optional[str]
@@ -68,31 +107,6 @@ class OutputContext:
     _events: List["DagsterEvent"]
     _user_events: List[Union[AssetMaterialization, AssetObservation, Materialization]]
     _metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]]
-
-    """
-    The context object that is available to the `handle_output` method of an :py:class:`IOManager`.
-
-    Attributes:
-        step_key (Optional[str]): The step_key for the compute step that produced the output.
-        name (Optional[str]): The name of the output that produced the output.
-        pipeline_name (Optional[str]): The name of the pipeline definition.
-        run_id (Optional[str]): The id of the run that produced the output.
-        metadata (Optional[Mapping[str, RawMetadataValue]]): A dict of the metadata that is assigned to the
-            OutputDefinition that produced the output.
-        mapping_key (Optional[str]): The key that identifies a unique mapped output. None for regular outputs.
-        config (Optional[Any]): The configuration for the output.
-        solid_def (Optional[SolidDefinition]): The definition of the solid that produced the output.
-        dagster_type (Optional[DagsterType]): The type of this output.
-        log (Optional[DagsterLogManager]): The log manager to use for this output.
-        version (Optional[str]): (Experimental) The version of the output.
-        resource_config (Optional[Mapping[str, Any]]): The config associated with the resource that
-            initializes the RootInputManager.
-        resources (Optional[Resources]): The resources required by the output manager, specified by the
-            `required_resource_keys` parameter.
-        op_def (Optional[OpDefinition]): The definition of the op that produced the output.
-        asset_info: Optional[AssetOutputInfo]: (Experimental) Asset info corresponding to the
-            output.
-    """
 
     def __init__(
         self,


### PR DESCRIPTION
Adds examples, and cautions to not instantiate directly.