### PR TITLE
Be more defensive in PythonErrorInfo when rendering causes

### DIFF
--- a/js_modules/dagit/packages/core/src/app/PythonErrorInfo.tsx
+++ b/js_modules/dagit/packages/core/src/app/PythonErrorInfo.tsx
@@ -37,13 +37,17 @@ export const PythonErrorInfo: React.FC<IPythonErrorInfoProps> = (props) => {
           </div>
         ) : null}
         {stack ? <Trace>{stack.join('')}</Trace> : null}
-        {causes.map((cause) => (
-          <>
-            <CauseHeader>The above exception was caused by the following exception:</CauseHeader>
-            <ErrorHeader>{cause.message}</ErrorHeader>
-            {stack ? <Trace>{cause.stack.join('')}</Trace> : null}
-          </>
-        ))}
+        {causes
+          ? causes.map((cause) => (
+              <>
+                <CauseHeader>
+                  The above exception was caused by the following exception:
+                </CauseHeader>
+                <ErrorHeader>{cause.message}</ErrorHeader>
+                {stack ? <Trace>{cause.stack.join('')}</Trace> : null}
+              </>
+            ))
+          : null}
         {props.showReload && (
           <Button icon={<Icon name="refresh" />} onClick={() => window.location.reload()}>
             Reload


### PR DESCRIPTION
Summary:
Got an error in dagit that maps to this not always being set to an empty list. Be more defensive

Test Plan:
Push this change to dogfood and hit redeploy on the workspace tab, get a clearer error

### Summary & Motivation

### How I Tested These Changes
