### PR TITLE
Add missing `job_name` argument for creating run request for partioned jobs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -550,6 +550,7 @@ class JobDefinition(PipelineDefinition):
         partition_key: str,
         run_key: Optional[str],
         tags: Optional[Mapping[str, str]] = None,
+        job_name: Optional[str] = None,        
     ) -> RunRequest:
         partition_set = self.get_partition_set_def()
         if not partition_set:
@@ -563,7 +564,7 @@ class JobDefinition(PipelineDefinition):
             else partition_set.tags_for_partition(partition)
         )
 
-        return RunRequest(run_key=run_key, run_config=run_config, tags=run_request_tags)
+        return RunRequest(run_key=run_key, run_config=run_config, tags=run_request_tags, job_name=job_name)
 
     def with_hooks(self, hook_defs: AbstractSet[HookDefinition]) -> "JobDefinition":
         """Apply a set of hooks to all op instances within the job."""

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -564,7 +564,7 @@ class JobDefinition(PipelineDefinition):
             else partition_set.tags_for_partition(partition)
         )
 
-        return RunRequest(run_key=run_key, run_config=run_config, tags=run_request_tags, job_name=job_name)
+        return RunRequest(run_key=run_key, run_config=run_config, tags=run_request_tags, job_name=self.name)
 
     def with_hooks(self, hook_defs: AbstractSet[HookDefinition]) -> "JobDefinition":
         """Apply a set of hooks to all op instances within the job."""

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -550,7 +550,6 @@ class JobDefinition(PipelineDefinition):
         partition_key: str,
         run_key: Optional[str],
         tags: Optional[Mapping[str, str]] = None,
-        job_name: Optional[str] = None,        
     ) -> RunRequest:
         partition_set = self.get_partition_set_def()
         if not partition_set:


### PR DESCRIPTION
### Summary & Motivation

Creating a `RunRequest` for a partitioned job is missing `job_name` argument. This causes errors when using a sensor that triggers multiple jobs.

When a sensor defined to trigger multiple jobs, it asks for each RunRequest to have a `job_name` argument, therefore we need to have `job_name`, like below.

``` py
@sensor(jobs=[job1_with_no_partition, job2_with_partition], minimum_interval_seconds=60 * 20)
def my_cool_sensor(context: SensorEvaluationContext):
    """
    Checks a process and starts multiple jobs.
    """
    yield RunRequest(
        run_key=None, run_config={...}, job_name='job1_with_no_partition')
    yield job2_with_partition.run_request_for_partition(
        partition_key="my_partition_key", run_key="my_partition_key", job_name='job2_with_partition')

    context.update_cursor(...)

```

### How I Tested These Changes

I can add if needed.