### PR TITLE
[dagit] Fix generic error in PythonErrorInfo

### DIFF
--- a/js_modules/dagit/packages/core/src/app/PythonErrorInfo.test.tsx
+++ b/js_modules/dagit/packages/core/src/app/PythonErrorInfo.test.tsx
@@ -1,0 +1,35 @@
+import {render, screen} from '@testing-library/react';
+import * as React from 'react';
+
+import {GenericError, PythonErrorInfo} from './PythonErrorInfo';
+import {PythonErrorFragment} from './types/PythonErrorFragment';
+
+describe('PythonErrorInfo', () => {
+  it('renders a real PythonErrorFragment', async () => {
+    const error: PythonErrorFragment = {
+      __typename: 'PythonError',
+      message: 'lol oh no',
+      stack: ['u have failed', 'rofl'],
+      causes: [
+        {
+          __typename: 'PythonError',
+          message: 'u wrote bad code',
+          stack: ['problem here', 'whoops'],
+        },
+      ],
+    };
+    render(<PythonErrorInfo error={error} />);
+
+    expect(screen.getByText(/lol oh no/i)).toBeVisible();
+    expect(screen.getByText(/u wrote bad code/i)).toBeVisible();
+  });
+
+  it('renders a generic error without errors', async () => {
+    const error: GenericError = {
+      message: 'failure all around',
+    };
+    render(<PythonErrorInfo error={error} />);
+
+    expect(screen.queryByText(/failure all around/i)).toBeVisible();
+  });
+});

--- a/js_modules/dagit/packages/core/src/app/PythonErrorInfo.tsx
+++ b/js_modules/dagit/packages/core/src/app/PythonErrorInfo.tsx
@@ -7,20 +7,27 @@ import {MetadataEntries} from '../metadata/MetadataEntry';
 import {MetadataEntryFragment} from '../metadata/types/MetadataEntryFragment';
 import {ErrorSource} from '../types/globalTypes';
 
-import {PythonErrorFragment} from './types/PythonErrorFragment';
+import {
+  PythonErrorFragment,
+  PythonErrorFragment_causes as Cause,
+} from './types/PythonErrorFragment';
+
+export type GenericError = {
+  message: string;
+  stack?: string[];
+  causes?: Cause[];
+};
 
 interface IPythonErrorInfoProps {
   showReload?: boolean;
   centered?: boolean;
-  error: {message: string} | PythonErrorFragment;
+  error: GenericError | PythonErrorFragment;
   failureMetadata?: {metadataEntries: MetadataEntryFragment[]} | null;
   errorSource?: ErrorSource | null;
 }
 
 export const PythonErrorInfo: React.FC<IPythonErrorInfoProps> = (props) => {
-  const message = props.error.message;
-  const stack = (props.error as PythonErrorFragment).stack;
-  const causes = (props.error as PythonErrorFragment).causes;
+  const {message, stack = [], causes = []} = props.error;
 
   const Wrapper = props.centered ? ErrorWrapperCentered : ErrorWrapper;
   const context = props.errorSource ? <ErrorContext errorSource={props.errorSource} /> : null;
@@ -37,12 +44,12 @@ export const PythonErrorInfo: React.FC<IPythonErrorInfoProps> = (props) => {
           </div>
         ) : null}
         {stack ? <Trace>{stack.join('')}</Trace> : null}
-        {causes.map((cause) => (
-          <>
+        {causes.map((cause, ii) => (
+          <React.Fragment key={ii}>
             <CauseHeader>The above exception was caused by the following exception:</CauseHeader>
             <ErrorHeader>{cause.message}</ErrorHeader>
             {stack ? <Trace>{cause.stack.join('')}</Trace> : null}
-          </>
+          </React.Fragment>
         ))}
         {props.showReload && (
           <Button icon={<Icon name="refresh" />} onClick={() => window.location.reload()}>


### PR DESCRIPTION
### Summary & Motivation

`PythonErrorInfo` is able to render generic `{message: string}` errors that include no `stack` and no `causes` values.

Unfortunately, we are currently casting the object to `PythonErrorFragment` and referencing `stack` and `causes`, which leads to runtime errors when trying to map over the `causes` array.

Eliminate the cast and instead define the generic error as an object that may optionally have `stack` and `causes`, even though it never will. This allows us to reliably reference these keys and set them as empty arrays if they are not supplied, thus avoiding the runtime error of calling `map` on an undefined value.

I included a test to verify that the generic error type renders correctly.

### How I Tested These Changes

`yarn jest PythonErrorInfo`
