### PR TITLE
[docs] - Reformat category pages

### DIFF
--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -1,89 +1,241 @@
+---
+title: Concepts | Dagster Docs
+---
+
 # Concepts
 
-Dagster is a data orchestrator. It lets you define jobs in terms of the data flow between logical components called ops. These jobs can be developed locally and run anywhere.
+TODO
 
-## How to use the Concepts section
+---
 
-Each page in this section contains:
+## Software-defined assets
 
-- **Overview**: Description of the concept.
-- **Relevant APIs**: Index of top-level Dagster APIs that are relevant to the concept.
-- **Examples**: Easy-to-copy code snippets for the concept.
-- **Patterns**: A list of advanced patterns to use and anti-patterns to avoid with the concept.
+An asset is an object in persistent storage, such as a table, file, or persisted machine learning model. A software-defined asset is a Dagster object that couples an asset to the function and upstream assets that are used to produce its contents.
 
-## Sections
+<ArticleList>
+  <ArticleListItem
+    title="Software-defined assets"
+    href="/concepts/assets/software-defined-assets"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Asset materializations"
+    href="/concepts/assets/sasset-materializations"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Asset observations"
+    href="/concepts/assets/asset-observations"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Multi-assets"
+    href="/concepts/assets/multi-assets"
+  ></ArticleListItem>
+</ArticleList>
 
-<LinkGrid>
-  <LinkGridItem title="Assets" href="/concepts/assets/software-defined-assets">
-    Assets are data objects that you produce during a run. This section walks
-    you through how to inform Dagster about these assets so that they can be
-    tracked over time.
-  </LinkGridItem>
-  <LinkGridItem
-    title="Ops, Jobs, and Graphs"
+---
+
+## Ops
+
+Ops are the core unit of computation in Dagster. They typically perform relatively simple tasks, such as executing a database query or sending a Slack message.
+
+<ArticleList>
+  <ArticleListItem
+    title="Ops"
     href="/concepts/ops-jobs-graphs/ops"
-  >
-    Ops, Jobs, and Graphs are the building blocks of Dagster code. This section
-    covers how to define and use both ops and jobs.
-  </LinkGridItem>
-  <LinkGridItem
-    title="Schedules, Sensors, and Partitions"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Op events"
+    href="/concepts/ops-jobs-graphs/op-events"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Op hooks"
+    href="/concepts/ops-jobs-graphs/op-hooks"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Op retries"
+    href="/concepts/ops-jobs-graphs/op-retries"
+  ></ArticleListItem>
+</ArticleList>
+
+---
+
+## Graphs
+
+A graph is a set of interconnected ops or sub-graphs. While individual ops typically perform simple tasks, ops can be assembled into a graph to accomplish complex tasks.
+
+<ArticleList>
+  <ArticleListItem
+    title="Graphs"
+    href="/concepts/ops-jobs-graphs/graphs"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Nesting graphs"
+    href="/concepts/ops-jobs-graphs/nesting-graphs"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Dynamic graphs"
+    href="/concepts/ops-jobs-graphs/dynamic-graphs"
+  ></ArticleListItem>
+</ArticleList>
+
+---
+
+## Jobs
+
+Jobs are the main unit of execution and monitoring in Dagster. The core of a job is a graph of ops connected via data dependencies.
+
+<ArticleList>
+  <ArticleListItem
+    title="Jobs"
+    href="/concepts/ops-jobs-graphs/jobs"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Job execution"
+    href="/concepts/ops-jobs-graphs/job-execution"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Metadata and tags"
+    href="/concepts/ops-jobs-graphs/metadata-tags"
+  ></ArticleListItem>
+</ArticleList>
+
+---
+
+## Schedules
+
+Schedules launch runs on a fixed interval, while sensors allow you to do so based on an external state change. These features also support partitioning and backfilling.
+
+<ArticleList>
+  <ArticleListItem
+    title="Schedules"
     href="/concepts/partitions-schedules-sensors/schedules"
-  >
-    Schedulers can launch runs on a fixed interval, while sensors allow you to
-    run based on any external state change. This section demonstrates how to
-    define them and their convenient capabilities like partitioning and
-    backfilling.
-  </LinkGridItem>
-  <LinkGridItem
-    title="IO Management"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Sensors"
+    href="/concepts/partitions-schedules-sensors/sensors"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Partitions"
+    href="/concepts/partitions-schedules-sensors/partitions"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Backfills"
+    href="/concepts/partitions-schedules-sensors/backfills"
+  ></ArticleListItem>
+</ArticleList>
+
+---
+
+## I/O management
+
+IO Managers are user-provided objects that store asset and op outputs and load them as inputs to downstream assets and ops.
+
+<ArticleList>
+  <ArticleListItem
+    title="I/O managers"
     href="/concepts/io-management/io-managers"
-  >
-    IO Managers are user-provided objects that store op outputs and load them as
-    inputs to downstream ops. This section explains how Dagster thinks about IO
-    management and shows how to define and use IO managers and other IO-related
-    features.
-  </LinkGridItem>
-  <LinkGridItem
-    title="Configuration"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Sensors"
+    href="/concepts/io-management/unconnected-inputs"
+  ></ArticleListItem>
+</ArticleList>
+
+---
+
+## Configuration
+
+Dagster provides a configuration system that allows you to document, schematize, and error-check your configuration.
+
+<ArticleList>
+  <ArticleListItem
+    title="Run configuration"
     href="/concepts/configuration/config-schema"
-  >
-    Dagster provides a configuration system that allows you to document,
-    schematize, and error-check your configuration. This section demonstrates
-    how configurations work with different Dagster entities.
-  </LinkGridItem>
-  <LinkGridItem
-    title="Repositories and Workspaces"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Definition-time configuration"
+    href="/concepts/configuration/configured"
+  ></ArticleListItem>
+</ArticleList>
+
+---
+
+## Workspaces and repositories
+
+Workspaces are collections of repositories and info about where to find them. Dagster tools like Dagit and the Dagster CLI use workspaces to load your code.
+
+<ArticleList>
+  <ArticleListItem
+    title="Workspaces"
+    href="/concepts/repositories-workspaces/workspaces"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Repositories"
     href="/concepts/repositories-workspaces/repositories"
-  >
-    A workspace is a collection of user-defined repositories and information
-    about where to find them. Dagster tools, like Dagit and the Dagster CLI, use
-    workspaces to load user code. This section shows how to define and when to
-    use repositories and workspaces.
-  </LinkGridItem>
-  <LinkGridItem title="Resources" href="/concepts/resources">
-    Resources enable you to separate logic from its heavyweight external
-    dependencies. This makes testing and developing data jobs possible in
-    various environments.
-  </LinkGridItem>
-  <LinkGridItem title="Dagit & GraphQL API" href="/concepts/dagit/dagit">
-    Dagit is a web-based interface for viewing and interacting with Dagster
-    objects. This section walks you through Dagit's functionalities and the
-    GraphQL API used to interact with Dagster programatically.
-  </LinkGridItem>
-  <LinkGridItem title="Dagster Types" href="/concepts/types">
-    Dagster includes gradual, opt-in typing for the inputs and outputs of ops.
-    This section explains how to define, use, and test types in Dagster.
-  </LinkGridItem>
-  <LinkGridItem title="Logging" href="/concepts/logging/loggers">
-    Dagster includes a rich and extensible logging system. This section
-    showcases Dagster's built-in logger and shows how you can customize loggers
-    to fit your logging and monitoring infrastructure.
-  </LinkGridItem>
-  <LinkGridItem title="Testing" href="/concepts/testing">
-    Dagster enables you to build testable and maintainable data applications.
-    This section shows that Dagster enables you to unit-test your data jobs,
-    separate business logic from external dependencies, and run data quality
-    tests.
-  </LinkGridItem>
-</LinkGrid>
+  ></ArticleListItem>
+</ArticleList>
+
+---
+
+## Resources
+
+Resources enable you to separate logic from external dependencies, making developing and testing possible in multiple environments.
+
+[Learn more about resources](/concepts/resources).
+
+---
+
+## Dagit
+
+Dagit is a web-based interface for viewing and interacting with Dagster objects.
+
+[Learn more about Dagit](/concepts/dagit/dagit).
+
+---
+
+## GraphQL API
+
+The GraphQL API allows you to programmatically interact with Dagster.
+
+<ArticleList>
+  <ArticleListItem
+    title="GraphQL API"
+    href="/concepts/dagit/graphql"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="GraphQL Python client"
+    href="/concepts/dagit/graphql-client"
+  ></ArticleListItem>
+</ArticleList>
+
+---
+
+## Dagster types
+
+The Dagster type system provides gradual, opt-in typing for the inputs and outputs of assets and ops.
+
+[Learn more about Dagster types](/concepts/types).
+
+---
+
+## Logging
+
+A rich, extensible logging system, Dagster's built-in logger tracks all execution events. Loggers can also be customized to fit your infrastructure.
+
+<ArticleList>
+  <ArticleListItem
+    title="Loggers"
+    href="/concepts/logging/loggers"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Python logging"
+    href="/concepts/logging/python-logging"
+  ></ArticleListItem>
+</ArticleList>
+
+---
+
+## Testing
+
+Dagster enables you to build testable and maintainable data applications. It provides ways to allow you unit-test your data applications, separate business logic from environments, and set explicit expectations on uncontrollable inputs.
+
+[Learn more about testing](/concepts/testing).

--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -4,7 +4,7 @@ title: Concepts | Dagster Docs
 
 # Concepts
 
-TODO
+Learn more about each of Dagster's core concepts and how to use them in your data platform.
 
 ---
 

--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -4,13 +4,13 @@ title: Concepts | Dagster Docs
 
 # Concepts
 
-Learn about each of Dagster's core concepts and how to use them in your data platform.
+Learn about Dagster's core concepts and how to use them in your data platform.
 
 ---
 
 ## Software-defined assets
 
-An asset is an object in persistent storage, such as a table, file, or persisted machine learning model. A software-defined asset is a Dagster object that couples an asset to the function and upstream assets that are used to produce its contents.
+An asset is an object in persistent storage, such as a table, file, or persisted machine learning model. A software-defined asset is a Dagster object that couples an asset to the function and upstream assets used to produce its contents.
 
 <ArticleList>
   <ArticleListItem
@@ -194,7 +194,7 @@ Dagit is a web-based interface for viewing and interacting with Dagster objects.
 
 ## GraphQL API
 
-The GraphQL API allows you to programmatically interact with Dagster.
+The GraphQL API allows you to interact programmatically with Dagster.
 
 <ArticleList>
   <ArticleListItem

--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -4,7 +4,7 @@ title: Concepts | Dagster Docs
 
 # Concepts
 
-Learn more about each of Dagster's core concepts and how to use them in your data platform.
+Learn about each of Dagster's core concepts and how to use them in your data platform.
 
 ---
 

--- a/docs/content/guides.mdx
+++ b/docs/content/guides.mdx
@@ -1,16 +1,49 @@
+---
+title: Guides | Dagster Docs
+---
+
 # Guides
 
-## Dagster Guides
+Learn to accomplish common tasks in Dagster.
 
-This section explains how to accomplish common tasks in Dagster and showcases Dagster's experimental features.
+<ArticleList>
+  <ArticleListItem
+    title="Enriching with Software-defined Assets"
+    href="/guides/dagster/enriching-with-software-defined-assets"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Using the Hacker News example project"
+    href="/guides/dagster/example_project"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Re-excuting Dagster jobs"
+    href="/guides/dagster/re-execution"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Using Software-defined assets with Pandas and PySpark"
+    href="/guides/dagster/software-defined-assets"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Validating data with Dagster Type factories"
+    href="/guides/dagster/dagster_type_factories"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Migrating to graphs, jobs, and ops"
+    href="https://docs.dagster.io/0.15.7/guides/dagster/graph_job_op"
+  ></ArticleListItem>
+</ArticleList>
 
-| Name                                                                                             | Description                                                                                                                   |   |
-| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- | - |
-| [Upgrading to Software-Defined Assets](/guides/dagster/enriching-with-software-defined-assets)   | This guide describes how to enrich what you've built in Dagster with software-defined assets.                                 |   |
-| [Versioning and Memoization](/guides/dagster/memoization)                                        | This guide describes how to use Dagster's versioning and memoization features. <Experimental />                               |   |
-| [Software-Defined Assets with Pandas and PySpark](/guides/dagster/software-defined-assets)       | This guide offers a fast introduction to software-defined assets, with Pandas and PySpark.                                    |   |
-| [Run Attribution](/guides/dagster/run-attribution)                                               | This guide describes how to perform Run Attribution by using a Custom Run Coordinator <Experimental />                        |   |
-| [Migrating to Graphs, Jobs, and Ops](https://docs.dagster.io/0.15.7/guides/dagster/graph_job_op) | This guide describes how to migrate to the Graph, Job, and Op APIs from the legacy Dagster APIs (Solids and Pipelines).       |   |
-| [Re-execution](/guides/dagster/re-execution)                                                     | This guide describes how to re-execute a job within Dagit and using Dagster's APIs.                                           |   |
-| [Fully-Featured Example Project](/guides/dagster/example_project)                                | This guide describes the Hacker News example project, which takes advantage of many of Dagster's features                     |   |
-| [Validating Data with Dagster Type Factories](/guides/dagster/dagster_type_factories)            | This guide illustrates the use of a Dagster Type factory to validate Pandas dataframes using the third-party library Pandera. |   |
+---
+
+## Experimental features
+
+<ArticleList>
+  <ArticleListItem
+    title="Using versioning and memoization"
+    href="/guides/dagster/memoization"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Using Custom Run Coordinators to perform run attribution"
+    href="/guides/dagster/run-attribution"
+  ></ArticleListItem>
+</ArticleList>

--- a/docs/content/guides.mdx
+++ b/docs/content/guides.mdx
@@ -4,46 +4,28 @@ title: Guides | Dagster Docs
 
 # Guides
 
-Learn to accomplish common tasks in Dagster.
+Learn to apply [Dagster concepts](/concepts) to your work, explore experimental features, and check out some examples.
 
-<ArticleList>
-  <ArticleListItem
-    title="Enriching with Software-defined Assets"
-    href="/guides/dagster/enriching-with-software-defined-assets"
-  ></ArticleListItem>
-  <ArticleListItem
-    title="Using the Hacker News example project"
-    href="/guides/dagster/example_project"
-  ></ArticleListItem>
-  <ArticleListItem
-    title="Re-excuting Dagster jobs"
-    href="/guides/dagster/re-execution"
-  ></ArticleListItem>
-  <ArticleListItem
-    title="Using Software-defined assets with Pandas and PySpark"
-    href="/guides/dagster/software-defined-assets"
-  ></ArticleListItem>
-  <ArticleListItem
-    title="Validating data with Dagster Type factories"
-    href="/guides/dagster/dagster_type_factories"
-  ></ArticleListItem>
-  <ArticleListItem
-    title="Migrating to graphs, jobs, and ops"
-    href="https://docs.dagster.io/0.15.7/guides/dagster/graph_job_op"
-  ></ArticleListItem>
-</ArticleList>
+---
+
+## General
+
+- [Enriching with Software-defined Assets](/guides/dagster/enriching-with-software-defined-assets) - Learn to enrich what you've built in Dagster with Software-defined assets
+
+- [Using Software-defined assets with Pandas and PySpark](/guides/dagster/software-defined-assets) - A quick introduction to Sofware-defined assets, featuring Pandas and PySpark
+
+- [Using the Hacker News example project](/guides/dagster/example_project) - A walkthrough of an example project featuring many of Dagster's features, using Hacker News
+
+- [Re-executing Dagster jobs](/guides/dagster/re-execution) - Learn to re-execute Dagster jobs using both Dagit and Dagster's APIs
+
+- [Validating data with Dagster Type factories](/guides/dagster/dagster_type_factories) - Explore using a Dagster Type factory to validate Pandas dataframes using Pandera
+
+- [Migrating to graphs, jobs, and ops](https://docs.dagster.io/0.15.7/guides/dagster/graph_job_op) - Migrate to Dagster graphs, jobs, and ops from Dagster solids and pipelines (legacy)
 
 ---
 
 ## Experimental features
 
-<ArticleList>
-  <ArticleListItem
-    title="Using versioning and memoization"
-    href="/guides/dagster/memoization"
-  ></ArticleListItem>
-  <ArticleListItem
-    title="Using Custom Run Coordinators to perform run attribution"
-    href="/guides/dagster/run-attribution"
-  ></ArticleListItem>
-</ArticleList>
+- [Using versioning and memoization](/guides/dagster/memoization) - Learn to use Dagster's versioning and memoization features in job re-execution
+
+- [Using Custom Run Coordinators to perform run attribution](/guides/dagster/run-attribution) - A look at using a Custom Run Coordinator to perform run attribution

--- a/docs/content/integrations.mdx
+++ b/docs/content/integrations.mdx
@@ -5,59 +5,173 @@ description: Dagster is flexible and allows incremental adoption. It provides ad
 
 # Integrations
 
-Dagster is flexible and allows incremental adoption. It provides add-on libraries to integrate with your existing tools and infrastructure.
+Extend Dagster with our integration guides and libraries.
 
-## Guides
+---
 
-This section includes guides on how to use Dagster with other tools.
+## Integration guides
 
-| Name                                                                | Description                                                                          |
-| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [Dagster with dbt](/integrations/dbt)                               | Orchestrate dbt from Dagster.                                                        |
-| [Dagster with Great Expectations](/integrations/great-expectations) | Run data quality tests using Great Expectations in a Dagster pipeline.               |
-| [Dagster with Spark](/integrations/spark)                           | Define and execute Spark jobs in Dagster.                                            |
-| [Dagster with Pandas](/integrations/pandas)                         | How Dagster works with Pandas.                                                       |
-| [Dagster with Pandera](/integrations/pandera)                       | Validate Pandas dataframes and visualize dataframe schemas with Pandera.             |
-| [Dagster with Jupyter/Papermill](/integrations/dagstermill)         | How to orchestrate Jupyter notebooks from Dagster.                                   |
-| [Dagster with Airflow](/integrations/airflow)                       | Use Dagster in an Airflow cluster, or transform Airflow DAGs into Dagster pipelines. |
+<ArticleList>
+  <ArticleListItem
+    title="Airflow"
+    href="/integrations/airflow"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Dagstermill"
+    href="/integrations/dagstermill"
+  ></ArticleListItem>
+  <ArticleListItem title="dbt" href="/integrations/dbt"></ArticleListItem>
+  <ArticleListItem
+    title="Great Expectations"
+    href="/integrations/great-expectations"
+  ></ArticleListItem>
+  <ArticleListItem title="Pandas" href="/integrations/pandas"></ArticleListItem>
+  <ArticleListItem
+    title="Pandera"
+    href="/integrations/pandera"
+  ></ArticleListItem>
+  <ArticleListItem title="Spark" href="/integrations/spark"></ArticleListItem>
+</ArticleList>
 
-## Libraries
+---
 
-Here is a complete list of Dagster's integration libraries. See full documentation in [API Reference](/\_apidocs#libraries).
+## Intregration libraries
 
-| Integration        | Library                                                                  |
-| ------------------ | ------------------------------------------------------------------------ |
-| Airbyte            | [dagster-airbyte](/_apidocs/libraries/dagster-airbyte)                   |
-| Airflow            | [dagster-airflow](/_apidocs/libraries/dagster-airflow)                   |
-| AWS                | [dagster-aws](/_apidocs/libraries/dagster-aws)                           |
-| Azure              | [dagster-azure](/_apidocs/libraries/dagster-azure)                       |
-| Celery             | [dagster-celery](/_apidocs/libraries/dagster-celery)                     |
-| Celery + Docker    | [dagster-celery-docker](/_apidocs/libraries/dagster-celery-docker)       |
-| Dask               | [dagster-dask](/_apidocs/libraries/dagster-dask)                         |
-| Databricks         | [dagster-databricks](/_apidocs/libraries/dagster-databricks)             |
-| Datadog            | [dagster-datadog](/_apidocs/libraries/dagster-datadog)                   |
-| Docker             | [dagster-docker](/_apidocs/libraries/dagster-docker)                     |
-| dbt                | [dagster-dbt](/_apidocs/libraries/dagster-dbt)                           |
-| Fivetran           | [dagster-fivetran](/_apidocs/libraries/dagster-fivetran)                 |
-| GCP                | [dagster-gcp](/_apidocs/libraries/dagster-gcp)                           |
-| Great Expectations | [dagster-ge](/_apidocs/libraries/dagster-ge)                             |
-| Github             | [dagster-github](/_apidocs/libraries/dagster-github)                     |
-| Kubernetes         | [dagster-k8s](/_apidocs/libraries/dagster-k8s)                           |
-| Microsoft Teams    | [dagster-msteams](/_apidocs/libraries/dagster-msteams)                   |
-| MLflow             | [dagster-mlflow](/_apidocs/libraries/dagster-mlflow)                     |
-| MySQL              | [dagster-mysql](/_apidocs/libraries/dagster-mysql)                       |
-| PagerDuty          | [dagster-pagerduty](/_apidocs/libraries/dagster-pagerduty)               |
-| Pandas             | [dagster-pandas](/_apidocs/libraries/dagster-pandas)                     |
-| Pandera            | [dagster-pandera](/_apidocs/libraries/dagster-pandera)                   |
-| Papermill          | [dagstermill](/_apidocs/libraries/dagstermill)                           |
-| Papertrail         | [dagster-papertrail](/_apidocs/libraries/dagster-papertrail)             |
-| PostgreSQL         | [dagster-postgres](/_apidocs/libraries/dagster-postgres)                 |
-| Prometheus         | [dagster-prometheus](/_apidocs/libraries/dagster-prometheus)             |
-| Pyspark            | [dagster-pyspark](/_apidocs/libraries/dagster-pyspark)                   |
-| Shell              | [dagster-shell](/_apidocs/libraries/dagster-shell)                       |
-| Slack              | [dagster-slack](/_apidocs/libraries/dagster-slack)                       |
-| Snowflake          | [dagster-snowflake](/_apidocs/libraries/dagster-snowflake)               |
-| Snowflake + Pandas | [dagster-snowflake-pandas](/_apidocs/libraries/dagster-snowflake-pandas) |
-| Spark              | [dagster-spark](/_apidocs/libraries/dagster-spark)                       |
-| SSH / SFTP         | [dagster-ssh](/_apidocs/libraries/dagster-ssh)                           |
-| Twilio             | [dagster-twilio](/_apidocs/libraries/dagster-twilio)                     |
+<ArticleList>
+  <ArticleListItem
+    title="Airbyte"
+    href="/_apidocs/libraries/dagster-airbyte"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Airflow"
+    href="/_apidocs/libraries/dagster-airflow"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Amazon Web Services (AWS)"
+    href="/_apidocs/libraries/dagster-aws"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Azure"
+    href="/_apidocs/libraries/dagster-azure"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Celery"
+    href="/_apidocs/libraries/dagster-celery"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Celery + Docker"
+    href="/_apidocs/libraries/dagster-celery-docker"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Dask"
+    href="/_apidocs/libraries/dagster-dask"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Databricks"
+    href="/_apidocs/libraries/dagster-databricks"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Datadog"
+    href="/_apidocs/libraries/dagster-datadog"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Docker"
+    href="/_apidocs/libraries/dagster-docker"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="dbt"
+    href="/_apidocs/libraries/dagster-dbt"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Fivetran"
+    href="/_apidocs/libraries/dagster-fivetran"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Google Cloud Platform (GCP)"
+    href="/_apidocs/libraries/dagster-gcp"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Great Expectations"
+    href="/_apidocs/libraries/dagster-ge"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="GitHub"
+    href="/_apidocs/libraries/dagster-github"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Kubernetes"
+    href="/_apidocs/libraries/dagster-k8s"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Microsoft Teams"
+    href="/_apidocs/libraries/dagster-msteams"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="MLflow"
+    href="/_apidocs/libraries/dagster-mlfow"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="MySQL"
+    href="/_apidocs/libraries/dagster-mysql"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="PagerDuty"
+    href="/_apidocs/libraries/dagster-pagerduty"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Pandas"
+    href="/_apidocs/libraries/dagster-pandas"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Pandera"
+    href="/_apidocs/libraries/dagster-pandera"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Papermill"
+    href="/_apidocs/libraries/dagstermill"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Papertrail"
+    href="/_apidocs/libraries/dagster-papertrail"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="PostgreSQL"
+    href="/_apidocs/libraries/dagster-postgres"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Prometheus"
+    href="/_apidocs/libraries/dagster-prometheus"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="PySpark"
+    href="/_apidocs/libraries/dagster-pyspark"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Shell"
+    href="/_apidocs/libraries/dagster-shell"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Slack"
+    href="/_apidocs/libraries/dagster-slack"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Snowflake"
+    href="/_apidocs/libraries/dagster-snowflake"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Snowflake + Pandas"
+    href="/_apidocs/libraries/dagster-snowflake-pandas"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Spark"
+    href="/_apidocs/libraries/dagster-spark"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="SSH/SFTP"
+    href="/_apidocs/libraries/dagster-ssh"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Twilio"
+    href="/_apidocs/libraries/dagster-twilio"
+  ></ArticleListItem>
+</ArticleList>


### PR DESCRIPTION
This PR reformats the following category pages in the docs:

- [Guides](https://dagster-git-erin-category-pages-elementl.vercel.app/guides)
- [Concepts](https://dagster-git-erin-category-pages-elementl.vercel.app/concepts)
- [Integrations](https://dagster-git-erin-category-pages-elementl.vercel.app/integrations)