### PR TITLE
[dagster-databricks] safer databricks step launcher

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -35,7 +35,6 @@ class DatabricksClient:
 
     def read_file(self, dbfs_path, block_size=1024**2):
         """Read a file from DBFS to a **byte string**."""
-
         if dbfs_path.startswith("dbfs://"):
             dbfs_path = dbfs_path[7:]
         data = b""
@@ -48,6 +47,7 @@ class DatabricksClient:
                 path=dbfs_path, offset=bytes_read, length=block_size
             )
             data += base64.b64decode(jdoc["data"])
+
         return data
 
     def put_file(self, file_obj, dbfs_path, overwrite=False, block_size=1024**2):

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
@@ -11,7 +11,6 @@ parameters:
 import gzip
 import os
 import pickle
-import shutil
 import site
 import sys
 import tempfile
@@ -112,10 +111,8 @@ def main(
             pass
 
         def put_events(events):
-            tmp_path = f"/tmp/{PICKLED_EVENTS_FILE_NAME}"
-            with gzip.open(tmp_path, "wb") as handle:
+            with gzip.open(events_filepath, "wb") as handle:
                 pickle.dump(serialize_value(events), handle)
-            shutil.copy(tmp_path, events_filepath)
 
         # Set up a thread to handle writing events back to the plan process, so execution doesn't get
         # blocked on remote communication

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
@@ -8,8 +8,10 @@ parameters:
 - paths to any other zipped packages which have been uploaded to DBFS.
 """
 
+import gzip
 import os
 import pickle
+import shutil
 import site
 import sys
 import tempfile
@@ -110,8 +112,10 @@ def main(
             pass
 
         def put_events(events):
-            with open(events_filepath, "wb") as handle:
+            tmp_path = f"/tmp/{PICKLED_EVENTS_FILE_NAME}"
+            with gzip.open(tmp_path, "wb") as handle:
                 pickle.dump(serialize_value(events), handle)
+            shutil.copy(tmp_path, events_filepath)
 
         # Set up a thread to handle writing events back to the plan process, so execution doesn't get
         # blocked on remote communication


### PR DESCRIPTION
### Summary & Motivation

https://dagster.slack.com/archives/C01U954MEER/p1659046369167959

In situations where a large number of events being generated in the external step, we'll end up writing events to the pickled events file roughly once a second, every second, for many minutes. At the same time, we are reading from this file (by default) once every 5 seconds.

In addition, this file can get quite large. I have a test job that emits 20k dynamic outputs. Before the change, this pickled events file got up to over 70MB (!!) before the job died.

By comparison, the gzipped file (after the step successfully completed) was only .7 mb, giving us a healthy 100:1 compression ratio.

We also have a completely non-blocking read operation, which downloads the file in chunks.

These conditions resulted in situations where it was very easy to end up attempting to read from the file while it was being written to, causing an invalid set of bytes to be decoded.

With this change, plus some extra leniency with the backoffs, the 20k dynamic output job was able to complete successfully.

Also it's just fun to have three different serdes  `(dagster.serialize_value -> pickle.dumps -> gzip) -> (gunzip -> pickle.loads -> dagster.deserialize_value)` 😇 

### How I Tested These Changes

^ above
