### PR TITLE
make None annotations result in Nothing type

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/inference.py
+++ b/python_modules/dagster/dagster/_core/definitions/inference.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Callable, Dict, List, NamedTuple, Optional, Type
+from typing import Any, Callable, Dict, List, NamedTuple, Optional
 
 from dagster._seven import funcsigs, is_module_available
 
@@ -55,9 +55,9 @@ def _infer_output_description_from_docstring(fn: Callable) -> Optional[str]:
 def infer_output_props(fn: Callable) -> InferredOutputProps:
     signature = funcsigs.signature(fn)
 
-    annotation = None
+    annotation = inspect.Parameter.empty
     if not inspect.isgeneratorfunction(fn):
-        annotation = _coerce_annotation(signature.return_annotation)
+        annotation = signature.return_annotation
 
     return InferredOutputProps(
         annotation=annotation,
@@ -70,12 +70,6 @@ def has_explicit_return_type(fn: Callable) -> bool:
     return not signature.return_annotation is funcsigs.Signature.empty
 
 
-def _coerce_annotation(type_annotation: Type) -> Optional[Type]:
-    if type_annotation is not inspect.Parameter.empty:
-        return type_annotation
-    return None
-
-
 def _infer_inputs_from_params(
     params: List[funcsigs.Parameter],
     descriptions: Optional[Dict[str, Optional[str]]] = None,
@@ -86,14 +80,14 @@ def _infer_inputs_from_params(
         if param.default is not funcsigs.Parameter.empty:
             input_def = InferredInputProps(
                 param.name,
-                _coerce_annotation(param.annotation),
+                param.annotation,
                 default_value=param.default,
                 description=descriptions.get(param.name),
             )
         else:
             input_def = InferredInputProps(
                 param.name,
-                _coerce_annotation(param.annotation),
+                param.annotation,
                 description=descriptions.get(param.name),
             )
 

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
@@ -213,7 +214,7 @@ def _resolve_output_defs_from_outs(
         annotation = inferred_output_props.annotation
     else:
         inferred_output_props = None
-        annotation = None
+        annotation = inspect.Parameter.empty
 
     if outs is None:
         return [OutputDefinition.create_from_inferred(inferred_output_props)]
@@ -229,18 +230,22 @@ def _resolve_output_defs_from_outs(
 
     # Introspection on type annotations is experimental, so checking
     # metaclass is the best we can do.
-    if annotation and not get_origin(annotation) == tuple:
+    if annotation != inspect.Parameter.empty and not get_origin(annotation) == tuple:
         raise DagsterInvariantViolationError(
             "Expected Tuple annotation for multiple outputs, but received non-tuple annotation."
         )
-    if annotation and not len(annotation.__args__) == len(outs):
+    if annotation != inspect.Parameter.empty and not len(annotation.__args__) == len(outs):
         raise DagsterInvariantViolationError(
             "Expected Tuple annotation to have number of entries matching the "
             f"number of outputs for more than one output. Expected {len(outs)} "
             f"outputs but annotation has {len(annotation.__args__)}."
         )
     for idx, (name, cur_out) in enumerate(outs.items()):
-        annotation_type = annotation.__args__[idx] if annotation else None
+        annotation_type = (
+            annotation.__args__[idx]
+            if annotation != inspect.Parameter.empty
+            else inspect.Parameter.empty
+        )
         output_defs.append(cur_out.to_definition(annotation_type, name=name))
 
     return output_defs

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -115,7 +115,7 @@ def _get_annotation_for_output_position(
     position: int, solid_def: SolidDefinition, output_defs: Sequence[OutputDefinition]
 ) -> Any:
     if solid_def.is_from_decorator():
-        if len(output_defs) > 1 and solid_def.get_output_annotation():
+        if len(output_defs) > 1 and solid_def.get_output_annotation() != inspect.Parameter.empty:
             return get_args(solid_def.get_output_annotation())[position]
         else:
             return solid_def.get_output_annotation()
@@ -191,7 +191,9 @@ def validate_and_coerce_solid_result_to_iterator(
                         metadata_entries=list(dynamic_output.metadata_entries),
                     )
             elif isinstance(element, Output):
-                if annotation and not is_generic_output_annotation(annotation):
+                if annotation != inspect.Parameter.empty and not is_generic_output_annotation(
+                    annotation
+                ):
                     raise DagsterInvariantViolationError(
                         f"Error with output for {context.describe_op()}: received Output object for output '{output_def.name}' which does not have an Output annotation. Annotation has type {annotation}."
                     )

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Any
 
 import pytest
 
@@ -397,6 +398,34 @@ def test_infer_input_dagster_type():
         pass
 
     assert my_asset.op.input_defs[0].dagster_type.display_name == "String"
+    assert my_asset.op.input_defs[0].dagster_type.typing_type == str
+
+
+def test_infer_output_dagster_type():
+    @asset
+    def my_asset() -> str:
+        pass
+
+    assert my_asset.op.outs["result"].dagster_type.display_name == "String"
+    assert my_asset.op.outs["result"].dagster_type.typing_type == str
+
+
+def test_infer_output_dagster_type_none():
+    @asset
+    def my_asset() -> None:
+        pass
+
+    assert my_asset.op.outs["result"].dagster_type.typing_type is None
+    assert my_asset.op.outs["result"].dagster_type.display_name == "Nothing"
+
+
+def test_infer_output_dagster_type_empty():
+    @asset
+    def my_asset():
+        pass
+
+    assert my_asset.op.outs["result"].dagster_type.typing_type is Any
+    assert my_asset.op.outs["result"].dagster_type.display_name == "Any"
 
 
 def test_invoking_simple_assets():

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -1359,3 +1359,11 @@ def test_output_mismatch_tuple_lengths():
 
     with pytest.raises(DagsterInvariantViolationError, match="Length mismatch"):
         the_op()
+
+
+def test_none_annotated_input():
+    with pytest.raises(DagsterInvalidDefinitionError, match="is annotated with Nothing"):
+
+        @op
+        def op1(input1: None):
+            ...

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_io_manager.py
@@ -1,6 +1,7 @@
 import os
 import pickle
 import tempfile
+from typing import Tuple
 
 import pytest
 
@@ -284,7 +285,7 @@ def test_fs_io_manager_partitioned_multi_asset():
                 "out_2": Out(asset_key=AssetKey("upstream_asset_2")),
             },
         )
-        def upstream_asset():
+        def upstream_asset() -> Tuple[Output[int], Output[int]]:
             return (Output(1, output_name="out_1"), Output(2, output_name="out_2"))
 
         @asset(

--- a/python_modules/dagster/dagster_tests/core_tests/test_multi_dependency.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_multi_dependency.py
@@ -225,24 +225,18 @@ def test_fan_in_manual():
 
 
 def test_nothing_deps():
-
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match=r'Input "stuff" expects a value of type \[Any\] and output '
-        '"result" returns type Nothing',
-    ):
-        PipelineDefinition(
-            name="input_test",
-            solid_defs=[emit_num, emit_nothing, emit_str, collect],
-            dependencies={
-                "collect": {
-                    "stuff": MultiDependencyDefinition(
-                        [
-                            DependencyDefinition("emit_num"),
-                            DependencyDefinition("emit_nothing"),
-                            DependencyDefinition("emit_str"),
-                        ]
-                    )
-                }
-            },
-        )
+    PipelineDefinition(
+        name="input_test",
+        solid_defs=[emit_num, emit_nothing, emit_str, collect],
+        dependencies={
+            "collect": {
+                "stuff": MultiDependencyDefinition(
+                    [
+                        DependencyDefinition("emit_num"),
+                        DependencyDefinition("emit_nothing"),
+                        DependencyDefinition("emit_str"),
+                    ]
+                )
+            }
+        },
+    )


### PR DESCRIPTION
Prior to this change, the following test would fail:
```
    @asset
    def my_asset() -> None:
        pass

    assert my_asset.op.outs["result"].dagster_type.typing_type is None
```

`my_asset.op.outs["result"].dagster_type.typing_type` would come out as `Any`