### PR TITLE
[ecs] fix err msg in health check

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -418,7 +418,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
                 return CheckRunHealthResult(
                     WorkerStatus.FAILED,
                     f"ECS task failed. Stop code: {t.get('stopCode')}. Stop reason {t.get('stopReason')}. "
-                    f"{container_str} {c.get('name') for c in failed_containers} failed."
+                    f"{container_str} {[c.get('name') for c in failed_containers]} failed."
                     f"Check the logs for task {t.get('taskArn')} for details.",
                 )
 


### PR DESCRIPTION
currently prints:

`Stop reason None. Container <generator object EcsRunLauncher.check_run_worker_health.<locals>.<genexpr> at 0x7fa030a2d890> failed`

### How I Tested These Changes

eyes