### PR TITLE
remove legacy arguments from api docs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -154,7 +154,7 @@ def repository(
 
     The decorated function should take no arguments and its return value should one of:
 
-    1. ``List[Union[JobDefinition, PipelineDefinition, PartitionSetDefinition, ScheduleDefinition, SensorDefinition]]``.
+    1. ``List[Union[JobDefinition, ScheduleDefinition, SensorDefinition]]``.
     Use this form when you have no need to lazy load pipelines or other definitions. This is the
     typical use case.
 
@@ -164,8 +164,6 @@ def repository(
 
         {
             'jobs': Dict[str, Callable[[], JobDefinition]],
-            'pipelines': Dict[str, Callable[[], PipelineDefinition]],
-            'partition_sets': Dict[str, Callable[[], PartitionSetDefinition]],
             'schedules': Dict[str, Callable[[], ScheduleDefinition]]
             'sensors': Dict[str, Callable[[], SensorDefinition]]
         }

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -80,8 +80,6 @@ def schedule(
     Args:
         cron_schedule (str): A valid cron string specifying when the schedule will run, e.g.,
             ``'45 23 * * 6'`` for a schedule that runs at 11:45 PM every Saturday.
-        pipeline_name (Optional[str]): (legacy)  The name of the pipeline to execute when the
-            schedule runs.
         name (Optional[str]): The name of the schedule to create.
         tags (Optional[Dict[str, str]]): A dictionary of tags (string key-value pairs) to attach
             to the scheduled runs.
@@ -89,10 +87,6 @@ def schedule(
             that generates tags to attach to the schedules runs. Takes a
             :py:class:`~dagster.ScheduleEvaluationContext` and returns a dictionary of tags (string
             key-value pairs). You may set only one of ``tags`` and ``tags_fn``.
-        solid_selection (Optional[List[str]]): A list of solid subselection (including single
-            solid names) to execute when the schedule runs. e.g. ``['*some_solid+', 'other_solid']``
-        mode (Optional[str]): The pipeline mode in which to execute this schedule.
-            (Default: 'default')
         should_execute (Optional[Callable[[ScheduleEvaluationContext], bool]]): A function that runs at
             schedule execution time to determine whether a schedule should execute or skip. Takes a
             :py:class:`~dagster.ScheduleEvaluationContext` and returns a boolean (``True`` if the

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -46,17 +46,8 @@ def sensor(
     Takes a :py:class:`~dagster.SensorEvaluationContext`.
 
     Args:
-        pipeline_name (Optional[str]): (legacy) Name of the target pipeline. Cannot be used in
-            conjunction with `job` or `jobs` parameters.
         name (Optional[str]): The name of the sensor. Defaults to the name of the decorated
             function.
-        solid_selection (Optional[List[str]]): (legacy) A list of solid subselection (including single
-            solid names) to execute for runs for this sensor e.g.
-            ``['*some_solid+', 'other_solid']``.
-            Cannot be used in conjunction with `job` or `jobs` parameters.
-        mode (Optional[str]): (legacy) The mode to apply when executing runs for this sensor. Cannot be used
-            in conjunction with `job` or `jobs` parameters.
-            (default: 'default')
         minimum_interval_seconds (Optional[int]): The minimum number of seconds that will elapse
             between sensor evaluations.
         description (Optional[str]): A human-readable description of the sensor.
@@ -119,16 +110,8 @@ def asset_sensor(
 
     Args:
         asset_key (AssetKey): The asset_key this sensor monitors.
-        pipeline_name (Optional[str]): (legacy) Name of the target pipeline. Cannot be used in conjunction with `job` or `jobs` parameters.
         name (Optional[str]): The name of the sensor. Defaults to the name of the decorated
             function.
-        solid_selection (Optional[List[str]]): (legacy) A list of solid subselection (including single
-            solid names) to execute for runs for this sensor e.g.
-            ``['*some_solid+', 'other_solid']``. Cannot be used in conjunction with `job` or `jobs`
-            parameters.
-        mode (Optional[str]): (legacy) The mode to apply when executing runs for this sensor. Cannot be used
-            in conjunction with `job` or `jobs` parameters.
-            (default: 'default')
         minimum_interval_seconds (Optional[int]): The minimum number of seconds that will elapse
             between sensor evaluations.
         description (Optional[str]): A human-readable description of the sensor.

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -205,7 +205,6 @@ class ScheduleDefinition:
             "_schedule".
         cron_schedule (str): A valid cron string specifying when the schedule will run, e.g.,
             '45 23 * * 6' for a schedule that runs at 11:45 PM every Saturday.
-        pipeline_name (Optional[str]): (legacy) The name of the pipeline to execute when the schedule runs.
         execution_fn (Callable[ScheduleEvaluationContext]): The core evaluation function for the
             schedule, which is run at an interval to determine whether a run should be launched or
             not. Takes a :py:class:`~dagster.ScheduleEvaluationContext`.
@@ -224,9 +223,6 @@ class ScheduleDefinition:
             function that generates tags to attach to the schedules runs. Takes a
             :py:class:`~dagster.ScheduleEvaluationContext` and returns a dictionary of tags (string
             key-value pairs). You may set only one of ``tags``, ``tags_fn``, and ``execution_fn``.
-        solid_selection (Optional[Sequence[str]]): A list of solid subselection (including single
-            solid names) to execute when the schedule runs. e.g. ``['*some_solid+', 'other_solid']``
-        mode (Optional[str]): (legacy) The mode to apply when executing this schedule. (default: 'default')
         should_execute (Optional[Callable[[ScheduleEvaluationContext], bool]]): A function that runs
             at schedule execution time to determine whether a schedule should execute or skip. Takes
             a :py:class:`~dagster.ScheduleEvaluationContext` and returns a boolean (``True`` if the

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -190,14 +190,6 @@ class SensorDefinition:
             This function must return a generator, which must yield either a single SkipReason
             or one or more RunRequest objects.
         name (Optional[str]): The name of the sensor to create. Defaults to name of evaluation_fn
-        pipeline_name (Optional[str]): (legacy) The name of the pipeline to execute when the sensor
-            fires. Cannot be used in conjunction with `job` or `jobs` parameters.
-        solid_selection (Optional[Sequence[str]]): (legacy) A list of solid subselection (including single
-            solid names) to execute when the sensor runs. e.g. ``['*some_solid+', 'other_solid']``.
-            Cannot be used in conjunction with `job` or `jobs` parameters.
-        mode (Optional[str]): (legacy) The mode to apply when executing runs triggered by this
-            sensor. Cannot be used in conjunction with `job` or `jobs` parameters. (default:
-            'default')
         minimum_interval_seconds (Optional[int]): The minimum number of seconds that will elapse
             between sensor evaluations.
         description (Optional[str]): A human-readable description of the sensor.
@@ -602,8 +594,6 @@ class AssetSensorDefinition(SensorDefinition):
     Args:
         name (str): The name of the sensor to create.
         asset_key (AssetKey): The asset_key this sensor monitors.
-        pipeline_name (Optional[str]): (legacy) The name of the pipeline to execute when the sensor
-            fires. Cannot be used in conjunction with `job` or `jobs` parameters.
         asset_materialization_fn (Callable[[SensorEvaluationContext, EventLogEntry], Union[Iterator[Union[RunRequest, SkipReason]], RunRequest, SkipReason]]): The core
             evaluation function for the sensor, which is run at an interval to determine whether a
             run should be launched or not. Takes a :py:class:`~dagster.SensorEvaluationContext` and
@@ -611,12 +601,6 @@ class AssetSensorDefinition(SensorDefinition):
 
             This function must return a generator, which must yield either a single SkipReason
             or one or more RunRequest objects.
-        solid_selection (Optional[Sequence[str]]): (legacy) A list of solid subselection (including single
-            solid names) to execute when the sensor runs. e.g. ``['*some_solid+', 'other_solid']``.
-            Cannot be used in conjunction with `job` or `jobs` parameters.
-        mode (Optional[str]): (legacy) The mode to apply when executing runs triggered by this sensor.
-            (default: 'default').
-            Cannot be used in conjunction with `job` or `jobs` parameters.
         minimum_interval_seconds (Optional[int]): The minimum number of seconds that will elapse
             between sensor evaluations.
         description (Optional[str]): A human-readable description of the sensor.

--- a/python_modules/dagster/dagster/_core/events/log.py
+++ b/python_modules/dagster/dagster/_core/events/log.py
@@ -72,8 +72,6 @@ class EventLogEntry(
             generated outside of a job context.
         dagster_event (Optional[DagsterEvent]): For framework and user events, the associated
             structured event.
-        pipeline_name (Optional[str]): (legacy) The pipeline which generated this event. Some events are
-            generated outside of a pipeline context.
     """
 
     def __new__(

--- a/python_modules/dagster/dagster/_core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/_core/execution/context/hook.py
@@ -48,14 +48,11 @@ class HookContext:
     Attributes:
         log (DagsterLogManager): Centralized log dispatch from user code.
         hook_def (HookDefinition): The hook that the context object belongs to.
-        solid (Solid): The solid instance associated with the hook.
         op (Op): The op instance associated with the hook.
         step_key (str): The key for the step where this hook is being triggered.
         required_resource_keys (Set[str]): Resources required by this hook.
         resources (Resources): Resources available in the hook context.
-        solid_config (Any): The parsed config specific to this solid.
         op_config (Any): The parsed config specific to this op.
-        pipeline_name (str): The name of the pipeline where this hook is being triggered.
         job_name (str): The name of the job where this hook is being triggered.
         run_id (str): The id of the run where this hook is being triggered.
         mode_def (ModeDefinition): The mode with which the pipeline is being run.

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -32,8 +32,6 @@ class InputContext:
 
     Attributes:
         name (Optional[str]): The name of the input that we're loading.
-        pipeline_name (Optional[str]): The name of the pipeline.
-        solid_def (Optional[SolidDefinition]): The definition of the solid that's loading the input.
         config (Optional[Any]): The config attached to the input that we're loading.
         metadata (Optional[Dict[str, Any]]): A dict of metadata that is assigned to the
             InputDefinition that we're loading for.

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -55,13 +55,11 @@ class OutputContext:
     Attributes:
         step_key (Optional[str]): The step_key for the compute step that produced the output.
         name (Optional[str]): The name of the output that produced the output.
-        pipeline_name (Optional[str]): The name of the pipeline definition.
         run_id (Optional[str]): The id of the run that produced the output.
         metadata (Optional[Mapping[str, RawMetadataValue]]): A dict of the metadata that is assigned to the
             OutputDefinition that produced the output.
         mapping_key (Optional[str]): The key that identifies a unique mapped output. None for regular outputs.
         config (Optional[Any]): The configuration for the output.
-        solid_def (Optional[SolidDefinition]): The definition of the solid that produced the output.
         dagster_type (Optional[DagsterType]): The type of this output.
         log (Optional[DagsterLogManager]): The log manager to use for this output.
         version (Optional[str]): (Experimental) The version of the output.


### PR DESCRIPTION
Unclear if we'll be able to remove the actual arguments in time for 1.0, but at the very least we can remove them from the docs.