### PR TITLE
Publicity audit for dagster core

### DIFF
--- a/docs/sphinx/sections/api/apidocs/execution.rst
+++ b/docs/sphinx/sections/api/apidocs/execution.rst
@@ -39,6 +39,8 @@ Execution results
    :inherited-members:
 
 .. autoclass:: ExecuteJobResult
+   :members:
+   :inherited-members:
 
 .. autoclass:: DagsterEvent
    :members:

--- a/docs/sphinx/sections/api/apidocs/internals.rst
+++ b/docs/sphinx/sections/api/apidocs/internals.rst
@@ -97,6 +97,7 @@ Run storage
 .. autoclass:: DagsterRunStatus
    :members:
    :undoc-members:
+   :inherited-members:
 
 .. currentmodule:: dagster._core.storage.runs
 

--- a/docs/sphinx/sections/api/apidocs/internals.rst
+++ b/docs/sphinx/sections/api/apidocs/internals.rst
@@ -107,6 +107,10 @@ Run storage
 
 .. autoclass:: SqliteRunStorage
 
+.. currentmodule:: dagster._core.storage.pipeline_run
+
+.. autoclass:: RunRecord
+
 
 See also: :py:class:`dagster_postgres.PostgresRunStorage` and :py:class:`dagster_mysql.MySQLRunStorage`.
 
@@ -132,6 +136,8 @@ Event log storage
 .. autoclass:: SqliteEventLogStorage
 
 .. autoclass:: ConsolidatedSqliteEventLogStorage
+
+.. autoclass:: AssetRecord
 
 See also: :py:class:`dagster_postgres.PostgresEventLogStorage` and :py:class:`dagster_mysql.MySQLEventLogStorage`.
 

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -18,6 +18,7 @@ from typing import (
 )
 
 import dagster._check as check
+from dagster._annotations import PublicAttr, public
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._serdes.serdes import (
@@ -45,11 +46,11 @@ class NodeInvocation(
     NamedTuple(
         "Node",
         [
-            ("name", str),
-            ("alias", Optional[str]),
-            ("tags", Dict[str, Any]),
-            ("hook_defs", AbstractSet[HookDefinition]),
-            ("retry_policy", Optional[RetryPolicy]),
+            ("name", PublicAttr[str]),
+            ("alias", PublicAttr[Optional[str]]),
+            ("tags", PublicAttr[Dict[str, Any]]),
+            ("hook_defs", PublicAttr[AbstractSet[HookDefinition]]),
+            ("retry_policy", PublicAttr[Optional[RetryPolicy]]),
         ],
     )
 ):
@@ -672,7 +673,12 @@ class DependencyDefinition(
 class MultiDependencyDefinition(
     NamedTuple(
         "_MultiDependencyDefinition",
-        [("dependencies", List[Union[DependencyDefinition, Type["MappedInputPlaceholder"]]])],
+        [
+            (
+                "dependencies",
+                PublicAttr[List[Union[DependencyDefinition, Type["MappedInputPlaceholder"]]]],
+            )
+        ],
     ),
     IDependencyDefinition,
 ):
@@ -743,12 +749,15 @@ class MultiDependencyDefinition(
     def get_solid_dependencies(self) -> List[DependencyDefinition]:
         return [dep for dep in self.dependencies if isinstance(dep, DependencyDefinition)]
 
+    @public
     def get_node_dependencies(self) -> List[DependencyDefinition]:
         return self.get_solid_dependencies()
 
+    @public
     def is_fan_in(self) -> bool:
         return True
 
+    @public
     def get_dependencies_and_mappings(self) -> List:
         return self.dependencies
 

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -230,10 +230,12 @@ class Output(Generic[T]):
     def metadata_entries(self) -> Sequence[Union[PartitionMetadataEntry, MetadataEntry]]:
         return self._metadata_entries
 
+    @public  # type: ignore
     @property
     def value(self) -> Any:
         return self._value
 
+    @public  # type: ignore
     @property
     def output_name(self) -> str:
         return self._output_name
@@ -296,14 +298,17 @@ class DynamicOutput(Generic[T]):
     def metadata_entries(self) -> Sequence[Union[PartitionMetadataEntry, MetadataEntry]]:
         return self._metadata_entries
 
+    @public  # type: ignore
     @property
     def mapping_key(self) -> str:
         return self._mapping_key
 
+    @public  # type: ignore
     @property
     def value(self) -> T:
         return self._value
 
+    @public  # type: ignore
     @property
     def output_name(self) -> str:
         return self._output_name
@@ -638,9 +643,9 @@ class TypeCheck(
     NamedTuple(
         "_TypeCheck",
         [
-            ("success", bool),
-            ("description", Optional[str]),
-            ("metadata_entries", List[MetadataEntry]),
+            ("success", PublicAttr[bool]),
+            ("description", PublicAttr[Optional[str]]),
+            ("metadata_entries", PublicAttr[List[MetadataEntry]]),
         ],
     )
 ):

--- a/python_modules/dagster/dagster/_core/definitions/hook_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/hook_definition.py
@@ -1,6 +1,7 @@
 from typing import AbstractSet, Any, Callable, Iterator, NamedTuple, Optional, cast
 
 import dagster._check as check
+from dagster._annotations import PublicAttr
 
 from ..decorator_utils import get_function_params
 from ..errors import DagsterInvalidInvocationError
@@ -12,10 +13,10 @@ class HookDefinition(
     NamedTuple(
         "_HookDefinition",
         [
-            ("name", str),
-            ("hook_fn", Callable),
-            ("required_resource_keys", AbstractSet[str]),
-            ("decorated_fn", Optional[Callable]),
+            ("name", PublicAttr[str]),
+            ("hook_fn", PublicAttr[Callable]),
+            ("required_resource_keys", PublicAttr[AbstractSet[str]]),
+            ("decorated_fn", PublicAttr[Optional[Callable]]),
         ],
     ),
     RequiresResources,

--- a/python_modules/dagster/dagster/_core/definitions/input.py
+++ b/python_modules/dagster/dagster/_core/definitions/input.py
@@ -15,6 +15,7 @@ from typing import (
 )
 
 import dagster._check as check
+from dagster._annotations import PublicAttr
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import (
     MetadataEntry,
@@ -403,14 +404,20 @@ class In(
     NamedTuple(
         "_In",
         [
-            ("dagster_type", Union[DagsterType, Type[NoValueSentinel]]),
-            ("description", Optional[str]),
-            ("default_value", Any),
-            ("root_manager_key", Optional[str]),
-            ("metadata", Optional[Mapping[str, Any]]),
-            ("asset_key", Optional[Union[AssetKey, Callable[["InputContext"], AssetKey]]]),
-            ("asset_partitions", Optional[Union[Set[str], Callable[["InputContext"], Set[str]]]]),
-            ("input_manager_key", Optional[str]),
+            ("dagster_type", PublicAttr[Union[DagsterType, Type[NoValueSentinel]]]),
+            ("description", PublicAttr[Optional[str]]),
+            ("default_value", PublicAttr[Any]),
+            ("root_manager_key", PublicAttr[Optional[str]]),
+            ("metadata", PublicAttr[Optional[Mapping[str, Any]]]),
+            (
+                "asset_key",
+                PublicAttr[Optional[Union[AssetKey, Callable[["InputContext"], AssetKey]]]],
+            ),
+            (
+                "asset_partitions",
+                PublicAttr[Optional[Union[Set[str], Callable[["InputContext"], Set[str]]]]],
+            ),
+            ("input_manager_key", PublicAttr[Optional[str]]),
         ],
     )
 ):
@@ -503,7 +510,7 @@ class In(
         )
 
 
-class GraphIn(NamedTuple("_GraphIn", [("description", Optional[str])])):
+class GraphIn(NamedTuple("_GraphIn", [("description", PublicAttr[Optional[str]])])):
     """
     Represents information about an input that a graph maps.
 

--- a/python_modules/dagster/dagster/_core/definitions/logger_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/logger_definition.py
@@ -2,6 +2,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast, overload
 
 import dagster._check as check
+from dagster._annotations import public
 from dagster._core.errors import DagsterInvalidInvocationError
 
 from ..decorator_utils import get_function_params
@@ -84,14 +85,17 @@ class LoggerDefinition(AnonymousConfigurableDefinition):
 
             return logger_invocation_result(self, context)
 
+    @public  # type: ignore
     @property
     def logger_fn(self) -> "InitLoggerFunction":
         return self._logger_fn
 
+    @public  # type: ignore
     @property
     def config_schema(self) -> Any:
         return self._config_schema
 
+    @public  # type: ignore
     @property
     def description(self) -> Optional[str]:
         return self._description

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -531,6 +531,7 @@ class TextMetadataValue(  # type: ignore
             cls, check.opt_str_param(text, "text", default="")
         )
 
+    @public  # type: ignore
     @property
     def value(self) -> Optional[str]:
         return self.text
@@ -557,6 +558,7 @@ class UrlMetadataValue(  # type: ignore
             cls, check.opt_str_param(url, "url", default="")
         )
 
+    @public  # type: ignore
     @property
     def value(self) -> Optional[str]:
         return self.url
@@ -762,6 +764,7 @@ class DagsterAssetMetadataValue(
             cls, check.inst_param(asset_key, "asset_key", AssetKey)
         )
 
+    @public  # type: ignore
     @property
     def value(self) -> "AssetKey":
         return self.value
@@ -786,6 +789,7 @@ class TableMetadataValue(
         schema (Optional[TableSchema]): A schema for the table.
     """
 
+    @public  # type: ignore
     @staticmethod
     def infer_column_type(value):
         if isinstance(value, bool):
@@ -823,6 +827,7 @@ class TableMetadataValue(
             schema,
         )
 
+    @public  # type: ignore
     @property
     def value(self):
         return self

--- a/python_modules/dagster/dagster/_core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/table.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, NamedTuple, Optional, Type, Union, cast
 
 import dagster._check as check
-from dagster._annotations import experimental
+from dagster._annotations import PublicAttr, experimental
 from dagster._serdes.serdes import DefaultNamedTupleSerializer, whitelist_for_serdes
 
 # ########################
@@ -21,7 +21,9 @@ class _TableRecordSerializer(DefaultNamedTupleSerializer):
 
 @experimental
 @whitelist_for_serdes(serializer=_TableRecordSerializer)
-class TableRecord(NamedTuple("TableRecord", [("data", Dict[str, Union[str, int, float, bool]])])):
+class TableRecord(
+    NamedTuple("TableRecord", [("data", PublicAttr[Dict[str, Union[str, int, float, bool]]])])
+):
     """Represents one record in a table. All passed keyword arguments are treated as field key/value
     pairs in the record. Field keys are arbitrary strings-- field values must be strings, integers,
     floats, or bools.
@@ -47,8 +49,8 @@ class TableSchema(
     NamedTuple(
         "TableSchema",
         [
-            ("columns", List["TableColumn"]),
-            ("constraints", "TableConstraints"),
+            ("columns", PublicAttr[List["TableColumn"]]),
+            ("constraints", PublicAttr["TableConstraints"]),
         ],
     )
 ):
@@ -130,7 +132,7 @@ class TableConstraints(
     NamedTuple(
         "TableConstraints",
         [
-            ("other", List[str]),
+            ("other", PublicAttr[List[str]]),
         ],
     )
 ):
@@ -165,10 +167,10 @@ class TableColumn(
     NamedTuple(
         "TableColumn",
         [
-            ("name", str),
-            ("type", str),
-            ("description", Optional[str]),
-            ("constraints", "TableColumnConstraints"),
+            ("name", PublicAttr[str]),
+            ("type", PublicAttr[str]),
+            ("description", PublicAttr[Optional[str]]),
+            ("constraints", PublicAttr["TableColumnConstraints"]),
         ],
     )
 ):
@@ -220,9 +222,9 @@ class TableColumnConstraints(
     NamedTuple(
         "TableColumnConstraints",
         [
-            ("nullable", bool),
-            ("unique", bool),
-            ("other", Optional[List[str]]),
+            ("nullable", PublicAttr[bool]),
+            ("unique", PublicAttr[bool]),
+            ("other", PublicAttr[Optional[List[str]]]),
         ],
     )
 ):

--- a/python_modules/dagster/dagster/_core/definitions/output.py
+++ b/python_modules/dagster/dagster/_core/definitions/output.py
@@ -15,6 +15,7 @@ from typing import (
 )
 
 import dagster._check as check
+from dagster._annotations import PublicAttr
 from dagster._core.definitions.events import AssetKey, DynamicAssetKey
 from dagster._core.definitions.metadata import MetadataEntry, MetadataUserInput, normalize_metadata
 from dagster._core.errors import DagsterError, DagsterInvalidDefinitionError
@@ -360,17 +361,19 @@ class Out(
     NamedTuple(
         "_Out",
         [
-            ("dagster_type", Union[DagsterType, Type[NoValueSentinel]]),
-            ("description", Optional[str]),
-            ("is_required", bool),
-            ("io_manager_key", str),
-            ("metadata", Optional[MetadataUserInput]),
-            ("asset_key", Optional[Union[AssetKey, DynamicAssetKey]]),
+            ("dagster_type", PublicAttr[Union[DagsterType, Type[NoValueSentinel]]]),
+            ("description", PublicAttr[Optional[str]]),
+            ("is_required", PublicAttr[bool]),
+            ("io_manager_key", PublicAttr[str]),
+            ("metadata", PublicAttr[Optional[MetadataUserInput]]),
+            ("asset_key", PublicAttr[Optional[Union[AssetKey, DynamicAssetKey]]]),
             (
                 "asset_partitions",
-                Optional[Union[AbstractSet[str], Callable[["OutputContext"], AbstractSet[str]]]],
+                PublicAttr[
+                    Optional[Union[AbstractSet[str], Callable[["OutputContext"], AbstractSet[str]]]]
+                ],
             ),
-            ("asset_partitions_def", Optional["PartitionsDefinition"]),
+            ("asset_partitions_def", PublicAttr[Optional["PartitionsDefinition"]]),
         ],
     )
 ):
@@ -525,7 +528,7 @@ class DynamicOut(Out):
         )
 
 
-class GraphOut(NamedTuple("_GraphOut", [("description", Optional[str])])):
+class GraphOut(NamedTuple("_GraphOut", [("description", PublicAttr[Optional[str]])])):
     """
     Represents information about the outputs that a graph maps.
 

--- a/python_modules/dagster/dagster/_core/definitions/policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/policy.py
@@ -3,6 +3,7 @@ from random import random
 from typing import NamedTuple, Optional
 
 import dagster._check as check
+from dagster._annotations import PublicAttr
 from dagster._core.errors import DagsterInvalidDefinitionError
 
 
@@ -33,11 +34,11 @@ class RetryPolicy(
     NamedTuple(
         "_RetryPolicy",
         [
-            ("max_retries", int),
-            ("delay", Optional[check.Numeric]),
+            ("max_retries", PublicAttr[int]),
+            ("delay", PublicAttr[Optional[check.Numeric]]),
             # declarative time modulation to allow calc witout running user function
-            ("backoff", Optional[Backoff]),
-            ("jitter", Optional[Jitter]),
+            ("backoff", PublicAttr[Optional[Backoff]]),
+            ("jitter", PublicAttr[Optional[Jitter]]),
         ],
     ),
 ):

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition.py
@@ -18,6 +18,7 @@ from typing import (
 )
 
 import dagster._check as check
+from dagster._annotations import public
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._utils import merge_dicts
 
@@ -224,6 +225,7 @@ class RepositoryData(ABC):
             List[PipelineDefinition]: All pipelines/jobs in the repository.
         """
 
+    @public
     def get_all_jobs(self) -> List[JobDefinition]:
         """Return all jobs in the repository as a list.
 
@@ -240,6 +242,7 @@ class RepositoryData(ABC):
         """
         return [pipeline_def.name for pipeline_def in self.get_all_pipelines()]
 
+    @public
     def get_job_names(self) -> List[str]:
         """Get the names of all jobs in the repository.
 
@@ -259,6 +262,7 @@ class RepositoryData(ABC):
         """
         return pipeline_name in self.get_pipeline_names()
 
+    @public
     def has_job(self, job_name: str) -> bool:
         """Check if a job with a given name is present in the repository.
 
@@ -288,6 +292,7 @@ class RepositoryData(ABC):
             )
         return pipelines_with_name[0]
 
+    @public
     def get_job(self, job_name: str) -> JobDefinition:
         """Get a job by name.
 
@@ -349,6 +354,7 @@ class RepositoryData(ABC):
             )
         return partition_sets_with_name[0]
 
+    @public
     def get_schedule_names(self) -> List[str]:
         """Get the names of all schedules in the repository.
 
@@ -357,6 +363,7 @@ class RepositoryData(ABC):
         """
         return [schedule.name for schedule in self.get_all_schedules()]
 
+    @public
     def get_all_schedules(self) -> List[ScheduleDefinition]:
         """Return all schedules in the repository as a list.
 
@@ -365,6 +372,7 @@ class RepositoryData(ABC):
         """
         return []
 
+    @public
     def get_schedule(self, schedule_name: str) -> ScheduleDefinition:
         """Get a schedule by name.
 
@@ -386,12 +394,15 @@ class RepositoryData(ABC):
     def has_schedule(self, schedule_name: str) -> bool:
         return schedule_name in self.get_schedule_names()
 
+    @public
     def get_all_sensors(self) -> List[SensorDefinition]:
         return []
 
+    @public
     def get_sensor_names(self) -> List[str]:
         return [sensor.name for sensor in self.get_all_sensors()]
 
+    @public
     def get_sensor(self, sensor_name: str) -> SensorDefinition:
         sensors_with_name = [
             sensor for sensor in self.get_all_sensors() if sensor.name == sensor_name
@@ -402,9 +413,11 @@ class RepositoryData(ABC):
             )
         return sensors_with_name[0]
 
+    @public
     def has_sensor(self, sensor_name: str) -> bool:
         return sensor_name in self.get_sensor_names()
 
+    @public
     def get_source_assets_by_key(self) -> Mapping[AssetKey, SourceAsset]:
         return {}
 

--- a/python_modules/dagster/dagster/_core/definitions/version_strategy.py
+++ b/python_modules/dagster/dagster/_core/definitions/version_strategy.py
@@ -3,6 +3,8 @@ import inspect
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 
+from dagster._annotations import public
+
 if TYPE_CHECKING:
     from .op_definition import OpDefinition
     from .resource_definition import ResourceDefinition
@@ -58,10 +60,12 @@ class VersionStrategy(ABC):
     outputs do not have an up-to-date version will run.
     """
 
+    @public
     @abstractmethod
     def get_op_version(self, context: OpVersionContext) -> str:
         raise NotImplementedError()
 
+    @public
     def get_resource_version(
         self, context: ResourceVersionContext  # pylint: disable=unused-argument
     ) -> Optional[str]:
@@ -80,6 +84,7 @@ class SourceHashVersionStrategy(VersionStrategy):
         code_as_str = inspect.getsource(fn)
         return hashlib.sha1(code_as_str.encode("utf-8")).hexdigest()
 
+    @public
     def get_op_version(self, context: OpVersionContext) -> str:
         compute_fn = context.op_def.compute_fn
         if callable(compute_fn):
@@ -87,5 +92,6 @@ class SourceHashVersionStrategy(VersionStrategy):
         else:
             return self._get_source_hash(compute_fn.decorated_fn)
 
+    @public
     def get_resource_version(self, context: ResourceVersionContext) -> Optional[str]:
         return self._get_source_hash(context.resource_def.resource_fn)

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -19,6 +19,7 @@ from typing import (
 )
 
 import dagster._check as check
+from dagster._annotations import public
 from dagster._core.definitions import (
     AssetKey,
     AssetMaterialization,
@@ -525,19 +526,23 @@ class DagsterEvent(
         solid_handle = cast(NodeHandle, self.solid_handle)
         return solid_handle.name
 
+    @public  # type: ignore
     @property
     def event_type(self) -> DagsterEventType:
         """DagsterEventType: The type of this event."""
         return DagsterEventType(self.event_type_value)
 
+    @public  # type: ignore
     @property
     def is_step_event(self) -> bool:
         return self.event_type in STEP_EVENTS
 
+    @public  # type: ignore
     @property
     def is_hook_event(self) -> bool:
         return self.event_type in HOOK_EVENTS
 
+    @public  # type: ignore
     @property
     def is_alert_event(self) -> bool:
         return self.event_type in ALERT_EVENTS
@@ -548,30 +553,37 @@ class DagsterEvent(
 
         return StepKind(self.step_kind_value)
 
+    @public  # type: ignore
     @property
     def is_step_success(self) -> bool:
         return self.event_type == DagsterEventType.STEP_SUCCESS
 
+    @public  # type: ignore
     @property
     def is_successful_output(self) -> bool:
         return self.event_type == DagsterEventType.STEP_OUTPUT
 
+    @public  # type: ignore
     @property
     def is_step_start(self) -> bool:
         return self.event_type == DagsterEventType.STEP_START
 
+    @public  # type: ignore
     @property
     def is_step_failure(self) -> bool:
         return self.event_type == DagsterEventType.STEP_FAILURE
 
+    @public  # type: ignore
     @property
     def is_step_skipped(self) -> bool:
         return self.event_type == DagsterEventType.STEP_SKIPPED
 
+    @public  # type: ignore
     @property
     def is_step_up_for_retry(self) -> bool:
         return self.event_type == DagsterEventType.STEP_UP_FOR_RETRY
 
+    @public  # type: ignore
     @property
     def is_step_restarted(self) -> bool:
         return self.event_type == DagsterEventType.STEP_RESTARTED
@@ -584,6 +596,7 @@ class DagsterEvent(
     def is_pipeline_failure(self) -> bool:
         return self.event_type == DagsterEventType.RUN_FAILURE
 
+    @public  # type: ignore
     @property
     def is_failure(self) -> bool:
         return self.event_type in FAILURE_EVENTS
@@ -592,34 +605,42 @@ class DagsterEvent(
     def is_pipeline_event(self) -> bool:
         return self.event_type in PIPELINE_EVENTS
 
+    @public  # type: ignore
     @property
     def is_engine_event(self) -> bool:
         return self.event_type == DagsterEventType.ENGINE_EVENT
 
+    @public  # type: ignore
     @property
     def is_handled_output(self) -> bool:
         return self.event_type == DagsterEventType.HANDLED_OUTPUT
 
+    @public  # type: ignore
     @property
     def is_loaded_input(self) -> bool:
         return self.event_type == DagsterEventType.LOADED_INPUT
 
+    @public  # type: ignore
     @property
     def is_step_materialization(self) -> bool:
         return self.event_type == DagsterEventType.ASSET_MATERIALIZATION
 
+    @public  # type: ignore
     @property
     def is_expectation_result(self) -> bool:
         return self.event_type == DagsterEventType.STEP_EXPECTATION_RESULT
 
+    @public  # type: ignore
     @property
     def is_asset_observation(self) -> bool:
         return self.event_type == DagsterEventType.ASSET_OBSERVATION
 
+    @public  # type: ignore
     @property
     def is_asset_materialization_planned(self) -> bool:
         return self.event_type == DagsterEventType.ASSET_MATERIALIZATION_PLANNED
 
+    @public  # type: ignore
     @property
     def asset_key(self) -> Optional[AssetKey]:
         if self.event_type == DagsterEventType.ASSET_MATERIALIZATION:
@@ -631,6 +652,7 @@ class DagsterEvent(
         else:
             return None
 
+    @public  # type: ignore
     @property
     def partition(self) -> Optional[str]:
         if self.event_type == DagsterEventType.ASSET_MATERIALIZATION:

--- a/python_modules/dagster/dagster/_core/events/log.py
+++ b/python_modules/dagster/dagster/_core/events/log.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, NamedTuple, Optional, Union
 
 import dagster._check as check
+from dagster._annotations import PublicAttr, public
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.events import DagsterEvent
 from dagster._core.utils import coerce_valid_log_level
@@ -40,20 +41,20 @@ class EventLogEntry(
     NamedTuple(
         "_EventLogEntry",
         [
-            ("error_info", Optional[SerializableErrorInfo]),
-            ("level", Union[str, int]),
-            ("user_message", str),
-            ("run_id", str),
-            ("timestamp", float),
-            ("step_key", Optional[str]),
-            ("pipeline_name", Optional[str]),
-            ("dagster_event", Optional[DagsterEvent]),
+            ("error_info", PublicAttr[Optional[SerializableErrorInfo]]),
+            ("level", PublicAttr[Union[str, int]]),
+            ("user_message", PublicAttr[str]),
+            ("run_id", PublicAttr[str]),
+            ("timestamp", PublicAttr[float]),
+            ("step_key", PublicAttr[Optional[str]]),
+            ("pipeline_name", PublicAttr[Optional[str]]),
+            ("dagster_event", PublicAttr[Optional[DagsterEvent]]),
         ],
     )
 ):
     """Entries in the event log.
 
-    These entries may originate from the logging machinery (DagsterLogManager/context.log), from
+    Users should not instantiate this object directly. These entries may originate from the logging machinery (DagsterLogManager/context.log), from
     framework events (e.g. EngineEvent), or they may correspond to events yielded by user code
     (e.g. Output).
 
@@ -105,14 +106,17 @@ class EventLogEntry(
             check.opt_inst_param(dagster_event, "dagster_event", DagsterEvent),
         )
 
+    @public  # type: ignore
     @property
     def is_dagster_event(self) -> bool:
         return bool(self.dagster_event)
 
+    @public  # type: ignore
     @property
     def job_name(self) -> Optional[str]:
         return self.pipeline_name
 
+    @public  # type: ignore
     def get_dagster_event(self) -> DagsterEvent:
         if not isinstance(self.dagster_event, DagsterEvent):
             check.failed(
@@ -128,10 +132,12 @@ class EventLogEntry(
     def from_json(json_str):
         return deserialize_json_to_dagster_namedtuple(json_str)
 
+    @public  # type: ignore
     @property
     def dagster_event_type(self):
         return self.dagster_event.event_type if self.dagster_event else None
 
+    @public  # type: ignore
     @property
     def message(self) -> str:
         """

--- a/python_modules/dagster/dagster/_core/execution/execute_in_process_result.py
+++ b/python_modules/dagster/dagster/_core/execution/execute_in_process_result.py
@@ -1,6 +1,7 @@
 from typing import Any, Mapping, Optional, Sequence
 
 import dagster._check as check
+from dagster._annotations import public
 from dagster._core.definitions import JobDefinition, NodeHandle
 from dagster._core.definitions.utils import DEFAULT_OUTPUT
 from dagster._core.errors import DagsterInvariantViolationError
@@ -14,7 +15,7 @@ from .execution_result import ExecutionResult
 class ExecuteInProcessResult(ExecutionResult):
     """Result object returned by in-process testing APIs.
 
-    Used for retrieving run success, events, and outputs from execution methods that return this object.
+    Users should not instantiate this object directly. Used for retrieving run success, events, and outputs from execution methods that return this object.
 
     This object is returned by:
     - :py:meth:`dagster.GraphDefinition.execute_in_process`
@@ -45,20 +46,24 @@ class ExecuteInProcessResult(ExecutionResult):
             output_capture, "output_capture", key_type=StepOutputHandle
         )
 
+    @public  # type: ignore
     @property
     def job_def(self) -> JobDefinition:
         return self._job_def
 
+    @public  # type: ignore
     @property
     def dagster_run(self) -> DagsterRun:
         return self._dagster_run
 
+    @public  # type: ignore
     @property
     def all_events(self) -> Sequence[DagsterEvent]:
         """List[DagsterEvent]: All dagster events emitted during execution."""
 
         return self._event_list
 
+    @public  # type: ignore
     @property
     def run_id(self) -> str:
         return self.dagster_run.run_id
@@ -97,6 +102,7 @@ class ExecuteInProcessResult(ExecutionResult):
             )
         return mapped_outputs
 
+    @public
     def output_for_node(self, node_str: str, output_name: str = DEFAULT_OUTPUT) -> Any:
         """Retrieves output value with a particular name from the in-process run of the job.
 
@@ -113,6 +119,7 @@ class ExecuteInProcessResult(ExecutionResult):
             node_str, output_name=output_name
         )
 
+    @public
     def output_value(self, output_name: str = DEFAULT_OUTPUT) -> Any:
         """Retrieves output of top-level job, if an output is returned.
 

--- a/python_modules/dagster/dagster/_core/executor/base.py
+++ b/python_modules/dagster/dagster/_core/executor/base.py
@@ -1,9 +1,11 @@
 from abc import ABC, abstractmethod
 
+from dagster._annotations import public
 from dagster._core.execution.retries import RetryMode
 
 
 class Executor(ABC):  # pylint: disable=no-init
+    @public
     @abstractmethod
     def execute(self, plan_context, execution_plan):
         """
@@ -17,6 +19,7 @@ class Executor(ABC):  # pylint: disable=no-init
             A stream of dagster events.
         """
 
+    @public  # type: ignore
     @property
     @abstractmethod
     def retries(self) -> RetryMode:

--- a/python_modules/dagster/dagster/_core/executor/init.py
+++ b/python_modules/dagster/dagster/_core/executor/init.py
@@ -1,6 +1,7 @@
 from typing import Mapping, NamedTuple
 
 import dagster._check as check
+from dagster._annotations import PublicAttr
 from dagster._core.definitions import ExecutorDefinition, IPipeline
 from dagster._core.instance import DagsterInstance
 
@@ -9,10 +10,10 @@ class InitExecutorContext(
     NamedTuple(
         "InitExecutorContext",
         [
-            ("job", IPipeline),
-            ("executor_def", ExecutorDefinition),
-            ("executor_config", Mapping[str, object]),
-            ("instance", DagsterInstance),
+            ("job", PublicAttr[IPipeline]),
+            ("executor_def", PublicAttr[ExecutorDefinition]),
+            ("executor_config", PublicAttr[Mapping[str, object]]),
+            ("instance", PublicAttr[DagsterInstance]),
         ],
     )
 ):

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -750,8 +750,8 @@ class DagsterInstance:
     # run storage
     @public
     @traced
-    def get_run_by_id(self, run_id: str) -> Optional[PipelineRun]:
-        return self._run_storage.get_run_by_id(run_id)
+    def get_run_by_id(self, run_id: str) -> Optional[DagsterRun]:
+        return cast(DagsterRun, self._run_storage.get_run_by_id(run_id))
 
     @traced
     def get_pipeline_snapshot(self, snapshot_id: str) -> "PipelineSnapshot":
@@ -1380,7 +1380,6 @@ class DagsterInstance:
 
     # asset storage
 
-    @public
     @traced
     def all_asset_keys(self):
         return self._event_storage.all_asset_keys()
@@ -1395,13 +1394,13 @@ class DagsterInstance:
     def has_asset_key(self, asset_key: AssetKey) -> bool:
         return self._event_storage.has_asset_key(asset_key)
 
-    @public
     @traced
     def get_latest_materialization_events(
         self, asset_keys: Sequence[AssetKey]
     ) -> Mapping[AssetKey, Optional["EventLogEntry"]]:
         return self._event_storage.get_latest_materialization_events(asset_keys)
 
+    @public
     @traced
     def get_event_records(
         self,
@@ -1430,7 +1429,6 @@ class DagsterInstance:
     ) -> Iterable["AssetRecord"]:
         return self._event_storage.get_asset_records(asset_keys)
 
-    @public
     @traced
     def run_ids_for_asset_key(self, asset_key):
         check.inst_param(asset_key, "asset_key", AssetKey)

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -30,6 +30,7 @@ from typing import (
 import yaml
 
 import dagster._check as check
+from dagster._annotations import public
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
 from dagster._core.definitions.pipeline_definition import (
@@ -358,6 +359,7 @@ class DagsterInstance:
 
     # ctors
 
+    @public
     @staticmethod
     def ephemeral(
         tempdir: Optional[str] = None, preload: Optional[List["DebugRunPayload"]] = None
@@ -382,6 +384,7 @@ class DagsterInstance:
             run_launcher=SyncInMemoryRunLauncher(),
         )
 
+    @public
     @staticmethod
     def get() -> "DagsterInstance":
         dagster_home_path = os.getenv("DAGSTER_HOME")
@@ -423,6 +426,7 @@ class DagsterInstance:
 
         return DagsterInstance.from_config(dagster_home_path)
 
+    @public
     @staticmethod
     def local_temp(tempdir=None, overrides=None) -> "DagsterInstance":
         if tempdir is None:
@@ -744,6 +748,7 @@ class DagsterInstance:
         self._compute_log_manager.dispose()
 
     # run storage
+    @public
     @traced
     def get_run_by_id(self, run_id: str) -> Optional[PipelineRun]:
         return self._run_storage.get_run_by_id(run_id)
@@ -1289,6 +1294,7 @@ class DagsterInstance:
     ) -> Dict[str, Dict[str, Union[Iterable[PipelineRun], int]]]:
         return self._run_storage.get_run_groups(filters=filters, cursor=cursor, limit=limit)
 
+    @public
     @traced
     def get_run_records(
         self,
@@ -1328,6 +1334,7 @@ class DagsterInstance:
         self._run_storage.wipe()
         self._event_storage.wipe()
 
+    @public
     @traced
     def delete_run(self, run_id: str):
         self._run_storage.delete_run(run_id)
@@ -1373,18 +1380,22 @@ class DagsterInstance:
 
     # asset storage
 
+    @public
     @traced
     def all_asset_keys(self):
         return self._event_storage.all_asset_keys()
 
+    @public
     @traced
     def get_asset_keys(self, prefix=None, limit=None, cursor=None):
         return self._event_storage.get_asset_keys(prefix=prefix, limit=limit, cursor=cursor)
 
+    @public
     @traced
     def has_asset_key(self, asset_key: AssetKey) -> bool:
         return self._event_storage.has_asset_key(asset_key)
 
+    @public
     @traced
     def get_latest_materialization_events(
         self, asset_keys: Sequence[AssetKey]
@@ -1412,17 +1423,20 @@ class DagsterInstance:
         """
         return self._event_storage.get_event_records(event_records_filter, limit, ascending)
 
+    @public
     @traced
     def get_asset_records(
         self, asset_keys: Optional[Sequence[AssetKey]] = None
     ) -> Iterable["AssetRecord"]:
         return self._event_storage.get_asset_records(asset_keys)
 
+    @public
     @traced
     def run_ids_for_asset_key(self, asset_key):
         check.inst_param(asset_key, "asset_key", AssetKey)
         return self._event_storage.get_asset_run_ids(asset_key)
 
+    @public
     @traced
     def wipe_assets(self, asset_keys):
         check.list_param(asset_keys, "asset_keys", of_type=AssetKey)

--- a/python_modules/dagster/dagster/_core/storage/event_log/__init__.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/__init__.py
@@ -1,4 +1,5 @@
 from .base import (
+    AssetRecord,
     EventLogEntry,
     EventLogRecord,
     EventLogStorage,

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -34,6 +34,8 @@ class RunShardedEventsCursor(NamedTuple):
 class EventLogRecord(NamedTuple):
     """Internal representation of an event record, as stored in a
     :py:class:`~dagster._core.storage.event_log.EventLogStorage`.
+
+    Users should not instantiate this class directly.
     """
 
     storage_id: PublicAttr[int]
@@ -122,6 +124,11 @@ class AssetEntry(
 
 
 class AssetRecord(NamedTuple):
+    """Internal representation of an asset record, as stored in a :py:class:`~dagster._core.storage.event_log.EventLogStorage`.
+
+    Users should not invoke this class directly.
+    """
+
     storage_id: int
     asset_entry: AssetEntry
 

--- a/python_modules/dagster/dagster/_core/storage/file_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/file_manager.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from typing import BinaryIO, Optional, TextIO, Union
 
 import dagster._check as check
+from dagster._annotations import public
 from dagster._config import Field, StringSource
 from dagster._core.definitions.resource_definition import resource
 from dagster._core.instance import DagsterInstance
@@ -28,6 +29,7 @@ class FileHandle(ABC):
     such as S3.
     """
 
+    @public  # type: ignore
     @property
     @abstractmethod
     def path_desc(self) -> str:
@@ -41,11 +43,13 @@ class LocalFileHandle(FileHandle):
     def __init__(self, path: str):
         self._path = check.str_param(path, "path")
 
+    @public  # type: ignore
     @property
     def path(self) -> str:
         """The file's path."""
         return self._path
 
+    @public  # type: ignore
     @property
     def path_desc(self) -> str:
         """A representation of the file path for display purposes only."""
@@ -61,6 +65,7 @@ class FileManager(ABC):  # pylint: disable=no-init
     For examples of usage, see the documentation of the concrete file manager implementations.
     """
 
+    @public
     @abstractmethod
     def copy_handle_to_local_temp(self, file_handle: FileHandle) -> str:
         """Copy a file represented by a file handle to a temp file.
@@ -84,6 +89,7 @@ class FileManager(ABC):  # pylint: disable=no-init
         """
         raise NotImplementedError()
 
+    @public
     @abstractmethod
     def delete_local_temp(self):
         """Delete all local temporary files created by previous calls to
@@ -93,6 +99,7 @@ class FileManager(ABC):  # pylint: disable=no-init
         """
         raise NotImplementedError()
 
+    @public
     @abstractmethod
     def read(self, file_handle: FileHandle, mode: str = "rb") -> Union[TextIO, BinaryIO]:
         """Return a file-like stream for the file handle.
@@ -109,6 +116,7 @@ class FileManager(ABC):  # pylint: disable=no-init
         """
         raise NotImplementedError()
 
+    @public
     @abstractmethod
     def read_data(self, file_handle: FileHandle) -> bytes:
         """Return the bytes for a given file handle. This may incur an expensive network
@@ -122,6 +130,7 @@ class FileManager(ABC):  # pylint: disable=no-init
         """
         raise NotImplementedError()
 
+    @public
     @abstractmethod
     def write(
         self, file_obj: Union[TextIO, BinaryIO], mode: str = "wb", ext: Optional[str] = None
@@ -140,6 +149,7 @@ class FileManager(ABC):  # pylint: disable=no-init
         """
         raise NotImplementedError()
 
+    @public
     @abstractmethod
     def write_data(self, data: bytes, ext: Optional[str] = None) -> FileHandle:
         """Write raw bytes into the file manager.

--- a/python_modules/dagster/dagster/_core/storage/memoizable_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/memoizable_io_manager.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from typing import Union
 
 import dagster._check as check
-from dagster._annotations import experimental
+from dagster._annotations import experimental, public
 from dagster._config import Field, StringSource
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.context.input import InputContext
@@ -20,6 +20,7 @@ class MemoizableIOManager(IOManager):
     ``has_output`` method, which returns a boolean representing whether a data object can be found.
     """
 
+    @public
     @abstractmethod
     def has_output(self, context: OutputContext) -> bool:
         """The user-defined method that returns whether data exists given the metadata.

--- a/python_modules/dagster/dagster/_core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/_core/storage/pipeline_run.py
@@ -16,6 +16,7 @@ from typing import (
 )
 
 import dagster._check as check
+from dagster._annotations import public
 from dagster._core.definitions.events import AssetKey
 from dagster._core.origin import PipelinePythonOrigin
 from dagster._core.storage.tags import PARENT_RUN_ID_TAG, ROOT_RUN_ID_TAG
@@ -459,22 +460,27 @@ class PipelineRun(
 
         return {**repository_tags, **self.tags}
 
+    @public  # type: ignore
     @property
     def is_finished(self):
         return self.status in FINISHED_STATUSES
 
+    @public  # type: ignore
     @property
     def is_success(self):
         return self.status == PipelineRunStatus.SUCCESS
 
+    @public  # type: ignore
     @property
     def is_failure(self):
         return self.status == PipelineRunStatus.FAILURE
 
+    @public  # type: ignore
     @property
     def is_failure_or_canceled(self):
         return self.status == PipelineRunStatus.FAILURE or self.status == PipelineRunStatus.CANCELED
 
+    @public  # type: ignore
     @property
     def is_resume_retry(self):
         return self.tags.get(RESUME_RETRY_TAG) == "true"
@@ -484,6 +490,7 @@ class PipelineRun(
         # Compat
         return self.parent_run_id
 
+    @public  # type: ignore
     @property
     def job_name(self) -> str:
         return self.pipeline_name

--- a/python_modules/dagster/dagster/_core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/_core/storage/pipeline_run.py
@@ -657,6 +657,8 @@ class RunRecord(
 ):
     """Internal representation of a run record, as stored in a
     :py:class:`~dagster._core.storage.runs.RunStorage`.
+
+    Users should not invoke this class directly.
     """
 
     def __new__(


### PR DESCRIPTION
Adds publicity attribution for remaining public classes in `dagster._core`. Too many to effectively list; but some notable inclusions:
- `DagsterRun`, had to change the docs for this to get inherited members.
- `ExecuteInProcessResult`, also had to change the docs here
- `DagsterInstance`, which follows the audit that @alangenfeld did a while back for BITL.
- Notes that users should not instantiate `EventLogEntry`
- `InitExecutorContext` exposes `IPipeline`, which is a private, somewhat legacy API. Since `InitExecutorContext` is experimental (only used when someone is writing their own executor, I feel like it's probably fine to not do anything about this in the short term, but thought I would flag).