### PR TITLE
Move dagster msteams off of legacy APIs

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-msteams.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-msteams.rst
@@ -12,4 +12,4 @@ Microsoft Teams (dagster-msteams)
 .. autodata:: teams_on_success
   :annotation: HookDefinition
 
-.. autofunction:: make_teams_on_pipeline_failure_sensor
+.. autofunction:: make_teams_on_run_failure_sensor

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -153,7 +153,7 @@ class RunFailureSensorContext(RunStatusSensorContext):
 
     Attributes:
         sensor_name (str): the name of the sensor.
-        pipeline_run (PipelineRun): the failed pipeline run.
+        dagster_run (DagsterRun): the failed pipeline run.
         failure_event (DagsterEvent): the pipeline failure event.
     """
 

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/__init__.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/__init__.py
@@ -3,7 +3,7 @@ from dagster._core.utils import check_dagster_package_version
 from .card import Card
 from .hooks import teams_on_failure, teams_on_success
 from .resources import msteams_resource
-from .sensors import make_teams_on_pipeline_failure_sensor
+from .sensors import make_teams_on_run_failure_sensor
 from .version import __version__
 
 check_dagster_package_version("dagster-msteams", __version__)

--- a/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_sensors.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_sensors.py
@@ -1,17 +1,17 @@
 import os
 
-from dagster_msteams.sensors import make_teams_on_pipeline_failure_sensor
+from dagster_msteams.sensors import make_teams_on_run_failure_sensor
 
 from dagster import repository
 from dagster._core.test_utils import environ
 
 
-def test_teams_pipeline_failure_sensor_def():
+def test_teams_run_failure_sensor_def():
     with environ({"TEAMS_WEBHOOK_URL": "https://some_url_here/"}):
 
         sensor_name = "my_failure_sensor"
 
-        my_sensor = make_teams_on_pipeline_failure_sensor(
+        my_sensor = make_teams_on_run_failure_sensor(
             hook_url=os.getenv("TEAMS_WEBHOOK_URL"),
             name=sensor_name,
         )


### PR DESCRIPTION
Moves `make_teams_on_pipeline_failure_sensor` to `make_teams_on_run_failure_sensor`. 