### PR TITLE
[1.0] Mark a bunch of stuff experimental

### DIFF
--- a/docs/sphinx/sections/api/apidocs/internals.rst
+++ b/docs/sphinx/sections/api/apidocs/internals.rst
@@ -14,7 +14,7 @@ customize it.
 Executors (Experimental)
 ------------------------
 
-APIs for constructing custom executors. While this is considered advanced experimental usage, significant advanced warning will be given before any breakages occur to this set of APIs. Please note that using dagster-provided executors is considered stable, common usage.
+APIs for constructing custom executors. This is considered advanced experimental usage. Please note that using Dagster-provided executors is considered stable, common usage.
 
 .. autodecorator:: executor
 

--- a/docs/sphinx/sections/api/apidocs/internals.rst
+++ b/docs/sphinx/sections/api/apidocs/internals.rst
@@ -3,8 +3,7 @@ Internals
 
 .. currentmodule:: dagster
 
-Please note that internal APIs are likely to be in much greater flux pre-1.0 than user-facing APIs,
-particularly if not exported in the top level ``dagster`` module.
+Note that APIs imported from Dagster submodules are not considered stable, and are potentially subject to change in the future.
 
 If you find yourself consulting these docs because you are writing custom components and plug-ins,
 please get in touch with the core team `on our Slack <https://join.slack.com/t/dagster/shared_invite/enQtNjEyNjkzNTA2OTkzLTI0MzdlNjU0ODVhZjQyOTMyMGM1ZDUwZDQ1YjJmYjI3YzExZGViMDI1ZDlkNTY5OThmYWVlOWM1MWVjN2I3NjU>`_.
@@ -12,8 +11,11 @@ We're curious what you're up to, happy to help, excited for new community contri
 to make the system as easy to work with as possible -- including for teams who are looking to
 customize it.
 
-Executors
----------
+Executors (Experimental)
+------------------------
+
+APIs for constructing custom executors. While this is considered advanced experimental usage, significant advanced warning will be given before any breakages occur to this set of APIs. Please note that using dagster-provided executors is considered stable, common usage.
+
 .. autodecorator:: executor
 
 .. autoclass:: ExecutorDefinition
@@ -27,8 +29,8 @@ Executors
 
 ----
 
-File Manager
---------------
+File Manager (Experimental)
+---------------------------
 
 .. currentmodule:: dagster._core.storage.file_manager
 
@@ -39,6 +41,11 @@ File Manager
 
 .. autodata:: local_file_manager
    :annotation: ResourceDefinition
+
+.. autoclass:: FileHandle
+   :members:
+
+.. autoclass:: LocalFileHandle
 
 ----
 

--- a/docs/sphinx/sections/api/apidocs/io-managers.rst
+++ b/docs/sphinx/sections/api/apidocs/io-managers.rst
@@ -46,6 +46,16 @@ Built-in IO Managers
   :annotation: IOManagerDefinition
 
 
+Input Managers (Experimental)
+----------------------------------
+
+Input managers load inputs from either upstream outputs or from provided default values.
+
+.. autodecorator:: input_manager
+
+.. autoclass:: InputManager
+    :members:
+
 Root Input Managers (Experimental)
 ----------------------------------
 

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-aws.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-aws.rst
@@ -35,8 +35,6 @@ S3
 File Manager (Experimental)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-File Manager APIs will be removed from the main dagster library in version ``1.1.0``, and these APIs will be removed in version ``0.17.0`` of ``dagster-aws``.
-
 .. autoclass:: dagster_aws.s3.S3FileHandle
   :members:
 

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-aws.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-aws.rst
@@ -10,12 +10,6 @@ S3
 
 .. autoclass:: dagster_aws.s3.S3ComputeLogManager
 
-.. autoclass:: dagster_aws.s3.S3FileHandle
-  :members:
-
-.. autoconfigurable:: dagster_aws.s3.s3_file_manager
-  :annotation: ResourceDefinition
-
 .. autoconfigurable:: dagster_aws.s3.s3_resource
   :annotation: ResourceDefinition
 
@@ -37,6 +31,17 @@ S3
 
 .. autoconfigurable:: dagster_aws.s3.s3_pickle_io_manager
   :annotation: IOManagerDefinition
+
+File Manager (Experimental)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+File Manager APIs will be removed from the main dagster library in version ``1.1.0``, and these APIs will be removed in version ``0.17.0`` of ``dagster-aws``.
+
+.. autoclass:: dagster_aws.s3.S3FileHandle
+  :members:
+
+.. autoconfigurable:: dagster_aws.s3.s3_file_manager
+  :annotation: ResourceDefinition
 
 
 ECS

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-azure.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-azure.rst
@@ -26,7 +26,6 @@ dependency on an old version, via ``snowflake-connector-python``.
 File Manager (Experimental)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-File Manager APIs will be removed from the main dagster library in version ``1.1.0``, and these APIs will be removed in version ``0.17.0`` of ``dagster-azure``.
 .. autoconfigurable:: dagster_azure.adls2.adls2_file_manager
   :annotation: ResourceDefinition
 

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-azure.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-azure.rst
@@ -20,11 +20,15 @@ dependency on an old version, via ``snowflake-connector-python``.
 
 .. autoclass:: dagster_azure.blob.AzureBlobComputeLogManager
 
+.. autoconfigurable:: dagster_azure.adls2.adls2_pickle_io_manager
+  :annotation: IOManagerDefinition
+
+File Manager (Experimental)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+File Manager APIs will be removed from the main dagster library in version ``1.1.0``, and these APIs will be removed in version ``0.17.0`` of ``dagster-azure``.
 .. autoconfigurable:: dagster_azure.adls2.adls2_file_manager
   :annotation: ResourceDefinition
 
 .. autoclass:: dagster_azure.adls2.ADLS2FileHandle
   :members:
-
-.. autoconfigurable:: dagster_azure.adls2.adls2_pickle_io_manager
-  :annotation: IOManagerDefinition

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-gcp.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-gcp.rst
@@ -39,11 +39,16 @@ GCS
 .. autoconfigurable:: gcs_resource
   :annotation: ResourceDefinition
 
+.. autoconfigurable:: dagster_gcp.gcs.gcs_pickle_io_manager
+  :annotation: IOManagerDefinition
+
+File Manager (Experimental)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+File Manager APIs will be removed from the main dagster library in version ``1.1.0``, and these APIs will be removed in version ``0.17.0`` of ``dagster-gcp``.
+
 .. autoclass:: GCSFileHandle
   :members:
 
 .. autodata:: gcs_file_manager
   :annotation: ResourceDefinition
-
-.. autoconfigurable:: dagster_gcp.gcs.gcs_pickle_io_manager
-  :annotation: IOManagerDefinition

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-gcp.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-gcp.rst
@@ -45,8 +45,6 @@ GCS
 File Manager (Experimental)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-File Manager APIs will be removed from the main dagster library in version ``1.1.0``, and these APIs will be removed in version ``0.17.0`` of ``dagster-gcp``.
-
 .. autoclass:: GCSFileHandle
   :members:
 

--- a/docs/sphinx/sections/api/apidocs/memoization.rst
+++ b/docs/sphinx/sections/api/apidocs/memoization.rst
@@ -1,4 +1,4 @@
-Versioning and Memoization
+Versioning and Memoization (Experimental)
 ==========================
 
 Dagster allows for code versioning and memoization of previous outputs based upon that versioning.
@@ -11,8 +11,15 @@ Versioning
 .. currentmodule:: dagster
 
 .. autoclass:: VersionStrategy
+    :members:
 
 .. autoclass:: SourceHashVersionStrategy
+
+.. autoclass:: OpVersionContext
+    :members:
+
+.. autoclass:: ResourceVersionContext
+    :members:
 
 Memoization
 -----------

--- a/docs/sphinx/sections/api/apidocs/memoization.rst
+++ b/docs/sphinx/sections/api/apidocs/memoization.rst
@@ -1,5 +1,5 @@
 Versioning and Memoization (Experimental)
-==========================
+=========================================
 
 Dagster allows for code versioning and memoization of previous outputs based upon that versioning.
 Listed here are APIs related to versioning and memoization.
@@ -16,10 +16,8 @@ Versioning
 .. autoclass:: SourceHashVersionStrategy
 
 .. autoclass:: OpVersionContext
-    :members:
 
 .. autoclass:: ResourceVersionContext
-    :members:
 
 Memoization
 -----------

--- a/docs/sphinx/sections/api/apidocs/types.rst
+++ b/docs/sphinx/sections/api/apidocs/types.rst
@@ -49,11 +49,6 @@ Built-in types
             done(wait_int())
 
 
-.. autoclass:: FileHandle
-   :members:
-
-.. autoclass:: LocalFileHandle
-
 Making New Types
 ----------------
 

--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
@@ -676,7 +676,7 @@ def define_memoization_pipeline():
         return "foo"
 
     class BasicVersionStrategy(VersionStrategy):
-        def get_solid_version(self, _):
+        def get_op_version(self, _):
             return "foo"
 
     @pipeline(

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -184,7 +184,12 @@ from dagster._core.definitions.utils import (
     config_from_pkg_resources,
     config_from_yaml_strings,
 )
-from dagster._core.definitions.version_strategy import SourceHashVersionStrategy, VersionStrategy
+from dagster._core.definitions.version_strategy import (
+    OpVersionContext,
+    ResourceVersionContext,
+    SourceHashVersionStrategy,
+    VersionStrategy,
+)
 from dagster._core.errors import (
     DagsterConfigMappingFunctionError,
     DagsterError,
@@ -242,7 +247,6 @@ from dagster._core.storage.event_log import (
     EventRecordsFilter,
     RunShardedEventsCursor,
 )
-from dagster._core.storage.file_manager import FileHandle, LocalFileHandle, local_file_manager
 from dagster._core.storage.fs_io_manager import custom_path_fs_io_manager, fs_io_manager
 from dagster._core.storage.input_manager import InputManager, input_manager
 from dagster._core.storage.io_manager import IOManager, IOManagerDefinition, io_manager
@@ -292,6 +296,7 @@ from dagster._utils.log import get_dagster_logger
 if typing.TYPE_CHECKING:
     # pylint:disable=reimported
 
+    from dagster._core.storage.file_manager import FileHandle, LocalFileHandle, local_file_manager
     from dagster._core.types.config_schema import DagsterTypeMaterializer, dagster_type_materializer
 
     # pylint:enable=reimported
@@ -306,6 +311,21 @@ _DEPRECATED = {
         "dagster._core.types.config_schema",
         "1.1.0",
         "Instead, use an input manager or root input manager.",
+    ),
+    "FileHandle": (
+        "dagster._core.storage.file_manager",
+        "1.1.0",
+        "It is recommended to handle I/O to a filesystem within an IO manager.",
+    ),
+    "LocalFileHandle": (
+        "dagster._core.storage.file_manager",
+        "1.1.0",
+        "Local file I/O can be handled by the fs_io_manager.",
+    ),
+    "local_file_manager": (
+        "dagster._core.storage.file_manager",
+        "1.1.0",
+        "Local file I/O can be handled by the fs_io_manager.",
     ),
 }
 
@@ -608,6 +628,8 @@ __all__ = [
     "MEMOIZED_RUN_TAG",
     "MemoizableIOManager",
     "SourceHashVersionStrategy",
+    "OpVersionContext",
+    "ResourceVersionContext",
     "colored_console_logger",
     "default_loggers",
     "default_system_loggers",

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -247,6 +247,7 @@ from dagster._core.storage.event_log import (
     EventRecordsFilter,
     RunShardedEventsCursor,
 )
+from dagster._core.storage.file_manager import FileHandle, LocalFileHandle, local_file_manager
 from dagster._core.storage.fs_io_manager import custom_path_fs_io_manager, fs_io_manager
 from dagster._core.storage.input_manager import InputManager, input_manager
 from dagster._core.storage.io_manager import IOManager, IOManagerDefinition, io_manager
@@ -295,8 +296,6 @@ from dagster._utils.log import get_dagster_logger
 
 if typing.TYPE_CHECKING:
     # pylint:disable=reimported
-
-    from dagster._core.storage.file_manager import FileHandle, LocalFileHandle, local_file_manager
     from dagster._core.types.config_schema import DagsterTypeMaterializer, dagster_type_materializer
 
     # pylint:enable=reimported
@@ -311,21 +310,6 @@ _DEPRECATED = {
         "dagster._core.types.config_schema",
         "1.1.0",
         "Instead, use an input manager or root input manager.",
-    ),
-    "FileHandle": (
-        "dagster._core.storage.file_manager",
-        "1.1.0",
-        "It is recommended to handle I/O to a filesystem within an IO manager.",
-    ),
-    "LocalFileHandle": (
-        "dagster._core.storage.file_manager",
-        "1.1.0",
-        "Local file I/O can be handled by the fs_io_manager.",
-    ),
-    "local_file_manager": (
-        "dagster._core.storage.file_manager",
-        "1.1.0",
-        "Local file I/O can be handled by the fs_io_manager.",
     ),
 }
 

--- a/python_modules/dagster/dagster/_core/definitions/version_strategy.py
+++ b/python_modules/dagster/dagster/_core/definitions/version_strategy.py
@@ -1,5 +1,6 @@
 import hashlib
 import inspect
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 
 if TYPE_CHECKING:
@@ -31,7 +32,7 @@ SolidVersionContext = OpVersionContext
 
 
 class ResourceVersionContext(NamedTuple):
-    """Version-specific resource context.
+    """Provides execution-time information for computing the version for a resource.
 
     Attributes:
         resource_def (ResourceDefinition): The definition of the resource whose version will be computed.
@@ -42,24 +43,22 @@ class ResourceVersionContext(NamedTuple):
     resource_config: Any
 
 
-class VersionStrategy:
-    """Abstract class for defining a strategy to version solids and resources.
+class VersionStrategy(ABC):
+    """Abstract class for defining a strategy to version ops and resources.
 
-    When subclassing, `get_solid_version` must be implemented, and `get_resource_version` can be
+    When subclassing, `get_op_version` must be implemented, and `get_resource_version` can be
     optionally implemented.
 
-    `get_solid_version` should ingest a SolidVersionContext, and `get_resource_version` should ingest a
+    `get_op_vresion` should ingest an OpVersionContext, and `get_resource_version` should ingest a
     ResourceVersionContext. From that,  each synthesize a unique string called a `version`, which will
     be tagged to outputs of that solid in the pipeline. Providing a `VersionStrategy` instance to a
     job will enable memoization on that job, such that only steps whose outputs do not have an
     up-to-date version will run.
     """
 
-    def get_solid_version(self, context: SolidVersionContext) -> str:
-        pass
-
+    @abstractmethod
     def get_op_version(self, context: OpVersionContext) -> str:
-        return self.get_solid_version(context)
+        raise NotImplementedError()
 
     def get_resource_version(
         self, context: ResourceVersionContext  # pylint: disable=unused-argument
@@ -68,6 +67,11 @@ class VersionStrategy:
 
 
 class SourceHashVersionStrategy(VersionStrategy):
+    """VersionStrategy that checks for changes to the source code of ops and resources.
+
+    Only checks for changes within the immediate body of the op/resource's decorated function (or compute function, if the op/resource was constructed directly from a definition).
+    """
+
     def _get_source_hash(self, fn):
         code_as_str = inspect.getsource(fn)
         return hashlib.sha1(code_as_str.encode("utf-8")).hexdigest()

--- a/python_modules/dagster/dagster/_core/definitions/version_strategy.py
+++ b/python_modules/dagster/dagster/_core/definitions/version_strategy.py
@@ -46,14 +46,16 @@ class ResourceVersionContext(NamedTuple):
 class VersionStrategy(ABC):
     """Abstract class for defining a strategy to version ops and resources.
 
-    When subclassing, `get_op_version` must be implemented, and `get_resource_version` can be
-    optionally implemented.
+    When subclassing, `get_op_version` must be implemented, and
+    `get_resource_version` can be optionally implemented.
 
-    `get_op_vresion` should ingest an OpVersionContext, and `get_resource_version` should ingest a
-    ResourceVersionContext. From that,  each synthesize a unique string called a `version`, which will
-    be tagged to outputs of that solid in the pipeline. Providing a `VersionStrategy` instance to a
-    job will enable memoization on that job, such that only steps whose outputs do not have an
-    up-to-date version will run.
+    `get_op_version` should ingest an OpVersionContext, and `get_resource_version` should ingest a
+    ResourceVersionContext. From that,  each synthesize a unique string called
+    a `version`, which will
+    be tagged to outputs of that solid in the pipeline. Providing a
+    `VersionStrategy` instance to a
+    job will enable memoization on that job, such that only steps whose
+    outputs do not have an up-to-date version will run.
     """
 
     @abstractmethod
@@ -69,7 +71,9 @@ class VersionStrategy(ABC):
 class SourceHashVersionStrategy(VersionStrategy):
     """VersionStrategy that checks for changes to the source code of ops and resources.
 
-    Only checks for changes within the immediate body of the op/resource's decorated function (or compute function, if the op/resource was constructed directly from a definition).
+    Only checks for changes within the immediate body of the op/resource's
+    decorated function (or compute function, if the op/resource was
+    constructed directly from a definition).
     """
 
     def _get_source_hash(self, fn):

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_io_manager.py
@@ -106,7 +106,7 @@ def test_fs_io_manager_memoization():
         my_op()
 
     class MyVersionStrategy(VersionStrategy):
-        def get_solid_version(self, _):
+        def get_op_version(self, _):
             return "foo"
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/python_modules/dagster/dagster_tests/core_tests/test_resolve_versions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_resolve_versions.py
@@ -763,7 +763,7 @@ bad_str = "'well this doesn't work !'"
 
 
 class BadSolidStrategy(VersionStrategy):
-    def get_solid_version(self, _):
+    def get_op_version(self, _):
         return bad_str
 
     def get_resource_version(self, _):
@@ -771,7 +771,7 @@ class BadSolidStrategy(VersionStrategy):
 
 
 class BadResourceStrategy(VersionStrategy):
-    def get_solid_version(self, _):
+    def get_op_version(self, _):
         return "foo"
 
     def get_resource_version(self, _):
@@ -856,7 +856,7 @@ def get_version_strategy_pipeline():
         return 5
 
     class MyVersionStrategy(VersionStrategy):
-        def get_solid_version(self, _):
+        def get_op_version(self, _):
             return "foo"
 
     @pipeline(
@@ -891,7 +891,7 @@ def test_version_strategy_no_resource_version():
         return "bar"
 
     class MyVersionStrategy(VersionStrategy):
-        def get_solid_version(self, _):
+        def get_op_version(self, _):
             return "foo"
 
     @pipeline(

--- a/python_modules/dagster/dagster_tests/execution_tests/test_memoized_dev_loop.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_memoized_dev_loop.py
@@ -105,7 +105,7 @@ def test_memoization_with_default_strategy():
         my_op()
 
     class MyVersionStrategy(VersionStrategy):
-        def get_solid_version(self, _):
+        def get_op_version(self, _):
             return "foo"
 
         def get_resource_version(self, _):
@@ -197,7 +197,7 @@ def test_memoization_with_default_strategy_overriden():
     version = ["foo"]
 
     class MyVersionStrategy(VersionStrategy):
-        def get_solid_version(self, _):
+        def get_op_version(self, _):
             return version[0]
 
     recorder = []
@@ -257,7 +257,7 @@ def test_version_strategy_depends_from_context():
     graph_executed = []
 
     class ContextDependantVersionStrategy(VersionStrategy):
-        def get_solid_version(self, context):
+        def get_op_version(self, context):
             version_strategy_called.append("versioned")
             solid_arg = context.solid_config["arg"]
             return version[solid_arg]
@@ -327,7 +327,7 @@ def test_version_strategy_depends_from_context():
 
 def test_version_strategy_root_input_manager():
     class MyVersionStrategy(VersionStrategy):
-        def get_solid_version(self, _):
+        def get_op_version(self, _):
             return "foo"
 
         def get_resource_version(self, _):
@@ -362,7 +362,7 @@ def test_version_strategy_root_input_manager():
 
 def test_dynamic_memoization_error():
     class MyVersionStrategy(VersionStrategy):
-        def get_solid_version(self, _):
+        def get_op_version(self, _):
             return "foo"
 
         def get_resource_version(self, _):

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
@@ -99,7 +99,7 @@ def test_s3_pickle_io_manager_prefix(mock_s3_bucket):
 
 def test_memoization_s3_io_manager(mock_s3_bucket):
     class BasicVersionStrategy(VersionStrategy):
-        def get_solid_version(self, _):
+        def get_op_version(self, _):
             return "foo"
 
     @op

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/repo.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/repo.py
@@ -329,7 +329,7 @@ def bar_solid():
 
 
 class BasicVersionStrategy(VersionStrategy):
-    def get_solid_version(self, _):
+    def get_op_version(self, _):
         return "bar"
 
 

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_execute.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_execute.py
@@ -282,7 +282,7 @@ def foo_solid():
 
 
 class BasicVersionStrategy(VersionStrategy):
-    def get_solid_version(self, _):
+    def get_op_version(self, _):
         return "foo"
 
 


### PR DESCRIPTION
Marks FileManager APIs experimental, custom executors experimental, and adds some memoization imports / docstrings. 

One interesting thing is the blurb at the top of `internals.rst` - `internals.rst` in general has a bunch of imports from... internal modules. Do we want to keep that as the case? If so, how do we communicate against it? Took a stab, but would be good to have a once over on this stuff.