### PR TITLE
[docs] - Sidenav cleanup

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -15,10 +15,6 @@
       {
         "title": "Telemetry",
         "path": "/getting-started/telemetry"
-      },
-      {
-        "title": "Releases and Changes",
-        "path": "/getting-started/releases"
       }
     ]
   },
@@ -704,18 +700,21 @@
     ]
   },
   {
-    "title": "Changelog",
-    "icon": "Change",
-    "path": "/changelog",
+    "title": "About",
+    "icon": "InfoCircle",
     "isUnversioned": true,
     "children": [
+      {
+        "title": "Releases and Changes",
+        "path": "/getting-started/releases"
+      },
       {
         "title": "Changelog",
         "path": "/changelog",
         "isUnversioned": true
       },
       {
-        "title": "Migration Guides",
+        "title": "Migration guides",
         "path": "/migration",
         "isUnversioned": true
       }

--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -368,37 +368,36 @@
     "path": "/integrations",
     "children": [
       {
-        "title": "Integration Guides",
-        "children": [
-          {
-            "title": "Dagster with dbt",
-            "path": "/integrations/dbt"
-          },
-          {
-            "title": "Dagster with Airflow",
-            "path": "/integrations/airflow"
-          },
-          {
-            "title": "Dagster with Great Expectations",
-            "path": "/integrations/great-expectations"
-          },
-          {
-            "title": "Dagster with PySpark",
-            "path": "/integrations/spark"
-          },
-          {
-            "title": "Dagster with Pandas",
-            "path": "/integrations/pandas"
-          },
-          {
-            "title": "Dagster with Pandera",
-            "path": "/integrations/pandera"
-          },
-          {
-            "title": "Dagster with Jupyter/Papermill",
-            "path": "/integrations/dagstermill"
-          }
-        ]
+        "title": "Airflow",
+        "path": "/integrations/airflow"
+      },
+      {
+        "title": "dbt",
+        "path": "/integrations/dbt"
+      },
+      {
+        "title": "Great Expectations",
+        "path": "/integrations/great-expectations"
+      },
+      {
+        "title": "Jupyter/Papermill",
+        "path": "/integrations/dagstermill"
+      },
+      {
+        "title": "Pandas",
+        "path": "/integrations/pandas"
+      },
+      {
+        "title": "Pandera",
+        "path": "/integrations/pandera"
+      },
+      {
+        "title": "PySpark",
+        "path": "/integrations/spark"
+      },
+      {
+        "title": "All integrations",
+        "path": "/integrations"
       }
     ]
   },

--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -720,11 +720,5 @@
         "isUnversioned": true
       }
     ]
-  },
-  {
-    "title": "Dagster Cloud Docs",
-    "icon": "Cloud",
-    "path": "https://docs.dagster.cloud/",
-    "isExternalLink": true
   }
 ]

--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -684,7 +684,7 @@
     "path": "/community",
     "children": [
       {
-        "title": "Code of Conduct",
+        "title": "Code of conduct",
         "path": "/community/code-of-conduct"
       },
       {
@@ -692,8 +692,14 @@
         "path": "/community/contributing"
       },
       {
-        "title": "Changing Public APIs",
-        "path": "/community/public-apis"
+        "title": "Slack",
+        "path": "https://dagster-slackin.herokuapp.com/",
+        "isExternalLink": true
+      },
+      {
+        "title": "GitHub",
+        "path": "https://github.com/dagster-io/dagster",
+        "isExternalLink": true
       }
     ]
   },

--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -720,5 +720,11 @@
         "isUnversioned": true
       }
     ]
+  },
+  {
+    "title": "Dagster Cloud Docs",
+    "icon": "Cloud",
+    "path": "https://docs.dagster.cloud/",
+    "isExternalLink": true
   }
 ]

--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -705,7 +705,7 @@
     "isUnversioned": true,
     "children": [
       {
-        "title": "Releases and Changes",
+        "title": "Releases and changes",
         "path": "/getting-started/releases"
       },
       {


### PR DESCRIPTION
This PR cleans up the sidenav in the docs:

- Consolidates some top-level items
- Removes a section from **Integrations**
- Adds **About** section
- Adds links to **Community**