### PR TITLE
Fix GQL error when loading assets whose graph name does not match their graph definition name.

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -205,8 +205,9 @@ class GrapheneAssetNode(graphene.ObjectType):
     ) -> Union[CompositeSolidDefSnap, SolidDefSnap]:
         if self._node_definition_snap is None and len(self._external_asset_node.job_names) > 0:
             node_key = check.not_none(
-                self._external_asset_node.graph_name
-                or self._external_asset_node.node_definition_name
+                self._external_asset_node.node_definition_name
+                # nodes serialized using an older Dagster version may not have node_definition_name
+                or self._external_asset_node.graph_name
                 or self._external_asset_node.op_name
             )
             self._node_definition_snap = self.get_external_pipeline().get_node_def_snap(node_key)


### PR DESCRIPTION
### Summary & Motivation

If you create two assets from the same graph, their names will be `graph_name` and `graph_name_2`. A node def snap will only exist for `graph_name`, so trying to load it for the other name will result in an error.

The `node_definition_name` is the source of truth for the true name of the definition, and should be used whenever possible. However, to retain compatibility with older versions, if this field is not present, then we will try to use the graph name or op name, which are likely to match up with the node definition name in most cases.

This PR changes the order of operations, so that node_definition_name has the highest priority.

### How I Tested These Changes

loaded dagit before the change, got error.
loaded dagit after the change, no error.
