### PR TITLE
fix master: downgrade pinned virtualenv pip in tox

### DIFF
--- a/examples/feature_graph_backed_assets/tox.ini
+++ b/examples/feature_graph_backed_assets/tox.ini
@@ -4,7 +4,7 @@ envlist = py{39, 38, 37},pylint,mypy
 [testenv]
 usedevelop = true
 setenv =
-  VIRTUALENV_PIP=22.1.2
+  VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[mypy,test]


### PR DESCRIPTION
### Summary & Motivation
unbreak master for now.

i thought we dropped py36 but it seems like it's still testing against 36
### How I Tested These Changes
