### PR TITLE
Docs search use window.location.href instead

### DIFF
--- a/docs/next/components/Search.tsx
+++ b/docs/next/components/Search.tsx
@@ -2,9 +2,7 @@ import { DocSearchModal, useDocSearchKeyboardEvents } from "@docsearch/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import Head from "next/head";
-import Link from "next/link";
 import { createPortal } from "react-dom";
-import { useRouter } from "next/router";
 
 const ACTION_KEY_DEFAULT = ["Ctrl ", "Control"];
 const ACTION_KEY_APPLE = ["⌘", "Command"];
@@ -18,15 +16,13 @@ function Hit({ hit, children }) {
       </a>
     );
   }
-  return (
-    <Link href={hit.url}>
-      <a>{children}</a>
-    </Link>
-  );
+  const onClick = () => {
+    window.location.href = hit.url;
+  };
+  return <a onClick={onClick}>{children}</a>;
 }
 
 export function Search() {
-  const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
   const searchButtonRef = useRef();
   const [initialQuery, setInitialQuery] = useState(null);
@@ -133,7 +129,7 @@ export function Search() {
             navigator={{
               navigate({ itemUrl }) {
                 setIsOpen(false);
-                router.push(itemUrl);
+                window.location.href = itemUrl;
               },
             }}
             hitComponent={Hit}


### PR DESCRIPTION
[Linear](https://linear.app/elementl/issue/DREL-328/%5Bdocs%5D-nextjs-redirect-routing-doesnt-work-with-anchors#comment-c97d097e)

Navigating via search to pages that contain redirects do not navigate to the correct section. The current implementation is to use `NextRouter` to avoid reloading all contents of the page, but the caching/redirecting is potentially interfering with navigation to the appropriate section.

In the future, we can revert back to this behavior, but for now, this PR amends the navigation behavior to do a direct reload on search so that the appropriate section will be loaded. I think the added load time is worth the search working correctly.

Test this here: https://dagster-git-claire-search-elementl.vercel.app/getting-started