### PR TITLE
Remove Legacy section from API reference page

### DIFF
--- a/docs/content/_apidocs.mdx
+++ b/docs/content/_apidocs.mdx
@@ -52,18 +52,6 @@ APIs from the core `dagster` package, divided roughly by topic:
 
 - [Internals](/\_apidocs/internals) Core internal APIs that are important if you are interested in understanding how Dagster works with an eye towards extending it: logging, executors, system storage, the Dagster instance & plugin machinery, storage, schedulers.
 
-## Legacy
-
-APIs from the core `dagster`package that are still supported, but no longer recommended.
-
-- [Solids](/\_apidocs/solids) APIs to define or decorate functions as solids, declare their inputs and outputs, compose solids with each other, as well as the datatypes that solid execution can return or yield.
-
-- [Pipelines](/\_apidocs/pipeline) APIs to define pipelines, dependencies and fan-in dependencies between solids, and aliased instances of solids.
-
-- [Modes](/\_apidocs/modes) APIs to define pipeline modes.
-
-- [Presets](/\_apidocs/presets) APIs to define configuration presets.
-
 ## Libraries
 
 Dagster also provides a growing set of optional add-on libraries to integrate with infrastructure and other components of the data ecosystem:


### PR DESCRIPTION
### Summary & Motivation

I missed this in my earlier change that ripped out legacy API docs

### How I Tested These Changes
