### PR TITLE
[dagster-databricks] more reliable stdout/stderr retrieval

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -201,16 +201,28 @@ class DatabricksPySparkStepLauncher(StepLauncher):
                 self._log_logs_from_cluster(log, databricks_run_id)
 
     def log_compute_logs(self, log, run_id, step_key):
-        stdout = self.databricks_runner.client.read_file(
-            self._dbfs_path(run_id, step_key, "stdout")
-        ).decode()
-        stderr = self.databricks_runner.client.read_file(
-            self._dbfs_path(run_id, step_key, "stderr")
-        ).decode()
-        log.info(f"Captured stdout for step {step_key}:")
-        log.info(stdout)
-        log.info(f"Captured stderr for step {step_key}:")
-        log.info(stderr)
+        try:
+            stdout = self.databricks_runner.client.read_file(
+                self._dbfs_path(run_id, step_key, "stdout")
+            ).decode()
+            log.info(f"Captured stdout for step {step_key}:")
+            log.info(stdout)
+        except Exception as e:
+            log.error(
+                f"Encountered exception {e} when attempting to load stdout logs for step {step_key}. "
+                "Check the databricks console for more info."
+            )
+        try:
+            stderr = self.databricks_runner.client.read_file(
+                self._dbfs_path(run_id, step_key, "stderr")
+            ).decode()
+            log.info(f"Captured stderr for step {step_key}:")
+            log.info(stderr)
+        except Exception as e:
+            log.error(
+                f"Encountered exception {e} when attempting to load stderr logs for step {step_key}. "
+                "Check the databricks console for more info."
+            )
 
     def step_events_iterator(self, step_context, step_key: str, databricks_run_id: int):
         """The launched Databricks job writes all event records to a specific dbfs file. This iterator

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -60,22 +60,22 @@ PICKLED_CONFIG_FILE_NAME = "config.pkl"
         "local_pipeline_package_path": Field(
             StringSource,
             is_required=False,
-            description="Absolute path to the package that contains the pipeline definition(s) "
-            "whose steps will execute remotely on Databricks. This is a path on the local "
-            "fileystem of the process executing the pipeline. Before every step run, the "
-            "launcher will zip up the code in this path, upload it to DBFS, and unzip it "
-            "into the Python path of the remote Spark process. This gives the remote process "
-            "access to up-to-date user code.",
+            description="Absolute path to root python package containing your Dagster code. If you "
+            "set this value to a directory lower than the root package, and have user relative "
+            "imports in your code (e.g. `from .foo import bar`), it's likely you'll encounter an "
+            "import error on the remote step. Before every step run, the launcher will zip up the "
+            "code in this local path, upload it to DBFS, and unzip it into the Python path of the "
+            "remote Spark process. This gives the remote process access to up-to-date user code.",
         ),
         "local_dagster_job_package_path": Field(
             StringSource,
             is_required=False,
-            description="Absolute path to the package that contains the dagster job definition(s) "
-            "whose steps will execute remotely on Databricks. This is a path on the local "
-            "fileystem of the process executing the dagster job. Before every step run, the "
-            "launcher will zip up the code in this path, upload it to DBFS, and unzip it "
-            "into the Python path of the remote Spark process. This gives the remote process "
-            "access to up-to-date user code.",
+            description="Absolute path to root python package containing your Dagster code. If you "
+            "set this value to a directory lower than the root package, and have user relative "
+            "imports in your code (e.g. `from .foo import bar`), it's likely you'll encounter an "
+            "import error on the remote step. Before every step run, the launcher will zip up the "
+            "code in this local path, upload it to DBFS, and unzip it into the Python path of the "
+            "remote Spark process. This gives the remote process access to up-to-date user code.",
         ),
         "staging_prefix": Field(
             StringSource,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
@@ -70,84 +70,84 @@ def main(
     setup_filepath,
     dagster_job_zip,
 ):
-    # Extract any zip files to a temporary directory and add that temporary directory
-    # to the site path so the contained files can be imported.
-    #
-    # We can't rely on pip or other packaging tools because the zipped files might not
-    # even be Python packages.
-    with tempfile.TemporaryDirectory() as tmp:
+    # We can use regular local filesystem APIs to access DBFS inside the Databricks runtime.
+    with open(setup_filepath, "rb") as handle:
+        databricks_config = pickle.load(handle)
 
-        with zipfile.ZipFile(dagster_job_zip) as zf:
-            zf.extractall(tmp)
-        site.addsitedir(tmp)
+    # sc and dbutils are globally defined in the Databricks runtime.
+    databricks_config.setup(dbutils, sc)  # noqa pylint: disable=undefined-variable
 
-        # We can use regular local filesystem APIs to access DBFS inside the Databricks runtime.
-        with open(setup_filepath, "rb") as handle:
-            databricks_config = pickle.load(handle)
+    with open(step_run_ref_filepath, "rb") as handle:
+        step_run_ref = pickle.load(handle)
 
-        # sc and dbutils are globally defined in the Databricks runtime.
-        databricks_config.setup(dbutils, sc)  # noqa pylint: disable=undefined-variable
+    step_run_dir = os.path.dirname(step_run_ref_filepath)
+    if step_run_ref.known_state is not None:
+        attempt_count = step_run_ref.known_state.get_retry_state().get_attempt_count(
+            step_run_ref.step_key
+        )
+    else:
+        attempt_count = 0
+    events_filepath = os.path.join(
+        step_run_dir,
+        f"{attempt_count}_{PICKLED_EVENTS_FILE_NAME}",
+    )
+    stdout_filepath = os.path.join(step_run_dir, "stdout")
+    stderr_filepath = os.path.join(step_run_dir, "stderr")
 
-        with open(step_run_ref_filepath, "rb") as handle:
-            step_run_ref = pickle.load(handle)
-        print("Running dagster job")  # noqa pylint: disable=print-call
+    # create empty files
+    with open(events_filepath, "wb"), open(stdout_filepath, "wb"), open(stderr_filepath, "wb"):
+        pass
 
-        step_run_dir = os.path.dirname(step_run_ref_filepath)
-        if step_run_ref.known_state is not None:
-            attempt_count = step_run_ref.known_state.get_retry_state().get_attempt_count(
-                step_run_ref.step_key
+    def put_events(events):
+        with gzip.open(events_filepath, "wb") as handle:
+            pickle.dump(serialize_value(events), handle)
+
+    with tempfile.TemporaryDirectory() as tmp, StringIO() as stderr, StringIO() as stdout, redirect_stderr(
+        stderr
+    ), redirect_stdout(
+        stdout
+    ):
+        try:
+            print("Running dagster job")  # noqa pylint: disable=print-call
+            # Extract any zip files to a temporary directory and add that temporary directory
+            # to the site path so the contained files can be imported.
+            #
+            # We can't rely on pip or other packaging tools because the zipped files might not
+            # even be Python packages.
+            with zipfile.ZipFile(dagster_job_zip) as zf:
+                zf.extractall(tmp)
+            site.addsitedir(tmp)
+
+            # Set up a thread to handle writing events back to the plan process, so execution doesn't get
+            # blocked on remote communication
+            events_queue = Queue()
+            event_writing_thread = Thread(
+                target=event_writing_loop,
+                kwargs=dict(events_queue=events_queue, put_events_fn=put_events),
             )
-        else:
-            attempt_count = 0
-        events_filepath = os.path.join(
-            step_run_dir,
-            f"{attempt_count}_{PICKLED_EVENTS_FILE_NAME}",
-        )
-        stdout_filepath = os.path.join(step_run_dir, "stdout")
-        stderr_filepath = os.path.join(step_run_dir, "stderr")
+            event_writing_thread.start()
 
-        # create empty files
-        with open(events_filepath, "wb"), open(stdout_filepath, "wb"), open(stderr_filepath, "wb"):
-            pass
-
-        def put_events(events):
-            with gzip.open(events_filepath, "wb") as handle:
-                pickle.dump(serialize_value(events), handle)
-
-        # Set up a thread to handle writing events back to the plan process, so execution doesn't get
-        # blocked on remote communication
-        events_queue = Queue()
-        event_writing_thread = Thread(
-            target=event_writing_loop,
-            kwargs=dict(events_queue=events_queue, put_events_fn=put_events),
-        )
-        event_writing_thread.start()
-
-        with StringIO() as stderr, StringIO() as stdout, redirect_stderr(stderr), redirect_stdout(
-            stdout
-        ):
-            try:
-                instance = external_instance_from_step_run_ref(
-                    step_run_ref, event_listener_fn=events_queue.put
-                )
-                # consume iterator
-                list(run_step_from_ref(step_run_ref, instance))
-            except Exception as e:
-                # ensure that exceptiosn make their way into stdout
-                traceback.print_exc()
-                raise e
-            finally:
-                events_queue.put(DONE)
-                event_writing_thread.join()
-                # write final stdout and stderr
-                with open(stderr_filepath, "wb") as handle:
-                    stderr_str = stderr.getvalue()
-                    sys.stderr.write(stderr_str)
-                    handle.write(stderr_str.encode())
-                with open(stdout_filepath, "wb") as handle:
-                    stdout_str = stdout.getvalue()
-                    sys.stdout.write(stdout_str)
-                    handle.write(stdout_str.encode())
+            instance = external_instance_from_step_run_ref(
+                step_run_ref, event_listener_fn=events_queue.put
+            )
+            # consume iterator
+            list(run_step_from_ref(step_run_ref, instance))
+        except Exception as e:
+            # ensure that exceptions make their way into stdout
+            traceback.print_exc()
+            raise e
+        finally:
+            events_queue.put(DONE)
+            event_writing_thread.join()
+            # write final stdout and stderr
+            with open(stderr_filepath, "wb") as handle:
+                stderr_str = stderr.getvalue()
+                sys.stderr.write(stderr_str)
+                handle.write(stderr_str.encode())
+            with open(stdout_filepath, "wb") as handle:
+                stdout_str = stdout.getvalue()
+                sys.stdout.write(stdout_str)
+                handle.write(stdout_str.encode())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary & Motivation

Addresses: https://github.com/dagster-io/dagster/issues/9039

If something goes wrong with the external databricks step other than an error within user code, we used to give a pretty unhelpful error message (basically a "file not found" error). This is because we always attempt to load the stdout/stderr logs from the databricks cluster, but we only create those output files after several things have already happened, many of which can result in the step failing.

This change:
a) makes it so that if the file reading fails, we output a slightly more helpful error message
b) creates the stdout/stderr files much earlier in the databricks_step_main.py file, making it possible to catch significantly more failures in the stderr logs. this makes (a) mostly irrelevant, as it should be very unlikely to ever have the file missing


### How I Tested These Changes

Ran stuff on an actual databricks cluster.
