### PR TITLE
Remove requirements.txt from scaffold template and examples

### DIFF
--- a/examples/assets_dbt_python/requirements.txt
+++ b/examples/assets_dbt_python/requirements.txt
@@ -1,3 +1,0 @@
--e assets_dbt_python
-# It's recommended to include environment-specific requirements in this file.
-# For example, pinning a package's version for deployment.

--- a/examples/assets_modern_data_stack/requirements.txt
+++ b/examples/assets_modern_data_stack/requirements.txt
@@ -1,3 +1,0 @@
--e assets_modern_data_stack
-# It's recommended to include environment-specific requirements in this file.
-# For example, pinning a package's version for deployment.

--- a/examples/development_to_production/development_to_production/requirements.txt
+++ b/examples/development_to_production/development_to_production/requirements.txt
@@ -1,3 +1,0 @@
--e development_to_production
-# It's recommended to include environment-specific requirements in this file.
-# For example, pinning a package's version for deployment.

--- a/examples/feature_graph_backed_assets/requirements.txt
+++ b/examples/feature_graph_backed_assets/requirements.txt
@@ -1,3 +1,0 @@
--e feature_graph_backed_assets
-# It's recommended to include environment-specific requirements in this file.
-# For example, pinning a package's version for deployment.

--- a/examples/with_airflow/requirements.txt
+++ b/examples/with_airflow/requirements.txt
@@ -1,3 +1,0 @@
--e with_airflow
-# It's recommended to include environment-specific requirements in this file.
-# For example, pinning a package's version for deployment.

--- a/examples/with_great_expectations/requirements.txt
+++ b/examples/with_great_expectations/requirements.txt
@@ -1,3 +1,0 @@
--e with_great_expectations
-# It's recommended to include environment-specific requirements in this file.
-# For example, pinning a package's version for deployment.

--- a/examples/with_pyspark/requirements.txt
+++ b/examples/with_pyspark/requirements.txt
@@ -1,3 +1,0 @@
--e with_pyspark
-# It's recommended to include environment-specific requirements in this file.
-# For example, pinning a package's version for deployment.

--- a/examples/with_pyspark_emr/requirements.txt
+++ b/examples/with_pyspark_emr/requirements.txt
@@ -1,3 +1,0 @@
--e with_pyspark_emr
-# It's recommended to include environment-specific requirements in this file.
-# For example, pinning a package's version for deployment.

--- a/python_modules/dagster/dagster/_generate/templates/PROJECT_NAME_PLACEHOLDER/README.md
+++ b/python_modules/dagster/dagster/_generate/templates/PROJECT_NAME_PLACEHOLDER/README.md
@@ -27,9 +27,6 @@ You can start writing assets in `{{ repo_name }}/assets/`. The assets are automa
 
 You can specify new Python dependencies in `setup.py`.
 
-If you have concrete requirements, such as pins, index selection, or other pip flags needed for a specific environment (e.g. cloud deployment), you can include these in `requirements.txt`.
-
-
 ### Unit testing
 
 Tests are in the `{{ repo_name }}_tests` directory and you can run tests using `pytest`:

--- a/python_modules/dagster/dagster/_generate/templates/REPO_NAME_PLACEHOLDER/requirements.txt.tmpl
+++ b/python_modules/dagster/dagster/_generate/templates/REPO_NAME_PLACEHOLDER/requirements.txt.tmpl
@@ -1,3 +1,0 @@
--e {{ repo_name }}
-# It's recommended to include environment-specific requirements in this file.
-# For example, pinning a package's version for deployment.


### PR DESCRIPTION
### Summary & Motivation
per [slack discussion](https://elementl-workspace.slack.com/archives/C03A0D72A6T/p1658515403719279), we decided to leave requirements out and only rely on setup.py for dependency.
 
### How I Tested These Changes
