### PR TITLE
Update published images for new version scheme

### DIFF
--- a/python_modules/automation/automation/docker/images/dagster-celery-k8s/Dockerfile
+++ b/python_modules/automation/automation/docker/images/dagster-celery-k8s/Dockerfile
@@ -3,14 +3,16 @@ FROM "${BASE_IMAGE}"
 
 ARG DAGSTER_VERSION
 
+# All packages are hard-pinned to `dagster`, so setting the version on just `DAGSTER` will ensure
+# compatible versions.
 RUN pip install \
     dagster==${DAGSTER_VERSION} \
-    dagster-azure==${DAGSTER_VERSION} \
-    dagster-postgres==${DAGSTER_VERSION} \
-    dagster-k8s==${DAGSTER_VERSION} \
-    dagster-aws==${DAGSTER_VERSION} \
-    dagster-celery[flower,redis,kubernetes]==${DAGSTER_VERSION} \
-    dagster-celery-k8s==${DAGSTER_VERSION} \
-    dagster-gcp==${DAGSTER_VERSION} \
-    dagster-graphql==${DAGSTER_VERSION} \
-    dagit==${DAGSTER_VERSION}
+    dagster-azure \
+    dagster-postgres \
+    dagster-k8s \
+    dagster-aws \
+    dagster-celery[flower,redis,kubernetes] \
+    dagster-celery-k8s \
+    dagster-gcp \
+    dagster-graphql \
+    dagit

--- a/python_modules/automation/automation/docker/images/dagster-k8s/Dockerfile
+++ b/python_modules/automation/automation/docker/images/dagster-k8s/Dockerfile
@@ -3,12 +3,14 @@ FROM "${BASE_IMAGE}"
 
 ARG DAGSTER_VERSION
 
+# All packages are hard-pinned to `dagster`, so setting the version on just `DAGSTER` will ensure
+# compatible versions.
 RUN pip install \
     dagster==${DAGSTER_VERSION} \
-    dagster-azure==${DAGSTER_VERSION} \
-    dagster-postgres==${DAGSTER_VERSION} \
-    dagster-k8s==${DAGSTER_VERSION} \
-    dagster-aws==${DAGSTER_VERSION} \
-    dagster-gcp==${DAGSTER_VERSION} \
-    dagster-graphql==${DAGSTER_VERSION} \
-    dagit==${DAGSTER_VERSION}
+    dagster-azure \
+    dagster-postgres \
+    dagster-k8s \
+    dagster-aws \
+    dagster-gcp \
+    dagster-graphql \
+    dagit

--- a/python_modules/automation/automation/docker/images/k8s-dagit-example/Dockerfile
+++ b/python_modules/automation/automation/docker/images/k8s-dagit-example/Dockerfile
@@ -5,15 +5,17 @@ ARG DAGSTER_VERSION
 
 COPY build_cache/ /
 
+# All packages are hard-pinned to `dagster`, so setting the version on just `DAGSTER` will ensure
+# compatible versions.
 RUN pip install \
     dagit==${DAGSTER_VERSION} \
-    dagster==${DAGSTER_VERSION} \
-    dagster-aws==${DAGSTER_VERSION} \
-    dagster-celery[flower,redis,kubernetes]==${DAGSTER_VERSION} \
-    dagster-celery-k8s==${DAGSTER_VERSION} \
-    dagster-graphql==${DAGSTER_VERSION} \
-    dagster-k8s==${DAGSTER_VERSION} \
-    dagster-postgres==${DAGSTER_VERSION}
+    dagster \
+    dagster-aws \
+    dagster-celery[flower,redis,kubernetes] \
+    dagster-celery-k8s \
+    dagster-graphql \
+    dagster-k8s \
+    dagster-postgres
 
 COPY example_project/ /
 WORKDIR /example_project

--- a/python_modules/automation/automation/docker/images/user-code-example/Dockerfile
+++ b/python_modules/automation/automation/docker/images/user-code-example/Dockerfile
@@ -3,13 +3,15 @@ FROM "${BASE_IMAGE}"
 
 ARG DAGSTER_VERSION
 
+# All packages are hard-pinned to `dagster`, so setting the version on just `DAGSTER` will ensure
+# compatible versions.
 RUN pip install \
     dagster==${DAGSTER_VERSION} \
-    dagster-postgres==${DAGSTER_VERSION} \
-    dagster-aws==${DAGSTER_VERSION} \
-    dagster-k8s==${DAGSTER_VERSION} \
-    dagster-celery[flower,redis,kubernetes]==${DAGSTER_VERSION} \
-    dagster-celery-k8s==${DAGSTER_VERSION}
+    dagster-postgres \
+    dagster-aws \
+    dagster-k8s \
+    dagster-celery[flower,redis,kubernetes] \
+    dagster-celery-k8s
 
 # Get example pipelines
 COPY build_cache/ /


### PR DESCRIPTION
### Summary & Motivation

This updates some Dockerfiles to not have all installed packages hardcode a single $DAGSTER_VERSION. This is necessary because, post-1.0, not all packages will have the same version.

### How I Tested These Changes
