### PR TITLE
[1.0] tying up loose ends

### DIFF
--- a/docs/sphinx/sections/api/apidocs/io-managers.rst
+++ b/docs/sphinx/sections/api/apidocs/io-managers.rst
@@ -42,9 +42,6 @@ Built-in IO Managers
 .. autodata:: fs_io_manager
   :annotation: IOManagerDefinition
 
-.. autodata:: custom_path_fs_io_manager
-  :annotation: IOManagerDefinition
-
 
 Input Managers (Experimental)
 ----------------------------------

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -248,7 +248,7 @@ from dagster._core.storage.event_log import (
     RunShardedEventsCursor,
 )
 from dagster._core.storage.file_manager import FileHandle, LocalFileHandle, local_file_manager
-from dagster._core.storage.fs_io_manager import custom_path_fs_io_manager, fs_io_manager
+from dagster._core.storage.fs_io_manager import fs_io_manager
 from dagster._core.storage.input_manager import InputManager, input_manager
 from dagster._core.storage.io_manager import IOManager, IOManagerDefinition, io_manager
 from dagster._core.storage.mem_io_manager import mem_io_manager

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -248,22 +248,27 @@ class JobDefinition(PipelineDefinition):
     def describe_target(self):
         return f"{self.target_type} '{self.name}'"
 
+    @public  # type: ignore
     @property
     def executor_def(self) -> ExecutorDefinition:
         return self.get_mode_definition().executor_defs[0]
 
+    @public  # type: ignore
     @property
     def resource_defs(self) -> Mapping[str, ResourceDefinition]:
         return self.get_mode_definition().resource_defs
 
+    @public  # type: ignore
     @property
     def partitioned_config(self) -> Optional[PartitionedConfig]:
         return self.get_mode_definition().partitioned_config
 
+    @public  # type: ignore
     @property
     def config_mapping(self) -> Optional[ConfigMapping]:
         return self.get_mode_definition().config_mapping
 
+    @public  # type: ignore
     @property
     def loggers(self) -> Mapping[str, LoggerDefinition]:
         return self.get_mode_definition().loggers
@@ -539,6 +544,7 @@ class JobDefinition(PipelineDefinition):
 
         return self._cached_partition_set
 
+    @public  # type: ignore
     @property
     def partitions_def(self) -> Optional[PartitionsDefinition]:
         mode = self.get_mode_definition()

--- a/python_modules/dagster/dagster/_core/definitions/materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/materialize.py
@@ -2,7 +2,6 @@ import warnings
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Set, Union
 
 import dagster._check as check
-from dagster._annotations import experimental
 from dagster._utils import merge_dicts
 from dagster._utils.backcompat import ExperimentalWarning
 
@@ -20,7 +19,6 @@ if TYPE_CHECKING:
     from ..execution.execute_in_process_result import ExecuteInProcessResult
 
 
-@experimental
 def materialize(
     assets: Sequence[Union[AssetsDefinition, SourceAsset]],
     run_config: Any = None,
@@ -72,7 +70,6 @@ def materialize(
         ).execute_in_process(run_config=run_config, instance=instance, partition_key=partition_key)
 
 
-@experimental
 def materialize_to_memory(
     assets: Sequence[Union[AssetsDefinition, SourceAsset]],
     run_config: Any = None,

--- a/python_modules/dagster/dagster/_core/definitions/materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/materialize.py
@@ -2,6 +2,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Set, Union
 
 import dagster._check as check
+from dagster._annotations import experimental
 from dagster._utils import merge_dicts
 from dagster._utils.backcompat import ExperimentalWarning
 
@@ -19,6 +20,7 @@ if TYPE_CHECKING:
     from ..execution.execute_in_process_result import ExecuteInProcessResult
 
 
+@experimental
 def materialize(
     assets: Sequence[Union[AssetsDefinition, SourceAsset]],
     run_config: Any = None,
@@ -70,6 +72,7 @@ def materialize(
         ).execute_in_process(run_config=run_config, instance=instance, partition_key=partition_key)
 
 
+@experimental
 def materialize_to_memory(
     assets: Sequence[Union[AssetsDefinition, SourceAsset]],
     run_config: Any = None,

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -579,6 +579,7 @@ class PathMetadataValue(  # type: ignore
             cls, check.opt_path_param(path, "path", default="")
         )
 
+    @public  # type: ignore
     @property
     def value(self) -> Optional[str]:
         return self.path
@@ -609,6 +610,7 @@ class JsonMetadataValue(
             raise DagsterInvalidMetadata("Value is a dictionary but is not JSON serializable.")
         return super(JsonMetadataValue, cls).__new__(cls, data)
 
+    @public  # type: ignore
     @property
     def value(self) -> Dict[str, Any]:
         return self.data
@@ -663,6 +665,7 @@ class PythonArtifactMetadataValue(
             cls, check.str_param(module, "module"), check.str_param(name, "name")
         )
 
+    @public  # type: ignore
     @property
     def value(self) -> object:
         return self

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition.py
@@ -1131,10 +1131,12 @@ class RepositoryDefinition:
         self._description = check.opt_str_param(description, "description")
         self._repository_data = check.inst_param(repository_data, "repository_data", RepositoryData)
 
+    @public  # type: ignore
     @property
     def name(self) -> str:
         return self._name
 
+    @public  # type: ignore
     @property
     def description(self) -> Optional[str]:
         return self._description
@@ -1148,6 +1150,7 @@ class RepositoryDefinition:
         """List[str]: Names of all pipelines/jobs in the repository"""
         return self._repository_data.get_pipeline_names()
 
+    @public  # type: ignore
     @property
     def job_names(self) -> List[str]:
         """List[str]: Names of all jobs in the repository"""
@@ -1190,6 +1193,7 @@ class RepositoryDefinition:
         """
         return self._repository_data.get_all_pipelines()
 
+    @public  # type: ignore
     def has_job(self, name: str) -> bool:
         """Check if a job with a given name is present in the repository.
 
@@ -1201,6 +1205,7 @@ class RepositoryDefinition:
         """
         return self._repository_data.has_job(name)
 
+    @public  # type: ignore
     def get_job(self, name: str) -> JobDefinition:
         """Get a job by name.
 
@@ -1217,6 +1222,7 @@ class RepositoryDefinition:
         """
         return self._repository_data.get_job(name)
 
+    @public  # type: ignore
     def get_all_jobs(self) -> List[JobDefinition]:
         """Return all jobs in the repository as a list.
 
@@ -1235,23 +1241,29 @@ class RepositoryDefinition:
     def get_partition_set_def(self, name: str) -> PartitionSetDefinition:
         return self._repository_data.get_partition_set(name)
 
+    @public  # type: ignore
     @property
     def schedule_defs(self) -> List[ScheduleDefinition]:
         return self._repository_data.get_all_schedules()
 
+    @public  # type: ignore
     def get_schedule_def(self, name: str) -> ScheduleDefinition:
         return self._repository_data.get_schedule(name)
 
+    @public  # type: ignore
     def has_schedule_def(self, name: str) -> bool:
         return self._repository_data.has_schedule(name)
 
+    @public  # type: ignore
     @property
     def sensor_defs(self) -> List[SensorDefinition]:
         return self._repository_data.get_all_sensors()
 
+    @public  # type: ignore
     def get_sensor_def(self, name: str) -> SensorDefinition:
         return self._repository_data.get_sensor(name)
 
+    @public  # type: ignore
     def has_sensor_def(self, name: str) -> bool:
         return self._repository_data.has_sensor(name)
 

--- a/python_modules/dagster/dagster/_core/events/log.py
+++ b/python_modules/dagster/dagster/_core/events/log.py
@@ -47,7 +47,7 @@ class EventLogEntry(
             ("run_id", PublicAttr[str]),
             ("timestamp", PublicAttr[float]),
             ("step_key", PublicAttr[Optional[str]]),
-            ("pipeline_name", PublicAttr[Optional[str]]),
+            ("pipeline_name", Optional[str]),
             ("dagster_event", PublicAttr[Optional[DagsterEvent]]),
         ],
     )

--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -15,6 +15,7 @@ from typing import (
 )
 
 import dagster._check as check
+from dagster._annotations import experimental
 from dagster._core.definitions import IPipeline, JobDefinition, PipelineDefinition
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
 from dagster._core.definitions.pipeline_definition import PipelineSubsetDefinition
@@ -420,6 +421,7 @@ class ReexecutionOptions(NamedTuple):
         return ReexecutionOptions(parent_run_id=run_id, step_selection=step_keys_to_execute)
 
 
+@experimental
 def execute_job(
     job: ReconstructableJob,
     instance: "DagsterInstance",

--- a/python_modules/dagster/dagster/_core/execution/execute_job_result.py
+++ b/python_modules/dagster/dagster/_core/execution/execute_job_result.py
@@ -1,6 +1,7 @@
 from typing import Any, Sequence
 
 import dagster._check as check
+from dagster._annotations import public
 from dagster._core.definitions import JobDefinition, NodeHandle
 from dagster._core.definitions.utils import DEFAULT_OUTPUT
 from dagster._core.errors import DagsterInvariantViolationError
@@ -41,22 +42,27 @@ class ExecuteJobResult(ExecutionResult):
         self._context = None
         return exit_result
 
+    @public  # type: ignore
     @property
     def job_def(self) -> JobDefinition:
         return self._job_def
 
+    @public  # type: ignore
     @property
     def dagster_run(self) -> DagsterRun:
         return self._dagster_run
 
+    @public  # type: ignore
     @property
     def all_events(self) -> Sequence[DagsterEvent]:
         return self._event_list
 
+    @public  # type: ignore
     @property
     def run_id(self) -> str:
         return self.dagster_run.run_id
 
+    @public
     def output_value(self, output_name: str = DEFAULT_OUTPUT) -> Any:
         """Retrieves output of top-level job, if an output is returned.
 
@@ -71,6 +77,7 @@ class ExecuteJobResult(ExecutionResult):
         """
         return super(ExecuteJobResult, self).output_value(output_name=output_name)
 
+    @public
     def output_for_node(self, node_str: str, output_name: str = DEFAULT_OUTPUT) -> Any:
         """Retrieves output value with a particular name from the run of the job.
 


### PR DESCRIPTION
Marks `execute_job` as experimental. Removes `custom_path_fs_io_manager` from imports (was already removed from __all__), which is subsumed by existing fs_io_manager functionality. Adds public-ness for some stuff that was forgot about `ExecuteJobResult`, some properties of `JobDefinition`, various metadata types.