### PR TITLE
[dagit] Expose more context values for Instance page

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppProvider.tsx
@@ -25,6 +25,7 @@ import {BrowserRouter} from 'react-router-dom';
 import {createGlobalStyle} from 'styled-components/macro';
 import {SubscriptionClient} from 'subscriptions-transport-ws';
 
+import {InstancePageContext} from '../instance/InstancePageContext';
 import {WorkspaceProvider} from '../workspace/WorkspaceContext';
 
 import {AppContext} from './AppContext';
@@ -159,6 +160,13 @@ export const AppProvider: React.FC<AppProviderProps> = (props) => {
   );
 
   const analytics = React.useMemo(() => dummyAnalytics(), []);
+  const instancePageValue = React.useMemo(
+    () => ({
+      pageTitle: 'Instance status',
+      healthTitle: 'Health',
+    }),
+    [],
+  );
 
   return (
     <AppContext.Provider value={appContextValue}>
@@ -178,7 +186,9 @@ export const AppProvider: React.FC<AppProviderProps> = (props) => {
                 <WorkspaceProvider>
                   <CustomConfirmationProvider>
                     <AnalyticsContext.Provider value={analytics}>
-                      <LayoutProvider>{props.children}</LayoutProvider>
+                      <InstancePageContext.Provider value={instancePageValue}>
+                        <LayoutProvider>{props.children}</LayoutProvider>
+                      </InstancePageContext.Provider>
                     </AnalyticsContext.Provider>
                   </CustomConfirmationProvider>
                   <CustomTooltipProvider />

--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -18,6 +18,7 @@ import {Loading} from '../ui/Loading';
 
 import {BACKFILL_TABLE_FRAGMENT, BackfillTable} from './BackfillTable';
 import {INSTANCE_HEALTH_FRAGMENT} from './InstanceHealthFragment';
+import {InstancePageContext} from './InstancePageContext';
 import {InstanceTabs} from './InstanceTabs';
 import {
   InstanceBackfillsQuery,
@@ -30,6 +31,7 @@ const PAGE_SIZE = 10;
 export const InstanceBackfills = () => {
   useTrackPageView();
 
+  const {pageTitle} = React.useContext(InstancePageContext);
   const queryData = useQuery<InstanceHealthForBackfillsQuery>(INSTANCE_HEALTH_FOR_BACKFILLS_QUERY);
 
   const {queryResult, paginationProps} = useCursorPaginatedQuery<
@@ -54,7 +56,7 @@ export const InstanceBackfills = () => {
   return (
     <>
       <PageHeader
-        title={<Heading>Instance status</Heading>}
+        title={<Heading>{pageTitle}</Heading>}
         tabs={<InstanceTabs tab="backfills" refreshState={refreshState} />}
       />
       <Loading queryResult={queryResult} allowStaleData={true}>

--- a/js_modules/dagit/packages/core/src/instance/InstanceConfig.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceConfig.tsx
@@ -18,6 +18,7 @@ import {createGlobalStyle} from 'styled-components/macro';
 import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 
+import {InstancePageContext} from './InstancePageContext';
 import {InstanceTabs} from './InstanceTabs';
 import {InstanceConfigQuery} from './types/InstanceConfigQuery';
 
@@ -36,6 +37,7 @@ const InstanceConfigStyle = createGlobalStyle`
 export const InstanceConfig = React.memo(() => {
   useTrackPageView();
 
+  const {pageTitle} = React.useContext(InstancePageContext);
   const queryResult = useQuery<InstanceConfigQuery>(INSTANCE_CONFIG_QUERY, {
     fetchPolicy: 'cache-and-network',
     notifyOnNetworkStatusChange: true,
@@ -70,7 +72,7 @@ export const InstanceConfig = React.memo(() => {
     <>
       <InstanceConfigStyle />
       <PageHeader
-        title={<Heading>Instance status</Heading>}
+        title={<Heading>{pageTitle}</Heading>}
         tabs={<InstanceTabs tab="config" refreshState={refreshState} />}
       />
       <Box

--- a/js_modules/dagit/packages/core/src/instance/InstanceHealthPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceHealthPage.tsx
@@ -7,12 +7,14 @@ import {useTrackPageView} from '../app/analytics';
 
 import {DaemonList} from './DaemonList';
 import {INSTANCE_HEALTH_FRAGMENT} from './InstanceHealthFragment';
+import {InstancePageContext} from './InstancePageContext';
 import {InstanceTabs} from './InstanceTabs';
 import {InstanceHealthQuery} from './types/InstanceHealthQuery';
 
 export const InstanceHealthPage = () => {
   useTrackPageView();
 
+  const {pageTitle} = React.useContext(InstancePageContext);
   const queryData = useQuery<InstanceHealthQuery>(INSTANCE_HEALTH_QUERY, {
     fetchPolicy: 'cache-and-network',
     notifyOnNetworkStatusChange: true,
@@ -36,7 +38,7 @@ export const InstanceHealthPage = () => {
   return (
     <>
       <PageHeader
-        title={<Heading>Instance status</Heading>}
+        title={<Heading>{pageTitle}</Heading>}
         tabs={<InstanceTabs tab="health" refreshState={refreshState} />}
       />
       <Box padding={{vertical: 16, horizontal: 24}}>

--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -41,6 +41,7 @@ import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePipelinePath} from '../workspace/workspacePath';
 
+import {InstancePageContext} from './InstancePageContext';
 import {InstanceTabs} from './InstanceTabs';
 import {JobMenu} from './JobMenu';
 import {LastRunSummary} from './LastRunSummary';
@@ -89,6 +90,8 @@ export const InstanceOverviewPage = () => {
   useTrackPageView();
 
   const [state, dispatch] = React.useReducer(reducer, initialState);
+
+  const {pageTitle} = React.useContext(InstancePageContext);
   const {allRepos, visibleRepos} = React.useContext(WorkspaceContext);
   const {searchValue} = state;
 
@@ -264,7 +267,7 @@ export const InstanceOverviewPage = () => {
     return (
       <>
         <PageHeader
-          title={<Heading>Instance status</Heading>}
+          title={<Heading>{pageTitle}</Heading>}
           tabs={<InstanceTabs tab="overview" refreshState={refreshState} />}
         />
         <Box padding={64}>
@@ -279,7 +282,7 @@ export const InstanceOverviewPage = () => {
   return (
     <>
       <PageHeader
-        title={<Heading>Instance status</Heading>}
+        title={<Heading>{pageTitle}</Heading>}
         tabs={<InstanceTabs tab="overview" refreshState={refreshState} />}
       />
       <Box

--- a/js_modules/dagit/packages/core/src/instance/InstancePageContext.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstancePageContext.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+type InstancePageContextValue = {
+  pageTitle: string;
+  healthTitle: string;
+};
+
+export const InstancePageContext = React.createContext<InstancePageContextValue>({
+  pageTitle: '',
+  healthTitle: '',
+});

--- a/js_modules/dagit/packages/core/src/instance/InstanceSchedules.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceSchedules.tsx
@@ -16,12 +16,14 @@ import {REPOSITORY_INFO_FRAGMENT} from '../workspace/RepositoryInformation';
 import {buildRepoPath, buildRepoAddress} from '../workspace/buildRepoAddress';
 
 import {INSTANCE_HEALTH_FRAGMENT} from './InstanceHealthFragment';
+import {InstancePageContext} from './InstancePageContext';
 import {InstanceTabs} from './InstanceTabs';
 import {InstanceSchedulesQuery} from './types/InstanceSchedulesQuery';
 
 export const InstanceSchedules = React.memo(() => {
   useTrackPageView();
 
+  const {pageTitle} = React.useContext(InstancePageContext);
   const queryData = useQuery<InstanceSchedulesQuery>(INSTANCE_SCHEDULES_QUERY, {
     fetchPolicy: 'cache-and-network',
     notifyOnNetworkStatusChange: true,
@@ -31,7 +33,7 @@ export const InstanceSchedules = React.memo(() => {
   return (
     <>
       <PageHeader
-        title={<Heading>Instance status</Heading>}
+        title={<Heading>{pageTitle}</Heading>}
         tabs={<InstanceTabs tab="schedules" refreshState={refreshState} />}
       />
       <Loading queryResult={queryData} allowStaleData={true}>

--- a/js_modules/dagit/packages/core/src/instance/InstanceSensors.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceSensors.tsx
@@ -16,12 +16,14 @@ import {REPOSITORY_INFO_FRAGMENT} from '../workspace/RepositoryInformation';
 import {buildRepoPath, buildRepoAddress} from '../workspace/buildRepoAddress';
 
 import {INSTANCE_HEALTH_FRAGMENT} from './InstanceHealthFragment';
+import {InstancePageContext} from './InstancePageContext';
 import {InstanceTabs} from './InstanceTabs';
 import {InstanceSensorsQuery} from './types/InstanceSensorsQuery';
 
 export const InstanceSensors = React.memo(() => {
   useTrackPageView();
 
+  const {pageTitle} = React.useContext(InstancePageContext);
   const queryData = useQuery<InstanceSensorsQuery>(INSTANCE_SENSORS_QUERY, {
     fetchPolicy: 'cache-and-network',
     notifyOnNetworkStatusChange: true,
@@ -31,7 +33,7 @@ export const InstanceSensors = React.memo(() => {
   return (
     <>
       <PageHeader
-        title={<Heading>Instance status</Heading>}
+        title={<Heading>{pageTitle}</Heading>}
         tabs={<InstanceTabs tab="sensors" refreshState={refreshState} />}
       />
       <Loading queryResult={queryData} allowStaleData={true}>

--- a/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {TabLink} from '../ui/TabLink';
 
+import {InstancePageContext} from './InstancePageContext';
 import {useCanSeeConfig} from './useCanSeeConfig';
 
 interface Props<TData> {
@@ -13,10 +14,11 @@ interface Props<TData> {
   tab: string;
 }
 
+// todo dish: Delete this once Cloud is switched to use `InstancePageContext`.
 export const InstanceTabContext = React.createContext({healthTitle: 'Daemons'});
 
 export const InstanceTabs = <TData extends Record<string, any>>(props: Props<TData>) => {
-  const {healthTitle} = React.useContext(InstanceTabContext);
+  const {healthTitle} = React.useContext(InstancePageContext);
   const {refreshState, tab} = props;
   const canSeeConfig = useCanSeeConfig();
 

--- a/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
@@ -26,6 +26,7 @@ import {
 } from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
+import {InstancePageContext} from '../instance/InstancePageContext';
 import {useCanSeeConfig} from '../instance/useCanSeeConfig';
 import {RunStatus} from '../types/globalTypes';
 import {Loading} from '../ui/Loading';
@@ -340,6 +341,7 @@ const RUNS_ROOT_QUERY = gql`
 
 const QueueDaemonAlert = () => {
   const {data} = useQuery<QueueDaemonStatusQuery>(QUEUE_DAEMON_STATUS_QUERY);
+  const {pageTitle} = React.useContext(InstancePageContext);
   const status = data?.instance.daemonHealth.daemonStatus;
   if (status?.required && !status?.healthy) {
     return (
@@ -348,7 +350,7 @@ const QueueDaemonAlert = () => {
         title="The queued run coordinator is not healthy."
         description={
           <div>
-            View <Link to="/instance/health">Instance status</Link> for details.
+            View <Link to="/instance/health">{pageTitle}</Link> for details.
           </div>
         }
       />


### PR DESCRIPTION
### Summary & Motivation

Cloud uses slightly different strings in a few places on the Instance section of Dagit. Expose a bit more via context.

### How I Tested These Changes

Load Dagit, view Instance pages. Verify correct strings. Load Cloud in its current master, verify that it still works correctly. Load Cloud with new context provider in place, verify overridden strings.
