### PR TITLE
[solid removal 1/n] Add return description to outputs for ops

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -10,7 +10,6 @@ from ..output import Out
 from ..policy import RetryPolicy
 from ..utils import DEFAULT_OUTPUT
 from .solid_decorator import DecoratedSolidFunction, NoContextDecoratedSolidFunction
-from ..inference import infer_input_props, infer_output_props
 
 if TYPE_CHECKING:
     from ..op_definition import OpDefinition
@@ -63,14 +62,9 @@ class _Op:
 
         outs: Optional[Mapping[str, Out]] = None
         if self.out is not None and isinstance(self.out, Out):
-            outs = {DEFAULT_OUTPUT: self.out.combine_with_inferred(infer_output_props(fn))}
+            outs = {DEFAULT_OUTPUT: self.out}
         elif self.out is not None:
             outs = check.mapping_param(self.out, "out", key_type=str, value_type=Out)
-
-            outs = {
-                name: out.combine_with_inferred(infer_output_props(fn))
-                for name, out in outs.items()
-            }
 
         op_def = OpDefinition(
             name=self.name,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -10,6 +10,7 @@ from ..output import Out
 from ..policy import RetryPolicy
 from ..utils import DEFAULT_OUTPUT
 from .solid_decorator import DecoratedSolidFunction, NoContextDecoratedSolidFunction
+from ..inference import infer_input_props, infer_output_props
 
 if TYPE_CHECKING:
     from ..op_definition import OpDefinition
@@ -62,9 +63,14 @@ class _Op:
 
         outs: Optional[Mapping[str, Out]] = None
         if self.out is not None and isinstance(self.out, Out):
-            outs = {DEFAULT_OUTPUT: self.out}
+            outs = {DEFAULT_OUTPUT: self.out.combine_with_inferred(infer_output_props(fn))}
         elif self.out is not None:
             outs = check.mapping_param(self.out, "out", key_type=str, value_type=Out)
+
+            outs = {
+                name: out.combine_with_inferred(infer_output_props(fn))
+                for name, out in outs.items()
+            }
 
         op_def = OpDefinition(
             name=self.name,

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -205,9 +205,11 @@ def _resolve_output_defs_from_outs(
             cast(DecoratedSolidFunction, compute_fn).decorated_fn
         )
         annotation = inferred_output_props.annotation
+        description = inferred_output_props.description
     else:
         inferred_output_props = None
         annotation = inspect.Parameter.empty
+        description = None
 
     if outs is None:
         return [OutputDefinition.create_from_inferred(inferred_output_props)]
@@ -217,7 +219,7 @@ def _resolve_output_defs_from_outs(
     if len(outs) == 1:
         name = list(outs.keys())[0]
         only_out = outs[name]
-        return [only_out.to_definition(annotation, name)]
+        return [only_out.to_definition(annotation, name, description)]
 
     output_defs = []
 
@@ -239,6 +241,8 @@ def _resolve_output_defs_from_outs(
             if annotation != inspect.Parameter.empty
             else inspect.Parameter.empty
         )
-        output_defs.append(cur_out.to_definition(annotation_type, name=name))
+        # Don't provide description when using multiple outputs. Introspection
+        # is challenging when faced with multiple inputs.
+        output_defs.append(cur_out.to_definition(annotation_type, name=name, description=None))
 
     return output_defs

--- a/python_modules/dagster/dagster/_core/definitions/output.py
+++ b/python_modules/dagster/dagster/_core/definitions/output.py
@@ -455,7 +455,9 @@ class Out(
             asset_partitions_def=output_def.asset_partitions_def,  # pylint: disable=protected-access
         )
 
-    def to_definition(self, annotation_type: type, name: Optional[str]) -> "OutputDefinition":
+    def to_definition(
+        self, annotation_type: type, name: Optional[str], description: Optional[str]
+    ) -> "OutputDefinition":
         dagster_type = (
             self.dagster_type
             if self.dagster_type is not NoValueSentinel
@@ -467,7 +469,7 @@ class Out(
         return klass(
             dagster_type=dagster_type,
             name=name,
-            description=self.description,
+            description=self.description or description,
             is_required=self.is_required,
             io_manager_key=self.io_manager_key,
             metadata=self.metadata,
@@ -479,26 +481,6 @@ class Out(
     @property
     def is_dynamic(self) -> bool:
         return False
-
-    def combine_with_inferred(self: TOut, inferred: InferredOutputProps) -> TOut:
-        dagster_type = self.dagster_type
-        if dagster_type == NoValueSentinel:
-            dagster_type = _checked_inferred_type(inferred.annotation)
-        if self.description is None:
-            description = inferred.description
-        else:
-            description = self.description
-
-        return self.__class__(
-            dagster_type=dagster_type,
-            description=description,
-            is_required=self.is_required,
-            io_manager_key=self.io_manager_key,
-            metadata=self.metadata,
-            asset_key=cast(Optional[AssetKey], self.asset_key),
-            asset_partitions=self.asset_partitions,
-            asset_partitions_def=self.asset_partitions_def,
-        )
 
 
 class DynamicOut(Out):
@@ -539,7 +521,9 @@ class DynamicOut(Out):
                 summarize_directory(file_results.collect())
     """
 
-    def to_definition(self, annotation_type: type, name: Optional[str]) -> "OutputDefinition":
+    def to_definition(
+        self, annotation_type: type, name: Optional[str], description: Optional[str]
+    ) -> "OutputDefinition":
         dagster_type = (
             self.dagster_type
             if self.dagster_type is not NoValueSentinel
@@ -549,7 +533,7 @@ class DynamicOut(Out):
         return DynamicOutputDefinition(
             dagster_type=dagster_type,
             name=name,
-            description=self.description,
+            description=self.description or description,
             is_required=self.is_required,
             io_manager_key=self.io_manager_key,
             metadata=self.metadata,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -124,6 +124,10 @@ def test_ins_dagster_types():
 def test_out():
     @op(out=Out(metadata={"x": 1}))
     def my_op() -> int:
+        """
+        Returns:
+            int: some int
+        """
         return 1
 
     assert my_op.outs == {
@@ -132,6 +136,7 @@ def test_out():
             dagster_type=Int,
             is_required=True,
             io_manager_key="io_manager",
+            description="some int",
         )
     }
     assert my_op.output_defs[0].metadata == {"x": 1}
@@ -150,9 +155,14 @@ def test_out_dagster_types():
 def test_multi_out():
     @op(out={"a": Out(metadata={"x": 1}), "b": Out(metadata={"y": 2})})
     def my_op() -> Tuple[int, str]:
+        """
+        Returns:
+            Tuple[int, str]: A tuple of values
+        """
         return 1, "q"
 
     assert len(my_op.output_defs) == 2
+    assert all([output_def.description is None for output_def in my_op.output_defs])
 
     assert my_op.outs == {
         "a": Out(


### PR DESCRIPTION
Solids are able to infer the description for single-output cases. This preserves the behavior for ops.

We can't do this for the multi-output case because it's not always clear how to split up the return statement; consider the following example:
```python
@op(out={"a": Out(), "b": Out()})
def the_op() -> Tuple[str, int]:
    """
    Returns:
         Tuple[str, int]: A string, and an int.
    """
```
The return docstring refers to both output defs, so it is not clear how to split.