### PR TITLE
docs infra: switch to use default version when not in prod (i.e. preview and local)

### DIFF
--- a/docs/next/util/useNavigation.ts
+++ b/docs/next/util/useNavigation.ts
@@ -1,5 +1,5 @@
 import masterNavigation from "../../content/_navigation.json";
-import { useVersion, latestVersion } from "./useVersion";
+import { useVersion, latestVersion, defaultVersion } from "./useVersion";
 import versionedNavigation from "../.versioned_content/_versioned_navigation.json";
 
 type NavEntry = {
@@ -59,8 +59,12 @@ export const latestAllPaths = () => {
 };
 
 export const latestAllVersionedPaths = () => {
-  // latest version, excluding paths that are
-  return flatten(versionedNavigation[latestVersion])
+  const navigationForLatestVersion =
+    defaultVersion === "master" // when it's not in prod, the latest version defaults to master
+      ? masterNavigation
+      : versionedNavigation[defaultVersion];
+
+  return flatten(navigationForLatestVersion)
     .filter((n: NavEntry) => n.path && !n.isExternalLink && !n.isUnversioned)
     .map(({ path }) => path.split("/").splice(1))
     .map((page: string[]) => {

--- a/docs/next/util/useVersion.ts
+++ b/docs/next/util/useVersion.ts
@@ -5,7 +5,7 @@ import { useRouter } from "next/router";
 
 export const latestVersion = ALL_VERSIONS[ALL_VERSIONS.length - 1];
 
-let defaultVersion = latestVersion;
+export let defaultVersion = latestVersion;
 if (process.env.NEXT_PUBLIC_VERCEL_ENV !== "production") {
   // We use NEXT_PUBLIC_VERCEL_ENV to default Vercel previews to master because
   // * NEXT_PUBLIC_VERCEL_ENV is exposed to the browser


### PR DESCRIPTION
### Summary & Motivation
this simulates the docs build in release process:
fresh pyenv
```
cd docs
pip install -r ./docs-dagster-requirements.txt --no-deps
pip install -r ./docs-build-requirements.txt
cd next
yarn build
```

this fixes the version mismatch issue surfaced in the release process ([slack](https://elementl-workspace.slack.com/archives/C03MMSAQKU7/p1659656146679369))
also improves the devX as now the previews show the master nav, previously it shows the the latest released version

### How I Tested These Changes
- local: `yarn build` green
- preview: green