### PR TITLE
Correct dagster/library version mismatch warnings

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/test_utils.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_utils.py
@@ -1,7 +1,10 @@
+import warnings
+
 import pytest
 
+import dagster.version
 from dagster._core.test_utils import environ
-from dagster._core.utils import parse_env_var
+from dagster._core.utils import check_dagster_package_version, parse_env_var
 
 
 def test_parse_env_var_no_equals():
@@ -26,3 +29,24 @@ def test_parse_env_var_containing_equals():
     env_var = "FOO_ENV_VAR=HERE_COMES_THE_EQUALS=THERE_IT_WENT"
 
     assert parse_env_var(env_var) == ("FOO_ENV_VAR", "HERE_COMES_THE_EQUALS=THERE_IT_WENT")
+
+
+def test_check_dagster_package_version(monkeypatch):
+
+    monkeypatch.setattr(dagster.version, "__version__", "1.1.0")
+
+    # Ensure no warning emitted
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        check_dagster_package_version("foo", "1.1.0")
+
+    # Lib version matching 1.1.0-- see dagster._utils.library_version_from_core_version
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        check_dagster_package_version("foo", "0.17.0")
+
+    with pytest.warns():
+        check_dagster_package_version("foo", "1.0.0")
+
+    with pytest.warns():
+        check_dagster_package_version("foo", "0.16.5")

--- a/python_modules/dagster/dagster_tests/core_tests/test_utils.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_utils.py
@@ -45,8 +45,14 @@ def test_check_dagster_package_version(monkeypatch):
         warnings.simplefilter("error")
         check_dagster_package_version("foo", "0.17.0")
 
-    with pytest.warns():
-        check_dagster_package_version("foo", "1.0.0")
+    with pytest.warns(Warning):  # minor version
+        check_dagster_package_version("foo", "1.2.0")
 
-    with pytest.warns():
-        check_dagster_package_version("foo", "0.16.5")
+    with pytest.warns(Warning):  # patch version
+        check_dagster_package_version("foo", "1.1.1")
+
+    with pytest.warns(Warning):  # minor version
+        check_dagster_package_version("foo", "0.18.0")
+
+    with pytest.warns(Warning):  # patch version
+        check_dagster_package_version("foo", "0.17.1")


### PR DESCRIPTION
### Summary & Motivation

Changes `check_dagster_package_version` warning logic so that it properly accounts for our version scheme:

- If a library is post-1.0, it must match dagster.__version__
- If a library is pre-1.0, it must have the matching library version given by this function where inputs are version parts of `dagster.__version__`:

```
lambda major, minor, patch: ".".join([0, 16 + minor, patch])
```

### How I Tested These Changes

Added unit tests for this that mock the dagster `__version__`.
