### PR TITLE
[easy]docs: update example links to guide or example dir

### DIFF
--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -34,7 +34,7 @@ Use one of our examples to get started with Dagster in just a few clicks:
 <ArticleList>
   <ArticleListItem
     title="Fully-featured project"
-    href="https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/README.md"
+    href="/guides/dagster/example_project"
   ></ArticleListItem>
   <ArticleListItem
     title="View all examples"
@@ -42,7 +42,7 @@ Use one of our examples to get started with Dagster in just a few clicks:
   ></ArticleListItem>
   <ArticleListItem
     title="dbt + Dagster"
-    href="https://github.com/dagster-io/dagster/blob/master/examples/assets_dbt_python/README.md"
+    href="https://github.com/dagster-io/dagster/blob/master/examples/assets_dbt_python"
   ></ArticleListItem>
 </ArticleList>
 


### PR DESCRIPTION
### Summary & Motivation
Update the fully-featured project link to the guide walkthrough
Update the dbt + dagster link to the example dir not the README because the github dir shows the folder structure and readme.

### How I Tested These Changes
preview