### PR TITLE
example with_airflow: pin markupsafe

### DIFF
--- a/examples/with_airflow/setup.py
+++ b/examples/with_airflow/setup.py
@@ -11,5 +11,7 @@ if __name__ == "__main__":
             "dagster_airflow",
             # See https://github.com/dagster-io/dagster/issues/2701
             "apache-airflow==1.10.10",
+            # Conflicts with `Jinja2` which is used in dagster cli that dagster_airflow depends on
+            "markupsafe<=2.0.1",
         ],
     )


### PR DESCRIPTION
### Summary & Motivation
pin markupsafe before 2.0.1 because of https://github.com/pallets/markupsafe/issues/304

im not too worried about this breaking users in early 1.0 because `dagster project from-example` downloads from master

### How I Tested These Changes
before:

<img width="524" alt="Screen Shot 2022-08-05 at 12 19 04 AM" src="https://user-images.githubusercontent.com/4531914/183023724-82cd3d60-2595-4bd1-9e0e-737e28d83556.png">
- same error in local dagit
<img width="500" alt="image" src="https://user-images.githubusercontent.com/4531914/183023857-7e9a5eac-a36f-4e6a-b07c-87ad223b7982.png">

after:
<img width="549" alt="image" src="https://user-images.githubusercontent.com/4531914/183023639-e92d1703-09f1-4808-9e15-9fdbcae59c48.png">
