### PR TITLE
Add DagsterTypeMaterializerContext and DagsterTypeLoaderContext APIs

### DIFF
--- a/docs/content/concepts/io-management/unconnected-inputs.mdx
+++ b/docs/content/concepts/io-management/unconnected-inputs.mdx
@@ -7,12 +7,13 @@ description:
 
 ## Relevant APIs
 
-| Name                                                                 | Description                                                                 |
-| -------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| <PyObject module="dagster" object="dagster_type_loader" decorator /> | The decorator used to define a Dagster Type Loader.                         |
-| <PyObject module="dagster" object="DagsterTypeLoader" />             | The base class used to specify how to load inputs that depends on the type. |
-| <PyObject module="dagster" object="input_manager" decorator />       | The decorator used to define an input manager.                              |
-| <PyObject module="dagster" object="InputManager" />                  | The base class used to specify how to load inputs.                          |
+| Name                                                                 | Description                                                                      |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| <PyObject module="dagster" object="dagster_type_loader" decorator /> | The decorator used to define a Dagster Type Loader.                              |
+| <PyObject module="dagster" object="DagsterTypeLoader" />             | The base class used to specify how to load inputs that depends on the type.      |
+| <PyObject module="dagster" object="DagsterTypeLoaderContext" />      | The context object provided to the function decorated by `@dagster_type_loader`. |
+| <PyObject module="dagster" object="input_manager" decorator />       | The decorator used to define an input manager.                                   |
+| <PyObject module="dagster" object="InputManager" />                  | The base class used to specify how to load inputs.                               |
 
 ## Overview
 
@@ -54,10 +55,24 @@ my_job.execute_in_process(
 When you have an op at the beginning of your job that operates on a dagster type that you've defined, you can write your own <PyObject module="dagster" object="DagsterTypeLoader" /> to define how to load that input via run config.
 
 ```python file=/concepts/io_management/load_custom_type_from_config.py startafter=def_start_marker endbefore=def_end_marker
+from typing import Dict, Union
+
+from dagster import (
+    DagsterTypeLoaderContext,
+    In,
+    dagster_type_loader,
+    job,
+    op,
+    usable_as_dagster_type,
+)
+
+
 @dagster_type_loader(
     config_schema={"diameter": float, "juiciness": float, "cultivar": str}
 )
-def apple_loader(_context, config):
+def apple_loader(
+    _context: DagsterTypeLoaderContext, config: Dict[str, Union[float, str]]
+):
     return Apple(
         diameter=config["diameter"],
         juiciness=config["juiciness"],

--- a/docs/sphinx/sections/api/apidocs/types.rst
+++ b/docs/sphinx/sections/api/apidocs/types.rst
@@ -60,9 +60,13 @@ Making New Types
 
 .. autoclass:: DagsterTypeLoader
 
+.. autoclass:: DagsterTypeLoaderContext
+
 .. autofunction:: dagster_type_materializer
 
 .. autoclass:: DagsterTypeMaterializer
+
+.. autoclass:: DagsterTypeMaterializerContext
 
 .. autofunction:: usable_as_dagster_type
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/load_custom_type_from_config.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/load_custom_type_from_config.py
@@ -1,11 +1,23 @@
-from dagster import In, dagster_type_loader, job, op, usable_as_dagster_type
-
-
+# isort: split
 # def_start_marker
+from typing import Dict, Union
+
+from dagster import (
+    DagsterTypeLoaderContext,
+    In,
+    dagster_type_loader,
+    job,
+    op,
+    usable_as_dagster_type,
+)
+
+
 @dagster_type_loader(
     config_schema={"diameter": float, "juiciness": float, "cultivar": str}
 )
-def apple_loader(_context, config):
+def apple_loader(
+    _context: DagsterTypeLoaderContext, config: Dict[str, Union[float, str]]
+):
     return Apple(
         diameter=config["diameter"],
         juiciness=config["juiciness"],
@@ -32,6 +44,7 @@ def my_job():
 
 
 # def_end_marker
+# isort: split
 
 
 def execute_with_config():

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -508,7 +508,6 @@ from dagster._loggers import (
 )
 from dagster._core.execution.context.system import (
     DagsterTypeLoaderContext as DagsterTypeLoaderContext,
-    DagsterTypeMaterializerContext as DagsterTypeMaterializerContext,
 )
 from dagster._serdes.serdes import (
     deserialize_value as deserialize_value,
@@ -555,6 +554,7 @@ from dagster._utils.backcompat import deprecation_warning, rename_warning
 
 if TYPE_CHECKING:
     # pylint:disable=reimported
+    from dagster._core.execution.context.system import DagsterTypeMaterializerContext
     from dagster._core.types.config_schema import DagsterTypeMaterializer, dagster_type_materializer
 
     # pylint:enable=reimported
@@ -567,6 +567,11 @@ _DEPRECATED: Final[Mapping[str, TypingTuple[str, str, str]]] = {
     ),
     "DagsterTypeMaterializer": (
         "dagster._core.types.config_schema",
+        "1.1.0",
+        "Instead, use an IOManager.",
+    ),
+    "DagsterTypeMaterializerContext": (
+        "dagster._core.execution.context.system",
         "1.1.0",
         "Instead, use an IOManager.",
     ),

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -506,6 +506,10 @@ from dagster._loggers import (
     default_system_loggers as default_system_loggers,
     json_console_logger as json_console_logger,
 )
+from dagster._core.execution.context.system import (
+    DagsterTypeLoaderContext as DagsterTypeLoaderContext,
+    DagsterTypeMaterializerContext as DagsterTypeMaterializerContext,
+)
 from dagster._serdes.serdes import (
     deserialize_value as deserialize_value,
     serialize_value as serialize_value,

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -680,7 +680,7 @@ def _create_type_materializations(
                             "Unexpected attempt to materialize with no materializer available on dagster_type"
                         )
                     materializations = materializer.materialize_runtime_values(
-                        step_context, output_spec, value
+                        step_context.get_type_materializer_context(), output_spec, value
                     )
 
                 for materialization in materializations:

--- a/python_modules/dagster/dagster/_core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/inputs.py
@@ -632,7 +632,9 @@ class FromConfig(
             dagster_type = self.get_associated_input_def(step_context.pipeline_def).dagster_type
             config_data = self.get_associated_config(step_context.resolved_run_config)
             loader = check.not_none(dagster_type.loader)
-            return loader.construct_from_config_value(step_context, config_data)
+            return loader.construct_from_config_value(
+                step_context.get_type_loader_context(), config_data
+            )
 
     def required_resource_keys(self, pipeline_def: PipelineDefinition) -> AbstractSet[str]:
         dagster_type = self.get_associated_input_def(pipeline_def).dagster_type

--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -34,7 +34,7 @@ if t.TYPE_CHECKING:
         NodeDefinition,
     )
     from dagster._core.execution.context.system import (  # pylint: disable=unused-import
-        StepExecutionContext,
+        DagsterTypeLoaderContext,
         TypeCheckContext,
     )
 
@@ -597,7 +597,7 @@ class NoneableInputSchema(DagsterTypeLoader):
         return self._schema_type
 
     def construct_from_config_value(
-        self, context: "StepExecutionContext", config_value: object
+        self, context: "DagsterTypeLoaderContext", config_value: object
     ) -> object:
         if config_value is None:
             return None


### PR DESCRIPTION
@dagster_type_loader and @dagster_type_materializer both take in a `StepExecutionContext` to their functions, which in 1.0 is in a private submodule. Rather than expose `StepExecutionContext`, this PR adds `DagsterTypeMaterializerContext` and `DagsterTypeLoaderContext` as subclasses of `StepExecutionContext` (necessary so as to not break people upgrading to 1.0). Also adds docs.