### PR TITLE
[docs] Add persistent tabs

### DIFF
--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -4,6 +4,32 @@ title: "Welcome to Dagster! | Dagster Docs"
 
 # Welcome to Dagster!
 
+## Subheading one
+
+Are you using Dagster Cloud or OSS? If you refresh the page, this stays the same!
+
+<TabGroup persistentKey="ossOrCloud">
+  <TabItem name="Open Source">
+    <p>Dagster OSS is neat</p>
+  </TabItem>
+  <TabItem name="Cloud">
+    <p>Dagster Cloud rocks</p>
+  </TabItem>
+</TabGroup>
+
+## Subheading two
+
+<TabGroup persistentKey="ossOrCloud">
+  <TabItem name="Open Source">
+    <p>Wow, some more OSS stuff!</p>
+  </TabItem>
+  <TabItem name="Cloud">
+    <p>Cool, some more Cloud stuff!</p>
+  </TabItem>
+</TabGroup>
+
+## Subheading three
+
 Dagster is an orchestrator that's designed for developing and maintaining data assets, such as tables, data sets, machine learning models, and reports.
 
 You declare functions that you want to run and the data assets that those functions produce or update. Dagster then helps you run your functions at the right time and keep your assets up-to-date.

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -4,32 +4,6 @@ title: "Welcome to Dagster! | Dagster Docs"
 
 # Welcome to Dagster!
 
-## Subheading one
-
-Are you using Dagster Cloud or OSS? If you refresh the page, this stays the same!
-
-<TabGroup persistentKey="ossOrCloud">
-  <TabItem name="Open Source">
-    <p>Dagster OSS is neat</p>
-  </TabItem>
-  <TabItem name="Cloud">
-    <p>Dagster Cloud rocks</p>
-  </TabItem>
-</TabGroup>
-
-## Subheading two
-
-<TabGroup persistentKey="ossOrCloud">
-  <TabItem name="Open Source">
-    <p>Wow, some more OSS stuff!</p>
-  </TabItem>
-  <TabItem name="Cloud">
-    <p>Cool, some more Cloud stuff!</p>
-  </TabItem>
-</TabGroup>
-
-## Subheading three
-
 Dagster is an orchestrator that's designed for developing and maintaining data assets, such as tables, data sets, machine learning models, and reports.
 
 You declare functions that you want to run and the data assets that those functions produce or update. Dagster then helps you run your functions at the right time and keep your assets up-to-date.

--- a/docs/next/components/PersistentTabContext.tsx
+++ b/docs/next/components/PersistentTabContext.tsx
@@ -1,18 +1,18 @@
-import React from "react";
+import React from 'react';
 
 export const PersistentTabContext = React.createContext<{
   getTabState: (string) => number;
   setTabState: (string, number) => void;
-}>({ getTabState: () => 0, setTabState: () => {} });
+}>({getTabState: () => 0, setTabState: () => {}});
 
-export const PersistentTabProvider: React.FC = ({ children }) => {
-  const [tabState, setTabState] = React.useState<{ [key: string]: number }>({});
+export const PersistentTabProvider: React.FC = ({children}) => {
+  const [tabState, setTabState] = React.useState<{[key: string]: number}>({});
 
-  const windowExists = typeof window !== "undefined";
+  const windowExists = typeof window !== 'undefined';
   React.useEffect(() => {
     console.log(windowExists);
     if (windowExists) {
-      const ts = localStorage.getItem("persistentTabStates");
+      const ts = localStorage.getItem('persistentTabStates');
       if (ts) {
         setTabState(JSON.parse(ts));
       }
@@ -20,10 +20,10 @@ export const PersistentTabProvider: React.FC = ({ children }) => {
   }, [setTabState, windowExists]);
 
   const setTabStateAndPersist = (key: string, value: number) => {
-    const newTabState = { ...tabState, [key]: value };
+    const newTabState = {...tabState, [key]: value};
     setTabState(newTabState);
-    if (typeof window !== "undefined") {
-      localStorage.setItem("persistentTabStates", JSON.stringify(newTabState));
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('persistentTabStates', JSON.stringify(newTabState));
     }
   };
 

--- a/docs/next/components/PersistentTabContext.tsx
+++ b/docs/next/components/PersistentTabContext.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+export const PersistentTabContext = React.createContext<{
+  getTabState: (string) => number;
+  setTabState: (string, number) => void;
+}>({ getTabState: () => 0, setTabState: () => {} });
+
+export const PersistentTabProvider: React.FC = ({ children }) => {
+  const [tabState, setTabState] = React.useState<{ [key: string]: number }>({});
+
+  const windowExists = typeof window !== "undefined";
+  React.useEffect(() => {
+    console.log(windowExists);
+    if (windowExists) {
+      const ts = localStorage.getItem("persistentTabStates");
+      if (ts) {
+        setTabState(JSON.parse(ts));
+      }
+    }
+  }, [setTabState, windowExists]);
+
+  const setTabStateAndPersist = (key: string, value: number) => {
+    const newTabState = { ...tabState, [key]: value };
+    setTabState(newTabState);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("persistentTabStates", JSON.stringify(newTabState));
+    }
+  };
+
+  return (
+    <PersistentTabContext.Provider
+      value={{
+        getTabState: (key: string) => tabState[key] || 0,
+        setTabState: setTabStateAndPersist,
+      }}
+    >
+      {children}
+    </PersistentTabContext.Provider>
+  );
+};

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -8,6 +8,7 @@
 import path from 'path';
 
 import {Tab, Transition} from '@headlessui/react';
+import {PersistentTabContext} from 'components/PersistentTabContext';
 import NextImage from 'next/image';
 import NextLink from 'next/link';
 import React, {useContext, useRef, useState} from 'react';
@@ -17,7 +18,6 @@ import {useVersion} from '../../util/useVersion';
 import Icons from '../Icons';
 import Link from '../Link';
 
-import {PersistentTabContext} from 'components/PersistentTabContext';
 import 'react-medium-image-zoom/dist/styles.css';
 import BDCreateConfigureAgent from './includes/dagster-cloud/BDCreateConfigureAgent.mdx';
 import GenerateAgentToken from './includes/dagster-cloud/GenerateAgentToken.mdx';

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -17,9 +17,10 @@ import {useVersion} from '../../util/useVersion';
 import Icons from '../Icons';
 import Link from '../Link';
 
+import {PersistentTabContext} from 'components/PersistentTabContext';
+import 'react-medium-image-zoom/dist/styles.css';
 import BDCreateConfigureAgent from './includes/dagster-cloud/BDCreateConfigureAgent.mdx';
 import GenerateAgentToken from './includes/dagster-cloud/GenerateAgentToken.mdx';
-import 'react-medium-image-zoom/dist/styles.css';
 
 export const SearchIndexContext = React.createContext(null);
 
@@ -491,40 +492,57 @@ function classNames(...classes) {
   return classes.filter(Boolean).join(' ');
 }
 
-const TabGroup = ({children}) => {
+const TabGroup: React.FC<{children: any; persistentKey?: string}> = ({children, persistentKey}) => {
+  const contents = (
+    <>
+      <Tab.List className="flex space-x-2 m-2">
+        {React.Children.map(children, (child, idx) => {
+          return (
+            <Tab
+              key={idx}
+              className={({selected}) =>
+                classNames(
+                  'w-full py-3 text-sm font-bold leading-5',
+                  'focus:outline-none border-gray-200',
+                  selected
+                    ? 'border-b-2 border-primary-500 text-primary-500'
+                    : 'border-b hover:border-gray-500 hover:text-gray-700',
+                )
+              }
+            >
+              {child?.props?.name}
+            </Tab>
+          );
+        })}
+      </Tab.List>
+      <Tab.Panels>
+        {React.Children.map(children, (child, idx) => {
+          return (
+            <Tab.Panel key={idx} className={classNames('p-3')}>
+              {child.props.children}
+            </Tab.Panel>
+          );
+        })}
+      </Tab.Panels>
+    </>
+  );
+
   return (
     <div className="w-full px-2 py-2 sm:px-0">
-      <Tab.Group>
-        <Tab.List className="flex space-x-2 m-2">
-          {React.Children.map(children, (child, idx) => {
-            return (
-              <Tab
-                key={idx}
-                className={({selected}) =>
-                  classNames(
-                    'w-full py-3 text-sm font-bold leading-5',
-                    'focus:outline-none border-gray-200',
-                    selected
-                      ? 'border-b-2 border-primary-500 text-primary-500'
-                      : 'border-b hover:border-gray-500 hover:text-gray-700',
-                  )
-                }
-              >
-                {child?.props?.name}
-              </Tab>
-            );
-          })}
-        </Tab.List>
-        <Tab.Panels>
-          {React.Children.map(children, (child, idx) => {
-            return (
-              <Tab.Panel key={idx} className={classNames('p-3')}>
-                {child.props.children}
-              </Tab.Panel>
-            );
-          })}
-        </Tab.Panels>
-      </Tab.Group>
+      {persistentKey ? (
+        <PersistentTabContext.Consumer>
+          {(context) => (
+            <Tab.Group
+              selectedIndex={context.getTabState(persistentKey)}
+              onChange={(idx) => context.setTabState(persistentKey, idx)}
+            >
+              {contents}
+            </Tab.Group>
+          )}
+        </PersistentTabContext.Consumer>
+      ) : (
+        <Tab.Group>{contents}</Tab.Group>
+      )}
     </div>
   );
 };

--- a/docs/next/pages/_app.tsx
+++ b/docs/next/pages/_app.tsx
@@ -3,12 +3,11 @@ import '../styles/prism.css';
 
 import {useVersion} from 'util/useVersion';
 
+import {PersistentTabProvider} from 'components/PersistentTabContext';
 import {DefaultSeo} from 'next-seo';
 import {AppProps} from 'next/app';
 import {useRouter} from 'next/router';
 import * as React from 'react';
-import {useEffect} from 'react';
-import {PersistentTabProvider} from 'components/PersistentTabContext';
 
 import Layout from '../layouts/MainLayout';
 import * as gtag from '../util/gtag';

--- a/docs/next/pages/_app.tsx
+++ b/docs/next/pages/_app.tsx
@@ -7,6 +7,8 @@ import {DefaultSeo} from 'next-seo';
 import {AppProps} from 'next/app';
 import {useRouter} from 'next/router';
 import * as React from 'react';
+import {useEffect} from 'react';
+import {PersistentTabProvider} from 'components/PersistentTabContext';
 
 import Layout from '../layouts/MainLayout';
 import * as gtag from '../util/gtag';
@@ -57,9 +59,11 @@ const MyApp = ({Component, pageProps}: AppProps) => {
   return (
     <>
       <DefaultSeo canonical={canonicalUrl} {...DEFAULT_SEO} />
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
+      <PersistentTabProvider>
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
+      </PersistentTabProvider>
     </>
   );
 };


### PR DESCRIPTION
## Summary

Adds the option to supply a `TabGroup` with a `persistentKey`. Groups which have this key set will retain their selections on refresh, or between multiple different pages.

Multiple groups with the same key will share a selected tab state, making it a good way to e.g. persist selection between OSS/Cloud.

e.g.

```mdx
## Subheading one

Are you using Dagster Cloud or OSS? If you refresh the page, this stays the same!

<TabGroup
  persistentKey="ossOrCloud" 
  entries={[
    { name: "Open Source", content: <p>Dagster OSS is neat</p> },
    { name: "Cloud", content: <p>Dagster Cloud rocks</p> }
  ]}
/>


## Subheading two

<TabGroup
  persistentKey="ossOrCloud"
  entries={[    
    { name: "Open Source", content: <p>Wow, some more OSS stuff</p> },
    { name: "Cloud", content: <p>Cool, some more cloud stuff</p> }
  ]}
/>
```

## Test Plan

See vercel build  https://dagster-git-benpankow-add-persistent-tabs-component-elementl.vercel.app/getting-started