### PR TITLE
update sensor keys in fully featured example

### DIFF
--- a/examples/project_fully_featured/project_fully_featured/sensors/hn_tables_updated_sensor.py
+++ b/examples/project_fully_featured/project_fully_featured/sensors/hn_tables_updated_sensor.py
@@ -25,7 +25,7 @@ def make_hn_tables_updated_sensor(job) -> SensorDefinition:
         comments_event_records = context.instance.get_event_records(
             EventRecordsFilter(
                 event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                asset_key=AssetKey(["snowflake", "hackernews", "comments"]),
+                asset_key=AssetKey(["snowflake", "core", "comments"]),
                 after_cursor=comments_cursor,
             ),
             ascending=False,
@@ -34,7 +34,7 @@ def make_hn_tables_updated_sensor(job) -> SensorDefinition:
         stories_event_records = context.instance.get_event_records(
             EventRecordsFilter(
                 event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                asset_key=AssetKey(["snowflake", "hackernews", "stories"]),
+                asset_key=AssetKey(["snowflake", "core", "stories"]),
                 after_cursor=stories_cursor,
             ),
             ascending=False,


### PR DESCRIPTION
### Summary & Motivation
The fully featured example sensors do not kick off due to obsolete asset keys mentioned [here](https://github.com/dagster-io/dagster/blob/e43a821334354b8f9002868578f62d0a348c9da6/examples/project_fully_featured/project_fully_featured/sensors/hn_tables_updated_sensor.py#L28)
and [here](https://github.com/dagster-io/dagster/blob/e43a821334354b8f9002868578f62d0a348c9da6/examples/project_fully_featured/project_fully_featured/sensors/hn_tables_updated_sensor.py#L37)
The correct keys based on asset [here](https://github.com/dagster-io/dagster/blob/e43a821334354b8f9002868578f62d0a348c9da6/examples/project_fully_featured/project_fully_featured/assets/core/items.py#L66) are  [snowflake, core, comments] or [snowflake, core, stories] 

### How I Tested These Changes
Running the example locally with these changes did trigger the sensors

<img width="1100" alt="Screen Shot 2022-08-06 at 10 05 11 AM" src="https://user-images.githubusercontent.com/1118244/183252307-c99561c7-1bbb-4e12-a973-0782778dbbf4.png">

