### PR TITLE
[dagit] Rename `solid_selection` tag to `op_selection`

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTag.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTag.tsx
@@ -6,6 +6,7 @@ export enum DagsterTag {
   Namespace = 'dagster/',
   Backfill = 'dagster/backfill',
   SolidSelection = 'dagster/solid_selection',
+  OpSelection = 'dagster/op_selection',
   StepSelection = 'dagster/step_selection',
   PartitionSet = 'dagster/partition_set',
   Partition = 'dagster/partition',

--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
@@ -13,6 +13,7 @@ import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {RunStatus, RunsFilter} from '../types/globalTypes';
 import {DagsterRepoOption, useRepositoryOptions} from '../workspace/WorkspaceContext';
 
+import {canAddTagToFilter} from './RunTags';
 import {
   RunsSearchSpaceQuery,
   RunsSearchSpaceQuery_pipelineRunTags,
@@ -157,6 +158,7 @@ function searchSuggestionsForRuns(
       values: () => {
         const all: string[] = [];
         [...(pipelineRunTags || [])]
+          .filter(({key}) => canAddTagToFilter(key))
           .sort((a, b) => a.key.localeCompare(b.key))
           .forEach((t) => t.values.forEach((v) => all.push(`${t.key}=${v}`)));
         return all;


### PR DESCRIPTION
### Summary & Motivation

Rename `solid_selection` tags to `op_selection`, disallow them from being added to the run filter via the tag hover interaction, and remove them from the run filter typeahead.

<img width="355" alt="Screen Shot 2022-08-07 at 11 26 35 AM" src="https://user-images.githubusercontent.com/2823852/183301230-529799b6-4427-4881-a942-d38b8100d5a9.png">


### How I Tested These Changes

View runs list in Dagit. Verify that `solid_selection: *` now renders as `op_selection: *`, that on hover the "Add to filter" option is not present for these tags (but is present for other tags) and that there is no `tag:dagster/...` typeahead option for these tags in the run filter.
