### PR TITLE
[dagit] Update WorkspaceLocationEntry mock status

### DIFF
--- a/js_modules/dagit/packages/core/src/testing/defaultMocks.ts
+++ b/js_modules/dagit/packages/core/src/testing/defaultMocks.ts
@@ -1,5 +1,7 @@
 import faker from 'faker';
 
+import {RepositoryLocationLoadStatus} from '../types/globalTypes';
+
 export const hyphenatedName = (wordCount = 2) =>
   faker.random.words(wordCount).replace(/ /g, '-').toLowerCase();
 const randomId = () => faker.datatype.uuid();
@@ -56,6 +58,7 @@ export const defaultMocks = {
   }),
   WorkspaceLocationEntry: () => ({
     id: randomId,
+    loadStatus: () => RepositoryLocationLoadStatus.LOADED,
   }),
   Schedule: () => ({
     id: hyphenatedName,


### PR DESCRIPTION
### Summary & Motivation

Update the `WorkspaceLocationEntry.loadStatus` default mock to be `LOADED` so that we don't end up with a dice roll on that value during test runs and see `LOADING` states where we don't expect them.

Resolves sporadic failures like https://buildkite.com/dagster/dagster/builds/34260#01827a82-cf18-49d5-b1b4-f2e3ed9f9053.

### How I Tested These Changes

`yarn jest` a whole bunch of times.
