### PR TITLE
dagster project scaffold: move dagit and pytest to extras_require 1/2

### DIFF
--- a/docs/content/getting-started/create-new-project.mdx
+++ b/docs/content/getting-started/create-new-project.mdx
@@ -65,7 +65,7 @@ For more info about the examples, visit the [Dagster GitHub repository](https://
 The newly generated `my-dagster-project` directory is a fully functioning [Python package](https://docs.python.org/3/tutorial/modules.html#packages) and can be installed with `pip`. To install it as a package and its Python dependencies, run:
 
 ```bash
-pip install -e .
+pip install -e ".[dev]"
 ```
 
 <Note>

--- a/python_modules/dagster/dagster/_generate/templates/PROJECT_NAME_PLACEHOLDER/README.md
+++ b/python_modules/dagster/dagster/_generate/templates/PROJECT_NAME_PLACEHOLDER/README.md
@@ -7,7 +7,7 @@ This is a [Dagster](https://dagster.io/) project scaffolded with [`dagster proje
 First, install your Dagster repository as a Python package. By using the --editable flag, pip will install your repository in ["editable mode"](https://pip.pypa.io/en/latest/topics/local-project-installs/#editable-installs) so that as you develop, local code changes will automatically apply.
 
 ```bash
-pip install -e .
+pip install -e ".[dev]"
 ```
 
 Then, start the Dagit web server:

--- a/python_modules/dagster/dagster/_generate/templates/REPO_NAME_PLACEHOLDER/setup.py.tmpl
+++ b/python_modules/dagster/dagster/_generate/templates/REPO_NAME_PLACEHOLDER/setup.py.tmpl
@@ -6,7 +6,6 @@ if __name__ == "__main__":
         packages=find_packages(exclude=["{{ repo_name }}_tests"]),
         install_requires=[
             "dagster",
-            "dagit",
-            "pytest",
         ],
+        extras_require={"dev": ["dagit", "pytest"]},
     )


### PR DESCRIPTION
### Summary & Motivation
as part of dogfooding to deploy examples to cloud, when we are installing the example as a python package, i.e. using setup.py to install deps, i realized dagit and pytest aren't deps of the project itself and dagit is a heavy dep - they are more of a "dev" dependencies. so i moved them to "dev" and updated the readme and doc to refer to `pip install ".[dev]"` (alternatively, we could get rid of them, but then in the readme, we'll need to mention `pip install dagit`. i feel this pr's path is easier for new users.

### How I Tested These Changes
scaffolded a new project. `pip install -e ".[dev]"` worked 
