### PR TITLE
dagster examples: move dagit and pytest to extras_require 2/2

### DIFF
--- a/examples/assets_dbt_python/README.md
+++ b/examples/assets_dbt_python/README.md
@@ -13,7 +13,7 @@ dagster project from-example --name my-dagster-project --example assets_dbt_pyth
 To install this example and its Python dependencies, run:
 
 ```bash
-pip install -e .
+pip install -e ".[dev]"
 ```
 
 Once you've done this, you can run:

--- a/examples/assets_dbt_python/setup.py
+++ b/examples/assets_dbt_python/setup.py
@@ -7,13 +7,12 @@ if __name__ == "__main__":
         package_data={"assets_dbt_python": ["dbt_project/*"]},
         install_requires=[
             "dagster",
-            "dagit",
             "dagster-dbt",
             "pandas",
             "numpy",
             "scipy",
             "dbt-core",
             "dbt-duckdb",
-            "pytest",
         ],
+        extras_require={"dev": ["dagit", "pytest"]},
     )

--- a/examples/assets_modern_data_stack/README.md
+++ b/examples/assets_modern_data_stack/README.md
@@ -14,7 +14,7 @@ dagster project from-example --name my-dagster-project --example assets_modern_d
 To install this example and its Python dependencies, run:
 
 ```bash
-pip install -e .
+pip install -e ".[dev]"
 ```
 
 Once you've done this, you can run:

--- a/examples/assets_modern_data_stack/setup.py
+++ b/examples/assets_modern_data_stack/setup.py
@@ -7,7 +7,6 @@ if __name__ == "__main__":
         package_data={"assets_modern_data_stack": ["dbt_project/*"]},
         install_requires=[
             "dagster",
-            "dagit",
             "dagster-airbyte",
             "dagster-dbt",
             "dagster-postgres",
@@ -17,4 +16,5 @@ if __name__ == "__main__":
             "dbt-core",
             "dbt-postgres",
         ],
+        extras_require={"dev": ["dagit", "pytest"]},
     )

--- a/examples/assets_pandas_pyspark/README.md
+++ b/examples/assets_pandas_pyspark/README.md
@@ -16,7 +16,7 @@ dagster project from-example --name my-dagster-project --example assets_pandas_p
 To install this example and its Python dependencies, run:
 
 ```bash
-pip install -e .
+pip install -e ".[dev]"
 ```
 
 Once you've done this, you can run:

--- a/examples/assets_pandas_pyspark/setup.py
+++ b/examples/assets_pandas_pyspark/setup.py
@@ -6,11 +6,12 @@ if __name__ == "__main__":
         packages=find_packages(exclude=["assets_pandas_pyspark_tests"]),
         install_requires=[
             "dagster",
-            "dagit",
-            "pytest",
             "pandas",
             "pyspark",
             # "pyarrow",
         ],
-        extras_require={"test": ["pandas", "pyarrow; python_version < '3.9'", "pyspark"]},
+        extras_require={
+            "dev": ["dagit", "pytest"],
+            "test": ["pandas", "pyarrow; python_version < '3.9'", "pyspark"],
+        },
     )

--- a/examples/assets_pandas_type_metadata/README.md
+++ b/examples/assets_pandas_type_metadata/README.md
@@ -21,7 +21,7 @@ dagster project from-example --name my-dagster-project --example assets_pandas_t
 To install this example and its Python dependencies, run:
 
 ```bash
-pip install -e .
+pip install -e ".[dev]"
 ```
 
 Once you've done this, you can run:

--- a/examples/assets_pandas_type_metadata/setup.py
+++ b/examples/assets_pandas_type_metadata/setup.py
@@ -6,13 +6,12 @@ if __name__ == "__main__":
         packages=find_packages(exclude=["assets_pandas_type_metadata_tests"]),
         install_requires=[
             "dagster",
-            "dagit",
             "dagster-pandera",
             "jupyterlab",
             "matplotlib",
             "seaborn",
             "pandera",
             "pandas",
-            "pytest",
         ],
+        extras_require={"dev": ["dagit", "pytest"]},
     )

--- a/examples/development_to_production/README.md
+++ b/examples/development_to_production/README.md
@@ -13,7 +13,7 @@ To run this example locally
 ```
 dagster project from-example --name my-dagster-project --example development_to_production
 cd my-dagster-project
-pip install -e .
+pip install -e ".[dev]"
 
 # Load it in the web UI
 dagit -w workspace.yaml

--- a/examples/development_to_production/setup.py
+++ b/examples/development_to_production/setup.py
@@ -9,7 +9,6 @@ setup(
         "dagster",
         "dagster-snowflake",
         "dagster-snowflake-pandas",
-        "dagit",
         "pandas",
         "requests",
     ],  # external packages as dependencies
@@ -24,4 +23,5 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
+    extras_require={"dev": ["dagit", "pytest"]},
 )

--- a/examples/feature_graph_backed_assets/README.md
+++ b/examples/feature_graph_backed_assets/README.md
@@ -11,3 +11,17 @@ This example creates an asset containing airline passenger info and parses the d
 ```bash
 dagster project from-example --name my-dagster-project --example feature_graph_backed_assets
 ```
+
+To install this example and its Python dependencies, run:
+
+```bash
+pip install -e ".[dev]"
+```
+
+Once you've done this, you can run:
+
+```
+dagit
+```
+
+to view this example in Dagster's UI, Dagit.

--- a/examples/feature_graph_backed_assets/setup.py
+++ b/examples/feature_graph_backed_assets/setup.py
@@ -4,7 +4,7 @@ if __name__ == "__main__":
     setup(
         name="feature_graph_backed_assets",
         packages=find_packages(exclude=["feature_graph_backed_assets_tests"]),
-        install_requires=["dagster", "dagit", "pytest", "pandas"],
+        install_requires=["dagster", "pandas"],
         license="Apache-2.0",
         description="Dagster example of op and graph-backed assets.",
         url="https://github.com/dagster-io/dagster/tree/master/examples/feature_graph_backed_assets",
@@ -15,4 +15,5 @@ if __name__ == "__main__":
             "License :: OSI Approved :: Apache Software License",
             "Operating System :: OS Independent",
         ],
+        extras_require={"dev": ["dagit", "pytest"]},
     )

--- a/examples/project_fully_featured/README.md
+++ b/examples/project_fully_featured/README.md
@@ -23,7 +23,7 @@ dagster project from-example --name my-dagster-project --example project_fully_f
 To install this example and its Python dependencies, run:
 
 ```bash
-pip install -e .
+pip install -e ".[dev]"
 ```
 
 Once you've done this, you can run:

--- a/examples/project_fully_featured/setup.py
+++ b/examples/project_fully_featured/setup.py
@@ -26,7 +26,6 @@ setup(
         "dbt-core",
         "dbt-duckdb",
         "dbt-snowflake",
-        "dagit",
         "duckdb!=0.3.3",  # missing wheels
         "mock",
         # DataFrames were not written to Snowflake, causing errors
@@ -41,5 +40,5 @@ setup(
         "sklearn",
         "snowflake-sqlalchemy",
     ],
-    extras_require={"tests": ["mypy", "pylint", "pytest"]},
+    extras_require={"dev": ["dagit", "pytest"], "tests": ["mypy", "pylint", "pytest"]},
 )

--- a/examples/with_airflow/setup.py
+++ b/examples/with_airflow/setup.py
@@ -6,12 +6,11 @@ if __name__ == "__main__":
         packages=find_packages(exclude=["with_airflow_tests"]),
         install_requires=[
             "dagster",
-            "dagit",
-            "pytest",
             "dagster_airflow",
             # See https://github.com/dagster-io/dagster/issues/2701
             "apache-airflow==1.10.10",
             # Conflicts with `Jinja2` which is used in dagster cli that dagster_airflow depends on
             "markupsafe<=2.0.1",
         ],
+        extras_require={"dev": ["dagit", "pytest"]},
     )

--- a/examples/with_great_expectations/setup.py
+++ b/examples/with_great_expectations/setup.py
@@ -6,9 +6,8 @@ if __name__ == "__main__":
         packages=find_packages(exclude=["with_great_expectations_tests"]),
         install_requires=[
             "dagster",
-            "dagit",
-            "pytest",
             "dagster-ge",
             "great_expectations>=0.14.12",  # pinned because pip is using the cached wheel for 0.13.14
         ],
+        extras_require={"dev": ["dagit", "pytest"]},
     )

--- a/examples/with_pyspark/setup.py
+++ b/examples/with_pyspark/setup.py
@@ -6,9 +6,8 @@ if __name__ == "__main__":
         packages=find_packages(exclude=["with_pyspark_tests"]),
         install_requires=[
             "dagster",
-            "dagit",
-            "pytest",
             "dagster-spark",
             "dagster-pyspark",
         ],
+        extras_require={"dev": ["dagit", "pytest"]},
     )

--- a/examples/with_pyspark_emr/setup.py
+++ b/examples/with_pyspark_emr/setup.py
@@ -6,9 +6,8 @@ if __name__ == "__main__":
         packages=find_packages(exclude=["with_pyspark_emr_tests"]),
         install_requires=[
             "dagster",
-            "dagit",
-            "pytest",
             "dagster-aws",
             "dagster-pyspark",
         ],
+        extras_require={"dev": ["dagit", "pytest"]},
     )


### PR DESCRIPTION
### Summary & Motivation
follow up the previous stack (1/2). i moved all the dagit and pytest into extras_require and updated the readmes
### How I Tested These Changes
