### PR TITLE
[dagit] Allow searching by op_selection

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -294,7 +294,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
               ...(currentSession.solidSelectionQuery
                 ? [
                     {
-                      key: DagsterTag.SolidSelection,
+                      key: DagsterTag.OpSelection,
                       value: currentSession.solidSelectionQuery,
                     },
                   ]

--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
@@ -13,7 +13,6 @@ import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {RunStatus, RunsFilter} from '../types/globalTypes';
 import {DagsterRepoOption, useRepositoryOptions} from '../workspace/WorkspaceContext';
 
-import {canAddTagToFilter} from './RunTags';
 import {
   RunsSearchSpaceQuery,
   RunsSearchSpaceQuery_pipelineRunTags,
@@ -158,7 +157,6 @@ function searchSuggestionsForRuns(
       values: () => {
         const all: string[] = [];
         [...(pipelineRunTags || [])]
-          .filter(({key}) => canAddTagToFilter(key))
           .sort((a, b) => a.key.localeCompare(b.key))
           .forEach((t) => t.values.forEach((v) => all.push(`${t.key}=${v}`)));
         return all;


### PR DESCRIPTION
### Summary & Motivation

Restore `solid_selection` tag rendering, update Launchpad to use `op_selection` for future runs.

Thus, `solid_selection` and `op_selection` may appear side by side in the run list and the filter input, and @dpeng817 will look at changing the backend to handle filtering.

### How I Tested These Changes

Perform a run with the new `op_selection` key, see it on the Run page and the Runs list. Verify that I can add the tag and filter by it. Verify that `solid_selection` tags also behave as before, addable and filterable.
