### PR TITLE
interpret solid selection as op selection for querying runs.

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/in_memory.py
@@ -408,7 +408,10 @@ class InMemoryRunStorage(RunStorage):
 
 
 def tags_match_filter_backcompat(filter_tags: Dict[str, Any], run_tags: Dict[str, Any]) -> bool:
-    # Handle backcompat between solid selection and op selection tags
+    # Pre-1.0, we recorded op selections under the
+    # SOLID_SELECTION_TAG on jobs. In order to get historical runs
+    # to show up when filtering, we check for both
+    # SOLID_SELECTION_TAG and OP_SELECTION_TAG.
     if OP_SELECTION_TAG in filter_tags:
         if OP_SELECTION_TAG not in run_tags and SOLID_SELECTION_TAG not in run_tags:
             return False

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -29,6 +29,8 @@ STEP_SELECTION_TAG = "{prefix}step_selection".format(prefix=SYSTEM_TAG_PREFIX)
 
 SOLID_SELECTION_TAG = "{prefix}solid_selection".format(prefix=SYSTEM_TAG_PREFIX)
 
+OP_SELECTION_TAG = "{prefix}op_selection".format(prefix=SYSTEM_TAG_PREFIX)
+
 PRESET_NAME_TAG = "{prefix}preset_name".format(prefix=SYSTEM_TAG_PREFIX)
 
 GRPC_INFO_TAG = "{prefix}grpc_info".format(prefix=HIDDEN_TAG_PREFIX)


### PR DESCRIPTION
Until https://github.com/dagster-io/dagster/pull/9280 lands, we have been writing selection tags as `solid_selection` instead of `op_selection`. We want to be able to filter runs s.t. when searching for the op_selection tag, historic runs which still stored using the solid_selection tag, show up.

In order to test this; I created some fresh runs on current-master in my local dagster installation using selection; which persisted those runs with the `solid_selection` tag clearly visible. I then rebased Dish's change from https://github.com/dagster-io/dagster/pull/9280 on top of this PR, and re-launched another run, which launched with the `op_selection` tag. Searching by the op_selection tag surfaces the runs with a matching solid selection:
<img width="1588" alt="Screen Shot 2022-08-10 at 10 41 25 AM" src="https://user-images.githubusercontent.com/17576880/183980759-e7acdff3-7c6f-4d02-b59d-2bc81d3a46e9.png">

Searching by solid_selection only surfaces items with the solid_selection tag, which I think is fine.

Requires a companion PR for dagster-cloud; https://github.com/dagster-io/internal/pull/3317
