### PR TITLE
fix InputContext partition methods for when upstream asset is not par…

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_partitions.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import dagster._check as check
 from dagster._core.definitions import AssetsDefinition
 
@@ -10,7 +12,7 @@ def get_upstream_partitions_for_partition_range(
     downstream_assets_def: AssetsDefinition,
     upstream_partitions_def: PartitionsDefinition,
     upstream_asset_key: AssetKey,
-    downstream_partition_key_range: PartitionKeyRange,
+    downstream_partition_key_range: Optional[PartitionKeyRange],
 ) -> PartitionKeyRange:
     """Returns the range of partition keys in the upstream asset that include data necessary
     to compute the contents of the given partition key range in the downstream asset.

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -33,11 +33,11 @@ class TimeWindowPartitionMapping(PartitionMapping):
 
     def get_upstream_partitions_for_partition_range(
         self,
-        downstream_partition_key_range: PartitionKeyRange,
+        downstream_partition_key_range: Optional[PartitionKeyRange],
         downstream_partitions_def: Optional[PartitionsDefinition],
         upstream_partitions_def: PartitionsDefinition,
     ) -> PartitionKeyRange:
-        if downstream_partitions_def is None:
+        if downstream_partitions_def is None or downstream_partition_key_range is None:
             check.failed("downstream asset is not partitioned")
 
         return self._map_partitions(

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -763,11 +763,16 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             upstream_asset_partitions_def = asset_layer.partitions_def_for_asset(upstream_asset_key)
 
             if assets_def is not None and upstream_asset_partitions_def is not None:
+                partition_key_range = (
+                    PartitionKeyRange(self.partition_key, self.partition_key)
+                    if assets_def.partitions_def
+                    else None
+                )
                 return get_upstream_partitions_for_partition_range(
                     assets_def,
                     upstream_asset_partitions_def,
                     upstream_asset_key,
-                    PartitionKeyRange(self.partition_key, self.partition_key),
+                    partition_key_range,
                 )
 
         check.failed("The input has no asset partitions")

--- a/python_modules/dagster/dagster/_core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/inputs.py
@@ -187,7 +187,10 @@ class FromSourceAsset(
             resources=resources,
             artificial_output_context=OutputContext(
                 resources=resources,
-                asset_info=AssetOutputInfo(key=input_asset_key),
+                asset_info=AssetOutputInfo(
+                    key=input_asset_key,
+                    partitions_def=asset_layer.partitions_def_for_asset(input_asset_key),
+                ),
                 name=input_asset_key.path[-1],
                 step_key="none",
                 metadata=asset_layer.metadata_for_asset(input_asset_key),

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_partition_mappings.py
@@ -45,7 +45,7 @@ def test_filter_mapping_partitions_dep():
 
         def get_upstream_partitions_for_partition_range(
             self,
-            downstream_partition_key_range: PartitionKeyRange,
+            downstream_partition_key_range,
             downstream_partitions_def: Optional[
                 PartitionsDefinition
             ],  # pylint: disable=unused-argument
@@ -111,7 +111,7 @@ def test_access_partition_keys_from_context_non_identity_partition_mapping():
 
         def get_upstream_partitions_for_partition_range(
             self,
-            downstream_partition_key_range: PartitionKeyRange,
+            downstream_partition_key_range,
             downstream_partitions_def: Optional[PartitionsDefinition],
             upstream_partitions_def: PartitionsDefinition,
         ) -> PartitionKeyRange:
@@ -177,7 +177,7 @@ def test_asset_partitions_time_window_non_identity_partition_mapping():
 
         def get_upstream_partitions_for_partition_range(
             self,
-            downstream_partition_key_range: PartitionKeyRange,
+            downstream_partition_key_range,
             downstream_partitions_def: Optional[PartitionsDefinition],
             upstream_partitions_def: PartitionsDefinition,
         ) -> PartitionKeyRange:
@@ -238,7 +238,7 @@ def test_multi_asset_non_identity_partition_mapping():
 
         def get_upstream_partitions_for_partition_range(
             self,
-            downstream_partition_key_range: PartitionKeyRange,
+            downstream_partition_key_range,
             downstream_partitions_def: Optional[PartitionsDefinition],
             upstream_partitions_def: PartitionsDefinition,
         ) -> PartitionKeyRange:
@@ -320,7 +320,7 @@ def test_from_graph():
 
         def get_upstream_partitions_for_partition_range(
             self,
-            downstream_partition_key_range: PartitionKeyRange,
+            downstream_partition_key_range,
             downstream_partitions_def: Optional[
                 PartitionsDefinition
             ],  # pylint: disable=unused-argument

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
@@ -15,6 +15,7 @@ from dagster import (
     SourceAsset,
     StaticPartitionsDefinition,
     define_asset_job,
+    materialize,
 )
 from dagster._core.definitions import asset, build_assets_job, multi_asset
 from dagster._core.definitions.asset_partitions import (
@@ -145,6 +146,7 @@ def test_access_partition_keys_from_context_only_one_asset_partitioned():
                 assert not context.has_asset_partitions
             else:
                 assert context.has_asset_partitions
+                assert context.asset_partition_key_range == PartitionKeyRange("a", "c")
 
     @asset(partitions_def=upstream_partitions_def)
     def upstream_asset(context):
@@ -158,15 +160,19 @@ def test_access_partition_keys_from_context_only_one_asset_partitioned():
     def double_downstream_asset(downstream_asset):
         assert downstream_asset is None
 
-    my_job = build_assets_job(
-        "my_job",
+    result = materialize(
         assets=[upstream_asset, downstream_asset, double_downstream_asset],
-        resource_defs={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
+        resources={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
+        partition_key="b",
     )
-    result = my_job.execute_in_process(partition_key="b")
     assert result.asset_materializations_for_node("upstream_asset") == [
         AssetMaterialization(asset_key=AssetKey(["upstream_asset"]), partition="b")
     ]
+
+    assert materialize(
+        assets=[upstream_asset.to_source_assets()[0], downstream_asset, double_downstream_asset],
+        resources={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
+    ).success
 
 
 def test_output_context_asset_partitions_time_window():
@@ -213,12 +219,17 @@ def test_input_context_asset_partitions_time_window():
     def downstream_asset(upstream_asset):
         assert upstream_asset is None
 
-    my_job = build_assets_job(
-        "my_job",
-        assets=[downstream_asset, upstream_asset],
-        resource_defs={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
-    )
-    my_job.execute_in_process(partition_key="2021-06-06")
+    assert materialize(
+        assets=[upstream_asset, downstream_asset],
+        resources={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
+        partition_key="2021-06-06",
+    ).success
+
+    assert materialize(
+        assets=[upstream_asset.to_source_assets()[0], downstream_asset],
+        resources={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
+        partition_key="2021-06-06",
+    ).success
 
 
 def test_cross_job_different_partitions():


### PR DESCRIPTION
…t of run

### Summary & Motivation

In some situations where we materialize an asset that depends on a partitioned asset, and that upstream partitioned asset isn't part of the run, the methods of InputContext return incorrect values or fail. This fixes that.

This fixes part of the issue reported here: https://github.com/dagster-io/dagster/issues/9277.

### How I Tested These Changes

Modified tests. Ran the HN example (along with changing to the example itself to use InputContext directly instead of upstream_output).