### PR TITLE
avoid using InputContext.upstream_output in asset examples

### DIFF
--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -544,14 +544,14 @@ class PandasAssetIOManager(IOManager):
         file_path = self._get_path(context)
         store_pandas_dataframe(name=file_path, table=obj)
 
-    def _get_path(self, output_context):
+    def _get_path(self, context):
         return os.path.join(
             "storage",
-            f"{output_context.name}.csv",
+            f"{context.asset_key.path[-1]}.csv",
         )
 
     def load_input(self, context):
-        file_path = self._get_path(context.upstream_output)
+        file_path = self._get_path(context)
         return load_pandas_dataframe(name=file_path)
 
 
@@ -562,7 +562,7 @@ def pandas_asset_io_manager():
 
 class NumpyAssetIOManager(PandasAssetIOManager):
     def load_input(self, context):
-        file_path = self._get_path(context.upstream_output)
+        file_path = self._get_path(context)
         return load_numpy_array(name=file_path)
 
 
@@ -576,9 +576,7 @@ def upstream_asset():
     return pd.DataFrame([1, 2, 3])
 
 
-@asset(
-    ins={"upstream": AssetIn(key_prefix="public", input_manager_key="numpy_manager")}
-)
+@asset(ins={"upstream": AssetIn(key_prefix="public", input_manager_key="numpy_manager")})
 def downstream_asset(upstream):
     return upstream.shape
 

--- a/docs/content/integrations/dbt.mdx
+++ b/docs/content/integrations/dbt.mdx
@@ -209,7 +209,7 @@ class PandasIOManager(IOManager):
 
     def load_input(self, context) -> pd.DataFrame:
         """Load the contents of a table as a pandas DataFrame."""
-        table_name = context.upstream_output.asset_key.path[-1]
+        table_name = context.asset_key.path[-1]
         return pd.read_sql(f"SELECT * FROM {table_name}", con=self._con)
 
 @io_manager(config_schema={"con_string": str})

--- a/examples/assets_modern_data_stack/assets_modern_data_stack/db_io_manager.py
+++ b/examples/assets_modern_data_stack/assets_modern_data_stack/db_io_manager.py
@@ -25,7 +25,7 @@ class DbIOManager(IOManager):
 
     def load_input(self, context) -> pd.DataFrame:
         """Load the contents of a table as a pandas DataFrame."""
-        model_name = context.upstream_output.asset_key.path[-1]
+        model_name = context.asset_key.path[-1]
         return pd.read_sql(f"SELECT * FROM {model_name}", con=self._con)
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_input_managers.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_input_managers.py
@@ -60,14 +60,14 @@ class PandasAssetIOManager(IOManager):
         file_path = self._get_path(context)
         store_pandas_dataframe(name=file_path, table=obj)
 
-    def _get_path(self, output_context):
+    def _get_path(self, context):
         return os.path.join(
             "storage",
-            f"{output_context.name}.csv",
+            f"{context.asset_key.path[-1]}.csv",
         )
 
     def load_input(self, context):
-        file_path = self._get_path(context.upstream_output)
+        file_path = self._get_path(context)
         return load_pandas_dataframe(name=file_path)
 
 
@@ -78,7 +78,7 @@ def pandas_asset_io_manager():
 
 class NumpyAssetIOManager(PandasAssetIOManager):
     def load_input(self, context):
-        file_path = self._get_path(context.upstream_output)
+        file_path = self._get_path(context)
         return load_numpy_array(name=file_path)
 
 
@@ -92,9 +92,7 @@ def upstream_asset():
     return pd.DataFrame([1, 2, 3])
 
 
-@asset(
-    ins={"upstream": AssetIn(key_prefix="public", input_manager_key="numpy_manager")}
-)
+@asset(ins={"upstream": AssetIn(key_prefix="public", input_manager_key="numpy_manager")})
 def downstream_asset(upstream):
     return upstream.shape
 

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -97,7 +97,7 @@ def scope_input_manager():
 
         def load_input(self, context) -> pd.DataFrame:
             """Load the contents of a table as a pandas DataFrame."""
-            table_name = context.upstream_output.asset_key.path[-1]
+            table_name = context.asset_key.path[-1]
             return pd.read_sql(f"SELECT * FROM {table_name}", con=self._con)
 
     @io_manager(config_schema={"con_string": str})

--- a/examples/project_fully_featured/project_fully_featured/resources/fixed_s3_pickle_io_manager.py
+++ b/examples/project_fully_featured/project_fully_featured/resources/fixed_s3_pickle_io_manager.py
@@ -11,7 +11,7 @@ def s3_client():
 
 class FixedS3PickleIOManager(IOManager):
     def load_input(self, context):
-        key = context.upstream_output.asset_key.path[-1]
+        key = context.asset_key.path[-1]
         bucket = context.resource_config["bucket"]
         return pickle.loads(s3_client().get_object(Bucket=bucket, Key=key)["Body"].read())
 

--- a/examples/project_fully_featured/project_fully_featured/resources/parquet_io_manager.py
+++ b/examples/project_fully_featured/project_fully_featured/resources/parquet_io_manager.py
@@ -4,7 +4,7 @@ from typing import Union
 import pandas
 import pyspark
 
-from dagster import Field, IOManager, MetadataEntry, OutputContext
+from dagster import Field, IOManager, InputContext, MetadataEntry, OutputContext
 from dagster import _check as check
 from dagster import io_manager
 from dagster._seven.temp_dir import get_system_temp_directory
@@ -44,7 +44,7 @@ class PartitionedParquetIOManager(IOManager):
         yield MetadataEntry.path(path=path, label="path")
 
     def load_input(self, context) -> Union[pyspark.sql.DataFrame, str]:
-        path = self._get_path(context.upstream_output)
+        path = self._get_path(context)
         if context.dagster_type.typing_type == pyspark.sql.DataFrame:
             # return pyspark dataframe
             return context.resources.pyspark.spark_session.read.parquet(path)
@@ -54,7 +54,7 @@ class PartitionedParquetIOManager(IOManager):
             "for this input either on the argument of the @asset-decorated function."
         )
 
-    def _get_path(self, context: OutputContext):
+    def _get_path(self, context: Union[InputContext, OutputContext]):
         key = context.asset_key.path[-1]  # type: ignore
 
         if context.has_asset_partitions:

--- a/examples/project_fully_featured/project_fully_featured/resources/snowflake_io_manager.py
+++ b/examples/project_fully_featured/project_fully_featured/resources/snowflake_io_manager.py
@@ -12,9 +12,7 @@ from snowflake.connector.pandas_tools import pd_writer
 from snowflake.sqlalchemy import URL  # pylint: disable=no-name-in-module,import-error
 from sqlalchemy import create_engine
 
-from dagster import IOManager, InputContext, MetadataEntry, OutputContext
-from dagster import _check as check
-from dagster import io_manager
+from dagster import IOManager, InputContext, MetadataEntry, OutputContext, io_manager
 
 SNOWFLAKE_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 
@@ -152,9 +150,7 @@ class SnowflakeIOManager(IOManager):
             return f"DELETE FROM {schema}.{table}"
 
     def load_input(self, context: InputContext) -> PandasDataFrame:
-        upstream_output = check.not_none(context.upstream_output)
-        asset_key = check.not_none(upstream_output.asset_key)
-
+        asset_key = context.asset_key
         schema, table = asset_key.path[-2], asset_key.path[-1]
         with connect_snowflake(config=self._config) as con:
             result = read_sql(


### PR DESCRIPTION
### Summary & Motivation

"Upstream output" doesn't always make sense in the context of assets, and the implementation also doesn't work well with partitions.

With https://github.com/dagster-io/dagster/pull/9288, this fixes https://github.com/dagster-io/dagster/issues/9277.

### How I Tested These Changes

Ran the HN demo locally.