### PR TITLE
[docs] - Rename `instance deployment` > `full deployment`

### DIFF
--- a/docs/content/dagster-cloud/account/managing-users.mdx
+++ b/docs/content/dagster-cloud/account/managing-users.mdx
@@ -47,7 +47,7 @@ To add a new user to a deployment:
 3. Fill in the following:
 
    - **Email** - Enter the user's email address
-   - **Role** - Select the [user role](#understanding-user-permissions) for the user. **Note**: With the exception of the **Organization Admin** role, this role will only apply to the instance deployment you're adding the user to.
+   - **Role** - Select the [user role](#understanding-user-permissions) for the user. **Note**: With the exception of the **Organization Admin** role, this role will only apply to the full deployment you're adding the user to.
 
    For example:
 

--- a/docs/content/dagster-cloud/account/managing-users.mdx
+++ b/docs/content/dagster-cloud/account/managing-users.mdx
@@ -32,13 +32,13 @@ Before you start, note that:
 
 - **Users are managed on a per-deployment basis**. **Organization Admins** are the exception and have access to the entire organization.
 
-  For example, if you have two instance deployments (`prod` and `dev`), users who aren't **Organization Admins** must be added to each deployment to have access.
+  For example, if you have two full deployments (`prod` and `dev`), users who aren't **Organization Admins** must be added to each deployment to have access.
 
 - **If using Google for SSO**, users must be added in Dagster Cloud before they can log in.
 
 - **If using a SAML-based solution like Okta**, users must be assigned to the Dagster app in the SSO portal to log in. These users will be granted Viewer permissions by default.
 
-To add a new user to an instance deployment:
+To add a new user to a deployment:
 
 1. Sign in to your Dagster Cloud account.
 
@@ -62,7 +62,7 @@ To add a new user to an instance deployment:
 
 ### Removing a user
 
-To remove a user from an instance deployment:
+To remove a user from a deployment:
 
 1. Sign in to your Dagster Cloud account.
 2. Click the **user menu (your icon) > Cloud Settings**.
@@ -70,7 +70,7 @@ To remove a user from an instance deployment:
 4. Click **Remove**.
 5. When prompted, confirm the removal.
 
-**Note**: This won't remove user from other instance deployments. For example, if a user has been added to both `prod` and `dev` but only removed in `prod`, they'll still be a user in `dev`.
+**Note**: This won't remove users from other deployments. For example, if a user has been added to both `prod` and `dev` but only removed in `prod`, they'll still be a user in `dev`.
 
 ---
 

--- a/docs/content/dagster-cloud/account/setting-up-alerts.mdx
+++ b/docs/content/dagster-cloud/account/setting-up-alerts.mdx
@@ -16,6 +16,8 @@ Alert policies define which jobs will trigger an alert, the conditions under whi
 
 An alert policy includes a set of configured tags. If an alert policy has no configured tags, all jobs will be eligible for that alert. Otherwise, only jobs that contain all the tags for a given alert policy are eligible for that alert.
 
+Alert policies are configured on a per deployment basis. For example, alerts configured in a `prod` deployment are only applicable to jobs in that deployment.
+
 Currently, Slack and email notifications are supported.
 
 ---
@@ -111,22 +113,22 @@ height={153}
 
 With the [`dagster-cloud` CLI](/dagster-cloud/developing-testing/dagster-cloud-cli), you can:
 
-- [Set an instance deployment's policies](#setting-an-instance-deployments-policies)
-- [View an instance deployment's policies](#viewing-an-instance-deployments-policies)
+- [Set a full deployment's policies](#setting-a-full-deployments-policies)
+- [View a full deployment's policies](#viewing-a-full-deployments-policies)
 - [Configure a Slack alert policy](#configuring-a-slack-alert-policy)
 - [Configure an email alert policy](#configuring-an-email-alert-policy)
 
-### Setting an instance deployment's policies
+### Setting a full deployment's policies
 
-A list of alert policies can be defined in a single YAML file. After declaring your policies, set them for your instance deployment using the following command:
+A list of alert policies can be defined in a single YAML file. After declaring your policies, set them for the deployment using the following command:
 
 ```bash
 dagster-cloud deployment alert-policies sync -a <ALERT_POLICIES_PATH>
 ```
 
-### Viewing an instance deployment's policies
+### Viewing a full deployment's policies
 
-List the policies currently configured on your instance deployment by running:
+List the policies currently configured on the deployment by running:
 
 ```bash
 dagster-cloud deployment alert-policies list

--- a/docs/content/dagster-cloud/deployment/agents/running-multiple-agents.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/running-multiple-agents.mdx
@@ -7,7 +7,7 @@ platform_type: "cloud"
 
 <Note>This guide is applicable to Dagster Cloud.</Note>
 
-Each Dagster Cloud instance deployment needs to have at least one agent running. Since the agent is lightweight and can tolerate short downtimes (e.g. during an upgrade), a single agent is adequate for most use cases.
+Each Dagster Cloud full deployment (e.g., `prod`) needs to have at least one agent running. Since the agent is lightweight and can tolerate short downtimes such as during an upgrade, a single agent is adequate for most use cases.
 
 If you want to distribute runs across multiple Kubernetes clusters, ECS clusters, EC2 instances, or other environments, you can run multiple agents. For example, one in each cluster, instance, etc.
 

--- a/docs/content/dagster-cloud/developing-testing/code-locations.mdx
+++ b/docs/content/dagster-cloud/developing-testing/code-locations.mdx
@@ -24,7 +24,7 @@ For an example of a Github repo set up to run in Dagster Cloud, see our
 
 A code location specifies a single Python package or file that defines your Dagster code. When you add a code location in Dagster Code, you're instructing the agent where to find your code.
 
-When you add or update a code location, the agent uses the location configuration to load your code and upload metadata about your jobs to Dagster Cloud. Each Dagster Cloud instance deployment can include code from one or more code locations.
+When you add or update a code location, the agent uses the location configuration to load your code and upload metadata about your jobs to Dagster Cloud. Each full deployment - for example, `prod` - can include code from one or more code locations.
 
 Note that, unlike Dagster Open Source, Dagster Cloud doesn't require a `workspace.yaml` file. Instead, you use the Dagster Cloud API to configure your workspace. You can still create a `workspace.yaml` file if you want to load your code in an open-source Dagit instance, but doing so won't affect how your code is loaded in Dagster Cloud.
 

--- a/docs/content/dagster-cloud/getting-started/getting-started-with-hybrid-deployment.mdx
+++ b/docs/content/dagster-cloud/getting-started/getting-started-with-hybrid-deployment.mdx
@@ -104,7 +104,7 @@ In this step, you'll run your first job in Dagster Cloud.
 
 ## Step 5: Set up Continuous Integration
 
-Branch Deployments allow you to quickly and collaboratively develop your Dagster jobs. When a branch is created or updated in your Dagster repository, Branch Deployments will create a testing environment in your Dagster Cloud instance.
+Branch Deployments allow you to quickly and collaboratively develop your Dagster jobs. When a branch is created or updated in your Dagster repository, Branch Deployments will create a testing environment in the current Dagster Cloud deployment. For example, `prod`.
 
 Check out the [Branch Deployment docs](/dagster-cloud/developing-testing/branch-deployments) for more info. If you skip this step now, you can always set it up later.
 


### PR DESCRIPTION
This renames `instance deployment` to `full deployment` in the Dagster Cloud docs. This brings the docs in line with the recent decision to use `full deployment`.