### PR TITLE
docs fix: cloud docs should say dagster project *from-example*

### DIFF
--- a/docs/content/dagster-cloud/deployment/serverless.mdx
+++ b/docs/content/dagster-cloud/deployment/serverless.mdx
@@ -60,7 +60,7 @@ First, [create a new project](https://docs.dagster.io/getting-started/create-new
 
 ```shell
 pip install dagster
-dagster project scaffold \
+dagster project from-example \
   --name my-dagster-project \
   --example assets_modern_data_stack
 ```

--- a/docs/content/dagster-cloud/getting-started/getting-started-with-hybrid-deployment.mdx
+++ b/docs/content/dagster-cloud/getting-started/getting-started-with-hybrid-deployment.mdx
@@ -67,7 +67,7 @@ A code location specifies a single Python package or file that defines your Dags
 To complete this step, you can use your own Dagster code or a [project scaffold](/getting-started/create-new-project). Our examples use the scaffold. Scaffold a new project by running:
 
 ```shell
-dagster project scaffold \
+dagster project from-example \
   --name <PROJECT_NAME> \
   --example <EXAMPLE_PROJECT_NAME>
 ```


### PR DESCRIPTION
### Summary & Motivation
wrong subcommand
### How I Tested These Changes
