### PR TITLE
docs: serverless cli calls out including dagster-cloud

### DIFF
--- a/docs/content/dagster-cloud/deployment/serverless.mdx
+++ b/docs/content/dagster-cloud/deployment/serverless.mdx
@@ -2,8 +2,6 @@
 title: "Serverless deployment in Dagster Cloud | Dagster Docs"
 ---
 
-<Note>This guide is applicable to Dagster Cloud.</Note>
-
 # Serverless deployment in Dagster Cloud
 
 <Note>This guide is applicable to Dagster Cloud.</Note>

--- a/docs/content/dagster-cloud/deployment/serverless.mdx
+++ b/docs/content/dagster-cloud/deployment/serverless.mdx
@@ -65,7 +65,10 @@ dagster project from-example \
   --example assets_modern_data_stack
 ```
 
-Once scaffolded, add `dagster-cloud` as a dependency in your `setup.py` file.
+<Note>
+  Once scaffolded, add <code>dagster-cloud</code> as a dependency in your{" "}
+  <code>setup.py</code> file.
+</Note>
 
 Next, install the [dagster-cloud CLI](/dagster-cloud/developing-testing/dagster-cloud-cli) and log in to your org. **Note**: The CLI requires a recent version of Python 3 and Docker.
 


### PR DESCRIPTION
### Summary & Motivation
not sure if thats a good idea but it's easy to miss the line in the status quo 
https://dagster-git-yuhan-08-08-docsserverlessclicallso-a35e74-elementl.vercel.app/dagster-cloud/deployment/serverless#without-github-gitlab-bitbucket-or-local-development

### How I Tested These Changes
