### PR TITLE
[docs] - Rename cloud_workspace.yaml > dagster_cloud.yaml

### DIFF
--- a/docs/content/dagster-cloud/developing-testing/branch-deployments/using-branch-deployments-with-github.mdx
+++ b/docs/content/dagster-cloud/developing-testing/branch-deployments/using-branch-deployments-with-github.mdx
@@ -52,7 +52,7 @@ In this step, you'll add the required GitHub workflow files to your GitHub repos
 
 Copy the following files to your repository:
 
-- [`cloud_workspace.yaml`](https://github.com/dagster-io/dagster-cloud-branch-deployments-quickstart/blob/main/cloud_workspace.yaml)
+- [`dagster_cloud.yaml`](https://github.com/dagster-io/dagster-cloud-branch-deployments-quickstart/blob/main/dagster_cloud.yaml)
 - [`.github/workflows/branch_deployments.yml`](https://github.com/dagster-io/dagster-cloud-branch-deployments-quickstart/blob/main/.github/workflows/branch_deployments.yml)
 - [`.github/workflows/deploy.yml`](https://github.com/dagster-io/dagster-cloud-branch-deployments-quickstart/blob/main/.github/workflows/deploy.yml)
 
@@ -64,24 +64,24 @@ In the next step, you'll modify these files to work with your Dagster Cloud setu
 
 In this section, you'll:
 
-1. [Add the agent registry to `cloud_workspace.yaml`](#step-41-add-the-agent-registry-to-cloud_workspaceyaml)
+1. [Add the agent registry to `dagster_cloud.yaml`](#step-41-add-the-agent-registry-to-dagster_cloudyaml)
 2. [Configure GitHub Action secrets](#step-42-configure-github-action-secrets)
 3. [Update GitHub Workflow files](#step-43-update-github-workflow-files)
 4. [Verify Action runs](#step-44-verify-action-runs)
 
-### Step 4.1: Add the agent registry to cloud_workspace.yaml
+### Step 4.1: Add the agent registry to dagster_cloud.yaml
 
 <Note>
   If you're using Serverless deployment, this step isn't required.{" "}
   <a href="#step-42-configure-github-action-secrets">Skip to the next step</a>.
 </Note>
 
-In the `cloud_workspace.yaml` file, replace `build.registry` with the registry used by the [agent you created in Step 2](#step-2-create-and-configure-an-agent).
+In the `dagster_cloud.yaml` file, replace `build.registry` with the registry used by the [agent you created in Step 2](#step-2-create-and-configure-an-agent).
 
 For example:
 
 ```yaml
-# cloud_workspace.yaml
+# dagster_cloud.yaml
 
 locations:
   - location_name: example_location

--- a/docs/content/dagster-cloud/developing-testing/branch-deployments/using-branch-deployments-with-github.mdx
+++ b/docs/content/dagster-cloud/developing-testing/branch-deployments/using-branch-deployments-with-github.mdx
@@ -52,7 +52,7 @@ In this step, you'll add the required GitHub workflow files to your GitHub repos
 
 Copy the following files to your repository:
 
-- [`dagster_cloud.yaml`](https://github.com/dagster-io/dagster-cloud-branch-deployments-quickstart/blob/main/dagster_cloud.yaml)
+- [`cloud_workspace.yaml`](https://github.com/dagster-io/dagster-cloud-branch-deployments-quickstart/blob/main/cloud_workspace.yaml) - **Note**: Save this file as `dagster_cloud.yaml`. This file has been re-named, but not yet reflected in this template repository.
 - [`.github/workflows/branch_deployments.yml`](https://github.com/dagster-io/dagster-cloud-branch-deployments-quickstart/blob/main/.github/workflows/branch_deployments.yml)
 - [`.github/workflows/deploy.yml`](https://github.com/dagster-io/dagster-cloud-branch-deployments-quickstart/blob/main/.github/workflows/deploy.yml)
 

--- a/docs/content/dagster-cloud/developing-testing/code-locations.mdx
+++ b/docs/content/dagster-cloud/developing-testing/code-locations.mdx
@@ -231,9 +231,9 @@ dagster-cloud workspace delete-location <LOCATION_NAME>
 
 You can also keep the YAML configuration for your entire workspace in a file and use the `dagster-cloud sync` command to reconcile the workspace config in Dagster Cloud with that local file.
 
-For example, if you have the following `cloud_workspace.yaml` file:
+For example, if you have the following `dagster_cloud.yaml` file:
 
-```yaml caption=cloud_workspace.yaml
+```yaml caption=dagster_cloud.yaml
 locations:
   - location_name: machine-learning
     image: myregistry/dagster-machine-learning:mytag
@@ -251,5 +251,5 @@ locations:
 Reconcile the above file with Dagster Cloud's remote workspace by running:
 
 ```shell
-dagster-cloud workspace sync -w cloud_workspace.yaml
+dagster-cloud workspace sync -w dagster_cloud.yaml
 ```


### PR DESCRIPTION
This PR renames `cloud_workspace.yaml` to `dagster_cloud.yaml`