### PR TITLE
[dagit] Guard against missing workspace on repo reload

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/WorkspaceStatus.tsx
+++ b/js_modules/dagit/packages/core/src/nav/WorkspaceStatus.tsx
@@ -81,11 +81,11 @@ export const WorkspaceStatus = React.memo(() => {
   // and/or b) a toast indicating that a code location is being reloaded.
   React.useEffect(() => {
     const previousEntries =
-      previousData?.workspaceOrError.__typename === 'Workspace'
+      previousData?.workspaceOrError?.__typename === 'Workspace'
         ? previousData?.workspaceOrError.locationEntries
         : [];
     const currentEntries =
-      data?.workspaceOrError.__typename === 'Workspace'
+      data?.workspaceOrError?.__typename === 'Workspace'
         ? data?.workspaceOrError.locationEntries
         : [];
 


### PR DESCRIPTION
### Summary & Motivation

It is possible to get into a state where a repo reload will lead to a JS error because the Apollo cache will be reset, leading to an unexpected empty `data` object in the query result. We don't expect to guard against this kind of object in TypeScript, because the `data` object is never expected to empty in this way. Definitely an Apollo bug, but we need to cover it here.

### How I Tested These Changes

Reload a repo from the Workspace page. Verify that the page doesn't crash.
