### PR TITLE
docs infra: backfill _versioned_navigation.json

### DIFF
--- a/docs/next/.versioned_content/_versioned_navigation.json
+++ b/docs/next/.versioned_content/_versioned_navigation.json
@@ -46770,6 +46770,16 @@
         {
           "children": [
             {
+              "children": [
+                {
+                  "path": "/dagster-cloud/getting-started/getting-started-with-serverless-deployment",
+                  "title": "Serverless Deployment"
+                },
+                {
+                  "path": "/dagster-cloud/getting-started/getting-started-with-hybrid-deployment",
+                  "title": "Hybrid Deployment"
+                }
+              ],
               "path": "/dagster-cloud/getting-started",
               "title": "Getting started"
             },


### PR DESCRIPTION
### Summary & Motivation
this is the one used in the left nav
### How I Tested These Changes
the `1.0.2 (latest)` version should have the two new entries in deployment/getting-started
