### PR TITLE
[docs] - Remove broken image

### DIFF
--- a/docs/content/dagster-cloud/developing-testing/branch-deployments/using-branch-deployments-with-github.mdx
+++ b/docs/content/dagster-cloud/developing-testing/branch-deployments/using-branch-deployments-with-github.mdx
@@ -203,14 +203,7 @@ width={922}
 height={521}
 />
 
-Clicking the link will open a branch deployment - or a preview of the changes - in Dagster Cloud:
-
-<Image
-alt="Clicking the GitHub pull request View in Cloud link and opening the branch deployment in Dagster Cloud"
-src="/images/dagster-cloud/developing-testing/branch-deployments/github-preview-link-click.gif"
-width={640}
-height={480}
-/>
+Clicking the link will open a branch deployment - or a preview of the changes - in Dagster Cloud.
 
 ### Directly in Dagster Cloud
 


### PR DESCRIPTION
This PR removes a broken image from the Branch Deployment docs.

This was addressed in a previous PR, but it looks like it made its way back in. 