### PR TITLE
make it easy to build custom schedules from partitioned jobs

### DIFF
--- a/python_modules/dagster-test/dagster_test_tests/test_toys.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_toys.py
@@ -45,14 +45,13 @@ def test_dynamic_job(executor_def):
 
 
 def test_longitudinal_job(executor_def):
-    partition_set = longitudinal_schedule().get_partition_set()
+    partitions_def = longitudinal_schedule().job.partitions_def
     try:
         result = longitudinal.to_job(
             resource_defs={"io_manager": fs_io_manager},
             executor_def=executor_def,
-        ).execute_in_process(
-            run_config=partition_set.run_config_for_partition(partition_set.get_partitions()[0]),
-        )
+            config=longitudinal_schedule().job.partitioned_config,
+        ).execute_in_process(partition_key=partitions_def.get_partition_keys()[0])
         assert result.success
     except IntentionalRandomFailure:
         pass

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -2,7 +2,7 @@ import copy
 import datetime
 import warnings
 from functools import update_wrapper
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, cast
 
 import dagster._check as check
 from dagster._core.definitions.partition import (
@@ -25,9 +25,7 @@ from dagster._utils.partitions import (
     create_offset_partition_selector,
 )
 
-from ..graph_definition import GraphDefinition
 from ..mode import DEFAULT_MODE_NAME
-from ..pipeline_definition import PipelineDefinition
 from ..run_request import RunRequest, SkipReason
 from ..schedule_definition import (
     DecoratedScheduleFunction,
@@ -38,6 +36,7 @@ from ..schedule_definition import (
     ScheduleEvaluationContext,
     is_context_provided,
 )
+from ..target import ExecutableDefinition
 from ..utils import validate_tags
 
 if TYPE_CHECKING:
@@ -58,7 +57,7 @@ def schedule(
     environment_vars: Optional[Dict[str, str]] = None,
     execution_timezone: Optional[str] = None,
     description: Optional[str] = None,
-    job: Optional[Union[PipelineDefinition, GraphDefinition]] = None,
+    job: Optional[ExecutableDefinition] = None,
     default_status: DefaultScheduleStatus = DefaultScheduleStatus.STOPPED,
 ) -> Callable[[RawScheduleEvaluationFunction], ScheduleDefinition]:
     """
@@ -96,8 +95,8 @@ def schedule(
             Supported strings for timezones are the ones provided by the
             `IANA time zone database <https://www.iana.org/time-zones>` - e.g. "America/Los_Angeles".
         description (Optional[str]): A human-readable description of the schedule.
-        job (Optional[Union[GraphDefinition, JobDefinition]]): The job that should execute when this
-            schedule runs.
+        job (Optional[Union[GraphDefinition, JobDefinition, UnresolvedAssetJobDefinition]]): The job
+            that should execute when this schedule runs.
         default_status (DefaultScheduleStatus): Whether the schedule starts as running or not. The default
             status can be overridden from Dagit or via the GraphQL API.
     """

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -562,7 +562,7 @@ def test_partitioned_schedule():
 
     schedule = schedule_from_partitions(job)
 
-    spd = schedule.get_partition_set()._partitions_def  # pylint: disable=protected-access
+    spd = schedule.job.partitions_def
     assert spd == partitions_def
 
 


### PR DESCRIPTION
### Summary & Motivation

Reading https://github.com/dagster-io/dagster/pull/9105/files made me think about "what's our replacement for custom partition selectors in a post-legacy world?"

This PR posits that we should basically encourage users to use `@schedule` instead of `build_schedule_from_partitioned_job` when they want to implement custom partition selection logic.

To make this possible / prove that this is possible, it implements `build_schedule_from_partitioned_job` on top of `@schedule` and adds methods to JobDefinition and PartitionsDefinition to make the implementation simple.

### How I Tested These Changes
