### PR TITLE
Incompatible variable type fixed

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -61,7 +61,7 @@ class _Op:
         )
 
         outs: Optional[Mapping[str, Out]] = None
-        if self.out is not None and isinstance(self.out, Out):
+        if self.out is None and isinstance(self.out, Out):
             outs = {DEFAULT_OUTPUT: self.out}
         elif self.out is not None:
             outs = check.mapping_param(self.out, "out", key_type=str, value_type=Out)


### PR DESCRIPTION
**"filename"**: "python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py"
**"warning_type"**: "Incompatible variable type [9]"
**"warning_message"**: " outs is declared to have type `Optional[Mapping[str, Out]]` but is used as type `Dict[str, Union[Mapping[str, Out], Out]]`."
**"warning_line"**:63
**"fix"**: self.out is None
