### PR TITLE
[dagit] Remove x-frame-options restriction

### DIFF
--- a/python_modules/dagit/dagit/webserver.py
+++ b/python_modules/dagit/dagit/webserver.py
@@ -80,7 +80,6 @@ class DagitWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
             "Feature-Policy": "microphone 'none'; camera 'none'",
             "Referrer-Policy": "strict-origin-when-cross-origin",
             "X-Content-Type-Options": "nosniff",
-            "X-Frame-Options": "deny",
         }
 
     def make_csp_header(self, nonce: str) -> str:


### PR DESCRIPTION
### Summary & Motivation

I previously removed frame-ancestors to allow consumers to embed their Dagit UI in iframes as needed, but overlooked the `x-frame-ancestors` CSP response header.

### How I Tested These Changes

Build and load dagit locally, verify updated CSP. Load local dagit in an iframe, verify success.
