### PR TITLE
[docs] Small Cloud user docs tweaks

### DIFF
--- a/docs/content/dagster-cloud/account/managing-user-agent-tokens.mdx
+++ b/docs/content/dagster-cloud/account/managing-user-agent-tokens.mdx
@@ -18,7 +18,7 @@ In this guide, we'll walk you through creating and revoking user and agent token
   tokens. This includes viewing existing tokens.
 </Note>
 
-Agent tokens are used to authenticate [agents](/dagster-cloud/deployment/agents) to the Dagster Cloud Agents API.
+Agent tokens are used to authenticate [Hybrid agents](/dagster-cloud/deployment/agents) with the Dagster Cloud Agents API.
 
 1. Sign in to your Dagster Cloud account.
 2. Click the **user menu (your icon) > Cloud Settings**.
@@ -27,7 +27,8 @@ Agent tokens are used to authenticate [agents](/dagster-cloud/deployment/agents)
 
 After the token is created:
 
-- **To view a token**, click **Reveal token**.
+- **To edit a token's description**, click the **pencil icon**.
+- **To view a token**, click **Reveal token**. Clicking on the token value will copy it to the clipboard.
 - **To revoke a token**, click **Revoke**.
 
 ---
@@ -47,7 +48,8 @@ After the token is created:
 
 After the token is created:
 
-- **To view a token**, click **Reveal token**.
+- **To edit a token's description**, click the **pencil icon**.
+- **To view a token**, click **Reveal token**. Clicking on the token value will copy it to the clipboard.
 - **To revoke a token**, click **Revoke**.
 
 To manage tokens for another user, select the user from the **Manage tokens for** dropdown:

--- a/docs/content/dagster-cloud/account/managing-users.mdx
+++ b/docs/content/dagster-cloud/account/managing-users.mdx
@@ -10,12 +10,6 @@ In this guide, we'll walk you through adding, removing, and assigning user roles
 
 ---
 
-## Seeding users
-
-When your organization is first created, we will seed your database with admin users as requested. If you need to add more users, configure SAML or SSO, or are having trouble with your permissions, contact these seed users.
-
----
-
 ## Adding and removing users
 
 <Note>


### PR DESCRIPTION
## Summary

Some small tweaks to the user and token docs pages I noticed while browsing through our docs.

Further clarified that agent tokens are used for Hybrid agents + added a note about copying/adding descriptions to tokens.

Removed the section about seeded users - this was a holdover from when organizations were manually set up by us. Now that users can self-onboard, this is less relevant.
