### PR TITLE
Provide install_default_libraries for databricks_pyspark_step_launcher run_config

### DIFF
--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_input_managers.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_input_managers.py
@@ -92,7 +92,9 @@ def upstream_asset():
     return pd.DataFrame([1, 2, 3])
 
 
-@asset(ins={"upstream": AssetIn(key_prefix="public", input_manager_key="numpy_manager")})
+@asset(
+    ins={"upstream": AssetIn(key_prefix="public", input_manager_key="numpy_manager")}
+)
 def downstream_asset(upstream):
     return upstream.shape
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
@@ -502,10 +502,16 @@ def _define_submit_run_fields():
         "This token should have at most 64 characters.",
         is_required=False,
     )
+    install_default_libraries = Field(
+        Bool,
+        description="To install default libraries or not.",
+        is_required=False,
+    )
     return {
         "cluster": _define_cluster(),
         "run_name": run_name,
         "libraries": _define_libraries(),
+        "install_default_libraries": install_default_libraries,
         "timeout_seconds": timeout_seconds,
         "idempotency_token": idempotency_token,
     }

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
@@ -504,7 +504,9 @@ def _define_submit_run_fields():
     )
     install_default_libraries = Field(
         Bool,
-        description="To install default libraries or not.",
+        description="By default, Dagster installs a version of dagster, dagster-databricks, and "
+        "dagster-pyspark matching the locally-installed versions of those libraries. If you would "
+        "like to disable this behavior, this value can be set to False.",
         is_required=False,
     )
     return {

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -173,14 +173,16 @@ class DatabricksJobRunner:
         # since they're imported by our scripts.
         # Add them if they're not already added by users in config.
         libraries = list(run_config.get("libraries", []))
-        python_libraries = {
-            x["pypi"]["package"].split("==")[0].replace("_", "-") for x in libraries if "pypi" in x
-        }
-        for library in ["dagster", "dagster-databricks", "dagster-pyspark"]:
-            if library not in python_libraries:
-                libraries.append(
-                    {"pypi": {"package": "{}=={}".format(library, dagster.__version__)}}
-                )
+        install_default_libraries = run_config.get("install_default_libraries", True)
+        if install_default_libraries == True:
+            python_libraries = {
+                x["pypi"]["package"].split("==")[0].replace("_", "-") for x in libraries if "pypi" in x
+            }
+            for library in ["dagster", "dagster-databricks", "dagster-pyspark"]:
+                if library not in python_libraries:
+                    libraries.append(
+                        {"pypi": {"package": "{}=={}".format(library, dagster.__version__)}}
+                    )
 
         # Only one task should be able to be chosen really; make sure of that here.
         check.invariant(

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -174,9 +174,11 @@ class DatabricksJobRunner:
         # Add them if they're not already added by users in config.
         libraries = list(run_config.get("libraries", []))
         install_default_libraries = run_config.get("install_default_libraries", True)
-        if install_default_libraries == True:
+        if install_default_libraries:
             python_libraries = {
-                x["pypi"]["package"].split("==")[0].replace("_", "-") for x in libraries if "pypi" in x
+                x["pypi"]["package"].split("==")[0].replace("_", "-")
+                for x in libraries
+                if "pypi" in x
             }
             for library in ["dagster", "dagster-databricks", "dagster-pyspark"]:
                 if library not in python_libraries:

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -173,6 +173,14 @@ class DatabricksJobRunner:
         # since they're imported by our scripts.
         # Add them if they're not already added by users in config.
         libraries = list(run_config.get("libraries", []))
+        python_libraries = {
+            x["pypi"]["package"].split("==")[0].replace("_", "-") for x in libraries if "pypi" in x
+        }
+        for library in ["dagster", "dagster-databricks", "dagster-pyspark"]:
+            if library not in python_libraries:
+                libraries.append(
+                    {"pypi": {"package": "{}=={}".format(library, dagster.__version__)}}
+                )
 
         # Only one task should be able to be chosen really; make sure of that here.
         check.invariant(

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -173,14 +173,6 @@ class DatabricksJobRunner:
         # since they're imported by our scripts.
         # Add them if they're not already added by users in config.
         libraries = list(run_config.get("libraries", []))
-        python_libraries = {
-            x["pypi"]["package"].split("==")[0].replace("_", "-") for x in libraries if "pypi" in x
-        }
-        for library in ["dagster", "dagster-databricks", "dagster-pyspark"]:
-            if library not in python_libraries:
-                libraries.append(
-                    {"pypi": {"package": "{}=={}".format(library, dagster.__version__)}}
-                )
 
         # Only one task should be able to be chosen really; make sure of that here.
         check.invariant(

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/conftest.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/conftest.py
@@ -9,4 +9,7 @@ def databricks_run_config():
         "task": {
             "spark_jar_task": {"main_class_name": "my-class", "parameters": ["first", "second"]}
         },
+        "libraries": [
+            {"pypi": {"package": "python_package_test==1.0.0"}},
+        ]
     }

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/conftest.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/conftest.py
@@ -9,7 +9,4 @@ def databricks_run_config():
         "task": {
             "spark_jar_task": {"main_class_name": "my-class", "parameters": ["first", "second"]}
         },
-        "libraries": [
-            {"pypi": {"package": "python_package_test==1.0.0"}},
-        ]
     }

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
@@ -24,9 +24,7 @@ def test_databricks_submit_job_existing_cluster(mock_submit_run, databricks_run_
         existing_cluster_id=databricks_run_config["cluster"]["existing"],
         spark_jar_task=task["spark_jar_task"],
         libraries=[
-            {"pypi": {"package": "dagster=={}".format(dagster.__version__)}},
-            {"pypi": {"package": "dagster-databricks=={}".format(dagster.__version__)}},
-            {"pypi": {"package": "dagster-pyspark=={}".format(dagster.__version__)}},
+            {"pypi": {"package": "python_package_test==1.0.0"}},
         ],
     )
 
@@ -57,9 +55,7 @@ def test_databricks_submit_job_new_cluster(mock_submit_run, databricks_run_confi
         existing_cluster_id=None,
         spark_jar_task=task["spark_jar_task"],
         libraries=[
-            {"pypi": {"package": "dagster=={}".format(dagster.__version__)}},
-            {"pypi": {"package": "dagster-databricks=={}".format(dagster.__version__)}},
-            {"pypi": {"package": "dagster-pyspark=={}".format(dagster.__version__)}},
+            {"pypi": {"package": "python_package_test==1.0.0"}},
         ],
     )
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
@@ -24,7 +24,9 @@ def test_databricks_submit_job_existing_cluster(mock_submit_run, databricks_run_
         existing_cluster_id=databricks_run_config["cluster"]["existing"],
         spark_jar_task=task["spark_jar_task"],
         libraries=[
-            {"pypi": {"package": "python_package_test==1.0.0"}},
+            {"pypi": {"package": "dagster=={}".format(dagster.__version__)}},
+            {"pypi": {"package": "dagster-databricks=={}".format(dagster.__version__)}},
+            {"pypi": {"package": "dagster-pyspark=={}".format(dagster.__version__)}},
         ],
     )
 
@@ -55,7 +57,9 @@ def test_databricks_submit_job_new_cluster(mock_submit_run, databricks_run_confi
         existing_cluster_id=None,
         spark_jar_task=task["spark_jar_task"],
         libraries=[
-            {"pypi": {"package": "python_package_test==1.0.0"}},
+            {"pypi": {"package": "dagster=={}".format(dagster.__version__)}},
+            {"pypi": {"package": "dagster-databricks=={}".format(dagster.__version__)}},
+            {"pypi": {"package": "dagster-pyspark=={}".format(dagster.__version__)}},
         ],
     )
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
@@ -18,7 +18,7 @@ def test_databricks_submit_job_existing_cluster(mock_submit_run, databricks_run_
     runner = DatabricksJobRunner(HOST, TOKEN)
     task = databricks_run_config.pop("task")
     runner.submit_run(databricks_run_config, task)
-    mock_submit_run.assert_called_once_with(
+    mock_submit_run.assert_called_with(
         run_name=databricks_run_config["run_name"],
         new_cluster=None,
         existing_cluster_id=databricks_run_config["cluster"]["existing"],
@@ -28,6 +28,16 @@ def test_databricks_submit_job_existing_cluster(mock_submit_run, databricks_run_
             {"pypi": {"package": "dagster-databricks=={}".format(dagster.__version__)}},
             {"pypi": {"package": "dagster-pyspark=={}".format(dagster.__version__)}},
         ],
+    )
+
+    databricks_run_config["install_default_libraries"] = False
+    runner.submit_run(databricks_run_config, task)
+    mock_submit_run.assert_called_with(
+        run_name=databricks_run_config["run_name"],
+        new_cluster=None,
+        existing_cluster_id=databricks_run_config["cluster"]["existing"],
+        spark_jar_task=task["spark_jar_task"],
+        libraries=[],
     )
 
 


### PR DESCRIPTION
### Summary & Motivation
We are using dagster_databricks. When dagster upgrades to a new version, the job submit to Databricks will fail because Databricks cluster cannot automatically install new version without delete older version.

In production environment, we cannot just go to Databricks cluster and delete the old libraries. The default libraries in this case make this difficult to handle the situation. Thus, this PR is to provide the options to run Databricks jobs without libraries by adding a install_default_libraries params in run_config.

### How I Tested These Changes
Unit test + Local test
