### PR TITLE
include ResourceClosedError in retry_mysql_connection_fn

### DIFF
--- a/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
@@ -100,6 +100,7 @@ def retry_mysql_connection_fn(fn, retry_limit=5, retry_wait=0.2):
             mysql.OperationalError,
             db.exc.DatabaseError,
             db.exc.OperationalError,
+            db.exc.ResourceClosedError,
             mysql.errors.InterfaceError,
         ) as exc:
             logging.warning("Retrying failed database connection")


### PR DESCRIPTION
It seems that the `mysql` `dbapi` under `sqlalchemy` implicitly holds connections, so we get `ResourceClosedError` on long lived processes even with no explicit pooling turned on.

It should be fine to retry the connection in this condition. Worst case scenario is that it repeats this failure until the retries are exhausted. Ideally will cause the second attempt to connect. 

### How I Tested These Changes

existing tests