### PR TITLE
change "library_version" to "pre_stable_version"

### DIFF
--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -52,14 +52,18 @@ PICKLE_PROTOCOL = 4
 
 DEFAULT_WORKSPACE_YAML_FILENAME = "workspace.yaml"
 
-# Use this to get the "library version" (pre-1.0 version) from the "core version" (post 1.0
-# version). 16 is from the 0.16.0 that library versions stayed on when core went to 1.0.0.
-def library_version_from_core_version(core_version: str) -> str:
-    release = parse_package_version(core_version).release
+def pre_stable_version_from_stable_version(stable_version: str) -> str:
+    """Get the "pre-stable version" (pre-1.0 version) from the "stable version". "Stable version"
+    here is defined as the version of dagster core. Prior to 1.0, versions of all packages were the
+    same, so there was no distinction between pre-and-post-stable versions. Therefore this function
+    is an identity function for pre-1.0 inputs. After 1.0, some "pre-stable" packages
+    remained on a pre-1.0 version track, with exactly one pre-stable version for every stable
+    version. This function returns that pre-stable version for post-1.0 inputs."""
+    release = parse_package_version(stable_version).release
     if release[0] >= 1:
         return ".".join(["0", str(16 + release[1]), str(release[2])])
     else:
-        return core_version
+        return stable_version
 
 
 def parse_package_version(version_str: str) -> packaging.version.Version:

--- a/python_modules/dagster/dagster_tests/core_tests/test_utils.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_utils.py
@@ -40,7 +40,7 @@ def test_check_dagster_package_version(monkeypatch):
         warnings.simplefilter("error")
         check_dagster_package_version("foo", "1.1.0")
 
-    # Lib version matching 1.1.0-- see dagster._utils.library_version_from_core_version
+    # Lib version matching 1.1.0-- see dagster._utils.pre_stable_version_from_stable_version
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         check_dagster_package_version("foo", "0.17.0")


### PR DESCRIPTION
### Summary & Motivation

Improving the nomenclature for our two package versioning tracks. See https://elementl-workspace.slack.com/archives/C03AFEEDDNX/p1660243421069989.

### How I Tested These Changes

BK.
