### PR TITLE
Add execute_op_for_test

### DIFF
--- a/python_modules/dagster/dagster_tests/execution_tests/test_execute_op_for_test.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_execute_op_for_test.py
@@ -1,0 +1,27 @@
+import pytest
+
+from dagster import DagsterInvariantViolationError, op
+from dagster._utils.test import execute_op_for_test
+
+
+def test_execute_op():
+    @op(required_resource_keys={"foo"}, config_schema=int)
+    def the_op(context, x: int) -> int:
+        return context.resources.foo + x + context.op_config
+
+    result = execute_op_for_test(
+        the_op,
+        resources={"foo": 5},
+        input_values={"x": 6},
+        run_config={"ops": {"the_op": {"config": 7}}},
+    )
+    assert result.success
+    assert result.output_value() == 18
+
+    with pytest.raises(DagsterInvariantViolationError):
+        execute_op_for_test(
+            the_op,
+            resources={"foo": 5},
+            input_values={"x": 6, "y": 8},
+            run_config={"ops": {"the_op": {"config": 7}}},
+        )


### PR DESCRIPTION
Currently, much of our test suite utilizes `execute_solid` in order to test core functionality. Op invocation is not an adequate replacement for these use cases, because it ignores some parts of the core execution loop. 

This PR adds `execute_op_for_test`, intended to replace `execute_solid` internally. Leverages some of the enhanced ergonomics around ops/jobs/graphs to make for a slightly cleaner API.