### PR TITLE
improve dagster import perf

### DIFF
--- a/docs/sphinx/sections/api/apidocs/internals.rst
+++ b/docs/sphinx/sections/api/apidocs/internals.rst
@@ -119,7 +119,7 @@ See also: :py:class:`dagster_postgres.PostgresRunStorage` and :py:class:`dagster
 Event log storage
 -----------------
 
-.. currentmodule:: dagster._core.storage.event_log
+.. currentmodule:: dagster
 
 .. autoclass:: EventLogEntry
 
@@ -128,6 +128,8 @@ Event log storage
 .. autoclass:: EventRecordsFilter
 
 .. autoclass:: RunShardedEventsCursor
+
+.. currentmodule:: dagster._core.storage.event_log
 
 .. autoclass:: EventLogStorage
 

--- a/integration_tests/test_suites/daemon-test-suite/conftest.py
+++ b/integration_tests/test_suites/daemon-test-suite/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 from dagster import file_relative_path
 from dagster._core.test_utils import instance_for_test
-from dagster._core.workspace import WorkspaceProcessContext
+from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import PythonFileTarget
 
 

--- a/python_modules/dagit/dagit/cli.py
+++ b/python_modules/dagit/dagit/cli.py
@@ -14,7 +14,7 @@ from dagster._cli.workspace import (
 from dagster._cli.workspace.cli_target import WORKSPACE_TARGET_WARNING
 from dagster._core.telemetry import START_DAGIT_WEBSERVER, log_action
 from dagster._core.telemetry_upload import uploading_logging_thread
-from dagster._core.workspace import WorkspaceProcessContext
+from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._utils import DEFAULT_WORKSPACE_YAML_FILENAME
 from dagster._utils.log import configure_loggers
 

--- a/python_modules/dagit/dagit/debug.py
+++ b/python_modules/dagit/dagit/debug.py
@@ -5,7 +5,7 @@ import click
 from dagster import DagsterInstance
 from dagster import _check as check
 from dagster._cli.debug import DebugRunPayload
-from dagster._core.workspace import WorkspaceProcessContext
+from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._serdes import deserialize_json_to_dagster_namedtuple
 
 from .cli import (

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -10,7 +10,7 @@ from dagster._core.host_representation import (
     ManagedGrpcPythonEnvRepositoryLocationOrigin,
     RepositoryLocation,
 )
-from dagster._core.workspace import WorkspaceLocationEntry, WorkspaceLocationLoadStatus
+from dagster._core.workspace.context import WorkspaceLocationEntry, WorkspaceLocationLoadStatus
 
 from .asset_graph import GrapheneAssetGroup, GrapheneAssetNode
 from .errors import GraphenePythonError, GrapheneRepositoryNotFoundError

--- a/python_modules/dagster-graphql/dagster_graphql/test/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/test/utils.py
@@ -6,7 +6,7 @@ from graphql import graphql
 import dagster._check as check
 from dagster._core.instance import DagsterInstance
 from dagster._core.test_utils import wait_for_runs_to_finish
-from dagster._core.workspace import WorkspaceProcessContext
+from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import PythonFileTarget
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
@@ -21,7 +21,7 @@ from dagster._core.storage.runs import InMemoryRunStorage
 from dagster._core.storage.schedules.sqlite.sqlite_schedule_storage import SqliteScheduleStorage
 from dagster._core.test_utils import ExplodingRunLauncher, instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._core.workspace import WorkspaceProcessContext
+from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import (
     GrpcServerTarget,
     ModuleTarget,

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -436,7 +436,8 @@ from dagster._core.launcher.default_run_launcher import (
 from dagster._core.log_manager import (
     DagsterLogManager as DagsterLogManager,
 )
-from dagster._core.storage.event_log.base import (
+
+from dagster._core.event_api import (
     EventLogRecord as EventLogRecord,
     EventRecordsFilter as EventRecordsFilter,
     RunShardedEventsCursor as RunShardedEventsCursor,
@@ -525,7 +526,8 @@ from dagster._utils.backcompat import (
 from dagster._utils.log import (
     get_dagster_logger as get_dagster_logger,
 )
-from dagster._utils.test import (
+
+from dagster._utils.dagster_type import (
     check_dagster_type as check_dagster_type,
 )
 

--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -175,7 +175,7 @@ def get_workspace_load_target(kwargs: Dict[str, str]):
 def get_workspace_process_context_from_kwargs(
     instance: DagsterInstance, version: str, read_only: bool, kwargs: Dict[str, str]
 ) -> "WorkspaceProcessContext":
-    from dagster._core.workspace import WorkspaceProcessContext
+    from dagster._core.workspace.context import WorkspaceProcessContext
 
     return WorkspaceProcessContext(
         instance, get_workspace_load_target(kwargs), version=version, read_only=read_only

--- a/python_modules/dagster/dagster/_core/definitions/preset.py
+++ b/python_modules/dagster/dagster/_core/definitions/preset.py
@@ -1,7 +1,5 @@
 from typing import Dict, List, NamedTuple, Optional
 
-import pkg_resources
-
 import dagster._check as check
 from dagster._core.definitions.utils import config_from_files, config_from_yaml_strings
 from dagster._core.errors import DagsterInvariantViolationError
@@ -176,6 +174,8 @@ class PresetDefinition(
             DagsterInvariantViolationError: When one of the YAML documents is invalid and has a
                 parse error.
         """
+        import pkg_resources  # expensive, import only on use
+
         pkg_resource_defs = check.opt_list_param(
             pkg_resource_defs, "pkg_resource_defs", of_type=tuple
         )

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -303,7 +303,8 @@ class RunStatusSensorDefinition(SensorDefinition):
         request_jobs: Optional[Sequence[Union[GraphDefinition, JobDefinition]]] = None,
     ):
 
-        from dagster._core.storage.event_log.base import EventRecordsFilter, RunShardedEventsCursor
+        from dagster._core.event_api import RunShardedEventsCursor
+        from dagster._core.storage.event_log.base import EventRecordsFilter
 
         check.str_param(name, "name")
         check.inst_param(run_status, "run_status", DagsterRunStatus)

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -4,7 +4,6 @@ import re
 from glob import glob
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
-import pkg_resources
 import yaml
 
 import dagster._check as check
@@ -220,6 +219,8 @@ def config_from_pkg_resources(pkg_resource_defs: List[Tuple[str, str]]) -> Dict[
         DagsterInvariantViolationError: When one of the YAML documents is invalid and has a
             parse error.
     """
+    import pkg_resources  # expensive, import only on use
+
     pkg_resource_defs = check.list_param(pkg_resource_defs, "pkg_resource_defs", of_type=tuple)
 
     try:

--- a/python_modules/dagster/dagster/_core/event_api.py
+++ b/python_modules/dagster/dagster/_core/event_api.py
@@ -1,0 +1,98 @@
+from datetime import datetime
+from typing import List, NamedTuple, Optional, Union
+
+import dagster._check as check
+from dagster._annotations import PublicAttr
+from dagster._core.definitions.events import AssetKey
+from dagster._core.events import DagsterEventType
+from dagster._core.events.log import EventLogEntry
+from dagster._serdes import whitelist_for_serdes
+
+
+class RunShardedEventsCursor(NamedTuple):
+    """Pairs an id-based event log cursor with a timestamp-based run cursor, for improved
+    performance on run-sharded event log storages (e.g. the default SqliteEventLogStorage). For
+    run-sharded storages, the id field is ignored, since they may not be unique across shards
+    """
+
+    id: int
+    run_updated_after: datetime
+
+
+class EventLogRecord(NamedTuple):
+    """Internal representation of an event record, as stored in a
+    :py:class:`~dagster._core.storage.event_log.EventLogStorage`.
+
+    Users should not instantiate this class directly.
+    """
+
+    storage_id: PublicAttr[int]
+    event_log_entry: PublicAttr[EventLogEntry]
+
+
+@whitelist_for_serdes
+class EventRecordsFilter(
+    NamedTuple(
+        "_EventRecordsFilter",
+        [
+            ("event_type", DagsterEventType),
+            ("asset_key", Optional[AssetKey]),
+            ("asset_partitions", Optional[List[str]]),
+            ("after_cursor", Optional[Union[int, RunShardedEventsCursor]]),
+            ("before_cursor", Optional[Union[int, RunShardedEventsCursor]]),
+            ("after_timestamp", Optional[float]),
+            ("before_timestamp", Optional[float]),
+        ],
+    )
+):
+    """Defines a set of filter fields for fetching a set of event log entries or event log records.
+
+    Args:
+        event_type (DagsterEventType): Filter argument for dagster event type
+        asset_key (Optional[AssetKey]): Asset key for which to get asset materialization event
+            entries / records.
+        asset_partitions (Optional[List[str]]): Filter parameter such that only asset
+            materialization events with a partition value matching one of the provided values.  Only
+            valid when the `asset_key` parameter is provided.
+        after_cursor (Optional[Union[int, RunShardedEventsCursor]]): Filter parameter such that only
+            records with storage_id greater than the provided value are returned. Using a
+            run-sharded events cursor will result in a significant performance gain when run against
+            a SqliteEventLogStorage implementation (which is run-sharded)
+        before_cursor (Optional[Union[int, RunShardedEventsCursor]]): Filter parameter such that
+            records with storage_id less than the provided value are returned. Using a run-sharded
+            events cursor will result in a significant performance gain when run against
+            a SqliteEventLogStorage implementation (which is run-sharded)
+        after_timestamp (Optional[float]): Filter parameter such that only event records for
+            events with timestamp greater than the provided value are returned.
+        before_timestamp (Optional[float]): Filter parameter such that only event records for
+            events with timestamp less than the provided value are returned.
+    """
+
+    def __new__(
+        cls,
+        event_type: DagsterEventType,
+        asset_key: Optional[AssetKey] = None,
+        asset_partitions: Optional[List[str]] = None,
+        after_cursor: Optional[Union[int, RunShardedEventsCursor]] = None,
+        before_cursor: Optional[Union[int, RunShardedEventsCursor]] = None,
+        after_timestamp: Optional[float] = None,
+        before_timestamp: Optional[float] = None,
+    ):
+        check.opt_list_param(asset_partitions, "asset_partitions", of_type=str)
+        check.inst_param(event_type, "event_type", DagsterEventType)
+
+        # type-ignores work around mypy type inference bug
+        return super(EventRecordsFilter, cls).__new__(
+            cls,
+            event_type=event_type,
+            asset_key=check.opt_inst_param(asset_key, "asset_key", AssetKey),
+            asset_partitions=asset_partitions,
+            after_cursor=check.opt_inst_param(  # type: ignore
+                after_cursor, "after_cursor", (int, RunShardedEventsCursor)
+            ),
+            before_cursor=check.opt_inst_param(  # type: ignore
+                before_cursor, "before_cursor", (int, RunShardedEventsCursor)
+            ),
+            after_timestamp=check.opt_float_param(after_timestamp, "after_timestamp"),
+            before_timestamp=check.opt_float_param(before_timestamp, "before_timestamp"),
+        )

--- a/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
@@ -3,7 +3,7 @@ import threading
 import uuid
 from abc import abstractmethod
 from contextlib import AbstractContextManager
-from typing import Generic, NamedTuple, Optional, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Generic, NamedTuple, Optional, TypeVar, Union, cast
 
 import pendulum
 
@@ -14,9 +14,11 @@ from dagster._core.host_representation.origin import (
     RepositoryLocationOrigin,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._grpc.client import DagsterGrpcClient
 from dagster._grpc.server import GrpcServerProcess
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
+
+if TYPE_CHECKING:
+    from dagster._grpc.client import DagsterGrpcClient
 
 
 class GrpcServerEndpoint(
@@ -39,7 +41,9 @@ class GrpcServerEndpoint(
             check.opt_str_param(socket, "socket"),
         )
 
-    def create_client(self) -> DagsterGrpcClient:
+    def create_client(self) -> "DagsterGrpcClient":
+        from dagster._grpc.client import DagsterGrpcClient
+
         return DagsterGrpcClient(port=self.port, socket=self.socket, host=self.host)
 
 

--- a/python_modules/dagster/dagster/_core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/repository_location.py
@@ -54,7 +54,6 @@ from dagster._grpc.types import GetCurrentImageResult
 from dagster._serdes import deserialize_as
 from dagster._seven.compat.pendulum import PendulumDateTime
 from dagster._utils import merge_dicts
-from dagster._utils.hosted_user_process import external_repo_from_def
 
 from .selector import PipelineSelector
 
@@ -268,6 +267,7 @@ class RepositoryLocation(AbstractContextManager):
 class InProcessRepositoryLocation(RepositoryLocation):
     def __init__(self, origin: InProcessRepositoryLocationOrigin):
         from dagster._grpc.server import LoadedRepositories
+        from dagster._utils.hosted_user_process import external_repo_from_def
 
         self._origin = check.inst_param(origin, "origin", InProcessRepositoryLocationOrigin)
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/__init__.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/__init__.py
@@ -1,11 +1,4 @@
-from .base import (
-    AssetRecord,
-    EventLogEntry,
-    EventLogRecord,
-    EventLogStorage,
-    EventRecordsFilter,
-    RunShardedEventsCursor,
-)
+from .base import AssetRecord, EventLogRecord, EventLogStorage
 from .in_memory import InMemoryEventLogStorage
 from .polling_event_watcher import SqlPollingEventWatcher
 from .schema import AssetKeyTable, SqlEventLogStorageMetadata, SqlEventLogStorageTable

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -1,13 +1,12 @@
 import base64
 from abc import ABC, abstractmethod
-from datetime import datetime
 from enum import Enum
 from typing import Callable, Iterable, List, Mapping, NamedTuple, Optional, Sequence, Set, Union
 
 import dagster._check as check
-from dagster._annotations import PublicAttr
 from dagster._core.assets import AssetDetails
 from dagster._core.definitions.events import AssetKey
+from dagster._core.event_api import EventLogRecord, EventRecordsFilter
 from dagster._core.events import DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.stats import (
@@ -17,29 +16,7 @@ from dagster._core.execution.stats import (
 )
 from dagster._core.instance import MayHaveInstanceWeakref
 from dagster._core.storage.pipeline_run import PipelineRunStatsSnapshot
-from dagster._serdes import whitelist_for_serdes
 from dagster._seven import json
-
-
-class RunShardedEventsCursor(NamedTuple):
-    """Pairs an id-based event log cursor with a timestamp-based run cursor, for improved
-    performance on run-sharded event log storages (e.g. the default SqliteEventLogStorage). For
-    run-sharded storages, the id field is ignored, since they may not be unique across shards
-    """
-
-    id: int
-    run_updated_after: datetime
-
-
-class EventLogRecord(NamedTuple):
-    """Internal representation of an event record, as stored in a
-    :py:class:`~dagster._core.storage.event_log.EventLogStorage`.
-
-    Users should not instantiate this class directly.
-    """
-
-    storage_id: PublicAttr[int]
-    event_log_entry: PublicAttr[EventLogEntry]
 
 
 class EventLogConnection(NamedTuple):
@@ -131,74 +108,6 @@ class AssetRecord(NamedTuple):
 
     storage_id: int
     asset_entry: AssetEntry
-
-
-@whitelist_for_serdes
-class EventRecordsFilter(
-    NamedTuple(
-        "_EventRecordsFilter",
-        [
-            ("event_type", DagsterEventType),
-            ("asset_key", Optional[AssetKey]),
-            ("asset_partitions", Optional[List[str]]),
-            ("after_cursor", Optional[Union[int, RunShardedEventsCursor]]),
-            ("before_cursor", Optional[Union[int, RunShardedEventsCursor]]),
-            ("after_timestamp", Optional[float]),
-            ("before_timestamp", Optional[float]),
-        ],
-    )
-):
-    """Defines a set of filter fields for fetching a set of event log entries or event log records.
-
-    Args:
-        event_type (DagsterEventType): Filter argument for dagster event type
-        asset_key (Optional[AssetKey]): Asset key for which to get asset materialization event
-            entries / records.
-        asset_partitions (Optional[List[str]]): Filter parameter such that only asset
-            materialization events with a partition value matching one of the provided values.  Only
-            valid when the `asset_key` parameter is provided.
-        after_cursor (Optional[Union[int, RunShardedEventsCursor]]): Filter parameter such that only
-            records with storage_id greater than the provided value are returned. Using a
-            run-sharded events cursor will result in a significant performance gain when run against
-            a SqliteEventLogStorage implementation (which is run-sharded)
-        before_cursor (Optional[Union[int, RunShardedEventsCursor]]): Filter parameter such that
-            records with storage_id less than the provided value are returned. Using a run-sharded
-            events cursor will result in a significant performance gain when run against
-            a SqliteEventLogStorage implementation (which is run-sharded)
-        after_timestamp (Optional[float]): Filter parameter such that only event records for
-            events with timestamp greater than the provided value are returned.
-        before_timestamp (Optional[float]): Filter parameter such that only event records for
-            events with timestamp less than the provided value are returned.
-    """
-
-    def __new__(
-        cls,
-        event_type: DagsterEventType,
-        asset_key: Optional[AssetKey] = None,
-        asset_partitions: Optional[List[str]] = None,
-        after_cursor: Optional[Union[int, RunShardedEventsCursor]] = None,
-        before_cursor: Optional[Union[int, RunShardedEventsCursor]] = None,
-        after_timestamp: Optional[float] = None,
-        before_timestamp: Optional[float] = None,
-    ):
-        check.opt_list_param(asset_partitions, "asset_partitions", of_type=str)
-        check.inst_param(event_type, "event_type", DagsterEventType)
-
-        # type-ignores work around mypy type inference bug
-        return super(EventRecordsFilter, cls).__new__(
-            cls,
-            event_type=event_type,
-            asset_key=check.opt_inst_param(asset_key, "asset_key", AssetKey),
-            asset_partitions=asset_partitions,
-            after_cursor=check.opt_inst_param(  # type: ignore
-                after_cursor, "after_cursor", (int, RunShardedEventsCursor)
-            ),
-            before_cursor=check.opt_inst_param(  # type: ignore
-                before_cursor, "before_cursor", (int, RunShardedEventsCursor)
-            ),
-            after_timestamp=check.opt_float_param(after_timestamp, "after_timestamp"),
-            before_timestamp=check.opt_float_param(before_timestamp, "before_timestamp"),
-        )
 
 
 class EventLogStorage(ABC, MayHaveInstanceWeakref):

--- a/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
@@ -6,6 +6,7 @@ from typing import Dict, Iterable, Mapping, Optional, Sequence, Set, cast
 import dagster._check as check
 from dagster._core.assets import AssetDetails
 from dagster._core.definitions.events import AssetKey
+from dagster._core.event_api import RunShardedEventsCursor
 from dagster._core.events import DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._core.storage.event_log.base import AssetEntry, AssetRecord
@@ -19,7 +20,6 @@ from .base import (
     EventLogRecord,
     EventLogStorage,
     EventRecordsFilter,
-    RunShardedEventsCursor,
 )
 
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -12,6 +12,7 @@ import dagster._seven as seven
 from dagster._core.assets import AssetDetails
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
 from dagster._core.errors import DagsterEventLogInvalidForRun
+from dagster._core.event_api import RunShardedEventsCursor
 from dagster._core.events import MARKER_EVENTS, DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.stats import build_run_step_stats_from_events
@@ -32,7 +33,6 @@ from .base import (
     EventLogRecord,
     EventLogStorage,
     EventRecordsFilter,
-    RunShardedEventsCursor,
 )
 from .migration import ASSET_DATA_MIGRATIONS, ASSET_KEY_INDEX_COLS, EVENT_LOG_DATA_MIGRATIONS
 from .schema import AssetKeyTable, SecondaryIndexMigrationTable, SqlEventLogStorageTable

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -466,7 +466,7 @@ def log_repo_stats(instance, source, pipeline=None, repo=None):
 
 
 def log_workspace_stats(instance, workspace_process_context):
-    from dagster._core.workspace import IWorkspaceProcessContext
+    from dagster._core.workspace.context import IWorkspaceProcessContext
 
     check.inst_param(instance, "instance", DagsterInstance)
     check.inst_param(

--- a/python_modules/dagster/dagster/_core/workspace/__init__.py
+++ b/python_modules/dagster/dagster/_core/workspace/__init__.py
@@ -1,2 +1,0 @@
-from .context import IWorkspaceProcessContext, WorkspaceProcessContext
-from .workspace import IWorkspace, WorkspaceLocationEntry, WorkspaceLocationLoadStatus

--- a/python_modules/dagster/dagster/_core/workspace/workspace.py
+++ b/python_modules/dagster/dagster/_core/workspace/workspace.py
@@ -1,10 +1,11 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Dict, NamedTuple, Optional
+from typing import TYPE_CHECKING, Dict, NamedTuple, Optional
 
-from dagster._core.host_representation import RepositoryLocation, RepositoryLocationOrigin
 from dagster._utils.error import SerializableErrorInfo
 
+if TYPE_CHECKING:
+    from dagster._core.host_representation import RepositoryLocation, RepositoryLocationOrigin
 
 # For locations that are loaded asynchronously
 class WorkspaceLocationLoadStatus(Enum):
@@ -13,8 +14,8 @@ class WorkspaceLocationLoadStatus(Enum):
 
 
 class WorkspaceLocationEntry(NamedTuple):
-    origin: RepositoryLocationOrigin
-    repository_location: Optional[RepositoryLocation]
+    origin: "RepositoryLocationOrigin"
+    repository_location: Optional["RepositoryLocation"]
     load_error: Optional[SerializableErrorInfo]
     load_status: WorkspaceLocationLoadStatus
     display_metadata: Dict[str, str]
@@ -27,7 +28,7 @@ class IWorkspace(ABC):
     """
 
     @abstractmethod
-    def get_repository_location(self, location_name: str) -> RepositoryLocation:
+    def get_repository_location(self, location_name: str) -> "RepositoryLocation":
         """Return the RepositoryLocation for the given location name, or raise an error if there is an error loading it."""
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -12,7 +12,7 @@ from dagster._core.execution.backfill import (
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.pipeline_run import PipelineRun, RunsFilter
 from dagster._core.storage.tags import PARTITION_NAME_TAG
-from dagster._core.workspace import IWorkspace
+from dagster._core.workspace.context import IWorkspace
 from dagster._utils.error import serializable_error_info_from_exc_info
 
 # out of abundance of caution, sleep at checkpoints in case we are pinning CPU by submitting lots

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -11,7 +11,7 @@ import pendulum
 import dagster._check as check
 from dagster._core.host_representation.grpc_server_registry import ProcessGrpcServerRegistry
 from dagster._core.instance import DagsterInstance
-from dagster._core.workspace import IWorkspace
+from dagster._core.workspace.context import IWorkspace
 from dagster._core.workspace.load_target import WorkspaceLoadTarget
 from dagster._daemon.auto_run_reexecution.event_log_consumer import EventLogConsumerDaemon
 from dagster._daemon.daemon import (

--- a/python_modules/dagster/dagster/_daemon/daemon.py
+++ b/python_modules/dagster/dagster/_daemon/daemon.py
@@ -13,7 +13,7 @@ import pendulum
 from dagster import DagsterInstance
 from dagster import _check as check
 from dagster._core.telemetry import DAEMON_ALIVE, log_action
-from dagster._core.workspace import IWorkspace
+from dagster._core.workspace.context import IWorkspace
 from dagster._daemon.backfill import execute_backfill_iteration
 from dagster._daemon.monitoring import execute_monitoring_iteration
 from dagster._daemon.sensor import execute_sensor_iteration_loop

--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -12,7 +12,7 @@ from dagster._core.storage.pipeline_run import (
     RunsFilter,
 )
 from dagster._core.storage.tags import PRIORITY_TAG
-from dagster._core.workspace import IWorkspace
+from dagster._core.workspace.context import IWorkspace
 from dagster._daemon.daemon import IntervalDaemon
 from dagster._utils.error import serializable_error_info_from_exc_info
 

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -28,7 +28,7 @@ from dagster._core.scheduler.instigation import (
 from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus, RunsFilter
 from dagster._core.storage.tags import RUN_KEY_TAG, SENSOR_NAME_TAG
 from dagster._core.telemetry import SENSOR_RUN_CREATED, hash_name, log_action
-from dagster._core.workspace import IWorkspace
+from dagster._core.workspace.context import IWorkspace
 from dagster._utils import merge_dicts
 from dagster._utils.error import serializable_error_info_from_exc_info
 

--- a/python_modules/dagster/dagster/_daemon/workspace.py
+++ b/python_modules/dagster/dagster/_daemon/workspace.py
@@ -11,8 +11,9 @@ from dagster._core.host_representation.repository_location import (
     GrpcServerRepositoryLocation,
     RepositoryLocation,
 )
-from dagster._core.workspace import IWorkspace, WorkspaceLocationEntry, WorkspaceLocationLoadStatus
+from dagster._core.workspace.context import IWorkspace
 from dagster._core.workspace.load_target import WorkspaceLoadTarget
+from dagster._core.workspace.workspace import WorkspaceLocationEntry, WorkspaceLocationLoadStatus
 from dagster._utils.error import serializable_error_info_from_exc_info
 
 

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -26,7 +26,7 @@ from dagster._core.scheduler.scheduler import DEFAULT_MAX_CATCHUP_RUNS, DagsterS
 from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus, RunsFilter
 from dagster._core.storage.tags import RUN_KEY_TAG, SCHEDULED_EXECUTION_TIME_TAG
 from dagster._core.telemetry import SCHEDULED_RUN_CREATED, hash_name, log_action
-from dagster._core.workspace import IWorkspace
+from dagster._core.workspace.context import IWorkspace
 from dagster._seven.compat.pendulum import to_timezone
 from dagster._utils import merge_dicts
 from dagster._utils.error import serializable_error_info_from_exc_info

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -23,7 +23,6 @@ from typing import Optional, Type, TypeVar, Union, cast, overload
 from warnings import warn
 
 import packaging.version
-import yaml
 from typing_extensions import Literal
 
 import dagster._check as check

--- a/python_modules/dagster/dagster/_utils/dagster_type.py
+++ b/python_modules/dagster/dagster/_utils/dagster_type.py
@@ -1,0 +1,63 @@
+from dagster._core.definitions.events import Failure, TypeCheck
+from dagster._core.definitions.pipeline_base import InMemoryPipeline
+from dagster._core.definitions.pipeline_definition import PipelineDefinition
+from dagster._core.errors import DagsterInvariantViolationError
+from dagster._core.execution.api import create_execution_plan
+from dagster._core.execution.context_creation_pipeline import scoped_pipeline_context
+from dagster._core.instance import DagsterInstance
+from dagster._core.types.dagster_type import resolve_dagster_type
+
+from .typing_api import is_typing_type
+
+
+def check_dagster_type(dagster_type, value):
+    """Test a custom Dagster type.
+
+    Args:
+        dagster_type (Any): The Dagster type to test. Should be one of the
+            :ref:`built-in types <builtin>`, a dagster type explicitly constructed with
+            :py:func:`as_dagster_type`, :py:func:`@usable_as_dagster_type <dagster_type>`, or
+            :py:func:`PythonObjectDagsterType`, or a Python type.
+        value (Any): The runtime value to test.
+
+    Returns:
+        TypeCheck: The result of the type check.
+
+
+    Examples:
+
+        .. code-block:: python
+
+            assert check_dagster_type(Dict[Any, Any], {'foo': 'bar'}).success
+    """
+
+    if is_typing_type(dagster_type):
+        raise DagsterInvariantViolationError(
+            (
+                "Must pass in a type from dagster module. You passed {dagster_type} "
+                "which is part of python's typing module."
+            ).format(dagster_type=dagster_type)
+        )
+
+    dagster_type = resolve_dagster_type(dagster_type)
+
+    pipeline = InMemoryPipeline(PipelineDefinition([], "empty"))
+    pipeline_def = pipeline.get_definition()
+
+    instance = DagsterInstance.ephemeral()
+    execution_plan = create_execution_plan(pipeline)
+    pipeline_run = instance.create_run_for_pipeline(pipeline_def)
+    with scoped_pipeline_context(execution_plan, pipeline, {}, pipeline_run, instance) as context:
+        context = context.for_type(dagster_type)
+        try:
+            type_check = dagster_type.type_check(context, value)
+        except Failure as failure:
+            return TypeCheck(success=False, description=failure.description)
+
+        if not isinstance(type_check, TypeCheck):
+            raise DagsterInvariantViolationError(
+                "Type checks can only return TypeCheck. Type {type_name} returned {value}.".format(
+                    type_name=dagster_type.display_name, value=repr(type_check)
+                )
+            )
+        return type_check

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/hello_world_in_file/test_hello_world_in_file_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/hello_world_in_file/test_hello_world_in_file_workspace.py
@@ -1,5 +1,5 @@
 from dagster import DagsterInstance
-from dagster._core.workspace import WorkspaceProcessContext
+from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load import load_workspace_process_context_from_yaml_paths
 from dagster._utils import file_relative_path
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/hello_world_in_module/test_hello_world_in_module_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/hello_world_in_module/test_hello_world_in_module_workspace.py
@@ -1,5 +1,5 @@
 from dagster import DagsterInstance
-from dagster._core.workspace import WorkspaceProcessContext
+from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load import load_workspace_process_context_from_yaml_paths
 from dagster._utils import file_relative_path
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/multi_location/test_multi_location_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/multi_location/test_multi_location_workspace.py
@@ -7,7 +7,7 @@ import yaml
 from dagster import DagsterInstance
 from dagster._core.host_representation import GrpcServerRepositoryLocation
 from dagster._core.test_utils import instance_for_test
-from dagster._core.workspace import WorkspaceProcessContext
+from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load import (
     load_workspace_process_context_from_yaml_paths,
     location_origins_from_config,

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
@@ -6,7 +6,7 @@ from dagster import file_relative_path, repository
 from dagster._core.definitions.repository_definition import RepositoryData
 from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._core.workspace import WorkspaceProcessContext
+from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import GrpcServerTarget
 from dagster._grpc.server import GrpcServerProcess
 from dagster._legacy import lambda_solid, pipeline

--- a/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_default_run_launcher.py
@@ -27,7 +27,7 @@ from dagster._core.test_utils import (
     poll_for_step_start,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._core.workspace import WorkspaceProcessContext
+from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import GrpcServerTarget, PythonFileTarget
 from dagster._grpc.client import DagsterGrpcClient
 from dagster._grpc.server import GrpcServerProcess

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -15,9 +15,12 @@ from dagster import (
     AssetMaterialization,
     AssetObservation,
     DagsterInstance,
+    EventLogRecord,
+    EventRecordsFilter,
     Field,
     Output,
     RetryRequested,
+    RunShardedEventsCursor,
 )
 from dagster import _check as check
 from dagster import _seven as seven
@@ -39,11 +42,6 @@ from dagster._core.execution.plan.handle import StepHandle
 from dagster._core.execution.plan.objects import StepFailureData, StepSuccessData
 from dagster._core.execution.stats import StepEventStatus
 from dagster._core.storage.event_log import InMemoryEventLogStorage, SqlEventLogStorage
-from dagster._core.storage.event_log.base import (
-    EventLogRecord,
-    EventRecordsFilter,
-    RunShardedEventsCursor,
-)
 from dagster._core.storage.event_log.migration import (
     EVENT_LOG_DATA_MIGRATIONS,
     migrate_asset_key_data,

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_terminate.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_terminate.py
@@ -7,7 +7,7 @@ from dagster_shell.utils import execute
 from dagster import repository
 from dagster._core.storage.pipeline_run import PipelineRunStatus
 from dagster._core.test_utils import instance_for_test, poll_for_finished_run, poll_for_step_start
-from dagster._core.workspace import WorkspaceProcessContext
+from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import PythonFileTarget
 from dagster._legacy import pipeline, solid
 from dagster._utils import file_relative_path


### PR DESCRIPTION
Collection of changes identified from profiling:
* defer `pgk_resources` import
* move public event api classes in to own file
* defer most imports in `DefaultRunLauncher`
* move `check_dagster_type` to own file
* remove hoisted imports from `__init__.py` in `workspace` 

reduces import cost on my machine from roughly 1s to .5s

### How I Tested These Changes
`imp.py` :
```
from dagster import job, op


@op
def foo():
    pass


@job
def j():
    foo()
```

`python -X importtime /tmp/imp.py &> /tmp/import.txt && tuna /tmp/import.txt`

![Screen Shot 2022-08-15 at 3 45 22 PM](https://user-images.githubusercontent.com/202219/184715361-392cd110-b6c3-45c5-8441-1be13dfdd4ee.png)
