### PR TITLE
[dagit] Use h23 cycle for run log timestamps

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/LogsRowComponents.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRowComponents.tsx
@@ -127,7 +127,7 @@ export const TimestampColumn: React.FC<{time: string | null}> = React.memo((prop
         hour: '2-digit',
         minute: '2-digit',
         second: '2-digit',
-        hour12: false,
+        hourCycle: 'h23',
         timeZone: timezone === 'Automatic' ? browserTimezone() : timezone,
       });
       const fractionalSec = (timeNumber % 1000) / 1000;


### PR DESCRIPTION
### Summary & Motivation

The `hour12` time format property isn't quite what we want for run log timestamps, `hourCycle` is. We're seeing `24:00` for midnight, which is `hourCycle: h24` and may make sense to some viewers, but looks pretty weird to en-US viewers.

Use `hourCycle: h23` instead, which makes midnight `00:00` as expected.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat

### How I Tested These Changes

Verified behavior in Chrome console.
