### PR TITLE
Check for signal handler existence before replacing interrupt signal

### DIFF
--- a/python_modules/dagster/dagster/_utils/interrupts.py
+++ b/python_modules/dagster/dagster/_utils/interrupts.py
@@ -86,5 +86,9 @@ def raise_interrupts_as(error_cls):
 
         yield
     finally:
-        if signal_replaced:
+        # If this code block is running during deletion, then
+        # original_signal_handler may have already been garbage collected
+        # (garbage collection order is random in python 3.x).
+        # Only attempt to replace the signal if this isn't the case.
+        if signal_replaced and original_signal_handler:
             _replace_interrupt_signal(original_signal_handler)


### PR DESCRIPTION
### Summary & Motivation
This is a follow up to https://github.com/dagster-io/dagster/issues/9362 - in order to use resources without opening a context manager, we implicitly open a context manager when build_op_context runs. If an error occurs before deletion happens, during teardown it's possible that some versions of python will garbage-collect the signals module before the exit/delete block runs in the resource context manager - due to the random order of garbage collection in 3.x. This fixes the issue by gating the signal replacement on the existence of the signal handler.

### How I Tested These Changes
It's difficult to write a test to ensure that this won't break in the future, the only way that I've been able to induce this error is by explicitly erroring within an op, and invoking. The resulting TypeError is ignored since it happens during the deletion/teardown phase though, and I haven't been able to reproduce it outside of that context. I did induce the error, make the change, and ensure that the error disappeared however.

Example op that enduces the error:
```python
def test_failing_op_resource_spindown():
    @op(required_resource_keys={"foo"})
    def the_op(_):
        raise Exception("ohno")

    the_context = build_op_context(resources={"foo": "bar"})
    try:
        the_op(the_context)
    except Exception as e:
        assert str(e) == "ohno"

    assert False
```
