### PR TITLE
[grpc] env var override for default timeout

### DIFF
--- a/python_modules/dagit/dagit_tests/stress/dag_gen.py
+++ b/python_modules/dagit/dagit_tests/stress/dag_gen.py
@@ -1,12 +1,12 @@
 import random
 from collections import defaultdict
+from typing import Dict
 
-from dagster import DependencyDefinition, Field, Output
+from dagster import DependencyDefinition, Field, GraphDefinition, In, OpDefinition, Out, Output
 from dagster import _check as check
-from dagster._legacy import InputDefinition, OutputDefinition, PipelineDefinition, SolidDefinition
 
 
-def generate_solid(solid_id, num_inputs, num_outputs, num_cfg):
+def generate_op(op_id, num_inputs, num_outputs, num_cfg) -> OpDefinition:
     def compute_fn(_context, **_kwargs):
         for i in range(num_outputs):
             yield Output(i, "out_{}".format(i))
@@ -15,19 +15,16 @@ def generate_solid(solid_id, num_inputs, num_outputs, num_cfg):
     for i in range(num_cfg):
         config[f"field_{i}"] = Field(str, is_required=False)
 
-    return SolidDefinition(
-        name=solid_id,
-        input_defs=[
-            InputDefinition(name="in_{}".format(i), default_value="default")
-            for i in range(num_inputs)
-        ],
-        output_defs=[OutputDefinition(name="out_{}".format(i)) for i in range(num_outputs)],
+    return OpDefinition(
+        name=op_id,
+        ins={f"in_{i}": In(default_value="default") for i in range(num_inputs)},
+        outs={f"out_{i}": Out() for i in range(num_outputs)},
         compute_fn=compute_fn,
         config_schema=config,
     )
 
 
-def generate_pipeline(name, size, connect_factor=1.0):
+def generate_job(name, size, connect_factor=1.0):
     check.int_param(size, "size")
     check.invariant(size > 3, "Can not create pipelines with less than 3 nodes")
     check.float_param(connect_factor, "connect_factor")
@@ -35,38 +32,36 @@ def generate_pipeline(name, size, connect_factor=1.0):
     random.seed(name)
 
     # generate nodes
-    solids = {}
+    ops: Dict[str, OpDefinition] = {}
     for i in range(size):
         num_inputs = random.randint(1, 3)
         num_outputs = random.randint(1, 3)
         num_cfg = random.randint(0, 5)
-        solid_id = "{}_solid_{}".format(name, i)
-        solids[solid_id] = generate_solid(
-            solid_id=solid_id,
+        op_id = "{}_op_{}".format(name, i)
+        ops[op_id] = generate_op(
+            op_id=op_id,
             num_inputs=num_inputs,
             num_outputs=num_outputs,
             num_cfg=num_cfg,
         )
 
-    solid_ids = list(solids.keys())
+    op_ids = list(ops.keys())
     # connections
     deps = defaultdict(dict)
     for i in range(int(size * connect_factor)):
         # choose output
-        out_idx = random.randint(0, len(solid_ids) - 2)
-        out_solid_id = solid_ids[out_idx]
-        output_solid = solids[out_solid_id]
-        output_name = output_solid.output_defs[
-            random.randint(0, len(output_solid.output_defs) - 1)
-        ].name
+        out_idx = random.randint(0, len(op_ids) - 2)
+        out_op_id = op_ids[out_idx]
+        output_op = ops[out_op_id]
+        output_name = output_op.output_defs[random.randint(0, len(output_op.output_defs) - 1)].name
 
         # choose input
-        in_idx = random.randint(out_idx + 1, len(solid_ids) - 1)
-        in_solid_id = solid_ids[in_idx]
-        input_solid = solids[in_solid_id]
-        input_name = input_solid.input_defs[random.randint(0, len(input_solid.input_defs) - 1)].name
+        in_idx = random.randint(out_idx + 1, len(op_ids) - 1)
+        in_op_id = op_ids[in_idx]
+        input_op = ops[in_op_id]
+        input_name = input_op.input_defs[random.randint(0, len(input_op.input_defs) - 1)].name
 
         # map
-        deps[in_solid_id][input_name] = DependencyDefinition(out_solid_id, output_name)
+        deps[in_op_id][input_name] = DependencyDefinition(out_op_id, output_name)
 
-    return PipelineDefinition(name=name, solid_defs=list(solids.values()), dependencies=deps)
+    return GraphDefinition(name=name, node_defs=list(ops.values()), dependencies=deps).to_job()

--- a/python_modules/dagit/dagit_tests/stress/manydags.py
+++ b/python_modules/dagit/dagit_tests/stress/manydags.py
@@ -1,0 +1,11 @@
+from dagit_tests.stress.dag_gen import generate_job
+
+from dagster import repository
+
+
+@repository
+def dagit_stress_many_jobs():
+    jobs = []
+    for i in range(1500):
+        jobs.append(generate_job(f"job_{i}", 50))
+    return jobs

--- a/python_modules/dagit/dagit_tests/stress/megadags.py
+++ b/python_modules/dagit/dagit_tests/stress/megadags.py
@@ -1,4 +1,4 @@
-from dagit_tests.stress.dag_gen import generate_pipeline
+from dagit_tests.stress.dag_gen import generate_job
 
 from dagster import repository
 
@@ -6,6 +6,6 @@ from dagster import repository
 @repository
 def dagit_stress_tests():
     return [
-        generate_pipeline("1000_nodes", 1000, 1.0),
-        generate_pipeline("2500_nodes", 2500, 1.0),
+        generate_job("1000_nodes", 1000, 1.0),
+        generate_job("2500_nodes", 2500, 1.0),
     ]

--- a/python_modules/dagster/dagster/_grpc/client.py
+++ b/python_modules/dagster/dagster/_grpc/client.py
@@ -33,11 +33,11 @@ from .types import (
     PipelineSubsetSnapshotArgs,
     SensorExecutionArgs,
 )
-from .utils import max_rx_bytes, max_send_bytes
+from .utils import default_grpc_timeout, max_rx_bytes, max_send_bytes
 
 CLIENT_HEARTBEAT_INTERVAL = 1
 
-DEFAULT_GRPC_TIMEOUT = 60
+DEFAULT_GRPC_TIMEOUT = default_grpc_timeout()
 
 
 def client_heartbeat_thread(client, shutdown_event):

--- a/python_modules/dagster/dagster/_grpc/utils.py
+++ b/python_modules/dagster/dagster/_grpc/utils.py
@@ -56,7 +56,7 @@ def get_loadable_targets(
         check.failed("invalid")
 
 
-def max_rx_bytes():
+def max_rx_bytes() -> int:
     env_set = os.getenv("DAGSTER_GRPC_MAX_RX_BYTES")
     if env_set:
         return int(env_set)
@@ -65,10 +65,19 @@ def max_rx_bytes():
     return 50 * (10**6)
 
 
-def max_send_bytes():
+def max_send_bytes() -> int:
     env_set = os.getenv("DAGSTER_GRPC_MAX_SEND_BYTES")
     if env_set:
         return int(env_set)
 
     # default 50 MB
     return 50 * (10**6)
+
+
+def default_grpc_timeout() -> int:
+    env_set = os.getenv("DAGSTER_GRPC_TIMEOUT_SECONDS")
+    if env_set:
+        return int(env_set)
+
+    # default 60 seconds
+    return 60


### PR DESCRIPTION
to allow users to override

### How I Tested These Changes
with  `dagster.yaml` containing
```
code_servers:
  local_startup_timeout: 120

```
run
```
(py39) ~/dagster:al/08-16-_grpc_env_var_override_for_default_timeout$ dagit -f python_modules/dagit/dagit_tests/stress/manydags.py
/Users/alangenfeld/dagster/python_modules/dagster/dagster/_core/workspace/context.py:559: UserWarning: Error loading repository location manydags.py:dagster._core.errors.DagsterUserCodeUnreachableError: Could not reach user code server

Stack Trace:
  File "/Users/alangenfeld/dagster/python_modules/dagster/dagster/_core/workspace/context.py", line 556, in _load_location
    location = self._create_location_from_origin(origin)
  File "/Users/alangenfeld/dagster/python_modules/dagster/dagster/_core/workspace/context.py", line 488, in _create_location_from_origin
    return GrpcServerRepositoryLocation(
  File "/Users/alangenfeld/dagster/python_modules/dagster/dagster/_core/host_representation/repository_location.py", line 581, in __init__
    self._external_repositories_data = sync_get_streaming_external_repositories_data_grpc(
  File "/Users/alangenfeld/dagster/python_modules/dagster/dagster/_api/snapshot_repository.py", line 25, in sync_get_streaming_external_repositories_data_grpc
    external_repository_chunks = list(
  File "/Users/alangenfeld/dagster/python_modules/dagster/dagster/_grpc/client.py", line 260, in streaming_external_repository
    for res in self._streaming_query(
  File "/Users/alangenfeld/dagster/python_modules/dagster/dagster/_grpc/client.py", line 124, in _streaming_query
    raise DagsterUserCodeUnreachableError("Could not reach user code server") from e

The above exception was caused by the following exception:
grpc._channel._MultiThreadedRendezvous: <_MultiThreadedRendezvous of RPC that terminated with:
	status = StatusCode.DEADLINE_EXCEEDED
	details = "Deadline Exceeded"
	debug_error_string = "{"created":"@1660678019.539392000","description":"Deadline Exceeded","file":"src/core/ext/filters/deadline/deadline_filter.cc","file_line":81,"grpc_status":4}"
>

Stack Trace:
  File "/Users/alangenfeld/dagster/python_modules/dagster/dagster/_grpc/client.py", line 122, in _streaming_query
    yield from response_stream
  File "/Users/alangenfeld/venvs/x86/py39/lib/python3.9/site-packages/grpc/_channel.py", line 426, in __next__
    return self._next()
  File "/Users/alangenfeld/venvs/x86/py39/lib/python3.9/site-packages/grpc/_channel.py", line 826, in _next
    raise self

  warnings.warn(
2022-08-16 14:26:59 -0500 - dagit - INFO - Serving dagit on http://127.0.0.1:3000 in process 20265
```
then set env var

```
(py39) ~/dagster:al/08-16-_grpc_env_var_override_for_default_timeout$ DAGSTER_GRPC_TIMEOUT_SECONDS=120 dagit -f python_modules/dagit/dagit_tests/stress/manydags.py
2022-08-16 14:30:42 -0500 - dagit - INFO - Serving dagit on http://127.0.0.1:3000 in process 20333
```