### PR TITLE
[dagit] Clean up "Wipe materializations" dialog a bit

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetWipeDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetWipeDialog.tsx
@@ -35,16 +35,20 @@ export const AssetWipeDialog: React.FC<{
   };
 
   return (
-    <Dialog
-      isOpen={isOpen}
-      title={`Wipe materializations of ${
-        assetKeys.length === 1 ? displayNameForAssetKey(assetKeys[0]) : 'selected assets'
-      }?`}
-      onClose={onClose}
-      style={{width: 400}}
-    >
+    <Dialog isOpen={isOpen} title="Wipe materializations" onClose={onClose} style={{width: 600}}>
       <DialogBody>
-        <Group direction="column" spacing={8}>
+        <Group direction="column" spacing={16}>
+          <div>Are you sure you want to wipe materializations for these assets?</div>
+          <ul style={{paddingLeft: 32, margin: 0}}>
+            {assetKeys.map((assetKey) => {
+              const name = displayNameForAssetKey(assetKey);
+              return (
+                <li style={{marginBottom: 4}} key={name}>
+                  {name}
+                </li>
+              );
+            })}
+          </ul>
           <div>
             Assets defined only by their historical materializations will disappear from the Asset
             Catalog. Software-defined assets will remain unless their definition is also deleted
@@ -53,7 +57,7 @@ export const AssetWipeDialog: React.FC<{
           <strong>This action cannot be undone.</strong>
         </Group>
       </DialogBody>
-      <DialogFooter>
+      <DialogFooter topBorder>
         <Button intent="none" onClick={onClose}>
           Cancel
         </Button>


### PR DESCRIPTION
### Summary & Motivation

The asset key display name doesn't really fit in the "Wipe materializations" dialog title, so I'm just moving it out of the title and into the body of the dialog. All selected asset keys will be shown in a list.

<img width="638" alt="Screen Shot 2022-08-16 at 2 17 30 PM" src="https://user-images.githubusercontent.com/2823852/184966571-e85abf2b-121b-40c3-aed7-18a2a08e612c.png">

### How I Tested These Changes

Select some assets, open wipe dialog. Verify rendering of the asset key list. Verify that very long asset key names wrap nicely.
