### PR TITLE
Convert dagstermill examples to use define_dagstermill_op

### DIFF
--- a/examples/docs_snippets/docs_snippets/legacy/data_science/iris_classify_dev.yaml
+++ b/examples/docs_snippets/docs_snippets/legacy/data_science/iris_classify_dev.yaml
@@ -1,4 +1,4 @@
-solids:
+ops:
   k_means_iris:
     inputs:
       path: "iris.data"

--- a/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
+++ b/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
@@ -8,11 +8,11 @@ from dagstermill.io_managers import local_output_notebook_io_manager
 from dagster import (
     Field,
     FileHandle,
+    In,
     Int,
     List,
     Out,
     ResourceDefinition,
-    In,
     String,
     fs_io_manager,
     job,
@@ -21,14 +21,7 @@ from dagster import (
 )
 from dagster._core.definitions.utils import DEFAULT_OUTPUT
 from dagster._core.storage.file_manager import local_file_manager
-from dagster._legacy import (
-    InputDefinition,
-    ModeDefinition,
-    OutputDefinition,
-    composite_solid,
-    pipeline,
-    solid,
-)
+from dagster._legacy import InputDefinition, ModeDefinition, composite_solid, pipeline, solid
 from dagster._utils import PICKLE_PROTOCOL, file_relative_path
 
 try:

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -464,9 +464,10 @@ def define_dagstermill_op(
     ins = check.opt_mapping_param(ins, "ins", key_type=str, value_type=In)
 
     if output_notebook_name is not None:
+        required_resource_keys.add("output_notebook_io_manager")
         outs = {
-            cast(str, output_notebook_name): Out(io_manager_key="output_notebook_io_manager"),
             **outs,
+            cast(str, output_notebook_name): Out(io_manager_key="output_notebook_io_manager"),
         }
 
     if isinstance(asset_key_prefix, str):


### PR DESCRIPTION
### Summary & Motivation
Also includes a fix where the outs ordering in define_dagstermill_op was causing errors in some cases. The injected Out needs to be at the end of the dictionary.
### How I Tested These Changes
