### PR TITLE
[dagit] Refetch queries instead of dumping Apollo cache

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/RepositoryLocationStateObserver.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepositoryLocationStateObserver.tsx
@@ -78,8 +78,7 @@ export const RepositoryLocationStateObserver = () => {
               underline="always"
               onClick={() => {
                 setUpdatedLocations([]);
-                refetch();
-                client.resetStore();
+                client.refetchQueries({include: 'active'});
               }}
             >
               Update data

--- a/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
@@ -187,8 +187,8 @@ export const useRepositoryLocationReload = ({
 
         invalidateConfigs(repositories);
 
-        // Clear and refetch all the queries bound to the UI.
-        apollo.resetStore();
+        // Refetch all the queries bound to the UI.
+        apollo.refetchQueries({include: 'active'});
       },
     },
   );


### PR DESCRIPTION
### Summary & Motivation

Now that we have `refetchQueries` available in Apollo, use it instead of resetting the entire Apollo store. This will hopefully make it a bit less jarring when the user reloads a repository or entire workspace.

### How I Tested These Changes

Load Dagit. Reload a repo after making changes to its Python, verify with console logging that queries are refetched and that the UI refreshes correctly. Reload the entire Workspace, verify same.
