### PR TITLE
event watcher thread only join if alive

### DIFF
--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_watcher.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_watcher.py
@@ -130,6 +130,7 @@ class PostgresEventWatcher:
     def close(self):
         if self._watcher_thread:
             self._watcher_thread_exit.set()
-            self._watcher_thread.join()
+            if self._watcher_thread.is_alive():
+                self._watcher_thread.join()
             self._watcher_thread_exit = None
             self._watcher_thread = None


### PR DESCRIPTION
In some rare cases (in tests) we may quickly shutdown before the thread has had a chance to start - only join if its alive. 

### How I Tested These Changes

ran test that sporadically failed  100 times