### PR TITLE
[dagit] Repair Asset table

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -120,7 +120,10 @@ export const AssetTable = ({
                   checkedPathsOnscreen.length > 0 &&
                   checkedPathsOnscreen.length !== pageDisplayPathKeys.length
                 }
-                checked={checkedPathsOnscreen.length === pageDisplayPathKeys.length}
+                checked={
+                  checkedPathsOnscreen.length > 0 &&
+                  checkedPathsOnscreen.length === pageDisplayPathKeys.length
+                }
                 onChange={(e) => {
                   if (e.target instanceof HTMLInputElement) {
                     onToggleAll(checkedPathsOnscreen.length !== pageDisplayPathKeys.length);
@@ -129,9 +132,9 @@ export const AssetTable = ({
               />
             </th>
             <th>{view === 'directory' ? 'Asset Key Prefix' : 'Asset Key'}</th>
-            <th style={{width: 340}}>Defined In</th>
+            <th style={{width: 340}}>Defined in</th>
             <th style={{width: 265}}>Materialized</th>
-            <th style={{width: 115}}>Latest Run</th>
+            <th style={{width: 115}}>Latest run</th>
             <th style={{width: 80}}>Actions</th>
           </tr>
         </thead>

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
@@ -360,6 +360,7 @@ function buildNamespaceProps(assets: Asset[], prefixPath: string[], cursor: stri
   const namespaceForAsset = (asset: Asset) => {
     return asset.key.path.slice(prefixPath.length, prefixPath.length + 1);
   };
+
   const namespaces = Array.from(
     new Set(assets.map((asset) => JSON.stringify(namespaceForAsset(asset)))),
   )
@@ -378,21 +379,21 @@ function buildNamespaceProps(assets: Asset[], prefixPath: string[], cursor: stri
     };
   }
 
-  const slice = namespaces.slice(cursorIndex, cursorIndex + PAGE_SIZE);
   const prevPageIndex = Math.max(0, cursorIndex - PAGE_SIZE);
   const prevCursor = cursorIndex !== 0 ? cursorValue(namespaces[prevPageIndex]) : undefined;
   const nextPageIndex = cursorIndex + PAGE_SIZE;
   const nextCursor =
     namespaces.length > nextPageIndex ? cursorValue(namespaces[nextPageIndex]) : undefined;
+  const displayed = filterAssetsByNamespace(
+    assets,
+    namespaces.map((ns) => [...prefixPath, ...ns]),
+  ).slice(cursorIndex, cursorIndex + PAGE_SIZE);
 
   return {
     nextCursor,
     prevCursor,
     displayPathForAsset: namespaceForAsset,
-    displayed: filterAssetsByNamespace(
-      assets,
-      slice.map((ns) => [...prefixPath, ...ns]),
-    ),
+    displayed,
   };
 }
 


### PR DESCRIPTION
### Summary & Motivation

An odd bug appears in circumstances where there are lots of namespaces in an asset table. We're slicing the namespaces for the entire set of assets before comparing the set to the prefix path, which means there's a good chance that we end up missing prefix path matches in the asset set.

Instead, slice the list of displayed assets *after* filter matches are found.

Also fix a bug where an empty asset table has the check-all checkbox set to `checked` because we're not checking how many checked items we have.

### How I Tested These Changes

View a very large asset table at a point where nested assets would incorrectly fail to show any filtered assets. Verify that they now appear correctly, and can be navigated as normal.

Verify also that an empty asset table will not have the check-all box checked.
