### PR TITLE
[dagster-dbt] fix default params for dbt_cli_resource

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
@@ -99,7 +99,11 @@ class DbtCliResource(DbtResource):
         )
 
     def compile(
-        self, models: Optional[List[str]] = None, exclude: Optional[List[str]] = None, **kwargs
+        self,
+        models: Optional[List[str]] = None,
+        exclude: Optional[List[str]] = None,
+        select: Optional[List[str]] = None,
+        **kwargs,
     ) -> DbtCliOutput:
         """
         Run the ``compile`` command on a dbt project. kwargs are passed in as additional parameters.
@@ -107,28 +111,34 @@ class DbtCliResource(DbtResource):
         Args:
             models (List[str], optional): the models to include in compilation.
             exclude (List[str]), optional): the models to exclude from compilation.
+            select (List[str], optional): the models to include in compilation.
 
         Returns:
             DbtCliOutput: An instance of :class:`DbtCliOutput<dagster_dbt.DbtCliOutput>` containing
                 parsed log output as well as the contents of run_results.json (if applicable).
         """
-        return self.cli("compile", models=models, exclude=exclude, **kwargs)
+        return self.cli("compile", models=models, exclude=exclude, select=select, **kwargs)
 
     def run(
-        self, models: Optional[List[str]] = None, exclude: Optional[List[str]] = None, **kwargs
+        self,
+        models: Optional[List[str]] = None,
+        exclude: Optional[List[str]] = None,
+        select: Optional[List[str]] = None,
+        **kwargs,
     ) -> DbtCliOutput:
         """
         Run the ``run`` command on a dbt project. kwargs are passed in as additional parameters.
 
         Args:
-            models (List[str], optional): the models to include in compilation.
-            exclude (List[str]), optional): the models to exclude from compilation.
+            models (List[str], optional): the models to include in the run.
+            exclude (List[str]), optional): the models to exclude from the run.
+            select (List[str], optional): the models to include in the run.
 
         Returns:
             DbtCliOutput: An instance of :class:`DbtCliOutput<dagster_dbt.DbtCliOutput>` containing
                 parsed log output as well as the contents of run_results.json (if applicable).
         """
-        return self.cli("run", models=models, exclude=exclude, **kwargs)
+        return self.cli("run", models=models, exclude=exclude, select=select, **kwargs)
 
     def snapshot(
         self, select: Optional[List[str]] = None, exclude: Optional[List[str]] = None, **kwargs
@@ -152,6 +162,7 @@ class DbtCliResource(DbtResource):
         exclude: Optional[List[str]] = None,
         data: bool = True,
         schema: bool = True,
+        select: Optional[List[str]] = None,
         **kwargs,
     ) -> DbtCliOutput:
         """
@@ -162,6 +173,7 @@ class DbtCliResource(DbtResource):
             exclude (List[str], optional): the models to exclude from testing.
             data (bool, optional): If ``True`` (default), then run data tests.
             schema (bool, optional): If ``True`` (default), then run schema tests.
+            select (List[str], optional): the models to include in testing.
 
         Returns:
             DbtCliOutput: An instance of :class:`DbtCliOutput<dagster_dbt.DbtCliOutput>` containing
@@ -172,7 +184,15 @@ class DbtCliResource(DbtResource):
             # versions of dbt, and for older versions the functionality is the same regardless of
             # if both are set or neither are set.
             return self.cli("test", models=models, exclude=exclude, **kwargs)
-        return self.cli("test", models=models, exclude=exclude, data=data, schema=schema, **kwargs)
+        return self.cli(
+            "test",
+            models=models,
+            exclude=exclude,
+            data=data,
+            schema=schema,
+            select=select,
+            **kwargs,
+        )
 
     def seed(
         self,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_ops.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_ops.py
@@ -53,6 +53,21 @@ def test_run_op(
     assert len(dbt_results[-1].value.result["results"]) == 4
 
 
+def test_run_op_with_select(
+    dbt_build, conn_string, test_project_dir, dbt_config_dir
+):  # pylint: disable=unused-argument
+
+    dbt_resource = dbt_cli_resource.configured(
+        {"project_dir": test_project_dir, "profiles_dir": dbt_config_dir, "select": "least_caloric"}
+    )
+    dbt_results = list(dbt_run_op(build_op_context(resources={"dbt": dbt_resource})))
+
+    # includes asset materializations
+    assert len(dbt_results) == 2
+
+    assert len(dbt_results[-1].value.result["results"]) == 1
+
+
 def test_run_test_job(
     dbt_seed, conn_string, test_project_dir, dbt_config_dir
 ):  # pylint: disable=unused-argument


### PR DESCRIPTION
### Summary & Motivation

You can pass in parameters to the dbt_cli_resource which are meant to be passed into every invocation of every command. For example, if you configure your resource with {"foo": "bar"}, calling context.resources.dbt.run() should actually execute the command `dbt run --foo bar`,  and similarly calling `context.resources.dbt.test()` should actually execute `dbt test --foo bar`.

This works slightly differently for the `select, models, and exclude` parameters. These flags only apply to a subset of the total commands that run in dbt, so we're a little "smarter" about when to include them in the invocation. Basically, if they're not part of the method signature on the dbt_cli_resource class, we just ignore them and don't pass them in as flags.

Anyway, select got added as a parameter to a bunch of dbt commands (it used to be `models`), so this change makes it so that we don't ignore the default select parameter anymore.

### How I Tested These Changes
