### PR TITLE
[dagster-io/ui] Support spinner in Tag

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/BaseTag.tsx
+++ b/js_modules/dagit/packages/ui/src/components/BaseTag.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components/macro';
 
 import {Colors} from './Colors';
 import {IconWrapper} from './Icon';
+import {SpinnerWrapper} from './Spinner';
 
 interface Props {
   fillColor?: string;
@@ -82,17 +83,18 @@ export const StyledTag = styled.div<StyledTagProps>`
     white-space: nowrap;
     text-overflow: ellipsis;
   }
-  > ${IconWrapper}:first-child {
+
+  > ${IconWrapper}:first-child, > ${SpinnerWrapper}:first-child {
     margin-right: 4px;
     margin-left: -4px;
   }
 
-  > ${IconWrapper}:last-child {
+  > ${IconWrapper}:last-child, > ${SpinnerWrapper}:last-child {
     margin-left: 4px;
     margin-right: -4px;
   }
 
-  > ${IconWrapper}:first-child:last-child {
+  > ${IconWrapper}:first-child:last-child, > ${SpinnerWrapper}:first-child:last-child {
     margin: 0 -4px;
   }
 `;

--- a/js_modules/dagit/packages/ui/src/components/Tag.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Tag.stories.tsx
@@ -30,3 +30,23 @@ export const Basic = () => {
     </Group>
   );
 };
+
+export const Loading = () => {
+  return (
+    <Group direction="column" spacing={8}>
+      {INTENTS.map((intent) => (
+        <Group direction="row" spacing={8} key={intent}>
+          <Tag intent={intent} icon="alternate_email" rightIcon="spinner">
+            Lorem
+          </Tag>
+          <Tag intent={intent} icon="spinner" rightIcon="toggle_off">
+            Lorem
+          </Tag>
+          <Tag intent={intent} icon="spinner">
+            Lorem
+          </Tag>
+        </Group>
+      ))}
+    </Group>
+  );
+};

--- a/js_modules/dagit/packages/ui/src/components/Tag.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Tag.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import {BaseTag} from './BaseTag';
 import {Colors} from './Colors';
 import {IconName, Icon} from './Icon';
+import {Spinner} from './Spinner';
 
 const intentToFillColor = (intent: React.ComponentProps<typeof BlueprintTag>['intent']) => {
   switch (intent) {
@@ -55,30 +56,34 @@ const intentToIconColor = (intent: React.ComponentProps<typeof BlueprintTag>['in
 };
 
 interface Props extends Omit<React.ComponentProps<typeof BlueprintTag>, 'icon' | 'rightIcon'> {
-  icon?: IconName;
-  rightIcon?: IconName;
+  icon?: IconName | 'spinner';
+  rightIcon?: IconName | 'spinner';
 }
 
+const IconOrSpinner: React.FC<{icon: IconName | 'spinner' | null; color: string}> = React.memo(
+  ({icon, color}) => {
+    if (icon === 'spinner') {
+      return <Spinner fillColor={color} purpose="body-text" />;
+    }
+    return icon ? <Icon name={icon} color={color} /> : null;
+  },
+);
+
 export const Tag: React.FC<Props> = (props) => {
-  const {children, icon, rightIcon, intent, ...rest} = props;
+  const {children, icon = null, rightIcon = null, intent, ...rest} = props;
 
   const fillColor = intentToFillColor(intent);
   const textColor = intentToTextColor(intent);
   const iconColor = intentToIconColor(intent);
-
-  const iconWithColor = icon ? <Icon name={icon} color={iconColor} /> : null;
-  const rightIconWithColor = rightIcon ? <Icon name={rightIcon} color={iconColor} /> : null;
 
   return (
     <BaseTag
       {...rest}
       fillColor={fillColor}
       textColor={textColor}
-      icon={iconWithColor}
-      rightIcon={rightIconWithColor}
+      icon={<IconOrSpinner icon={icon} color={iconColor} />}
+      rightIcon={<IconOrSpinner icon={rightIcon} color={iconColor} />}
       label={children}
     />
   );
 };
-
-Tag.displayName = 'Tag';


### PR DESCRIPTION
### Summary & Motivation

We often want to put spinners in `Tag` components, so let's just support that without requiring anyone to use `BaseTag`.

<img width="275" alt="Screen Shot 2022-08-18 at 1 14 41 PM" src="https://user-images.githubusercontent.com/2823852/185466400-858db0dd-c914-4793-ba0d-223c2f6cadc6.png">


### How I Tested These Changes

Storybook examples.
