### PR TITLE
captured log manager

### DIFF
--- a/python_modules/dagit/dagit/webserver.py
+++ b/python_modules/dagit/dagit/webserver.py
@@ -27,6 +27,7 @@ import dagster._check as check
 from dagster import __version__ as dagster_version
 from dagster._core.debug import DebugRunPayload
 from dagster._core.storage.compute_log_manager import ComputeIOType
+from dagster._core.storage.local_compute_log_manager import LocalComputeLogManager
 from dagster._core.workspace.context import BaseWorkspaceRequestContext, IWorkspaceProcessContext
 from dagster._seven import json
 from dagster._utils import Counter, traced_counter
@@ -172,6 +173,23 @@ class DagitWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
             filename=f"{run_id}_{step_key}.{file_type}",
         )
 
+    async def download_captured_logs_endpoint(self, request: Request):
+        [*log_key, file_extension] = request.path_params["path"].split("/")
+        context = self.make_request_context(request)
+
+        if not isinstance(context.instance.compute_log_manager, LocalComputeLogManager):
+            raise HTTPException(404)
+
+        location = context.instance.compute_log_manager.get_captured_local_path(
+            log_key, file_extension
+        )
+
+        if not location or not path.exists(location):
+            raise HTTPException(404)
+
+        filebase = "__".join(log_key)
+        return FileResponse(location, filename=f"{filebase}.{file_extension}")
+
     def index_html_endpoint(self, _request: Request):
         """
         Serves root html
@@ -259,6 +277,10 @@ class DagitWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
                 Route(
                     "/download/{run_id:str}/{step_key:str}/{file_type:str}",
                     self.download_compute_logs_endpoint,
+                ),
+                Route(
+                    "/logs/{path:path}",
+                    self.download_captured_logs_endpoint,
                 ),
                 Route(
                     "/dagit/notebook",

--- a/python_modules/dagit/dagit/webserver.py
+++ b/python_modules/dagit/dagit/webserver.py
@@ -162,7 +162,7 @@ class DagitWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
         )
 
         if not path.exists(file):
-            raise HTTPException(404)
+            raise HTTPException(404, detail="No log files available for download")
 
         return FileResponse(
             context.instance.compute_log_manager.get_local_path(
@@ -178,14 +178,16 @@ class DagitWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
         context = self.make_request_context(request)
 
         if not isinstance(context.instance.compute_log_manager, LocalComputeLogManager):
-            raise HTTPException(404)
+            raise HTTPException(
+                404, detail="Compute log manager is not compatible for local downloads"
+            )
 
         location = context.instance.compute_log_manager.get_captured_local_path(
             log_key, file_extension
         )
 
         if not location or not path.exists(location):
-            raise HTTPException(404)
+            raise HTTPException(404, detail="No log files available for download")
 
         filebase = "__".join(log_key)
         return FileResponse(location, filename=f"{filebase}.{file_extension}")

--- a/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
@@ -1,0 +1,217 @@
+# pylint: disable=unused-argument
+
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from typing import List, NamedTuple, Optional
+
+MAX_BYTES_CHUNK_READ = 4194304  # 4 MB
+
+
+class CapturedLogData(
+    NamedTuple(
+        "_CapturedLogData",
+        [
+            ("log_key", List[str]),
+            ("stdout", Optional[bytes]),
+            ("stderr", Optional[bytes]),
+            ("cursor", Optional[str]),
+        ],
+    )
+):
+    """
+    Object representing captured log data, either a partial chunk of the log data or the full
+    capture.  Contains the raw bytes and optionally the cursor offset for the partial chunk.
+    """
+
+    def __new__(
+        cls,
+        log_key: List[str],
+        stdout: Optional[bytes] = None,
+        stderr: Optional[bytes] = None,
+        cursor: Optional[str] = None,
+    ):
+        return super(CapturedLogData, cls).__new__(cls, log_key, stdout, stderr, cursor)
+
+
+class CapturedLogMetadata(
+    NamedTuple(
+        "_CapturedLogMetadata",
+        [
+            ("external_url", Optional[str]),
+            ("stdout_location", Optional[str]),
+            ("stderr_location", Optional[str]),
+            ("stdout_download_url", Optional[str]),
+            ("stderr_download_url", Optional[str]),
+        ],
+    )
+):
+    """
+    Object representing metadata info for the captured log data, containing a display string for
+    the location of the log data and a URL for direct download of the captured log data.
+    """
+
+    def __new__(
+        cls,
+        external_url: Optional[str] = None,
+        stdout_location: Optional[str] = None,
+        stderr_location: Optional[str] = None,
+        stdout_download_url: Optional[str] = None,
+        stderr_download_url: Optional[str] = None,
+    ):
+        return super(CapturedLogMetadata, cls).__new__(
+            cls,
+            external_url=external_url,
+            stdout_location=stdout_location,
+            stderr_location=stderr_location,
+            stdout_download_url=stdout_download_url,
+            stderr_download_url=stderr_download_url,
+        )
+
+
+class CapturedLogSubscription:
+    def __init__(self, manager, log_key, cursor):
+        self._manager = manager
+        self._log_key = log_key
+        self._cursor = cursor
+        self._observer = None
+
+    def __call__(self, observer):
+        self._observer = observer
+        self.fetch()
+        if self._manager.is_capture_complete(self._log_key):
+            self.complete()
+        return self
+
+    @property
+    def log_key(self):
+        return self._log_key
+
+    def dispose(self):
+        # called when the connection gets closed, allowing the observer to get GC'ed
+        if self._observer and callable(getattr(self._observer, "dispose", None)):
+            self._observer.dispose()
+        self._observer = None
+        self._manager.on_unsubscribe(self)
+
+    def fetch(self):
+        if not self._observer:
+            return
+
+        should_fetch = True
+        while should_fetch:
+            log_data = self._manager.get_log_data(
+                self._log_key,
+                self._cursor,
+                max_bytes=MAX_BYTES_CHUNK_READ,
+            )
+            if not self._cursor or log_data.cursor != self._cursor:
+                self._observer.on_next(log_data)
+                self._cursor = log_data.cursor
+            should_fetch = _has_max_data(log_data.stdout) or _has_max_data(log_data.stderr)
+
+    def complete(self):
+        if not self._observer:
+            return
+        self._observer.on_completed()
+
+
+def _has_max_data(chunk):
+    return chunk and len(chunk) >= MAX_BYTES_CHUNK_READ
+
+
+class CapturedLogManager(ABC):
+    """Abstract base class for capturing the unstructured logs (stdout/stderr) in the current
+    process, stored / retrieved with a provided log_key."""
+
+    @abstractmethod
+    @contextmanager
+    def capture_logs(self, log_key: List[str]):
+        """
+        Context manager for capturing the stdout/stderr within the current process, and persisting
+        it under the given log key.
+
+        Args:
+            log_key (List[String]): The log key identifying the captured logs
+        """
+
+    @abstractmethod
+    def is_capture_complete(self, log_key: List[str]):
+        """Flag indicating when the log capture for a given log key has completed.
+
+        Args:
+            log_key (List[String]): The log key identifying the captured logs
+
+        Returns:
+            Boolean
+        """
+
+    @abstractmethod
+    def on_progress(self, log_key: List[str]):
+        """Utility method that can be called periodically while logs are being captured, in order
+        to support different batched streaming implementations.
+
+        Args:
+            log_key (List[String]): The log key identifying the captured logs
+
+        """
+
+    @abstractmethod
+    def get_log_data(
+        self,
+        log_key: List[str],
+        cursor: Optional[str] = None,
+        max_bytes: Optional[int] = None,
+    ) -> CapturedLogData:
+        """Returns a chunk of the captured stdout logs for a given log key
+
+        Args:
+            log_key (List[String]): The log key identifying the captured logs
+            cursor (Optional[str]): A cursor representing the position of the log chunk to fetch
+            max_bytes (Optional[int]): A limit on the size of the log chunk to fetch
+
+        Returns:
+            CapturedLogData
+        """
+
+    @abstractmethod
+    def get_contextual_log_metadata(self, log_key: List[str]) -> CapturedLogMetadata:
+        """Returns the metadata of the captured logs for a given log key, including
+        displayable information on where the logs are persisted.
+
+        Args:
+            log_key (List[String]): The log key identifying the captured logs
+
+        Returns:
+            CapturedLogMetadata
+        """
+
+    @abstractmethod
+    def subscribe(
+        self, log_key: List[str], cursor: Optional[str] = None
+    ) -> CapturedLogSubscription:
+        """Registers an observable object for log data
+
+        Args:
+            log_key (List[String]): The log key identifying the captured logs
+            cursor (Optional[String]): The string cursor marking the position within the log stream
+        Returns:
+            ComputeLogSubscription
+        """
+
+    @abstractmethod
+    def unsubscribe(self, subscription: CapturedLogSubscription):
+        """Deregisters an observable object from receiving log updates
+
+        Args:
+            subscription (CapturedLogSubscription): subscription object which manages when to send
+                back data to the subscriber
+        """
+
+    def get_in_progress_log_keys(self, prefix: Optional[List[str]] = None) -> List[List[str]]:
+        """Utility method to help with keeping track of the set of in-progress capture.  Helpful for
+        streaming updates for block-upload captured log managers"""
+        return []
+
+    def build_log_key_for_run(self, run_id, step_key):
+        """Legacy adapter to translate run_id/key to captured log manager-based log_key"""
+        return [run_id, "compute_logs", step_key]

--- a/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
@@ -2,7 +2,9 @@
 
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import List, NamedTuple, Optional
+from typing import IO, Generator, List, NamedTuple, Optional
+
+from dagster._core.storage.compute_log_manager import ComputeIOType
 
 MAX_BYTES_CHUNK_READ = 4194304  # 4 MB
 
@@ -135,7 +137,20 @@ class CapturedLogManager(ABC):
         """
 
     @abstractmethod
-    def is_capture_complete(self, log_key: List[str]):
+    @contextmanager
+    def open_log_stream(
+        self, log_key: List[str], io_type: ComputeIOType
+    ) -> Generator[Optional[IO], None, None]:
+        """
+        Context manager for providing an IO stream that enables the caller to write to a log stream
+        managed by the captured log manager, to be read later using the given log key.
+
+        Args:
+            log_key (List[String]): The log key identifying the captured logs
+        """
+
+    @abstractmethod
+    def is_capture_complete(self, log_key: List[str]) -> bool:
         """Flag indicating when the log capture for a given log key has completed.
 
         Args:
@@ -152,7 +167,6 @@ class CapturedLogManager(ABC):
 
         Args:
             log_key (List[String]): The log key identifying the captured logs
-
         """
 
     @abstractmethod
@@ -183,6 +197,14 @@ class CapturedLogManager(ABC):
 
         Returns:
             CapturedLogMetadata
+        """
+
+    @abstractmethod
+    def delete_logs(self, log_key: List[str]):
+        """Deletes the captured logs for a given log key.
+
+        Args:
+            log_key (List[String]): The log key identifying the captured logs
         """
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
@@ -177,15 +177,6 @@ class CapturedLogManager(ABC):
         """
 
     @abstractmethod
-    def on_progress(self, log_key: List[str]):
-        """Utility method that can be called periodically while logs are being captured, in order
-        to support different batched streaming implementations.
-
-        Args:
-            log_key (List[String]): The log key identifying the captured logs
-        """
-
-    @abstractmethod
     def get_log_data(
         self,
         log_key: List[str],
@@ -244,11 +235,6 @@ class CapturedLogManager(ABC):
             subscription (CapturedLogSubscription): subscription object which manages when to send
                 back data to the subscriber
         """
-
-    def get_in_progress_log_keys(self, prefix: Optional[List[str]] = None) -> List[List[str]]:
-        """Utility method to help with keeping track of the set of in-progress capture.  Helpful for
-        streaming updates for block-upload captured log managers"""
-        return []
 
     def build_log_key_for_run(self, run_id, step_key):
         """Legacy adapter to translate run_id/key to captured log manager-based log_key"""

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_captured_log_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_captured_log_manager.py
@@ -1,0 +1,23 @@
+import tempfile
+
+import pytest
+
+from dagster._core.storage.local_compute_log_manager import LocalComputeLogManager
+from dagster._core.test_utils import instance_for_test
+
+from .utils.captured_log_manager import TestCapturedLogManager
+
+
+def test_compute_log_manager_instance():
+    with instance_for_test() as instance:
+        assert instance.compute_log_manager
+        assert instance.compute_log_manager._instance  # pylint: disable=protected-access
+
+
+class TestLocalCapturedLogManager(TestCapturedLogManager):
+    __test__ = True
+
+    @pytest.fixture(name="captured_log_manager")
+    def captured_log_manager(self):
+        with tempfile.TemporaryDirectory() as tmpdir_path:
+            return LocalComputeLogManager(tmpdir_path)

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/captured_log_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/captured_log_manager.py
@@ -1,0 +1,80 @@
+import random
+import string
+import sys
+
+import pytest
+
+from dagster._core.execution.compute_logs import should_disable_io_stream_redirect
+
+
+class TestCapturedLogManager:
+    """
+    You can extend this class to easily run these set of tests on any compute log manager. When
+    extending, you simply need to override the `compute_log_manager` fixture and return your
+    implementation of `CapturedLogManager`.
+
+    For example:
+
+    ```
+    class TestMyComputeLogManagerImplementation(TestCapturedLogManager):
+        __test__ = True
+
+        @pytest.fixture(scope='function', name='captured_log_manager')
+        def captured_log_manager(self):  # pylint: disable=arguments-differ
+            return MyCapturedLogManagerImplementation()
+    ```
+    """
+
+    __test__ = False
+
+    @pytest.fixture(name="captured_log_manager")
+    def captured_log_manager(self):
+        yield
+
+    @pytest.mark.skipif(
+        should_disable_io_stream_redirect(), reason="compute logs disabled for win / py3.6+"
+    )
+    def test_capture(self, captured_log_manager):
+        log_key = ["foo"]
+
+        with captured_log_manager.capture_logs(log_key):
+            print("HELLO WORLD")  # pylint: disable=print-call
+            print("HELLO ERROR", file=sys.stderr)  # pylint: disable=print-call
+            assert not captured_log_manager.is_capture_complete(log_key)
+
+        assert captured_log_manager.is_capture_complete(log_key)
+
+        log_data = captured_log_manager.get_log_data(log_key)
+        assert log_data.stdout == b"HELLO WORLD\n"
+        assert log_data.stderr == b"HELLO ERROR\n"
+        assert log_data.cursor
+
+        log_metadata = captured_log_manager.get_contextual_log_metadata(log_key)
+        assert log_metadata.stdout_location
+        assert log_metadata.stderr_location
+        assert log_metadata.stdout_download_url
+        assert log_metadata.stderr_download_url
+
+    @pytest.mark.skipif(
+        should_disable_io_stream_redirect(), reason="compute logs disabled for win / py3.6+"
+    )
+    def test_long_key(self, captured_log_manager):
+        log_key = ["".join(random.choice(string.ascii_lowercase) for x in range(300))]
+
+        with captured_log_manager.capture_logs(log_key):
+            print("HELLO WORLD")  # pylint: disable=print-call
+            print("HELLO ERROR", file=sys.stderr)  # pylint: disable=print-call
+            assert not captured_log_manager.is_capture_complete(log_key)
+
+        assert captured_log_manager.is_capture_complete(log_key)
+
+        log_data = captured_log_manager.get_log_data(log_key)
+        assert log_data.stdout == b"HELLO WORLD\n"
+        assert log_data.stderr == b"HELLO ERROR\n"
+        assert log_data.cursor
+
+        log_metadata = captured_log_manager.get_contextual_log_metadata(log_key)
+        assert log_metadata.stdout_location
+        assert log_metadata.stderr_location
+        assert log_metadata.stdout_download_url
+        assert log_metadata.stderr_download_url

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/captured_log_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/captured_log_manager.py
@@ -37,10 +37,11 @@ class TestCapturedLogManager:
     def test_capture(self, captured_log_manager):
         log_key = ["foo"]
 
-        with captured_log_manager.capture_logs(log_key):
+        with captured_log_manager.capture_logs(log_key) as context:
             print("HELLO WORLD")  # pylint: disable=print-call
             print("HELLO ERROR", file=sys.stderr)  # pylint: disable=print-call
             assert not captured_log_manager.is_capture_complete(log_key)
+            assert context.log_key == log_key
 
         assert captured_log_manager.is_capture_complete(log_key)
 
@@ -49,7 +50,7 @@ class TestCapturedLogManager:
         assert log_data.stderr == b"HELLO ERROR\n"
         assert log_data.cursor
 
-        log_metadata = captured_log_manager.get_contextual_log_metadata(log_key)
+        log_metadata = captured_log_manager.get_log_metadata(log_key)
         assert log_metadata.stdout_location
         assert log_metadata.stderr_location
         assert log_metadata.stdout_download_url
@@ -61,10 +62,11 @@ class TestCapturedLogManager:
     def test_long_key(self, captured_log_manager):
         log_key = ["".join(random.choice(string.ascii_lowercase) for x in range(300))]
 
-        with captured_log_manager.capture_logs(log_key):
+        with captured_log_manager.capture_logs(log_key) as context:
             print("HELLO WORLD")  # pylint: disable=print-call
             print("HELLO ERROR", file=sys.stderr)  # pylint: disable=print-call
             assert not captured_log_manager.is_capture_complete(log_key)
+            assert context.log_key == log_key
 
         assert captured_log_manager.is_capture_complete(log_key)
 
@@ -73,7 +75,7 @@ class TestCapturedLogManager:
         assert log_data.stderr == b"HELLO ERROR\n"
         assert log_data.cursor
 
-        log_metadata = captured_log_manager.get_contextual_log_metadata(log_key)
+        log_metadata = captured_log_manager.get_log_metadata(log_key)
         assert log_metadata.stdout_location
         assert log_metadata.stderr_location
         assert log_metadata.stdout_download_url


### PR DESCRIPTION
### Summary & Motivation
Creates a new, simplified API for capturing logs.

Also, this converts the existing local compute log manager to implement the CapturedLogManager interface, and implements the local compute log manager interface on top of the more general captured log manager implementation.

Also added a generic test class for captured logs to minimize copy/paste testing for each implementation.

Not included in this diff:
* Hooking up the compute log subscription to this interface.
* Changing executors to capture by process rather than by step.
* Changing the compute logs UI in any way

### How I Tested These Changes
BK