### PR TITLE
walk back automatic secret passing into serverless image

### DIFF
--- a/docs/content/dagster-cloud/deployment/serverless.mdx
+++ b/docs/content/dagster-cloud/deployment/serverless.mdx
@@ -89,7 +89,7 @@ dagster-cloud serverless deploy \
 
 Often you'll need to securely access secrets from your jobs. With Dagster Cloud Serverless, secrets are added as environment variables that can be read using APIs like [StringSource](/guides/dagster/transitioning-data-pipelines-from-development-to-production#part-two-deployment).
 
-- If you're using our GitHub integration, all [GitHub Actions Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) are available as environment variables.
+- If you're using our GitHub integration, you can pass in secrets as a JSON string input to the serverless deploy step in your repository's Github action script.
 - If you're using the CLI directly, you can pass `KEY=VALUE` pairs using the `--env` flag. Run `dagster-cloud serverless deploy --help` to learn more.
 
 ---


### PR DESCRIPTION
### Summary & Motivation
Not sure we want to automatically bake all GH secrets into the serverless image.  This should only affect folks who clone *after* we push https://github.com/dagster-io/dagster-cloud-serverless-quickstart/pull/13

### How I Tested These Changes
BK