### PR TITLE
Convert solid selection tags to op selection in storage

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -29,6 +29,8 @@ STEP_SELECTION_TAG = "{prefix}step_selection".format(prefix=SYSTEM_TAG_PREFIX)
 
 SOLID_SELECTION_TAG = "{prefix}solid_selection".format(prefix=SYSTEM_TAG_PREFIX)
 
+OP_SELECTION_TAG = "{prefix}op_selection".format(prefix=SYSTEM_TAG_PREFIX)
+
 PRESET_NAME_TAG = "{prefix}preset_name".format(prefix=SYSTEM_TAG_PREFIX)
 
 GRPC_INFO_TAG = "{prefix}grpc_info".format(prefix=HIDDEN_TAG_PREFIX)


### PR DESCRIPTION
### Summary & Motivation
This adds an optional data migration which migrates runs with a solid_selection tag to have an op_selection tag. This is so that when filtering runs by an op_selection tag, runs that were previously being stored with a solid_selection will appear.

### How I Tested These Changes
Not yet
