### PR TITLE
[dagit] Add overflow: auto to allow scrolling of long asset metadata entries

### DIFF
--- a/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   Button,
   Colors,
-  DialogBody,
   DialogFooter,
   Dialog,
   Group,
@@ -101,7 +100,7 @@ export const MetadataEntry: React.FC<{
               margin={{bottom: 12}}
               padding={24}
               border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-              style={{whiteSpace: 'pre-wrap', fontFamily: FontFamily.monospace}}
+              style={{whiteSpace: 'pre-wrap', fontFamily: FontFamily.monospace, overflow: 'auto'}}
             >
               {JSON.stringify(JSON.parse(entry.jsonString), null, 2)}
             </Box>
@@ -132,9 +131,14 @@ export const MetadataEntry: React.FC<{
           label={entry.label}
           copyContent={() => entry.mdStr}
           content={() => (
-            <DialogBody>
+            <Box
+              padding={{vertical: 16, horizontal: 20}}
+              background={Colors.White}
+              style={{overflow: 'auto'}}
+              margin={{bottom: 12}}
+            >
               <Markdown>{entry.mdStr}</Markdown>
-            </DialogBody>
+            </Box>
           )}
         >
           [Show Markdown]


### PR DESCRIPTION
### Summary & Motivation

This is a small fix for https://github.com/dagster-io/dagster/issues/8878. I simulated an asset outputting JSON and Markdown with long URLs in them. Both modals needed to be updated to allow for horizontal scrolling when a node couldn't be wrapped to fit. 

### How I Tested These Changes


