### PR TITLE
[dagit] Implement repo-bucketed Run timeline

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Flags.tsx
+++ b/js_modules/dagit/packages/core/src/app/Flags.tsx
@@ -8,6 +8,7 @@ export const DAGIT_FLAGS_KEY = 'DAGIT_FLAGS';
 export enum FeatureFlag {
   flagDebugConsoleLogging = 'flagDebugConsoleLogging',
   flagDisableWebsockets = 'flagDisableWebsockets',
+  flagRunBucketing = 'flagRunBucketing',
 }
 
 export const getFeatureFlags: () => FeatureFlag[] = memoize(

--- a/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
@@ -116,6 +116,16 @@ const UserSettingsRoot: React.FC<SettingsRootProps> = ({tabs}) => {
                 />
               ),
             },
+            {
+              key: 'Bucket run timeline and jobs page by repo',
+              value: (
+                <Checkbox
+                  format="switch"
+                  checked={flags.includes(FeatureFlag.flagRunBucketing)}
+                  onChange={() => toggleFlag(FeatureFlag.flagRunBucketing)}
+                />
+              ),
+            },
           ]}
         />
       </Box>

--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -22,6 +22,7 @@ import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {ScheduleOrSensorTag} from '../nav/ScheduleOrSensorTag';
 import {LegacyPipelineTag} from '../pipelines/LegacyPipelineTag';
 import {PipelineReference} from '../pipelines/PipelineReference';
+import {HourWindow, makeJobKey, QueryfulRunTimeline} from '../runs/QueryfulRunTimeline';
 import {RunStatusPezList} from '../runs/RunStatusPez';
 import {
   failedStatuses,
@@ -29,7 +30,7 @@ import {
   queuedStatuses,
   successStatuses,
 } from '../runs/RunStatuses';
-import {RunTimelineContainer, TimelineJob, makeJobKey, HourWindow} from '../runs/RunTimeline';
+import {TimelineJob} from '../runs/RunTimeline';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {RunTimeFragment} from '../runs/types/RunTimeFragment';
 import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
@@ -374,6 +375,7 @@ const RunTimelineSection = ({jobs, loading}: {jobs: JobItem[]; loading: boolean}
   const timelineJobs: TimelineJob[] = jobs.map((job) => ({
     key: makeJobKey(job.repoAddress, job.job.name),
     jobName: job.job.name,
+    repoAddress: job.repoAddress,
     path: workspacePipelinePath({
       repoName: job.repoAddress.name,
       repoLocation: job.repoAddress.location,
@@ -417,7 +419,7 @@ const RunTimelineSection = ({jobs, loading}: {jobs: JobItem[]; loading: boolean}
         </Box>
       </Box>
       {shown ? (
-        <RunTimelineContainer range={[start, end]} jobs={timelineJobs} hourWindow={hourWindow} />
+        <QueryfulRunTimeline range={[start, end]} jobs={timelineJobs} hourWindow={hourWindow} />
       ) : null}
     </>
   );

--- a/js_modules/dagit/packages/core/src/runs/QueryfulRunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/QueryfulRunTimeline.tsx
@@ -1,0 +1,241 @@
+import {gql, useQuery} from '@apollo/client';
+import * as React from 'react';
+
+import {useFeatureFlags} from '../app/Flags';
+import {SCHEDULE_FUTURE_TICKS_FRAGMENT} from '../instance/NextTick';
+import {InstigationStatus, RunStatus} from '../types/globalTypes';
+import {LoadingSpinner} from '../ui/Loading';
+import {buildRepoAddress} from '../workspace/buildRepoAddress';
+import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {RepoAddress} from '../workspace/types';
+import {workspacePipelinePath} from '../workspace/workspacePath';
+
+import {doneStatuses} from './RunStatuses';
+import {RunTimeline, TimelineJob, TimelineRun} from './RunTimeline';
+import {RUN_TIME_FRAGMENT} from './RunUtils';
+import {overlap} from './batchRunsForTimeline';
+import {RunTimelineQuery, RunTimelineQueryVariables} from './types/RunTimelineQuery';
+
+export type HourWindow = '1' | '6' | '12' | '24';
+
+export const makeJobKey = (repoAddress: RepoAddress, jobName: string) =>
+  `${jobName}-${repoAddressAsString(repoAddress)}`;
+
+export const QueryfulRunTimeline = ({
+  range,
+  jobs,
+  hourWindow,
+}: {
+  range: [number, number];
+  jobs: TimelineJob[];
+  hourWindow: HourWindow;
+}) => {
+  const [start, end] = range;
+  const [jobsWithRuns, setJobsWithRuns] = React.useState<TimelineJob[]>([]);
+  const [loadedWindow, setLoadedWindow] = React.useState<HourWindow>();
+
+  const {flagRunBucketing} = useFeatureFlags();
+
+  const {data, loading} = useQuery<RunTimelineQuery, RunTimelineQueryVariables>(
+    RUN_TIMELINE_QUERY,
+    {
+      fetchPolicy: 'network-only',
+      notifyOnNetworkStatusChange: true,
+      variables: {
+        inProgressFilter: {
+          statuses: [RunStatus.CANCELING, RunStatus.STARTED],
+          createdBefore: end / 1000.0,
+        },
+        terminatedFilter: {
+          statuses: Array.from(doneStatuses),
+          createdBefore: end / 1000.0,
+          updatedAfter: start / 1000.0,
+        },
+      },
+    },
+  );
+
+  const jobsByKey = React.useMemo(() => {
+    return jobs.reduce((accum, job: TimelineJob) => {
+      return {...accum, [job.key]: job};
+    }, {} as {[key: string]: TimelineJob});
+  }, [jobs]);
+
+  React.useEffect(() => {
+    if (loading) {
+      return;
+    }
+
+    const {unterminated, terminated, workspaceOrError} = data || {};
+
+    const runsByJob: {[jobName: string]: TimelineRun[]} = {};
+    const now = Date.now();
+
+    // fetch all the runs in the given range
+    [
+      ...(unterminated?.__typename === 'Runs' ? unterminated.results : []),
+      ...(terminated?.__typename === 'Runs' ? terminated.results : []),
+    ].forEach((run) => {
+      if (!run.startTime) {
+        return;
+      }
+      if (
+        !overlap(
+          {start, end},
+          {
+            start: run.startTime * 1000,
+            end: run.endTime ? run.endTime * 1000 : now,
+          },
+        )
+      ) {
+        return;
+      }
+      runsByJob[run.pipelineName] = [
+        ...(runsByJob[run.pipelineName] || []),
+        {
+          id: run.id,
+          status: run.status,
+          startTime: run.startTime * 1000,
+          endTime: run.endTime ? run.endTime * 1000 : now,
+        },
+      ];
+    });
+
+    const jobs = [];
+    if (workspaceOrError && workspaceOrError.__typename === 'Workspace') {
+      for (const locationEntry of workspaceOrError.locationEntries) {
+        if (
+          locationEntry.__typename === 'WorkspaceLocationEntry' &&
+          locationEntry.locationOrLoadError?.__typename === 'RepositoryLocation'
+        ) {
+          for (const repository of locationEntry.locationOrLoadError.repositories) {
+            const repoAddress = buildRepoAddress(
+              repository.name,
+              locationEntry.locationOrLoadError.name,
+            );
+            for (const pipeline of repository.pipelines) {
+              const jobKey = makeJobKey(repoAddress, pipeline.name);
+              if (!(jobKey in jobsByKey)) {
+                continue;
+              }
+
+              const schedules = (repository.schedules || []).filter(
+                (schedule) => schedule.pipelineName === pipeline.name,
+              );
+
+              const jobTicks: TimelineRun[] = [];
+              for (const schedule of schedules) {
+                if (schedule.scheduleState.status === InstigationStatus.RUNNING) {
+                  schedule.futureTicks.results.forEach(({timestamp}) => {
+                    const startTime = timestamp * 1000;
+                    if (overlap({start, end}, {start: startTime, end: startTime})) {
+                      jobTicks.push({
+                        id: `${schedule.pipelineName}-future-run-${timestamp}`,
+                        status: 'SCHEDULED',
+                        startTime,
+                        endTime: startTime + 10 * 1000,
+                      });
+                    }
+                  });
+                }
+              }
+
+              const jobRuns = runsByJob[pipeline.name] || [];
+              if (jobTicks.length || jobRuns.length) {
+                jobs.push({
+                  key: jobKey,
+                  jobName: pipeline.name,
+                  repoAddress,
+                  path: workspacePipelinePath({
+                    repoName: repoAddress.name,
+                    repoLocation: repoAddress.location,
+                    pipelineName: pipeline.name,
+                    isJob: pipeline.isJob,
+                  }),
+                  runs: [...jobRuns, ...jobTicks],
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+
+    const earliest = jobs.reduce((accum, job) => {
+      const startTimes = job.runs.map((job) => job.startTime);
+      return {...accum, [job.key]: Math.min(...startTimes)};
+    }, {} as {[jobKey: string]: number});
+
+    setJobsWithRuns(jobs.sort((a, b) => earliest[a.key] - earliest[b.key]));
+    setLoadedWindow(hourWindow);
+  }, [data, start, end, loading, jobsByKey, hourWindow]);
+
+  if (loading && hourWindow !== loadedWindow) {
+    return <LoadingSpinner purpose="section" />;
+  }
+
+  return <RunTimeline range={[start, end]} jobs={jobsWithRuns} bucketByRepo={flagRunBucketing} />;
+};
+
+const RUN_TIMELINE_QUERY = gql`
+  query RunTimelineQuery($inProgressFilter: RunsFilter!, $terminatedFilter: RunsFilter!) {
+    unterminated: runsOrError(filter: $inProgressFilter) {
+      ... on Runs {
+        results {
+          id
+          pipelineName
+          ...RunTimeFragment
+        }
+      }
+    }
+    terminated: runsOrError(filter: $terminatedFilter) {
+      ... on Runs {
+        results {
+          id
+          pipelineName
+          ...RunTimeFragment
+        }
+      }
+    }
+    workspaceOrError {
+      ... on Workspace {
+        locationEntries {
+          id
+          name
+          loadStatus
+          displayMetadata {
+            key
+            value
+          }
+          locationOrLoadError {
+            ... on RepositoryLocation {
+              id
+              name
+              repositories {
+                id
+                name
+                pipelines {
+                  id
+                  name
+                  isJob
+                }
+                schedules {
+                  id
+                  name
+                  pipelineName
+                  scheduleState {
+                    id
+                    status
+                  }
+                  ...ScheduleFutureTicksFragment
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  ${RUN_TIME_FRAGMENT}
+  ${SCHEDULE_FUTURE_TICKS_FRAGMENT}
+`;

--- a/js_modules/dagit/packages/core/src/testing/generateRunMocks.ts
+++ b/js_modules/dagit/packages/core/src/testing/generateRunMocks.ts
@@ -5,7 +5,7 @@ import {RunStatus} from '../types/globalTypes';
 export const generateRunMocks = (runCount: number, range: [number, number]) => {
   const [start, end] = range;
   const now = Date.now();
-  return [...new Array(6)]
+  return [...new Array(runCount)]
     .map(() => faker.date.between(new Date(start), new Date(end)))
     .map((startDate) => {
       const endTime = Math.min(startDate.getTime() + faker.datatype.number() * 10, now);

--- a/js_modules/dagit/packages/core/src/ui/findDuplicateRepoNames.tsx
+++ b/js_modules/dagit/packages/core/src/ui/findDuplicateRepoNames.tsx
@@ -1,0 +1,12 @@
+export const findDuplicateRepoNames = (repoNames: string[]) => {
+  const uniques = new Set<string>();
+  const duplicates = new Set<string>();
+  repoNames.forEach((repoName) => {
+    if (uniques.has(repoName)) {
+      duplicates.add(repoName);
+    } else {
+      uniques.add(repoName);
+    }
+  });
+  return duplicates;
+};

--- a/js_modules/dagit/packages/core/src/ui/useRepoExpansionState.tsx
+++ b/js_modules/dagit/packages/core/src/ui/useRepoExpansionState.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+
+import {AppContext} from '../app/AppContext';
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
+import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {RepoAddress} from '../workspace/types';
+
+const validateExpandedKeys = (parsed: unknown) => (Array.isArray(parsed) ? parsed : []);
+
+/**
+ * Use localStorage to persist the expanded/collapsed visual state of repository containers,
+ * e.g. for the left nav or run timeline.
+ */
+export const useRepoExpansionState = (storageKey: string) => {
+  const {basePath} = React.useContext(AppContext);
+  const [expandedKeys, setExpandedKeys] = useStateWithStorage<string[]>(
+    `${basePath}:dagit.${storageKey}`,
+    validateExpandedKeys,
+  );
+
+  const onToggle = React.useCallback(
+    (repoAddress: RepoAddress) => {
+      const key = repoAddressAsString(repoAddress);
+      setExpandedKeys((current) => {
+        const nextExpandedKeys = new Set(current || []);
+        if (nextExpandedKeys.has(key)) {
+          nextExpandedKeys.delete(key);
+        } else {
+          nextExpandedKeys.add(key);
+        }
+        return Array.from(nextExpandedKeys);
+      });
+    },
+    [setExpandedKeys],
+  );
+
+  return React.useMemo(
+    () => ({
+      expandedKeys,
+      onToggle,
+    }),
+    [expandedKeys, onToggle],
+  );
+};


### PR DESCRIPTION
### Summary & Motivation

Implement repo-level bucketing on the run timeline component, with collapsed/expanded state preserved in localStorage. This is behind a client-side feature flag for now.

The idea here is to make the run timeline a little easier to visually parse and consume, and allow users to focus on the specific jobs they care about.

<img width="1049" alt="Screen Shot 2022-08-22 at 4 43 51 PM" src="https://user-images.githubusercontent.com/2823852/186025855-35f1c328-e315-4089-805b-f27aad5065b9.png">


### How I Tested These Changes

Storybook example. Toggle bucketing on and off, verify correct rendering in each case. Verify that expand/collapse works as expected, and that identically-named repos display the repo location name as well.
