### PR TITLE
[dagit] [workspace] Add flag, move "Code locations" page

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Flags.tsx
+++ b/js_modules/dagit/packages/core/src/app/Flags.tsx
@@ -8,6 +8,7 @@ export const DAGIT_FLAGS_KEY = 'DAGIT_FLAGS';
 export enum FeatureFlag {
   flagDebugConsoleLogging = 'flagDebugConsoleLogging',
   flagDisableWebsockets = 'flagDisableWebsockets',
+  flagNewWorkspace = 'flagNewWorkspace',
   flagRunBucketing = 'flagRunBucketing',
 }
 

--- a/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
@@ -117,6 +117,16 @@ const UserSettingsRoot: React.FC<SettingsRootProps> = ({tabs}) => {
               ),
             },
             {
+              key: 'New Workspace page',
+              value: (
+                <Checkbox
+                  format="switch"
+                  checked={flags.includes(FeatureFlag.flagNewWorkspace)}
+                  onChange={() => toggleFlag(FeatureFlag.flagNewWorkspace)}
+                />
+              ),
+            },
+            {
               key: 'Bucket run timeline and jobs page by repo',
               value: (
                 <Checkbox

--- a/js_modules/dagit/packages/core/src/instance/CodeLocationsPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/CodeLocationsPage.tsx
@@ -1,0 +1,47 @@
+import {Box, Heading, PageHeader, Subheading} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {useTrackPageView} from '../app/analytics';
+import {ReloadAllButton} from '../workspace/ReloadAllButton';
+import {RepositoryLocationsList} from '../workspace/RepositoryLocationsList';
+import {WorkspaceContext} from '../workspace/WorkspaceContext';
+
+import {InstancePageContext} from './InstancePageContext';
+import {InstanceTabs} from './InstanceTabs';
+
+export const CodeLocationsPage = () => {
+  useTrackPageView();
+
+  const {pageTitle} = React.useContext(InstancePageContext);
+  const {locationEntries, loading} = React.useContext(WorkspaceContext);
+  const entryCount = locationEntries.length;
+
+  const subheadingText = () => {
+    if (loading || !entryCount) {
+      return 'Code locations';
+    }
+    return entryCount === 1 ? '1 code location' : `${entryCount} code locations`;
+  };
+
+  return (
+    <>
+      <PageHeader
+        title={<Heading>{pageTitle}</Heading>}
+        tabs={<InstanceTabs tab="code-locations" />}
+      />
+      <Box
+        padding={{vertical: 16, horizontal: 24}}
+        flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
+        style={{height: '64px'}} // Preserve height whether "Reload all" is present or not
+      >
+        <Subheading id="repository-locations">{subheadingText()}</Subheading>
+        {entryCount > 1 ? <ReloadAllButton /> : null}
+      </Box>
+      <RepositoryLocationsList />
+    </>
+  );
+};
+
+// Imported via React.lazy, which requires a default export.
+// eslint-disable-next-line import/no-default-export
+export default CodeLocationsPage;

--- a/js_modules/dagit/packages/core/src/instance/InstanceStatusRoot.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceStatusRoot.tsx
@@ -9,6 +9,8 @@ import {InstanceOverviewPage} from './InstanceOverviewPage';
 import {InstanceSchedules} from './InstanceSchedules';
 import {InstanceSensors} from './InstanceSensors';
 
+const CodeLocationsPage = React.lazy(() => import('./CodeLocationsPage'));
+
 export const InstanceStatusRoot = () => (
   <Page>
     <Switch>
@@ -29,6 +31,11 @@ export const InstanceStatusRoot = () => (
       </Route>
       <Route path="/instance/config">
         <InstanceConfig />
+      </Route>
+      <Route path="/instance/code-locations">
+        <React.Suspense fallback={<div />}>
+          <CodeLocationsPage />
+        </React.Suspense>
       </Route>
       <Route path="*" render={() => <Redirect to="/instance" />} />
     </Switch>

--- a/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
@@ -2,6 +2,7 @@ import {QueryResult} from '@apollo/client';
 import {Box, Tabs} from '@dagster-io/ui';
 import * as React from 'react';
 
+import {useFeatureFlags} from '../app/Flags';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {TabLink} from '../ui/TabLink';
 
@@ -9,7 +10,7 @@ import {InstancePageContext} from './InstancePageContext';
 import {useCanSeeConfig} from './useCanSeeConfig';
 
 interface Props<TData> {
-  refreshState: QueryRefreshState;
+  refreshState?: QueryRefreshState;
   queryData?: QueryResult<TData, any>;
   tab: string;
 }
@@ -18,14 +19,19 @@ interface Props<TData> {
 export const InstanceTabContext = React.createContext({healthTitle: 'Daemons'});
 
 export const InstanceTabs = <TData extends Record<string, any>>(props: Props<TData>) => {
-  const {healthTitle} = React.useContext(InstancePageContext);
   const {refreshState, tab} = props;
+
+  const {healthTitle} = React.useContext(InstancePageContext);
+  const {flagNewWorkspace} = useFeatureFlags();
   const canSeeConfig = useCanSeeConfig();
 
   return (
     <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
       <Tabs selectedTabId={tab}>
         <TabLink id="overview" title="Overview" to="/instance/overview" />
+        {flagNewWorkspace ? (
+          <TabLink id="code-locations" title="Code locations" to="/instance/code-locations" />
+        ) : null}
         <TabLink id="health" title={healthTitle} to="/instance/health" />
         <TabLink id="schedules" title="Schedules" to="/instance/schedules" />
         <TabLink id="sensors" title="Sensors" to="/instance/sensors" />

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewRoot.tsx
@@ -12,6 +12,7 @@ import {
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
+import {useFeatureFlags} from '../app/Flags';
 import {useTrackPageView} from '../app/analytics';
 import {LoadingSpinner} from '../ui/Loading';
 
@@ -23,6 +24,8 @@ import {workspacePath} from './workspacePath';
 
 export const WorkspaceOverviewRoot = () => {
   useTrackPageView();
+
+  const {flagNewWorkspace} = useFeatureFlags();
   const {loading, error, options} = useRepositoryOptions();
 
   const content = () => {
@@ -121,15 +124,19 @@ export const WorkspaceOverviewRoot = () => {
   return (
     <Page>
       <PageHeader title={<Heading>Workspace</Heading>} />
-      <Box padding={{vertical: 16, horizontal: 24}}>
-        <Group direction="row" spacing={12} alignItems="center">
-          <Subheading id="repository-locations">Locations</Subheading>
-          <ReloadAllButton />
-        </Group>
-      </Box>
-      <Box padding={{bottom: 24}}>
-        <RepositoryLocationsList />
-      </Box>
+      {flagNewWorkspace ? null : (
+        <>
+          <Box padding={{vertical: 16, horizontal: 24}}>
+            <Group direction="row" spacing={12} alignItems="center">
+              <Subheading id="repository-locations">Locations</Subheading>
+              <ReloadAllButton />
+            </Group>
+          </Box>
+          <Box padding={{bottom: 24}}>
+            <RepositoryLocationsList />
+          </Box>
+        </>
+      )}
       <Box
         padding={{vertical: 16, horizontal: 24}}
         border={{side: 'top', width: 1, color: Colors.KeylineGray}}


### PR DESCRIPTION
### Summary & Motivation

First step in some of the information architecture changes we're planning in Dagit. Move "Code locations" to a tab under "Status", behind a client-side feature flag.

### How I Tested These Changes

Enable flag, verify that Workspace and Status pages look correct. Disable flag, verify that things are as they were before.
