### PR TITLE
filter job runs by repo in metadata page

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
@@ -7,6 +7,7 @@ import {DagsterTag} from '../runs/RunTag';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
 import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
+import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {LatestRunTag} from './LatestRunTag';
@@ -30,7 +31,7 @@ export const JobMetadata: React.FC<Props> = (props) => {
         tags: [
           {
             key: DagsterTag.RepositoryLabelTag,
-            value: `${repoAddress.name}@${repoAddress.location}`,
+            value: repoAddressAsString(repoAddress),
           },
         ],
       },

--- a/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
@@ -3,6 +3,7 @@ import {Box, Button, ButtonLink, Colors, DialogFooter, Dialog, Table, Tag} from 
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
+import {DagsterTag} from '../runs/RunTag';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
 import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
@@ -26,6 +27,12 @@ export const JobMetadata: React.FC<Props> = (props) => {
     variables: {
       runsFilter: {
         pipelineName,
+        tags: [
+          {
+            key: DagsterTag.RepositoryLabelTag,
+            value: `${repoAddress.name}@${repoAddress.location}`,
+          },
+        ],
       },
       params: {
         pipelineName,
@@ -52,7 +59,7 @@ export const JobMetadata: React.FC<Props> = (props) => {
   return (
     <>
       {job ? <JobScheduleOrSensorTag job={job} repoAddress={repoAddress} /> : null}
-      <LatestRunTag pipelineName={pipelineName} />
+      <LatestRunTag pipelineName={pipelineName} repoAddress={repoAddress} />
       {runsForAssetScan ? <RelatedAssetsTag runs={runsForAssetScan} /> : null}
     </>
   );

--- a/js_modules/dagit/packages/core/src/nav/LatestRunTag.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LatestRunTag.tsx
@@ -6,18 +6,36 @@ import {Link} from 'react-router-dom';
 import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {timingStringForStatus} from '../runs/RunDetails';
 import {RunStatusIndicator} from '../runs/RunStatusDots';
+import {DagsterTag} from '../runs/RunTag';
 import {RunTime, RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {RunStatus} from '../types/globalTypes';
+import {RepoAddress} from '../workspace/types';
 
 import {LatestRunTagQuery, LatestRunTagQueryVariables} from './types/LatestRunTagQuery';
 
 const TIME_FORMAT = {showSeconds: true, showTimezone: false};
 
-export const LatestRunTag: React.FC<{pipelineName: string}> = ({pipelineName}) => {
+export const LatestRunTag: React.FC<{pipelineName: string; repoAddress: RepoAddress}> = ({
+  pipelineName,
+  repoAddress,
+}) => {
   const lastRunQuery = useQuery<LatestRunTagQuery, LatestRunTagQueryVariables>(
     LATEST_RUN_TAG_QUERY,
-    {variables: {runsFilter: {pipelineName}}, notifyOnNetworkStatusChange: true},
+    {
+      variables: {
+        runsFilter: {
+          pipelineName,
+          tags: [
+            {
+              key: DagsterTag.RepositoryLabelTag,
+              value: `${repoAddress.name}@${repoAddress.location}`,
+            },
+          ],
+        },
+      },
+      notifyOnNetworkStatusChange: true,
+    },
   );
 
   useQueryRefreshAtInterval(lastRunQuery, FIFTEEN_SECONDS);

--- a/js_modules/dagit/packages/core/src/nav/LatestRunTag.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LatestRunTag.tsx
@@ -10,6 +10,7 @@ import {DagsterTag} from '../runs/RunTag';
 import {RunTime, RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {RunStatus} from '../types/globalTypes';
+import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {LatestRunTagQuery, LatestRunTagQueryVariables} from './types/LatestRunTagQuery';
@@ -29,7 +30,7 @@ export const LatestRunTag: React.FC<{pipelineName: string; repoAddress: RepoAddr
           tags: [
             {
               key: DagsterTag.RepositoryLabelTag,
-              value: `${repoAddress.name}@${repoAddress.location}`,
+              value: repoAddressAsString(repoAddress),
             },
           ],
         },


### PR DESCRIPTION
### Summary & Motivation
With 1.0, we started to separate out the different run views by repo.

### How I Tested These Changes
Created different repos with the same named jobs, saw that the runs did not cross-pollute.