### PR TITLE
[docs] - Remove broken image from Cloud alert docs

### DIFF
--- a/docs/content/dagster-cloud/account/setting-up-alerts.mdx
+++ b/docs/content/dagster-cloud/account/setting-up-alerts.mdx
@@ -87,14 +87,7 @@ height={153}
 
 ### Enabling and disabling alert policies
 
-To enable or disable an alert, use the toggle on the left side of the alert policy:
-
-<Image
-alt="Enabling and disabling an alert policy in Dagster Cloud"
-src="/images/dagster-cloud/alerts/enable-disable-alert-policy.gif"
-width={822}
-height={158}
-/>
+To enable or disable an alert, use the toggle on the left side of the alert policy.
 
 ### Deleting alert policies
 


### PR DESCRIPTION
This PR (temporarily) removes an image from the Cloud alert docs.