### PR TITLE
enable PartitionedConfig with asset jobs

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -229,15 +229,6 @@ async function stateForLaunchingAssets(
   const anyResourcesHaveRequiredConfig = resources.some((r) => r.configField?.isRequired);
 
   const anyAssetsHaveRequiredConfig = assets.some((a) => a.configField?.isRequired);
-  if ((anyAssetsHaveRequiredConfig || anyResourcesHaveRequiredConfig) && partitionDefinition) {
-    return {
-      type: 'error',
-      error:
-        'Cannot materialize assets using both partitions and asset or required resource config.',
-    };
-  }
-
-  // Ok! Assertions met, how do we launch this run
 
   if (partitionDefinition) {
     const assetKeys = new Set(assets.map((a) => JSON.stringify(a.assetKey)));

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -173,12 +173,21 @@ class JobDefinition(PipelineDefinition):
         partitioned_config = None
 
         if partitions_def:
-            if isinstance(config, (ConfigMapping, PartitionedConfig)):
-                check.failed(
-                    "Can't supply a ConfigMapping or PartitionedConfig for 'config' when 'partitions_def' is supplied."
+            check.invariant(
+                not isinstance(config, ConfigMapping),
+                "Can't supply a ConfigMappi/ng for 'config' when 'partitions_def' is supplied.",
+            )
+
+            if isinstance(config, PartitionedConfig):
+                check.invariant(
+                    config.partitions_def == partitions_def,
+                    "Can't supply a PartitionedConfig for 'config' with a different "
+                    "PartitionsDefinition than supplied for 'partitions_def'.",
                 )
-            hardcoded_config = config if config else {}
-            partitioned_config = PartitionedConfig(partitions_def, lambda _: hardcoded_config)
+                partitioned_config = config
+            else:
+                hardcoded_config = config if config else {}
+                partitioned_config = PartitionedConfig(partitions_def, lambda _: hardcoded_config)
 
         if isinstance(config, ConfigMapping):
             config_mapping = config


### PR DESCRIPTION
### Summary & Motivation

This will make it easier for existing users with partitioned config to migrate to software-defined assets.

Partly motivated by: https://dagster.slack.com/archives/C01U954MEER/p1661189328445639

### How I Tested These Changes

Added a test and made sure launching worked in Dagit:

```
from dagster import (
    op,
    graph,
    repository,
    define_asset_job,
    AssetsDefinition,
    DailyPartitionsDefinition,
    daily_partitioned_config,
)


@op(config_schema={"a": int})
def op1():
    ...


@graph
def graph1():
    return op1()


asset1 = AssetsDefinition.from_graph(
    graph1, partitions_def=DailyPartitionsDefinition(start_date="2020-01-01")
)


@daily_partitioned_config(start_date="2020-01-01")
def partconf1(start, end):
    return {"ops": {"graph1": {"ops": {"op1": {"config": {"a": 5}}}}}}


@repository
def repo():
    return [asset1, define_asset_job("graph2", config=partconf1)]
```
