### PR TITLE
[dagit] Fix asset graph rendering in Firefox, Safari

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -366,7 +366,11 @@ export const AssetGraphExplorerWithData: React.FC<
 
                           <GroupOutline
                             style={{
-                              top: repositoryDisambiguationRequired ? 24 + 18 : 24,
+                              marginTop: 6,
+                              height:
+                                bounds.height -
+                                (repositoryDisambiguationRequired ? 24 + 18 : 24) -
+                                3,
                               border: `${Math.max(2, 2 / _scale)}px dashed ${Colors.Gray300}`,
                               background: `rgba(223, 223, 223, ${
                                 0.4 - Math.max(0, _scale - MINIMAL_SCALE) * 0.3
@@ -502,8 +506,7 @@ const SVGContainer = styled.svg`
 `;
 
 const GroupOutline = styled.div`
-  inset: 0;
-  position: absolute;
+  width: 100%;
   border-radius: 10px;
   pointer-events: none;
 `;
@@ -511,6 +514,8 @@ const GroupOutline = styled.div`
 const GroupRepoName = styled.div`
   font-size: 0.8rem;
   line-height: 0.7rem;
+  white-space: nowrap;
+  margin-bottom: 4px;
 `;
 
 // Helpers

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -44,88 +44,90 @@ export const AssetNode: React.FC<{
   const {lastMaterialization, computeStatus} = liveData || MISSING_LIVE_DATA;
 
   return (
-    <AssetNodeContainer $selected={selected}>
-      <AssetNodeBox $selected={selected}>
-        <Name>
-          <span style={{marginTop: 1}}>
-            <Icon name="asset" />
-          </span>
-          <div style={{overflow: 'hidden', textOverflow: 'ellipsis', marginTop: -1}}>
-            {withMiddleTruncation(displayName, {
-              maxLength: ASSET_NODE_NAME_MAX_LENGTH,
-            })}
-          </div>
-          <div style={{flex: 1}} />
-          <div style={{maxWidth: ASSET_NODE_ANNOTATIONS_MAX_WIDTH}}>
-            <ComputeStatusNotice computeStatus={computeStatus} />
-          </div>
-        </Name>
-        {definition.description && !inAssetCatalog && (
-          <Description>{markdownToPlaintext(definition.description).split('\n')[0]}</Description>
-        )}
-        {computeName && displayName !== computeName && (
-          <Description>
-            <Box
-              flex={{gap: 4, alignItems: 'flex-end'}}
-              style={{marginLeft: -2, overflow: 'hidden'}}
-            >
-              <Icon name={definition.graphName ? 'job' : 'op'} size={16} />
-              <div style={{minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis'}}>
-                {computeName}
-              </div>
-            </Box>
-          </Description>
-        )}
+    <AssetInsetForHoverEffect>
+      <AssetNodeContainer $selected={selected}>
+        <AssetNodeBox $selected={selected}>
+          <Name>
+            <span style={{marginTop: 1}}>
+              <Icon name="asset" />
+            </span>
+            <div style={{overflow: 'hidden', textOverflow: 'ellipsis', marginTop: -1}}>
+              {withMiddleTruncation(displayName, {
+                maxLength: ASSET_NODE_NAME_MAX_LENGTH,
+              })}
+            </div>
+            <div style={{flex: 1}} />
+            <div style={{maxWidth: ASSET_NODE_ANNOTATIONS_MAX_WIDTH}}>
+              <ComputeStatusNotice computeStatus={computeStatus} />
+            </div>
+          </Name>
+          {definition.description && !inAssetCatalog && (
+            <Description>{markdownToPlaintext(definition.description).split('\n')[0]}</Description>
+          )}
+          {computeName && displayName !== computeName && (
+            <Description>
+              <Box
+                flex={{gap: 4, alignItems: 'flex-end'}}
+                style={{marginLeft: -2, overflow: 'hidden'}}
+              >
+                <Icon name={definition.graphName ? 'job' : 'op'} size={16} />
+                <div style={{minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis'}}>
+                  {computeName}
+                </div>
+              </Box>
+            </Description>
+          )}
 
-        <Stats>
-          {lastMaterialization ? (
-            <StatsRow>
-              <span>Materialized</span>
-              <CaptionMono style={{textAlign: 'right'}}>
-                <AssetRunLink
-                  runId={lastMaterialization.runId}
-                  event={{stepKey, timestamp: lastMaterialization.timestamp}}
-                >
-                  <TimestampDisplay
-                    timestamp={Number(lastMaterialization.timestamp) / 1000}
-                    timeFormat={{showSeconds: false, showTimezone: false}}
-                  />
-                </AssetRunLink>
-              </CaptionMono>
-            </StatsRow>
-          ) : (
-            <>
+          <Stats>
+            {lastMaterialization ? (
               <StatsRow>
                 <span>Materialized</span>
-                <span>–</span>
+                <CaptionMono style={{textAlign: 'right'}}>
+                  <AssetRunLink
+                    runId={lastMaterialization.runId}
+                    event={{stepKey, timestamp: lastMaterialization.timestamp}}
+                  >
+                    <TimestampDisplay
+                      timestamp={Number(lastMaterialization.timestamp) / 1000}
+                      timeFormat={{showSeconds: false, showTimezone: false}}
+                    />
+                  </AssetRunLink>
+                </CaptionMono>
               </StatsRow>
-            </>
-          )}
-          <StatsRow>
-            <span>Latest&nbsp;Run</span>
-            <CaptionMono style={{textAlign: 'right'}}>
-              <AssetLatestRunWithNotices liveData={liveData} />
-            </CaptionMono>
-          </StatsRow>
-        </Stats>
-        {definition.computeKind && (
-          <OpTags
-            minified={false}
-            style={{right: -2, paddingTop: 5}}
-            tags={[
-              {
-                label: definition.computeKind,
-                onClick: () => {
-                  window.requestAnimationFrame(() =>
-                    document.dispatchEvent(new Event('show-kind-info')),
-                  );
+            ) : (
+              <>
+                <StatsRow>
+                  <span>Materialized</span>
+                  <span>–</span>
+                </StatsRow>
+              </>
+            )}
+            <StatsRow>
+              <span>Latest&nbsp;Run</span>
+              <CaptionMono style={{textAlign: 'right'}}>
+                <AssetLatestRunWithNotices liveData={liveData} />
+              </CaptionMono>
+            </StatsRow>
+          </Stats>
+          {definition.computeKind && (
+            <OpTags
+              minified={false}
+              style={{right: -2, paddingTop: 5}}
+              tags={[
+                {
+                  label: definition.computeKind,
+                  onClick: () => {
+                    window.requestAnimationFrame(() =>
+                      document.dispatchEvent(new Event('show-kind-info')),
+                    );
+                  },
                 },
-              },
-            ]}
-          />
-        )}
-      </AssetNodeBox>
-    </AssetNodeContainer>
+              ]}
+            />
+          )}
+        </AssetNodeBox>
+      </AssetNodeContainer>
+    </AssetInsetForHoverEffect>
   );
 }, isEqual);
 
@@ -136,13 +138,15 @@ export const AssetNodeMinimal: React.FC<{
   const displayName = definition.assetKey.path[definition.assetKey.path.length - 1];
 
   return (
-    <MinimalAssetNodeContainer $selected={selected}>
-      <MinimalAssetNodeBox $selected={selected}>
-        <MinimalName style={{fontSize: 28}}>
-          {withMiddleTruncation(displayName, {maxLength: 17})}
-        </MinimalName>
-      </MinimalAssetNodeBox>
-    </MinimalAssetNodeContainer>
+    <AssetInsetForHoverEffect>
+      <MinimalAssetNodeContainer $selected={selected}>
+        <MinimalAssetNodeBox $selected={selected}>
+          <MinimalName style={{fontSize: 28}}>
+            {withMiddleTruncation(displayName, {maxLength: 17})}
+          </MinimalName>
+        </MinimalAssetNodeBox>
+      </MinimalAssetNodeContainer>
+    </AssetInsetForHoverEffect>
   );
 };
 
@@ -200,17 +204,17 @@ const BoxColors = {
   Stats: 'rgba(236, 236, 248, 1)',
 };
 
+const AssetInsetForHoverEffect = styled.div`
+  padding: 10px 4px 2px 4px;
+  height: 100%;
+`;
+
 const AssetNodeContainer = styled.div<{$selected: boolean}>`
   outline: ${(p) => (p.$selected ? `2px dashed ${NodeHighlightColors.Border}` : 'none')};
   border-radius: 6px;
   outline-offset: -1px;
   background: ${(p) => (p.$selected ? NodeHighlightColors.Background : 'white')};
-  inset: 0;
   padding: 4px;
-  margin-top: 10px;
-  margin-right: 4px;
-  margin-left: 4px;
-  margin-bottom: 2px;
 `;
 
 const AssetNodeBox = styled.div<{$selected: boolean}>`
@@ -236,18 +240,19 @@ const Name = styled.div`
 `;
 
 const MinimalAssetNodeContainer = styled(AssetNodeContainer)`
-  position: absolute;
   border-radius: 12px;
   outline-offset: 2px;
   outline-width: 4px;
+  height: 100%;
 `;
 
 const MinimalAssetNodeBox = styled(AssetNodeBox)`
   background: ${Colors.White};
   border: 4px solid ${Colors.Blue200};
   border-radius: 10px;
-  position: absolute;
-  inset: 4px;
+  position: relative;
+  padding: 4px;
+  height: 100%;
 `;
 
 const MinimalName = styled(Name)`

--- a/js_modules/dagit/packages/core/src/asset-graph/layout.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/layout.ts
@@ -163,7 +163,7 @@ export const layoutAssetGraph = (graphData: GraphData): AssetGraphLayout => {
       }
     }
     for (const group of Object.values(groups)) {
-      group.bounds = padBounds(group.bounds, {x: 15, y: 30});
+      group.bounds = padBounds(group.bounds, {x: 15, top: 30, bottom: 15});
     }
   }
 
@@ -203,12 +203,12 @@ export const getForeignNodeDimensions = (id: string) => {
   return {width: displayNameForAssetKey({path}).length * 8 + 30, height: 30};
 };
 
-export const padBounds = (a: IBounds, padding: {x: number; y: number}) => {
+export const padBounds = (a: IBounds, padding: {x: number; top: number; bottom: number}) => {
   return {
     x: a.x - padding.x,
-    y: a.y - padding.y,
+    y: a.y - padding.top,
     width: a.width + padding.x * 2,
-    height: a.height + padding.y * 2,
+    height: a.height + padding.top + padding.bottom,
   };
 };
 
@@ -237,7 +237,7 @@ export const getAssetNodeDimensions = (def: {
   graphName: string | null;
   description?: string | null;
 }) => {
-  let height = 82;
+  let height = 100;
   if (def.description) {
     height += 25;
   }


### PR DESCRIPTION
### Summary & Motivation

This PR fixes the issue shown in the screenshot below, and makes some tiny adjustments to the heights of nodes to fit them in the group boxes better.

This was happening because 1) Safari does not allow a `foreignObject` to be the relative container for `absolute` positioning, and 2) it does not honor "margin" properties on the top level of elements within a `foreignObject`. This unfortunately means that we needed to wrap AssetNode in one more `<div>` to get the correct rendering.

![image](https://user-images.githubusercontent.com/1037212/186272325-86225006-df5b-4181-ac32-6432b312fc43.png)




### How I Tested These Changes
