### PR TITLE
[dagit] [workspace] Create Jobs tab under Workspace

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -7,11 +7,8 @@ import {
   Icon,
   PageHeader,
   Spinner,
-  Table,
-  Body,
   Heading,
   TextInput,
-  FontFamily,
 } from '@dagster-io/ui';
 import * as React from 'react';
 
@@ -19,11 +16,7 @@ import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useMergedRefresh, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
-import {ScheduleOrSensorTag} from '../nav/ScheduleOrSensorTag';
-import {LegacyPipelineTag} from '../pipelines/LegacyPipelineTag';
-import {PipelineReference} from '../pipelines/PipelineReference';
 import {HourWindow, makeJobKey, QueryfulRunTimeline} from '../runs/QueryfulRunTimeline';
-import {RunStatusPezList} from '../runs/RunStatusPez';
 import {
   failedStatuses,
   inProgressStatuses,
@@ -38,15 +31,12 @@ import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
 import {REPOSITORY_INFO_FRAGMENT} from '../workspace/RepositoryInformation';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
-import {RepoAddress} from '../workspace/types';
 import {workspacePipelinePath} from '../workspace/workspacePath';
 
 import {InstancePageContext} from './InstancePageContext';
 import {InstanceTabs} from './InstanceTabs';
-import {JobMenu} from './JobMenu';
-import {LastRunSummary} from './LastRunSummary';
-import {NextTick, SCHEDULE_FUTURE_TICKS_FRAGMENT} from './NextTick';
+import {JobItem, JobItemWithRuns, JobTable} from './JobTable';
+import {SCHEDULE_FUTURE_TICKS_FRAGMENT} from './NextTick';
 import {RepoFilterButton} from './RepoFilterButton';
 import {
   InstanceOverviewInitialQuery,
@@ -54,18 +44,6 @@ import {
   InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors as Sensor,
 } from './types/InstanceOverviewInitialQuery';
 import {LastTenRunsPerJobQuery} from './types/LastTenRunsPerJobQuery';
-import {OverviewJobFragment} from './types/OverviewJobFragment';
-
-type JobItem = {
-  job: OverviewJobFragment;
-  repoAddress: RepoAddress;
-  schedules: Schedule[];
-  sensors: Sensor[];
-};
-
-type JobItemWithRuns = JobItem & {
-  runs: RunTimeFragment[];
-};
 
 type State = {
   searchValue: string;
@@ -123,9 +101,9 @@ export const InstanceOverviewPage = () => {
     const queued = [];
     const neverRan = [];
 
-    const sortFn = (a: JobItem, b: JobItem) => {
-      const aRun = a.job.runs[0] || null;
-      const bRun = b.job.runs[0] || null;
+    const sortFn = (a: JobItemWithRuns, b: JobItemWithRuns) => {
+      const aRun = a.runs[0] || null;
+      const bRun = b.runs[0] || null;
 
       if (aRun.startTime) {
         return bRun.startTime ? bRun.startTime - aRun.startTime : -1;
@@ -133,7 +111,7 @@ export const InstanceOverviewPage = () => {
         return -1;
       }
 
-      return a.job.name.toLocaleLowerCase().localeCompare(b.job.name.toLocaleLowerCase());
+      return a.name.toLocaleLowerCase().localeCompare(b.name.toLocaleLowerCase());
     };
 
     if (data && Object.keys(data).length && data?.workspaceOrError.__typename === 'Workspace') {
@@ -158,11 +136,13 @@ export const InstanceOverviewPage = () => {
 
               if (runs.length) {
                 const {status} = runs[0];
-                const item: JobItem = {
-                  job: pipeline,
+                const item: JobItemWithRuns = {
+                  isJob: pipeline.isJob,
+                  name: pipeline.name,
                   schedules,
                   sensors,
                   repoAddress,
+                  runs,
                 };
                 if (failedStatuses.has(status)) {
                   failed.push(item);
@@ -193,14 +173,14 @@ export const InstanceOverviewPage = () => {
 
   const filteredJobs = React.useMemo(() => {
     const searchToLower = searchValue.toLocaleLowerCase();
-    const filterJobs = ({job, repoAddress}: JobItem) =>
+    const filterJobs = ({name, repoAddress}: JobItem) =>
       visibleRepos.some(
         (r) =>
           r.repository.name === repoAddress.name &&
           r.repositoryLocation.name === repoAddress.location,
       ) &&
-      job.name.toLocaleLowerCase().includes(searchToLower) &&
-      !isHiddenAssetGroupJob(job.name);
+      name.toLocaleLowerCase().includes(searchToLower) &&
+      !isHiddenAssetGroupJob(name);
 
     const {failed, inProgress, queued, succeeded, neverRan} = bucketed;
     return {
@@ -248,8 +228,8 @@ export const InstanceOverviewPage = () => {
 
   const filteredJobsWithRuns = React.useMemo(() => {
     const appendRuns = (jobItem: JobItem) => {
-      const {job, repoAddress} = jobItem;
-      const jobKey = makeJobKey(repoAddress, job.name);
+      const {name, repoAddress} = jobItem;
+      const jobKey = makeJobKey(repoAddress, name);
       const matchingRuns = lastTenRunsFlattened ? lastTenRunsFlattened[jobKey] || [] : [];
       return {...jobItem, runs: [...matchingRuns].reverse()};
     };
@@ -373,14 +353,14 @@ const RunTimelineSection = ({jobs, loading}: {jobs: JobItem[]; loading: boolean}
   }, [range]);
 
   const timelineJobs: TimelineJob[] = jobs.map((job) => ({
-    key: makeJobKey(job.repoAddress, job.job.name),
-    jobName: job.job.name,
+    key: makeJobKey(job.repoAddress, job.name),
+    jobName: job.name,
     repoAddress: job.repoAddress,
     path: workspacePipelinePath({
       repoName: job.repoAddress.name,
       repoLocation: job.repoAddress.location,
-      pipelineName: job.job.name,
-      isJob: job.job.isJob,
+      pipelineName: job.name,
+      isJob: job.isJob,
     }),
     runs: [],
   }));
@@ -443,74 +423,7 @@ const JobSection = (props: JobSectionProps) => {
         {icon}
         <Heading>{heading}</Heading>
       </Box>
-      <Table>
-        <thead>
-          <tr>
-            <th style={{width: '40%'}}>Job</th>
-            <th style={{width: '25%'}}>Trigger</th>
-            <th style={{width: '35%'}}>Latest run</th>
-            <th />
-          </tr>
-        </thead>
-        <tbody>
-          {jobs.map(({job, repoAddress, runs, schedules, sensors}) => {
-            const jobKey = makeJobKey(repoAddress, job.name);
-            const repoAddressString = repoAddressAsString(repoAddress);
-            return (
-              <tr key={jobKey}>
-                <td>
-                  <Box
-                    flex={{
-                      direction: 'row',
-                      justifyContent: 'space-between',
-                      alignItems: 'flex-start',
-                    }}
-                  >
-                    <Box flex={{direction: 'column', gap: 4}}>
-                      <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-                        <PipelineReference
-                          pipelineName={job.name}
-                          isJob={job.isJob}
-                          pipelineHrefContext={repoAddress}
-                        />
-                        {!job.isJob ? <LegacyPipelineTag /> : null}
-                      </Box>
-                      <Body color={Colors.Gray400} style={{fontFamily: FontFamily.monospace}}>
-                        {repoAddressString}
-                      </Body>
-                    </Box>
-                    {runs ? (
-                      <Box margin={{top: 4}}>
-                        <RunStatusPezList fade runs={runs} repoAddress={repoAddressString} />
-                      </Box>
-                    ) : null}
-                  </Box>
-                </td>
-                <td>
-                  {schedules.length || sensors.length ? (
-                    <Box flex={{direction: 'column', alignItems: 'flex-start', gap: 8}}>
-                      <ScheduleOrSensorTag
-                        schedules={schedules}
-                        sensors={sensors}
-                        repoAddress={repoAddress}
-                      />
-                      {schedules.length ? <NextTick schedules={schedules} /> : null}
-                    </Box>
-                  ) : (
-                    <div style={{color: Colors.Gray500}}>None</div>
-                  )}
-                </td>
-                <td>
-                  <LastRunSummary run={job.runs[0]} />
-                </td>
-                <td>
-                  <JobMenu job={job} repoAddress={repoAddress} />
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </Table>
+      <JobTable jobs={jobs} />
     </>
   );
 };
@@ -536,7 +449,7 @@ const OVERVIEW_JOB_FRAGMENT = gql`
   ${RUN_TIME_FRAGMENT}
 `;
 
-const INSTANCE_OVERVIEW_INITIAL_QUERY = gql`
+export const INSTANCE_OVERVIEW_INITIAL_QUERY = gql`
   query InstanceOverviewInitialQuery {
     workspaceOrError {
       ... on Workspace {
@@ -601,7 +514,7 @@ const INSTANCE_OVERVIEW_INITIAL_QUERY = gql`
   ${PYTHON_ERROR_FRAGMENT}
 `;
 
-const LAST_TEN_RUNS_PER_JOB_QUERY = gql`
+export const LAST_TEN_RUNS_PER_JOB_QUERY = gql`
   query LastTenRunsPerJobQuery {
     workspaceOrError {
       ... on Workspace {

--- a/js_modules/dagit/packages/core/src/instance/JobMenu.tsx
+++ b/js_modules/dagit/packages/core/src/instance/JobMenu.tsx
@@ -5,16 +5,16 @@ import * as React from 'react';
 import {usePermissions} from '../app/Permissions';
 import {canRunAllSteps, canRunFromFailure} from '../runs/RunActionButtons';
 import {RunFragments} from '../runs/RunFragments';
+import {RunTimeFragment} from '../runs/types/RunTimeFragment';
 import {useJobReExecution} from '../runs/useJobReExecution';
 import {MenuLink} from '../ui/MenuLink';
 import {RepoAddress} from '../workspace/types';
 import {workspacePipelinePath} from '../workspace/workspacePath';
 
-import {OverviewJobFragment} from './types/OverviewJobFragment';
 import {RunReExecutionQuery} from './types/RunReExecutionQuery';
 
 interface Props {
-  job: OverviewJobFragment;
+  job: {isJob: boolean; name: string; runs: RunTimeFragment[]};
   repoAddress: RepoAddress;
 }
 
@@ -24,14 +24,14 @@ interface Props {
  */
 export const JobMenu = (props: Props) => {
   const {job, repoAddress} = props;
-  const lastRun = job.runs[0];
+  const lastRun = job.runs.length ? job.runs[0] : null;
   const {canLaunchPipelineReexecution} = usePermissions();
   const [fetchHasExecutionPlan, {data}] = useLazyQuery<RunReExecutionQuery>(RUN_RE_EXECUTION_QUERY);
 
   const run = data?.pipelineRunOrError.__typename === 'Run' ? data?.pipelineRunOrError : null;
 
   const fetchIfPossible = React.useCallback(() => {
-    if (lastRun.id) {
+    if (lastRun?.id) {
       fetchHasExecutionPlan({variables: {runId: lastRun.id}});
     }
   }, [lastRun, fetchHasExecutionPlan]);

--- a/js_modules/dagit/packages/core/src/instance/JobTable.tsx
+++ b/js_modules/dagit/packages/core/src/instance/JobTable.tsx
@@ -1,0 +1,114 @@
+import {Body, Box, Colors, FontFamily, Table} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {ScheduleOrSensorTag} from '../nav/ScheduleOrSensorTag';
+import {LegacyPipelineTag} from '../pipelines/LegacyPipelineTag';
+import {PipelineReference} from '../pipelines/PipelineReference';
+import {makeJobKey} from '../runs/QueryfulRunTimeline';
+import {RunStatusPezList} from '../runs/RunStatusPez';
+import {RunTimeFragment} from '../runs/types/RunTimeFragment';
+import {ScheduleSwitchFragment} from '../schedules/types/ScheduleSwitchFragment';
+import {SensorSwitchFragment} from '../sensors/types/SensorSwitchFragment';
+import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {RepoAddress} from '../workspace/types';
+
+import {JobMenu} from './JobMenu';
+import {LastRunSummary} from './LastRunSummary';
+import {NextTick} from './NextTick';
+import {ScheduleFutureTicksFragment} from './types/ScheduleFutureTicksFragment';
+
+export type ScheduleFragment = ScheduleSwitchFragment & ScheduleFutureTicksFragment;
+
+export type JobItem = {
+  name: string;
+  isJob: boolean;
+  repoAddress: RepoAddress;
+  schedules: ScheduleFragment[];
+  sensors: SensorSwitchFragment[];
+};
+
+export type JobItemWithRuns = JobItem & {
+  runs: RunTimeFragment[];
+};
+
+interface Props {
+  jobs: JobItemWithRuns[];
+}
+
+export const JobTable = (props: Props) => {
+  const {jobs} = props;
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th style={{width: '40%'}}>Job</th>
+          <th style={{width: '25%'}}>Trigger</th>
+          <th style={{width: '35%'}}>Latest run</th>
+          <th />
+        </tr>
+      </thead>
+      <tbody>
+        {jobs.map(({isJob, name, repoAddress, runs, schedules, sensors}) => {
+          const jobKey = makeJobKey(repoAddress, name);
+          const repoAddressString = repoAddressAsString(repoAddress);
+          return (
+            <tr key={jobKey}>
+              <td>
+                <Box
+                  flex={{
+                    direction: 'row',
+                    justifyContent: 'space-between',
+                    alignItems: 'flex-start',
+                  }}
+                >
+                  <Box flex={{direction: 'column', gap: 4}}>
+                    <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+                      <PipelineReference
+                        pipelineName={name}
+                        isJob={isJob}
+                        pipelineHrefContext={repoAddress}
+                      />
+                      {!isJob ? <LegacyPipelineTag /> : null}
+                    </Box>
+                    <Body color={Colors.Gray400} style={{fontFamily: FontFamily.monospace}}>
+                      {repoAddressString}
+                    </Body>
+                  </Box>
+                  {runs.length ? (
+                    <Box margin={{top: 4}}>
+                      <RunStatusPezList fade runs={runs} repoAddress={repoAddressString} />
+                    </Box>
+                  ) : null}
+                </Box>
+              </td>
+              <td>
+                {schedules.length || sensors.length ? (
+                  <Box flex={{direction: 'column', alignItems: 'flex-start', gap: 8}}>
+                    <ScheduleOrSensorTag
+                      schedules={schedules}
+                      sensors={sensors}
+                      repoAddress={repoAddress}
+                    />
+                    {schedules.length ? <NextTick schedules={schedules} /> : null}
+                  </Box>
+                ) : (
+                  <div style={{color: Colors.Gray500}}>None</div>
+                )}
+              </td>
+              <td>
+                {runs.length ? (
+                  <LastRunSummary run={runs[0]} />
+                ) : (
+                  <div style={{color: Colors.Gray500}}>None</div>
+                )}
+              </td>
+              <td>
+                <JobMenu job={{isJob, name, runs}} repoAddress={repoAddress} />
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </Table>
+  );
+};

--- a/js_modules/dagit/packages/core/src/runs/RepoSectionHeader.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RepoSectionHeader.tsx
@@ -1,0 +1,75 @@
+import {Box, Colors, Icon, IconWrapper} from '@dagster-io/ui';
+import * as React from 'react';
+import styled from 'styled-components/macro';
+
+export const SECTION_HEADER_HEIGHT = 32;
+
+interface Props {
+  expanded: boolean;
+  onClick: () => void;
+  repoName: string;
+  repoLocation: string;
+  showLocation: boolean;
+  rightElement?: React.ReactNode;
+}
+
+export const RepoSectionHeader = (props: Props) => {
+  const {expanded, onClick, repoName, repoLocation, showLocation, rightElement} = props;
+  return (
+    <SectionHeaderButton $open={expanded} onClick={onClick}>
+      <Box
+        flex={{alignItems: 'center', justifyContent: 'space-between'}}
+        padding={{left: 20, right: 20}}
+      >
+        <Box flex={{alignItems: 'center', gap: 8}}>
+          <Icon name="folder" color={Colors.Dark} />
+          <div>
+            <RepoName>{repoName}</RepoName>
+            {showLocation ? <RepoLocation>{`@${repoLocation}`}</RepoLocation> : null}
+          </div>
+        </Box>
+        <Box flex={{alignItems: 'center', gap: 8}}>
+          {rightElement}
+          <Box margin={{top: 2}}>
+            <Icon name="arrow_drop_down" />
+          </Box>
+        </Box>
+      </Box>
+    </SectionHeaderButton>
+  );
+};
+
+const SectionHeaderButton = styled.button<{$open: boolean}>`
+  background-color: ${Colors.Gray50};
+  border: 0;
+  box-shadow: inset 0px -1px 0 ${Colors.KeylineGray}, inset 0px 1px 0 ${Colors.KeylineGray};
+  cursor: pointer;
+  display: block;
+  width: 100%;
+  margin: 0;
+  height: ${SECTION_HEADER_HEIGHT}px;
+  text-align: left;
+
+  :focus,
+  :active {
+    outline: none;
+  }
+
+  :hover {
+    background-color: ${Colors.Gray100};
+  }
+
+  ${IconWrapper}[aria-label="arrow_drop_down"] {
+    transition: transform 100ms linear;
+    ${({$open}) => ($open ? null : `transform: rotate(-90deg);`)}
+  }
+`;
+
+const RepoName = styled.span`
+  font-weight: 600;
+`;
+
+const RepoLocation = styled.span`
+  font-weight: 400;
+  color: ${Colors.Gray700};
+`;

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -1,14 +1,4 @@
-import {
-  Box,
-  Colors,
-  Popover,
-  Mono,
-  FontFamily,
-  Icon,
-  Tag,
-  Tooltip,
-  IconWrapper,
-} from '@dagster-io/ui';
+import {Box, Colors, Popover, Mono, FontFamily, Tooltip, Tag} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -23,6 +13,7 @@ import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {repoAddressFromPath} from '../workspace/repoAddressFromPath';
 import {RepoAddress} from '../workspace/types';
 
+import {RepoSectionHeader, SECTION_HEADER_HEIGHT} from './RepoSectionHeader';
 import {RunStatusDot} from './RunStatusDots';
 import {failedStatuses, inProgressStatuses, queuedStatuses, successStatuses} from './RunStatuses';
 import {TimeElapsed} from './TimeElapsed';
@@ -30,7 +21,6 @@ import {batchRunsForTimeline, RunBatch} from './batchRunsForTimeline';
 
 const ROW_HEIGHT = 32;
 const TIME_HEADER_HEIGHT = 36;
-const SECTION_HEADER_HEIGHT = 32;
 const EMPTY_STATE_HEIGHT = 48;
 const LABEL_WIDTH = 320;
 
@@ -169,43 +159,36 @@ interface TimelineSectionProps {
 const TimelineSection = (props: TimelineSectionProps) => {
   const {expanded, onToggle, repoKey, isDuplicateRepoName, jobs, range, top, width} = props;
   const repoAddress = repoAddressFromPath(repoKey);
-  const name = repoAddress?.name || 'Unknown repo';
-  const location = repoAddress?.location || 'Unknown location';
+  const repoName = repoAddress?.name || 'Unknown repo';
+  const repoLocation = repoAddress?.location || 'Unknown location';
   const onClick = React.useCallback(() => {
     repoAddress && onToggle(repoAddress);
   }, [onToggle, repoAddress]);
+  const jobCount = jobs.length;
 
   return (
     <div>
-      <SectionHeader $top={top} $open={expanded} onClick={onClick}>
-        <Box
-          flex={{alignItems: 'center', justifyContent: 'space-between'}}
-          padding={{left: 20, right: 20}}
-        >
-          <Box flex={{alignItems: 'center', gap: 8}}>
-            <Icon name="folder" color={Colors.Dark} />
-            <div>
-              <RepoName>{name}</RepoName>
-              {isDuplicateRepoName ? <RepoLocation>{`@${location}`}</RepoLocation> : null}
-            </div>
-          </Box>
-          <Box flex={{alignItems: 'center', gap: 8}}>
+      <SectionHeaderContainer $top={top}>
+        <RepoSectionHeader
+          expanded={expanded}
+          repoName={repoName}
+          repoLocation={repoLocation}
+          onClick={onClick}
+          showLocation={isDuplicateRepoName}
+          rightElement={
             <Tooltip
               content={
                 <span style={{whiteSpace: 'nowrap'}}>
-                  {jobs.length === 1 ? '1 job with runs' : `${jobs.length} jobs with runs`}
+                  {jobCount === 1 ? '1 job with runs' : `${jobCount} jobs with runs`}
                 </span>
               }
               placement="top"
             >
-              <Tag intent="primary">{jobs.length}</Tag>
+              <Tag intent="primary">{jobCount}</Tag>
             </Tooltip>
-            <Box margin={{top: 2}}>
-              <Icon name="arrow_drop_down" />
-            </Box>
-          </Box>
-        </Box>
-      </SectionHeader>
+          }
+        />
+      </SectionHeaderContainer>
       {expanded
         ? jobs.map((job, ii) => (
             <RunTimelineRow
@@ -221,43 +204,13 @@ const TimelineSection = (props: TimelineSectionProps) => {
   );
 };
 
-const SectionHeader = styled.button<{$top: number; $open: boolean}>`
-  background-color: ${Colors.Gray50};
-  border: 0;
-  box-shadow: inset 0px -1px 0 ${Colors.KeylineGray}, inset 0px 1px 0 ${Colors.KeylineGray};
-  cursor: pointer;
-  margin: 0;
+const SectionHeaderContainer = styled.div<{$top: number}>`
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
-  height: ${SECTION_HEADER_HEIGHT}px;
-  text-align: left;
 
   ${({$top}) => `transform: translateY(${$top}px);`}
-
-  :focus,
-  :active {
-    outline: none;
-  }
-
-  :hover {
-    background-color: ${Colors.Gray100};
-  }
-
-  ${IconWrapper}[aria-label="arrow_drop_down"] {
-    transition: transform 100ms linear;
-    ${({$open}) => ($open ? null : `transform: rotate(-90deg);`)}
-  }
-`;
-
-const RepoName = styled.span`
-  font-weight: 600;
-`;
-
-const RepoLocation = styled.span`
-  font-weight: 400;
-  color: ${Colors.Gray700};
 `;
 
 type TimeMarker = {

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceJobsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceJobsRoot.tsx
@@ -1,0 +1,398 @@
+import {gql, useQuery} from '@apollo/client';
+import {
+  Box,
+  Heading,
+  NonIdealState,
+  Page,
+  PageHeader,
+  Spinner,
+  Tag,
+  TextInput,
+  Tooltip,
+} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {useTrackPageView} from '../app/analytics';
+import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
+import {JobItemWithRuns, JobTable, ScheduleFragment} from '../instance/JobTable';
+import {SCHEDULE_FUTURE_TICKS_FRAGMENT} from '../instance/NextTick';
+import {RepoFilterButton} from '../instance/RepoFilterButton';
+import {makeJobKey} from '../runs/QueryfulRunTimeline';
+import {RepoSectionHeader} from '../runs/RepoSectionHeader';
+import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
+import {RunTimeFragment} from '../runs/types/RunTimeFragment';
+import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
+import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
+import {SensorSwitchFragment} from '../sensors/types/SensorSwitchFragment';
+import {useRepoExpansionState} from '../ui/useRepoExpansionState';
+
+import {REPOSITORY_INFO_FRAGMENT} from './RepositoryInformation';
+import {DagsterRepoOption, WorkspaceContext} from './WorkspaceContext';
+import {WorkspaceTabs} from './WorkspaceTabs';
+import {buildRepoAddress} from './buildRepoAddress';
+import {repoAddressAsString} from './repoAddressAsString';
+import {RepoAddress} from './types';
+import {RecentRunsPerJobQuery} from './types/RecentRunsPerJobQuery';
+import {WorkspaceJobsQuery} from './types/WorkspaceJobsQuery';
+
+const JOBS_EXPANSION_STATE_STORAGE_KEY = 'jobs-page-expansion-state';
+
+export const WorkspaceJobsRoot = () => {
+  useTrackPageView();
+
+  const [searchValue, setSearchValue] = React.useState('');
+  const {expandedKeys, onToggle} = useRepoExpansionState(JOBS_EXPANSION_STATE_STORAGE_KEY);
+
+  const {allRepos, loading} = React.useContext(WorkspaceContext);
+
+  const queryResultOverview = useQuery<WorkspaceJobsQuery>(WORKSPACE_JOBS_QUERY, {
+    fetchPolicy: 'network-only',
+    notifyOnNetworkStatusChange: true,
+  });
+  const {data} = queryResultOverview;
+
+  const queryResultLastRuns = useQuery<RecentRunsPerJobQuery>(RECENT_RUNS_PER_JOB_QUERY, {
+    fetchPolicy: 'network-only',
+    notifyOnNetworkStatusChange: true,
+  });
+  const {data: recentRunsData} = queryResultLastRuns;
+
+  // Batch up the data and bucket by repo.
+  const runsByJob = useRunsByJob(recentRunsData);
+  const schedulesAndSensorsByJob = useSchedulesAndSensorsByJob(data);
+  const repoBuckets = useRepoBuckets(allRepos, runsByJob, schedulesAndSensorsByJob);
+
+  const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
+  const anySearch = sanitizedSearch.length > 0;
+
+  const filteredBySearch = React.useMemo(() => {
+    const searchToLower = sanitizedSearch.toLocaleLowerCase();
+    return repoBuckets
+      .map(({repoAddress, jobs}) => ({
+        repoAddress,
+        jobs: jobs.filter(({name}) => name.toLocaleLowerCase().includes(searchToLower)),
+      }))
+      .filter(({jobs}) => jobs.length > 0);
+  }, [repoBuckets, sanitizedSearch]);
+
+  const content = () => {
+    if (!filteredBySearch.length) {
+      if (anySearch) {
+        return (
+          <Box padding={{top: 20}}>
+            <NonIdealState
+              icon="search"
+              title="No matching jobs"
+              description={
+                <div>
+                  No jobs matching <strong>{searchValue}</strong> were found in this workspace
+                </div>
+              }
+            />
+          </Box>
+        );
+      }
+
+      return (
+        <Box padding={{top: 20}}>
+          <NonIdealState
+            icon="search"
+            title="No jobs"
+            description="No jobs were found in this workspace"
+          />
+        </Box>
+      );
+    }
+
+    return filteredBySearch.map(({repoAddress, jobs}) => {
+      const repoKey = repoAddressAsString(repoAddress);
+      const expanded = anySearch || expandedKeys.includes(repoKey);
+      const jobCount = jobs.length;
+      const tooltipContent = () => {
+        if (anySearch) {
+          return jobCount === 1 ? `1 matching job` : `${jobCount} matching jobs`;
+        }
+        return jobCount === 1 ? '1 job' : `${jobCount} jobs`;
+      };
+
+      return (
+        <div key={repoKey} style={{width: '100%'}}>
+          <RepoSectionHeader
+            repoName={repoAddress.name}
+            repoLocation={repoAddress.location}
+            expanded={expanded}
+            onClick={() => {
+              if (!anySearch) {
+                onToggle(repoAddress);
+              }
+            }}
+            showLocation={false}
+            rightElement={
+              <Tooltip
+                content={<span style={{whiteSpace: 'nowrap'}}>{tooltipContent()}</span>}
+                placement="top"
+              >
+                <Tag intent="primary">{jobCount}</Tag>
+              </Tooltip>
+            }
+          />
+          {expanded ? <JobTable jobs={jobs} /> : null}
+        </div>
+      );
+    });
+  };
+
+  return (
+    <Page>
+      <PageHeader title={<Heading>Workspace</Heading>} tabs={<WorkspaceTabs tab="jobs" />} />
+      {loading && !allRepos.length ? (
+        <Box padding={64}>
+          <Spinner purpose="page" />
+        </Box>
+      ) : (
+        <>
+          <Box
+            padding={{horizontal: 24, top: 16}}
+            flex={{direction: 'row', alignItems: 'center', gap: 12, grow: 0}}
+          >
+            {allRepos.length > 1 ? <RepoFilterButton /> : null}
+            <TextInput
+              icon="search"
+              value={searchValue}
+              onChange={(e) => setSearchValue(e.target.value)}
+              placeholder="Filter by job name…"
+              style={{width: '340px'}}
+            />
+          </Box>
+          <Box padding={{top: 20}}>{content()}</Box>
+        </>
+      )}
+    </Page>
+  );
+};
+
+type ScheduelesAndSensorsByJob = {
+  [key: string]: {schedules: ScheduleFragment[]; sensors: SensorSwitchFragment[]};
+};
+
+const useSchedulesAndSensorsByJob = (
+  data: WorkspaceJobsQuery | undefined,
+): ScheduelesAndSensorsByJob => {
+  return React.useMemo(() => {
+    if (!data || data?.workspaceOrError.__typename !== 'Workspace') {
+      return {};
+    }
+
+    const byJobKey = {};
+    data.workspaceOrError.locationEntries.forEach((entry) => {
+      if (entry.locationOrLoadError?.__typename !== 'RepositoryLocation') {
+        return;
+      }
+
+      const location = entry.locationOrLoadError;
+      entry.locationOrLoadError.repositories.forEach((repo) => {
+        const repoAddress = buildRepoAddress(repo.name, location.name);
+        repo.schedules.forEach((schedule) => {
+          const jobKey = makeJobKey(repoAddress, schedule.pipelineName);
+          const dataForJob = {...(byJobKey[jobKey] || {schedules: [], sensors: []})};
+          dataForJob.schedules.push(schedule);
+          byJobKey[jobKey] = dataForJob;
+        });
+        repo.sensors.forEach((sensor) => {
+          (sensor?.targets || []).forEach((target) => {
+            const jobKey = makeJobKey(repoAddress, target.pipelineName);
+            const dataForJob = {...(byJobKey[jobKey] || {schedules: [], sensors: []})};
+            dataForJob.sensors.push(sensor);
+            byJobKey[jobKey] = dataForJob;
+          });
+        });
+      });
+    });
+
+    return byJobKey;
+  }, [data]);
+};
+
+type RunsByJob = {
+  [jobKey: string]: RunTimeFragment[];
+};
+
+const useRunsByJob = (recentRunsData: RecentRunsPerJobQuery | undefined): RunsByJob => {
+  return React.useMemo(() => {
+    if (!recentRunsData || recentRunsData?.workspaceOrError.__typename !== 'Workspace') {
+      return {};
+    }
+
+    const byJobKey = {};
+    recentRunsData.workspaceOrError.locationEntries.forEach((entry) => {
+      if (entry.locationOrLoadError?.__typename !== 'RepositoryLocation') {
+        return;
+      }
+      const location = entry.locationOrLoadError;
+      entry.locationOrLoadError.repositories.forEach((repo) => {
+        const repoAddress = buildRepoAddress(repo.name, location.name);
+        repo.pipelines.forEach((job) => {
+          const jobKey = makeJobKey(repoAddress, job.name);
+          byJobKey[jobKey] = job.runs;
+        });
+      });
+    });
+
+    return byJobKey;
+  }, [recentRunsData]);
+};
+
+type RepoBucket = {
+  repoAddress: RepoAddress;
+  jobs: JobItemWithRuns[];
+};
+
+const useRepoBuckets = (
+  allRepos: DagsterRepoOption[],
+  runsByJob: RunsByJob,
+  schedulesAndSensorsByJob: ScheduelesAndSensorsByJob,
+): RepoBucket[] => {
+  return React.useMemo(() => {
+    return [...allRepos]
+      .sort((a, b) =>
+        a.repository.name.toLocaleLowerCase().localeCompare(b.repository.name.toLocaleLowerCase()),
+      )
+      .map((repo) => {
+        const {name, pipelines} = repo.repository;
+        const repoAddress = buildRepoAddress(name, repo.repositoryLocation.name);
+        return {
+          repoAddress,
+          jobs: pipelines
+            .filter(({name}) => !isHiddenAssetGroupJob(name))
+            .map((pipeline) => {
+              const jobKey = makeJobKey(repoAddress, pipeline.name);
+              const dataForJob = schedulesAndSensorsByJob[jobKey];
+
+              return {
+                isJob: pipeline.isJob,
+                name: pipeline.name,
+                repoAddress,
+                schedules: dataForJob?.schedules || [],
+                sensors: dataForJob?.sensors || [],
+                runs: runsByJob[jobKey] || [],
+              };
+            }),
+        };
+      })
+      .filter((repo) => repo.jobs.length > 0);
+  }, [allRepos, runsByJob, schedulesAndSensorsByJob]);
+};
+
+const WORKSPACE_JOB_FRAGMENT = gql`
+  fragment WorkspaceJobFragment on Pipeline {
+    id
+    name
+    isJob
+    modes {
+      id
+      name
+    }
+  }
+`;
+
+export const WORKSPACE_JOBS_QUERY = gql`
+  query WorkspaceJobsQuery {
+    workspaceOrError {
+      ... on Workspace {
+        locationEntries {
+          id
+          name
+          loadStatus
+          displayMetadata {
+            key
+            value
+          }
+          locationOrLoadError {
+            ... on RepositoryLocation {
+              id
+              name
+              repositories {
+                id
+                name
+                pipelines {
+                  id
+                  ...WorkspaceJobFragment
+                }
+                ...RepositoryInfoFragment
+                schedules {
+                  id
+                  name
+                  pipelineName
+                  scheduleState {
+                    id
+                    status
+                  }
+                  ...ScheduleFutureTicksFragment
+                  ...ScheduleSwitchFragment
+                }
+                sensors {
+                  id
+                  name
+                  targets {
+                    pipelineName
+                  }
+                  sensorState {
+                    id
+                    status
+                  }
+                  ...SensorSwitchFragment
+                }
+              }
+            }
+            ...PythonErrorFragment
+          }
+        }
+      }
+      ...PythonErrorFragment
+    }
+  }
+
+  ${WORKSPACE_JOB_FRAGMENT}
+  ${REPOSITORY_INFO_FRAGMENT}
+  ${SCHEDULE_FUTURE_TICKS_FRAGMENT}
+  ${SCHEDULE_SWITCH_FRAGMENT}
+  ${SENSOR_SWITCH_FRAGMENT}
+  ${PYTHON_ERROR_FRAGMENT}
+`;
+
+export const RECENT_RUNS_PER_JOB_QUERY = gql`
+  query RecentRunsPerJobQuery {
+    workspaceOrError {
+      ... on Workspace {
+        locationEntries {
+          id
+          locationOrLoadError {
+            ... on RepositoryLocation {
+              id
+              name
+              repositories {
+                id
+                name
+                pipelines {
+                  id
+                  name
+                  isJob
+                  runs(limit: 5) {
+                    id
+                    ...RunTimeFragment
+                  }
+                }
+              }
+            }
+            ...PythonErrorFragment
+          }
+        }
+      }
+      ...PythonErrorFragment
+    }
+  }
+
+  ${PYTHON_ERROR_FRAGMENT}
+  ${RUN_TIME_FRAGMENT}
+`;

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewRoot.tsx
@@ -10,7 +10,7 @@ import {
   Subheading,
 } from '@dagster-io/ui';
 import * as React from 'react';
-import {Link} from 'react-router-dom';
+import {Link, Redirect} from 'react-router-dom';
 
 import {useFeatureFlags} from '../app/Flags';
 import {useTrackPageView} from '../app/analytics';
@@ -27,6 +27,10 @@ export const WorkspaceOverviewRoot = () => {
 
   const {flagNewWorkspace} = useFeatureFlags();
   const {loading, error, options} = useRepositoryOptions();
+
+  if (flagNewWorkspace) {
+    return <Redirect to="/workspace/jobs" />;
+  }
 
   const content = () => {
     if (loading) {

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
@@ -2,6 +2,7 @@ import {Box, MainContent, NonIdealState} from '@dagster-io/ui';
 import * as React from 'react';
 import {Route, Switch, useParams} from 'react-router-dom';
 
+import {useFeatureFlags} from '../app/Flags';
 import {AssetGroupRoot} from '../assets/AssetGroupRoot';
 import {PipelineRoot} from '../pipelines/PipelineRoot';
 import {ScheduleRoot} from '../schedules/ScheduleRoot';
@@ -9,6 +10,7 @@ import {SensorRoot} from '../sensors/SensorRoot';
 
 import {GraphRoot} from './GraphRoot';
 import {WorkspaceContext} from './WorkspaceContext';
+import {WorkspaceJobsRoot} from './WorkspaceJobsRoot';
 import {WorkspaceOverviewRoot} from './WorkspaceOverviewRoot';
 import {WorkspacePipelineRoot} from './WorkspacePipelineRoot';
 import {WorkspaceRepoRoot} from './WorkspaceRepoRoot';
@@ -110,21 +112,29 @@ const RepoRouteContainer = () => {
   );
 };
 
-export const WorkspaceRoot = () => (
-  <MainContent>
-    <Switch>
-      <Route path="/workspace" exact>
-        <WorkspaceOverviewRoot />
-      </Route>
-      <Route path={['/workspace/pipelines/:pipelinePath', '/workspace/jobs/:pipelinePath']}>
-        <WorkspacePipelineRoot />
-      </Route>
-      <Route path="/workspace/:repoPath">
-        <RepoRouteContainer />
-      </Route>
-    </Switch>
-  </MainContent>
-);
+export const WorkspaceRoot = () => {
+  const {flagNewWorkspace} = useFeatureFlags();
+  return (
+    <MainContent>
+      <Switch>
+        <Route path="/workspace" exact>
+          <WorkspaceOverviewRoot />
+        </Route>
+        {flagNewWorkspace ? (
+          <Route path="/workspace/jobs" exact>
+            <WorkspaceJobsRoot />
+          </Route>
+        ) : null}
+        <Route path={['/workspace/pipelines/:pipelinePath', '/workspace/jobs/:pipelinePath']}>
+          <WorkspacePipelineRoot />
+        </Route>
+        <Route path="/workspace/:repoPath">
+          <RepoRouteContainer />
+        </Route>
+      </Switch>
+    </MainContent>
+  );
+};
 
 // Imported via React.lazy, which requires a default export.
 // eslint-disable-next-line import/no-default-export

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceTabs.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceTabs.tsx
@@ -1,0 +1,33 @@
+import {QueryResult} from '@apollo/client';
+import {Box, Tabs} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
+import {TabLink} from '../ui/TabLink';
+
+interface Props<TData> {
+  refreshState?: QueryRefreshState;
+  queryData?: QueryResult<TData, any>;
+  tab: string;
+}
+
+export const WorkspaceTabs = <TData extends Record<string, any>>(props: Props<TData>) => {
+  const {refreshState, tab} = props;
+
+  return (
+    <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
+      <Tabs selectedTabId={tab}>
+        <TabLink id="jobs" title="Jobs" to="/workspace/jobs" />
+        {/* <TabLink id="schedules" title="Schedules" to="/workspace/schedules" />
+        <TabLink id="sensors" title="Sensors" to="/workspace/sensors" />
+        <TabLink id="graphs" title="Graphs" to="/workspace/graphs" />
+        <TabLink id="ops" title="Ops" to="/workspace/ops" /> */}
+      </Tabs>
+      {refreshState ? (
+        <Box padding={{bottom: 8}}>
+          <QueryRefreshCountdown refreshState={refreshState} />
+        </Box>
+      ) : null}
+    </Box>
+  );
+};

--- a/js_modules/dagit/packages/core/src/workspace/types/RecentRunsPerJobQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/RecentRunsPerJobQuery.ts
@@ -1,0 +1,87 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { RunStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: RecentRunsPerJobQuery
+// ====================================================
+
+export interface RecentRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_runs {
+  __typename: "Run";
+  id: string;
+  runId: string;
+  status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
+}
+
+export interface RecentRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+  isJob: boolean;
+  runs: RecentRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_runs[];
+}
+
+export interface RecentRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories {
+  __typename: "Repository";
+  id: string;
+  name: string;
+  pipelines: RecentRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines[];
+}
+
+export interface RecentRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation {
+  __typename: "RepositoryLocation";
+  id: string;
+  name: string;
+  repositories: RecentRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories[];
+}
+
+export interface RecentRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError_causes {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface RecentRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  causes: RecentRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError_causes[];
+}
+
+export type RecentRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError = RecentRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation | RecentRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError;
+
+export interface RecentRunsPerJobQuery_workspaceOrError_Workspace_locationEntries {
+  __typename: "WorkspaceLocationEntry";
+  id: string;
+  locationOrLoadError: RecentRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError | null;
+}
+
+export interface RecentRunsPerJobQuery_workspaceOrError_Workspace {
+  __typename: "Workspace";
+  locationEntries: RecentRunsPerJobQuery_workspaceOrError_Workspace_locationEntries[];
+}
+
+export interface RecentRunsPerJobQuery_workspaceOrError_PythonError_causes {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface RecentRunsPerJobQuery_workspaceOrError_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  causes: RecentRunsPerJobQuery_workspaceOrError_PythonError_causes[];
+}
+
+export type RecentRunsPerJobQuery_workspaceOrError = RecentRunsPerJobQuery_workspaceOrError_Workspace | RecentRunsPerJobQuery_workspaceOrError_PythonError;
+
+export interface RecentRunsPerJobQuery {
+  workspaceOrError: RecentRunsPerJobQuery_workspaceOrError;
+}

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceJobFragment.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceJobFragment.ts
@@ -1,0 +1,22 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: WorkspaceJobFragment
+// ====================================================
+
+export interface WorkspaceJobFragment_modes {
+  __typename: "Mode";
+  id: string;
+  name: string;
+}
+
+export interface WorkspaceJobFragment {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+  isJob: boolean;
+  modes: WorkspaceJobFragment_modes[];
+}

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceJobsQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceJobsQuery.ts
@@ -1,0 +1,157 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { RepositoryLocationLoadStatus, InstigationStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: WorkspaceJobsQuery
+// ====================================================
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_displayMetadata {
+  __typename: "RepositoryMetadata";
+  key: string;
+  value: string;
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_modes {
+  __typename: "Mode";
+  id: string;
+  name: string;
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+  isJob: boolean;
+  modes: WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_modes[];
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_location {
+  __typename: "RepositoryLocation";
+  id: string;
+  name: string;
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_displayMetadata {
+  __typename: "RepositoryMetadata";
+  key: string;
+  value: string;
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_scheduleState {
+  __typename: "InstigationState";
+  id: string;
+  status: InstigationStatus;
+  selectorId: string;
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_futureTicks_results {
+  __typename: "FutureInstigationTick";
+  timestamp: number;
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_futureTicks {
+  __typename: "FutureInstigationTicks";
+  results: WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_futureTicks_results[];
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules {
+  __typename: "Schedule";
+  id: string;
+  name: string;
+  pipelineName: string;
+  scheduleState: WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_scheduleState;
+  executionTimezone: string | null;
+  futureTicks: WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_futureTicks;
+  cronSchedule: string;
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors_targets {
+  __typename: "Target";
+  pipelineName: string;
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors_sensorState {
+  __typename: "InstigationState";
+  id: string;
+  status: InstigationStatus;
+  selectorId: string;
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors {
+  __typename: "Sensor";
+  id: string;
+  name: string;
+  targets: WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors_targets[] | null;
+  sensorState: WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors_sensorState;
+  jobOriginId: string;
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories {
+  __typename: "Repository";
+  id: string;
+  name: string;
+  pipelines: WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines[];
+  location: WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_location;
+  displayMetadata: WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_displayMetadata[];
+  schedules: WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules[];
+  sensors: WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors[];
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation {
+  __typename: "RepositoryLocation";
+  id: string;
+  name: string;
+  repositories: WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories[];
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError_causes {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  causes: WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError_causes[];
+}
+
+export type WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError = WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation | WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError;
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries {
+  __typename: "WorkspaceLocationEntry";
+  id: string;
+  name: string;
+  loadStatus: RepositoryLocationLoadStatus;
+  displayMetadata: WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_displayMetadata[];
+  locationOrLoadError: WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError | null;
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_Workspace {
+  __typename: "Workspace";
+  locationEntries: WorkspaceJobsQuery_workspaceOrError_Workspace_locationEntries[];
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_PythonError_causes {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface WorkspaceJobsQuery_workspaceOrError_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  causes: WorkspaceJobsQuery_workspaceOrError_PythonError_causes[];
+}
+
+export type WorkspaceJobsQuery_workspaceOrError = WorkspaceJobsQuery_workspaceOrError_Workspace | WorkspaceJobsQuery_workspaceOrError_PythonError;
+
+export interface WorkspaceJobsQuery {
+  workspaceOrError: WorkspaceJobsQuery_workspaceOrError;
+}


### PR DESCRIPTION
### Summary & Motivation

Create a "Jobs" tab under Workspace that includes a repo-bucketed list of all jobs in the Workspace, with table rendering similar to the current Instance Overview page.

This change also includes the addition of `WorkspaceTabs` and a new `JobsTable` used both here and in Instance Overview, and some changes to the structure of job item objects used in the table.

### How I Tested These Changes

Enable feature flag, view Status and Workspace pages. Verify that they render the correct pages, tabs, etc.

Disable feature flag, verify that rendering and behavior is unchanged from current UI.

Tested in Cloud as well, which will need a handful of changes for custom routes.
