### PR TITLE
[dagit] Swap Runs list pagintion buttons

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/CursorControls.tsx
+++ b/js_modules/dagit/packages/ui/src/components/CursorControls.tsx
@@ -25,7 +25,7 @@ export const CursorPaginationControls: React.FC<CursorPaginationProps> = ({
       </Button>
       <Button
         disabled={!hasNextCursor}
-        icon={<Icon name="arrow_forward" />}
+        rightIcon={<Icon name="arrow_forward" />}
         onClick={advanceCursor}
       >
         Next
@@ -42,15 +42,15 @@ export const CursorHistoryControls: React.FC<CursorPaginationProps> = ({
 }) => {
   return (
     <CursorControlsContainer>
-      <Button icon={<Icon name="arrow_back" />} disabled={!hasNextCursor} onClick={advanceCursor}>
-        <span className="hideable-button-text">Older</span>
+      <Button icon={<Icon name="arrow_back" />} disabled={!hasPrevCursor} onClick={popCursor}>
+        <span className="hideable-button-text">Newer</span>
       </Button>
       <Button
         rightIcon={<Icon name="arrow_forward" />}
-        disabled={!hasPrevCursor}
-        onClick={popCursor}
+        disabled={!hasNextCursor}
+        onClick={advanceCursor}
       >
-        <span className="hideable-button-text">Newer</span>
+        <span className="hideable-button-text">Older</span>
       </Button>
     </CursorControlsContainer>
   );


### PR DESCRIPTION
### Summary & Motivation

When viewing a Run list in Dagit, the "Older" button is to the left and "Newer" to the right. In my opinion this feels backward, given that Runs are ordered from newest to oldest -- paging "forward" should mean going backward in time.

<img width="213" alt="Screen Shot 2022-08-24 at 1 02 09 PM" src="https://user-images.githubusercontent.com/2823852/186490993-800326df-0695-471b-a7b1-f85d8a52fcf4.png">


### How I Tested These Changes

View Runs list, verify button order and behavior.
