### PR TITLE
[Docs] Use `asPath` from pageProps if available instead of `router`

### DIFF
--- a/docs/next/pages/_app.tsx
+++ b/docs/next/pages/_app.tsx
@@ -38,8 +38,9 @@ const DEFAULT_SEO = {
 
 const MyApp = ({Component, pageProps}: AppProps) => {
   const router = useRouter();
+  const {asPath} = useVersion();
 
-  const canonicalUrl = `${BASE_URL}${router.route}`;
+  const canonicalUrl = `${BASE_URL}${asPath}`;
 
   React.useEffect(() => {
     const handleRouteChange = (url: string) => {
@@ -53,7 +54,7 @@ const MyApp = ({Component, pageProps}: AppProps) => {
 
   return (
     <>
-      <DefaultSeo canonical={canonicalUrl} {...DEFAULT_SEO} />
+      {router.isReady ? <DefaultSeo canonical={canonicalUrl} {...DEFAULT_SEO} /> : null}
       <Layout>
         <Component {...pageProps} />
       </Layout>

--- a/docs/next/pages/_app.tsx
+++ b/docs/next/pages/_app.tsx
@@ -38,9 +38,11 @@ const DEFAULT_SEO = {
 
 const MyApp = ({Component, pageProps}: AppProps) => {
   const router = useRouter();
+  const asPathFromPageProps = pageProps?.data?.asPath;
+
   const {asPath} = useVersion();
 
-  const canonicalUrl = `${BASE_URL}${asPath}`;
+  const canonicalUrl = `${BASE_URL}${asPathFromPageProps ?? asPath}`;
 
   React.useEffect(() => {
     const handleRouteChange = (url: string) => {
@@ -54,7 +56,7 @@ const MyApp = ({Component, pageProps}: AppProps) => {
 
   return (
     <>
-      {router.isReady ? <DefaultSeo canonical={canonicalUrl} {...DEFAULT_SEO} /> : null}
+      <DefaultSeo canonical={canonicalUrl} {...DEFAULT_SEO} />
       <Layout>
         <Component {...pageProps} />
       </Layout>

--- a/docs/next/pages/_app.tsx
+++ b/docs/next/pages/_app.tsx
@@ -38,9 +38,8 @@ const DEFAULT_SEO = {
 
 const MyApp = ({Component, pageProps}: AppProps) => {
   const router = useRouter();
-  const {asPath} = useVersion();
 
-  const canonicalUrl = `${BASE_URL}${asPath}`;
+  const canonicalUrl = `${BASE_URL}${router.route}`;
 
   React.useEffect(() => {
     const handleRouteChange = (url: string) => {

--- a/docs/next/pages/_app.tsx
+++ b/docs/next/pages/_app.tsx
@@ -42,6 +42,8 @@ const MyApp = ({Component, pageProps}: AppProps) => {
 
   const {asPath} = useVersion();
 
+  console.log({asPathFromPageProps});
+
   const canonicalUrl = `${BASE_URL}${asPathFromPageProps ?? asPath}`;
 
   React.useEffect(() => {

--- a/docs/next/pages/_app.tsx
+++ b/docs/next/pages/_app.tsx
@@ -42,8 +42,6 @@ const MyApp = ({Component, pageProps}: AppProps) => {
 
   const {asPath} = useVersion();
 
-  console.log({asPathFromPageProps});
-
   const canonicalUrl = `${BASE_URL}${asPathFromPageProps ?? asPath}`;
 
   React.useEffect(() => {

--- a/docs/next/util/useVersion.ts
+++ b/docs/next/util/useVersion.ts
@@ -69,5 +69,5 @@ export function versionFromPage(page: string | string[]) {
 export const useVersion = () => {
   const router = useRouter();
 
-  return normalizeVersionPath(router.isReady ? router.asPath : '/', ALL_VERSIONS);
+  return normalizeVersionPath(router?.isReady ? router?.asPath : '/', ALL_VERSIONS);
 };

--- a/docs/next/util/useVersion.ts
+++ b/docs/next/util/useVersion.ts
@@ -1,5 +1,4 @@
 import {useRouter} from 'next/router';
-import {useEffect, useState} from 'react';
 
 import ALL_VERSIONS from '../.versioned_content/_versions.json';
 
@@ -69,13 +68,6 @@ export function versionFromPage(page: string | string[]) {
 
 export const useVersion = () => {
   const router = useRouter();
-  const [asPath, setAsPath] = useState('/');
 
-  useEffect(() => {
-    if (router.isReady) {
-      setAsPath(router.asPath);
-    }
-  }, [router]);
-
-  return normalizeVersionPath(asPath, ALL_VERSIONS);
+  return normalizeVersionPath(router.isReady ? router.asPath : '/', ALL_VERSIONS);
 };


### PR DESCRIPTION
### Summary & Motivation

Currently we're setting the canonical URL using the `asPath` from the `router`. The problem with this is that the router is not available during Server Side Rendering (SSR) so initially the canonical url is always "/" and only after a second render pass on the client does the canonical URL get updated correctly. 

To fix the issue this PR grabs `asPath` from `pageProps` if its available and falls back to the router if not.

### How I Tested These Changes

![Screen Shot 2022-08-24 at 2 15 06 PM](https://user-images.githubusercontent.com/2286579/186492997-9eb70c1a-3f0d-417f-a9b1-0ee24aa67be8.png)

view-source:https://dagster-ml54zkbn1-elementl.vercel.app/getting-started

