### PR TITLE
[dagit] Add elapsed time tooltips to log row timestamps

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagit_ui.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagit_ui.py
@@ -11,6 +11,10 @@ def build_dagit_ui_steps() -> List[CommandStep]:
         .run(
             "cd js_modules/dagit",
             "pip install -U virtualenv",
+            # Explicitly install Node 16.x because BK is otherwise running 12.x.
+            # Todo: Fix BK images to use newer Node versions, remove this.
+            "curl -sL https://deb.nodesource.com/setup_16.x | bash -",
+            "apt-get -yqq --no-install-recommends install nodejs",
             "tox -vv -e py39",
             "mv packages/core/coverage/lcov.info lcov.dagit.$BUILDKITE_BUILD_ID.info",
             "buildkite-agent artifact upload lcov.dagit.$BUILDKITE_BUILD_ID.info",

--- a/js_modules/dagit/packages/core/src/app/formatElapsedTime.test.tsx
+++ b/js_modules/dagit/packages/core/src/app/formatElapsedTime.test.tsx
@@ -1,0 +1,53 @@
+import {formatElapsedTime, formatElapsedTimeWithMsec} from './Util';
+
+describe('Elapsed time formatters', () => {
+  describe('formatElapsedTime', () => {
+    it('formats times under 10s', () => {
+      expect(formatElapsedTime(500)).toBe('0.500s');
+      expect(formatElapsedTime(5000)).toBe('5.000s');
+      expect(formatElapsedTime(-5250)).toBe('-5.250s');
+    });
+
+    it('formats times over 10s', () => {
+      expect(formatElapsedTime(50000)).toBe('0:00:50');
+      expect(formatElapsedTime(500000)).toBe('0:08:20');
+      expect(formatElapsedTime(-500000)).toBe('-0:08:20');
+      expect(formatElapsedTime(363599999)).toBe('100:59:59');
+    });
+  });
+
+  describe('formatElapsedTimeWithMsec', () => {
+    it('formats times', () => {
+      expect(formatElapsedTimeWithMsec(50)).toBe('0:00:00.050');
+      expect(formatElapsedTimeWithMsec(50000)).toBe('0:00:50.000');
+      expect(formatElapsedTimeWithMsec(500000)).toBe('0:08:20.000');
+      expect(formatElapsedTimeWithMsec(-500000)).toBe('-0:08:20.000');
+      expect(formatElapsedTimeWithMsec(363599999)).toBe('100:59:59.999');
+      expect(formatElapsedTimeWithMsec(-363599999)).toBe('-100:59:59.999');
+    });
+  });
+
+  describe('Internationalization for decimal point', () => {
+    let languageGetter;
+
+    beforeAll(() => {
+      languageGetter = jest.spyOn(global.navigator, 'language', 'get');
+      languageGetter.mockReturnValue('es-ES');
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('handles decimal correctly in `formatElapsedTime`', () => {
+      expect(formatElapsedTime(5000)).toBe('5,000s');
+      expect(formatElapsedTime(-5250)).toBe('-5,250s');
+    });
+
+    it('handles decimal correctly in `formatElapsedTimeWithMsec`', () => {
+      expect(formatElapsedTimeWithMsec(500000)).toBe('0:08:20,000');
+      expect(formatElapsedTimeWithMsec(-500000)).toBe('-0:08:20,000');
+      expect(formatElapsedTimeWithMsec(363599999)).toBe('100:59:59,999');
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/app/timeByParts.test.tsx
+++ b/js_modules/dagit/packages/core/src/app/timeByParts.test.tsx
@@ -1,0 +1,109 @@
+import {timeByParts} from './timeByParts';
+
+describe('timeByParts', () => {
+  it('parses millisecond-only values', () => {
+    expect(timeByParts(120)).toEqual({
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+      milliseconds: 120,
+    });
+
+    expect(timeByParts(-120)).toEqual({
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+      milliseconds: 120,
+    });
+  });
+
+  it('parses seconds and milliseconds', () => {
+    expect(timeByParts(8000)).toEqual({
+      hours: 0,
+      minutes: 0,
+      seconds: 8,
+      milliseconds: 0,
+    });
+
+    expect(timeByParts(8250)).toEqual({
+      hours: 0,
+      minutes: 0,
+      seconds: 8,
+      milliseconds: 250,
+    });
+
+    expect(timeByParts(-18250)).toEqual({
+      hours: 0,
+      minutes: 0,
+      seconds: 18,
+      milliseconds: 250,
+    });
+  });
+
+  it('parses minutes, seconds, and milliseconds', () => {
+    expect(timeByParts(60000)).toEqual({
+      hours: 0,
+      minutes: 1,
+      seconds: 0,
+      milliseconds: 0,
+    });
+
+    expect(timeByParts(63250)).toEqual({
+      hours: 0,
+      minutes: 1,
+      seconds: 3,
+      milliseconds: 250,
+    });
+
+    expect(timeByParts(-63250)).toEqual({
+      hours: 0,
+      minutes: 1,
+      seconds: 3,
+      milliseconds: 250,
+    });
+
+    expect(timeByParts(123250)).toEqual({
+      hours: 0,
+      minutes: 2,
+      seconds: 3,
+      milliseconds: 250,
+    });
+
+    expect(timeByParts(3599999)).toEqual({
+      hours: 0,
+      minutes: 59,
+      seconds: 59,
+      milliseconds: 999,
+    });
+  });
+
+  it('parses hours, minutes, seconds, and milliseconds', () => {
+    expect(timeByParts(3600000)).toEqual({
+      hours: 1,
+      minutes: 0,
+      seconds: 0,
+      milliseconds: 0,
+    });
+
+    expect(timeByParts(-3600000)).toEqual({
+      hours: 1,
+      minutes: 0,
+      seconds: 0,
+      milliseconds: 0,
+    });
+
+    expect(timeByParts(360000000)).toEqual({
+      hours: 100,
+      minutes: 0,
+      seconds: 0,
+      milliseconds: 0,
+    });
+
+    expect(timeByParts(363599999)).toEqual({
+      hours: 100,
+      minutes: 59,
+      seconds: 59,
+      milliseconds: 999,
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/app/timeByParts.tsx
+++ b/js_modules/dagit/packages/core/src/app/timeByParts.tsx
@@ -1,0 +1,16 @@
+export const timeByParts = (msec: number) => {
+  let count = Math.abs(msec);
+
+  const milliseconds = count % 1000;
+  count = (count - milliseconds) / 1000;
+
+  const seconds = count % 60;
+  count = (count - seconds) / 60;
+
+  const minutes = count % 60;
+  count = (count - minutes) / 60;
+
+  const hours = count;
+
+  return {hours, minutes, seconds, milliseconds};
+};

--- a/js_modules/dagit/packages/core/src/runs/LogsRow.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRow.tsx
@@ -194,20 +194,30 @@ const StructuredMemoizedContent: React.FC<{
   node: LogsRowStructuredFragment;
   metadata: IRunMetadataDict;
   highlighted: boolean;
-}> = React.memo(({node, metadata, highlighted}) => (
-  <Row
-    level={LogLevel.INFO}
-    onMouseEnter={() => setHighlightedGanttChartTime(node.timestamp)}
-    onMouseLeave={() => setHighlightedGanttChartTime(null)}
-    highlighted={highlighted}
-  >
-    <OpColumn stepKey={'stepKey' in node && node.stepKey} />
-    <StructuredContent>
-      <LogsRowStructuredContent node={node} metadata={metadata} />
-    </StructuredContent>
-    <TimestampColumn time={'timestamp' in node ? node.timestamp : null} />
-  </Row>
-));
+}> = React.memo(({node, metadata, highlighted}) => {
+  const stepKey = node.stepKey;
+  const step = stepKey ? metadata.steps[stepKey] : null;
+  const stepStartTime = step?.start;
+
+  return (
+    <Row
+      level={LogLevel.INFO}
+      onMouseEnter={() => setHighlightedGanttChartTime(node.timestamp)}
+      onMouseLeave={() => setHighlightedGanttChartTime(null)}
+      highlighted={highlighted}
+    >
+      <OpColumn stepKey={'stepKey' in node && node.stepKey} />
+      <StructuredContent>
+        <LogsRowStructuredContent node={node} metadata={metadata} />
+      </StructuredContent>
+      <TimestampColumn
+        time={'timestamp' in node ? node.timestamp : null}
+        runStartTime={metadata.startedPipelineAt}
+        stepStartTime={stepStartTime}
+      />
+    </Row>
+  );
+});
 
 StructuredMemoizedContent.displayName = 'StructuredMemoizedContent';
 
@@ -215,6 +225,7 @@ interface UnstructuredProps {
   node: LogsRowUnstructuredFragment;
   style: React.CSSProperties;
   highlighted: boolean;
+  metadata: IRunMetadataDict;
 }
 
 export class Unstructured extends React.Component<UnstructuredProps> {
@@ -228,7 +239,11 @@ export class Unstructured extends React.Component<UnstructuredProps> {
   render() {
     return (
       <CellTruncationProvider style={this.props.style} onExpand={this.onExpand}>
-        <UnstructuredMemoizedContent node={this.props.node} highlighted={this.props.highlighted} />
+        <UnstructuredMemoizedContent
+          node={this.props.node}
+          highlighted={this.props.highlighted}
+          metadata={this.props.metadata}
+        />
       </CellTruncationProvider>
     );
   }
@@ -248,23 +263,34 @@ export const LOGS_ROW_UNSTRUCTURED_FRAGMENT = gql`
 
 const UnstructuredMemoizedContent: React.FC<{
   node: LogsRowUnstructuredFragment;
+  metadata: IRunMetadataDict;
   highlighted: boolean;
-}> = React.memo(({node, highlighted}) => (
-  <Row
-    level={node.level}
-    onMouseEnter={() => setHighlightedGanttChartTime(node.timestamp)}
-    onMouseLeave={() => setHighlightedGanttChartTime(null)}
-    highlighted={highlighted}
-  >
-    <OpColumn stepKey={node.stepKey} />
-    <EventTypeColumn>
-      <span style={{marginLeft: 8}}>{node.level}</span>
-    </EventTypeColumn>
-    <Box padding={{horizontal: 12}} style={{flex: 1}}>
-      {node.message}
-    </Box>
-    <TimestampColumn time={node.timestamp} />
-  </Row>
-));
+}> = React.memo(({node, highlighted, metadata}) => {
+  const stepKey = node.stepKey;
+  const step = stepKey ? metadata.steps[stepKey] : null;
+  const stepStartTime = step?.start;
+
+  return (
+    <Row
+      level={node.level}
+      onMouseEnter={() => setHighlightedGanttChartTime(node.timestamp)}
+      onMouseLeave={() => setHighlightedGanttChartTime(null)}
+      highlighted={highlighted}
+    >
+      <OpColumn stepKey={node.stepKey} />
+      <EventTypeColumn>
+        <span style={{marginLeft: 8}}>{node.level}</span>
+      </EventTypeColumn>
+      <Box padding={{horizontal: 12}} style={{flex: 1}}>
+        {node.message}
+      </Box>
+      <TimestampColumn
+        time={node.timestamp}
+        runStartTime={metadata.startedPipelineAt}
+        stepStartTime={stepStartTime}
+      />
+    </Row>
+  );
+});
 
 UnstructuredMemoizedContent.displayName = 'UnstructuredMemoizedContent';

--- a/js_modules/dagit/packages/core/src/runs/LogsScrollingTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsScrollingTable.tsx
@@ -293,6 +293,7 @@ class LogsScrollingTableSized extends React.Component<ILogsScrollingTableSizedPr
         {node.__typename === 'LogMessageEvent' ? (
           <Unstructured
             node={node}
+            metadata={metadata}
             style={{...style, width: this.props.width, ...lastRowStyles}}
             highlighted={textMatch || focusedTimeMatch}
           />

--- a/js_modules/dagit/packages/ui/src/components/MetadataTable.tsx
+++ b/js_modules/dagit/packages/ui/src/components/MetadataTable.tsx
@@ -8,12 +8,13 @@ import {Table, TableProps} from './Table';
 type Row = {key: string; value: React.ReactNode};
 
 interface Props {
+  dark?: boolean;
   rows: (Row | null | undefined)[];
   spacing: 0 | 2 | 4;
 }
 
 export const MetadataTable = (props: Props) => {
-  const {rows, spacing} = props;
+  const {rows, spacing, dark = false} = props;
 
   return (
     <StyledTable>
@@ -27,7 +28,7 @@ export const MetadataTable = (props: Props) => {
             <tr key={key}>
               <td>
                 <Box padding={{vertical: spacing, right: 32}}>
-                  <MetadataKey>{key}</MetadataKey>
+                  <MetadataKey $dark={dark}>{key}</MetadataKey>
                 </Box>
               </td>
               <td>
@@ -56,8 +57,8 @@ export const StyledTable = styled.table`
   }
 `;
 
-const MetadataKey = styled.div`
-  color: ${Colors.Gray600};
+const MetadataKey = styled.div<{$dark: boolean}>`
+  color: ${({$dark}) => ($dark ? Colors.Gray200 : Colors.Gray600)};
   font-weight: 400;
 `;
 


### PR DESCRIPTION
### Summary & Motivation

Resolves #9209.

Add a tooltip to log timestamps to show the elapsed time since the start of the run, and if applicable, the elapsed time since the start of the relevant step.

I did some refactoring of the time utilities here. Tests are included.

<img width="367" alt="Screen Shot 2022-08-24 at 2 00 27 PM" src="https://user-images.githubusercontent.com/2823852/186552897-a89b527d-1dc3-42b9-99c6-b1e7493fd9dd.png">


### How I Tested These Changes

View a run, hover over timestamps. Verify that the tooltips render correctly, including "negative" times that are for logs that occur prior to the start of the run.
