### PR TITLE
Fix batch materialization loader refetch

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -320,7 +320,7 @@ class BatchMaterializationLoader:
                 f"Asset key {asset_key} not recognized for this loader.  Expected one of: {self._asset_keys}"
             )
 
-        if self._materializations.get(asset_key) is None:
+        if not self._fetched:
             self._fetch()
         return self._materializations.get(asset_key)
 


### PR DESCRIPTION
`get_asset_records` is called repeatedly in Cloud ([link](https://elementl-workspace.slack.com/archives/C03CA4TVCAW/p1661372312362079)).

The source of the error is that `get_asset_records` returns no records if none of the assets have been materialized. So, the batch loader believes that the fetch has not occurred yet and refetches once for every single selected asset. This PR fixes this bug.
