### PR TITLE
[docs][infra] Add back useEffect and useState in useVersion to avoid hydration mismatch

### DIFF
--- a/docs/next/util/useVersion.ts
+++ b/docs/next/util/useVersion.ts
@@ -1,4 +1,5 @@
 import {useRouter} from 'next/router';
+import {useState, useEffect} from 'react';
 
 import ALL_VERSIONS from '../.versioned_content/_versions.json';
 
@@ -69,5 +70,12 @@ export function versionFromPage(page: string | string[]) {
 export const useVersion = () => {
   const router = useRouter();
 
-  return normalizeVersionPath(router?.isReady ? router?.asPath : '/', ALL_VERSIONS);
+  const [asPath, setAsPath] = useState('/');
+
+  useEffect(() => {
+    if (router.isReady) {
+      setAsPath(router.asPath);
+    }
+  }, [router]);
+  return normalizeVersionPath(asPath, ALL_VERSIONS);
 };


### PR DESCRIPTION
### Summary & Motivation

This was removed in https://github.com/dagster-io/dagster/pull/9475/files to get rid of an extra render when updating the canonical tag. Unfortunately we need it to happen in an extra render to guarantee that the server and client don't have a mismatch when hydrating.



