### PR TITLE
allow Nothing annotations on @graph

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/output.py
+++ b/python_modules/dagster/dagster/_core/definitions/output.py
@@ -280,6 +280,8 @@ def _checked_inferred_type(inferred: Any) -> DagsterType:
         if inferred == inspect.Parameter.empty:
             return resolve_dagster_type(None)
         elif inferred is None:
+            # When inferred.annotation is None, it means someone explicitly put "None" as the
+            # annotation, so want to map it to a DagsterType that checks for the None type
             return resolve_dagster_type(type(None))
         else:
             return resolve_dagster_type(inferred)
@@ -287,7 +289,7 @@ def _checked_inferred_type(inferred: Any) -> DagsterType:
     except DagsterError as e:
         raise DagsterInvalidDefinitionError(
             f"Problem using type '{inferred}' from return type annotation, correct the issue "
-            "or explicitly set the dagster_type on your OutputDefinition."
+            "or explicitly set the dagster_type via Out()."
         ) from e
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_solid_io.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_solid_io.py
@@ -143,7 +143,7 @@ def test_not_type_input():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match=r"Problem using type '.*' from type annotation for argument 'arg_b', correct the issue or explicitly set the dagster_type on your InputDefinition.",
+        match=r"Problem using type '.*' from type annotation for argument 'arg_b', correct the issue or explicitly set the dagster_type",
     ):
 
         @solid
@@ -156,7 +156,7 @@ def test_not_type_input():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match=r"Problem using type '.*' from type annotation for argument 'arg_b', correct the issue or explicitly set the dagster_type on your InputDefinition.",
+        match=r"Problem using type '.*' from type annotation for argument 'arg_b', correct the issue or explicitly set the dagster_type",
     ):
 
         @solid(input_defs=[InputDefinition("arg_b")])
@@ -169,7 +169,7 @@ def test_not_type_input():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match=r"Problem using type '.*' from return type annotation, correct the issue or explicitly set the dagster_type on your OutputDefinition.",
+        match=r"Problem using type '.*' from return type annotation, correct the issue or explicitly set the dagster_type",
     ):
 
         @solid

--- a/python_modules/dagster/dagster_tests/core_tests/test_nothing_dependencies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_nothing_dependencies.py
@@ -14,10 +14,12 @@ from dagster import (
     Out,
     Output,
     asset,
+    graph,
     job,
     materialize_to_memory,
     op,
 )
+from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.execution.api import create_execution_plan
 
 
@@ -318,12 +320,47 @@ def test_nothing_infer():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="must be used via InputDefinition and no parameter should be included in the @op decorated function",
+        match=r"must be used via In\(\) and no parameter should be included in the @op decorated function",
     ):
 
         @op
         def _bad(_previous_steps_complete: Nothing):
             pass
+
+
+def test_mapped_nothing():
+    @op(ins={"start_after": In(Nothing)})
+    def emit():
+        return 1
+
+    @graph
+    def wrapped_no_type(mapped):
+        emit(mapped)
+
+    # This is not necessarily desirable, but documents the current behavior
+    # that if a user wraps a Nothing op in a graph, that the untyped mapping
+    # is inferred as Any and expects a config value
+    with pytest.raises(DagsterInvalidConfigError):
+        wrapped_no_type.execute_in_process()
+
+    # The above issue forces the user to using typing to declare the mapping as a
+    # Nothing
+    @graph
+    def wrapped_nothing_type(mapped: Nothing):
+        emit(mapped)
+
+    result = wrapped_nothing_type.execute_in_process()
+    assert result.success
+    assert result.output_for_node("emit") == 1
+
+    # None can be used instead if passing mypy is desired
+    @graph
+    def wrapped_none_type(mapped: None):
+        emit(mapped)
+
+    result = wrapped_none_type.execute_in_process()
+    assert result.success
+    assert result.output_for_node("emit") == 1
 
 
 def test_none_output_non_none_input():


### PR DESCRIPTION
as shown in added test case - the specific case cant upgrade to 1.X since we have not yet gotten to a sane end state with graph mappings as discussed in https://github.com/dagster-io/dagster/issues/7109

This stop gap allows users actively trying to upgrade to 1.X who are hitting this issue to proceed while we work towards a better final state. 

### How I Tested These Changes

added test