### PR TITLE
docs: fix graph/job/op migration guide page

### DIFF
--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -39,7 +39,10 @@ const PyObject: React.FunctionComponent<{
   const objects = value.objects as any;
   const moduleObjects = objects[module];
   // fifth field is the name of the object
-  const objectData = moduleObjects && moduleObjects.find(([, , , , name]) => name === object);
+  const objectData =
+    moduleObjects &&
+    Array.isArray(moduleObjects) &&
+    moduleObjects.find(([, , , , name]) => name === object);
 
   let textValue = displayText || object;
   if (pluralize) {


### PR DESCRIPTION
### Summary & Motivation
this fixes the page `0.15.7/guides/dagster/graph_job_op` and any other older versions.

the 404 was due to an error in PyObject when rendering the graph_job_op.mdx file stored in s3. the root cause was introduced in https://github.com/dagster-io/dagster/pull/9437 where the change was not backwards compatible and therefore it broke the rendering of PyObject components in older versions.

### How I Tested These Changes
[preview](https://dagster-git-yuhan-08-25-docsfixgraphjobopmigrat-b09e35-elementl.vercel.app/0.15.7/guides/dagster/graph_job_op) works
