### PR TITLE
set->frozenset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -84,7 +84,7 @@ class RunRequest(
             run_config=check.opt_dict_param(run_config, "run_config", key_type=str),
             tags=check.opt_dict_param(tags, "tags", key_type=str, value_type=str),
             job_name=check.opt_str_param(job_name, "job_name"),
-            asset_selection=check.opt_sequence_param(
+            asset_selection=check.opt_nullable_sequence_param(
                 asset_selection, "asset_selection", of_type=AssetKey
             ),
         )

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -789,5 +789,7 @@ def _create_sensor_run(
         parent_pipeline_snapshot=external_pipeline.parent_pipeline_snapshot,
         external_pipeline_origin=external_pipeline.get_external_origin(),
         pipeline_code_origin=external_pipeline.get_python_origin(),
-        asset_selection=set(run_request.asset_selection),
+        asset_selection=frozenset(run_request.asset_selection)
+        if run_request.asset_selection
+        else None,
     )


### PR DESCRIPTION
### Summary & Motivation

Fixes an issue where "unhashable type" errors could be spawned from sensor executions. DagsterRun (PipelineRun) objects require the type of asset_selection to be Optional[FrozenSet[AssetKey]] and we were passing in Set[AssetKey].

This wasn't caught by mypy because the instance methods are untyped.

### How I Tested These Changes
