### PR TITLE
CompositePartitionsDefinition

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -16,6 +16,7 @@ from dagster._core.host_representation import ExternalRepository, RepositoryLoca
 from dagster._core.host_representation.external import ExternalPipeline
 from dagster._core.host_representation.external_data import (
     ExternalAssetNode,
+    ExternalCompositePartitionsDefinitionData,
     ExternalStaticPartitionsDefinitionData,
     ExternalTimeWindowPartitionsDefinitionData,
 )
@@ -229,8 +230,14 @@ class GrapheneAssetNode(graphene.ObjectType):
         partitions_def_data = self._external_asset_node.partitions_def_data
         if partitions_def_data:
             if isinstance(
-                partitions_def_data, ExternalStaticPartitionsDefinitionData
-            ) or isinstance(partitions_def_data, ExternalTimeWindowPartitionsDefinitionData):
+                partitions_def_data,
+                (
+                    ExternalStaticPartitionsDefinitionData,
+                    ExternalTimeWindowPartitionsDefinitionData,
+                    ExternalCompositePartitionsDefinitionData,
+                    ExternalCompositePartitionsDefinitionData,
+                ),
+            ):
                 return [
                     partition.name
                     for partition in partitions_def_data.get_partitions_definition().get_partitions()

--- a/python_modules/dagster/dagster/_core/definitions/composite_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/composite_partitions.py
@@ -1,0 +1,39 @@
+import itertools
+from datetime import datetime
+from typing import Optional, Sequence
+
+from .partition import Partition, PartitionsDefinition
+
+
+class CompositePartitionsDefinition(PartitionsDefinition):
+    """The set of partitions is the cross product of partitions in the inner partitions
+    definitions"""
+
+    def __init__(self, partitions_defs: Sequence[PartitionsDefinition]):
+        self._partitions_defs = partitions_defs
+
+    @property
+    def partitions_defs(self):
+        return self._partitions_defs
+
+    def get_partitions(self, current_time: Optional[datetime] = None) -> Sequence[Partition]:
+        partition_sequences = [
+            partitions_def.get_partitions(current_time=current_time)
+            for partitions_def in self._partitions_defs
+        ]
+        return [
+            Partition(
+                value=tuple(partition.value for partition in partitions_tuple),
+                name="|".join(partition.name for partition in partitions_tuple),
+            )
+            for partitions_tuple in itertools.product(*partition_sequences)
+        ]
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, CompositePartitionsDefinition)
+            and self.partitions_defs == other.partitions_defs
+        )
+
+    def __hash__(self):
+        return hash(tuple(self.partitions_defs))

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -22,6 +22,7 @@ from dagster._core.definitions import (
     SourceAsset,
 )
 from dagster._core.definitions.asset_layer import AssetOutputInfo
+from dagster._core.definitions.composite_partitions import CompositePartitionsDefinition
 from dagster._core.definitions.dependency import NodeOutputHandle
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataEntry, MetadataUserInput, normalize_metadata
@@ -526,6 +527,23 @@ class ExternalStaticPartitionsDefinitionData(
 
 
 @whitelist_for_serdes
+class ExternalCompositePartitionsDefinitionData(
+    ExternalPartitionsDefinitionData,
+    NamedTuple(
+        "_ExternalCompositePartitionsDefinitionData",
+        [("external_partitions_defs", Sequence[ExternalPartitionsDefinitionData])],
+    ),
+):
+    def get_partitions_definition(self):
+        return CompositePartitionsDefinition(
+            [
+                external_partitions_def.get_partitions_definition()
+                for external_partitions_def in self.external_partitions_defs
+            ]
+        )
+
+
+@whitelist_for_serdes
 class ExternalPartitionSetData(
     NamedTuple(
         "_ExternalPartitionSetData",
@@ -918,16 +936,7 @@ def external_asset_graph_from_defs(
 
         partitions_def = asset_info.partitions_def
         if partitions_def:
-            if isinstance(partitions_def, TimeWindowPartitionsDefinition):
-                partitions_def_data = external_time_window_partitions_definition_from_def(
-                    partitions_def
-                )
-            elif isinstance(partitions_def, StaticPartitionsDefinition):
-                partitions_def_data = external_static_partitions_definition_from_def(partitions_def)
-            else:
-                raise DagsterInvalidDefinitionError(
-                    "Only static partition and time window partitions are currently supported."
-                )
+            partitions_def_data = external_partitions_definition_from_def(partitions_def)
 
         # if the asset is produced by an op at the top level of the graph, graph_name should be None
         graph_name = None
@@ -997,6 +1006,21 @@ def external_schedule_data_from_def(schedule_def: ScheduleDefinition) -> Externa
     )
 
 
+def external_partitions_definition_from_def(
+    partitions_def: PartitionsDefinition,
+) -> ExternalPartitionsDefinitionData:
+    if isinstance(partitions_def, TimeWindowPartitionsDefinition):
+        return external_time_window_partitions_definition_from_def(partitions_def)
+    elif isinstance(partitions_def, StaticPartitionsDefinition):
+        return external_static_partitions_definition_from_def(partitions_def)
+    elif isinstance(partitions_def, CompositePartitionsDefinition):
+        return external_composite_partitions_definition_from_def(partitions_def)
+    else:
+        raise DagsterInvalidDefinitionError(
+            "Only static, time window, and composite partitions are currently supported."
+        )
+
+
 def external_time_window_partitions_definition_from_def(
     partitions_def: TimeWindowPartitionsDefinition,
 ) -> ExternalTimeWindowPartitionsDefinitionData:
@@ -1020,6 +1044,15 @@ def external_static_partitions_definition_from_def(
     return ExternalStaticPartitionsDefinitionData(
         partition_keys=partitions_def.get_partition_keys()
     )
+
+
+def external_composite_partitions_definition_from_def(
+    partitions_def: CompositePartitionsDefinition,
+) -> ExternalCompositePartitionsDefinitionData:
+    external_partitions_defs = []
+    for sub_partitions_def in partitions_def.partitions_defs:
+        external_partitions_defs.append(external_partitions_definition_from_def(sub_partitions_def))
+    return ExternalCompositePartitionsDefinitionData(external_partitions_defs)
 
 
 def external_partition_set_data_from_def(

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composite_partitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composite_partitions.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+
+from dagster import DailyPartitionsDefinition, StaticPartitionsDefinition
+from dagster._core.definitions.composite_partitions import CompositePartitionsDefinition
+
+DATE_FORMAT = "%Y-%m-%d"
+
+
+def test_composite_static_partitions():
+    partitions1 = StaticPartitionsDefinition(["a", "b", "c"])
+    partitions2 = StaticPartitionsDefinition(["x", "y", "z"])
+    composite = CompositePartitionsDefinition([partitions1, partitions2])
+    assert composite.get_partition_keys() == [
+        "a|x",
+        "a|y",
+        "a|z",
+        "b|x",
+        "b|y",
+        "b|z",
+        "c|x",
+        "c|y",
+        "c|z",
+    ]
+
+
+def test_composite_time_window_static_partitions():
+    time_window_partitions = DailyPartitionsDefinition(start_date="2021-05-05")
+    static_partitions = StaticPartitionsDefinition(["a", "b", "c"])
+    composite = CompositePartitionsDefinition([time_window_partitions, static_partitions])
+    assert composite.get_partition_keys(
+        current_time=datetime.strptime("2021-05-07", DATE_FORMAT)
+    ) == [
+        "2021-05-05|a",
+        "2021-05-05|b",
+        "2021-05-05|c",
+        "2021-05-06|a",
+        "2021-05-06|b",
+        "2021-05-06|c",
+    ]


### PR DESCRIPTION
### Summary & Motivation

Fixes #4591.

Open questions and reservations:
- Is this the right name? What if we want to add something in the future that's union of two PartitionsDefinitions, instead of the cross-product?
- How do we feel this approach where we keep partition keys as strings and stuff multiple dimensions inside them with a delimiter? An alternative would be to turn partition keys into tuples, although that would require touching lots and lots of code.
- Assuming we do want to go with the string approach, this would break if someone already has the delimiter inside their partition key.

Future work:
- Make it possible to slice along a particular axis when viewing partition status or launching backfills.


### How I Tested These Changes

Loaded this in Dagit:
```
from dagster import (
    StaticPartitionsDefinition,
    DailyPartitionsDefinition,
    asset,
)
from dagster._core.definitions.composite_partitions import CompositePartitionsDefinition


partitions_def = CompositePartitionsDefinition(
    [
        StaticPartitionsDefinition(["a", "b", "c"]),
        DailyPartitionsDefinition(start_date="2022-08-01"),
    ]
)


@asset(partitions_def=partitions_def)
def asset1():
    ...
```

and launched a materialization.

<img width="576" alt="image" src="https://user-images.githubusercontent.com/654855/187001021-e12708bf-f2e8-4d82-94f1-3cfbc1c07777.png">
