### PR TITLE
Allow fetching fields of a Source Asset without Dagit throwing exceptions

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -501,11 +501,15 @@ class GrapheneAssetNode(graphene.ObjectType):
         )
 
     def resolve_required_resources(self, _graphene_info) -> Sequence[GrapheneResourceRequirement]:
+        if self.is_source_asset():
+            return []
         node_def_snap = self.get_node_definition_snap()
         all_unique_keys = self.get_required_resource_keys(node_def_snap)
         return [GrapheneResourceRequirement(key) for key in all_unique_keys]
 
     def resolve_type(self, _graphene_info) -> Optional[str]:
+        if self.is_source_asset():
+            return None
         external_pipeline = self.get_external_pipeline()
         output_name = self.external_asset_node.output_name
         if output_name:


### PR DESCRIPTION
### Summary & Motivation
This resolves the issue described in https://github.com/dagster-io/dagster/issues/9230

I'm not wild about these extra checks - it seems like a lot of the AssetNode resolvers call `get_external_pipeline` and those raise exceptions when called on a source asset. This fixes the two callsites that were in use / causing problems in Dagit and I didn't see more, but there could be others.

### How I Tested These Changes
