### PR TITLE
Fix issue with one-to-many input/output mappings in GraphQL responses

### DIFF
--- a/python_modules/dagster/dagster/_core/snap/solid.py
+++ b/python_modules/dagster/dagster/_core/snap/solid.py
@@ -255,20 +255,6 @@ class CompositeSolidDefSnap(
             ),
         )
 
-    def get_input_mapping_snap(self, name: str) -> InputMappingSnap:
-        check.str_param(name, "name")
-        for input_mapping_snap in self.input_mapping_snaps:
-            if input_mapping_snap.external_input_name == name:
-                return input_mapping_snap
-        check.failed("Could not find input mapping snap named " + name)
-
-    def get_output_mapping_snap(self, name: str) -> OutputMappingSnap:
-        check.str_param(name, "name")
-        for output_mapping_snap in self.output_mapping_snaps:
-            if output_mapping_snap.external_output_name == name:
-                return output_mapping_snap
-        check.failed("Could not find output mapping snap named " + name)
-
     def get_input_snap(self, name: str) -> InputDefSnap:
         return _get_input_snap(self, name)
 


### PR DESCRIPTION
### Summary & Motivation
This is a fix for the issue described in https://github.com/dagster-io/dagster/issues/9224.

Given the example in that issue (a two op graph, where the second op is a composite graph and both inner ops depend on the first), the following GraphQL query returned the wrong data. Rather than two input mappings, we only see one. It appears this is due to the fact that the input_mappings resolver is iterating over input_defs and then retrieving the input mapping for each def. There can be more than one, but it just returns the first hit.

We have input_mapping_defs now (maybe we didn't initially?) and iterating over those fixes this. 

I also removed the "input def => mapping" lookup functions because the code was not used elsewhere and doesn't capture the "more than one mapping" case correctly.

Before:
![image](https://user-images.githubusercontent.com/1037212/187283566-2d1a55de-0de5-420d-9865-be7d9bbb5ebf.png)

After:

![image](https://user-images.githubusercontent.com/1037212/187283481-21307a1a-0f5a-4cd6-a357-f400cc92d2cd.png)



### How I Tested These Changes
