### PR TITLE
[dagit] Run timeline fixes

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -414,7 +414,7 @@ const RunTimelineRow = ({
               }}
             >
               <Popover
-                content={<RunHoverContent jobKey={job.key} batch={batch} />}
+                content={<RunHoverContent job={job} batch={batch} />}
                 position="top"
                 interactionKind="hover"
                 className="chunk-popover-target"
@@ -519,19 +519,22 @@ const BatchCount = styled.div`
 `;
 
 interface RunHoverContentProps {
-  jobKey: string;
+  job: TimelineJob;
   batch: RunBatch<TimelineRun>;
 }
 
 const RunHoverContent = (props: RunHoverContentProps) => {
-  const {jobKey, batch} = props;
+  const {job, batch} = props;
+  const sliced = batch.runs.slice(0, 50);
+  const remaining = batch.runs.length - sliced.length;
+
   return (
     <Box style={{width: '260px'}}>
       <Box padding={12} border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
-        <HoverContentJobName>{jobKey}</HoverContentJobName>
+        <HoverContentJobName>{job.jobName}</HoverContentJobName>
       </Box>
       <div style={{maxHeight: '240px', overflowY: 'auto'}}>
-        {batch.runs.map((run, ii) => (
+        {sliced.map((run, ii) => (
           <Box
             key={run.id}
             border={ii > 0 ? {side: 'top', width: 1, color: Colors.KeylineGray} : null}
@@ -558,6 +561,11 @@ const RunHoverContent = (props: RunHoverContentProps) => {
           </Box>
         ))}
       </div>
+      {remaining > 0 ? (
+        <Box padding={12} border={{side: 'top', width: 1, color: Colors.KeylineGray}}>
+          <Link to={`${job.path}runs`}>+ {remaining} more</Link>
+        </Box>
+      ) : null}
     </Box>
   );
 };


### PR DESCRIPTION
### Summary & Motivation

A couple of run timeline fixes. I noticed these things were broken (or not ideal) while looking at some heavier timelines.

- Very large batches need the hover content broken up, otherwise we try to render a ton of rows. Slice at 50 and link to the Runs tab for the job.
- Do not allow runs to batch if the batch would overlap the "now" line. The goal here is to keep scheduled ticks separate from past or ongoing runs, at all times.

### How I Tested These Changes

Jest. Loaded timeline affected by these issues, verified that the hover content is sane and that scheduled ticks are no longer batched with previous/ongoing runs.
