### PR TITLE
[dagit] Add "Now" tag to run timeline, improve empty state

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Popover, Mono, FontFamily, Tooltip, Tag} from '@dagster-io/ui';
+import {Box, Colors, Popover, Mono, FontFamily, Tooltip, Tag, NonIdealState} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -20,8 +20,8 @@ import {TimeElapsed} from './TimeElapsed';
 import {batchRunsForTimeline, RunBatch} from './batchRunsForTimeline';
 
 const ROW_HEIGHT = 32;
-const TIME_HEADER_HEIGHT = 36;
-const EMPTY_STATE_HEIGHT = 48;
+const TIME_HEADER_HEIGHT = 42;
+const EMPTY_STATE_HEIGHT = 140;
 const LABEL_WIDTH = 320;
 
 const ONE_HOUR_MSEC = 60 * 60 * 1000;
@@ -271,7 +271,10 @@ const TimeDividers = (props: TimeDividersProps) => {
           <DividerLine key={marker.key} style={{left: `${marker.left.toPrecision(3)}%`}} />
         ))}
         {now >= start && now <= end ? (
-          <DividerLine style={{left: nowLeft, backgroundColor: Colors.Blue500, zIndex: 1}} />
+          <>
+            <NowMarker style={{left: nowLeft}}>Now</NowMarker>
+            <DividerLine style={{left: nowLeft, backgroundColor: Colors.Blue500, zIndex: 1}} />
+          </>
         ) : null}
       </DividerLines>
     </DividerContainer>
@@ -315,6 +318,20 @@ const DividerLine = styled.div`
   position: absolute;
   top: 0;
   width: 1px;
+`;
+
+const NowMarker = styled.div`
+  background-color: ${Colors.Blue500};
+  border-radius: 1px;
+  color: ${Colors.White};
+  cursor: default;
+  font-size: 12px;
+  line-height: 12px;
+  margin-left: -12px;
+  padding: 1px 4px;
+  position: absolute;
+  top: -14px;
+  user-select: none;
 `;
 
 const mergeStatusToColor = (runs: TimelineRun[]) => {
@@ -435,8 +452,12 @@ const RunTimelineRow = ({
 };
 
 const NoRunsTimeline = () => (
-  <Box flex={{justifyContent: 'center', alignItems: 'center'}} padding={24}>
-    No runs or upcoming runs found for this time window.
+  <Box padding={48}>
+    <NonIdealState
+      icon="schedule"
+      title="No runs found"
+      description="No runs or upcoming runs found for this time window"
+    />
   </Box>
 );
 


### PR DESCRIPTION
### Summary & Motivation

A couple changes to the time display on the run timeline:

- Add a small "Now" tag to clarify what the blue line means
- Use a `NonIdealState` for the empty state instead of the yolo text we have right now

<img width="1075" alt="Screen Shot 2022-08-29 at 5 10 56 PM" src="https://user-images.githubusercontent.com/2823852/187308723-e4d25d4d-1387-48af-83c3-5f033d4c1fcb.png">
<img width="1077" alt="Screen Shot 2022-08-29 at 5 12 42 PM" src="https://user-images.githubusercontent.com/2823852/187308725-ddf07af9-859a-4c2a-83b0-dbf93fd9510a.png">

### How I Tested These Changes

View Run timeline in Dagit, verify that the "Now" tag appears in the correct place and the empty state looks correct when I search for a string that has no matches.
