### PR TITLE
fix run status sensor launching jobs unnecessarily

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/toys/repo.py
@@ -37,6 +37,7 @@ from dagster_test.toys.retries import retry_job
 from dagster_test.toys.run_status_sensors import (
     cross_repo_job_sensor,
     cross_repo_sensor,
+    cross_repo_success_job_sensor,
     fails_job,
     fails_sensor,
     return_multi_run_request_success_sensor,
@@ -107,6 +108,7 @@ def toys_repository():
             fails_sensor,
             cross_repo_sensor,
             cross_repo_job_sensor,
+            cross_repo_success_job_sensor,
             status_job,
             df_stats_job,
             yield_multi_run_request_success_sensor,
@@ -120,7 +122,7 @@ def toys_repository():
 
 @repository
 def more_toys_repository():
-    return [fails_job]
+    return [fails_job, succeeds_job]
 
 
 @repository

--- a/python_modules/dagster-test/dagster_test/toys/run_status_sensors.py
+++ b/python_modules/dagster-test/dagster_test/toys/run_status_sensors.py
@@ -198,3 +198,27 @@ def cross_repo_sensor(context):
             }
         },
     )
+
+
+@run_status_sensor(
+    monitored_jobs=[
+        JobSelector(
+            location_name="dagster_test.toys.repo",
+            repository_name="more_toys_repository",
+            job_name="succeeds_job",
+        ),
+    ],
+    request_job=status_job,
+    run_status=DagsterRunStatus.SUCCESS,
+)
+def cross_repo_success_job_sensor(context):
+    return RunRequest(
+        run_key=None,
+        run_config={
+            "ops": {
+                "status_printer": {
+                    "config": {"message": f"{context.dagster_run.pipeline_name} job succeeded!!!"}
+                }
+            }
+        },
+    )

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -454,7 +454,7 @@ class RunStatusSensorDefinition(SensorDefinition):
                     pipeline_run.external_pipeline_origin.external_repository_origin.repository_name
                     == context.repository_name
                 ):
-                    if current_repo_jobs:
+                    if monitored_jobs:
                         if pipeline_run.pipeline_name in map(lambda x: x.name, current_repo_jobs):
                             job_match = True
                     else:


### PR DESCRIPTION
### Summary & Motivation
with the changes to run status sensor i created a condition where a run status sensor  would monitor all jobs in the current repo if you only had a JobSelector or RepositorySelector. This pr fixes it and puts it under test

### How I Tested These Changes
updates a daemon test to check for launched runs. The test fails with the old code and passes for the new code