### PR TITLE
Consolidate resource / instance logic for invocation

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
@@ -83,15 +83,7 @@ def _check_invocation_requirements(
 
     # Construct a context if None was provided. This will initialize an ephemeral instance, and
     # console log manager.
-    init_context = init_context or build_init_resource_context()
-
-    return InitResourceContext(
-        resource_config=resource_config,
-        resources=init_context.resources,
-        resource_def=resource_def,
-        instance=init_context.instance,
-        log_manager=init_context.log,
-    )
+    return init_context or cast("UnboundInitResourceContext", build_init_resource_context())
 
 
 def _resolve_bound_config(resource_config: Any, resource_def: "ResourceDefinition") -> Any:

--- a/python_modules/dagster/dagster/_core/definitions/solid_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/solid_invocation.py
@@ -45,12 +45,12 @@ def solid_invocation_result(
         if isinstance(solid_def_or_invocation, PendingNodeInvocation)
         else solid_def_or_invocation
     )
-
     _check_invocation_requirements(solid_def, context)
 
-    context = (context or build_solid_context()).bind(solid_def_or_invocation)
+    open_context = context or build_solid_context()
+    bound_context = open_context.bind(solid_def_or_invocation)
 
-    input_dict = _resolve_inputs(solid_def, args, kwargs, context)
+    input_dict = _resolve_inputs(solid_def, args, kwargs, bound_context)
 
     compute_fn = solid_def.compute_fn
     if not isinstance(compute_fn, DecoratedSolidFunction):
@@ -58,12 +58,12 @@ def solid_invocation_result(
 
     compute_fn = cast(DecoratedSolidFunction, compute_fn)
     result = (
-        compute_fn.decorated_fn(context, **input_dict)
+        compute_fn.decorated_fn(bound_context, **input_dict)
         if compute_fn.has_context_arg()
         else compute_fn.decorated_fn(**input_dict)
     )
 
-    return _type_check_output_wrapper(solid_def, result, context)
+    return _type_check_output_wrapper(solid_def, result, bound_context)
 
 
 def _check_invocation_requirements(

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -33,7 +33,6 @@ from dagster._core.definitions import (
 from dagster._core.definitions.events import AssetLineageInfo, ObjectStoreOperationType
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.errors import DagsterError, HookExecutionError
-from dagster._core.execution.context.hook import HookContext
 from dagster._core.execution.context.system import (
     IPlanContext,
     IStepContext,

--- a/python_modules/dagster/dagster/_core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/build_resources.py
@@ -40,7 +40,7 @@ def get_mapped_resource_config(
 
 @contextmanager
 def build_resources(
-    resources: Mapping[str, Any],
+    resources: Optional[Mapping[str, Any]] = None,
     instance: Optional[DagsterInstance] = None,
     resource_config: Optional[Mapping[str, Any]] = None,
     pipeline_run: Optional[PipelineRun] = None,
@@ -84,7 +84,7 @@ def build_resources(
 
     """
 
-    resources = check.dict_param(resources, "resource_defs", key_type=str)
+    resources = check.opt_mapping_param(resources, "resources", key_type=str)
     instance = check.opt_inst_param(instance, "instance", DagsterInstance)
     resource_config = check.opt_dict_param(resource_config, "resource_config", key_type=str)
     log_manager = check.opt_inst_param(log_manager, "log_manager", DagsterLogManager)

--- a/python_modules/dagster/dagster/_core/execution/context/resource_invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/resource_invocation.py
@@ -1,0 +1,110 @@
+from typing import Any, Mapping, Optional, Union, cast
+
+import dagster._check as check
+from dagster._core.definitions.resource_definition import (
+    IContainsGenerator,
+    ResourceDefinition,
+    Resources,
+)
+from dagster._core.errors import DagsterInvariantViolationError
+from dagster._core.instance import DagsterInstance
+
+
+class UsesResourcesContext:
+    def __init__(
+        self,
+        *,
+        context_str: str,
+        resources: Optional[Union[Resources, Mapping[str, Any]]] = None,
+        resources_config: Optional[Mapping[str, Any]] = None,
+        instance: Optional[DagsterInstance] = None,
+    ):
+        from dagster._core.execution.build_resources import wrap_resources_for_execution
+
+        self._resources_cm = None
+        self._instance_cm = None
+        self._instance = instance
+        self._context_str = context_str
+
+        # If resources object has already been provided, no need to construct resources
+        if isinstance(resources, Resources):
+            self._resources = resources
+            self._resource_defs = None
+            check.invariant(
+                resources_config is None,
+                "resources_config should not be set when resource instances are directly provided.",
+            )
+            self._resources_config = None
+        else:
+            self._resources = None
+            self._resource_defs = wrap_resources_for_execution(
+                check.opt_mapping_param(resources, "resources", key_type=str)
+            )
+            self._resources_config = check.opt_mapping_param(resources_config, "resources_config")
+
+    def get_resources(self) -> Resources:
+        from dagster._core.execution.build_resources import build_resources
+
+        if self._resources is None:
+            with build_resources(
+                resources=self._resource_defs,
+                instance=self._instance,
+                resource_config=self._resources_config,
+            ) as resources:
+                # We only find out that there is a generator resource after
+                # initialization, but ideally, we should be able to find out
+                # before resource initialization occurs.
+                if isinstance(resources, IContainsGenerator):
+                    raise DagsterInvariantViolationError(
+                        "At least one provided resource is a generator, but attempting to access "
+                        "resources outside of context manager scope. You can use the following syntax to "
+                        f"open a context manager: `with build_{self._context_str}_context(...) as context:`"
+                    )
+                self._resources = resources
+        return self._resources
+
+    def get_resource_defs(self) -> Mapping[str, ResourceDefinition]:
+        if self._resource_defs is None:
+            raise DagsterInvariantViolationError(
+                "Resource defs were not directly provided to this context."
+            )
+        return cast(Mapping[str, ResourceDefinition], self._resource_defs)
+
+    def get_resources_config(self) -> Mapping[str, Any]:
+        if self._resources_config is None:
+            raise DagsterInvariantViolationError(
+                "Resources config was not directly provided to this context."
+            )
+        return cast(Mapping[str, Any], self._resources_config)
+
+    def __enter__(self):
+        from dagster._core.execution.api import ephemeral_instance_if_missing
+        from dagster._core.execution.build_resources import build_resources
+
+        if not self._instance:
+            self._instance_cm = ephemeral_instance_if_missing(None)
+            self._instance = self._instance_cm.__enter__()
+
+        self._resources_cm = build_resources(
+            resources=self._resource_defs,
+            instance=self._instance,
+            resource_config=self._resources_config,
+        )
+        self._resources = self._resources_cm.__enter__()
+        return self
+
+    def __exit__(self, *exc):
+        if self._instance_cm:
+            self._instance = None
+            self._instance_cm.__exit__(*exc)
+        if self._resources_cm:
+            self._resources = None
+            self._resources_cm.__exit__(*exc)
+
+    def get_instance(self) -> DagsterInstance:
+        if not self._instance:
+            raise DagsterInvariantViolationError(
+                "No instance was provided, and context object is outside of context manager scope. You can use the following syntax to "
+                "open a context manager: `with build_op_context(...) as context:"
+            )
+        return self._instance


### PR DESCRIPTION
### Summary & Motivation
Consolidates the logic used to open resource-based context managers for direct invocation of dagster definitions. Also fixes https://github.com/dagster-io/dagster/issues/9362

### How I Tested These Changes
Existing unit tests + ensuring that the repro in linked issue does not result in an error.
