### PR TITLE
[dagit] Support composite input/output mappings with a name change

### DIFF
--- a/js_modules/dagit/packages/core/src/pipelines/CompositeSupport.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/CompositeSupport.ts
@@ -2,49 +2,11 @@ import {GraphExplorerSolidHandleFragment} from './types/GraphExplorerSolidHandle
 
 function explodeComposite(
   handles: GraphExplorerSolidHandleFragment[],
-  handle: GraphExplorerSolidHandleFragment,
+  composite: GraphExplorerSolidHandleFragment,
 ) {
-  if (handle.solid.definition.__typename !== 'CompositeSolidDefinition') {
+  if (composite.solid.definition.__typename !== 'CompositeSolidDefinition') {
     throw new Error('explodeComposite takes a composite handle.');
   }
-
-  // Replace all references to this composite's inputs in other solid defitions
-  // with the interior target of the input mappings
-  handle.solid.definition.inputMappings.forEach((inmap) => {
-    const solidName = `${handle.solid.name}.${inmap.mappedInput.solid.name}`;
-    handles.forEach((h) =>
-      h.solid.outputs.forEach((i) => {
-        i.dependedBy.forEach((dep) => {
-          if (
-            dep.definition.name === inmap.definition.name &&
-            dep.solid.name === handle.solid.name
-          ) {
-            dep.solid.name = solidName;
-            dep.definition.name = inmap.mappedInput.definition.name;
-          }
-        });
-      }),
-    );
-  });
-
-  // Replace all references to this composite's outputs in other solid defitions
-  // with the interior target of the output mappings
-  handle.solid.definition.outputMappings.forEach((outmap) => {
-    const solidName = `${handle.solid.name}.${outmap.mappedOutput.solid.name}`;
-    handles.forEach((h) =>
-      h.solid.inputs.forEach((i) => {
-        i.dependsOn.forEach((dep) => {
-          if (
-            dep.definition.name === outmap.definition.name &&
-            dep.solid.name === handle.solid.name
-          ) {
-            dep.solid.name = solidName;
-            dep.definition.name = outmap.mappedOutput.definition.name;
-          }
-        });
-      }),
-    );
-  });
 
   // Find all the solid handles that are within this composite and prefix their
   // names with the composite container's name, giving them names that should
@@ -52,57 +14,118 @@ function explodeComposite(
   // because we'd have to dig through `handles` to find each solid based on it's
   // name + parentHandleID and then get it's handleID - dependsOn, etc. provide
   // Solid references not SolidHandle references.)
-  const nested = handles.filter((h) => h.handleID === `${handle.handleID}.${h.solid.name}`);
+  const nested = handles.filter((h) => h.handleID === `${composite.handleID}.${h.solid.name}`);
   nested.forEach((n) => {
     n.solid.name = n.handleID;
     n.solid.inputs.forEach((i) => {
       i.dependsOn.forEach((d) => {
-        d.solid.name = `${handle.handleID}.${d.solid.name}`;
+        d.solid.name = `${composite.handleID}.${d.solid.name}`;
       });
     });
     n.solid.outputs.forEach((i) => {
       i.dependedBy.forEach((d) => {
-        d.solid.name = `${handle.handleID}.${d.solid.name}`;
+        d.solid.name = `${composite.handleID}.${d.solid.name}`;
       });
     });
   });
 
-  // Find all the input dependencies of a composite solid and transfer them to their mapped interior
-  // target solids
-  handle.solid.definition.inputMappings.forEach((inmap) => {
-    handle.solid.inputs.forEach((input) => {
-      const solidName = `${handle.solid.name}.${inmap.mappedInput.solid.name}`;
-      const [interiorTarget] = handles.filter((h) => h.handleID === solidName);
-      if (!interiorTarget) {
-        return;
-      }
-      const matchingInput = interiorTarget.solid.inputs.find(
-        (i) => i.definition.name === input.definition.name,
+  composite.solid.definition.inputMappings.forEach((inmap) => {
+    // For each input mapping on the composite, find the referenced parts of the graph:
+    // The composite input, mapped (interior) solid and interior solid input.
+    //
+    const compositeInput = composite.solid.inputs.find(
+      (i) => i.definition.name === inmap.definition.name,
+    );
+    if (!compositeInput) {
+      console.warn(`CompositeSupport: No composite input matching ${inmap.definition.name}`);
+      return;
+    }
+
+    const interiorTargetName = `${composite.solid.name}.${inmap.mappedInput.solid.name}`;
+    const [interiorTarget] = handles.filter((h) => h.handleID === interiorTargetName);
+    if (!interiorTarget) {
+      console.warn(`CompositeSupport: No interior solid matching ${interiorTargetName}`);
+      return;
+    }
+    const interiorTargetInput = interiorTarget.solid.inputs.find(
+      (i) => i.definition.name === inmap.mappedInput.definition.name,
+    );
+    if (!interiorTargetInput) {
+      console.warn(
+        `CompositeSupport: No interior solid input matching ${inmap.mappedInput.definition.name}`,
       );
-      if (!matchingInput) {
-        return;
-      }
-      matchingInput.dependsOn = matchingInput.dependsOn.concat(input.dependsOn);
-    });
+      return;
+    }
+
+    // Ok! We need to update the input.dependsOn AND the output.dependedBy
+    // (both references to the relationship) to ensure correct graph rendering.
+
+    // Change #1: Give the interior solid input (the target of the input mapping)
+    // the "dependsOn" of the composite input, effectively "applying" the mapping.
+    interiorTargetInput.dependsOn.push(...compositeInput.dependsOn);
+
+    // Change #2: Find handles on the graph that were bound to this composite input
+    // and change their output.dependedBy[] to point to the interior solid.
+    handles.forEach((h) =>
+      h.solid.outputs.forEach((i) => {
+        i.dependedBy.forEach((dep) => {
+          if (
+            dep.solid.name === composite.solid.name &&
+            dep.definition.name === compositeInput.definition.name
+          ) {
+            dep.solid.name = interiorTargetName;
+            dep.definition.name = interiorTargetInput.definition.name;
+          }
+        });
+      }),
+    );
   });
 
-  // Find all the output dependencies of a composite solid and transfer them to their mapped interior
-  // target solids
-  handle.solid.definition.outputMappings.forEach((outmap) => {
-    handle.solid.outputs.forEach((output) => {
-      const solidName = `${handle.solid.name}.${outmap.mappedOutput.solid.name}`;
-      const [interiorTarget] = handles.filter((h) => h.handleID === solidName);
-      if (!interiorTarget) {
-        return;
-      }
-      const matchingOutput = interiorTarget.solid.outputs.find(
-        (i) => i.definition.name === output.definition.name,
+  // Repeat the code above for outputs - this is just different enough that it's
+  // not worth abstracting to re-use code...
+
+  composite.solid.definition.outputMappings.forEach((outmap) => {
+    const compositeOutput = composite.solid.outputs.find(
+      (i) => i.definition.name === outmap.definition.name,
+    );
+    if (!compositeOutput) {
+      console.warn(`CompositeSupport: No composite input matching ${outmap.definition.name}`);
+      return;
+    }
+    const interiorTargetName = `${composite.solid.name}.${outmap.mappedOutput.solid.name}`;
+    const [interiorTarget] = handles.filter((h) => h.handleID === interiorTargetName);
+    if (!interiorTarget) {
+      console.warn(`CompositeSupport: No interior solid matching ${interiorTargetName}`);
+      return;
+    }
+    const interiorTargetOutput = interiorTarget.solid.outputs.find(
+      (i) => i.definition.name === outmap.mappedOutput.definition.name,
+    );
+    if (!interiorTargetOutput) {
+      console.warn(
+        `CompositeSupport: No interior solid output matching ${outmap.mappedOutput.definition.name}`,
       );
-      if (!matchingOutput) {
-        return;
-      }
-      matchingOutput.dependedBy = matchingOutput.dependedBy.concat(output.dependedBy);
-    });
+      return;
+    }
+    // Change #1: Give the interior solid output (the target of the output mapping)
+    // the "dependedBy" of the composite output, effectively "applying" the mapping.
+    interiorTargetOutput.dependedBy.push(...compositeOutput.dependedBy);
+
+    // Change #2: Find handles on the graph that were bound to this composite output
+    // and change their input.dependsOn[] to point to the interior solid.
+    handles.forEach((h) =>
+      h.solid.inputs.forEach((i) => {
+        i.dependsOn.forEach((dep) => {
+          if (
+            dep.solid.name === composite.solid.name &&
+            dep.definition.name === compositeOutput.definition.name
+          ) {
+            dep.solid.name = interiorTargetName;
+            dep.definition.name = interiorTargetOutput.definition.name;
+          }
+        });
+      }),
+    );
   });
 
   // Return the interior solids that replace the composite in the graph


### PR DESCRIPTION
### Summary & Motivation

This is the second (Dagit) fix for https://github.com/dagster-io/dagster/issues/9224. The other portion of the fix is a backend change in https://github.com/dagster-io/dagster/pull/9527.

To test this code, I expanded on the example in #9224 to create a worst case scenario where composite input mappings map external ops like `inp1`, `inp2` to inputs with a different name on the interior ops (just `inp`). It turns out we didn't support this in Dagit because of a minor error in this algorithm.

I also created a scenario where a composite has two inputs, and only some of the interior ops use each input. This was also not reflected correctly, because our algorithm applied each composite input mapping to each interior op, not just the mapped op.

Test case:

```
from dagster import AssetsDefinition, op, graph, asset, repository, define_asset_job


@op
def bar(inp):
    return inp


@op
def combine(x):
    return x


@op
def yoyoyo(zztop):
    return 5


@graph
def ag(inp1, inp2):
    a = bar(inp1)
    b = bar(inp1)
    c = yoyoyo(inp2)
    return combine([a, b, c]), b


ag_asset = AssetsDefinition.from_graph(ag)


@asset
def inp1():
    return 1


@asset
def inp2():
    return 2


@asset
def finalizer(ag):
    return 1


@asset
def hobbyproject(ag):
    return 2


@repository
def repo():
    return [ag_asset, finalizer, inp1, inp2, hobbyproject, define_asset_job("all")]
```

Graph:
<img width="767" alt="Screen Shot 2022-08-30 at 8 21 09 AM" src="https://user-images.githubusercontent.com/1037212/187450128-98205414-0dff-4453-bd4d-9be69706ce69.png">
<img width="766" alt="Screen Shot 2022-08-30 at 8 21 12 AM" src="https://user-images.githubusercontent.com/1037212/187450132-d059eb3e-e2c1-4744-b553-3adf604d99c8.png">




### How I Tested These Changes
