### PR TITLE
Allow scheduling of union of cron strings

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -2,7 +2,7 @@ import copy
 import datetime
 import warnings
 from functools import update_wrapper
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, cast, Union, Sequence
 
 import dagster._check as check
 from dagster._core.definitions.partition import (
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
 
 
 def schedule(
-    cron_schedule: str,
+    cron_schedule: Union[str, Sequence[str]],
     *,
     job_name: Optional[str] = None,
     name: Optional[str] = None,
@@ -76,8 +76,12 @@ def schedule(
     Returns a :py:class:`~dagster.ScheduleDefinition`.
 
     Args:
-        cron_schedule (str): A valid cron string specifying when the schedule will run, e.g.,
-            ``'45 23 * * 6'`` for a schedule that runs at 11:45 PM every Saturday.
+        cron_schedule (Union[str, Sequence[str]]): A valid cron string or sequence of cron strings
+            specifying when the schedule will run, e.g., ``'45 23 * * 6'`` for a schedule that runs
+            at 11:45 PM every Saturday. If a sequence is provided, then the schedule will run for
+            the union of all execution times for the provided cron strings, e.g.,
+            ``['45 23 * * 6', '30 9 * * 0]`` for a schedule that runs at 11:45 PM every Saturday and
+            9:30 AM every Sunday.
         name (Optional[str]): The name of the schedule to create.
         tags (Optional[Dict[str, str]]): A dictionary of tags (string key-value pairs) to attach
             to the scheduled runs.

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -2,7 +2,7 @@ import copy
 import datetime
 import warnings
 from functools import update_wrapper
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, cast, Union, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Union, cast
 
 import dagster._check as check
 from dagster._core.definitions.partition import (

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -261,11 +261,12 @@ class ScheduleDefinition:
         job: Optional[ExecutableDefinition] = None,
         default_status: DefaultScheduleStatus = DefaultScheduleStatus.STOPPED,
     ):
-        cron_schedule = check.inst_param(cron_schedule, "cron_schedule", (str, Sequence))
-        if not isinstance(cron_schedule, str):
-            cron_schedule = check.sequence_param(cron_schedule, "cron_schedule", of_type=str)
-        self._cron_schedule = cron_schedule
-        if not is_valid_cron_schedule(self._cron_schedule):
+
+        self._cron_schedule = check.inst_param(cron_schedule, "cron_schedule", (str, Sequence))
+        if not isinstance(self._cron_schedule, str):
+            check.sequence_param(self._cron_schedule, "cron_schedule", of_type=str)  # type: ignore
+
+        if not is_valid_cron_schedule(self._cron_schedule):  # type: ignore
             raise DagsterInvalidDefinitionError(
                 f"Found invalid cron schedule '{self._cron_schedule}' for schedule '{name}''. "
                 "Dagster recognizes standard cron expressions consisting of 5 fields."
@@ -462,8 +463,8 @@ class ScheduleDefinition:
 
     @public  # type: ignore
     @property
-    def cron_schedule(self) -> str:
-        return self._cron_schedule
+    def cron_schedule(self) -> Union[str, Sequence[str]]:
+        return self._cron_schedule  # type: ignore
 
     @public  # type: ignore
     @property

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -23,7 +23,7 @@ import dagster._check as check
 from dagster._annotations import public
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils import ensure_gen, merge_dicts
-from dagster._utils.schedules import is_valid_cron_string
+from dagster._utils.schedules import is_valid_cron_schedule
 
 from ..decorator_utils import get_function_params
 from ..errors import (
@@ -203,8 +203,12 @@ class ScheduleDefinition:
     Args:
         name (Optional[str]): The name of the schedule to create. Defaults to the job name plus
             "_schedule".
-        cron_schedule (str): A valid cron string specifying when the schedule will run, e.g.,
-            '45 23 * * 6' for a schedule that runs at 11:45 PM every Saturday.
+        cron_schedule (Union[str, Sequence[str]]): A valid cron string or sequence of cron strings
+            specifying when the schedule will run, e.g., ``'45 23 * * 6'`` for a schedule that runs
+            at 11:45 PM every Saturday. If a sequence is provided, then the schedule will run for
+            the union of all execution times for the provided cron strings, e.g.,
+            ``['45 23 * * 6', '30 9 * * 0]`` for a schedule that runs at 11:45 PM every Saturday and
+            9:30 AM every Sunday.
         execution_fn (Callable[ScheduleEvaluationContext]): The core evaluation function for the
             schedule, which is run at an interval to determine whether a run should be launched or
             not. Takes a :py:class:`~dagster.ScheduleEvaluationContext`.
@@ -243,7 +247,7 @@ class ScheduleDefinition:
         self,
         name: Optional[str] = None,
         *,
-        cron_schedule: Optional[str] = None,
+        cron_schedule: Optional[Union[str, Sequence[str]]] = None,
         job_name: Optional[str] = None,
         run_config: Optional[Any] = None,
         run_config_fn: Optional[ScheduleRunConfigFunction] = None,
@@ -257,10 +261,11 @@ class ScheduleDefinition:
         job: Optional[ExecutableDefinition] = None,
         default_status: DefaultScheduleStatus = DefaultScheduleStatus.STOPPED,
     ):
-
-        self._cron_schedule = check.str_param(cron_schedule, "cron_schedule")
-
-        if not is_valid_cron_string(self._cron_schedule):
+        cron_schedule = check.inst_param(cron_schedule, "cron_schedule", (str, Sequence))
+        if not isinstance(cron_schedule, str):
+            cron_schedule = check.sequence_param(cron_schedule, "cron_schedule", of_type=str)
+        self._cron_schedule = cron_schedule
+        if not is_valid_cron_schedule(self._cron_schedule):
             raise DagsterInvalidDefinitionError(
                 f"Found invalid cron schedule '{self._cron_schedule}' for schedule '{name}''. "
                 "Dagster recognizes standard cron expressions consisting of 5 fields."

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -245,7 +245,7 @@ class ExternalScheduleData(
         "_ExternalScheduleData",
         [
             ("name", str),
-            ("cron_schedule", str),
+            ("cron_schedule", Union[str, Sequence[str]]),
             ("pipeline_name", str),
             ("solid_selection", Optional[Sequence[str]]),
             ("mode", Optional[str]),
@@ -270,10 +270,14 @@ class ExternalScheduleData(
         description=None,
         default_status=None,
     ):
+        cron_schedule = check.inst_param(cron_schedule, "cron_schedule", (str, Sequence))
+        if not isinstance(cron_schedule, str):
+            cron_schedule = check.sequence_param(cron_schedule, "cron_schedule", of_type=str)
+
         return super(ExternalScheduleData, cls).__new__(
             cls,
             name=check.str_param(name, "name"),
-            cron_schedule=check.str_param(cron_schedule, "cron_schedule"),
+            cron_schedule=cron_schedule,
             pipeline_name=check.str_param(pipeline_name, "pipeline_name"),
             solid_selection=check.opt_nullable_list_param(solid_selection, "solid_selection", str),
             mode=check.opt_str_param(mode, "mode"),

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from inspect import Parameter
-from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Type, Union, Sequence
+from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Sequence, Type, Union
 
 import dagster._check as check
 from dagster._core.definitions.run_request import InstigatorType
@@ -78,11 +78,14 @@ SensorJobData = SensorInstigatorData
 @whitelist_for_serdes
 class ScheduleInstigatorData(
     NamedTuple(
-        "_ScheduleInstigatorData", [("cron_schedule", Union[str, Sequence[str]]), ("start_timestamp", Optional[float])]
+        "_ScheduleInstigatorData",
+        [("cron_schedule", Union[str, Sequence[str]]), ("start_timestamp", Optional[float])],
     )
 ):
     # removed scheduler, 1/5/2022 (0.13.13)
-    def __new__(cls, cron_schedule: Union[str, Sequence[str]], start_timestamp: Optional[float] = None):
+    def __new__(
+        cls, cron_schedule: Union[str, Sequence[str]], start_timestamp: Optional[float] = None
+    ):
         cron_schedule = check.inst_param(cron_schedule, "cron_schedule", (str, Sequence))
         if not isinstance(cron_schedule, str):
             cron_schedule = check.sequence_param(cron_schedule, "cron_schedule", of_type=str)

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from inspect import Parameter
-from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Type, Union
+from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Type, Union, Sequence
 
 import dagster._check as check
 from dagster._core.definitions.run_request import InstigatorType
@@ -78,14 +78,18 @@ SensorJobData = SensorInstigatorData
 @whitelist_for_serdes
 class ScheduleInstigatorData(
     NamedTuple(
-        "_ScheduleInstigatorData", [("cron_schedule", str), ("start_timestamp", Optional[float])]
+        "_ScheduleInstigatorData", [("cron_schedule", Union[str, Sequence[str]]), ("start_timestamp", Optional[float])]
     )
 ):
     # removed scheduler, 1/5/2022 (0.13.13)
-    def __new__(cls, cron_schedule: str, start_timestamp: Optional[float] = None):
+    def __new__(cls, cron_schedule: Union[str, Sequence[str]], start_timestamp: Optional[float] = None):
+        cron_schedule = check.inst_param(cron_schedule, "cron_schedule", (str, Sequence))
+        if not isinstance(cron_schedule, str):
+            cron_schedule = check.sequence_param(cron_schedule, "cron_schedule", of_type=str)
+
         return super(ScheduleInstigatorData, cls).__new__(
             cls,
-            check.str_param(cron_schedule, "cron_schedule"),
+            cron_schedule,
             # Time in UTC at which the user started running the schedule (distinct from
             # `start_date` on partition-based schedules, which is used to define
             # the range of partitions)

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Iterator, List, Optional, Union, Sequence
+from typing import Iterator, Optional, Sequence, Union
 
 import pendulum
 import pytz
@@ -21,7 +21,8 @@ def is_valid_cron_schedule(cron_schedule: Union[str, Sequence[str]]) -> bool:
     return (
         is_valid_cron_string(cron_schedule)
         if isinstance(cron_schedule, str)
-        else all(is_valid_cron_string(cron_string) for cron_string in cron_schedule)
+        else len(cron_schedule) > 0
+        and all(is_valid_cron_string(cron_string) for cron_string in cron_schedule)
     )
 
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -132,6 +132,12 @@ def define_bar_schedules():
             job_name="foo",
             run_config={},
         ),
+        "union_schedule": ScheduleDefinition(
+            "union_schedule",
+            cron_schedule=["* * * * *", "* * * * *"],
+            job_name="foo",
+            run_config={},
+        ),
         "partitioned_schedule": partition_set.create_schedule_definition(
             schedule_name="partitioned_schedule",
             cron_schedule="* * * * *",

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_schedule_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_schedule_commands.py
@@ -41,6 +41,9 @@ def test_schedules_list(gen_schedule_args):
                 "****************************************\n"
                 "Schedule: partitioned_schedule [STOPPED]\n"
                 "Cron Schedule: * * * * *\n"
+                "**********************************\n"
+                "Schedule: union_schedule [STOPPED]\n"
+                "Cron Schedule: ['* * * * *', '* * * * *']\n"
             )
 
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_schedule_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_schedule_iterator.py
@@ -118,3 +118,12 @@ def test_invalid_cron_string():
 
     with pytest.raises(CheckError):
         next(schedule_execution_time_iterator(start_time.timestamp(), "* * * * * *", "US/Pacific"))
+
+
+def test_empty_cron_string_union():
+    start_time = create_pendulum_time(
+        year=2022, month=2, day=21, hour=1, minute=30, second=1, tz="US/Pacific"
+    )
+
+    with pytest.raises(CheckError):
+        next(schedule_execution_time_iterator(start_time.timestamp(), [], "US/Pacific"))

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_schedule_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_schedule_iterator.py
@@ -79,6 +79,38 @@ def test_vixie_cronstring_schedule():
     )
 
 
+def test_union_of_cron_strings_schedule():
+    # Saturday
+    start_time = create_pendulum_time(year=2022, month=1, day=1, hour=2, tz="UTC")
+
+    time_iter = schedule_execution_time_iterator(
+        start_time.timestamp(),
+        [
+            "0 2 * * FRI-SAT",  # 02:00 Friday through Saturday
+            "0 2,8 * * MON,FRI",  # 02:00, 08:00 on Monday and Friday
+            "*/30 9 * * SUN",  # 09:00, 09:30 on Sunday
+        ],
+        "UTC",
+    )
+    # Test an entire week's cycle
+    next_timestamps = [next(time_iter).timestamp() for _ in range(8)]
+
+    expected_next_timestamps = [
+        dt.timestamp()
+        for dt in [
+            create_pendulum_time(year=2022, month=1, day=1, hour=2, tz="UTC"),
+            create_pendulum_time(year=2022, month=1, day=2, hour=9, tz="UTC"),
+            create_pendulum_time(year=2022, month=1, day=2, hour=9, minute=30, tz="UTC"),
+            create_pendulum_time(year=2022, month=1, day=3, hour=2, tz="UTC"),
+            create_pendulum_time(year=2022, month=1, day=3, hour=8, tz="UTC"),
+            create_pendulum_time(year=2022, month=1, day=7, hour=2, tz="UTC"),
+            create_pendulum_time(year=2022, month=1, day=7, hour=8, tz="UTC"),
+            create_pendulum_time(year=2022, month=1, day=8, hour=2, tz="UTC"),
+        ]
+    ]
+    assert next_timestamps == expected_next_timestamps
+
+
 def test_invalid_cron_string():
     start_time = create_pendulum_time(
         year=2022, month=2, day=21, hour=1, minute=30, second=1, tz="US/Pacific"


### PR DESCRIPTION
### Summary & Motivation
Allow users to specify a schedule as the union of cron strings, in which case the next execution datetime is obtained by computing the next cron datetime after the current execution datetime for each cron string in the list, and then choosing the earliest among them.

### How I Tested These Changes
