### PR TITLE
[dagit] Fix zero-index reference on potentially empty array

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -64,7 +64,8 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
 
   const {assetOrError} = queryResult.data || queryResult.previousData || {};
   const asset = assetOrError && assetOrError.__typename === 'Asset' ? assetOrError : null;
-  const lastMaterializedAt = asset?.assetMaterializations[0]?.timestamp;
+  const materializations = asset?.assetMaterializations;
+  const lastMaterializedAt = materializations?.length ? materializations[0].timestamp : undefined;
   const viewingMostRecent = !params.asOf || Number(lastMaterializedAt) <= Number(params.asOf);
 
   const definition = asset?.definition;


### PR DESCRIPTION
### Summary & Motivation

Based on an error that appeared in Cloud.

We aren't checking whether `assetMaterializations` actually has a zero element, just that `asset` is not nullish. The result is that checking `timestamp` on the zero-index element can lead to a runtime error.

Ensure that the array has a length before looking at its first element.

### How I Tested These Changes

Buildkite. Sanity check that an asset view loads.
