### PR TITLE
[dagit] Fix asset job links to cross-repository upstream assets

### DIFF
--- a/js_modules/dagit/packages/core/src/pipelines/PipelineOverviewRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineOverviewRoot.tsx
@@ -53,7 +53,7 @@ export const PipelineOverviewRoot: React.FC<Props> = (props) => {
 
   const onNavigateToForeignNode = React.useCallback(
     (node: AssetLocation) => {
-      if (!node.jobName || !node.opNames.length) {
+      if (!node.jobName || !node.opNames.length || !node.repoAddress) {
         // This op has no definition in any loaded repository (source asset).
         // The best we can do is show the asset page. This will still be mostly empty,
         // but there can be a description.
@@ -61,13 +61,22 @@ export const PipelineOverviewRoot: React.FC<Props> = (props) => {
         return;
       }
 
-      const token = tokenForAssetKey(node.assetKey);
-      onChangeExplorerPath(
-        {...explorerPath, opNames: [token], opsQuery: '', pipelineName: node.jobName!},
-        'replace',
-      );
+      // Note: asset location can be in another job AND in another repo! Need
+      // to build a full job URL using the `node` info here.
+      history.replace({
+        search: location.search,
+        pathname: workspacePathFromAddress(
+          node.repoAddress,
+          `/jobs/${explorerPathToString({
+            ...explorerPath,
+            opNames: [tokenForAssetKey(node.assetKey)],
+            opsQuery: '',
+            pipelineName: node.jobName!,
+          })}`,
+        ),
+      });
     },
-    [explorerPath, history, onChangeExplorerPath],
+    [explorerPath, history, location.search],
   );
 
   return (


### PR DESCRIPTION
### Summary & Motivation

This is a small fix for https://github.com/dagster-io/dagster/issues/9029. We were using a helper to change the explorer path, but foreign links can actually go to separate repos and need to create a new path from scratch.

### How I Tested These Changes
