### PR TITLE
[dagit] Move Backfills tab to Runs page, flagged

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -9,10 +9,12 @@ import {
 } from '@dagster-io/ui';
 import * as React from 'react';
 
+import {useFeatureFlags} from '../app/Flags';
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
+import {RunListTabs} from '../runs/RunListTabs';
 import {useCursorPaginatedQuery} from '../runs/useCursorPaginatedQuery';
 import {Loading} from '../ui/Loading';
 
@@ -31,6 +33,7 @@ const PAGE_SIZE = 10;
 export const InstanceBackfills = () => {
   useTrackPageView();
 
+  const {flagNewWorkspace} = useFeatureFlags();
   const {pageTitle} = React.useContext(InstancePageContext);
   const queryData = useQuery<InstanceHealthForBackfillsQuery>(INSTANCE_HEALTH_FOR_BACKFILLS_QUERY);
 
@@ -56,8 +59,14 @@ export const InstanceBackfills = () => {
   return (
     <>
       <PageHeader
-        title={<Heading>{pageTitle}</Heading>}
-        tabs={<InstanceTabs tab="backfills" refreshState={refreshState} />}
+        title={<Heading>{flagNewWorkspace ? 'Runs' : pageTitle}</Heading>}
+        tabs={
+          flagNewWorkspace ? (
+            <RunListTabs />
+          ) : (
+            <InstanceTabs tab="backfills" refreshState={refreshState} />
+          )
+        }
       />
       <Loading queryResult={queryResult} allowStaleData={true}>
         {({partitionBackfillsOrError}) => {

--- a/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
@@ -35,7 +35,9 @@ export const InstanceTabs = <TData extends Record<string, any>>(props: Props<TDa
         <TabLink id="health" title={healthTitle} to="/instance/health" />
         <TabLink id="schedules" title="Schedules" to="/instance/schedules" />
         <TabLink id="sensors" title="Sensors" to="/instance/sensors" />
-        <TabLink id="backfills" title="Backfills" to="/instance/backfills" />
+        {flagNewWorkspace ? null : (
+          <TabLink id="backfills" title="Backfills" to="/instance/backfills" />
+        )}
         {canSeeConfig ? <TabLink id="config" title="Configuration" to="/instance/config" /> : null}
       </Tabs>
       {refreshState ? (

--- a/js_modules/dagit/packages/core/src/runs/RunListTabs.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunListTabs.tsx
@@ -63,6 +63,9 @@ export const RunListTabs = React.memo(() => {
       />
       <TabLink title="Done" to={urlForStatus(Array.from(doneStatuses))} id="done" />
       <TabLink title="Scheduled" to="/instance/runs/scheduled" id="scheduled" />
+      {flagNewWorkspace ? (
+        <TabLink title="Backfills" to="/instance/backfills" id="backfills" />
+      ) : null}
     </Tabs>
   );
 });
@@ -74,6 +77,9 @@ export const useSelectedRunsTab = (filterTokens: TokenizingFieldValue[]) => {
   }
   if (pathname === '/instance/runs/scheduled') {
     return 'scheduled';
+  }
+  if (pathname === '/instance/backfills') {
+    return 'backfills';
   }
 
   const statusTokens = new Set(


### PR DESCRIPTION
### Summary & Motivation

Move the Backfills tab to the Runs page, behind the new workspace page flag.

### How I Tested These Changes

With flag disabled, verify that Backfills appear under Status with the correct header and tabs. With flag enabled, verify that it appears under Runs and behaves/renders correctly.
