### PR TITLE
Convert input mappings away from using InputDefinition

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_composites.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_composites.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots['TestComposites.test_composites[non_launchable_in_memory_instance_lazy_repository] 1'] = {
@@ -949,6 +950,1419 @@ snapshots['TestComposites.test_composites[non_launchable_in_memory_instance_mana
 }
 
 snapshots['TestComposites.test_composites[non_launchable_in_memory_instance_multi_location] 1'] = {
+    'pipelineOrError': {
+        '__typename': 'Pipeline',
+        'name': 'composites_pipeline',
+        'solidHandles': [
+            {
+                'handleID': 'add_four',
+                'solid': {
+                    'definition': {
+                        'inputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'num'
+                                },
+                                'mappedInput': {
+                                    'definition': {
+                                        'name': 'num'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            }
+                        ],
+                        'outputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'result'
+                                },
+                                'mappedOutput': {
+                                    'definition': {
+                                        'name': 'result'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            }
+                        ],
+                        'solids': [
+                            {
+                                'name': 'adder_1'
+                            },
+                            {
+                                'name': 'adder_2'
+                            }
+                        ]
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                            ]
+                        }
+                    ],
+                    'name': 'add_four',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                                {
+                                    'solid': {
+                                        'name': 'div_four'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_1',
+                'solid': {
+                    'definition': {
+                        'inputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'num'
+                                },
+                                'mappedInput': {
+                                    'definition': {
+                                        'name': 'num'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            }
+                        ],
+                        'outputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'result'
+                                },
+                                'mappedOutput': {
+                                    'definition': {
+                                        'name': 'result'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            }
+                        ],
+                        'solids': [
+                            {
+                                'name': 'adder_1'
+                            },
+                            {
+                                'name': 'adder_2'
+                            }
+                        ]
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                            ]
+                        }
+                    ],
+                    'name': 'adder_1',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_1.adder_1',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                            ]
+                        }
+                    ],
+                    'name': 'adder_1',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_1.adder_2',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    'name': 'adder_2',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_2',
+                'solid': {
+                    'definition': {
+                        'inputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'num'
+                                },
+                                'mappedInput': {
+                                    'definition': {
+                                        'name': 'num'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            }
+                        ],
+                        'outputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'result'
+                                },
+                                'mappedOutput': {
+                                    'definition': {
+                                        'name': 'result'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            }
+                        ],
+                        'solids': [
+                            {
+                                'name': 'adder_1'
+                            },
+                            {
+                                'name': 'adder_2'
+                            }
+                        ]
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    'name': 'adder_2',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_2.adder_1',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                            ]
+                        }
+                    ],
+                    'name': 'adder_1',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_2.adder_2',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    'name': 'adder_2',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'div_four',
+                'solid': {
+                    'definition': {
+                        'inputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'num'
+                                },
+                                'mappedInput': {
+                                    'definition': {
+                                        'name': 'num'
+                                    },
+                                    'solid': {
+                                        'name': 'div_1'
+                                    }
+                                }
+                            }
+                        ],
+                        'outputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'result'
+                                },
+                                'mappedOutput': {
+                                    'definition': {
+                                        'name': 'result'
+                                    },
+                                    'solid': {
+                                        'name': 'div_2'
+                                    }
+                                }
+                            }
+                        ],
+                        'solids': [
+                            {
+                                'name': 'div_1'
+                            },
+                            {
+                                'name': 'div_2'
+                            }
+                        ]
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                                {
+                                    'solid': {
+                                        'name': 'add_four'
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    'name': 'div_four',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'div_four.div_1',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                            ]
+                        }
+                    ],
+                    'name': 'div_1',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                                {
+                                    'solid': {
+                                        'name': 'div_2'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'div_four.div_2',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                                {
+                                    'solid': {
+                                        'name': 'div_1'
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    'name': 'div_2',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+
+snapshots['TestComposites.test_composites[non_launchable_postgres_instance_lazy_repository] 1'] = {
+    'pipelineOrError': {
+        '__typename': 'Pipeline',
+        'name': 'composites_pipeline',
+        'solidHandles': [
+            {
+                'handleID': 'add_four',
+                'solid': {
+                    'definition': {
+                        'inputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'num'
+                                },
+                                'mappedInput': {
+                                    'definition': {
+                                        'name': 'num'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            }
+                        ],
+                        'outputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'result'
+                                },
+                                'mappedOutput': {
+                                    'definition': {
+                                        'name': 'result'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            }
+                        ],
+                        'solids': [
+                            {
+                                'name': 'adder_1'
+                            },
+                            {
+                                'name': 'adder_2'
+                            }
+                        ]
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                            ]
+                        }
+                    ],
+                    'name': 'add_four',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                                {
+                                    'solid': {
+                                        'name': 'div_four'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_1',
+                'solid': {
+                    'definition': {
+                        'inputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'num'
+                                },
+                                'mappedInput': {
+                                    'definition': {
+                                        'name': 'num'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            }
+                        ],
+                        'outputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'result'
+                                },
+                                'mappedOutput': {
+                                    'definition': {
+                                        'name': 'result'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            }
+                        ],
+                        'solids': [
+                            {
+                                'name': 'adder_1'
+                            },
+                            {
+                                'name': 'adder_2'
+                            }
+                        ]
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                            ]
+                        }
+                    ],
+                    'name': 'adder_1',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_1.adder_1',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                            ]
+                        }
+                    ],
+                    'name': 'adder_1',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_1.adder_2',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    'name': 'adder_2',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_2',
+                'solid': {
+                    'definition': {
+                        'inputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'num'
+                                },
+                                'mappedInput': {
+                                    'definition': {
+                                        'name': 'num'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            }
+                        ],
+                        'outputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'result'
+                                },
+                                'mappedOutput': {
+                                    'definition': {
+                                        'name': 'result'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            }
+                        ],
+                        'solids': [
+                            {
+                                'name': 'adder_1'
+                            },
+                            {
+                                'name': 'adder_2'
+                            }
+                        ]
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    'name': 'adder_2',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_2.adder_1',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                            ]
+                        }
+                    ],
+                    'name': 'adder_1',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_2.adder_2',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    'name': 'adder_2',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'div_four',
+                'solid': {
+                    'definition': {
+                        'inputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'num'
+                                },
+                                'mappedInput': {
+                                    'definition': {
+                                        'name': 'num'
+                                    },
+                                    'solid': {
+                                        'name': 'div_1'
+                                    }
+                                }
+                            }
+                        ],
+                        'outputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'result'
+                                },
+                                'mappedOutput': {
+                                    'definition': {
+                                        'name': 'result'
+                                    },
+                                    'solid': {
+                                        'name': 'div_2'
+                                    }
+                                }
+                            }
+                        ],
+                        'solids': [
+                            {
+                                'name': 'div_1'
+                            },
+                            {
+                                'name': 'div_2'
+                            }
+                        ]
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                                {
+                                    'solid': {
+                                        'name': 'add_four'
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    'name': 'div_four',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'div_four.div_1',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                            ]
+                        }
+                    ],
+                    'name': 'div_1',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                                {
+                                    'solid': {
+                                        'name': 'div_2'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'div_four.div_2',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                                {
+                                    'solid': {
+                                        'name': 'div_1'
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    'name': 'div_2',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+
+snapshots['TestComposites.test_composites[non_launchable_postgres_instance_managed_grpc_env] 1'] = {
+    'pipelineOrError': {
+        '__typename': 'Pipeline',
+        'name': 'composites_pipeline',
+        'solidHandles': [
+            {
+                'handleID': 'add_four',
+                'solid': {
+                    'definition': {
+                        'inputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'num'
+                                },
+                                'mappedInput': {
+                                    'definition': {
+                                        'name': 'num'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            }
+                        ],
+                        'outputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'result'
+                                },
+                                'mappedOutput': {
+                                    'definition': {
+                                        'name': 'result'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            }
+                        ],
+                        'solids': [
+                            {
+                                'name': 'adder_1'
+                            },
+                            {
+                                'name': 'adder_2'
+                            }
+                        ]
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                            ]
+                        }
+                    ],
+                    'name': 'add_four',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                                {
+                                    'solid': {
+                                        'name': 'div_four'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_1',
+                'solid': {
+                    'definition': {
+                        'inputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'num'
+                                },
+                                'mappedInput': {
+                                    'definition': {
+                                        'name': 'num'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            }
+                        ],
+                        'outputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'result'
+                                },
+                                'mappedOutput': {
+                                    'definition': {
+                                        'name': 'result'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            }
+                        ],
+                        'solids': [
+                            {
+                                'name': 'adder_1'
+                            },
+                            {
+                                'name': 'adder_2'
+                            }
+                        ]
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                            ]
+                        }
+                    ],
+                    'name': 'adder_1',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_1.adder_1',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                            ]
+                        }
+                    ],
+                    'name': 'adder_1',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_1.adder_2',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    'name': 'adder_2',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_2',
+                'solid': {
+                    'definition': {
+                        'inputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'num'
+                                },
+                                'mappedInput': {
+                                    'definition': {
+                                        'name': 'num'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            }
+                        ],
+                        'outputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'result'
+                                },
+                                'mappedOutput': {
+                                    'definition': {
+                                        'name': 'result'
+                                    },
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            }
+                        ],
+                        'solids': [
+                            {
+                                'name': 'adder_1'
+                            },
+                            {
+                                'name': 'adder_2'
+                            }
+                        ]
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    'name': 'adder_2',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_2.adder_1',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                            ]
+                        }
+                    ],
+                    'name': 'adder_1',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_2'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'add_four.adder_2.adder_2',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                                {
+                                    'solid': {
+                                        'name': 'adder_1'
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    'name': 'adder_2',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'div_four',
+                'solid': {
+                    'definition': {
+                        'inputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'num'
+                                },
+                                'mappedInput': {
+                                    'definition': {
+                                        'name': 'num'
+                                    },
+                                    'solid': {
+                                        'name': 'div_1'
+                                    }
+                                }
+                            }
+                        ],
+                        'outputMappings': [
+                            {
+                                'definition': {
+                                    'name': 'result'
+                                },
+                                'mappedOutput': {
+                                    'definition': {
+                                        'name': 'result'
+                                    },
+                                    'solid': {
+                                        'name': 'div_2'
+                                    }
+                                }
+                            }
+                        ],
+                        'solids': [
+                            {
+                                'name': 'div_1'
+                            },
+                            {
+                                'name': 'div_2'
+                            }
+                        ]
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                                {
+                                    'solid': {
+                                        'name': 'add_four'
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    'name': 'div_four',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'div_four.div_1',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                            ]
+                        }
+                    ],
+                    'name': 'div_1',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                                {
+                                    'solid': {
+                                        'name': 'div_2'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                'handleID': 'div_four.div_2',
+                'solid': {
+                    'definition': {
+                    },
+                    'inputs': [
+                        {
+                            'definition': {
+                                'name': 'num'
+                            },
+                            'dependsOn': [
+                                {
+                                    'solid': {
+                                        'name': 'div_1'
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    'name': 'div_2',
+                    'outputs': [
+                        {
+                            'definition': {
+                                'name': 'result'
+                            },
+                            'dependedBy': [
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+
+snapshots['TestComposites.test_composites[non_launchable_postgres_instance_multi_location] 1'] = {
     'pipelineOrError': {
         '__typename': 'Pipeline',
         'name': 'composites_pipeline',

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -91,7 +91,7 @@ def _resolve_input_to_destinations(
         return [NodeInputHandle(node_handle=handle, input_name=name)]
     all_destinations: List[NodeInputHandle] = []
     for mapping in node_def.input_mappings:
-        if mapping.definition.name != name:
+        if mapping.graph_input_name != name:
             continue
         # recurse into graph structure
         all_destinations += _resolve_input_to_destinations(

--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -1084,7 +1084,7 @@ def do_composition(
     input_mappings = []
     for defn in actual_input_defs:
         mappings = [
-            mapping for mapping in context.input_mappings if mapping.definition.name == defn.name
+            mapping for mapping in context.input_mappings if mapping.graph_input_name == defn.name
         ]
 
         if len(mappings) == 0:

--- a/python_modules/dagster/dagster/_core/definitions/input.py
+++ b/python_modules/dagster/dagster/_core/definitions/input.py
@@ -270,12 +270,14 @@ class InputDefinition:
         check.str_param(input_name, "input_name")
         check.opt_int_param(fan_in_index, "fan_in_index")
 
-        maps_to: Union[FanInInputPointer, InputPointer]
-        if fan_in_index is not None:
-            maps_to = FanInInputPointer(solid_name, input_name, fan_in_index)
-        else:
-            maps_to = InputPointer(solid_name, input_name)
-        return InputMapping(self, maps_to)
+        return InputMapping(
+            graph_input_name=self.name,
+            mapped_node_name=solid_name,
+            mapped_node_input_name=input_name,
+            fan_in_index=fan_in_index,
+            graph_input_description=self.description,
+            dagster_type=self.dagster_type,
+        )
 
     @staticmethod
     def create_from_inferred(inferred: InferredInputProps) -> "InputDefinition":
@@ -366,20 +368,58 @@ class FanInInputPointer(
         )
 
 
-class InputMapping(
-    NamedTuple(
-        "_InputMapping",
-        [("definition", InputDefinition), ("maps_to", Union[InputPointer, FanInInputPointer])],
-    )
-):
-    """Defines an input mapping for a graph."""
+class InputMapping(NamedTuple):
+    """Defines an input mapping for a graph.
 
-    def __new__(cls, definition: InputDefinition, maps_to: Union[InputPointer, FanInInputPointer]):
-        return super(InputMapping, cls).__new__(
-            cls,
-            check.inst_param(definition, "definition", InputDefinition),
-            check.inst_param(maps_to, "maps_to", (InputPointer, FanInInputPointer)),
-        )
+    Args:
+        graph_input_name (str): Name of the input in the graph being mapped from.
+        mapped_node_name (str): Named of the node (op/graph) that the input is being mapped to.
+        mapped_node_input_name (str): Name of the input in the node (op/graph) that is being mapped to.
+        fan_in_index (Optional[int]): The index in to a fanned input, otherwise None.
+        graph_input_description (Optional[str]): A description of the input in the graph being mapped from.
+        dagster_type (Optional[DagsterType]): (Deprecated) The dagster type of the graph's input being mapped from. Users should not use this argument when instantiating the class.
+
+    Examples:
+
+        .. code-block:: python
+
+            from dagster import InputMapping, GraphDefinition, op, graph
+
+            @op
+            def needs_input(x):
+                return x + 1
+
+            # The following two graph definitions are equivalent
+            GraphDefinition(
+                name="the_graph",
+                node_defs=[needs_input],
+                input_mappings=[
+                    InputMapping(
+                        graph_input_name="maps_x", mapped_node_name="needs_input",
+                        mapped_node_input_name="x"
+                    )
+                ]
+            )
+
+            @graph
+            def the_graph(maps_x):
+                needs_input(maps_x)
+    """
+
+    graph_input_name: str
+    mapped_node_name: str
+    mapped_node_input_name: str
+    fan_in_index: Optional[int] = None
+    graph_input_description: Optional[str] = None
+    dagster_type: Optional[DagsterType] = None
+
+    @property
+    def maps_to(self) -> Union[InputPointer, FanInInputPointer]:
+        if self.fan_in_index is not None:
+            return FanInInputPointer(
+                self.mapped_node_name, self.mapped_node_input_name, self.fan_in_index
+            )
+        return InputPointer(self.mapped_node_name, self.mapped_node_input_name)
 
     @property
     def maps_to_fan_in(self) -> bool:
@@ -387,7 +427,16 @@ class InputMapping(
 
     def describe(self) -> str:
         idx = self.maps_to.fan_in_index if isinstance(self.maps_to, FanInInputPointer) else ""
-        return f"{self.definition.name} -> {self.maps_to.solid_name}:{self.maps_to.input_name}{idx}"
+        return (
+            f"{self.graph_input_name} -> {self.maps_to.solid_name}:{self.maps_to.input_name}{idx}"
+        )
+
+    def get_definition(self) -> "InputDefinition":
+        return InputDefinition(
+            name=self.graph_input_name,
+            description=self.graph_input_description,
+            dagster_type=self.dagster_type,
+        )
 
 
 class In(

--- a/python_modules/dagster/dagster/_core/definitions/solid_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/solid_definition.py
@@ -433,7 +433,7 @@ class CompositeSolidDefinition(GraphDefinition):
         tags: Optional[Mapping[str, str]] = None,
         positional_inputs: Optional[Sequence[str]] = None,
     ):
-        _check_io_managers_on_composite_solid(name, input_mappings, output_mappings)
+        _check_io_managers_on_composite_solid(name, output_mappings)
 
         super(CompositeSolidDefinition, self).__init__(
             name=name,
@@ -495,19 +495,8 @@ class CompositeSolidDefinition(GraphDefinition):
 
 def _check_io_managers_on_composite_solid(
     name: str,
-    input_mappings: Optional[Sequence[InputMapping]],
     output_mappings: Optional[Sequence[OutputMapping]],
 ) -> None:
-    # Ban root_manager_key on composite solids
-    if input_mappings:
-        for input_mapping in input_mappings:
-            input_def = input_mapping.definition
-            if input_def.root_manager_key:
-                raise DagsterInvalidDefinitionError(
-                    "Root input manager cannot be set on a composite solid: "
-                    f'root_manager_key "{input_def.root_manager_key}" '
-                    f'is set on InputDefinition "{input_def.name}" of composite solid "{name}". '
-                )
     # Ban io_manager_key on composite solids
     if output_mappings:
         for output_mapping in output_mappings:

--- a/python_modules/dagster/dagster/_core/execution/execute_in_process.py
+++ b/python_modules/dagster/dagster/_core/execution/execute_in_process.py
@@ -86,7 +86,7 @@ def core_execute_in_process(
 def _check_top_level_inputs(job_def: JobDefinition) -> None:
     for input_mapping in job_def.graph.input_mappings:
         node = job_def.graph.solid_named(input_mapping.maps_to.solid_name)
-        top_level_input_name = input_mapping.definition.name
+        top_level_input_name = input_mapping.graph_input_name
         input_name = input_mapping.maps_to.input_name
         _check_top_level_inputs_for_node(
             node,

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -535,7 +535,7 @@ def get_step_input_source(
                 if parent_step_inputs is None:
                     check.failed("unexpected error in composition descent during plan building")
 
-                parent_name = solid.container_mapped_fan_in_input(input_name, idx).definition.name
+                parent_name = solid.container_mapped_fan_in_input(input_name, idx).graph_input_name
                 parent_inputs = {step_input.name: step_input for step_input in parent_step_inputs}
                 parent_input = parent_inputs[parent_name]
                 source = parent_input.source
@@ -568,7 +568,7 @@ def get_step_input_source(
         if parent_step_inputs is None:
             check.failed("unexpected error in composition descent during plan building")
 
-        parent_name = solid.container_mapped_input(input_name).definition.name
+        parent_name = solid.container_mapped_input(input_name).graph_input_name
         parent_inputs = {step_input.name: step_input for step_input in parent_step_inputs}
         if parent_name in parent_inputs:
             parent_input = parent_inputs[parent_name]

--- a/python_modules/dagster/dagster/_core/snap/solid.py
+++ b/python_modules/dagster/dagster/_core/snap/solid.py
@@ -156,7 +156,7 @@ def build_input_mapping_snap(input_mapping: InputMapping) -> InputMappingSnap:
     return InputMappingSnap(
         mapped_solid_name=input_mapping.maps_to.solid_name,
         mapped_input_name=input_mapping.maps_to.input_name,
-        external_input_name=input_mapping.definition.name,
+        external_input_name=input_mapping.graph_input_name,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composition.py
@@ -303,13 +303,13 @@ def test_mapping_args_kwargs():
     def maps(m_c, m_b, m_a):
         take(m_a, b=m_b, c=m_c)
 
-    assert maps.input_mappings[2].definition.name == "m_a"
+    assert maps.input_mappings[2].graph_input_name == "m_a"
     assert maps.input_mappings[2].maps_to.input_name == "a"
 
-    assert maps.input_mappings[1].definition.name == "m_b"
+    assert maps.input_mappings[1].graph_input_name == "m_b"
     assert maps.input_mappings[1].maps_to.input_name == "b"
 
-    assert maps.input_mappings[0].definition.name == "m_c"
+    assert maps.input_mappings[0].graph_input_name == "m_c"
     assert maps.input_mappings[0].maps_to.input_name == "c"
 
 
@@ -487,10 +487,10 @@ def test_mapping_args_ordering():
         swizzle_2()
 
     for mapping in swizzle.input_mappings:
-        assert mapping.definition.name == mapping.maps_to.input_name
+        assert mapping.graph_input_name == mapping.maps_to.input_name
 
     for mapping in swizzle_2.input_mappings:
-        assert mapping.definition.name == mapping.maps_to.input_name
+        assert mapping.graph_input_name == mapping.maps_to.input_name
 
     execute_pipeline(
         ordered,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_input_defaults.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_input_defaults.py
@@ -114,20 +114,6 @@ def test_nothing():
             pass
 
 
-def test_composite_outer_default():
-    @lambda_solid(input_defs=[InputDefinition("x", Optional[int])])
-    def int_x(x):
-        return x
-
-    @composite_solid(input_defs=[InputDefinition("y", Optional[int], default_value=42)])
-    def wrap(y):
-        return int_x(y)
-
-    result = execute_solid(wrap)
-    assert result.success
-    assert result.output_value() == 42
-
-
 def test_composite_inner_default():
     @lambda_solid(input_defs=[InputDefinition("x", Optional[int], default_value=1337)])
     def int_x(x):
@@ -140,38 +126,6 @@ def test_composite_inner_default():
     result = execute_solid(wrap)
     assert result.success
     assert result.output_value() == 1337
-
-
-def test_composite_precedence_default():
-    @lambda_solid(input_defs=[InputDefinition("x", Optional[int], default_value=1337)])
-    def int_x(x):
-        return x
-
-    @composite_solid(input_defs=[InputDefinition("y", Optional[int], default_value=42)])
-    def wrap(y):
-        return int_x(y)
-
-    result = execute_solid(wrap)
-    assert result.success
-    assert result.output_value() == 42
-
-
-def test_composite_mid_default():
-    @lambda_solid(input_defs=[InputDefinition("x", Optional[int])])
-    def int_x(x):
-        return x
-
-    @composite_solid(input_defs=[InputDefinition("y", Optional[int], default_value=42)])
-    def wrap(y):
-        return int_x(y)
-
-    @composite_solid(input_defs=[InputDefinition("z", Optional[int])])
-    def outter_wrap(z):
-        return wrap(z)
-
-    result = execute_solid(outter_wrap)
-    assert result.success
-    assert result.output_value() == 42
 
 
 def test_custom_type_default():

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_input_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_input_manager.py
@@ -722,23 +722,6 @@ def test_mode_missing_input_manager_execute_solid():
     assert result.success
 
 
-def test_no_root_manager_composite():
-    @solid(input_defs=[InputDefinition("data", dagster_type=str)])
-    def inner_solid(_, data):
-        return data
-
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match="Root input manager cannot be set on a composite solid",
-    ):
-
-        @composite_solid(
-            input_defs=[InputDefinition("data", dagster_type=str, root_manager_key="my_root")]
-        )
-        def _(data):
-            _ = inner_solid(data=data)
-
-
 def test_root_manager_inside_composite():
     @root_input_manager(input_config_schema={"test": str})
     def my_root(context):


### PR DESCRIPTION
### Summary & Motivation
Previously, InputMapping required the use of InputDefinition for construction. This removes the need to have a definition-like construct at all when constructing an InputMapping. 
For https://github.com/dagster-io/dagster/issues/9531

### How I Tested These Changes
Added an additional test for constructing a GraphDefinition manually using InputMapping
