### PR TITLE
Make OutputMapping compliant with new APIs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -110,7 +110,7 @@ def _resolve_output_to_destinations(output_name, node_def, handle) -> Sequence[N
         return node_input_handles
 
     for mapping in node_def.output_mappings:
-        if mapping.definition.name != output_name:
+        if mapping.graph_output_name != output_name:
             continue
         output_pointer = mapping.maps_from
         output_node = node_def.solid_named(output_pointer.solid_name)
@@ -169,7 +169,7 @@ def _build_graph_dependencies(
                 assets_defs_by_node_handle,
             )
             outputs_by_graph_handle[curr_node_handle] = {
-                mapping.definition.name: NodeOutputHandle(
+                mapping.graph_output_name: NodeOutputHandle(
                     NodeHandle(mapping.maps_from.solid_name, parent=curr_node_handle),
                     mapping.maps_from.output_name,
                 )

--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -900,6 +900,27 @@ def composite_mapping_from_output(
                 )
             )
 
+    elif isinstance(output, InvokedSolidDynamicOutputWrapper):
+        if len(output_defs) == 1:
+            defn = output_defs[0]
+            return {
+                defn.name: defn.mapping_from(
+                    output.solid_name, output.output_name, from_dynamic_mapping=True
+                )
+            }
+        else:
+            raise DagsterInvalidDefinitionError(
+                "Returned a single output ({solid_name}.{output_name}) in "
+                "{decorator_name} '{name}' but {num} outputs are defined. "
+                "Return a dict to map defined outputs.".format(
+                    solid_name=output.solid_name,
+                    output_name=output.output_name,
+                    decorator_name=decorator_name,
+                    name=solid_name,
+                    num=len(output_defs),
+                )
+            )
+
     output_mapping_dict = {}
     output_def_dict = {output_def.name: output_def for output_def in output_defs}
 
@@ -952,9 +973,8 @@ def composite_mapping_from_output(
                     handle.solid_name, handle.output_name
                 )
             elif isinstance(handle, InvokedSolidDynamicOutputWrapper):
-                unwrapped = handle.unwrap_for_composite_mapping()
                 output_mapping_dict[name] = output_def_dict[name].mapping_from(
-                    unwrapped.solid_name, unwrapped.output_name
+                    handle.solid_name, handle.output_name, from_dynamic_mapping=True
                 )
             else:
                 raise DagsterInvalidDefinitionError(
@@ -966,11 +986,6 @@ def composite_mapping_from_output(
                 )
 
         return output_mapping_dict
-
-    elif isinstance(output, InvokedSolidDynamicOutputWrapper):
-        return composite_mapping_from_output(
-            output.unwrap_for_composite_mapping(), output_defs, solid_name, decorator_name
-        )
 
     # error
     if output is not None:

--- a/python_modules/dagster/dagster/_core/definitions/solid_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/solid_definition.py
@@ -40,7 +40,6 @@ from .resource_requirement import (
     SolidDefinitionResourceRequirement,
 )
 from .solid_invocation import solid_invocation_result
-from .utils import DEFAULT_IO_MANAGER_KEY
 
 if TYPE_CHECKING:
     from .asset_layer import AssetLayer
@@ -433,7 +432,6 @@ class CompositeSolidDefinition(GraphDefinition):
         tags: Optional[Mapping[str, str]] = None,
         positional_inputs: Optional[Sequence[str]] = None,
     ):
-        _check_io_managers_on_composite_solid(name, output_mappings)
 
         super(CompositeSolidDefinition, self).__init__(
             name=name,
@@ -491,19 +489,3 @@ class CompositeSolidDefinition(GraphDefinition):
     @property
     def is_graph_job_op_node(self) -> bool:
         return False
-
-
-def _check_io_managers_on_composite_solid(
-    name: str,
-    output_mappings: Optional[Sequence[OutputMapping]],
-) -> None:
-    # Ban io_manager_key on composite solids
-    if output_mappings:
-        for output_mapping in output_mappings:
-            output_def = output_mapping.definition
-            if output_def.io_manager_key != DEFAULT_IO_MANAGER_KEY:
-                raise DagsterInvalidDefinitionError(
-                    "IO manager cannot be set on a composite solid: "
-                    f'io_manager_key "{output_def.io_manager_key}" '
-                    f'is set  on OutputtDefinition "{output_def.name}" of composite solid "{name}". '
-                )

--- a/python_modules/dagster/dagster/_core/snap/solid.py
+++ b/python_modules/dagster/dagster/_core/snap/solid.py
@@ -128,7 +128,7 @@ def build_output_mapping_snap(output_mapping: OutputMapping) -> OutputMappingSna
     return OutputMappingSnap(
         mapped_solid_name=output_mapping.maps_from.solid_name,
         mapped_output_name=output_mapping.maps_from.output_name,
-        external_output_name=output_mapping.definition.name,
+        external_output_name=output_mapping.graph_output_name,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_io_manager_composites.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_io_manager_composites.py
@@ -1,6 +1,4 @@
-import pytest
-
-from dagster import DagsterInvalidDefinitionError, DagsterType, root_input_manager
+from dagster import DagsterType, root_input_manager
 from dagster._core.storage.io_manager import IOManager, io_manager
 from dagster._legacy import (
     InputDefinition,
@@ -45,16 +43,6 @@ def test_composite_solid_output():
     )
     def my_solid_takes_input(_, x):
         return x
-
-    # Error on io_manager_key on composite
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match="IO manager cannot be set on a composite solid",
-    ):
-
-        @composite_solid(output_defs=[OutputDefinition(io_manager_key="outer_manager")])
-        def _():
-            return my_solid_takes_input(my_solid())
 
     # Values ingested by inner_manager and outer_manager are stored in storage_dict
     storage_dict = {}

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_not_allowed.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_not_allowed.py
@@ -1,13 +1,7 @@
 import pytest
 
 from dagster import DagsterInvalidDefinitionError, DynamicOutput
-from dagster._legacy import (
-    DynamicOutputDefinition,
-    OutputDefinition,
-    composite_solid,
-    pipeline,
-    solid,
-)
+from dagster._legacy import DynamicOutputDefinition, composite_solid, pipeline, solid
 
 
 @solid(output_defs=[DynamicOutputDefinition()])
@@ -29,26 +23,6 @@ def echo(x):
 @solid
 def add(x, y):
     return x + y
-
-
-def test_composite():
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match="Definition types must align",
-    ):
-
-        @composite_solid(output_defs=[OutputDefinition()])
-        def _should_fail():
-            return dynamic_solid()
-
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match="must be a DynamicOutputDefinition since it is downstream of dynamic output",
-    ):
-
-        @composite_solid(output_defs=[OutputDefinition()])
-        def _should_fail():
-            return dynamic_solid().map(echo)
 
 
 def test_fan_in():


### PR DESCRIPTION
### Summary & Motivation
OutputMapping previously required an OutputDefinition to be constructed. This removes the usage of OutputDefinition from OutputMapping, and adds a new construction method.

### How I Tested These Changes
