### PR TITLE
Airbyte Improvements (normalized tables, make destination_tables options)

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -32,7 +32,7 @@ def build_airbyte_assets(
     @multi_asset(
         name=f"airbyte_sync_{connection_id[:5]}",
         outs={
-            table: AssetOut(key=AssetKey(asset_key_prefix + [table]))
+            table: AssetOut(key=AssetKey(asset_key_prefix + [table]), is_required=False)
             for table in destination_tables
         },
         required_resource_keys={"airbyte"},


### PR DESCRIPTION
### Summary & Motivation

This is a set of enhancements for Airbyte integration.

#### Normalized tables

Airbyte supports built-in JSON normalizations, which could produce tables other than the stream output tables. Currently if you enable normalization:
![image](https://user-images.githubusercontent.com/82426/187723835-de8915a5-5be1-41c5-aa1b-66fce35c8c32.png)

For instance, in this connection:
![image](https://user-images.githubusercontent.com/82426/187723989-a6b3001e-29d0-4caa-9459-42f605b05788.png)

Airbyte will add additional normalized tables like `src_tasks_customfields`.

<img src="https://user-images.githubusercontent.com/82426/187724101-9dbcef64-868a-436b-8728-b8428a89dab7.png" width=200>

The issue is when I add this connection with `build_airbyte_assets`,  dagster will fail no outputs for non-optional outputs:

![image](https://user-images.githubusercontent.com/82426/187724321-65d03203-931a-433c-8f87-9a415f7e7b3b.png)

Turning the tables to optional would solve the issue (partially), however, in this case we will miss their materialization timestamps. Thus, I introduced a new optional parameter `transformation_tables`. Users (including myself) can add here all tables generated by airbyte in their downstream processes, like basic normalization or custom airbyte-dbt steps. 

### How I Tested These Changes

If things make sense, I'll add tests to it.