### PR TITLE
Custom labels for ingress object

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/ingress.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/ingress.py
@@ -46,6 +46,7 @@ class FlowerIngressConfiguration(BaseModel):
 class Ingress(BaseModel):
     enabled: bool
     apiVersion: Optional[str]
+    labels: kubernetes.Labels
     annotations: kubernetes.Annotations
     dagit: DagitIngressConfiguration
     readOnlyDagit: DagitIngressConfiguration

--- a/helm/dagster/templates/ingress-v1beta1.yaml
+++ b/helm/dagster/templates/ingress-v1beta1.yaml
@@ -8,6 +8,9 @@ metadata:
   name: {{ include "dagster.fullname" . }}-ingress
   labels:
     {{- include "dagster.labels" . | nindent 4 }}
+    {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | squote }}
+    {{- end }}
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ $value | squote }}

--- a/helm/dagster/templates/ingress.yaml
+++ b/helm/dagster/templates/ingress.yaml
@@ -8,6 +8,9 @@ metadata:
   name: {{ include "dagster.fullname" . }}-ingress
   labels:
     {{- include "dagster.labels" . | nindent 4 }}
+    {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | squote }}
+    {{- end }}
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ $value | squote }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -900,6 +900,12 @@
                 "startupProbe"
             ]
         },
+        "Labels": {
+            "title": "Labels",
+            "type": "object",
+            "properties": {},
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+        },
         "IngressPathType": {
             "title": "IngressPathType",
             "description": "An enumeration.",
@@ -1058,6 +1064,9 @@
                     "title": "Apiversion",
                     "type": "string"
                 },
+                "labels": {
+                    "$ref": "#/definitions/Labels"
+                },
                 "annotations": {
                     "$ref": "#/definitions/Annotations"
                 },
@@ -1073,6 +1082,7 @@
             },
             "required": [
                 "enabled",
+                "labels",
                 "annotations",
                 "dagit",
                 "readOnlyDagit",
@@ -1587,12 +1597,6 @@
                 "CustomRunLauncher"
             ],
             "type": "string"
-        },
-        "Labels": {
-            "title": "Labels",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
         },
         "CeleryWorkerQueue": {
             "title": "CeleryWorkerQueue",

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -843,6 +843,7 @@ ingress:
   enabled: false
 
   annotations: {}
+  labels: {}
 
   # Specify the IngressClass used to implement this ingress.
   #


### PR DESCRIPTION
Closes https://github.com/dagster-io/dagster/issues/9446

Per the issue we should have something like this available across all objects. Probably both a global default and a per object setting? But getting this out to unblock