### PR TITLE
Ignore warnings sent from the dagster module

### DIFF
--- a/examples/assets_dbt_python/tox.ini
+++ b/examples/assets_dbt_python/tox.ini
@@ -16,7 +16,7 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  pytest -vv
+  pytest -c ../../pyproject.toml -vv
 
 [testenv:mypy]
 commands =

--- a/examples/assets_modern_data_stack/tox.ini
+++ b/examples/assets_modern_data_stack/tox.ini
@@ -18,7 +18,7 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  pytest -vv
+  pytest -c ../../pyproject.toml -vv
 
 [testenv:mypy]
 commands =

--- a/examples/assets_pandas_pyspark/tox.ini
+++ b/examples/assets_pandas_pyspark/tox.ini
@@ -17,7 +17,7 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  pytest -vv
+  pytest -c ../../pyproject.toml -vv
 
 [testenv:mypy]
 commands =

--- a/examples/assets_pandas_type_metadata/tox.ini
+++ b/examples/assets_pandas_type_metadata/tox.ini
@@ -16,7 +16,7 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  pytest -vv
+  pytest -c ../../pyproject.toml -vv
 
 [testenv:mypy]
 commands =

--- a/examples/deploy_docker/tox.ini
+++ b/examples/deploy_docker/tox.ini
@@ -12,7 +12,7 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  pytest -vv {posargs}
+  pytest -c ../../pyproject.toml -vv {posargs}
 
 [testenv:mypy]
 commands =

--- a/examples/deploy_k8s/tox.ini
+++ b/examples/deploy_k8s/tox.ini
@@ -17,7 +17,7 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  pytest -vv {posargs}
+  pytest -c ../../pyproject.toml -vv {posargs}
 
 [testenv:mypy]
 commands =

--- a/examples/development_to_production/tox.ini
+++ b/examples/development_to_production/tox.ini
@@ -17,7 +17,7 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  pytest -vv {posargs}
+  pytest -c ../../pyproject.toml -vv {posargs}
 
 [testenv:mypy]
 commands =

--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -28,7 +28,7 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  pytest -vv {posargs}
+  pytest -c ../../pyproject.toml -vv {posargs}
 
 [testenv:mypy]
 commands =

--- a/examples/feature_graph_backed_assets/tox.ini
+++ b/examples/feature_graph_backed_assets/tox.ini
@@ -14,7 +14,7 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  pytest -vv
+  pytest -c ../../pyproject.toml -vv
 
 [testenv:mypy]
 commands =

--- a/examples/project_fully_featured/tox.ini
+++ b/examples/project_fully_featured/tox.ini
@@ -21,7 +21,7 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  pytest -vv
+  pytest -c ../../pyproject.toml -vv
 
 [testenv:mypy]
 commands =

--- a/examples/with_airflow/tox.ini
+++ b/examples/with_airflow/tox.ini
@@ -15,7 +15,7 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  pytest -vv
+  pytest -c ../../pyproject.toml -vv
 
 [testenv:mypy]
 commands =

--- a/examples/with_great_expectations/tox.ini
+++ b/examples/with_great_expectations/tox.ini
@@ -16,7 +16,7 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  pytest -vv
+  pytest -c ../../pyproject.toml -vv
 
 [testenv:mypy]
 commands =

--- a/examples/with_pyspark/tox.ini
+++ b/examples/with_pyspark/tox.ini
@@ -16,7 +16,7 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  pytest -vv
+  pytest -c ../../pyproject.toml -vv
 
 [testenv:mypy]
 commands =

--- a/examples/with_pyspark_emr/tox.ini
+++ b/examples/with_pyspark_emr/tox.ini
@@ -17,7 +17,7 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  pytest -vv
+  pytest -c ../../pyproject.toml -vv
 
 [testenv:mypy]
 commands =

--- a/integration_tests/python_modules/dagster-k8s-test-infra/tox.ini
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/tox.ini
@@ -20,7 +20,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_k8s_test_infra --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_k8s_test_infra --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ show_error_codes = true
 # [Docs root]
 #   https://pylint.pycqa.org/en/latest/
 # [Rule/options reference]
-#   https://pylint.pycqa.org/en/latest/technical_reference/features.html 
+#   https://pylint.pycqa.org/en/latest/technical_reference/features.html
 #   This is a comprehensive reference of all Pylint checkers/rules and seems to be one of the only
 #   docs pages that's actually maintained.
 # [Changelog]
@@ -128,10 +128,10 @@ disable=[
   'C',
 
   # [category] refactoring-related checks-- too much noise
-  'R', 
+  'R',
 
   # [checker] redundant with mypy
-  'typecheck',  
+  'typecheck',
 
   # There are many places where we want to catch a maximally generic exception.
   'bare-except',
@@ -154,4 +154,13 @@ disable=[
   # This rule is incompatible with SDAs, which have parameters named the same as upstream assets.
   'redefined-outer-name',
 
+]
+
+[tool.pytest.ini_options]
+
+filterwarnings = [
+  "ignore::dagster.ExperimentalWarning",
+  "ignore::DeprecationWarning",
+  "ignore::UserWarning",
+  "ignore::pytest.PytestCollectionWarning",
 ]

--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -14,7 +14,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=automation --cov-append --cov-report= {posargs}
+  pytest -c ../../pyproject.toml -vv --junitxml=test_results.xml --cov=automation --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/dagster-test/tox.ini
+++ b/python_modules/dagster-test/tox.ini
@@ -25,7 +25,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv -s -p dagster_test.fixtures --junitxml=test_results.xml --cov=dagster_test --cov-append --cov-report= {posargs}
+  pytest -c ../../pyproject.toml -vv -s -p dagster_test.fixtures --junitxml=test_results.xml --cov=dagster_test --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -21,17 +21,17 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
 
-  api_tests: pytest -vv ./dagster_tests/api_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
-  cli_tests: pytest -vv ./dagster_tests/cli_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
-  core_tests: pytest -vv ./dagster_tests/core_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
-  definitions_tests_old_pendulum: pytest -vv ./dagster_tests/core_tests/definitions_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
-  core_tests_old_sqlalchemy: pytest -vv ./dagster_tests/core_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
-  daemon_sensor_tests: pytest -vv ./dagster_tests/daemon_sensor_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
-  daemon_tests: pytest -vv ./dagster_tests/daemon_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
-  scheduler_tests: pytest -vv ./dagster_tests/scheduler_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
-  scheduler_tests_old_pendulum: pytest -vv ./dagster_tests/scheduler_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10  {posargs}
-  general_tests: pytest -vv ./dagster_tests/general_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10  {posargs}
-  execution_tests: pytest -vv ./dagster_tests/execution_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10  {posargs}
+  api_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/api_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
+  cli_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/cli_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
+  core_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
+  definitions_tests_old_pendulum: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests/definitions_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
+  core_tests_old_sqlalchemy: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
+  daemon_sensor_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/daemon_sensor_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
+  daemon_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/daemon_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
+  scheduler_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/scheduler_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
+  scheduler_tests_old_pendulum: pytest -c ../../pyproject.toml -vv ./dagster_tests/scheduler_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10  {posargs}
+  general_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/general_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10  {posargs}
+  execution_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10  {posargs}
 
 [testenv:mypy]
 commands =

--- a/python_modules/libraries/dagster-airbyte/tox.ini
+++ b/python_modules/libraries/dagster-airbyte/tox.ini
@@ -11,7 +11,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_airbyte --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_airbyte --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-aws/tox.ini
+++ b/python_modules/libraries/dagster-aws/tox.ini
@@ -18,7 +18,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_aws --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_aws --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-azure/tox.ini
+++ b/python_modules/libraries/dagster-azure/tox.ini
@@ -15,7 +15,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_azure --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_azure --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-celery-docker/tox.ini
+++ b/python_modules/libraries/dagster-celery-docker/tox.ini
@@ -20,7 +20,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_celery_docker --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_celery_docker --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-celery-k8s/tox.ini
+++ b/python_modules/libraries/dagster-celery-k8s/tox.ini
@@ -25,7 +25,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_celery_k8s --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_celery_k8s --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-celery/tox.ini
+++ b/python_modules/libraries/dagster-celery/tox.ini
@@ -22,7 +22,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_celery --cov-append --cov-report= {posargs} -s
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_celery --cov-append --cov-report= {posargs} -s
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-census/tox.ini
+++ b/python_modules/libraries/dagster-census/tox.ini
@@ -12,7 +12,7 @@ whitelist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_census --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_census --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-dask/tox.ini
+++ b/python_modules/libraries/dagster-dask/tox.ini
@@ -21,7 +21,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_dask --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_dask --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-databricks/tox.ini
+++ b/python_modules/libraries/dagster-databricks/tox.ini
@@ -17,7 +17,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_databricks --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_databricks --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-datadog/tox.ini
+++ b/python_modules/libraries/dagster-datadog/tox.ini
@@ -13,7 +13,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_datadog --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_datadog --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-datahub/tox.ini
+++ b/python_modules/libraries/dagster-datahub/tox.ini
@@ -15,7 +15,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_datahub --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_datahub --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -17,7 +17,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_dbt --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_dbt --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-docker/tox.ini
+++ b/python_modules/libraries/dagster-docker/tox.ini
@@ -23,7 +23,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_docker --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_docker --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-fivetran/tox.ini
+++ b/python_modules/libraries/dagster-fivetran/tox.ini
@@ -11,7 +11,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_fivetran --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_fivetran --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-ge/tox.ini
+++ b/python_modules/libraries/dagster-ge/tox.ini
@@ -16,7 +16,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_ge --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_ge --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-github/tox.ini
+++ b/python_modules/libraries/dagster-github/tox.ini
@@ -13,7 +13,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_github --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_github --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-mlflow/tox.ini
+++ b/python_modules/libraries/dagster-mlflow/tox.ini
@@ -13,7 +13,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_mlflow --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_mlflow --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-msteams/tox.ini
+++ b/python_modules/libraries/dagster-msteams/tox.ini
@@ -13,7 +13,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_msteams --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_msteams --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-mysql/tox.ini
+++ b/python_modules/libraries/dagster-mysql/tox.ini
@@ -13,7 +13,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_mysql --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_mysql --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-pagerduty/tox.ini
+++ b/python_modules/libraries/dagster-pagerduty/tox.ini
@@ -13,7 +13,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_pagerduty --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_pagerduty --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-papertrail/tox.ini
+++ b/python_modules/libraries/dagster-papertrail/tox.ini
@@ -13,7 +13,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_papertrail --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_papertrail --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-postgres/tox.ini
+++ b/python_modules/libraries/dagster-postgres/tox.ini
@@ -13,7 +13,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_postgres --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_postgres --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-prometheus/tox.ini
+++ b/python_modules/libraries/dagster-prometheus/tox.ini
@@ -13,7 +13,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_prometheus --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_prometheus --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-pyspark/tox.ini
@@ -15,7 +15,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_pyspark --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_pyspark --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-shell/tox.ini
+++ b/python_modules/libraries/dagster-shell/tox.ini
@@ -15,7 +15,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_shell --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_shell --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-slack/tox.ini
+++ b/python_modules/libraries/dagster-slack/tox.ini
@@ -13,7 +13,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_slack --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_slack --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-snowflake-pandas/tox.ini
+++ b/python_modules/libraries/dagster-snowflake-pandas/tox.ini
@@ -12,7 +12,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_snowflake_pandas --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_snowflake_pandas --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-snowflake/tox.ini
+++ b/python_modules/libraries/dagster-snowflake/tox.ini
@@ -14,7 +14,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_snowflake --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_snowflake --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-spark/tox.ini
+++ b/python_modules/libraries/dagster-spark/tox.ini
@@ -13,7 +13,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_spark --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_spark --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-ssh/tox.ini
+++ b/python_modules/libraries/dagster-ssh/tox.ini
@@ -15,7 +15,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_ssh --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_ssh --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-twilio/tox.ini
+++ b/python_modules/libraries/dagster-twilio/tox.ini
@@ -13,7 +13,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
-  pytest -vv --junitxml=test_results.xml --cov=dagster_twilio --cov-append --cov-report= {posargs}
+  pytest -c ../../../pyproject.toml -vv --junitxml=test_results.xml --cov=dagster_twilio --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'


### PR DESCRIPTION
### Summary & Motivation
The gigantic slew of warnings at the end of our builds makes it super annoying to figure out what errors are. This attempts to significantly reduce the number that appear.

### Testing
You can see that it works by looking at the requisite build; the number of warnings is vastly reduced.

