### PR TITLE
[dagit] Virtualized Jobs table

### DIFF
--- a/js_modules/dagit/packages/core/package.json
+++ b/js_modules/dagit/packages/core/package.json
@@ -31,6 +31,7 @@
     "styled-components": "^5.3.3"
   },
   "dependencies": {
+    "@tanstack/react-virtual": "3.0.0-beta.18",
     "@vx/shape": "^0.0.192",
     "amator": "^1.1.0",
     "ansi-to-react": "^5.1.0",

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedJobTable.stories.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedJobTable.stories.tsx
@@ -1,0 +1,68 @@
+import {Box, TextInput} from '@dagster-io/ui';
+import {Meta} from '@storybook/react/types-6-0';
+import faker from 'faker';
+import * as React from 'react';
+
+import {StorybookProvider} from '../testing/StorybookProvider';
+
+import {VirtualizedJobTable} from './VirtualizedJobTable';
+import {buildRepoAddress} from './buildRepoAddress';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'VirtualizedJobTable',
+  component: VirtualizedJobTable,
+} as Meta;
+
+const mocks = {
+  Pipeline: () => ({
+    isJob: () => true,
+    description: () => faker.random.words(4),
+  }),
+};
+
+export const Standard = () => {
+  const [searchValue, setSearchValue] = React.useState('');
+
+  const workspace = React.useMemo(() => {
+    const repos = new Array(100)
+      .fill(null)
+      .map(() =>
+        buildRepoAddress(
+          faker.random.word().toLocaleLowerCase(),
+          faker.random.word().toLocaleLowerCase(),
+        ),
+      );
+    return repos.map((repoAddress) => ({
+      repoAddress,
+      jobs: new Array(500)
+        .fill(null)
+        .map(() => faker.random.words(2).replace(' ', '-').toLocaleLowerCase()),
+    }));
+  }, []);
+
+  const onChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchValue(e.target.value);
+  }, []);
+
+  const filtered = React.useMemo(() => {
+    const searchLower = searchValue.toLocaleLowerCase();
+    return workspace
+      .map(({repoAddress, jobs}) => ({
+        repoAddress,
+        jobs: jobs.filter((name) => name.includes(searchLower)),
+      }))
+      .filter(({jobs}) => jobs.length > 0);
+  }, [searchValue, workspace]);
+
+  return (
+    <StorybookProvider apolloProps={{mocks}}>
+      <div style={{position: 'fixed', height: '100%', width: '100%'}}>
+        <Box padding={{horizontal: 24, vertical: 12}}>
+          <TextInput value={searchValue} onChange={onChange} placeholder="Search for a job…" />
+        </Box>
+        <VirtualizedJobTable repos={filtered} />
+      </div>
+    </StorybookProvider>
+  );
+};

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedJobTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedJobTable.tsx
@@ -1,0 +1,218 @@
+import {gql, useLazyQuery} from '@apollo/client';
+import {Box, Caption, Colors, Tag} from '@dagster-io/ui';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import * as React from 'react';
+import styled from 'styled-components/macro';
+
+import {RepoSectionHeader} from '../runs/RepoSectionHeader';
+import {useRepoExpansionState} from '../ui/useRepoExpansionState';
+
+import {buildPipelineSelector} from './WorkspaceContext';
+import {repoAddressAsString} from './repoAddressAsString';
+import {RepoAddress} from './types';
+import {SingleJobQuery, SingleJobQueryVariables} from './types/SingleJobQuery';
+import {workspacePathFromAddress} from './workspacePath';
+
+type Repository = {
+  repoAddress: RepoAddress;
+  jobs: string[];
+};
+
+interface Props {
+  repos: Repository[];
+}
+
+type RowType =
+  | {type: 'header'; repoAddress: RepoAddress; jobCount: number}
+  | {type: 'job'; repoAddress: RepoAddress; name: string};
+
+const JOBS_EXPANSION_STATE_STORAGE_KEY = 'jobs-virtualized-expansion-state';
+
+export const VirtualizedJobTable: React.FC<Props> = ({repos}) => {
+  const parentRef = React.useRef<HTMLDivElement | null>(null);
+  const {expandedKeys, onToggle} = useRepoExpansionState(JOBS_EXPANSION_STATE_STORAGE_KEY);
+
+  const flattened: RowType[] = React.useMemo(() => {
+    const flat: RowType[] = [];
+    repos.forEach(({repoAddress, jobs}) => {
+      flat.push({type: 'header', repoAddress, jobCount: jobs.length});
+      const repoKey = repoAddressAsString(repoAddress);
+      if (expandedKeys.includes(repoKey)) {
+        jobs.forEach((name) => {
+          flat.push({type: 'job', repoAddress, name});
+        });
+      }
+    });
+    return flat;
+  }, [repos, expandedKeys]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: flattened.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: (ii: number) => {
+      const row = flattened[ii];
+      return row?.type === 'header' ? 32 : 64;
+    },
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const items = rowVirtualizer.getVirtualItems();
+
+  return (
+    <>
+      <Container ref={parentRef}>
+        <Inner $totalHeight={totalHeight}>
+          {items.map(({index, key, size, start}) => {
+            const row: RowType = flattened[index];
+            const type = row!.type;
+            return type === 'header' ? (
+              <RepoRow
+                repoAddress={row.repoAddress}
+                jobCount={row.jobCount}
+                key={key}
+                height={size}
+                start={start}
+                onToggle={onToggle}
+              />
+            ) : (
+              <JobRow
+                key={key}
+                name={row.name}
+                repoAddress={row.repoAddress}
+                height={size}
+                start={start}
+              />
+            );
+          })}
+        </Inner>
+      </Container>
+    </>
+  );
+};
+
+const RepoRow: React.FC<{
+  repoAddress: RepoAddress;
+  jobCount: number;
+  height: number;
+  start: number;
+  onToggle: (repoAddress: RepoAddress) => void;
+}> = ({repoAddress, jobCount, height, start, onToggle}) => {
+  return (
+    <Row $height={height} $start={start}>
+      <RepoSectionHeader
+        repoName={repoAddress.name}
+        repoLocation={repoAddress.location}
+        expanded
+        onClick={() => onToggle(repoAddress)}
+        showLocation={false}
+        rightElement={<Tag intent="primary">{jobCount}</Tag>}
+      />
+    </Row>
+  );
+};
+
+const JOB_QUERY_DELAY = 300;
+
+const JobRow: React.FC<{name: string; repoAddress: RepoAddress; height: number; start: number}> = ({
+  name,
+  repoAddress,
+  height,
+  start,
+}) => {
+  const [queryJob, {data}] = useLazyQuery<SingleJobQuery, SingleJobQueryVariables>(
+    SINGLE_JOB_QUERY,
+    {
+      fetchPolicy: 'cache-and-network',
+      variables: {
+        selector: buildPipelineSelector(repoAddress, name),
+      },
+    },
+  );
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => {
+      queryJob();
+    }, JOB_QUERY_DELAY);
+
+    return () => clearTimeout(timer);
+  }, [queryJob, name]);
+
+  return (
+    <Row $height={height} $start={start}>
+      <Box
+        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        style={{display: 'grid', gridTemplateColumns: '30% 30% 30% 10%'}}
+      >
+        <Box
+          flex={{direction: 'column', gap: 4}}
+          style={{height}}
+          padding={{horizontal: 24, top: 12}}
+          border={{side: 'right', width: 1, color: Colors.KeylineGray}}
+        >
+          <div style={{whiteSpace: 'nowrap'}}>
+            <a href={workspacePathFromAddress(repoAddress, `/jobs/${name}`)}>{name}</a>
+          </div>
+          <div>
+            <Caption style={{color: Colors.Gray500}}>
+              {data?.pipelineOrError.__typename === 'Pipeline'
+                ? data.pipelineOrError.description
+                : ''}
+            </Caption>
+          </div>
+        </Box>
+        <Box
+          flex={{alignItems: 'center'}}
+          padding={{horizontal: 24}}
+          style={{color: Colors.Gray300}}
+        >
+          Loading
+        </Box>
+      </Box>
+    </Row>
+  );
+};
+
+const Container = styled.div`
+  height: 100%;
+  overflow: auto;
+`;
+
+type InnerProps = {
+  $totalHeight: number;
+};
+
+const Inner = styled.div.attrs<InnerProps>(({$totalHeight}) => ({
+  style: {
+    height: `${$totalHeight}px`,
+  },
+}))<InnerProps>`
+  position: relative;
+  width: 100%;
+`;
+
+type RowProps = {$height: number; $start: number};
+
+const Row = styled.div.attrs<RowProps>(({$height, $start}) => ({
+  style: {
+    height: `${$height}px`,
+    transform: `translateY(${$start}px)`,
+  },
+}))<RowProps>`
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+`;
+
+const SINGLE_JOB_QUERY = gql`
+  query SingleJobQuery($selector: PipelineSelector!) {
+    pipelineOrError(params: $selector) {
+      ... on Pipeline {
+        id
+        name
+        isJob
+        description
+      }
+    }
+  }
+`;

--- a/js_modules/dagit/packages/core/src/workspace/types/SingleJobQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/SingleJobQuery.ts
@@ -1,0 +1,32 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { PipelineSelector } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: SingleJobQuery
+// ====================================================
+
+export interface SingleJobQuery_pipelineOrError_PipelineNotFoundError {
+  __typename: "PipelineNotFoundError" | "InvalidSubsetError" | "PythonError";
+}
+
+export interface SingleJobQuery_pipelineOrError_Pipeline {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+  isJob: boolean;
+  description: string | null;
+}
+
+export type SingleJobQuery_pipelineOrError = SingleJobQuery_pipelineOrError_PipelineNotFoundError | SingleJobQuery_pipelineOrError_Pipeline;
+
+export interface SingleJobQuery {
+  pipelineOrError: SingleJobQuery_pipelineOrError;
+}
+
+export interface SingleJobQueryVariables {
+  selector: PipelineSelector;
+}

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -5570,6 +5570,7 @@ __metadata:
     "@storybook/builder-webpack5": ^6.4.13
     "@storybook/manager-webpack5": ^6.4.13
     "@storybook/react": ^6.4.13
+    "@tanstack/react-virtual": 3.0.0-beta.18
     "@testing-library/dom": ^8.11.1
     "@testing-library/jest-dom": ^5.16.1
     "@testing-library/react": ^12.1.2
@@ -9185,6 +9186,24 @@ __metadata:
     "@svgr/plugin-jsx": ^6.2.1
     "@svgr/plugin-svgo": ^6.2.0
   checksum: 3da7e61942d7fc3c5cdd0ffd2fbc5520168bc75bf783920e843e920bdc462f9869d47a16ca37be9f3435c90eb89c0d4acd044a0f2e1ad478ff2bc90d65e6c2dd
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-virtual@npm:3.0.0-beta.18":
+  version: 3.0.0-beta.18
+  resolution: "@tanstack/react-virtual@npm:3.0.0-beta.18"
+  dependencies:
+    "@tanstack/virtual-core": 3.0.0-beta.18
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: e6d948b54179069776051434f021297d717d8cc911d8a9f71a6deac6ea9cb5f6438964049a5552265f0d97d2be584be4a68f95e60bcd859eb8c7ed07d277a155
+  languageName: node
+  linkType: hard
+
+"@tanstack/virtual-core@npm:3.0.0-beta.18":
+  version: 3.0.0-beta.18
+  resolution: "@tanstack/virtual-core@npm:3.0.0-beta.18"
+  checksum: fbf73de3c9cc296a14b262258e6c8da4826c744fc7ce98669b1c2692341313ffa4e34a13d20c3980f23b340720d7c771136b7f2673aa91d14558ddc086b92d1c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary & Motivation

A proof of concept for a scalable virtualized table for showing a list of jobs, then lazy-loading the details when the job is scrolled into view. Storybook example contains 100 repos with 500 jobs each (50k jobs total), and a search input.

https://user-images.githubusercontent.com/2823852/188006648-7071999e-ae7f-4ddb-b4db-4287f6d767a2.mov

### How I Tested These Changes

yarn storybook
