### PR TITLE
Expose dagster._core.definitions.events.HookExecutionResult

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -162,6 +162,7 @@ from dagster._core.definitions.events import (
     DynamicOutput as DynamicOutput,
     ExpectationResult as ExpectationResult,
     Failure as Failure,
+    HookExecutionResult as HookExecutionResult,
     Output as Output,
     RetryRequested as RetryRequested,
     TypeCheck as TypeCheck,


### PR DESCRIPTION
### Summary & Motivation
As in https://github.com/dagster-io/dagster/pull/8981, `dagster.core.*` are considered private and user code should not depend on them. However, we have an op hook that looks into the given `events: List[DagsterEvent]` and do actual work if some condition is met (i.e. it's not a simple success/failure hook). The hook implementation directly uses `dagster.core.definitions.events.HookExecutionResult` as it's the expected return type of the hook impl function.
 I think it'd be nice if `HookExecutionResult` is publicly accessible from such op hooks.

### How I Tested These Changes
Tests passed in my local dev environment. Also confirmed `dagster.HookExecutionResult` is accessible.