### PR TITLE
Convert singleton comparisons from equality to identity

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_job_retries.py
+++ b/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_job_retries.py
@@ -20,5 +20,5 @@ def test_instance(docs_snippets_folder):
         os.path.join(docs_snippets_folder, "deploying", "dagster_instance")
     )
 
-    assert ref.settings["run_retries"]["enabled"] == True
+    assert ref.settings["run_retries"]["enabled"] is True
     assert ref.settings["run_retries"]["max_retries"] == 3

--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -217,7 +217,7 @@ def test_run_monitoring(
 
     instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
 
-    assert instance["run_monitoring"]["enabled"] == True
+    assert instance["run_monitoring"]["enabled"] is True
 
 
 def test_run_retries(
@@ -233,7 +233,7 @@ def test_run_retries(
 
     instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
 
-    assert instance["run_retries"]["enabled"] == True
+    assert instance["run_retries"]["enabled"] is True
 
 
 def test_daemon_labels(template: HelmTemplate):
@@ -267,7 +267,7 @@ def test_sensor_threading(instance_template: HelmTemplate):
     instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
     sensors_config = instance["sensors"]
     assert sensors_config.keys() == sensors_daemon_config().config_type.fields.keys()
-    assert instance["sensors"]["use_threads"] == True
+    assert instance["sensors"]["use_threads"] is True
     assert instance["sensors"]["num_workers"] == 4
 
 

--- a/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
+++ b/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
@@ -257,7 +257,7 @@ def test_strategy(instance: DagsterInstance):
         instance,
         status=PipelineRunStatus.FAILURE,
     )
-    assert get_reexecution_strategy(run, instance) == None
+    assert get_reexecution_strategy(run, instance) is None
 
     run = create_run(
         instance,
@@ -278,4 +278,4 @@ def test_strategy(instance: DagsterInstance):
         status=PipelineRunStatus.FAILURE,
         tags={RETRY_STRATEGY_TAG: "not a strategy"},
     )
-    assert get_reexecution_strategy(run, instance) == None
+    assert get_reexecution_strategy(run, instance) is None

--- a/integration_tests/test_suites/daemon-test-suite/test_dagster_daemon_health.py
+++ b/integration_tests/test_suites/daemon-test-suite/test_dagster_daemon_health.py
@@ -236,7 +236,7 @@ def test_error_daemon(monkeypatch):
                         heartbeat_interval_seconds=heartbeat_interval_seconds,
                     )[SensorDaemon.daemon_type()]
 
-                    assert status.healthy == False
+                    assert status.healthy is False
 
                     # Errors build up until there are > 5, then pull off the last
                     if len(status.last_heartbeat.errors) >= 5:
@@ -354,7 +354,7 @@ def test_multiple_error_daemon(monkeypatch):
                         instance, [SensorDaemon.daemon_type()], now.float_timestamp
                     )[SensorDaemon.daemon_type()]
 
-                    if status.healthy == False and len(status.last_heartbeat.errors) == 2:
+                    if status.healthy is False and len(status.last_heartbeat.errors) == 2:
                         assert status.last_heartbeat.errors[0].message.strip() == "bizbuz"
                         assert status.last_heartbeat.errors[1].message.strip() == "foobar"
                         break

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -308,7 +308,7 @@ def _get_in_progress_runs_for_assets(
 
         selected_assets = (
             set.union(*[asset_key_by_step_key[run_step_key] for run_step_key in run_step_keys])
-            if asset_selection == None
+            if asset_selection is None
             else cast(frozenset, asset_selection)
         )  # only display in progress/unstarted indicators for selected assets
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -164,7 +164,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         return external_partition_sets[0]
 
     def _get_records(self, graphene_info):
-        if self._records == None:
+        if self._records is None:
             filters = RunsFilter.for_backfill(self._backfill_job.backfill_id)
             self._records = graphene_info.context.instance.get_run_records(
                 filters=filters,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -648,7 +648,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         assert result.data["assetNodes"]
         asset_node = result.data["assetNodes"][0]
         assert len(asset_node["latestMaterializationByPartition"]) == 1
-        assert asset_node["latestMaterializationByPartition"][0] == None
+        assert asset_node["latestMaterializationByPartition"][0] is None
 
         result = execute_dagster_graphql(
             graphql_context,
@@ -677,7 +677,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         new_start_time = materialization["stepStats"]["startTime"]
         assert new_start_time > start_time
 
-        assert asset_node["latestMaterializationByPartition"][1] == None
+        assert asset_node["latestMaterializationByPartition"][1] is None
 
     def test_materialization_count_by_partition(self, graphql_context):
         # test for unpartitioned asset
@@ -824,8 +824,8 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         assert result.data["assetsLatestInfo"]
         result = get_response_by_asset(result.data["assetsLatestInfo"])
 
-        assert result["asset_1"]["latestRun"] == None
-        assert result["asset_1"]["latestMaterialization"] == None
+        assert result["asset_1"]["latestRun"] is None
+        assert result["asset_1"]["latestMaterialization"] is None
         assert result["asset_1"]["computeStatus"] == "NONE"
 
         # Test with 1 run on all assets
@@ -851,10 +851,10 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         assert result["asset_1"]["latestMaterialization"]["runId"] == first_run_id
         assert result["asset_1"]["computeStatus"] == "UP_TO_DATE"
         assert result["asset_2"]["latestRun"]["id"] == first_run_id
-        assert result["asset_2"]["latestMaterialization"] == None
+        assert result["asset_2"]["latestMaterialization"] is None
         assert result["asset_2"]["computeStatus"] == "NONE"
         assert result["asset_3"]["latestRun"]["id"] == first_run_id
-        assert result["asset_3"]["latestMaterialization"] == None
+        assert result["asset_3"]["latestMaterialization"] is None
         assert result["asset_3"]["computeStatus"] == "NONE"
 
         # Confirm that asset selection is respected
@@ -1129,12 +1129,12 @@ class TestPersistentInstanceAssetInProgress(ExecutingGraphQLContextTestMatrix):
             assert assets_live_info[0]["inProgressRunIds"] == []
 
             assert assets_live_info[1]["assetKey"]["path"] == ["hanging_asset"]
-            assert assets_live_info[1]["latestMaterialization"] == None
+            assert assets_live_info[1]["latestMaterialization"] is None
             assert assets_live_info[1]["unstartedRunIds"] == []
             assert assets_live_info[1]["inProgressRunIds"] == [run_id]
 
             assert assets_live_info[2]["assetKey"]["path"] == ["never_runs_asset"]
-            assert assets_live_info[2]["latestMaterialization"] == None
+            assert assets_live_info[2]["latestMaterialization"] is None
             assert assets_live_info[2]["unstartedRunIds"] == [run_id]
             assert assets_live_info[2]["inProgressRunIds"] == []
 
@@ -1186,12 +1186,12 @@ class TestPersistentInstanceAssetInProgress(ExecutingGraphQLContextTestMatrix):
             assert len(assets_live_info) == 2
 
             assert assets_live_info[1]["assetKey"]["path"] == ["hanging_graph"]
-            assert assets_live_info[1]["latestMaterialization"] == None
+            assert assets_live_info[1]["latestMaterialization"] is None
             assert assets_live_info[1]["unstartedRunIds"] == []
             assert assets_live_info[1]["inProgressRunIds"] == [run_id]
 
             assert assets_live_info[0]["assetKey"]["path"] == ["downstream_asset"]
-            assert assets_live_info[0]["latestMaterialization"] == None
+            assert assets_live_info[0]["latestMaterialization"] is None
             assert assets_live_info[0]["unstartedRunIds"] == [run_id]
             assert assets_live_info[0]["inProgressRunIds"] == []
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_composites.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_composites.py
@@ -88,7 +88,7 @@ class TestComposites(NonLaunchableGraphQLContextTestMatrix):
         result = execute_dagster_graphql(
             graphql_context, SOLID_ID_QUERY, {"selector": selector, "id": "bonkahog"}
         )
-        assert result.data["pipelineOrError"]["solidHandle"] == None
+        assert result.data["pipelineOrError"]["solidHandle"] is None
 
     def test_recurse_composites_depends(self, graphql_context):
         selector = infer_pipeline_selector(graphql_context, "composites_pipeline")

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_dynamic_pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_dynamic_pipeline.py
@@ -285,18 +285,18 @@ def test_dynamic_dep_fields(graphql_context):
     assert not result.errors
     solids = {solid["name"]: solid for solid in result.data["pipelineOrError"]["solids"]}
 
-    assert solids["emit_ten"]["isDynamicMapped"] == False
-    assert solids["emit_ten"]["outputs"][0]["definition"]["isDynamic"] == False
+    assert solids["emit_ten"]["isDynamicMapped"] is False
+    assert solids["emit_ten"]["outputs"][0]["definition"]["isDynamic"] is False
 
-    assert solids["emit"]["isDynamicMapped"] == False
-    assert solids["emit"]["outputs"][0]["definition"]["isDynamic"] == True
+    assert solids["emit"]["isDynamicMapped"] is False
+    assert solids["emit"]["outputs"][0]["definition"]["isDynamic"] is True
 
-    assert solids["multiply_inputs"]["isDynamicMapped"] == True
+    assert solids["multiply_inputs"]["isDynamicMapped"] is True
 
-    assert solids["multiply_by_two"]["isDynamicMapped"] == True
+    assert solids["multiply_by_two"]["isDynamicMapped"] is True
 
-    assert solids["sum_numbers"]["isDynamicMapped"] == False
-    assert solids["sum_numbers"]["inputs"][0]["isDynamicCollect"] == True
+    assert solids["sum_numbers"]["isDynamicMapped"] is False
+    assert solids["sum_numbers"]["inputs"][0]["isDynamicCollect"] is True
 
-    assert solids["double_total"]["isDynamicMapped"] == False
-    assert solids["double_total"]["inputs"][0]["isDynamicCollect"] == False
+    assert solids["double_total"]["isDynamicMapped"] is False
+    assert solids["double_total"]["inputs"][0]["isDynamicCollect"] is False

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_execute_pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_execute_pipeline.py
@@ -858,7 +858,7 @@ def get_step_output_event(logs, step_key, output_name="result"):
 
 class TestExecutePipelineReadonlyFailure(ReadonlyGraphQLContextTestMatrix):
     def test_start_pipeline_execution_readonly_failure(self, graphql_context):
-        assert graphql_context.read_only == True
+        assert graphql_context.read_only is True
 
         selector = infer_pipeline_selector(graphql_context, "csv_hello_world")
         result = execute_dagster_graphql(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -639,7 +639,7 @@ def test_start_schedule_with_default_status(graphql_context):
 
 class TestSchedulePermissions(ReadonlyGraphQLContextTestMatrix):
     def test_start_schedule_failure(self, graphql_context):
-        assert graphql_context.read_only == True
+        assert graphql_context.read_only is True
 
         schedule_selector = infer_schedule_selector(
             graphql_context, "no_config_pipeline_hourly_schedule"

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -186,7 +186,7 @@ class ReconstructablePipeline(
             )
 
         check.invariant(
-            self.asset_selection == None, "Asset selection cannot be provided with a pipeline"
+            self.asset_selection is None, "Asset selection cannot be provided with a pipeline"
         )
         return (
             self.repository.get_definition().get_pipeline(self.pipeline_name)

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -940,7 +940,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
                     return
 
                 # because the materialization_fn can yield results (see _wrapped_fn in multi_asset_sensor decorator),
-                # even if you return None in a sensor, it will still cause in inspect.isgenerator(result) == True.
+                # even if you return None in a sensor, it will still cause in inspect.isgenerator(result) to be True.
                 # So keep track to see if we actually return any values and should update the cursor
                 runs_yielded = False
                 if inspect.isgenerator(result) or isinstance(result, list):

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/001_initial_1.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/001_initial_1.py
@@ -78,7 +78,7 @@ def upgrade():
 
         op.execute(
             SqlEventLogStorageTable.update(None)
-            .where(SqlEventLogStorageTable.c.run_id == None)
+            .where(SqlEventLogStorageTable.c.run_id.is_(None))
             .values({"run_id": context.config.attributes.get("run_id", None)})
         )
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -958,7 +958,7 @@ class SqlEventLogStorage(EventLogStorage):
         if self.has_secondary_index(ASSET_KEY_INDEX_COLS):
             query = query.where(
                 db.or_(
-                    AssetKeyTable.c.wipe_timestamp == None,
+                    AssetKeyTable.c.wipe_timestamp.is_(None),
                     AssetKeyTable.c.last_materialization_timestamp > AssetKeyTable.c.wipe_timestamp,
                 )
             )

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -167,7 +167,7 @@ def migrate_run_repo_tags(run_storage: RunStorage, print_fn=None):
         .select_from(
             RunsTable.join(subquery, RunsTable.c.run_id == subquery.c.tags_run_id, isouter=True)
         )
-        .where(subquery.c.tags_run_id == None)
+        .where(subquery.c.tags_run_id.is_(None))
         .order_by(db.asc(RunsTable.c.id))
         .limit(CHUNK_SIZE)
     )
@@ -222,7 +222,7 @@ def migrate_bulk_actions(run_storage: RunStorage, print_fn=None):
 
     base_query = (
         db.select([BulkActionsTable.c.body, BulkActionsTable.c.id])
-        .where(BulkActionsTable.c.action_type == None)
+        .where(BulkActionsTable.c.action_type.is_(None))
         .order_by(db.asc(BulkActionsTable.c.id))
         .limit(CHUNK_SIZE)
     )

--- a/python_modules/dagster/dagster/_core/storage/schedules/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/migration.py
@@ -74,7 +74,7 @@ def add_selector_id_to_jobs_table(storage, print_fn=None):
             conn.execute(
                 JobTable.update()  # pylint: disable=no-value-for-parameter
                 .where(JobTable.c.id == row_id)
-                .where(JobTable.c.selector_id == None)
+                .where(JobTable.c.selector_id.is_(None))
                 .values(selector_id=state.selector_id)
             )
 
@@ -98,7 +98,7 @@ def add_selector_id_to_ticks_table(storage, print_fn=None):
             conn.execute(
                 JobTickTable.update()  # pylint: disable=no-value-for-parameter
                 .where(JobTickTable.c.job_origin_id == state.instigator_origin_id)
-                .where(JobTickTable.c.selector_id == None)
+                .where(JobTickTable.c.selector_id.is_(None))
                 .values(selector_id=state.selector_id)
             )
 

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -308,7 +308,7 @@ class SqlScheduleStorage(ScheduleStorage):
                 db.or_(
                     JobTickTable.c.selector_id == selector_id,
                     db.and_(
-                        JobTickTable.c.selector_id == None,
+                        JobTickTable.c.selector_id.is_(None),
                         JobTickTable.c.job_origin_id == origin_id,
                     ),
                 )
@@ -392,7 +392,7 @@ class SqlScheduleStorage(ScheduleStorage):
                 db.or_(
                     JobTickTable.c.selector_id == selector_id,
                     db.and_(
-                        JobTickTable.c.selector_id == None,
+                        JobTickTable.c.selector_id.is_(None),
                         JobTickTable.c.job_origin_id == origin_id,
                     ),
                 )

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -340,7 +340,7 @@ def _get_instance_telemetry_enabled(instance):
 
 def get_or_set_instance_id():
     instance_id = _get_telemetry_instance_id()
-    if instance_id == None:
+    if instance_id is None:
         instance_id = _set_telemetry_instance_id()
     return instance_id
 

--- a/python_modules/dagster/dagster/_core/utils.py
+++ b/python_modules/dagster/dagster/_core/utils.py
@@ -103,6 +103,6 @@ def parse_env_var(env_var_str: str) -> Tuple[str, str]:
         return (split[0], split[1])
     else:
         env_var_value = os.getenv(env_var_str)
-        if env_var_value == None:
+        if env_var_value is None:
             raise Exception(f"Tried to load environment variable {env_var_str}, but it was not set")
         return (env_var_str, cast(str, env_var_value))

--- a/python_modules/dagster/dagster/_daemon/workspace.py
+++ b/python_modules/dagster/dagster/_daemon/workspace.py
@@ -35,7 +35,7 @@ class BaseDaemonWorkspace(IWorkspace):
         return self
 
     def get_workspace_snapshot(self) -> Dict[str, WorkspaceLocationEntry]:
-        if self._location_entries == None:
+        if self._location_entries is None:
             self._location_entries = self._load_workspace()
         return self._location_entries.copy()
 
@@ -47,7 +47,7 @@ class BaseDaemonWorkspace(IWorkspace):
         return DaemonIterationWorkspace(self.get_workspace_snapshot())
 
     def get_repository_location(self, location_name: str) -> RepositoryLocation:
-        if self._location_entries == None:
+        if self._location_entries is None:
             self._location_entries = self._load_workspace()
 
         if location_name not in self._location_entries:

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -106,7 +106,7 @@ class ExecuteRunArgs(
             set_exit_code_on_failure=(
                 True
                 if check.opt_bool_param(set_exit_code_on_failure, "set_exit_code_on_failure")
-                == True
+                is True
                 else None
             ),  # for back-compat
         )
@@ -151,7 +151,7 @@ class ResumeRunArgs(
             set_exit_code_on_failure=(
                 True
                 if check.opt_bool_param(set_exit_code_on_failure, "set_exit_code_on_failure")
-                == True
+                is True
                 else None
             ),  # for back-compat
         )

--- a/python_modules/dagster/dagster/_serdes/ipc.py
+++ b/python_modules/dagster/dagster/_serdes/ipc.py
@@ -162,7 +162,7 @@ def ipc_read_event_stream(file_path, timeout=30, ipc_process=None):
 
     with open(os.path.abspath(file_path), "r", encoding="utf8") as file_pointer:
         message = _process_line(file_pointer)
-        while elapsed_time < timeout and message == None:
+        while elapsed_time < timeout and message is None:
             _poll_process(ipc_process)
             elapsed_time += sleep_interval
             sleep(sleep_interval)
@@ -177,7 +177,7 @@ def ipc_read_event_stream(file_path, timeout=30, ipc_process=None):
 
         message = _process_line(file_pointer)
         while not isinstance(message, IPCEndMessage):
-            if message == None:
+            if message is None:
                 _poll_process(ipc_process)
             yield message
             message = _process_line(file_pointer)

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -98,7 +98,7 @@ class TestScheduleStorage:
         schedule = schedules[0]
         assert schedule.instigator_name == "my_schedule"
         assert schedule.instigator_data.cron_schedule == "* * * * *"
-        assert schedule.instigator_data.start_timestamp == None
+        assert schedule.instigator_data.start_timestamp is None
 
     def test_add_multiple_schedules(self, storage):
         assert storage
@@ -130,7 +130,7 @@ class TestScheduleStorage:
         schedule = storage.get_instigator_state(state.instigator_origin_id, state.selector_id)
 
         assert schedule.instigator_name == "my_schedule"
-        assert schedule.instigator_data.start_timestamp == None
+        assert schedule.instigator_data.start_timestamp is None
 
     def test_get_schedule_state_not_found(self, storage):
         assert storage
@@ -184,7 +184,7 @@ class TestScheduleStorage:
         schedule = schedules[0]
         assert schedule.instigator_name == "my_schedule"
         assert schedule.status == InstigatorStatus.STOPPED
-        assert schedule.instigator_data.start_timestamp == None
+        assert schedule.instigator_data.start_timestamp is None
 
     def test_update_schedule_not_found(self, storage):
         assert storage
@@ -256,7 +256,7 @@ class TestScheduleStorage:
         assert tick.timestamp == current_time
         assert tick.status == TickStatus.STARTED
         assert tick.run_ids == []
-        assert tick.error == None
+        assert tick.error is None
 
     def test_update_tick_to_success(self, storage):
         assert storage
@@ -276,7 +276,7 @@ class TestScheduleStorage:
         assert tick.timestamp == current_time
         assert tick.status == TickStatus.SUCCESS
         assert tick.run_ids == ["1234"]
-        assert tick.error == None
+        assert tick.error is None
 
     def test_update_tick_to_skip(self, storage):
         assert storage
@@ -296,7 +296,7 @@ class TestScheduleStorage:
         assert tick.timestamp == current_time
         assert tick.status == TickStatus.SKIPPED
         assert tick.run_ids == []
-        assert tick.error == None
+        assert tick.error is None
 
     def test_update_tick_to_failure(self, storage):
         assert storage
@@ -472,7 +472,7 @@ class TestScheduleStorage:
         assert tick.timestamp == current_time
         assert tick.status == TickStatus.STARTED
         assert tick.run_ids == []
-        assert tick.error == None
+        assert tick.error is None
 
     def test_get_sensor_tick(self, storage):
         assert storage
@@ -515,7 +515,7 @@ class TestScheduleStorage:
         assert tick.timestamp == current_time
         assert tick.status == TickStatus.SUCCESS
         assert tick.run_ids == ["1234"]
-        assert tick.error == None
+        assert tick.error is None
 
     def test_update_sensor_tick_to_skip(self, storage):
         assert storage
@@ -536,7 +536,7 @@ class TestScheduleStorage:
         assert tick.timestamp == current_time
         assert tick.status == TickStatus.SKIPPED
         assert tick.run_ids == []
-        assert tick.error == None
+        assert tick.error is None
 
     def test_update_sensor_tick_to_failure(self, storage):
         assert storage

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_pipeline.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_pipeline.py
@@ -26,7 +26,7 @@ def test_pipeline_snapshot_api_grpc(instance):
 
         external_pipeline_subset_result = _test_pipeline_subset_grpc(pipeline_handle, api_client)
         assert isinstance(external_pipeline_subset_result, ExternalPipelineSubsetResult)
-        assert external_pipeline_subset_result.success == True
+        assert external_pipeline_subset_result.success is True
         assert external_pipeline_subset_result.external_pipeline_data.name == "foo"
 
 
@@ -41,7 +41,7 @@ def test_pipeline_with_valid_subset_snapshot_api_grpc(instance):
             pipeline_handle, api_client, ["do_something"]
         )
         assert isinstance(external_pipeline_subset_result, ExternalPipelineSubsetResult)
-        assert external_pipeline_subset_result.success == True
+        assert external_pipeline_subset_result.success is True
         assert external_pipeline_subset_result.external_pipeline_data.name == "foo"
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_defaults.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_defaults.py
@@ -193,4 +193,4 @@ def test_post_process_config():
         "mau": "mau",
     }
     assert post_process_config(noneable_permissive_config_type, {"args": {}}).value["args"] == {}
-    assert post_process_config(noneable_permissive_config_type, None).value["args"] == None
+    assert post_process_config(noneable_permissive_config_type, None).value["args"] is None

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_source_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_source_types.py
@@ -91,8 +91,8 @@ def test_bool_source():
 
     with environ({"DAGSTER_TEST_ENV_VAR": ""}):
         assert process_config(BoolSource, {"env": "DAGSTER_TEST_ENV_VAR"}).success
-        assert process_config(BoolSource, {"env": "DAGSTER_TEST_ENV_VAR"}).value == False
+        assert process_config(BoolSource, {"env": "DAGSTER_TEST_ENV_VAR"}).value is False
 
     with environ({"DAGSTER_TEST_ENV_VAR": "True"}):
         assert process_config(BoolSource, {"env": "DAGSTER_TEST_ENV_VAR"}).success
-        assert process_config(BoolSource, {"env": "DAGSTER_TEST_ENV_VAR"}).value == True
+        assert process_config(BoolSource, {"env": "DAGSTER_TEST_ENV_VAR"}).value is True

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_autoalias.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_autoalias.py
@@ -17,7 +17,7 @@ def test_pipeline_autoalias():
         echo(echo(echo(hello())))
 
     result = execute_pipeline(autopipe)
-    assert result.success == True
+    assert result.success is True
     assert result.result_for_handle("echo_3").output_value() == "hello"
     assert result.result_for_handle("echo_2").output_value() == "hello"
     assert result.result_for_handle("echo").output_value() == "hello"
@@ -34,7 +34,7 @@ def test_composite_autoalias():
         mega_echo(hello())
 
     result = execute_pipeline(autopipe)
-    assert result.success == True
+    assert result.success is True
     assert result.result_for_handle("mega_echo.echo_3").output_value() == "hello"
     assert result.result_for_handle("mega_echo.echo_2").output_value() == "hello"
     assert result.result_for_handle("mega_echo.echo").output_value() == "hello"

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions.py
@@ -105,7 +105,7 @@ def test_solid_def_receives_version():
     def solid_no_version(_):
         pass
 
-    assert solid_no_version.version == None
+    assert solid_no_version.version is None
 
     @solid(version="42")
     def solid_with_version(_):

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_input_defaults.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_input_defaults.py
@@ -19,7 +19,7 @@ def test_none():
         return x
 
     result = execute_solid(none_x)
-    assert result.output_value() == None
+    assert result.output_value() is None
 
 
 def test_none_infer():
@@ -28,7 +28,7 @@ def test_none_infer():
         return x
 
     result = execute_solid(none_x)
-    assert result.output_value() == None
+    assert result.output_value() is None
 
 
 def test_int():
@@ -78,8 +78,8 @@ def bad_default(x):
 
 def test_mismatch():
     result = execute_solid(bad_default, raise_on_error=False)
-    assert result.success == False
-    assert result.input_events_during_compute[0].step_input_data.type_check_data.success == False
+    assert result.success is False
+    assert result.input_events_during_compute[0].step_input_data.type_check_data.success is False
 
 
 def test_env_precedence():
@@ -88,7 +88,7 @@ def test_env_precedence():
         run_config={"solids": {"bad_default": {"inputs": {"x": 1}}}},
         raise_on_error=False,
     )
-    assert result.success == True
+    assert result.success is True
     assert result.output_value() == 1
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_preset_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_preset_definition.py
@@ -81,16 +81,16 @@ def test_presets():
     assert execute_pipeline(pipe, preset="passing").success
 
     assert execute_pipeline(pipe, preset="passing_direct_dict").success
-    assert execute_pipeline(pipe, preset="failing_1", raise_on_error=False).success == False
+    assert execute_pipeline(pipe, preset="failing_1", raise_on_error=False).success is False
 
-    assert execute_pipeline(pipe, preset="failing_2", raise_on_error=False).success == False
+    assert execute_pipeline(pipe, preset="failing_2", raise_on_error=False).success is False
 
     with pytest.raises(DagsterInvariantViolationError, match="Could not find preset"):
         execute_pipeline(pipe, preset="not_failing", raise_on_error=False)
 
     assert (
         execute_pipeline(pipe, preset="passing_overide_to_fail", raise_on_error=False).success
-        == False
+        is False
     )
 
     assert execute_pipeline(

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
@@ -619,7 +619,7 @@ def test_resource_no_version():
     def no_version_resource(_):
         pass
 
-    assert no_version_resource.version == None
+    assert no_version_resource.version is None
 
 
 def test_resource_passed_version():

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/config_schema_tests/test_config_schema.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/config_schema_tests/test_config_schema.py
@@ -36,8 +36,8 @@ def test_dagster_type_loader_default_version():
     def _foo(_, hello):
         return hello
 
-    assert _foo.loader_version == None
-    assert _foo.compute_loaded_input_version({}) == None
+    assert _foo.loader_version is None
+    assert _foo.compute_loaded_input_version({}) is None
 
 
 def test_dagster_type_loader_provided_version():

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
@@ -101,7 +101,7 @@ def test_parse_clause():
 
 
 def test_parse_clause_invalid():
-    assert parse_clause("1+some_solid") == None
+    assert parse_clause("1+some_solid") is None
 
 
 def test_parse_solid_selection_single():

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -2017,12 +2017,12 @@ class TestEventLogStorage:
                 ][0]
                 assert asset_entry.last_materialization.dagster_event == materialize_event
                 assert asset_entry.last_run_id == result.run_id
-                assert asset_entry.asset_details == None
+                assert asset_entry.asset_details is None
 
                 if self.can_wipe():
                     storage.wipe_asset(my_asset_key)
 
-                    # confirm that last_run_id == None when asset is wiped
+                    # confirm that last_run_id is None when asset is wiped
                     assert len(storage.get_asset_records([my_asset_key])) == 0
 
                     result = _execute_job_and_store_events(
@@ -2078,7 +2078,7 @@ class TestEventLogStorage:
                 for event in events:
                     storage.store_event(event)
                 asset_entry = storage.get_asset_records([asset_key])[0].asset_entry
-                assert asset_entry.last_run_id == None
+                assert asset_entry.last_run_id is None
 
                 events, result = _synthesize_events(
                     lambda: materialize_asset(),
@@ -2102,7 +2102,7 @@ class TestEventLogStorage:
                     for event in events:
                         storage.store_event(event)
                     asset_entry = storage.get_asset_records([asset_key])[0].asset_entry
-                    assert asset_entry.last_run_id == None
+                    assert asset_entry.last_run_id is None
 
     def test_last_run_id_updates_on_materialization_planned(self, storage, instance):
         @asset
@@ -2134,7 +2134,7 @@ class TestEventLogStorage:
                 if self.can_wipe():
                     storage.wipe_asset(asset_key)
 
-                    # confirm that last_run_id == None when asset is wiped
+                    # confirm that last_run_id is None when asset is wiped
                     assert len(storage.get_asset_records([asset_key])) == 0
 
                     result = _execute_job_and_store_events(
@@ -2268,7 +2268,7 @@ class TestEventLogStorage:
             pytest.skip("storage does not support event consumer queries")
 
         storage.wipe()
-        assert storage.get_maximum_record_id() == None
+        assert storage.get_maximum_record_id() is None
 
         storage.store_event(
             EventLogEntry(

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -975,7 +975,7 @@ def test_single_step_reexecution():
     )
 
     assert reexecution_result.success
-    assert reexecution_result.result_for_solid("return_one").output_value() == None
+    assert reexecution_result.result_for_solid("return_one").output_value() is None
     assert reexecution_result.result_for_solid("add_one").output_value() == 2
 
 
@@ -1005,7 +1005,7 @@ def test_two_step_reexecution():
         step_selection=["add_one", "add_one_2"],
     )
     assert reexecution_result.success
-    assert reexecution_result.result_for_solid("return_one").output_value() == None
+    assert reexecution_result.result_for_solid("return_one").output_value() is None
     assert reexecution_result.result_for_solid("add_one_2").output_value() == 3
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_presets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_presets.py
@@ -21,7 +21,7 @@ def test_preset_yaml_roundtrip():
 
 def test_empty_preset():
     empty_preset = PresetDefinition("empty")
-    assert empty_preset.run_config == None
+    assert empty_preset.run_config is None
     assert empty_preset.get_environment_yaml() == "{}\n"
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_resolve_versions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_resolve_versions.py
@@ -65,7 +65,7 @@ class VersionedInMemoryIOManager(MemoizableIOManager):
 def test_join_and_hash():
     assert join_and_hash("foo") == hashlib.sha1(b"foo").hexdigest()
 
-    assert join_and_hash("foo", None, "bar") == None
+    assert join_and_hash("foo", None, "bar") is None
 
     assert join_and_hash("foo", "bar") == hashlib.sha1(b"barfoo").hexdigest()
 

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -511,9 +511,9 @@ def test_opt_float_elem():
 
     assert check.opt_float_elem(ddict, "a_float") == 1.0
 
-    assert check.opt_float_elem(ddict, "a_none") == None
+    assert check.opt_float_elem(ddict, "a_none") is None
 
-    assert check.opt_float_elem(ddict, "nonexistentkey") == None
+    assert check.opt_float_elem(ddict, "nonexistentkey") is None
 
     with pytest.raises(ElementCheckError):
         check.opt_float_elem(ddict, "a_bool")
@@ -641,7 +641,7 @@ def test_int_elem():
 
     assert check.int_elem(ddict, "a_int") == 1
 
-    assert check.int_elem(ddict, "a_bool") == True
+    assert check.int_elem(ddict, "a_bool") is True
 
     with pytest.raises(ElementCheckError):
         check.int_elem(ddict, "a_float")
@@ -658,11 +658,11 @@ def test_opt_int_elem():
 
     assert check.opt_int_elem(ddict, "a_int") == 1
 
-    assert check.opt_int_elem(ddict, "a_none") == None
+    assert check.opt_int_elem(ddict, "a_none") is None
 
-    assert check.opt_int_elem(ddict, "nonexistentkey") == None
+    assert check.opt_int_elem(ddict, "nonexistentkey") is None
 
-    assert check.opt_int_elem(ddict, "a_bool") == True
+    assert check.opt_int_elem(ddict, "a_bool") is True
 
     with pytest.raises(ElementCheckError):
         check.opt_int_elem(ddict, "a_float")
@@ -1133,7 +1133,7 @@ def test_opt_nullable_sequence_param():
     assert check.opt_nullable_sequence_param("foo", "sequence_param") == "foo"
     assert check.opt_nullable_sequence_param("foo", "sequence_param", of_type=str) == "foo"
 
-    assert check.opt_nullable_sequence_param(None, "sequence_param") == None
+    assert check.opt_nullable_sequence_param(None, "sequence_param") is None
 
     with pytest.raises(CheckError):
         check.opt_nullable_sequence_param(1, "sequence_param", of_type=int)  # type: ignore
@@ -1208,9 +1208,9 @@ def test_opt_string_elem():
 
     assert check.opt_str_elem(ddict, "a_str") == "a"
 
-    assert check.opt_str_elem(ddict, "a_none") == None
+    assert check.opt_str_elem(ddict, "a_none") is None
 
-    assert check.opt_str_elem(ddict, "nonexistentkey") == None
+    assert check.opt_str_elem(ddict, "nonexistentkey") is None
 
     with pytest.raises(ElementCheckError):
         check.opt_str_elem(ddict, "a_num")

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -977,7 +977,7 @@ def test_add_bulk_actions_columns():
             unmigrated_row_count = instance._run_storage.fetchone(
                 db.select([db.func.count()])
                 .select_from(BulkActionsTable)
-                .where(BulkActionsTable.c.selector_id == None)
+                .where(BulkActionsTable.c.selector_id.is_(None))
             )[0]
             assert unmigrated_row_count == 0
 

--- a/python_modules/dagster/dagster_tests/general_tests/seven_tests/test_seven.py
+++ b/python_modules/dagster/dagster_tests/general_tests/seven_tests/test_seven.py
@@ -65,10 +65,10 @@ def test_is_lambda():
     class Oof:
         test = lambda x: x
 
-    assert _seven.is_lambda(foo) == True
-    assert _seven.is_lambda(Oof.test) == True
-    assert _seven.is_lambda(bar) == False
-    assert _seven.is_lambda(baz) == False
+    assert _seven.is_lambda(foo) is True
+    assert _seven.is_lambda(Oof.test) is True
+    assert _seven.is_lambda(bar) is False
+    assert _seven.is_lambda(baz) is False
 
 
 def test_is_fn_or_decor_inst():
@@ -90,10 +90,10 @@ def test_is_fn_or_decor_inst():
     def yoodles():
         pass
 
-    assert _seven.is_function_or_decorator_instance_of(foo, Quux) == True
-    assert _seven.is_function_or_decorator_instance_of(bar, Quux) == True
-    assert _seven.is_function_or_decorator_instance_of(baz, Quux) == False
-    assert _seven.is_function_or_decorator_instance_of(yoodles, Quux) == True
+    assert _seven.is_function_or_decorator_instance_of(foo, Quux) is True
+    assert _seven.is_function_or_decorator_instance_of(bar, Quux) is True
+    assert _seven.is_function_or_decorator_instance_of(baz, Quux) is False
+    assert _seven.is_function_or_decorator_instance_of(yoodles, Quux) is True
 
 
 class Foo:

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/secretsmanager_tests/test_secrets.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/secretsmanager_tests/test_secrets.py
@@ -165,4 +165,4 @@ def test_secretmanager_secrets_resource(mock_secretsmanager_resource):
             "binary_secret": None,
         }
 
-        assert os.getenv("binary_secret") == None
+        assert os.getenv("binary_secret") is None

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/utils_tests/mrjob_tests/test_utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/utils_tests/mrjob_tests/test_utils.py
@@ -32,7 +32,7 @@ def test_client_error_status():
     assert _client_error_status(ex) == code
 
     empty_ex = botocore.exceptions.ClientError({}, "foo")
-    assert _client_error_status(empty_ex) == None
+    assert _client_error_status(empty_ex) is None
 
 
 def test_is_retriable_client_error():

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
@@ -290,7 +290,7 @@ def test_launcher_from_config(kubeconfig_file):
     ) as instance:
         run_launcher = instance.run_launcher
         assert isinstance(run_launcher, CeleryK8sRunLauncher)
-        assert run_launcher._fail_pod_on_run_failure == None  # pylint: disable=protected-access
+        assert run_launcher._fail_pod_on_run_failure is None  # pylint: disable=protected-access
 
     with instance_for_test(
         overrides={

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/conftest.py
@@ -84,7 +84,7 @@ def dbt_rpc_server(
 
     proc.terminate()  # clean up after ourself
     proc.wait(timeout=0.2)
-    if proc.poll() == None:  # still running
+    if proc.poll() is None:  # still running
         proc.kill()
     all_subprocs.remove(proc)
 

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -208,7 +208,7 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
 
     def check_run_worker_health(self, run: PipelineRun):
         container = self._get_container(run)
-        if container == None:
+        if container is None:
             return CheckRunHealthResult(WorkerStatus.NOT_FOUND)
         if container.status == "running":
             return CheckRunHealthResult(WorkerStatus.RUNNING)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/models.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/models.py
@@ -35,7 +35,7 @@ def _get_openapi_dict_value_type(attr_type):
 
 
 def _k8s_parse_value(data, classname, attr_name):
-    if data == None:
+    if data is None:
         return None
 
     if _is_openapi_list_type(classname):

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_container_context.py
@@ -125,16 +125,16 @@ def container_context_camel_case_volumes_fixture(container_context_config_camel_
 
 
 def test_empty_container_context(empty_container_context):
-    assert empty_container_context.image_pull_policy == None
+    assert empty_container_context.image_pull_policy is None
     assert empty_container_context.image_pull_secrets == []
-    assert empty_container_context.service_account_name == None
+    assert empty_container_context.service_account_name is None
     assert empty_container_context.env_config_maps == []
     assert empty_container_context.env_secrets == []
     assert empty_container_context.env_vars == []
     assert empty_container_context.volume_mounts == []
     assert empty_container_context.volumes == []
     assert empty_container_context.labels == {}
-    assert empty_container_context.namespace == None
+    assert empty_container_context.namespace is None
     assert empty_container_context.resources == {}
     assert empty_container_context.scheduler_name == None
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
@@ -52,7 +52,7 @@ def test_launcher_from_config(kubeconfig_file):
     ) as instance:
         run_launcher = instance.run_launcher
         assert isinstance(run_launcher, K8sRunLauncher)
-        assert run_launcher.fail_pod_on_run_failure == None
+        assert run_launcher.fail_pod_on_run_failure is None
         assert run_launcher.resources == resources
         assert run_launcher.scheduler_name == None
 

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_metadata_constraints.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_metadata_constraints.py
@@ -56,7 +56,7 @@ def test_failed_multi():
 
 def test_success_multi():
     mul_val = basic_multi_constraint.validate(DataFrame())
-    assert mul_val.success == True
+    assert mul_val.success is True
     assert mul_val.metadata_entries == []
 
 


### PR DESCRIPTION
### Summary & Motivation

Hey there, and congrats on 1.0! 

I was diving into the codebase a bit and noticed several places (though not everywhere) in which comparisons to `None`, `True`, and `False` use equality `==` rather than identity `is`. Generally, this is ill-advised and can cause subtle bugs unless it's done intentionally/explicitly, which didn't appear to be the case from what I could tell (see [PEP8](https://peps.python.org/pep-0008/#programming-recommendations), flake8 [E711](https://www.flake8rules.com/rules/E711.html)/[E712](https://www.flake8rules.com/rules/E712.html), pylint [C0121](https://pylint.pycqa.org/en/latest/user_guide/messages/convention/singleton-comparison.html), etc.). Of course, if the team has already discussed and has a convention around this stuff, let me know.

For use of `== None` in the context of SQLAlchemy queries, I switched it to leverage the `is_(None)` column operator, which in addition to being consistent with the above also happens to be a bit faster since it doesn't need to go through the overloading of `__eq__` first just to call `is_` anyways. Similarly, I left the pandas examples that use `==` for boolean comparison alone, since that's a special case that actually does rely on overloading `__eq__`.

As a side note, I also noticed that sometimes tests assert truthiness/falsiness rather than testing against `True|False` specifically, though it's inconsistent. I'd be happy to change this so that boolean test assertions are all consistent one way or the other, but I figured it'd be best to ask first.

Thanks!

### How I Tested These Changes

Tested against python 3.8 via `pytest python_modules/dagster/dagster_tests`
