### PR TITLE
TimeWindowPartitionsDefinition from cron_schedule

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -1,8 +1,7 @@
-from datetime import datetime, timedelta
 from typing import Optional, cast
 
 import dagster._check as check
-from dagster._core.definitions.partition import PartitionsDefinition, ScheduleType
+from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
@@ -75,38 +74,16 @@ class TimeWindowPartitionMapping(PartitionMapping):
         if to_partitions_def.timezone != from_partitions_def.timezone:
             raise DagsterInvalidDefinitionError("Timezones don't match")
 
-        to_period = to_partitions_def.schedule_type
-        from_period = from_partitions_def.schedule_type
+        from_start_dt = from_partitions_def.start_time_for_partition_key(
+            from_partition_key_range.start
+        )
+        from_end_dt = from_partitions_def.end_time_for_partition_key(from_partition_key_range.end)
 
-        from_start_dt = datetime.strptime(from_partition_key_range.start, from_partitions_def.fmt)
-        from_end_dt = datetime.strptime(from_partition_key_range.end, from_partitions_def.fmt)
-
-        if to_period > from_period:
-            to_start_dt = round_datetime_to_period(from_start_dt, to_period)
-            to_end_dt = round_datetime_to_period(from_end_dt, to_period)
-        elif to_period < from_period:
-            to_start_dt = from_start_dt
-            to_end_dt = (from_end_dt + from_period.delta) - to_period.delta
-        else:
-            to_start_dt = from_start_dt
-            to_end_dt = from_end_dt
-
-        return PartitionKeyRange(
-            to_start_dt.strftime(to_partitions_def.fmt),
-            to_end_dt.strftime(to_partitions_def.fmt),
+        to_start_partition_key = to_partitions_def.get_partition_key_for_timestamp(
+            from_start_dt.timestamp(), end_closed=False
+        )
+        to_end_partition_key = to_partitions_def.get_partition_key_for_timestamp(
+            from_end_dt.timestamp(), end_closed=True
         )
 
-
-def round_datetime_to_period(dt: datetime, period: ScheduleType) -> datetime:
-    if period == ScheduleType.MONTHLY:
-        return dt.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-    elif period == ScheduleType.WEEKLY:
-        return (dt - timedelta(days=dt.weekday())).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
-    elif period == ScheduleType.DAILY:
-        return dt.replace(hour=0, minute=0, second=0, microsecond=0)
-    elif period == ScheduleType.HOURLY:
-        return dt.replace(minute=0, second=0, microsecond=0)
-    else:
-        check.failed("Unknown schedule type")
+        return PartitionKeyRange(to_start_partition_key, to_end_partition_key)

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1,4 +1,5 @@
-from datetime import datetime, time
+import re
+from datetime import datetime
 from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Sequence, Union, cast
 
 import pendulum
@@ -6,7 +7,7 @@ import pendulum
 import dagster._check as check
 from dagster._annotations import PublicAttr, public
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
-from dagster._utils.schedules import schedule_execution_time_iterator
+from dagster._utils.schedules import cron_string_iterator, schedule_execution_time_iterator
 
 from .partition import (
     DEFAULT_DATE_FORMAT,
@@ -14,7 +15,7 @@ from .partition import (
     PartitionedConfig,
     PartitionsDefinition,
     ScheduleType,
-    get_cron_schedule,
+    cron_schedule_from_schedule_type_and_offsets,
 )
 from .partition_key_range import PartitionKeyRange
 
@@ -29,45 +30,80 @@ class TimeWindow(NamedTuple):
 class TimeWindowPartitionsDefinition(
     PartitionsDefinition[TimeWindow],  # pylint: disable=unsubscriptable-object
     NamedTuple(
-        "_TimeWindowPartitions",
+        "_TimeWindowPartitionsDefinition",
         [
-            ("schedule_type", PublicAttr[ScheduleType]),
             ("start", PublicAttr[datetime]),
             ("timezone", PublicAttr[str]),
             ("fmt", PublicAttr[str]),
             ("end_offset", PublicAttr[int]),
-            ("minute_offset", PublicAttr[int]),
-            ("hour_offset", PublicAttr[int]),
-            ("day_offset", PublicAttr[Optional[int]]),
+            ("cron_schedule", PublicAttr[str]),
         ],
     ),
 ):
+    """
+    A set of partitions where each partitions corresponds to a time window.
+
+    The provided cron_schedule determines the bounds of the time windows. E.g. a cron_schedule of
+    "0 0 \\* \\* \\*" will result in daily partitions that start at midnight and end at midnight of the
+    following day.
+
+    The string partition_key associated with each partition corresponds to the start of the
+    partition's time window.
+
+    The first partition in the set will start on at the first cron_schedule tick that is equal to
+    or after the given start datetime. The last partition in the set will end before the current
+    time, unless the end_offset argument is set to a positive number.
+
+    Args:
+        cron_schedule (str): Determines the bounds of the time windows.
+        start (datetime): The first partition in the set will start on at the first cron_schedule
+            tick that is equal to or after this value.
+        timezone (Optional[str]): The timezone in which each time should exist.
+            Supported strings for timezones are the ones provided by the
+            `IANA time zone database <https://www.iana.org/time-zones>` - e.g. "America/Los_Angeles".
+        fmt (str): The date format to use for partition_keys.
+        end_offset (int): Extends the partition set by a number of partitions equal to the value
+            passed. If end_offset is 0 (the default), the last partition ends before the current
+            time. If end_offset is 1, the second-to-last partition ends before the current time,
+            and so on.
+    """
+
     def __new__(  # pylint: disable=arguments-differ
         cls,
-        schedule_type: ScheduleType,
         start: Union[datetime, str],
-        timezone: Optional[str],
         fmt: str,
-        end_offset: int,
+        schedule_type: Optional[ScheduleType] = None,
+        timezone: Optional[str] = None,
+        end_offset: int = 0,
         minute_offset: int = 0,
         hour_offset: int = 0,
-        day_offset: Optional[int] = None,
+        day_offset: Optional[int] = 0,
+        cron_schedule: Optional[str] = None,
     ):
-        if isinstance(start, str):
-            start_dt = datetime.strptime(start, fmt)
-        else:
+        if isinstance(start, datetime):
             start_dt = start
+        else:
+            start_dt = datetime.strptime(start, fmt)
+
+        if cron_schedule is not None:
+            check.invariant(
+                schedule_type is None and not minute_offset and not hour_offset and not day_offset,
+                "If cron_schedule argument is provided, then schedule_type, minute_offset, "
+                "hour_offset, and day_offset can't also be provided",
+            )
+        else:
+            if schedule_type is None:
+                check.failed("One of schedule_type and cron_schedule must be provided")
+
+            cron_schedule = cron_schedule_from_schedule_type_and_offsets(
+                schedule_type=schedule_type,
+                minute_offset=minute_offset,
+                hour_offset=hour_offset,
+                day_offset=day_offset or 0,
+            )
 
         return super(TimeWindowPartitionsDefinition, cls).__new__(
-            cls,
-            schedule_type,
-            start_dt,
-            timezone or "UTC",
-            fmt,
-            end_offset,
-            minute_offset,
-            hour_offset,
-            day_offset,
+            cls, start_dt, timezone or "UTC", fmt, end_offset, cron_schedule
         )
 
     def get_partitions(
@@ -101,7 +137,12 @@ class TimeWindowPartitionsDefinition(
         return partitions
 
     def __str__(self) -> str:
-        partition_def_str = f"{self.schedule_type.value.capitalize()}, starting {self.start.strftime(self.fmt)} {self.timezone}."
+        schedule_str = (
+            self.schedule_type.value.capitalize() if self.schedule_type else self.cron_schedule
+        )
+        partition_def_str = (
+            f"{schedule_str}, starting {self.start.strftime(self.fmt)} {self.timezone}."
+        )
         if self.end_offset != 0:
             partition_def_str += f" End offsetted by {self.end_offset} partition{'' if self.end_offset == 1 else 's'}."
         return partition_def_str
@@ -112,6 +153,9 @@ class TimeWindowPartitionsDefinition(
 
     def start_time_for_partition_key(self, partition_key: str) -> datetime:
         return pendulum.instance(datetime.strptime(partition_key, self.fmt), tz=self.timezone)
+
+    def end_time_for_partition_key(self, partition_key: str) -> datetime:
+        return self.time_window_for_partition_key(partition_key).end
 
     def get_default_partition_mapping(self):
         from dagster._core.definitions.time_window_partition_mapping import (
@@ -133,6 +177,53 @@ class TimeWindowPartitionsDefinition(
 
         return result
 
+    @public  # type: ignore
+    @property
+    def schedule_type(self) -> Optional[ScheduleType]:
+        if re.match(r"\d+ \* \* \* \*", self.cron_schedule):
+            return ScheduleType.HOURLY
+        elif re.match(r"\d+ \d+ \* \* \*", self.cron_schedule):
+            return ScheduleType.DAILY
+        elif re.match(r"\d+ \d+ \* \* \d+", self.cron_schedule):
+            return ScheduleType.WEEKLY
+        elif re.match(r"\d+ \d+ \d+ \* \*", self.cron_schedule):
+            return ScheduleType.MONTHLY
+        else:
+            return None
+
+    @public  # type: ignore
+    @property
+    def minute_offset(self) -> int:
+        match = re.match(r"(\d+) (\d+|\*) (\d+|\*) (\d+|\*) (\d+|\*)", self.cron_schedule)
+        if match is None:
+            check.failed(f"{self.cron_schedule} has no minute offset")
+        return int(match.groups()[0])
+
+    @public  # type: ignore
+    @property
+    def hour_offset(self) -> int:
+        match = re.match(r"(\d+|\*) (\d+) (\d+|\*) (\d+|\*) (\d+|\*)", self.cron_schedule)
+        if match is None:
+            check.failed(f"{self.cron_schedule} has no hour offset")
+        return int(match.groups()[1])
+
+    @public  # type: ignore
+    @property
+    def day_offset(self) -> int:
+        schedule_type = self.schedule_type
+        if schedule_type == ScheduleType.WEEKLY:
+            match = re.match(r"(\d+|\*) (\d+|\*) (\d+|\*) (\d+|\*) (\d+)", self.cron_schedule)
+            if match is None:
+                check.failed(f"{self.cron_schedule} has no day offset")
+            return int(match.groups()[4])
+        elif schedule_type == ScheduleType.MONTHLY:
+            match = re.match(r"(\d+|\*) (\d+|\*) (\d+) (\d+|\*) (\d+|\*)", self.cron_schedule)
+            if match is None:
+                check.failed(f"{self.cron_schedule} has no day offset")
+            return int(match.groups()[2])
+        else:
+            check.failed(f"Unsupported schedule type for day_offset: {schedule_type}")
+
     @public
     def get_cron_schedule(
         self,
@@ -140,24 +231,41 @@ class TimeWindowPartitionsDefinition(
         hour_of_day: Optional[int] = None,
         day_of_week: Optional[int] = None,
         day_of_month: Optional[int] = None,
-    ):
-        """The schedule executes at the cadence specified by the partitioning."""
+    ) -> str:
+        """The schedule executes at the cadence specified by the partitioning, but may overwrite
+        the minute/hour/day offset of the partitioning.
+
+        This is useful e.g. if you have partitions that span midnight to midnight but you want to
+        schedule a job that runs at 2 am."""
+        if (
+            minute_of_hour is None
+            and hour_of_day is None
+            and day_of_week is None
+            and day_of_month is None
+        ):
+            return self.cron_schedule
+
+        schedule_type = self.schedule_type
+        if schedule_type is None:
+            check.failed(
+                f"{self.cron_schedule} does not support minute_of_hour/hour_of_day/day_of_week/day_of_month arguments"
+            )
+
         minute_of_hour = cast(
             int,
             check.opt_int_param(minute_of_hour, "minute_of_hour", default=self.minute_offset),
         )
 
-        if self.schedule_type == ScheduleType.HOURLY:
+        if schedule_type == ScheduleType.HOURLY:
             check.invariant(
                 hour_of_day is None, "Cannot set hour parameter with hourly partitions."
             )
+        else:
+            hour_of_day = cast(
+                int, check.opt_int_param(hour_of_day, "hour_of_day", default=self.hour_offset)
+            )
 
-        hour_of_day = cast(
-            int, check.opt_int_param(hour_of_day, "hour_of_day", default=self.hour_offset)
-        )
-        execution_time = time(minute=minute_of_hour, hour=hour_of_day)
-
-        if self.schedule_type == ScheduleType.DAILY:
+        if schedule_type == ScheduleType.DAILY:
             check.invariant(
                 day_of_week is None, "Cannot set day of week parameter with daily partitions."
             )
@@ -165,31 +273,30 @@ class TimeWindowPartitionsDefinition(
                 day_of_month is None, "Cannot set day of month parameter with daily partitions."
             )
 
-        if self.schedule_type == ScheduleType.MONTHLY:
+        if schedule_type == ScheduleType.MONTHLY:
             default = self.day_offset or 1
-            execution_day = check.opt_int_param(day_of_month, "day_of_month", default=default)
-        elif self.schedule_type == ScheduleType.WEEKLY:
+            day_offset = check.opt_int_param(day_of_month, "day_of_month", default=default)
+        elif schedule_type == ScheduleType.WEEKLY:
             default = self.day_offset or 0
-            execution_day = check.opt_int_param(day_of_week, "day_of_week", default=default)
+            day_offset = check.opt_int_param(day_of_week, "day_of_week", default=default)
         else:
-            execution_day = 0
+            day_offset = 0
 
-        return get_cron_schedule(self.schedule_type, execution_time, execution_day)
+        return cron_schedule_from_schedule_type_and_offsets(
+            schedule_type,
+            minute_offset=minute_of_hour,
+            hour_offset=hour_of_day or 0,
+            day_offset=day_offset,
+        )
 
     def _iterate_time_windows(self, start: datetime) -> Iterable[TimeWindow]:
         """
         Returns an infinite generator of time windows after the given start time.
         """
-        time_of_day = time(self.hour_offset, self.minute_offset)
-
         start_timestamp = pendulum.instance(start, tz=self.timezone).timestamp()
         iterator = schedule_execution_time_iterator(
             start_timestamp=start_timestamp,
-            cron_schedule=get_cron_schedule(
-                schedule_type=self.schedule_type,
-                time_of_day=time_of_day,
-                execution_day=self.day_offset,
-            ),
+            cron_schedule=self.cron_schedule,
             execution_timezone=self.timezone,
         )
 
@@ -202,9 +309,28 @@ class TimeWindowPartitionsDefinition(
             yield TimeWindow(prev_time, next_time)
             prev_time = next_time
 
+    def get_partition_key_for_timestamp(self, timestamp: float, end_closed: bool = False) -> str:
+        """
+        Args:
+            timestamp (float): Timestamp from the unix epoch, UTC.
+            end_closed (bool): Whether the interval is closed at the end or at the beginning.
+        """
+        iterator = cron_string_iterator(
+            timestamp, self.cron_schedule, self.timezone, start_offset=-1
+        )
+        # prev will be < timestamp
+        prev = next(iterator)
+        # prev_next will be >= timestamp
+        prev_next = next(iterator)
+
+        if end_closed or prev_next.timestamp() > timestamp:
+            return prev.strftime(self.fmt)
+        else:
+            return prev_next.strftime(self.fmt)
+
 
 class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
-    def __new__(
+    def __new__(  # pylint: disable=signature-differs
         cls,
         start_date: Union[datetime, str],
         minute_offset: int = 0,
@@ -336,7 +462,7 @@ def daily_partitioned_config(
 
 
 class HourlyPartitionsDefinition(TimeWindowPartitionsDefinition):
-    def __new__(
+    def __new__(  # pylint: disable=signature-differs
         cls,
         start_date: Union[datetime, str],
         minute_offset: int = 0,
@@ -452,7 +578,7 @@ def hourly_partitioned_config(
 
 
 class MonthlyPartitionsDefinition(TimeWindowPartitionsDefinition):
-    def __new__(
+    def __new__(  # pylint: disable=signature-differs
         cls,
         start_date: Union[datetime, str],
         minute_offset: int = 0,
@@ -584,7 +710,7 @@ def monthly_partitioned_config(
 
 
 class WeeklyPartitionsDefinition(TimeWindowPartitionsDefinition):
-    def __new__(
+    def __new__(  # pylint: disable=signature-differs
         cls,
         start_date: Union[datetime, str],
         minute_offset: int = 0,

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -468,51 +468,68 @@ class ExternalTimeWindowPartitionsDefinitionData(
     NamedTuple(
         "_ExternalTimeWindowPartitionsDefinitionData",
         [
-            ("schedule_type", ScheduleType),
             ("start", float),
             ("timezone", Optional[str]),
             ("fmt", str),
             ("end_offset", int),
-            ("minute_offset", int),
-            ("hour_offset", int),
+            ("cron_schedule", Optional[str]),
+            # superseded by cron_schedule, but kept around for backcompat
+            ("schedule_type", Optional[ScheduleType]),
+            # superseded by cron_schedule, but kept around for backcompat
+            ("minute_offset", Optional[int]),
+            # superseded by cron_schedule, but kept around for backcompat
+            ("hour_offset", Optional[int]),
+            # superseded by cron_schedule, but kept around for backcompat
             ("day_offset", Optional[int]),
         ],
     ),
 ):
     def __new__(
         cls,
-        schedule_type: ScheduleType,
         start: float,
         timezone: Optional[str],
         fmt: str,
         end_offset: int,
-        minute_offset: int = 0,
-        hour_offset: int = 0,
+        cron_schedule: Optional[str] = None,
+        schedule_type: Optional[ScheduleType] = None,
+        minute_offset: Optional[int] = None,
+        hour_offset: Optional[int] = None,
         day_offset: Optional[int] = None,
     ):
         return super(ExternalTimeWindowPartitionsDefinitionData, cls).__new__(
             cls,
-            schedule_type=check.inst_param(schedule_type, "schedule_type", ScheduleType),
+            schedule_type=check.opt_inst_param(schedule_type, "schedule_type", ScheduleType),
             start=check.float_param(start, "start"),
             timezone=check.opt_str_param(timezone, "timezone"),
             fmt=check.str_param(fmt, "fmt"),
             end_offset=check.int_param(end_offset, "end_offset"),
-            minute_offset=check.int_param(minute_offset, "minute_offset"),
-            hour_offset=check.int_param(hour_offset, "hour_offset"),
+            minute_offset=check.opt_int_param(minute_offset, "minute_offset"),
+            hour_offset=check.opt_int_param(hour_offset, "hour_offset"),
             day_offset=check.opt_int_param(day_offset, "day_offset"),
+            cron_schedule=check.opt_str_param(cron_schedule, "cron_schedule"),
         )
 
     def get_partitions_definition(self):
-        return TimeWindowPartitionsDefinition(
-            self.schedule_type,
-            datetime.fromtimestamp(self.start),
-            self.timezone,
-            self.fmt,
-            self.end_offset,
-            self.minute_offset,
-            self.hour_offset,
-            self.day_offset,
-        )
+        if self.cron_schedule is not None:
+            return TimeWindowPartitionsDefinition(
+                cron_schedule=self.cron_schedule,
+                start=datetime.fromtimestamp(self.start),
+                timezone=self.timezone,
+                fmt=self.fmt,
+                end_offset=self.end_offset,
+            )
+        else:
+            # backcompat case
+            return TimeWindowPartitionsDefinition(
+                schedule_type=self.schedule_type,
+                start=datetime.fromtimestamp(self.start),
+                timezone=self.timezone,
+                fmt=self.fmt,
+                end_offset=self.end_offset,
+                minute_offset=self.minute_offset,
+                hour_offset=self.hour_offset,
+                day_offset=self.day_offset,
+            )
 
 
 @whitelist_for_serdes
@@ -1006,14 +1023,11 @@ def external_time_window_partitions_definition_from_def(
 ) -> ExternalTimeWindowPartitionsDefinitionData:
     check.inst_param(partitions_def, "partitions_def", TimeWindowPartitionsDefinition)
     return ExternalTimeWindowPartitionsDefinitionData(
-        schedule_type=partitions_def.schedule_type,
+        cron_schedule=partitions_def.cron_schedule,
         start=partitions_def.start.timestamp(),
         timezone=partitions_def.timezone,
         fmt=partitions_def.fmt,
         end_offset=partitions_def.end_offset,
-        minute_offset=partitions_def.minute_offset,
-        hour_offset=partitions_def.hour_offset,
-        day_offset=partitions_def.day_offset,
     )
 
 

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -27,7 +27,7 @@ def is_valid_cron_schedule(cron_schedule: Union[str, Sequence[str]]) -> bool:
 
 
 def cron_string_iterator(
-    start_timestamp: float, cron_string: str, execution_timezone: Optional[str]
+    start_timestamp: float, cron_string: str, execution_timezone: Optional[str], start_offset=0
 ) -> Iterator[datetime.datetime]:
     """Generator of datetimes >= start_timestamp for the given cron string."""
     timezone_str = execution_timezone if execution_timezone else "UTC"
@@ -40,6 +40,10 @@ def cron_string_iterator(
     # Go back one iteration so that the next iteration is the first time that is >= start_datetime
     # and matches the cron schedule
     next_date = date_iter.get_prev(datetime.datetime)
+
+    check.invariant(start_offset <= 0)
+    for _ in range(-start_offset):
+        next_date = date_iter.get_prev(datetime.datetime)
 
     cron_parts, _ = croniter.expand(cron_string)
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_time_window_partition_mapping.py
@@ -1,17 +1,13 @@
-import pendulum
-import pytest
+from datetime import datetime
 
 from dagster import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
     MonthlyPartitionsDefinition,
+    TimeWindowPartitionsDefinition,
 )
-from dagster._core.definitions.partition import ScheduleType
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.time_window_partition_mapping import (
-    TimeWindowPartitionMapping,
-    round_datetime_to_period,
-)
+from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
 
 
 def test_get_upstream_partitions_for_partition_range_same_partitioning():
@@ -95,21 +91,49 @@ def test_get_upstream_partitions_for_partition_range_monthly_downstream_daily_up
     assert result == PartitionKeyRange("2021-05-01", "2021-07-31")
 
 
-@pytest.mark.parametrize(
-    "dt_str, period, expected_str",
-    [
-        ("2020-01-01", ScheduleType.DAILY, "2020-01-01"),
-        ("2020-01-01 01:00:00", ScheduleType.DAILY, "2020-01-01"),
-        ("2020-01-01 01:00:00", ScheduleType.HOURLY, "2020-01-01 01:00:00"),
-        ("2020-01-01", ScheduleType.MONTHLY, "2020-01-01"),
-        ("2020-01-02", ScheduleType.MONTHLY, "2020-01-01"),
-        ("2020-01-02 01:00:00", ScheduleType.MONTHLY, "2020-01-01"),
-        ("2021-12-03", ScheduleType.WEEKLY, "2021-11-29"),
-        ("2021-12-03 01:00:00", ScheduleType.WEEKLY, "2021-11-29"),
-        ("2021-11-29", ScheduleType.WEEKLY, "2021-11-29"),
-    ],
-)
-def test_round_datetime_to_period(dt_str, period, expected_str):
-    dt = pendulum.parse(dt_str)
-    expected_dt = pendulum.parse(expected_str)
-    assert round_datetime_to_period(dt, period) == expected_dt
+def test_get_upstream_partitions_for_partition_range_twice_daily_downstream_daily_upstream():
+    start = datetime(year=2020, month=1, day=5)
+    downstream_partitions_def = TimeWindowPartitionsDefinition(
+        cron_schedule="0 0 * * *", start=start, fmt="%Y-%m-%d"
+    )
+    upstream_partitions_def = TimeWindowPartitionsDefinition(
+        cron_schedule="0 0,11 * * *", start=start, fmt="%Y-%m-%d %H:%M"
+    )
+    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partition_range(
+        PartitionKeyRange("2021-05-01", "2021-05-03"),
+        downstream_partitions_def,
+        upstream_partitions_def,
+    )
+    assert result == PartitionKeyRange("2021-05-01 00:00", "2021-05-03 11:00")
+
+
+def test_get_upstream_partitions_for_partition_range_daily_downstream_twice_daily_upstream():
+    start = datetime(year=2020, month=1, day=5)
+    downstream_partitions_def = TimeWindowPartitionsDefinition(
+        cron_schedule="0 0,11 * * *", start=start, fmt="%Y-%m-%d %H:%M"
+    )
+    upstream_partitions_def = TimeWindowPartitionsDefinition(
+        cron_schedule="0 0 * * *", start=start, fmt="%Y-%m-%d"
+    )
+    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partition_range(
+        PartitionKeyRange("2021-05-01 00:00", "2021-05-03 00:00"),
+        downstream_partitions_def,
+        upstream_partitions_def,
+    )
+    assert result == PartitionKeyRange("2021-05-01", "2021-05-03")
+
+
+def test_get_upstream_partitions_for_partition_range_daily_non_aligned():
+    start = datetime(year=2020, month=1, day=5)
+    downstream_partitions_def = TimeWindowPartitionsDefinition(
+        cron_schedule="0 0 * * *", start=start, fmt="%Y-%m-%d"
+    )
+    upstream_partitions_def = TimeWindowPartitionsDefinition(
+        cron_schedule="0 11 * * *", start=start, fmt="%Y-%m-%d"
+    )
+    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partition_range(
+        PartitionKeyRange("2021-05-02", "2021-05-04"),
+        downstream_partitions_def,
+        upstream_partitions_def,
+    )
+    assert result == PartitionKeyRange("2021-05-01", "2021-05-04")


### PR DESCRIPTION
### Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/7938.  This was requested on Slack twice in the last few days.

This allows you to use arbitrary cron expressions to define TimeWindowPartitionsDefinitions.

### How I Tested These Changes
