### PR TITLE
Take job_config field out of k8s_job_op, replace with same fields that go on k8s executor op tags

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
@@ -1,8 +1,17 @@
+import kubernetes
 import pytest
 from dagster_k8s import k8s_job_op
 from dagster_k8s.client import DagsterK8sError
+from dagster_k8s.job import get_k8s_job_name
+from dagster_k8s.utils import get_pod_names_in_job, retrieve_pod_logs
 
 from dagster import job
+
+
+def _get_pod_logs(cluster_provider, job_name, namespace):
+    kubernetes.config.load_kube_config(cluster_provider.kubeconfig_file)
+    pod_names = get_pod_names_in_job(job_name, namespace=namespace)
+    return retrieve_pod_logs(pod_names[0], namespace=namespace)
 
 
 @pytest.mark.default
@@ -34,7 +43,13 @@ def test_k8s_job_op(namespace, cluster_provider):
     def my_full_job():
         second_op(first_op())
 
-    my_full_job.execute_in_process()
+    execute_result = my_full_job.execute_in_process()
+    run_id = execute_result.dagster_run.run_id
+    job_name = get_k8s_job_name(run_id, first_op.name)
+    assert "HI" in _get_pod_logs(cluster_provider, job_name, namespace)
+
+    job_name = get_k8s_job_name(run_id, second_op.name)
+    assert "GOODBYE" in _get_pod_logs(cluster_provider, job_name, namespace)
 
 
 @pytest.mark.default
@@ -81,3 +96,27 @@ def test_k8s_job_op_with_failure(namespace, cluster_provider):
 
     with pytest.raises(DagsterK8sError, match="Timed out while waiting for pod to become ready"):
         failure_job.execute_in_process()
+
+
+@pytest.mark.default
+def test_k8s_job_op_with_container_config(namespace, cluster_provider):
+    with_container_config = k8s_job_op.configured(
+        {
+            "image": "busybox",
+            "container_config": {"command": ["echo", "SHELL_FROM_CONTAINER_CONFIG"]},
+            "namespace": namespace,
+            "load_incluster_config": False,
+            "kubeconfig_file": cluster_provider.kubeconfig_file,
+        },
+        name="with_container_config",
+    )
+
+    @job
+    def with_config_job():
+        with_container_config()
+
+    execute_result = with_config_job.execute_in_process()
+    run_id = execute_result.dagster_run.run_id
+    job_name = get_k8s_job_name(run_id, with_container_config.name)
+
+    assert "SHELL_FROM_CONTAINER_CONFIG" in _get_pod_logs(cluster_provider, job_name, namespace)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -534,7 +534,7 @@ def construct_dagster_k8s_job(
     Args:
         job_config (DagsterK8sJobConfig): Job configuration to use for constructing the Kubernetes
             Job object.
-        args (List[str]): CLI arguments to use with dagster-graphql in this Job.
+        args (Optional[List[str]]): CLI arguments to use with in this Job.
         job_name (str): The name of the Job. Note that this name must be <= 63 characters in length.
         user_defined_k8s_config(Optional[UserDefinedDagsterK8sConfig]): Additional k8s config in tags or Dagster config
             to apply to the job.
@@ -549,7 +549,7 @@ def construct_dagster_k8s_job(
         kubernetes.client.V1Job: A Kubernetes Job object.
     """
     check.inst_param(job_config, "job_config", DagsterK8sJobConfig)
-    check.list_param(args, "args", of_type=str)
+    check.opt_list_param(args, "args", of_type=str)
     check.str_param(job_name, "job_name")
     user_defined_k8s_config = check.opt_inst_param(
         user_defined_k8s_config,
@@ -608,6 +608,9 @@ def construct_dagster_k8s_job(
 
     container_config = copy.deepcopy(user_defined_k8s_config.container_config)
 
+    if args != None:
+        container_config["args"] = args
+
     user_defined_env_vars = container_config.pop("env", [])
 
     user_defined_env_from = container_config.pop("env_from", [])
@@ -627,7 +630,6 @@ def construct_dagster_k8s_job(
         {
             "name": "dagster",
             "image": job_image,
-            "args": args,
             "image_pull_policy": job_config.image_pull_policy,
             "env": env + job_config.env + user_defined_env_vars,
             "env_from": job_config.env_from_sources + user_defined_env_from,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -59,15 +59,35 @@ from ..utils import (
                 default_value=None,
                 description="The kubeconfig file from which to load config. Defaults to using the default kubeconfig.",
             ),
-            "job_config": Field(
-                Permissive(),
-                is_required=False,
-                description="Raw k8s config for the v1Job. Keys can either snake_case or camelCase",
-            ),
             "timeout": Field(
                 int,
                 is_required=False,
                 description="How long to wait for the job to succeed before raising an exception",
+            ),
+            "container_config": Field(
+                Permissive(),
+                is_required=False,
+                description="Raw k8s config for the k8s pod's main container (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core). Keys can either snake_case or camelCase.",
+            ),
+            "pod_template_spec_metadata": Field(
+                Permissive(),
+                is_required=False,
+                description="Raw k8s config for the k8s pod's metadata (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta). Keys can either snake_case or camelCase.",
+            ),
+            "pod_spec_config": Field(
+                Permissive(),
+                is_required=False,
+                description="Raw k8s config for the k8s pod's pod spec (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podspec-v1-core). Keys can either snake_case or camelCase.",
+            ),
+            "job_metadata": Field(
+                Permissive(),
+                is_required=False,
+                description="Raw k8s config for the k8s job's metadata (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta). Keys can either snake_case or camelCase.",
+            ),
+            "job_spec_config": Field(
+                Permissive(),
+                is_required=False,
+                description="Raw k8s config for the k8s job's job spec (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#jobspec-v1-batch). Keys can either snake_case or camelCase.",
             ),
         },
     ),
@@ -125,11 +145,17 @@ def k8s_job_op(context):
 
     namespace = container_context.namespace
 
+    container_config = config.get("container_config", {})
     command = config.get("command")
+    if command:
+        container_config["command"] = command
 
     user_defined_k8s_config = UserDefinedDagsterK8sConfig(
-        job_config=config.get("job_config"),
-        container_config=({"command": command} if command else {}),
+        container_config=container_config,
+        pod_template_spec_metadata=config.get("pod_template_spec_metadata"),
+        pod_spec_config=config.get("pod_spec_config"),
+        job_metadata=config.get("job_metadata"),
+        job_spec_config=config.get("job_spec_config"),
     )
 
     k8s_job_config = DagsterK8sJobConfig(


### PR DESCRIPTION
job_config wasn't actually doing anything - each of its sub-fields are replaced within the k8s machinery. Add the individual sub-fields that the rest of our k8s infrastructure uses.
