### PR TITLE
Make daemon sensor test suite faster

### DIFF
--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
@@ -1,0 +1,58 @@
+import os
+import sys
+
+import pytest
+
+from dagster._core.test_utils import create_test_daemon_workspace, instance_for_test
+from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+from dagster._core.workspace.load_target import ModuleTarget
+
+
+@pytest.fixture(name="instance_module_scoped", scope="module")
+def instance_module_scoped_fixture():
+    with instance_for_test(
+        overrides={
+            "run_launcher": {"module": "dagster._core.test_utils", "class": "MockedRunLauncher"}
+        }
+    ) as instance:
+        yield instance
+
+
+@pytest.fixture(name="instance", scope="function")
+def instance_fixture(instance_module_scoped):
+    instance_module_scoped.wipe()
+    instance_module_scoped.wipe_all_schedules()
+    yield instance_module_scoped
+
+
+def workspace_load_target(attribute="the_repo"):
+    return ModuleTarget(
+        module_name="dagster_tests.daemon_sensor_tests.test_sensor_run",
+        attribute=attribute,
+        working_directory=os.path.dirname(__file__),
+        location_name="test_location",
+    )
+
+
+@pytest.fixture(name="workspace", scope="module")
+def workspace_fixture(instance_module_scoped):  # pylint: disable=unused-argument
+    with create_test_daemon_workspace(
+        workspace_load_target=workspace_load_target(), instance=instance_module_scoped
+    ) as workspace:
+        yield workspace
+
+
+@pytest.fixture(name="external_repo", scope="module")
+def external_repo_fixture(workspace):  # pylint: disable=unused-argument
+    return next(
+        iter(workspace.get_workspace_snapshot().values())
+    ).repository_location.get_repository("the_repo")
+
+
+def loadable_target_origin():
+    return LoadableTargetOrigin(
+        executable_path=sys.executable,
+        module_name="dagster_tests.daemon_sensor_tests.test_sensor_run",
+        working_directory=os.getcwd(),
+        attribute="the_repo",
+    )

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -1,0 +1,812 @@
+import tempfile
+import time
+from contextlib import contextmanager
+
+import pendulum
+import pytest
+
+from dagster import DagsterRunStatus
+from dagster._core.events import DagsterEvent, DagsterEventType
+from dagster._core.events.log import EventLogEntry
+from dagster._core.scheduler.instigation import TickStatus
+from dagster._core.storage.event_log.base import EventRecordsFilter
+from dagster._core.test_utils import create_test_daemon_workspace, instance_for_test
+
+from .conftest import workspace_load_target
+from .test_sensor_run import (
+    evaluate_sensors,
+    failure_job,
+    failure_pipeline,
+    foo_pipeline,
+    get_sensor_executors,
+    hanging_pipeline,
+    the_pipeline,
+    validate_tick,
+    wait_for_all_runs_to_finish,
+)
+
+
+@pytest.fixture(name="instance_module_scoped", scope="module")
+def instance_module_scoped_fixture():
+    # Overridden from conftest.py, uses DefaultRunLauncher since we care about
+    # runs actually completing for run status sensors
+    with instance_for_test(
+        overrides={},
+    ) as instance:
+        yield instance
+
+
+@contextmanager
+def instance_with_sensors(overrides=None, attribute="the_repo"):
+    with instance_for_test(overrides=overrides) as instance:
+        with create_test_daemon_workspace(
+            workspace_load_target(attribute=attribute), instance=instance
+        ) as workspace:
+            yield (
+                instance,
+                workspace,
+                next(
+                    iter(workspace.get_workspace_snapshot().values())
+                ).repository_location.get_repository(attribute),
+            )
+
+
+@contextmanager
+def instance_with_multiple_repos_with_sensors(overrides=None):
+    with instance_for_test(overrides) as instance:
+        with create_test_daemon_workspace(
+            workspace_load_target(None), instance=instance
+        ) as workspace:
+            yield (
+                instance,
+                workspace,
+                next(
+                    iter(workspace.get_workspace_snapshot().values())
+                ).repository_location.get_repositories(),
+            )
+
+
+@pytest.mark.parametrize("executor", get_sensor_executors())
+def test_run_status_sensor(caplog, executor, instance, workspace, external_repo):
+    freeze_datetime = pendulum.now()
+    with pendulum.test(freeze_datetime):
+        success_sensor = external_repo.get_external_sensor("my_pipeline_success_sensor")
+        instance.start_sensor(success_sensor)
+
+        started_sensor = external_repo.get_external_sensor("my_pipeline_started_sensor")
+        instance.start_sensor(started_sensor)
+
+        evaluate_sensors(instance, workspace, executor)
+
+        ticks = instance.get_ticks(
+            success_sensor.get_external_origin_id(), success_sensor.selector_id
+        )
+        assert len(ticks) == 1
+        validate_tick(
+            ticks[0],
+            success_sensor,
+            freeze_datetime,
+            TickStatus.SKIPPED,
+        )
+
+        freeze_datetime = freeze_datetime.add(seconds=60)
+        time.sleep(1)
+
+    with pendulum.test(freeze_datetime):
+        external_pipeline = external_repo.get_full_external_pipeline("failure_pipeline")
+        run = instance.create_run_for_pipeline(
+            failure_pipeline,
+            external_pipeline_origin=external_pipeline.get_external_origin(),
+            pipeline_code_origin=external_pipeline.get_python_origin(),
+        )
+        instance.submit_run(run.run_id, workspace)
+        wait_for_all_runs_to_finish(instance)
+        run = instance.get_runs()[0]
+        assert run.status == DagsterRunStatus.FAILURE
+        freeze_datetime = freeze_datetime.add(seconds=60)
+
+    with pendulum.test(freeze_datetime):
+
+        # should not fire the success sensor, should fire the started sensro
+        evaluate_sensors(instance, workspace, executor)
+
+        ticks = instance.get_ticks(
+            success_sensor.get_external_origin_id(), success_sensor.selector_id
+        )
+        assert len(ticks) == 2
+        validate_tick(
+            ticks[0],
+            success_sensor,
+            freeze_datetime,
+            TickStatus.SKIPPED,
+        )
+
+        ticks = instance.get_ticks(
+            started_sensor.get_external_origin_id(), started_sensor.selector_id
+        )
+        assert len(ticks) == 2
+        validate_tick(
+            ticks[0],
+            started_sensor,
+            freeze_datetime,
+            TickStatus.SUCCESS,
+        )
+
+    with pendulum.test(freeze_datetime):
+        external_pipeline = external_repo.get_full_external_pipeline("foo_pipeline")
+        run = instance.create_run_for_pipeline(
+            foo_pipeline,
+            external_pipeline_origin=external_pipeline.get_external_origin(),
+            pipeline_code_origin=external_pipeline.get_python_origin(),
+        )
+        instance.submit_run(run.run_id, workspace)
+        wait_for_all_runs_to_finish(instance)
+        run = instance.get_runs()[0]
+        assert run.status == DagsterRunStatus.SUCCESS
+        freeze_datetime = freeze_datetime.add(seconds=60)
+
+    caplog.clear()
+
+    with pendulum.test(freeze_datetime):
+
+        # should fire the success sensor and the started sensor
+        evaluate_sensors(instance, workspace, executor)
+
+        ticks = instance.get_ticks(
+            success_sensor.get_external_origin_id(), success_sensor.selector_id
+        )
+        assert len(ticks) == 3
+        validate_tick(
+            ticks[0],
+            success_sensor,
+            freeze_datetime,
+            TickStatus.SUCCESS,
+        )
+
+        ticks = instance.get_ticks(
+            started_sensor.get_external_origin_id(), started_sensor.selector_id
+        )
+        assert len(ticks) == 3
+        validate_tick(
+            ticks[0],
+            started_sensor,
+            freeze_datetime,
+            TickStatus.SUCCESS,
+        )
+
+        assert (
+            'Sensor "my_pipeline_started_sensor" acted on run status STARTED of run' in caplog.text
+        )
+        assert (
+            'Sensor "my_pipeline_success_sensor" acted on run status SUCCESS of run' in caplog.text
+        )
+
+
+@pytest.mark.parametrize("executor", get_sensor_executors())
+def test_run_failure_sensor(executor, instance, workspace, external_repo):
+    freeze_datetime = pendulum.now()
+    with pendulum.test(freeze_datetime):
+        failure_sensor = external_repo.get_external_sensor("my_run_failure_sensor")
+        instance.start_sensor(failure_sensor)
+
+        evaluate_sensors(instance, workspace, executor)
+
+        ticks = instance.get_ticks(
+            failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+        )
+        assert len(ticks) == 1
+        validate_tick(
+            ticks[0],
+            failure_sensor,
+            freeze_datetime,
+            TickStatus.SKIPPED,
+        )
+
+        freeze_datetime = freeze_datetime.add(seconds=60)
+        time.sleep(1)
+
+    with pendulum.test(freeze_datetime):
+        external_pipeline = external_repo.get_full_external_pipeline("failure_pipeline")
+        run = instance.create_run_for_pipeline(
+            failure_pipeline,
+            external_pipeline_origin=external_pipeline.get_external_origin(),
+            pipeline_code_origin=external_pipeline.get_python_origin(),
+        )
+        instance.submit_run(run.run_id, workspace)
+        wait_for_all_runs_to_finish(instance)
+        run = instance.get_runs()[0]
+        assert run.status == DagsterRunStatus.FAILURE
+        freeze_datetime = freeze_datetime.add(seconds=60)
+
+    with pendulum.test(freeze_datetime):
+
+        # should fire the failure sensor
+        evaluate_sensors(instance, workspace, executor)
+
+        ticks = instance.get_ticks(
+            failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+        )
+        assert len(ticks) == 2
+        validate_tick(
+            ticks[0],
+            failure_sensor,
+            freeze_datetime,
+            TickStatus.SUCCESS,
+        )
+
+
+@pytest.mark.parametrize("executor", get_sensor_executors())
+def test_run_failure_sensor_that_fails(executor, instance, workspace, external_repo):
+    freeze_datetime = pendulum.now()
+    with pendulum.test(freeze_datetime):
+        failure_sensor = external_repo.get_external_sensor(
+            "my_run_failure_sensor_that_itself_fails"
+        )
+        instance.start_sensor(failure_sensor)
+
+        evaluate_sensors(instance, workspace, executor)
+
+        ticks = instance.get_ticks(
+            failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+        )
+        assert len(ticks) == 1
+        validate_tick(
+            ticks[0],
+            failure_sensor,
+            freeze_datetime,
+            TickStatus.SKIPPED,
+        )
+
+        freeze_datetime = freeze_datetime.add(seconds=60)
+        time.sleep(1)
+
+    with pendulum.test(freeze_datetime):
+        external_pipeline = external_repo.get_full_external_pipeline("failure_pipeline")
+        run = instance.create_run_for_pipeline(
+            failure_pipeline,
+            external_pipeline_origin=external_pipeline.get_external_origin(),
+            pipeline_code_origin=external_pipeline.get_python_origin(),
+        )
+        instance.submit_run(run.run_id, workspace)
+        wait_for_all_runs_to_finish(instance)
+        run = instance.get_runs()[0]
+        assert run.status == DagsterRunStatus.FAILURE
+        freeze_datetime = freeze_datetime.add(seconds=60)
+
+    with pendulum.test(freeze_datetime):
+
+        # should fire the failure sensor and fail
+        evaluate_sensors(instance, workspace, executor)
+
+        ticks = instance.get_ticks(
+            failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+        )
+        assert len(ticks) == 2
+        validate_tick(
+            ticks[0],
+            failure_sensor,
+            freeze_datetime,
+            TickStatus.FAILURE,
+            expected_error="How meta",
+        )
+
+    # Next tick skips again
+    freeze_datetime = freeze_datetime.add(seconds=60)
+    with pendulum.test(freeze_datetime):
+        # should fire the failure sensor and fail
+        evaluate_sensors(instance, workspace, executor)
+
+        ticks = instance.get_ticks(
+            failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+        )
+        assert len(ticks) == 3
+        validate_tick(
+            ticks[0],
+            failure_sensor,
+            freeze_datetime,
+            TickStatus.SKIPPED,
+        )
+
+
+@pytest.mark.parametrize("executor", get_sensor_executors())
+def test_run_failure_sensor_filtered(executor, instance, workspace, external_repo):
+    freeze_datetime = pendulum.now()
+    with pendulum.test(freeze_datetime):
+        failure_sensor = external_repo.get_external_sensor("my_run_failure_sensor_filtered")
+        instance.start_sensor(failure_sensor)
+
+        evaluate_sensors(instance, workspace, executor)
+
+        ticks = instance.get_ticks(
+            failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+        )
+        assert len(ticks) == 1
+        validate_tick(
+            ticks[0],
+            failure_sensor,
+            freeze_datetime,
+            TickStatus.SKIPPED,
+        )
+
+        freeze_datetime = freeze_datetime.add(seconds=60)
+        time.sleep(1)
+
+    with pendulum.test(freeze_datetime):
+        external_pipeline = external_repo.get_full_external_pipeline("failure_pipeline")
+        run = instance.create_run_for_pipeline(
+            failure_pipeline,
+            external_pipeline_origin=external_pipeline.get_external_origin(),
+            pipeline_code_origin=external_pipeline.get_python_origin(),
+        )
+        instance.submit_run(run.run_id, workspace)
+        wait_for_all_runs_to_finish(instance)
+        run = instance.get_runs()[0]
+        assert run.status == DagsterRunStatus.FAILURE
+        freeze_datetime = freeze_datetime.add(seconds=60)
+
+    with pendulum.test(freeze_datetime):
+
+        # should not fire the failure sensor (filtered to failure job)
+        evaluate_sensors(instance, workspace, executor)
+
+        ticks = instance.get_ticks(
+            failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+        )
+        assert len(ticks) == 2
+        validate_tick(
+            ticks[0],
+            failure_sensor,
+            freeze_datetime,
+            TickStatus.SKIPPED,
+        )
+
+        freeze_datetime = freeze_datetime.add(seconds=60)
+        time.sleep(1)
+
+    with pendulum.test(freeze_datetime):
+        external_pipeline = external_repo.get_full_external_pipeline("failure_graph")
+        run = instance.create_run_for_pipeline(
+            failure_job,
+            external_pipeline_origin=external_pipeline.get_external_origin(),
+            pipeline_code_origin=external_pipeline.get_python_origin(),
+        )
+        instance.submit_run(run.run_id, workspace)
+        wait_for_all_runs_to_finish(instance)
+        run = instance.get_runs()[0]
+        assert run.status == DagsterRunStatus.FAILURE
+
+        freeze_datetime = freeze_datetime.add(seconds=60)
+
+    with pendulum.test(freeze_datetime):
+
+        # should not fire the failure sensor (filtered to failure job)
+        evaluate_sensors(instance, workspace, executor)
+
+        ticks = instance.get_ticks(
+            failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+        )
+        assert len(ticks) == 3
+        validate_tick(
+            ticks[0],
+            failure_sensor,
+            freeze_datetime,
+            TickStatus.SUCCESS,
+        )
+
+
+def sqlite_storage_config_fn(temp_dir):
+    # non-run sharded storage
+    return {
+        "run_storage": {
+            "module": "dagster._core.storage.runs",
+            "class": "SqliteRunStorage",
+            "config": {"base_dir": temp_dir},
+        },
+        "event_log_storage": {
+            "module": "dagster._core.storage.event_log",
+            "class": "SqliteEventLogStorage",
+            "config": {"base_dir": temp_dir},
+        },
+    }
+
+
+def default_storage_config_fn(_):
+    # run sharded storage
+    return {}
+
+
+def sql_event_log_storage_config_fn(temp_dir):
+    return {
+        "event_log_storage": {
+            "module": "dagster._core.storage.event_log",
+            "class": "ConsolidatedSqliteEventLogStorage",
+            "config": {"base_dir": temp_dir},
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "storage_config_fn",
+    [default_storage_config_fn, sqlite_storage_config_fn],
+)
+@pytest.mark.parametrize("executor", get_sensor_executors())
+def test_run_status_sensor_interleave(storage_config_fn, executor):
+    freeze_datetime = pendulum.now()
+    with tempfile.TemporaryDirectory() as temp_dir:
+
+        with instance_with_sensors(overrides=storage_config_fn(temp_dir)) as (
+            instance,
+            workspace,
+            external_repo,
+        ):
+            # start sensor
+            with pendulum.test(freeze_datetime):
+                failure_sensor = external_repo.get_external_sensor("my_run_failure_sensor")
+                instance.start_sensor(failure_sensor)
+
+                evaluate_sensors(instance, workspace, executor)
+
+                ticks = instance.get_ticks(
+                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                )
+                assert len(ticks) == 1
+                validate_tick(
+                    ticks[0],
+                    failure_sensor,
+                    freeze_datetime,
+                    TickStatus.SKIPPED,
+                )
+
+                freeze_datetime = freeze_datetime.add(seconds=60)
+                time.sleep(1)
+
+            with pendulum.test(freeze_datetime):
+                external_pipeline = external_repo.get_full_external_pipeline("hanging_pipeline")
+                # start run 1
+                run1 = instance.create_run_for_pipeline(
+                    hanging_pipeline,
+                    external_pipeline_origin=external_pipeline.get_external_origin(),
+                    pipeline_code_origin=external_pipeline.get_python_origin(),
+                )
+                instance.submit_run(run1.run_id, workspace)
+                freeze_datetime = freeze_datetime.add(seconds=60)
+                # start run 2
+                run2 = instance.create_run_for_pipeline(
+                    hanging_pipeline,
+                    external_pipeline_origin=external_pipeline.get_external_origin(),
+                    pipeline_code_origin=external_pipeline.get_python_origin(),
+                )
+                instance.submit_run(run2.run_id, workspace)
+                freeze_datetime = freeze_datetime.add(seconds=60)
+                # fail run 2
+                instance.report_run_failed(run2)
+                freeze_datetime = freeze_datetime.add(seconds=60)
+                run = instance.get_runs()[0]
+                assert run.status == DagsterRunStatus.FAILURE
+                assert run.run_id == run2.run_id
+
+            # check sensor
+            with pendulum.test(freeze_datetime):
+
+                # should fire for run 2
+                evaluate_sensors(instance, workspace, executor)
+
+                ticks = instance.get_ticks(
+                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                )
+                assert len(ticks) == 2
+                validate_tick(
+                    ticks[0],
+                    failure_sensor,
+                    freeze_datetime,
+                    TickStatus.SUCCESS,
+                )
+                assert len(ticks[0].origin_run_ids) == 1
+                assert ticks[0].origin_run_ids[0] == run2.run_id
+
+            # fail run 1
+            with pendulum.test(freeze_datetime):
+                # fail run 2
+                instance.report_run_failed(run1)
+                freeze_datetime = freeze_datetime.add(seconds=60)
+                time.sleep(1)
+
+            # check sensor
+            with pendulum.test(freeze_datetime):
+
+                # should fire for run 1
+                evaluate_sensors(instance, workspace, executor)
+
+                ticks = instance.get_ticks(
+                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                )
+                assert len(ticks) == 3
+                validate_tick(
+                    ticks[0],
+                    failure_sensor,
+                    freeze_datetime,
+                    TickStatus.SUCCESS,
+                )
+                assert len(ticks[0].origin_run_ids) == 1
+                assert ticks[0].origin_run_ids[0] == run1.run_id
+
+
+@pytest.mark.parametrize("storage_config_fn", [sql_event_log_storage_config_fn])
+@pytest.mark.parametrize("executor", get_sensor_executors())
+def test_run_failure_sensor_empty_run_records(storage_config_fn, executor):
+    freeze_datetime = pendulum.now()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with instance_with_sensors(overrides=storage_config_fn(temp_dir)) as (
+            instance,
+            workspace,
+            external_repo,
+        ):
+            with pendulum.test(freeze_datetime):
+                failure_sensor = external_repo.get_external_sensor("my_run_failure_sensor")
+                instance.start_sensor(failure_sensor)
+
+                evaluate_sensors(instance, workspace, executor)
+
+                ticks = instance.get_ticks(
+                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                )
+                assert len(ticks) == 1
+                validate_tick(
+                    ticks[0],
+                    failure_sensor,
+                    freeze_datetime,
+                    TickStatus.SKIPPED,
+                )
+
+                freeze_datetime = freeze_datetime.add(seconds=60)
+                time.sleep(1)
+
+            with pendulum.test(freeze_datetime):
+                # create a mismatch between event storage and run storage
+                instance.event_log_storage.store_event(
+                    EventLogEntry(
+                        error_info=None,
+                        level="debug",
+                        user_message="",
+                        run_id="fake_run_id",
+                        timestamp=time.time(),
+                        dagster_event=DagsterEvent(
+                            DagsterEventType.PIPELINE_FAILURE.value,
+                            "foo",
+                        ),
+                    )
+                )
+                runs = instance.get_runs()
+                assert len(runs) == 0
+                failure_events = instance.get_event_records(
+                    EventRecordsFilter(event_type=DagsterEventType.PIPELINE_FAILURE)
+                )
+                assert len(failure_events) == 1
+                freeze_datetime = freeze_datetime.add(seconds=60)
+
+            with pendulum.test(freeze_datetime):
+                # shouldn't fire the failure sensor due to the mismatch
+                evaluate_sensors(instance, workspace, executor)
+
+                ticks = instance.get_ticks(
+                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                )
+                assert len(ticks) == 2
+                validate_tick(
+                    ticks[0],
+                    failure_sensor,
+                    freeze_datetime,
+                    TickStatus.SKIPPED,
+                )
+
+
+@pytest.mark.parametrize("executor", get_sensor_executors())
+def test_cross_repo_run_status_sensor(executor):
+    freeze_datetime = pendulum.now()
+    with instance_with_multiple_repos_with_sensors() as (
+        instance,
+        workspace,
+        repos,
+    ):
+        the_repo = repos["the_repo"]
+        the_other_repo = repos["the_other_repo"]
+
+        with pendulum.test(freeze_datetime):
+            cross_repo_sensor = the_repo.get_external_sensor("cross_repo_sensor")
+            instance.start_sensor(cross_repo_sensor)
+
+            evaluate_sensors(instance, workspace, executor)
+
+            ticks = instance.get_ticks(
+                cross_repo_sensor.get_external_origin_id(), cross_repo_sensor.selector_id
+            )
+            assert len(ticks) == 1
+            validate_tick(
+                ticks[0],
+                cross_repo_sensor,
+                freeze_datetime,
+                TickStatus.SKIPPED,
+            )
+
+            freeze_datetime = freeze_datetime.add(seconds=60)
+            time.sleep(1)
+
+        with pendulum.test(freeze_datetime):
+            external_pipeline = the_other_repo.get_full_external_pipeline("the_pipeline")
+            run = instance.create_run_for_pipeline(
+                the_pipeline,
+                external_pipeline_origin=external_pipeline.get_external_origin(),
+                pipeline_code_origin=external_pipeline.get_python_origin(),
+            )
+            instance.submit_run(run.run_id, workspace)
+            wait_for_all_runs_to_finish(instance)
+            run = instance.get_runs()[0]
+            assert run.status == DagsterRunStatus.SUCCESS
+            freeze_datetime = freeze_datetime.add(seconds=60)
+
+        with pendulum.test(freeze_datetime):
+
+            evaluate_sensors(instance, workspace, executor)
+
+            ticks = instance.get_ticks(
+                cross_repo_sensor.get_external_origin_id(), cross_repo_sensor.selector_id
+            )
+            assert len(ticks) == 2
+            validate_tick(
+                ticks[0],
+                cross_repo_sensor,
+                freeze_datetime,
+                TickStatus.SUCCESS,
+            )
+
+
+@pytest.mark.parametrize("executor", get_sensor_executors())
+def test_cross_repo_job_run_status_sensor(executor):
+    freeze_datetime = pendulum.now()
+    with instance_with_multiple_repos_with_sensors() as (
+        instance,
+        workspace,
+        repos,
+    ):
+        the_repo = repos["the_repo"]
+        the_other_repo = repos["the_other_repo"]
+
+        with pendulum.test(freeze_datetime):
+            cross_repo_sensor = the_repo.get_external_sensor("cross_repo_job_sensor")
+            instance.start_sensor(cross_repo_sensor)
+
+            assert instance.get_runs_count() == 0
+
+            evaluate_sensors(instance, workspace, executor)
+            wait_for_all_runs_to_finish(instance)
+            assert instance.get_runs_count() == 0
+
+            ticks = instance.get_ticks(
+                cross_repo_sensor.get_external_origin_id(), cross_repo_sensor.selector_id
+            )
+            assert len(ticks) == 1
+            validate_tick(
+                ticks[0],
+                cross_repo_sensor,
+                freeze_datetime,
+                TickStatus.SKIPPED,
+            )
+
+            freeze_datetime = freeze_datetime.add(seconds=60)
+            time.sleep(1)
+
+        with pendulum.test(freeze_datetime):
+            external_pipeline = the_other_repo.get_full_external_pipeline("the_pipeline")
+            run = instance.create_run_for_pipeline(
+                the_pipeline,
+                external_pipeline_origin=external_pipeline.get_external_origin(),
+                pipeline_code_origin=external_pipeline.get_python_origin(),
+            )
+            instance.submit_run(run.run_id, workspace)
+            wait_for_all_runs_to_finish(instance)
+            assert instance.get_runs_count() == 1
+            run = instance.get_runs()[0]
+            assert run.status == DagsterRunStatus.SUCCESS
+            freeze_datetime = freeze_datetime.add(seconds=60)
+
+        with pendulum.test(freeze_datetime):
+            evaluate_sensors(instance, workspace, executor)
+            wait_for_all_runs_to_finish(instance)
+
+            ticks = instance.get_ticks(
+                cross_repo_sensor.get_external_origin_id(), cross_repo_sensor.selector_id
+            )
+            assert len(ticks) == 2
+            validate_tick(
+                ticks[0],
+                cross_repo_sensor,
+                freeze_datetime,
+                TickStatus.SUCCESS,
+            )
+
+            run_request_runs = [r for r in instance.get_runs() if r.pipeline_name == "the_graph"]
+            assert len(run_request_runs) == 1
+            assert run_request_runs[0].status == DagsterRunStatus.SUCCESS
+            freeze_datetime = freeze_datetime.add(seconds=60)
+
+        with pendulum.test(freeze_datetime):
+            # ensure that the success of the run launched by the sensor doesn't trigger the sensor
+            evaluate_sensors(instance, workspace, executor)
+            wait_for_all_runs_to_finish(instance)
+            run_request_runs = [r for r in instance.get_runs() if r.pipeline_name == "the_graph"]
+            assert len(run_request_runs) == 1
+
+            ticks = instance.get_ticks(
+                cross_repo_sensor.get_external_origin_id(), cross_repo_sensor.selector_id
+            )
+            assert len(ticks) == 3
+            validate_tick(
+                ticks[0],
+                cross_repo_sensor,
+                freeze_datetime,
+                TickStatus.SKIPPED,
+            )
+
+
+@pytest.mark.parametrize("executor", get_sensor_executors())
+def test_different_instance_run_status_sensor(executor):
+    freeze_datetime = pendulum.now()
+    with instance_with_sensors() as (
+        instance,
+        workspace,
+        the_repo,
+    ):
+        with instance_with_sensors(attribute="the_other_repo") as (
+            the_other_instance,
+            the_other_workspace,
+            the_other_repo,
+        ):
+
+            with pendulum.test(freeze_datetime):
+                cross_repo_sensor = the_repo.get_external_sensor("cross_repo_sensor")
+                instance.start_sensor(cross_repo_sensor)
+
+                evaluate_sensors(instance, workspace, executor)
+
+                ticks = instance.get_ticks(
+                    cross_repo_sensor.get_external_origin_id(), cross_repo_sensor.selector_id
+                )
+                assert len(ticks) == 1
+                validate_tick(
+                    ticks[0],
+                    cross_repo_sensor,
+                    freeze_datetime,
+                    TickStatus.SKIPPED,
+                )
+
+                freeze_datetime = freeze_datetime.add(seconds=60)
+                time.sleep(1)
+
+            with pendulum.test(freeze_datetime):
+                external_pipeline = the_other_repo.get_full_external_pipeline("the_pipeline")
+                run = the_other_instance.create_run_for_pipeline(
+                    the_pipeline,
+                    external_pipeline_origin=external_pipeline.get_external_origin(),
+                    pipeline_code_origin=external_pipeline.get_python_origin(),
+                )
+                the_other_instance.submit_run(run.run_id, the_other_workspace)
+                wait_for_all_runs_to_finish(the_other_instance)
+                run = the_other_instance.get_runs()[0]
+                assert run.status == DagsterRunStatus.SUCCESS
+                freeze_datetime = freeze_datetime.add(seconds=60)
+
+            with pendulum.test(freeze_datetime):
+
+                evaluate_sensors(instance, workspace, executor)
+
+                ticks = instance.get_ticks(
+                    cross_repo_sensor.get_external_origin_id(), cross_repo_sensor.selector_id
+                )
+                assert len(ticks) == 2
+                # the_pipeline was run in another instance, so the cross_repo_sensor should not trigger
+                validate_tick(
+                    ticks[0],
+                    cross_repo_sensor,
+                    freeze_datetime,
+                    TickStatus.SKIPPED,
+                )

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_failure_recovery.py
@@ -13,7 +13,6 @@ from dagster._core.test_utils import (
     cleanup_test_instance,
     create_test_daemon_workspace,
     get_crash_signals,
-    get_logger_output_from_capfd,
     wait_for_futures,
 )
 from dagster._daemon import get_default_daemon_logger
@@ -21,11 +20,7 @@ from dagster._daemon.sensor import execute_sensor_iteration
 from dagster._seven import IS_WINDOWS
 from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
 
-from .test_sensor_run import (
-    instance_with_sensors,
-    wait_for_all_runs_to_start,
-    workspace_load_target,
-)
+from .test_sensor_run import wait_for_all_runs_to_start, workspace_load_target
 
 spawn_ctx = multiprocessing.get_context("spawn")
 
@@ -59,88 +54,73 @@ def _test_launch_sensor_runs_in_subprocess(instance_ref, execution_datetime, deb
 )
 @pytest.mark.parametrize("crash_location", ["TICK_CREATED", "TICK_HELD"])
 @pytest.mark.parametrize("crash_signal", get_crash_signals())
-def test_failure_before_run_created(crash_location, crash_signal, capfd):
+def test_failure_before_run_created(crash_location, crash_signal, instance, external_repo):
     frozen_datetime = to_timezone(
         create_pendulum_time(year=2019, month=2, day=28, hour=0, minute=0, second=1, tz="UTC"),
         "US/Central",
     )
 
-    with instance_with_sensors() as (
-        instance,
-        _grpc_server_registry,
-        external_repo,
-    ):
-        with pendulum.test(frozen_datetime):
-            external_sensor = external_repo.get_external_sensor("simple_sensor")
-            instance.add_instigator_state(
-                InstigatorState(
-                    external_sensor.get_external_origin(),
-                    InstigatorType.SENSOR,
-                    InstigatorStatus.RUNNING,
-                )
+    with pendulum.test(frozen_datetime):
+        external_sensor = external_repo.get_external_sensor("simple_sensor")
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
             )
+        )
 
-            # create a tick
-            launch_process = spawn_ctx.Process(
-                target=_test_launch_sensor_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime, None],
-            )
-            launch_process.start()
-            launch_process.join(timeout=60)
-            ticks = instance.get_ticks(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
-            )
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.SKIPPED
-            capfd.readouterr()
+        # create a tick
+        launch_process = spawn_ctx.Process(
+            target=_test_launch_sensor_runs_in_subprocess,
+            args=[instance.get_ref(), frozen_datetime, None],
+        )
+        launch_process.start()
+        launch_process.join(timeout=60)
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 1
+        assert ticks[0].status == TickStatus.SKIPPED
 
-            # create a starting tick, but crash
-            debug_crash_flags = {external_sensor.name: {crash_location: crash_signal}}
-            launch_process = spawn_ctx.Process(
-                target=_test_launch_sensor_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime.add(seconds=31), debug_crash_flags],
-            )
-            launch_process.start()
-            launch_process.join(timeout=60)
+        # create a starting tick, but crash
+        debug_crash_flags = {external_sensor.name: {crash_location: crash_signal}}
+        launch_process = spawn_ctx.Process(
+            target=_test_launch_sensor_runs_in_subprocess,
+            args=[instance.get_ref(), frozen_datetime.add(seconds=31), debug_crash_flags],
+        )
+        launch_process.start()
+        launch_process.join(timeout=60)
 
-            assert launch_process.exitcode != 0
+        assert launch_process.exitcode != 0
 
-            capfd.readouterr()
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 2
+        assert ticks[0].status == TickStatus.STARTED
+        assert not int(ticks[0].timestamp) % 2  # skip condition for simple_sensor
+        assert instance.get_runs_count() == 0
 
-            ticks = instance.get_ticks(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
-            )
-            assert len(ticks) == 2
-            assert ticks[0].status == TickStatus.STARTED
-            assert not int(ticks[0].timestamp) % 2  # skip condition for simple_sensor
-            assert instance.get_runs_count() == 0
+        # create another tick, but ensure that the last evaluation time used is from the first,
+        # successful tick rather than the failed tick
+        launch_process = spawn_ctx.Process(
+            target=_test_launch_sensor_runs_in_subprocess,
+            args=[instance.get_ref(), frozen_datetime.add(seconds=62), None],
+        )
+        launch_process.start()
+        launch_process.join(timeout=60)
 
-            # create another tick, but ensure that the last evaluation time used is from the first,
-            # successful tick rather than the failed tick
-            launch_process = spawn_ctx.Process(
-                target=_test_launch_sensor_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime.add(seconds=62), None],
-            )
-            launch_process.start()
-            launch_process.join(timeout=60)
+        assert launch_process.exitcode == 0
+        wait_for_all_runs_to_start(instance)
 
-            assert launch_process.exitcode == 0
-            wait_for_all_runs_to_start(instance)
+        assert instance.get_runs_count() == 1
 
-            assert instance.get_runs_count() == 1
-            run = instance.get_runs()[0]
-            assert (
-                get_logger_output_from_capfd(capfd, "dagster.daemon.SensorDaemon")
-                == f"""2019-02-27 18:01:03 -0600 - dagster.daemon.SensorDaemon - INFO - Checking for new runs for sensor: simple_sensor
-2019-02-27 18:01:03 -0600 - dagster.daemon.SensorDaemon - INFO - Launching run for simple_sensor
-2019-02-27 18:01:03 -0600 - dagster.daemon.SensorDaemon - INFO - Completed launch of run {run.run_id} for simple_sensor"""
-            )
-
-            ticks = instance.get_ticks(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
-            )
-            assert len(ticks) == 3
-            assert ticks[0].status == TickStatus.SUCCESS
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 3
+        assert ticks[0].status == TickStatus.SUCCESS
 
 
 @pytest.mark.skipif(
@@ -148,78 +128,66 @@ def test_failure_before_run_created(crash_location, crash_signal, capfd):
 )
 @pytest.mark.parametrize("crash_location", ["RUN_CREATED"])
 @pytest.mark.parametrize("crash_signal", get_crash_signals())
-def test_failure_after_run_created_before_run_launched(crash_location, crash_signal, capfd):
+def test_failure_after_run_created_before_run_launched(
+    crash_location, crash_signal, instance, external_repo
+):
     frozen_datetime = to_timezone(
         create_pendulum_time(year=2019, month=2, day=28, hour=0, minute=0, second=0, tz="UTC"),
         "US/Central",
     )
-    with instance_with_sensors() as (
-        instance,
-        _grpc_server_registry,
-        external_repo,
-    ):
-        with pendulum.test(frozen_datetime):
-            external_sensor = external_repo.get_external_sensor("run_key_sensor")
-            instance.add_instigator_state(
-                InstigatorState(
-                    external_sensor.get_external_origin(),
-                    InstigatorType.SENSOR,
-                    InstigatorStatus.RUNNING,
-                )
+    with pendulum.test(frozen_datetime):
+        external_sensor = external_repo.get_external_sensor("run_key_sensor")
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
             )
+        )
 
-            # create a starting tick, but crash
-            debug_crash_flags = {external_sensor.name: {crash_location: crash_signal}}
-            launch_process = spawn_ctx.Process(
-                target=_test_launch_sensor_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime, debug_crash_flags],
-            )
-            launch_process.start()
-            launch_process.join(timeout=60)
+        # create a starting tick, but crash
+        debug_crash_flags = {external_sensor.name: {crash_location: crash_signal}}
+        launch_process = spawn_ctx.Process(
+            target=_test_launch_sensor_runs_in_subprocess,
+            args=[instance.get_ref(), frozen_datetime, debug_crash_flags],
+        )
+        launch_process.start()
+        launch_process.join(timeout=60)
 
-            assert launch_process.exitcode != 0
+        assert launch_process.exitcode != 0
 
-            ticks = instance.get_ticks(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
-            )
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
 
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.STARTED
-            assert instance.get_runs_count() == 1
+        assert len(ticks) == 1
+        assert ticks[0].status == TickStatus.STARTED
+        assert instance.get_runs_count() == 1
 
-            run = instance.get_runs()[0]
-            # Run was created, but hasn't launched yet
-            assert run.status == PipelineRunStatus.NOT_STARTED
-            assert run.tags.get(SENSOR_NAME_TAG) == "run_key_sensor"
-            assert run.tags.get(RUN_KEY_TAG) == "only_once"
+        run = instance.get_runs()[0]
+        # Run was created, but hasn't launched yet
+        assert run.status == PipelineRunStatus.NOT_STARTED
+        assert run.tags.get(SENSOR_NAME_TAG) == "run_key_sensor"
+        assert run.tags.get(RUN_KEY_TAG) == "only_once"
 
-            # clear output
-            capfd.readouterr()
+        launch_process = spawn_ctx.Process(
+            target=_test_launch_sensor_runs_in_subprocess,
+            args=[instance.get_ref(), frozen_datetime.add(seconds=31), None],
+        )
+        launch_process.start()
+        launch_process.join(timeout=60)
 
-            launch_process = spawn_ctx.Process(
-                target=_test_launch_sensor_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime.add(seconds=31), None],
-            )
-            launch_process.start()
-            launch_process.join(timeout=60)
+        assert launch_process.exitcode == 0
+        wait_for_all_runs_to_start(instance)
 
-            assert launch_process.exitcode == 0
-            wait_for_all_runs_to_start(instance)
+        assert instance.get_runs_count() == 1
+        run = instance.get_runs()[0]
 
-            assert instance.get_runs_count() == 1
-            run = instance.get_runs()[0]
-            captured = capfd.readouterr()
-
-            assert (
-                f"Run {run.run_id} already created with the run key `only_once` for run_key_sensor"
-                in captured.out
-            )
-
-            ticks = instance.get_ticks(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
-            )
-            assert len(ticks) == 2
-            assert ticks[0].status == TickStatus.SUCCESS
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 2
+        assert ticks[0].status == TickStatus.SUCCESS
 
 
 @pytest.mark.skipif(
@@ -227,7 +195,7 @@ def test_failure_after_run_created_before_run_launched(crash_location, crash_sig
 )
 @pytest.mark.parametrize("crash_location", ["RUN_LAUNCHED"])
 @pytest.mark.parametrize("crash_signal", get_crash_signals())
-def test_failure_after_run_launched(crash_location, crash_signal, capfd):
+def test_failure_after_run_launched(crash_location, crash_signal, instance, external_repo):
     frozen_datetime = to_timezone(
         create_pendulum_time(
             year=2019,
@@ -240,67 +208,55 @@ def test_failure_after_run_launched(crash_location, crash_signal, capfd):
         ),
         "US/Central",
     )
-    with instance_with_sensors() as (
-        instance,
-        _grpc_server_registry,
-        external_repo,
-    ):
-        with pendulum.test(frozen_datetime):
-            external_sensor = external_repo.get_external_sensor("run_key_sensor")
-            instance.add_instigator_state(
-                InstigatorState(
-                    external_sensor.get_external_origin(),
-                    InstigatorType.SENSOR,
-                    InstigatorStatus.RUNNING,
-                )
+    with pendulum.test(frozen_datetime):
+        external_sensor = external_repo.get_external_sensor("run_key_sensor")
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
             )
+        )
 
-            # create a run, launch but crash
-            debug_crash_flags = {external_sensor.name: {crash_location: crash_signal}}
-            launch_process = spawn_ctx.Process(
-                target=_test_launch_sensor_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime, debug_crash_flags],
-            )
-            launch_process.start()
-            launch_process.join(timeout=60)
+        # create a run, launch but crash
+        debug_crash_flags = {external_sensor.name: {crash_location: crash_signal}}
+        launch_process = spawn_ctx.Process(
+            target=_test_launch_sensor_runs_in_subprocess,
+            args=[instance.get_ref(), frozen_datetime, debug_crash_flags],
+        )
+        launch_process.start()
+        launch_process.join(timeout=60)
 
-            assert launch_process.exitcode != 0
+        assert launch_process.exitcode != 0
 
-            ticks = instance.get_ticks(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
-            )
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
 
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.STARTED
-            assert instance.get_runs_count() == 1
+        assert len(ticks) == 1
+        assert ticks[0].status == TickStatus.STARTED
+        assert instance.get_runs_count() == 1
 
-            run = instance.get_runs()[0]
-            wait_for_all_runs_to_start(instance)
-            assert run.tags.get(SENSOR_NAME_TAG) == "run_key_sensor"
-            assert run.tags.get(RUN_KEY_TAG) == "only_once"
-            capfd.readouterr()
+        run = instance.get_runs()[0]
+        wait_for_all_runs_to_start(instance)
+        assert run.tags.get(SENSOR_NAME_TAG) == "run_key_sensor"
+        assert run.tags.get(RUN_KEY_TAG) == "only_once"
 
-            launch_process = spawn_ctx.Process(
-                target=_test_launch_sensor_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime.add(seconds=31), None],
-            )
-            launch_process.start()
-            launch_process.join(timeout=60)
+        launch_process = spawn_ctx.Process(
+            target=_test_launch_sensor_runs_in_subprocess,
+            args=[instance.get_ref(), frozen_datetime.add(seconds=31), None],
+        )
+        launch_process.start()
+        launch_process.join(timeout=60)
 
-            assert launch_process.exitcode == 0
-            wait_for_all_runs_to_start(instance)
+        assert launch_process.exitcode == 0
+        wait_for_all_runs_to_start(instance)
 
-            assert instance.get_runs_count() == 1
-            run = instance.get_runs()[0]
-            captured = capfd.readouterr()
+        assert instance.get_runs_count() == 1
+        run = instance.get_runs()[0]
 
-            assert (
-                'Skipping 1 run for sensor run_key_sensor already completed with run keys: ["only_once"]'
-                in captured.out
-            )
-
-            ticks = instance.get_ticks(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
-            )
-            assert len(ticks) == 2
-            assert ticks[0].status == TickStatus.SKIPPED
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 2
+        assert ticks[0].status == TickStatus.SKIPPED


### PR DESCRIPTION
Summary:
use fixtures to not spin up a new instance/workspace for every single test - similar to the fixture setup in the scheduler tests.

### Summary & Motivation

### How I Tested These Changes
