### PR TITLE
docs mdxcomponents: change TabGrouop syntax to work with remark format DREL-363

### DIFF
--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -4,6 +4,26 @@ title: "Welcome to Dagster! | Dagster Docs"
 
 # Welcome to Dagster!
 
+<TabGroup>
+  <TabItem name="Tab1">
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+      est laborum.
+    </p>
+  </TabItem>
+  <TabItem name="Tab2">
+    <p>aaa</p>
+  </TabItem>
+  <TabItem name="Tab3">
+    <img src="https://www.firstbenefits.org/wp-content/uploads/2017/10/placeholder-1024x1024.png" />
+  </TabItem>
+</TabGroup>
+
 Dagster is an orchestrator that's designed for developing and maintaining data assets, such as tables, data sets, machine learning models, and reports.
 
 You declare functions that you want to run and the data assets that those functions produce or update. Dagster then helps you run your functions at the right time and keep your assets up-to-date.

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -481,48 +481,51 @@ const ExampleItem = ({title, hrefDoc = null, hrefCode, children, tags = []}) => 
   );
 };
 
-interface Entry {
+interface TabItem {
   name: string;
-  content: any;
+  children: any;
 }
+const TabItem = (_: TabItem) => {}; // container to pass through name and children
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ');
 }
 
-function TabGroup({entries}: {entries: Entry[]}) {
+const TabGroup = ({children}) => {
   return (
     <div className="w-full px-2 py-2 sm:px-0">
       <Tab.Group>
         <Tab.List className="flex space-x-2 m-2">
-          {entries.map((entry, idx) => (
-            <Tab
-              key={idx}
-              className={({selected}) =>
-                classNames(
-                  'w-full py-3 text-sm font-bold leading-5',
-                  'focus:outline-none border-gray-200',
-                  selected
-                    ? 'border-b-2 border-primary-500 text-primary-500'
-                    : 'border-b hover:border-gray-500 hover:text-gray-700',
-                )
-              }
-            >
-              {entry?.name}
-            </Tab>
-          ))}
+          {children.map((child, idx) => {
+            return (
+              <Tab
+                key={idx}
+                className={({selected}) =>
+                  classNames(
+                    'w-full py-3 text-sm font-bold leading-5',
+                    'focus:outline-none border-gray-200',
+                    selected
+                      ? 'border-b-2 border-primary-500 text-primary-500'
+                      : 'border-b hover:border-gray-500 hover:text-gray-700',
+                  )
+                }
+              >
+                {child?.props?.name}
+              </Tab>
+            );
+          })}
         </Tab.List>
         <Tab.Panels>
-          {entries.map((entry, idx) => (
+          {children.map((child, idx) => (
             <Tab.Panel key={idx} className={classNames('p-3')}>
-              {entry?.content}
+              {child.props.children}
             </Tab.Panel>
           ))}
         </Tab.Panels>
       </Tab.Group>
     </div>
   );
-}
+};
 
 const Image = ({children, ...props}) => {
   /* Only version images when all conditions meet:
@@ -600,4 +603,5 @@ export default {
   ExampleItemSmall,
   ExampleItem,
   TabGroup,
+  TabItem,
 };

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -496,7 +496,7 @@ const TabGroup = ({children}) => {
     <div className="w-full px-2 py-2 sm:px-0">
       <Tab.Group>
         <Tab.List className="flex space-x-2 m-2">
-          {children.map((child, idx) => {
+          {React.Children.map(children, (child, idx) => {
             return (
               <Tab
                 key={idx}
@@ -516,11 +516,13 @@ const TabGroup = ({children}) => {
           })}
         </Tab.List>
         <Tab.Panels>
-          {children.map((child, idx) => (
-            <Tab.Panel key={idx} className={classNames('p-3')}>
-              {child.props.children}
-            </Tab.Panel>
-          ))}
+          {React.Children.map(children, (child, idx) => {
+            return (
+              <Tab.Panel key={idx} className={classNames('p-3')}>
+                {child.props.children}
+              </Tab.Panel>
+            );
+          })}
         </Tab.Panels>
       </Tab.Group>
     </div>


### PR DESCRIPTION
### Summary & Motivation
the problem with snapshot or format cmd is that the mdx formatter (i.e. remarkjs) falsely identifies the `<TabGroup ... />` as `text` when the component gets longer.
i didn't find a good way to tell the formatter that it should be `html`.

so this pr changes the `TabGroup` syntax to adapt to the formatter, i.e. make the html components shorter.

### How I Tested These Changes
`make mdx-format` doesn't change the `TabGroup` component in mdx file
