### PR TITLE
[easy] Use next image route for head texture to reduce image size

### DIFF
--- a/docs/next/layouts/MainLayout.tsx
+++ b/docs/next/layouts/MainLayout.tsx
@@ -14,7 +14,7 @@ const Layout: React.FC = ({children}) => {
       <div
         style={{
           minHeight: '100vh',
-          backgroundImage: 'url("/assets/head-texture.jpg")',
+          backgroundImage: 'url("_next/image?url=/assets/head-texture.jpg&w=3840&q=75")',
           backgroundRepeat: 'no-repeat',
           backgroundPosition: 'top middle',
           backgroundSize: 'fit',

--- a/docs/next/layouts/MainLayout.tsx
+++ b/docs/next/layouts/MainLayout.tsx
@@ -14,7 +14,7 @@ const Layout: React.FC = ({children}) => {
       <div
         style={{
           minHeight: '100vh',
-          backgroundImage: 'url("_next/image?url=/assets/head-texture.jpg&w=3840&q=75")',
+          backgroundImage: 'url("_next/image?url=/assets/head-texture.jpg&w=3840&q=100")',
           backgroundRepeat: 'no-repeat',
           backgroundPosition: 'top middle',
           backgroundSize: 'fit',


### PR DESCRIPTION
### Summary & Motivation
before 461kb
<img width="936" alt="Screen Shot 2022-09-07 at 4 55 03 AM" src="https://user-images.githubusercontent.com/2286579/188836155-e9df5edb-2dc0-4ace-998c-29a1c53c9671.png">
after 253b
<img width="986" alt="Screen Shot 2022-09-07 at 4 55 36 AM" src="https://user-images.githubusercontent.com/2286579/188836198-5aab3ce9-d3e5-4cbe-9adc-6e9455069c59.png">



### How I Tested These Changes
Visually compare the two header textures and observe negligible differences.