### PR TITLE
ExternalRepository clean-up

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/test_queued.py
+++ b/integration_tests/test_suites/daemon-test-suite/test_queued.py
@@ -27,7 +27,7 @@ def assert_events_in_order(logs, expected_events):
 def test_queue_from_schedule_and_sensor(instance, foo_example_workspace, foo_example_repo):
     external_schedule = foo_example_repo.get_external_schedule("always_run_schedule")
     external_sensor = foo_example_repo.get_external_sensor("always_on_sensor")
-    external_pipeline = foo_example_repo.get_full_external_pipeline("foo_pipeline")
+    external_pipeline = foo_example_repo.get_full_external_job("foo_pipeline")
 
     instance.start_schedule(external_schedule)
     instance.start_sensor(external_sensor)
@@ -62,7 +62,7 @@ def test_queue_from_schedule_and_sensor(instance, foo_example_workspace, foo_exa
 
 def test_queued_runs(instance, foo_example_workspace, foo_example_repo):
     with start_daemon(workspace_file=file_relative_path(__file__, "repo.py")):
-        external_pipeline = foo_example_repo.get_full_external_pipeline("foo_pipeline")
+        external_pipeline = foo_example_repo.get_full_external_job("foo_pipeline")
 
         run = create_run(instance, external_pipeline)
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -11,23 +11,23 @@ from dagster._utils.error import serializable_error_info_from_exc_info
 from .utils import UserFacingGraphQLError, capture_error
 
 
-def get_full_external_pipeline_or_raise(graphene_info, selector):
+def get_full_external_job_or_raise(graphene_info, selector):
     from ..schema.errors import GraphenePipelineNotFoundError
 
     check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(selector, "selector", PipelineSelector)
 
-    if not graphene_info.context.has_external_pipeline(selector):
+    if not graphene_info.context.has_external_job(selector):
         raise UserFacingGraphQLError(GraphenePipelineNotFoundError(selector=selector))
 
-    return graphene_info.context.get_full_external_pipeline(selector)
+    return graphene_info.context.get_full_external_job(selector)
 
 
 def get_external_pipeline_or_raise(graphene_info, selector):
     check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(selector, "selector", PipelineSelector)
 
-    full_pipeline = get_full_external_pipeline_or_raise(graphene_info, selector)
+    full_pipeline = get_full_external_job_or_raise(graphene_info, selector)
 
     if selector.solid_selection is None and selector.asset_selection is None:
         return full_pipeline
@@ -55,7 +55,7 @@ def get_subset_external_pipeline(context, selector):
                     if error_info.cause
                     else "",
                 ),
-                pipeline=GraphenePipeline(context.get_full_external_pipeline(selector)),
+                pipeline=GraphenePipeline(context.get_full_external_job(selector)),
             )
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_pipelines.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_pipelines.py
@@ -3,7 +3,7 @@ from graphene import ResolveInfo
 import dagster._check as check
 from dagster._core.storage.pipeline_run import PipelineRun
 
-from .external import get_external_pipeline_or_raise, get_full_external_pipeline_or_raise
+from .external import get_external_pipeline_or_raise, get_full_external_job_or_raise
 from .utils import PipelineSelector, UserFacingGraphQLError, capture_error
 
 
@@ -13,7 +13,7 @@ def get_pipeline_snapshot_or_error_from_pipeline_selector(graphene_info, pipelin
 
     check.inst_param(pipeline_selector, "pipeline_selector", PipelineSelector)
     return GraphenePipelineSnapshot(
-        get_full_external_pipeline_or_raise(graphene_info, pipeline_selector)
+        get_full_external_job_or_raise(graphene_info, pipeline_selector)
     )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_solids.py
@@ -24,7 +24,7 @@ def get_used_solid_map(repo):
     inv_by_def_name = defaultdict(list)
     definitions = []
 
-    for external_pipeline in repo.get_all_external_pipelines():
+    for external_pipeline in repo.get_all_external_jobs():
         for handle in build_solid_handles(external_pipeline).values():
             definition = handle.solid.get_solid_definition()
             if definition.name not in inv_by_def_name:
@@ -67,7 +67,7 @@ def get_graph_or_error(graphene_info, graph_selector):
 
     repository = repo_loc.get_repository(graph_selector.repository_name)
 
-    for external_pipeline in repository.get_all_external_pipelines():
+    for external_pipeline in repository.get_all_external_jobs():
         # first check for graphs
         if external_pipeline.get_graph_name() == graph_selector.graph_name:
             return GrapheneGraph(external_pipeline)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -66,7 +66,7 @@ class RepositoryScopedBatchLoader:
         fetched = defaultdict(list)
 
         if data_type == RepositoryDataType.JOB_RUNS:
-            job_names = [x.name for x in self._repository.get_all_external_pipelines()]
+            job_names = [x.name for x in self._repository.get_all_external_jobs()]
             if self._instance.supports_bucket_queries:
                 records = self._instance.get_run_records(
                     filters=RunsFilter(
@@ -225,8 +225,7 @@ class RepositoryScopedBatchLoader:
 
     def get_run_records_for_job(self, job_name, limit):
         check.invariant(
-            job_name
-            in [pipeline.name for pipeline in self._repository.get_all_external_pipelines()]
+            job_name in [pipeline.name for pipeline in self._repository.get_all_external_jobs()]
         )
         return self._get(RepositoryDataType.JOB_RUNS, job_name, limit)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -205,7 +205,7 @@ class GrapheneAssetNode(graphene.ObjectType):
                 len(self._external_asset_node.job_names) >= 1,
                 "Asset must be part of at least one job",
             )
-            self._external_pipeline = self._external_repository.get_full_external_pipeline(
+            self._external_pipeline = self._external_repository.get_full_external_job(
                 self._external_asset_node.job_names[0]
             )
         return self._external_pipeline
@@ -414,9 +414,9 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_jobs(self, _graphene_info) -> Sequence[GraphenePipeline]:
         job_names = self._external_asset_node.job_names or []
         return [
-            GraphenePipeline(self._external_repository.get_full_external_pipeline(job_name))
+            GraphenePipeline(self._external_repository.get_full_external_job(job_name))
             for job_name in job_names
-            if self._external_repository.has_external_pipeline(job_name)
+            if self._external_repository.has_external_job(job_name)
         ]
 
     def resolve_latestMaterializationByPartition(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -214,7 +214,7 @@ class GrapheneRepository(graphene.ObjectType):
         return [
             GraphenePipeline(pipeline, self._batch_loader)
             for pipeline in sorted(
-                self._repository.get_all_external_pipelines(), key=lambda pipeline: pipeline.name
+                self._repository.get_all_external_jobs(), key=lambda pipeline: pipeline.name
             )
         ]
 
@@ -222,7 +222,7 @@ class GrapheneRepository(graphene.ObjectType):
         return [
             GrapheneJob(pipeline, self._batch_loader)
             for pipeline in sorted(
-                self._repository.get_all_external_pipelines(), key=lambda pipeline: pipeline.name
+                self._repository.get_all_external_jobs(), key=lambda pipeline: pipeline.name
             )
             if pipeline.is_job
         ]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -15,7 +15,7 @@ from ...implementation.execution import (
     terminate_pipeline_execution,
     wipe_assets,
 )
-from ...implementation.external import fetch_workspace, get_full_external_pipeline_or_raise
+from ...implementation.external import fetch_workspace, get_full_external_job_or_raise
 from ...implementation.telemetry import log_dagit_telemetry_event
 from ...implementation.utils import (
     ExecutionMetadata,
@@ -84,7 +84,7 @@ def create_execution_params(graphene_info, graphql_execution_params):
                 )
             )
 
-        external_pipeline = get_full_external_pipeline_or_raise(graphene_info, selector)
+        external_pipeline = get_full_external_job_or_raise(graphene_info, selector)
 
         if not external_pipeline.has_preset(preset_name):
             raise UserFacingGraphQLError(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_all_snapshot_ids.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_all_snapshot_ids.py
@@ -10,6 +10,6 @@ def test_all_snapshot_ids(snapshot):
     # schema of PipelineSnapshots you are free to rerecord
     with instance_for_test() as instance:
         with get_main_external_repo(instance) as repo:
-            for pipeline in sorted(repo.get_all_external_pipelines(), key=lambda p: p.name):
+            for pipeline in sorted(repo.get_all_external_jobs(), key=lambda p: p.name):
                 snapshot.assert_match(serialize_pp(pipeline.pipeline_snapshot))
                 snapshot.assert_match(pipeline.computed_pipeline_snapshot_id)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sync_run_launcher.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sync_run_launcher.py
@@ -28,7 +28,7 @@ def test_sync_run_launcher_run():
         with get_main_workspace(instance) as workspace:
             location = workspace.get_repository_location(main_repo_location_name())
             external_repo = location.get_repository(main_repo_name())
-            external_pipeline = external_repo.get_full_external_pipeline("noop_pipeline")
+            external_pipeline = external_repo.get_full_external_job("noop_pipeline")
 
             run = create_run_for_test(
                 instance=instance,

--- a/python_modules/dagster-test/dagster_test/dagster_core_docker_buildkite/__init__.py
+++ b/python_modules/dagster-test/dagster_test/dagster_core_docker_buildkite/__init__.py
@@ -50,9 +50,7 @@ def get_test_project_external_pipeline(pipeline_name):
             attribute="define_demo_execution_repo",
         )
     ).create_location() as location:
-        yield location.get_repository("demo_execution_repo").get_full_external_pipeline(
-            pipeline_name
-        )
+        yield location.get_repository("demo_execution_repo").get_full_external_job(pipeline_name)
 
 
 def get_default_docker_image_tag():

--- a/python_modules/dagster-test/dagster_test/test_project/__init__.py
+++ b/python_modules/dagster-test/dagster_test/test_project/__init__.py
@@ -280,7 +280,7 @@ def get_test_project_external_pipeline_hierarchy(instance, pipeline_name, contai
     with get_test_project_workspace(instance, container_image) as workspace:
         location = workspace.get_repository_location(workspace.repository_location_names[0])
         repo = location.get_repository("demo_execution_repo")
-        pipeline = repo.get_full_external_pipeline(pipeline_name)
+        pipeline = repo.get_full_external_job(pipeline_name)
         yield workspace, location, repo, pipeline
 
 

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -12,17 +12,17 @@ import dagster._check as check
 from dagster import __version__ as dagster_version
 from dagster._cli.workspace.cli_target import (
     WORKSPACE_TARGET_WARNING,
-    get_external_pipeline_or_job_from_external_repo,
-    get_external_pipeline_or_job_from_kwargs,
+    get_external_job_from_external_repo,
+    get_external_job_from_kwargs,
     get_external_repository_from_kwargs,
     get_external_repository_from_repo_location,
-    get_pipeline_or_job_python_origin_from_kwargs,
+    get_job_python_origin_from_kwargs,
     get_repository_location_from_workspace,
     get_workspace_from_kwargs,
     job_repository_target_argument,
     job_target_argument,
+    python_job_config_argument,
     python_job_target_argument,
-    python_pipeline_or_job_config_argument,
 )
 from dagster._core.definitions.pipeline_base import IPipeline
 from dagster._core.errors import DagsterBackfillFailedError, DagsterInvariantViolationError
@@ -77,13 +77,11 @@ def apply_click_params(command, *click_params):
 )
 @job_repository_target_argument
 def job_list_command(**kwargs):
-    return execute_list_command(kwargs, click.echo, True)
+    return execute_list_command(kwargs, click.echo)
 
 
-def execute_list_command(cli_args, print_fn, using_job_op_graph_apis=False):
-    with get_instance_for_service(
-        "``dagster job list``" if using_job_op_graph_apis else "``dagster pipeline list``"
-    ) as instance:
+def execute_list_command(cli_args, print_fn):
+    with get_instance_for_service("``dagster job list``") as instance:
         with get_external_repository_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
         ) as external_repository:
@@ -91,30 +89,19 @@ def execute_list_command(cli_args, print_fn, using_job_op_graph_apis=False):
             print_fn(title)
             print_fn("*" * len(title))
             first = True
-            for pipeline in (
-                external_repository.get_external_jobs()
-                if using_job_op_graph_apis
-                else external_repository.get_all_external_pipelines()
-            ):
-                pipeline_title = "{pipeline_or_job}: {name}".format(
-                    pipeline_or_job="Job" if using_job_op_graph_apis else "Pipeline",
-                    name=pipeline.name,
-                )
+            for job in external_repository.get_all_external_jobs():
+                job_title = f"Job: {job.name}"
 
                 if not first:
-                    print_fn("*" * len(pipeline_title))
+                    print_fn("*" * len(job_title))
                 first = False
 
-                print_fn(pipeline_title)
-                if pipeline.description:
+                print_fn(job_title)
+                if job.description:
                     print_fn("Description:")
-                    print_fn(format_description(pipeline.description, indent=" " * 4))
-                print_fn(
-                    "{solid_or_op}: (Execution Order)".format(
-                        solid_or_op="Ops" if using_job_op_graph_apis else "Solids"
-                    )
-                )
-                for solid_name in pipeline.pipeline_snapshot.solid_names_in_topological_order:
+                    print_fn(format_description(job.description, indent=" " * 4))
+                print_fn("Ops: (Execution Order)")
+                for solid_name in job.pipeline_snapshot.solid_names_in_topological_order:
                     print_fn("    " + solid_name)
 
 
@@ -148,66 +135,59 @@ def get_job_instructions(command_name):
 @job_target_argument
 def job_print_command(verbose, **cli_args):
     with get_instance_for_service("``dagster job print``") as instance:
-        return execute_print_command(
-            instance, verbose, cli_args, click.echo, using_job_op_graph_apis=True
-        )
+        return execute_print_command(instance, verbose, cli_args, click.echo)
 
 
-def execute_print_command(instance, verbose, cli_args, print_fn, using_job_op_graph_apis=False):
-    with get_external_pipeline_or_job_from_kwargs(
+def execute_print_command(instance, verbose, cli_args, print_fn):
+    with get_external_job_from_kwargs(
         instance,
         version=dagster_version,
         kwargs=cli_args,
-        using_job_op_graph_apis=using_job_op_graph_apis,
     ) as external_pipeline:
         pipeline_snapshot = external_pipeline.pipeline_snapshot
 
         if verbose:
-            print_pipeline_or_job(
+            print_job(
                 pipeline_snapshot,
                 print_fn=print_fn,
-                using_job_op_graph_apis=using_job_op_graph_apis,
             )
         else:
-            print_solids_or_ops(
+            print_ops(
                 pipeline_snapshot,
                 print_fn=print_fn,
-                using_job_op_graph_apis=using_job_op_graph_apis,
             )
 
 
-def print_solids_or_ops(
+def print_ops(
     pipeline_snapshot: PipelineSnapshot,
     print_fn: Callable[..., Any],
-    using_job_op_graph_apis: bool = False,
 ):
     check.inst_param(pipeline_snapshot, "pipeline", PipelineSnapshot)
     check.callable_param(print_fn, "print_fn")
 
     printer = IndentingPrinter(indent_level=2, printer=print_fn)
-    printer.line(f"{'Job' if using_job_op_graph_apis else 'Pipeline'}: {pipeline_snapshot.name}")
+    printer.line(f"Job: {pipeline_snapshot.name}")
 
-    printer.line(f"{'Ops' if using_job_op_graph_apis else 'Solids'}")
+    printer.line("Ops")
     for solid in pipeline_snapshot.dep_structure_snapshot.solid_invocation_snaps:
         with printer.with_indent():
-            printer.line(f"{'Op' if using_job_op_graph_apis else 'Solid'}: {solid.solid_name}")
+            printer.line(f"Op: {solid.solid_name}")
 
 
-def print_pipeline_or_job(
+def print_job(
     pipeline_snapshot: PipelineSnapshot,
     print_fn: Callable[..., Any],
-    using_job_op_graph_apis: bool = False,
 ):
     check.inst_param(pipeline_snapshot, "pipeline", PipelineSnapshot)
     check.callable_param(print_fn, "print_fn")
     printer = IndentingPrinter(indent_level=2, printer=print_fn)
-    printer.line(f"{'Job' if using_job_op_graph_apis else 'Pipeline'}: {pipeline_snapshot.name}")
+    printer.line(f"Job: {pipeline_snapshot.name}")
     print_description(printer, pipeline_snapshot.description)
 
-    printer.line(f"{'Ops' if using_job_op_graph_apis else 'Solids'}")
+    printer.line("Ops")
     for solid in pipeline_snapshot.dep_structure_snapshot.solid_invocation_snaps:
         with printer.with_indent():
-            print_solid_or_op(printer, pipeline_snapshot, solid, using_job_op_graph_apis)
+            print_op(printer, pipeline_snapshot, solid)
 
 
 def print_description(printer, desc):
@@ -228,17 +208,14 @@ def format_description(desc: str, indent: str):
     return filled
 
 
-def print_solid_or_op(
+def print_op(
     printer: IndentingPrinter,
     pipeline_snapshot: PipelineSnapshot,
     solid_invocation_snap: SolidInvocationSnap,
-    using_job_op_graph_apis: bool,
 ) -> None:
     check.inst_param(pipeline_snapshot, "pipeline_snapshot", PipelineSnapshot)
     check.inst_param(solid_invocation_snap, "solid_invocation_snap", SolidInvocationSnap)
-    printer.line(
-        f"{'Op' if using_job_op_graph_apis else 'Solid'}: {solid_invocation_snap.solid_name}"
-    )
+    printer.line(f"Op: {solid_invocation_snap.solid_name}")
     with printer.with_indent():
         printer.line("Inputs:")
         for input_dep_snap in solid_invocation_snap.input_dep_snaps:
@@ -259,7 +236,7 @@ def print_solid_or_op(
     ),
 )
 @python_job_target_argument
-@python_pipeline_or_job_config_argument("list_versions", using_job_op_graph_apis=True)
+@python_job_config_argument("list_versions")
 def job_list_versions_command(**kwargs):
     with DagsterInstance.get() as instance:
         execute_list_versions_command(instance, kwargs)
@@ -270,7 +247,7 @@ def execute_list_versions_command(instance: DagsterInstance, kwargs: Dict[str, o
 
     config = list(check.opt_tuple_param(kwargs.get("config"), "config", default=(), of_type=str))
 
-    job_origin = get_pipeline_or_job_python_origin_from_kwargs(kwargs, True)
+    job_origin = get_job_python_origin_from_kwargs(kwargs)
     job = recon_pipeline_from_origin(job_origin)
     run_config = get_run_config_from_file_list(config)
 
@@ -320,19 +297,18 @@ def add_step_to_table(memoized_plan):
     ),
 )
 @python_job_target_argument
-@python_pipeline_or_job_config_argument("execute", using_job_op_graph_apis=True)
+@python_job_config_argument("execute")
 @click.option("--tags", type=click.STRING, help="JSON string of tags to use for this job run")
 def job_execute_command(**kwargs):
     with capture_interrupts():
         with get_instance_for_service("``dagster job execute``") as instance:
-            execute_execute_command(instance, kwargs, True)
+            execute_execute_command(instance, kwargs)
 
 
 @telemetry_wrapper
 def execute_execute_command(
     instance: DagsterInstance,
     kwargs: Dict[str, object],
-    using_job_op_graph_apis: bool = False,
 ):
     check.inst_param(instance, "instance", DagsterInstance)
 
@@ -345,7 +321,7 @@ def execute_execute_command(
 
     tags = get_tags_from_args(kwargs)
 
-    pipeline_origin = get_pipeline_or_job_python_origin_from_kwargs(kwargs, using_job_op_graph_apis)
+    pipeline_origin = get_job_python_origin_from_kwargs(kwargs)
     pipeline = recon_pipeline_from_origin(pipeline_origin)
     solid_selection = get_solid_selection_from_args(kwargs)
     result = do_execute_command(pipeline, instance, config, mode, tags, solid_selection, preset)
@@ -443,7 +419,7 @@ def do_execute_command(
     ),
 )
 @job_target_argument
-@python_pipeline_or_job_config_argument("launch", True)
+@python_job_config_argument("launch")
 @click.option(
     "--config-json",
     type=click.STRING,
@@ -460,7 +436,6 @@ def job_launch_command(**kwargs):
 def execute_launch_command(
     instance: DagsterInstance,
     kwargs: Dict[str, str],
-    using_job_op_graph_apis: bool = False,
 ):
     preset = cast(Optional[str], kwargs.get("preset"))
     mode = cast(Optional[str], kwargs.get("mode"))
@@ -472,10 +447,9 @@ def execute_launch_command(
         external_repo = get_external_repository_from_repo_location(
             repo_location, cast(Optional[str], kwargs.get("repository"))
         )
-        external_pipeline = get_external_pipeline_or_job_from_external_repo(
+        external_pipeline = get_external_job_from_external_repo(
             external_repo,
-            cast(Optional[str], kwargs.get("pipeline_or_job")),
-            using_job_op_graph_apis,
+            cast(Optional[str], kwargs.get("job_name")),
         )
 
         log_external_repo_stats(
@@ -682,13 +656,11 @@ def _check_execute_external_pipeline_args(
 @python_job_target_argument
 @click.option("--print-only-required", default=False, is_flag=True)
 def job_scaffold_command(**kwargs):
-    execute_scaffold_command(kwargs, click.echo, using_job_op_graph_apis=True)
+    execute_scaffold_command(kwargs, click.echo)
 
 
-def execute_scaffold_command(cli_args, print_fn, using_job_op_graph_apis=False):
-    pipeline_origin = get_pipeline_or_job_python_origin_from_kwargs(
-        cli_args, using_job_op_graph_apis
-    )
+def execute_scaffold_command(cli_args, print_fn):
+    pipeline_origin = get_job_python_origin_from_kwargs(cli_args)
     pipeline = recon_pipeline_from_origin(pipeline_origin)
     skip_non_required = cli_args["print_only_required"]
     do_scaffold_command(pipeline.get_definition(), print_fn, skip_non_required)
@@ -747,10 +719,10 @@ def do_scaffold_command(
 @click.option("--noprompt", is_flag=True)
 def job_backfill_command(**kwargs):
     with DagsterInstance.get() as instance:
-        execute_backfill_command(kwargs, click.echo, instance, True)
+        execute_backfill_command(kwargs, click.echo, instance)
 
 
-def execute_backfill_command(cli_args, print_fn, instance, using_graph_job_op_apis=False):
+def execute_backfill_command(cli_args, print_fn, instance):
     with get_workspace_from_kwargs(instance, version=dagster_version, kwargs=cli_args) as workspace:
         repo_location = get_repository_location_from_workspace(workspace, cli_args.get("location"))
         _execute_backfill_command_at_location(
@@ -759,7 +731,6 @@ def execute_backfill_command(cli_args, print_fn, instance, using_graph_job_op_ap
             instance,
             workspace,
             repo_location,
-            using_graph_job_op_apis,
         )
 
 
@@ -769,15 +740,12 @@ def _execute_backfill_command_at_location(
     instance,
     workspace,
     repo_location,
-    using_graph_job_op_apis=False,
 ):
     external_repo = get_external_repository_from_repo_location(
         repo_location, cli_args.get("repository")
     )
 
-    external_pipeline = get_external_pipeline_or_job_from_external_repo(
-        external_repo, cli_args.get("pipeline_or_job")
-    )
+    external_pipeline = get_external_job_from_external_repo(external_repo, cli_args.get("job_name"))
 
     noprompt = cli_args.get("noprompt")
 
@@ -788,9 +756,7 @@ def _execute_backfill_command_at_location(
     }
 
     if not pipeline_partition_set_names:
-        raise click.UsageError(
-            "No partition sets found for pipeline/job `{}`".format(external_pipeline.name)
-        )
+        raise click.UsageError(f"No partition sets found for job `{external_pipeline.name}`")
     partition_set_name = cli_args.get("partition_set")
     if not partition_set_name:
         if len(pipeline_partition_set_names) == 1:
@@ -832,9 +798,7 @@ def _execute_backfill_command_at_location(
     )
 
     # Print backfill info
-    print_fn("\n Pipeline/Job: {}".format(external_pipeline.name))
-    if not using_graph_job_op_apis:
-        print_fn("Partition set: {}".format(partition_set_name))
+    print_fn("\n Job: {}".format(external_pipeline.name))
     print_fn("   Partitions: {}\n".format(print_partition_format(partition_names, indent_level=15)))
 
     # Confirm and launch

--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -192,12 +192,12 @@ def get_workspace_from_kwargs(
         yield workspace_process_context.create_request_context()
 
 
-def python_target_click_options(is_using_job_op_graph_apis: bool = False):
+def python_target_click_options():
     return [
         click.option(
             "--working-directory",
             "-d",
-            help=f"Specify working directory to use when loading the repository or {'job' if is_using_job_op_graph_apis else 'pipeline/job'}.",
+            help="Specify working directory to use when loading the repository or job",
             envvar="DAGSTER_WORKING_DIRECTORY",
         ),
         click.option(
@@ -206,26 +206,26 @@ def python_target_click_options(is_using_job_op_graph_apis: bool = False):
             # Checks that the path actually exists lower in the stack, where we
             # are better equipped to surface errors
             type=click.Path(exists=False),
-            help=f"Specify python file where repository or {'job' if is_using_job_op_graph_apis else 'pipeline/job'} function lives",
+            help="Specify python file where repository or job function lives",
             envvar="DAGSTER_PYTHON_FILE",
         ),
         click.option(
             "--package-name",
-            help=f"Specify Python package where repository or {'job' if is_using_job_op_graph_apis else 'pipeline/job'} function lives",
+            help="Specify Python package where repository or job function lives",
             envvar="DAGSTER_PACKAGE_NAME",
         ),
         click.option(
             "--module-name",
             "-m",
-            help=f"Specify module where repository or {'job' if is_using_job_op_graph_apis else 'pipeline/job'} function lives",
+            help="Specify module where repository or job function lives",
             envvar="DAGSTER_MODULE_NAME",
         ),
         click.option(
             "--attribute",
             "-a",
             help=(
-                f"Attribute that is either a 1) repository or {'job' if is_using_job_op_graph_apis else 'pipeline/job'} or "
-                f"2) a function that returns a repository or {'job' if is_using_job_op_graph_apis else 'pipeline/job'}"
+                "Attribute that is either a 1) repository or job or "
+                "2) a function that returns a repository or job"
             ),
             envvar="DAGSTER_ATTRIBUTE",
         ),
@@ -261,7 +261,7 @@ def grpc_server_target_click_options():
     ]
 
 
-def workspace_target_click_options(using_job_op_graph_apis: bool = False):
+def workspace_target_click_options():
     return (
         [
             click.option("--empty-workspace", is_flag=True, help="Allow an empty workspace"),
@@ -273,28 +273,14 @@ def workspace_target_click_options(using_job_op_graph_apis: bool = False):
                 help=("Path to workspace file. Argument can be provided multiple times."),
             ),
         ]
-        + python_target_click_options(using_job_op_graph_apis)
+        + python_target_click_options()
         + grpc_server_target_click_options()
-    )
-
-
-def python_pipeline_target_click_options():
-    return (
-        python_target_click_options()
-        + [
-            click.option(
-                "--repository",
-                "-r",
-                help=("Repository name, necessary if more than one repository is present."),
-            )
-        ]
-        + [pipeline_option()]
     )
 
 
 def python_job_target_click_options():
     return (
-        python_target_click_options(is_using_job_op_graph_apis=True)
+        python_target_click_options()
         + [
             click.option(
                 "--repository",
@@ -306,7 +292,7 @@ def python_job_target_click_options():
     )
 
 
-def target_with_config_option(command_name, using_job_op_graph_apis):
+def target_with_config_option(command_name):
     return click.option(
         "-c",
         "--config",
@@ -319,23 +305,19 @@ def target_with_config_option(command_name, using_job_op_graph_apis):
             "files at the key-level granularity. If the file is a pattern then you must "
             "enclose it in double quotes"
             "\n\nExample: "
-            "dagster {pipeline_or_job} {name} -f hello_world.py {pipeline_or_job_flag} pandas_hello_world "
+            f"dagster job {command_name} -f hello_world.py -j pandas_hello_world "
             '-c "pandas_hello_world/*.yaml"'
             "\n\nYou can also specify multiple files:"
             "\n\nExample: "
-            "dagster {pipeline_or_job} {name} -f hello_world.py {pipeline_or_job_flag} pandas_hello_world "
-            "-c pandas_hello_world/solids.yaml -c pandas_hello_world/env.yaml"
-        ).format(
-            name=command_name,
-            pipeline_or_job="job" if using_job_op_graph_apis else "pipeline",
-            pipeline_or_job_flag="-j" if using_job_op_graph_apis else "-p",
+            f"dagster job {command_name} -f hello_world.py -j pandas_hello_world "
+            "-c pandas_hello_world/ops.yaml -c pandas_hello_world/env.yaml"
         ),
     )
 
 
-def python_pipeline_or_job_config_argument(command_name, using_job_op_graph_apis=False):
+def python_job_config_argument(command_name):
     def wrap(f):
-        return target_with_config_option(command_name, using_job_op_graph_apis)(f)
+        return target_with_config_option(command_name)(f)
 
     return wrap
 
@@ -355,7 +337,7 @@ def workspace_target_argument(f):
 def job_workspace_target_argument(f):
     from dagster._cli.job import apply_click_params
 
-    return apply_click_params(f, *workspace_target_click_options(using_job_op_graph_apis=True))
+    return apply_click_params(f, *workspace_target_click_options())
 
 
 def grpc_server_origin_target_argument(f):
@@ -403,28 +385,11 @@ def job_repository_target_argument(f):
     return apply_click_params(job_workspace_target_argument(f), *repository_click_options())
 
 
-def pipeline_option():
-    return click.option(
-        "--pipeline",
-        "-p",
-        "pipeline_or_job",
-        help=(
-            "Pipeline/Job within the repository, necessary if more than one pipeline/job is present."
-        ),
-    )
-
-
-def pipeline_target_argument(f):
-    from dagster._cli.job import apply_click_params
-
-    return apply_click_params(repository_target_argument(f), pipeline_option())
-
-
 def job_option():
     return click.option(
         "--job",
         "-j",
-        "pipeline_or_job",
+        "job_name",
         help=("Job within the repository, necessary if more than one job is present."),
     )
 
@@ -435,43 +400,33 @@ def job_target_argument(f):
     return apply_click_params(job_repository_target_argument(f), job_option())
 
 
-def get_pipeline_or_job_python_origin_from_kwargs(kwargs, using_job_op_graph_apis=False):
+def get_job_python_origin_from_kwargs(kwargs):
     repository_origin = get_repository_python_origin_from_kwargs(kwargs)
-    provided_pipeline_name = kwargs.get("pipeline_or_job")
+    provided_name = kwargs.get("job_name")
 
     recon_repo = recon_repository_from_origin(repository_origin)
     repo_definition = recon_repo.get_definition()
 
-    pipeline_or_job_names = set(
-        repo_definition.job_names if using_job_op_graph_apis else repo_definition.pipeline_names
-    )
+    job_names = set(repo_definition.pipeline_names)  # pipeline (all) vs job (non legacy)
 
-    if provided_pipeline_name is None and len(pipeline_or_job_names) == 1:
-        pipeline_name = next(iter(pipeline_or_job_names))
-    elif provided_pipeline_name is None:
+    if provided_name is None and len(job_names) == 1:
+        pipeline_name = next(iter(job_names))
+    elif provided_name is None:
         raise click.UsageError(
             (
-                "Must provide {flag} as there is more than one pipeline/job "
-                "in {repository}. Options are: {pipelines}."
-            ).format(
-                flag="--job" if using_job_op_graph_apis else "--pipeline",
-                repository=repo_definition.name,
-                pipelines=_sorted_quoted(pipeline_or_job_names),
+                "Must provide --job as there is more than one job "
+                f"in {repo_definition.name}. Options are: {_sorted_quoted(job_names)}."
             )
         )
-    elif not provided_pipeline_name in pipeline_or_job_names:
+    elif not provided_name in job_names:
         raise click.UsageError(
             (
-                'Pipeline/Job "{provided_pipeline_name}" not found in repository "{repository_name}". '
-                "Found {found_names} instead."
-            ).format(
-                provided_pipeline_name=provided_pipeline_name,
-                repository_name=repo_definition.name,
-                found_names=_sorted_quoted(pipeline_or_job_names),
+                f'Job "{provided_name}" not found in repository "{repo_definition.name}" '
+                f"Found {_sorted_quoted(job_names)} instead."
             )
         )
     else:
-        pipeline_name = provided_pipeline_name
+        pipeline_name = provided_name
 
     return PipelinePythonOrigin(pipeline_name, repository_origin=repository_origin)
 
@@ -685,67 +640,46 @@ def get_external_repository_from_kwargs(instance, version, kwargs):
         yield get_external_repository_from_repo_location(repo_location, provided_repo_name)
 
 
-def get_external_pipeline_or_job_from_external_repo(
+def get_external_job_from_external_repo(
     external_repo: ExternalRepository,
-    provided_pipeline_or_job_name: Optional[str],
-    using_job_op_graph_apis: bool = False,
+    provided_name: Optional[str],
 ) -> ExternalPipeline:
     check.inst_param(external_repo, "external_repo", ExternalRepository)
-    check.opt_str_param(provided_pipeline_or_job_name, "provided_pipeline_or_job_name")
+    check.opt_str_param(provided_name, "provided_name")
 
-    external_pipelines = {
-        ep.name: ep
-        for ep in (
-            external_repo.get_external_jobs()
-            if using_job_op_graph_apis
-            else external_repo.get_all_external_pipelines()
-        )
-    }
+    external_pipelines = {ep.name: ep for ep in (external_repo.get_all_external_jobs())}
 
     check.invariant(external_pipelines)
 
-    if provided_pipeline_or_job_name is None and len(external_pipelines) == 1:
+    if provided_name is None and len(external_pipelines) == 1:
         return next(iter(external_pipelines.values()))
 
-    if provided_pipeline_or_job_name is None:
+    if provided_name is None:
         raise click.UsageError(
             (
-                "Must provide {flag} as there is more than one pipeline/job "
-                "in {repository}. Options are: {pipelines}."
-            ).format(
-                flag="--job" if using_job_op_graph_apis else "--pipeline",
-                repository=external_repo.name,
-                pipelines=_sorted_quoted(external_pipelines.keys()),
+                "Must provide --job as there is more than one job "
+                f"in {external_repo.name}. Options are: {_sorted_quoted(external_pipelines.keys())}."
             )
         )
 
-    if not provided_pipeline_or_job_name in external_pipelines:
+    if not provided_name in external_pipelines:
         raise click.UsageError(
             (
-                '{pipeline_or_job} "{provided_pipeline_name}" not found in repository "{repository_name}". '
-                "Found {found_names} instead."
-            ).format(
-                pipeline_or_job="Job" if using_job_op_graph_apis else "Pipeline",
-                provided_pipeline_name=provided_pipeline_or_job_name,
-                repository_name=external_repo.name,
-                found_names=_sorted_quoted(external_pipelines.keys()),
+                f'Job "{provided_name}" not found in repository "{external_repo.name}". '
+                f"Found {_sorted_quoted(external_pipelines.keys())} instead."
             )
         )
 
-    return external_pipelines[provided_pipeline_or_job_name]
+    return external_pipelines[provided_name]
 
 
 @contextmanager
-def get_external_pipeline_or_job_from_kwargs(
-    instance, version, kwargs, using_job_op_graph_apis=False
-):
+def get_external_job_from_kwargs(instance, version, kwargs):
     # Instance isn't strictly required to load an ExternalPipeline, but is included
     # to satisfy the WorkspaceProcessContext / WorkspaceRequestContext requirements
     with get_external_repository_from_kwargs(instance, version, kwargs) as external_repo:
-        provided_pipeline_or_job_name = kwargs.get("pipeline_or_job")
-        yield get_external_pipeline_or_job_from_external_repo(
-            external_repo, provided_pipeline_or_job_name, using_job_op_graph_apis
-        )
+        provided_name = kwargs.get("job_name")
+        yield get_external_job_from_external_repo(external_repo, provided_name)
 
 
 def _sorted_quoted(strings):

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -189,7 +189,7 @@ def submit_backfill_runs(instance, workspace, repo_location, backfill_job, parti
         )
         external_pipeline = repo_location.get_external_pipeline(pipeline_selector)
     else:
-        external_pipeline = external_repo.get_full_external_pipeline(
+        external_pipeline = external_repo.get_full_external_job(
             external_partition_set.pipeline_name
         )
     for partition_data in result.partition_data:

--- a/python_modules/dagster/dagster/_core/host_representation/historical.py
+++ b/python_modules/dagster/dagster/_core/host_representation/historical.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import dagster._check as check
 from dagster._core.snap import PipelineSnapshot
 
@@ -16,16 +18,28 @@ class HistoricalPipeline(RepresentedPipeline):
     """
 
     def __init__(
-        self, pipeline_snapshot, identifying_pipeline_snapshot_id, parent_pipeline_snapshot
+        self,
+        pipeline_snapshot: PipelineSnapshot,
+        identifying_pipeline_snapshot_id: str,
+        parent_pipeline_snapshot: Optional[PipelineSnapshot],
     ):
-        check.inst_param(pipeline_snapshot, "pipeline_snapshot", PipelineSnapshot)
-        check.opt_inst_param(parent_pipeline_snapshot, "parent_pipeline_snapshot", PipelineSnapshot)
+        self._snapshot = check.inst_param(pipeline_snapshot, "pipeline_snapshot", PipelineSnapshot)
+        self._parent_snapshot = check.opt_inst_param(
+            parent_pipeline_snapshot, "parent_pipeline_snapshot", PipelineSnapshot
+        )
         self._identifying_pipeline_snapshot_id = check.str_param(
             identifying_pipeline_snapshot_id, "identifying_pipeline_snapshot_id"
         )
-        super(HistoricalPipeline, self).__init__(
-            pipeline_index=PipelineIndex(pipeline_snapshot, parent_pipeline_snapshot),
-        )
+        self._index = None
+
+    @property
+    def _pipeline_index(self):
+        if self._index is None:
+            self._index = PipelineIndex(
+                self._snapshot,
+                self._parent_snapshot,
+            )
+        return self._index
 
     @property
     def identifying_pipeline_snapshot_id(self):

--- a/python_modules/dagster/dagster/_core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/repository_location.py
@@ -129,15 +129,20 @@ class RepositoryLocation(AbstractContextManager):
         a solid selection is specified, which requires access to the underlying PipelineDefinition
         to generate the subsetted pipeline snapshot."""
         if not selector.solid_selection and not selector.asset_selection:
-            return self.get_repository(selector.repository_name).get_full_external_pipeline(
+            return self.get_repository(selector.repository_name).get_full_external_job(
                 selector.pipeline_name
             )
 
         repo_handle = self.get_repository(selector.repository_name).handle
 
-        return ExternalPipeline(
-            self.get_subset_external_pipeline_result(selector).external_pipeline_data, repo_handle
-        )
+        subset_result = self.get_subset_external_pipeline_result(selector)
+        external_data = subset_result.external_pipeline_data
+        if external_data is None:
+            check.failed(
+                f"Failed to fetch subset data, success: {subset_result.success} error: {subset_result.error}"
+            )
+
+        return ExternalPipeline(external_data, repo_handle)
 
     @abstractmethod
     def get_subset_external_pipeline_result(

--- a/python_modules/dagster/dagster/_core/host_representation/represented.py
+++ b/python_modules/dagster/dagster/_core/host_representation/represented.py
@@ -21,16 +21,10 @@ class RepresentedPipeline(ABC):
     another process *or* could be referring to a historical view of the pipeline.
     """
 
-    _pipeline_index: PipelineIndex
-
-    def __init__(self, pipeline_index):
-        self._pipeline_index = check.inst_param(pipeline_index, "pipeline_index", PipelineIndex)
-
-    # Temporary method to allow for incrementally
-    # replacing pipeline index with the representation hierarchy
-    # Chosen for grepability
-    def get_pipeline_index_for_compat(self) -> PipelineIndex:
-        return self._pipeline_index
+    @property
+    @abstractmethod
+    def _pipeline_index(self) -> PipelineIndex:
+        ...
 
     @property
     def name(self) -> str:

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -395,7 +395,7 @@ def log_external_repo_stats(instance, source, external_repo, external_pipeline=N
 
         pipeline_name_hash = hash_name(external_pipeline.name) if external_pipeline else ""
         repo_hash = hash_name(external_repo.name)
-        num_pipelines_in_repo = len(external_repo.get_all_external_pipelines())
+        num_pipelines_in_repo = len(external_repo.get_all_external_jobs())
         num_schedules_in_repo = len(external_repo.get_external_schedules())
         num_sensors_in_repo = len(external_repo.get_external_sensors())
 

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -176,7 +176,7 @@ class BaseWorkspaceRequestContext(IWorkspace):
         self.process_context.reload_workspace()
         return self.process_context.create_request_context()
 
-    def has_external_pipeline(self, selector: PipelineSelector) -> bool:
+    def has_external_job(self, selector: PipelineSelector) -> bool:
         check.inst_param(selector, "selector", PipelineSelector)
         if not self.has_repository_location(selector.location_name):
             return False
@@ -184,13 +184,13 @@ class BaseWorkspaceRequestContext(IWorkspace):
         loc = self.get_repository_location(selector.location_name)
         return loc.has_repository(selector.repository_name) and loc.get_repository(
             selector.repository_name
-        ).has_external_pipeline(selector.pipeline_name)
+        ).has_external_job(selector.pipeline_name)
 
-    def get_full_external_pipeline(self, selector: PipelineSelector) -> ExternalPipeline:
+    def get_full_external_job(self, selector: PipelineSelector) -> ExternalPipeline:
         return (
             self.get_repository_location(selector.location_name)
             .get_repository(selector.repository_name)
-            .get_full_external_pipeline(selector.pipeline_name)
+            .get_full_external_job(selector.pipeline_name)
         )
 
     def get_external_execution_plan(

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -111,14 +111,14 @@ def retry_run(
 
     external_repo = repo_location.get_repository(repo_name)
 
-    if not external_repo.has_external_pipeline(failed_run.pipeline_name):
+    if not external_repo.has_external_job(failed_run.pipeline_name):
         instance.report_engine_event(
             f"Could not find job {failed_run.pipeline_name} in repository {repo_name}, unable to retry the run. It was likely renamed or deleted.",
             failed_run,
         )
         return
 
-    external_pipeline = external_repo.get_full_external_pipeline(failed_run.pipeline_name)
+    external_pipeline = external_repo.get_full_external_job(failed_run.pipeline_name)
 
     strategy = get_reexecution_strategy(failed_run, instance) or DEFAULT_REEXECUTION_POLICY
 

--- a/python_modules/dagster/dagster/_utils/hosted_user_process.py
+++ b/python_modules/dagster/dagster/_utils/hosted_user_process.py
@@ -44,7 +44,7 @@ def recon_repository_from_origin(origin: RepositoryPythonOrigin) -> "Reconstruct
 
 def external_repo_from_def(
     repository_def: "RepositoryDefinition", repository_handle: "RepositoryHandle"
-):
+) -> ExternalRepository:
     return ExternalRepository(external_repository_data_from_def(repository_def), repository_handle)
 
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_backfill_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_backfill_command.py
@@ -33,14 +33,14 @@ def run_test_backfill_inner(execution_args, instance, expected_count, error_mess
 @pytest.mark.parametrize("backfill_args_context", backfill_command_contexts())
 def test_backfill_no_pipeline_or_job(backfill_args_context):
     with backfill_args_context as (cli_args, instance):
-        args = merge_dicts(cli_args, {"pipeline_or_job": "nonexistent"})
+        args = merge_dicts(cli_args, {"job_name": "nonexistent"})
         run_test_backfill(args, instance, error_message="No pipeline or job found")
 
 
 @pytest.mark.parametrize("backfill_args_context", backfill_command_contexts())
 def test_backfill_no_partition_sets(backfill_args_context):
     with backfill_args_context as (cli_args, instance):
-        args = merge_dicts(cli_args, {"pipeline_or_job": "foo"})
+        args = merge_dicts(cli_args, {"job_name": "foo"})
         run_test_backfill(
             args,
             instance,
@@ -51,7 +51,7 @@ def test_backfill_no_partition_sets(backfill_args_context):
 @pytest.mark.parametrize("backfill_args_context", backfill_command_contexts())
 def test_backfill_multiple_partition_set_matches(backfill_args_context):
     with backfill_args_context as (cli_args, instance):
-        args = merge_dicts(cli_args, {"pipeline_or_job": "baz"})
+        args = merge_dicts(cli_args, {"job_name": "baz"})
         run_test_backfill(
             args,
             instance,
@@ -62,14 +62,14 @@ def test_backfill_multiple_partition_set_matches(backfill_args_context):
 @pytest.mark.parametrize("backfill_args_context", backfill_command_contexts())
 def test_backfill_single_partition_set_unspecified(backfill_args_context):
     with backfill_args_context as (cli_args, instance):
-        args = merge_dicts(cli_args, {"pipeline_or_job": "partitioned_scheduled_pipeline"})
+        args = merge_dicts(cli_args, {"job_name": "partitioned_scheduled_pipeline"})
         run_test_backfill(args, instance, expected_count=len(string.digits))
 
 
 @pytest.mark.parametrize("backfill_args_context", backfill_command_contexts())
 def test_backfill_no_named_partition_set(backfill_args_context):
     with backfill_args_context as (cli_args, instance):
-        args = merge_dicts(cli_args, {"pipeline_or_job": "baz", "partition_set": "nonexistent"})
+        args = merge_dicts(cli_args, {"job_name": "baz", "partition_set": "nonexistent"})
         run_test_backfill(
             args,
             instance,
@@ -80,9 +80,7 @@ def test_backfill_no_named_partition_set(backfill_args_context):
 @pytest.mark.parametrize("backfill_args_context", backfill_command_contexts())
 def test_backfill_error_partition_names(backfill_args_context):
     with backfill_args_context as (cli_args, instance):
-        args = merge_dicts(
-            cli_args, {"pipeline_or_job": "baz", "partition_set": "error_name_partitions"}
-        )
+        args = merge_dicts(cli_args, {"job_name": "baz", "partition_set": "error_name_partitions"})
         run_test_backfill(
             args,
             instance,
@@ -94,7 +92,7 @@ def test_backfill_error_partition_names(backfill_args_context):
 def test_backfill_error_partition_config(backfill_args_context):
     with backfill_args_context as (cli_args, instance):
         args = merge_dicts(
-            cli_args, {"pipeline_or_job": "baz", "partition_set": "error_config_partitions"}
+            cli_args, {"job_name": "baz", "partition_set": "error_config_partitions"}
         )
         run_test_backfill(
             args,
@@ -106,7 +104,7 @@ def test_backfill_error_partition_config(backfill_args_context):
 @pytest.mark.parametrize("backfill_args_context", backfill_command_contexts())
 def test_backfill_launch(backfill_args_context):
     with backfill_args_context as (cli_args, instance):
-        args = merge_dicts(cli_args, {"pipeline_or_job": "baz", "partition_set": "baz_partitions"})
+        args = merge_dicts(cli_args, {"job_name": "baz", "partition_set": "baz_partitions"})
         run_test_backfill(args, instance, expected_count=len(string.digits))
 
 
@@ -114,18 +112,18 @@ def test_backfill_launch(backfill_args_context):
 def test_backfill_partition_range(backfill_args_context):
     with backfill_args_context as (cli_args, instance):
         args = merge_dicts(
-            cli_args, {"pipeline_or_job": "baz", "partition_set": "baz_partitions", "from": "7"}
+            cli_args, {"job_name": "baz", "partition_set": "baz_partitions", "from": "7"}
         )
         run_test_backfill(args, instance, expected_count=3)
 
         args = merge_dicts(
-            cli_args, {"pipeline_or_job": "baz", "partition_set": "baz_partitions", "to": "2"}
+            cli_args, {"job_name": "baz", "partition_set": "baz_partitions", "to": "2"}
         )
         run_test_backfill(args, instance, expected_count=6)  # 3 more runs
 
         args = merge_dicts(
             cli_args,
-            {"pipeline_or_job": "baz", "partition_set": "baz_partitions", "from": "2", "to": "5"},
+            {"job_name": "baz", "partition_set": "baz_partitions", "from": "2", "to": "5"},
         )
         run_test_backfill(args, instance, expected_count=10)  # 4 more runs
 
@@ -135,7 +133,7 @@ def test_backfill_partition_enum(backfill_args_context):
     with backfill_args_context as (cli_args, instance):
         args = merge_dicts(
             cli_args,
-            {"pipeline_or_job": "baz", "partition_set": "baz_partitions", "partitions": "2,9,0"},
+            {"job_name": "baz", "partition_set": "baz_partitions", "partitions": "2,9,0"},
         )
         run_test_backfill(args, instance, expected_count=3)
 
@@ -149,7 +147,7 @@ def test_backfill_tags_pipeline(backfill_args_context):
                 "partition_set": "baz_partitions",
                 "partitions": "2",
                 "tags": '{ "foo": "bar" }',
-                "pipeline_or_job": "baz",
+                "job_name": "baz",
             },
         )
 
@@ -186,4 +184,4 @@ def test_job_backfill_command_cli(job_cli_args):
         runner = CliRunner()
 
         result = runner.invoke(job_backfill_command, job_cli_args)
-        assert result.exit_code == 0, result.stdout
+        assert result.exit_code == 0, result

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -334,7 +334,7 @@ def grpc_server_bar_kwargs(pipeline_name=None):
     with server_process.create_ephemeral_client() as client:
         args = {"grpc_host": client.host}
         if pipeline_name:
-            args["pipeline_or_job"] = "foo"
+            args["job_name"] = "foo"
         if client.port:
             args["grpc_port"] = client.port
         if client.socket:
@@ -344,21 +344,21 @@ def grpc_server_bar_kwargs(pipeline_name=None):
 
 
 @contextmanager
-def python_bar_cli_args(pipeline_or_job_name=None, using_job_op_graph_apis=False):
+def python_bar_cli_args(job_name=None):
     args = [
         "-m",
         "dagster_tests.cli_tests.command_tests.test_cli_commands",
         "-a",
         "bar",
     ]
-    if pipeline_or_job_name:
-        args.append("-j" if using_job_op_graph_apis else "-p")
-        args.append(pipeline_or_job_name)
+    if job_name:
+        args.append("-j")
+        args.append(job_name)
     yield args
 
 
 @contextmanager
-def grpc_server_bar_cli_args(pipeline_name=None, using_job_op_graph_apis=False):
+def grpc_server_bar_cli_args(job_name=None):
     server_process = GrpcServerProcess(
         loadable_target_origin=LoadableTargetOrigin(
             executable_path=sys.executable,
@@ -374,9 +374,9 @@ def grpc_server_bar_cli_args(pipeline_name=None, using_job_op_graph_apis=False):
         if client.socket:
             args.append("--grpc-socket")
             args.append(client.socket)
-        if pipeline_name:
-            args.append("--job" if using_job_op_graph_apis else "--pipeline")
-            args.append(pipeline_name)
+        if job_name:
+            args.append("--job")
+            args.append(job_name)
 
         yield args
     server_process.wait()
@@ -397,10 +397,10 @@ def launch_command_contexts():
     yield pytest.param(grpc_server_bar_pipeline_args())
 
 
-def pipeline_or_job_python_origin_contexts(using_job_op_graph_apis=False):
+def job_python_origin_contexts():
     return [
         args_with_default_cli_test_instance(target_args)
-        for target_args in valid_pipeline_or_job_python_origin_target_args(using_job_op_graph_apis)
+        for target_args in valid_job_python_origin_target_args()
     ]
 
 
@@ -474,30 +474,28 @@ def grpc_server_backfill_args():
 def non_existant_python_origin_target_args():
     return {
         "workspace": None,
-        "pipeline_or_job": "foo",
+        "job_name": "foo",
         "python_file": file_relative_path(__file__, "made_up_file.py"),
         "module_name": None,
         "attribute": "bar",
     }
 
 
-def valid_pipeline_or_job_python_origin_target_args(using_job_op_graph_apis=False):
-    pipeline_or_job_name = "qux" if using_job_op_graph_apis else "foo"
-    pipeline_or_job_fn_name = "qux_job" if using_job_op_graph_apis else "foo_pipeline"
-    pipeline_or_job_def_name = (
-        "define_qux_job" if using_job_op_graph_apis else "define_foo_pipeline"
-    )
+def valid_job_python_origin_target_args():
+    job_name = "qux"
+    job_fn_name = "qux_job"
+    job_def_name = "define_qux_job"
     return [
         {
             "workspace": None,
-            "pipeline_or_job": pipeline_or_job_name,
+            "job_name": job_name,
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
             "module_name": None,
             "attribute": "bar",
         },
         {
             "workspace": None,
-            "pipeline_or_job": pipeline_or_job_name,
+            "job_name": job_name,
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
             "module_name": None,
             "attribute": "bar",
@@ -505,14 +503,14 @@ def valid_pipeline_or_job_python_origin_target_args(using_job_op_graph_apis=Fals
         },
         {
             "workspace": None,
-            "pipeline_or_job": pipeline_or_job_name,
+            "job_name": job_name,
             "python_file": None,
             "module_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
             "attribute": "bar",
         },
         {
             "workspace": None,
-            "pipeline_or_job": pipeline_or_job_name,
+            "job_name": job_name,
             "python_file": None,
             "module_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
             "attribute": "bar",
@@ -520,14 +518,14 @@ def valid_pipeline_or_job_python_origin_target_args(using_job_op_graph_apis=Fals
         },
         {
             "workspace": None,
-            "pipeline_or_job": pipeline_or_job_name,
+            "job_name": job_name,
             "python_file": None,
             "package_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
             "attribute": "bar",
         },
         {
             "workspace": None,
-            "pipeline_or_job": pipeline_or_job_name,
+            "job_name": job_name,
             "python_file": None,
             "package_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
             "attribute": "bar",
@@ -535,39 +533,39 @@ def valid_pipeline_or_job_python_origin_target_args(using_job_op_graph_apis=Fals
         },
         {
             "workspace": None,
-            "pipeline_or_job": None,
+            "job_name": None,
             "python_file": None,
             "module_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
-            "attribute": pipeline_or_job_fn_name,
+            "attribute": job_fn_name,
         },
         {
             "workspace": None,
-            "pipeline_or_job": None,
+            "job_name": None,
             "python_file": None,
             "package_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
-            "attribute": pipeline_or_job_fn_name,
+            "attribute": job_fn_name,
         },
         {
             "workspace": None,
-            "pipeline_or_job": None,
+            "job_name": None,
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
             "module_name": None,
-            "attribute": pipeline_or_job_def_name,
+            "attribute": job_def_name,
         },
         {
             "workspace": None,
-            "pipeline_or_job": None,
+            "job_name": None,
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
             "module_name": None,
-            "attribute": pipeline_or_job_def_name,
+            "attribute": job_def_name,
             "working_directory": os.path.dirname(__file__),
         },
         {
             "workspace": None,
-            "pipeline_or_job": None,
+            "job_name": None,
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
             "module_name": None,
-            "attribute": pipeline_or_job_fn_name,
+            "attribute": job_fn_name,
         },
     ]
 
@@ -576,19 +574,19 @@ def valid_external_pipeline_target_args():
     return [
         {
             "workspace": (file_relative_path(__file__, "repository_file.yaml"),),
-            "pipeline_or_job": "foo",
+            "job_name": "foo",
             "python_file": None,
             "module_name": None,
             "attribute": None,
         },
         {
             "workspace": (file_relative_path(__file__, "repository_module.yaml"),),
-            "pipeline_or_job": "foo",
+            "job_name": "foo",
             "python_file": None,
             "module_name": None,
             "attribute": None,
         },
-    ] + [args for args in valid_pipeline_or_job_python_origin_target_args()]
+    ] + [args for args in valid_job_python_origin_target_args()]
 
 
 def valid_pipeline_python_origin_target_cli_args():
@@ -825,7 +823,7 @@ def test_run_list_limit():
     with instance_for_test():
         runner = CliRunner()
 
-        runner_pipeline_or_job_execute(
+        runner_job_execute(
             runner,
             [
                 "-f",
@@ -839,7 +837,7 @@ def test_run_list_limit():
             ],
         )
 
-        runner_pipeline_or_job_execute(
+        runner_job_execute(
             runner,
             [
                 "-f",
@@ -872,7 +870,7 @@ def test_run_list_limit():
         assert shows_two_results.output.count("Pipeline: double_adder_job") == 2
 
 
-def runner_pipeline_or_job_execute(runner, cli_args):
+def runner_job_execute(runner, cli_args):
     result = runner.invoke(
         job_execute_command,
         cli_args,
@@ -881,7 +879,7 @@ def runner_pipeline_or_job_execute(runner, cli_args):
         # CliRunner captures stdout so printing it out here
         raise Exception(
             (
-                "dagster {pipeline_or_job} execute commands with cli_args {cli_args} "
+                "dagster job execute commands with cli_args {cli_args} "
                 'returned exit_code {exit_code} with stdout:\n"{stdout}" and '
                 '\nresult as string: "{result}"'
             ).format(
@@ -889,7 +887,6 @@ def runner_pipeline_or_job_execute(runner, cli_args):
                 exit_code=result.exit_code,
                 stdout=result.stdout,
                 result=result,
-                pipeline_or_job="job",
             )
         )
     return result

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
@@ -12,9 +12,9 @@ from dagster._core.test_utils import instance_for_test, new_cwd
 from dagster._utils import file_relative_path, merge_dicts
 
 from .test_cli_commands import (
+    job_python_origin_contexts,
     non_existant_python_origin_target_args,
-    pipeline_or_job_python_origin_contexts,
-    runner_pipeline_or_job_execute,
+    runner_job_execute,
     valid_job_python_origin_target_cli_args,
 )
 
@@ -23,7 +23,7 @@ def test_execute_with_config_command():
     runner = CliRunner()
 
     with instance_for_test():
-        add_result = runner_pipeline_or_job_execute(
+        add_result = runner_job_execute(
             runner,
             [
                 "-f",
@@ -39,7 +39,7 @@ def test_execute_with_config_command():
 
         assert add_result
 
-        mult_result = runner_pipeline_or_job_execute(
+        mult_result = runner_job_execute(
             runner,
             [
                 "-f",
@@ -55,7 +55,7 @@ def test_execute_with_config_command():
 
         assert mult_result
 
-        double_adder_result = runner_pipeline_or_job_execute(
+        double_adder_result = runner_job_execute(
             runner,
             [
                 "-f",
@@ -81,19 +81,19 @@ def test_empty_execute_command():
         assert "Must specify a python file or module name" in result.output
 
 
-@pytest.mark.parametrize("gen_execute_args", pipeline_or_job_python_origin_contexts())
+@pytest.mark.parametrize("gen_execute_args", job_python_origin_contexts())
 def test_execute_command_no_env(gen_execute_args):
     with gen_execute_args as (cli_args, instance):
         execute_execute_command(kwargs=cli_args, instance=instance)
 
 
-@pytest.mark.parametrize("gen_execute_args", pipeline_or_job_python_origin_contexts(True))
+@pytest.mark.parametrize("gen_execute_args", job_python_origin_contexts())
 def test_job_execute_command_no_env(gen_execute_args):
     with gen_execute_args as (cli_args, instance):
-        execute_execute_command(kwargs=cli_args, instance=instance, using_job_op_graph_apis=True)
+        execute_execute_command(kwargs=cli_args, instance=instance)
 
 
-@pytest.mark.parametrize("gen_execute_args", pipeline_or_job_python_origin_contexts())
+@pytest.mark.parametrize("gen_execute_args", job_python_origin_contexts())
 def test_execute_command_env(gen_execute_args):
     with gen_execute_args as (cli_args, instance):
         kwargs = merge_dicts(
@@ -106,49 +106,29 @@ def test_execute_command_env(gen_execute_args):
         )
 
 
-@pytest.mark.parametrize("gen_execute_args", pipeline_or_job_python_origin_contexts(True))
+@pytest.mark.parametrize("gen_execute_args", job_python_origin_contexts())
 def test_job_execute_command_env(gen_execute_args):
     with gen_execute_args as (cli_args, instance):
         kwargs = merge_dicts(
             {"config": (file_relative_path(__file__, "default_log_error_env.yaml"),)},
             cli_args,
         )
-        execute_execute_command(kwargs=kwargs, instance=instance, using_job_op_graph_apis=True)
+        execute_execute_command(
+            kwargs=kwargs,
+            instance=instance,
+        )
 
 
 @pytest.mark.parametrize("cli_args", valid_job_python_origin_target_cli_args())
 def test_job_execute_command_runner(cli_args):
     runner = CliRunner()
     with instance_for_test():
-        runner_pipeline_or_job_execute(runner, cli_args)
+        runner_job_execute(runner, cli_args)
 
-        runner_pipeline_or_job_execute(
+        runner_job_execute(
             runner,
             ["--config", file_relative_path(__file__, "default_log_error_env.yaml")] + cli_args,
         )
-
-
-def test_job_command_only_selects_job():
-    with instance_for_test() as instance:
-        job_kwargs = {
-            "workspace": None,
-            "pipeline_or_job": "my_job",
-            "python_file": file_relative_path(__file__, "repo_pipeline_and_job.py"),
-            "module_name": None,
-            "attribute": "my_repo",
-        }
-        pipeline_kwargs = job_kwargs.copy()
-        pipeline_kwargs["pipeline_or_job"] = "my_pipeline"
-
-        result = execute_execute_command(
-            kwargs=job_kwargs, instance=instance, using_job_op_graph_apis=True
-        )
-        assert result.success
-
-        with pytest.raises(Exception, match="not found in repository"):
-            execute_execute_command(
-                kwargs=pipeline_kwargs, instance=instance, using_job_op_graph_apis=True
-            )
 
 
 def test_output_execute_log_stdout(capfd):
@@ -216,18 +196,16 @@ def test_output_execute_log_stderr(capfd):
         assert "FAILURE OP" in captured.err
 
 
-def test_more_than_one_pipeline_or_job():
+def test_more_than_one_job():
     with instance_for_test() as instance:
         with pytest.raises(
             UsageError,
-            match=re.escape(
-                "Must provide --pipeline as there is more than one pipeline/job in bar. "
-            ),
+            match=re.escape("Must provide --job as there is more than one job in bar"),
         ):
             execute_execute_command(
                 kwargs={
                     "repository_yaml": None,
-                    "pipeline_or_job": None,
+                    "job_name": None,
                     "python_file": file_relative_path(__file__, "test_cli_commands.py"),
                     "module_name": None,
                     "attribute": None,
@@ -237,31 +215,30 @@ def test_more_than_one_pipeline_or_job():
 
         with pytest.raises(
             UsageError,
-            match=re.escape("Must provide --job as there is more than one pipeline/job in bar. "),
+            match=re.escape("Must provide --job as there is more than one job in bar. "),
         ):
             execute_execute_command(
                 kwargs={
                     "repository_yaml": None,
-                    "pipeline_or_job": None,
+                    "job_name": None,
                     "python_file": file_relative_path(__file__, "test_cli_commands.py"),
                     "module_name": None,
                     "attribute": None,
                 },
                 instance=instance,
-                using_job_op_graph_apis=True,
             )
 
 
 def invalid_pipeline_python_origin_target_args():
     return [
         {
-            "pipeline_or_job": "foo",
+            "job_name": "foo",
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
             "module_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
             "attribute": "bar",
         },
         {
-            "pipeline_or_job": "foo",
+            "job_name": "foo",
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
             "module_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
             "attribute": None,
@@ -299,7 +276,7 @@ def test_attribute_not_found():
             execute_execute_command(
                 kwargs={
                     "repository_yaml": None,
-                    "pipeline_or_job": None,
+                    "job_name": None,
                     "python_file": file_relative_path(__file__, "test_cli_commands.py"),
                     "module_name": None,
                     "attribute": "nope",
@@ -320,7 +297,7 @@ def test_attribute_is_wrong_thing():
             execute_execute_command(
                 kwargs={
                     "repository_yaml": None,
-                    "pipeline_or_job": None,
+                    "job_name": None,
                     "python_file": file_relative_path(__file__, "test_cli_commands.py"),
                     "module_name": None,
                     "attribute": "not_a_repo_or_pipeline",
@@ -341,7 +318,7 @@ def test_attribute_fn_returns_wrong_thing():
             execute_execute_command(
                 kwargs={
                     "repository_yaml": None,
-                    "pipeline_or_job": None,
+                    "job_name": None,
                     "python_file": file_relative_path(__file__, "test_cli_commands.py"),
                     "module_name": None,
                     "attribute": "not_a_repo_or_pipeline_fn",
@@ -355,7 +332,7 @@ def test_default_memory_run_storage():
         cli_args = {
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
             "attribute": "bar",
-            "pipeline_or_job": "foo",
+            "job_name": "foo",
             "module_name": None,
         }
         result = execute_execute_command(kwargs=cli_args, instance=instance)
@@ -364,19 +341,17 @@ def test_default_memory_run_storage():
         cli_args = {
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
             "attribute": "bar",
-            "pipeline_or_job": "qux",
+            "job_name": "qux",
             "module_name": None,
         }
-        result = execute_execute_command(
-            kwargs=cli_args, instance=instance, using_job_op_graph_apis=True
-        )
+        result = execute_execute_command(kwargs=cli_args, instance=instance)
         assert result.success
 
 
 def test_multiproc():
     with instance_for_test():
         runner = CliRunner()
-        add_result = runner_pipeline_or_job_execute(
+        add_result = runner_job_execute(
             runner,
             [
                 "-f",
@@ -393,7 +368,7 @@ def test_multiproc():
 
         assert "RUN_SUCCESS" in add_result.output
 
-        add_result = runner_pipeline_or_job_execute(
+        add_result = runner_job_execute(
             runner,
             [
                 "-f",
@@ -407,7 +382,7 @@ def test_multiproc():
         assert "RUN_SUCCESS" in add_result.output
 
 
-def test_tags_pipeline_or_job():
+def test_tags_job():
     runner = CliRunner()
     with instance_for_test() as instance:
         result = runner.invoke(

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
@@ -65,7 +65,7 @@ def test_launch_job_cli(job_cli_args):
 
 @pytest.mark.parametrize(
     "gen_pipeline_args",
-    [python_bar_cli_args("qux", True), grpc_server_bar_cli_args("qux", True)],
+    [python_bar_cli_args("qux"), grpc_server_bar_cli_args("qux")],
 )
 def test_launch_with_run_id(gen_pipeline_args):
     runner = CliRunner()
@@ -100,7 +100,7 @@ def test_launch_with_run_id(gen_pipeline_args):
 
 @pytest.mark.parametrize(
     "gen_job_args",
-    [python_bar_cli_args("qux", True), grpc_server_bar_cli_args("qux", True)],
+    [python_bar_cli_args("qux"), grpc_server_bar_cli_args("qux")],
 )
 def test_job_launch_with_run_id(gen_job_args):
     runner = CliRunner()
@@ -135,7 +135,7 @@ def test_job_launch_with_run_id(gen_job_args):
 
 @pytest.mark.parametrize(
     "gen_pipeline_args",
-    [python_bar_cli_args("qux", True), grpc_server_bar_cli_args("qux", True)],
+    [python_bar_cli_args("qux"), grpc_server_bar_cli_args("qux")],
 )
 def test_launch_queued(gen_pipeline_args):
     runner = CliRunner()
@@ -167,7 +167,7 @@ def test_launch_queued(gen_pipeline_args):
 
 @pytest.mark.parametrize(
     "gen_pipeline_args",
-    [python_bar_cli_args("qux", True), grpc_server_bar_cli_args("qux", True)],
+    [python_bar_cli_args("qux"), grpc_server_bar_cli_args("qux")],
 )
 def test_job_launch_queued(gen_pipeline_args):
     runner = CliRunner()
@@ -220,7 +220,7 @@ def test_default_working_directory():
 def test_launch_using_memoization():
     runner = CliRunner()
     with default_cli_test_instance() as instance:
-        with python_bar_cli_args("memoizable_job", True) as args:
+        with python_bar_cli_args("memoizable_job") as args:
             result = runner.invoke(job_launch_command, args + ["--run-id", "first"])
             assert result.exit_code == 0
             run = instance.get_run_by_id("first")
@@ -238,23 +238,22 @@ def test_launch_using_memoization():
             assert len(run.step_keys_to_execute) == 0
 
 
-def test_job_launch_only_selects_job():
+def test_job_launch_handles_pipeline():
     job_kwargs = {
         "workspace": None,
-        "pipeline_or_job": "my_job",
+        "job_name": "my_job",
         "python_file": file_relative_path(__file__, "repo_pipeline_and_job.py"),
         "module_name": None,
         "attribute": "my_repo",
     }
     pipeline_kwargs = job_kwargs.copy()
-    pipeline_kwargs["pipeline_or_job"] = "my_pipeline"
+    pipeline_kwargs["job_name"] = "my_pipeline"
 
     with default_cli_test_instance() as instance:
         execute_launch_command(
             instance,
             job_kwargs,
-            using_job_op_graph_apis=True,
         )
 
-        with pytest.raises(Exception, match="not found in repository"):
-            execute_launch_command(instance, pipeline_kwargs, using_job_op_graph_apis=True)
+        # dont care if its a pipeline and not a job
+        execute_launch_command(instance, pipeline_kwargs)

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_list_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_list_command.py
@@ -22,44 +22,28 @@ def assert_correct_bar_repository_output(result):
     assert result.output == (
         "Repository bar\n"
         "**************\n"
-        "Pipeline: baz\n"
+        "Job: baz\n"
         "Description:\n"
         "Not much tbh\n"
-        "Solids: (Execution Order)\n"
+        "Ops: (Execution Order)\n"
         "    do_input\n"
-        "*************\n"
-        "Pipeline: foo\n"
-        "Solids: (Execution Order)\n"
+        "********\n"
+        "Job: foo\n"
+        "Ops: (Execution Order)\n"
         "    do_something\n"
         "    do_input\n"
-        "********************\n"
-        "Pipeline: memoizable\n"
-        "Solids: (Execution Order)\n"
+        "***************\n"
+        "Job: memoizable\n"
+        "Ops: (Execution Order)\n"
         "    my_solid\n"
-        "****************************************\n"
-        "Pipeline: partitioned_scheduled_pipeline\n"
-        "Solids: (Execution Order)\n"
-        "    do_something\n"
-        "******************\n"
-        "Pipeline: quux_job\n"
-        "Solids: (Execution Order)\n"
-        "    do_something_op\n"
-        "*************\n"
-        "Pipeline: qux\n"
-        "Solids: (Execution Order)\n"
-        "    do_something_op\n"
-        "    do_input_op\n"
-    )
-
-
-def assert_correct_job_list_bar_repository_output(result):
-    assert result.exit_code == 0
-    assert result.output == (
-        "Repository bar\n"
-        "**************\n"
+        "*******************\n"
         "Job: memoizable_job\n"
         "Ops: (Execution Order)\n"
         "    my_op\n"
+        "***********************************\n"
+        "Job: partitioned_scheduled_pipeline\n"
+        "Ops: (Execution Order)\n"
+        "    do_something\n"
         "*************\n"
         "Job: quux_job\n"
         "Ops: (Execution Order)\n"
@@ -77,21 +61,10 @@ def assert_correct_extra_repository_output(result):
     assert result.output == (
         "Repository extra\n"
         "****************\n"
-        "Pipeline: extra\n"
-        "Solids: (Execution Order)\n"
+        "Job: extra\n"
+        "Ops: (Execution Order)\n"
         "    do_something\n"
-        "*******************\n"
-        "Pipeline: extra_job\n"
-        "Solids: (Execution Order)\n"
-        "    do_something\n"
-    )
-
-
-def assert_correct_job_list_extra_repository_output(result):
-    assert result.exit_code == 0
-    assert result.output == (
-        "Repository extra\n"
-        "****************\n"
+        "**************\n"
         "Job: extra_job\n"
         "Ops: (Execution Order)\n"
         "    do_something\n"
@@ -122,13 +95,13 @@ def test_list_command_grpc_socket():
             )
 
             result = runner.invoke(job_list_command, ["--grpc-socket", api_client.socket])
-            assert_correct_job_list_bar_repository_output(result)
+            assert_correct_bar_repository_output(result)
 
             result = runner.invoke(
                 job_list_command,
                 ["--grpc-socket", api_client.socket, "--grpc-host", api_client.host],
             )
-            assert_correct_job_list_bar_repository_output(result)
+            assert_correct_bar_repository_output(result)
 
         server_process.wait()
 
@@ -148,16 +121,16 @@ def test_list_command_deployed_grpc():
 
         with server_process.create_ephemeral_client() as api_client:
             result = runner.invoke(job_list_command, ["--grpc-port", api_client.port])
-            assert_correct_job_list_bar_repository_output(result)
+            assert_correct_bar_repository_output(result)
 
             result = runner.invoke(
                 job_list_command,
                 ["--grpc-port", api_client.port, "--grpc-host", api_client.host],
             )
-            assert_correct_job_list_bar_repository_output(result)
+            assert_correct_bar_repository_output(result)
 
             result = runner.invoke(job_list_command, ["--grpc-port", api_client.port])
-            assert_correct_job_list_bar_repository_output(result)
+            assert_correct_bar_repository_output(result)
 
             result = runner.invoke(
                 job_list_command,
@@ -189,7 +162,7 @@ def test_list_command_cli():
             job_list_command,
             ["-f", file_relative_path(__file__, "test_cli_commands.py"), "-a", "bar"],
         )
-        assert_correct_job_list_bar_repository_output(result)
+        assert_correct_bar_repository_output(result)
 
         result = runner.invoke(
             job_list_command,
@@ -202,18 +175,18 @@ def test_list_command_cli():
                 os.path.dirname(__file__),
             ],
         )
-        assert_correct_job_list_bar_repository_output(result)
+        assert_correct_bar_repository_output(result)
 
         result = runner.invoke(
             job_list_command,
             ["-m", "dagster_tests.cli_tests.command_tests.test_cli_commands", "-a", "bar"],
         )
-        assert_correct_job_list_bar_repository_output(result)
+        assert_correct_bar_repository_output(result)
 
         result = runner.invoke(
             job_list_command, ["-w", file_relative_path(__file__, "workspace.yaml")]
         )
-        assert_correct_job_list_bar_repository_output(result)
+        assert_correct_bar_repository_output(result)
 
         result = runner.invoke(
             job_list_command,
@@ -224,7 +197,7 @@ def test_list_command_cli():
                 file_relative_path(__file__, "override.yaml"),
             ],
         )
-        assert_correct_job_list_extra_repository_output(result)
+        assert_correct_extra_repository_output(result)
 
         result = runner.invoke(
             job_list_command,
@@ -243,12 +216,12 @@ def test_list_command_cli():
             job_list_command,
             ["-m", "dagster_tests.cli_tests.command_tests.test_cli_commands"],
         )
-        assert_correct_job_list_bar_repository_output(result)
+        assert_correct_bar_repository_output(result)
 
         result = runner.invoke(
             job_list_command, ["-f", file_relative_path(__file__, "test_cli_commands.py")]
         )
-        assert_correct_job_list_bar_repository_output(result)
+        assert_correct_bar_repository_output(result)
 
 
 def test_list_command():
@@ -294,15 +267,3 @@ def test_list_command():
                 },
                 no_print,
             )
-
-
-def test_job_command_only_selects_job(capsys):  # pylint: disable=unused-argument
-    with instance_for_test():
-        runner = CliRunner()
-        result = runner.invoke(
-            job_list_command,
-            ["-f", file_relative_path(__file__, "repo_pipeline_and_job.py"), "-a", "my_repo"],
-        )
-
-        assert "my_job" in result.output
-        assert not "my_pipeline" in result.output

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_memoized_development_cli.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_memoized_development_cli.py
@@ -45,7 +45,7 @@ def test_execute_display_command():
 
             kwargs = {
                 "config": (os.path.join(temp_dir, "pipeline_config.yaml"),),
-                "pipeline": "asset_job",
+                "job_name": "asset_job",
                 "python_file": file_relative_path(
                     __file__, "../../execution_tests/memoized_dev_loop_pipeline.py"
                 ),

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_print_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_print_command.py
@@ -64,33 +64,3 @@ def test_print_command_baz():
             ],
         )
         assert res.exit_code == 0, res.stdout
-
-
-def test_job_command_only_selects_job():
-    job_kwargs = {
-        "workspace": None,
-        "pipeline_or_job": "my_job",
-        "python_file": file_relative_path(__file__, "repo_pipeline_and_job.py"),
-        "module_name": None,
-        "attribute": "my_repo",
-    }
-    pipeline_kwargs = job_kwargs.copy()
-    pipeline_kwargs["pipeline_or_job"] = "my_pipeline"
-
-    with instance_for_test() as instance:
-        execute_print_command(
-            instance=instance,
-            verbose=False,
-            cli_args=job_kwargs,
-            print_fn=no_print,
-            using_job_op_graph_apis=True,
-        )
-
-        with pytest.raises(Exception, match="not found in repository"):
-            execute_print_command(
-                instance,
-                verbose=False,
-                cli_args=pipeline_kwargs,
-                print_fn=no_print,
-                using_job_op_graph_apis=True,
-            )

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_scaffold_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_scaffold_command.py
@@ -4,8 +4,8 @@ from click.testing import CliRunner
 from dagster._cli.job import execute_scaffold_command, job_scaffold_command
 
 from .test_cli_commands import (
+    valid_job_python_origin_target_args,
     valid_job_python_origin_target_cli_args,
-    valid_pipeline_or_job_python_origin_target_args,
 )
 
 
@@ -13,7 +13,7 @@ def no_print(_):
     return None
 
 
-@pytest.mark.parametrize("cli_args", valid_pipeline_or_job_python_origin_target_args())
+@pytest.mark.parametrize("cli_args", valid_job_python_origin_target_args())
 def test_scaffold_command(cli_args):
     cli_args["print_only_required"] = True
     execute_scaffold_command(cli_args=cli_args, print_fn=no_print)

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_pipeline_load.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_pipeline_load.py
@@ -2,10 +2,7 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from dagster._cli.workspace.cli_target import (
-    get_external_pipeline_or_job_from_kwargs,
-    job_target_argument,
-)
+from dagster._cli.workspace.cli_target import get_external_job_from_kwargs, job_target_argument
 from dagster._core.host_representation import ExternalPipeline
 from dagster._core.instance import DagsterInstance
 from dagster._core.test_utils import instance_for_test
@@ -18,9 +15,7 @@ def load_pipeline_via_cli_runner(cli_args):
     @click.command(name="test_pipeline_command")
     @job_target_argument
     def command(**kwargs):
-        with get_external_pipeline_or_job_from_kwargs(
-            DagsterInstance.get(), "", kwargs, True
-        ) as external_pipeline:
+        with get_external_job_from_kwargs(DagsterInstance.get(), "", kwargs) as external_pipeline:
             capture_result["external_pipeline"] = external_pipeline
 
     with instance_for_test():
@@ -33,7 +28,7 @@ def load_pipeline_via_cli_runner(cli_args):
 
 def successfully_load_pipeline_via_cli(cli_args):
     result, external_pipeline = load_pipeline_via_cli_runner(cli_args)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result
     assert isinstance(external_pipeline, ExternalPipeline)
     return external_pipeline
 
@@ -103,6 +98,6 @@ def test_must_provide_name_to_multi_pipeline():
 
     assert result.exit_code == 2
     assert (
-        """Must provide --job as there is more than one pipeline/job in """
+        """Must provide --job as there is more than one job in """
         """multi_pipeline. Options are: ['pipeline_one', 'pipeline_two']."""
     ) in result.stdout

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
@@ -85,11 +85,11 @@ def test_repository_data_can_reload_without_restarting(workspace_process_context
     repo = repo_location.get_repository("bar_repo")
     # get_all_pipelines called on server init twice, then on repository load, so starts at 3
     # this is a janky test
-    assert repo.has_pipeline("foo_3")
-    assert not repo.has_pipeline("foo_1")
-    assert not repo.has_pipeline("foo_2")
+    assert repo.has_external_job("foo_3")
+    assert not repo.has_external_job("foo_1")
+    assert not repo.has_external_job("foo_2")
 
-    external_pipeline = repo.get_full_external_pipeline("foo_3")
+    external_pipeline = repo.get_full_external_job("foo_3")
     assert external_pipeline.has_solid_invocation("do_something_3")
 
     # Reloading the location changes the pipeline without needing
@@ -98,10 +98,10 @@ def test_repository_data_can_reload_without_restarting(workspace_process_context
     request_context = workspace_process_context.create_request_context()
     repo_location = request_context.get_repository_location("test")
     repo = repo_location.get_repository("bar_repo")
-    assert repo.has_pipeline("foo_4")
-    assert not repo.has_pipeline("foo_3")
+    assert repo.has_external_job("foo_4")
+    assert not repo.has_external_job("foo_3")
 
-    external_pipeline = repo.get_full_external_pipeline("foo_4")
+    external_pipeline = repo.get_full_external_job("foo_4")
     assert external_pipeline.has_solid_invocation("do_something_4")
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -148,7 +148,7 @@ def test_submit_run():
             external_pipeline = (
                 workspace.get_repository_location("bar_repo_location")
                 .get_repository("bar_repo")
-                .get_full_external_pipeline("foo")
+                .get_full_external_job("foo")
             )
 
             run = create_run_for_test(

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
@@ -75,7 +75,7 @@ def repo_location_fixture(workspace):
 
 @pytest.fixture(name="external_pipeline", scope="module")
 def external_pipeline_fixture(repo_location):
-    return repo_location.get_repository("repo").get_full_external_pipeline("conditional_fail_job")
+    return repo_location.get_repository("repo").get_full_external_job("conditional_fail_job")
 
 
 @pytest.fixture(name="failed_run", scope="module")

--- a/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_default_run_launcher.py
@@ -156,7 +156,7 @@ def test_successful_run(instance, workspace, run_config):  # pylint: disable=red
     external_pipeline = (
         workspace.get_repository_location("test")
         .get_repository("nope")
-        .get_full_external_pipeline("noop_pipeline")
+        .get_full_external_job("noop_pipeline")
     )
 
     pipeline_run = instance.create_run_for_pipeline(
@@ -212,7 +212,7 @@ def test_invalid_instance_run():
                         external_pipeline = (
                             workspace.get_repository_location("test")
                             .get_repository("nope")
-                            .get_full_external_pipeline("noop_pipeline")
+                            .get_full_external_job("noop_pipeline")
                         )
 
                         pipeline_run = instance.create_run_for_pipeline(
@@ -246,7 +246,7 @@ def test_crashy_run(instance, workspace, run_config):  # pylint: disable=redefin
     external_pipeline = (
         workspace.get_repository_location("test")
         .get_repository("nope")
-        .get_full_external_pipeline("crashy_pipeline")
+        .get_full_external_job("crashy_pipeline")
     )
 
     pipeline_run = instance.create_run_for_pipeline(
@@ -289,7 +289,7 @@ def test_exity_run(run_config, instance, workspace):  # pylint: disable=redefine
     external_pipeline = (
         workspace.get_repository_location("test")
         .get_repository("nope")
-        .get_full_external_pipeline("exity_pipeline")
+        .get_full_external_job("exity_pipeline")
     )
 
     pipeline_run = instance.create_run_for_pipeline(
@@ -330,7 +330,7 @@ def test_terminated_run(instance, workspace, run_config):  # pylint: disable=red
     external_pipeline = (
         workspace.get_repository_location("test")
         .get_repository("nope")
-        .get_full_external_pipeline("sleepy_pipeline")
+        .get_full_external_job("sleepy_pipeline")
     )
     pipeline_run = instance.create_run_for_pipeline(
         pipeline_def=sleepy_pipeline,
@@ -404,7 +404,7 @@ def test_cleanup_after_force_terminate(run_config, instance, workspace):
     external_pipeline = (
         workspace.get_repository_location("test")
         .get_repository("nope")
-        .get_full_external_pipeline("sleepy_pipeline")
+        .get_full_external_job("sleepy_pipeline")
     )
     pipeline_run = instance.create_run_for_pipeline(
         pipeline_def=sleepy_pipeline,
@@ -503,7 +503,7 @@ def test_single_solid_selection_execution(
     external_pipeline = (
         workspace.get_repository_location("test")
         .get_repository("nope")
-        .get_full_external_pipeline("math_diamond")
+        .get_full_external_job("math_diamond")
     )
     pipeline_run = instance.create_run_for_pipeline(
         pipeline_def=math_diamond,
@@ -540,7 +540,7 @@ def test_multi_solid_selection_execution(
     external_pipeline = (
         workspace.get_repository_location("test")
         .get_repository("nope")
-        .get_full_external_pipeline("math_diamond")
+        .get_full_external_job("math_diamond")
     )
 
     pipeline_run = instance.create_run_for_pipeline(
@@ -577,7 +577,7 @@ def test_engine_events(instance, workspace, run_config):  # pylint: disable=rede
     external_pipeline = (
         workspace.get_repository_location("test")
         .get_repository("nope")
-        .get_full_external_pipeline("math_diamond")
+        .get_full_external_job("math_diamond")
     )
     pipeline_run = instance.create_run_for_pipeline(
         pipeline_def=math_diamond,

--- a/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_persistent_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_persistent_grpc_run_launcher.py
@@ -45,7 +45,7 @@ def test_run_always_finishes():  # pylint: disable=redefined-outer-name
                 external_pipeline = (
                     workspace.get_repository_location("test")
                     .get_repository("nope")
-                    .get_full_external_pipeline("slow_pipeline")
+                    .get_full_external_job("slow_pipeline")
                 )
 
                 pipeline_run = instance.create_run_for_pipeline(
@@ -94,7 +94,7 @@ def test_terminate_after_shutdown():
             external_pipeline = (
                 workspace.get_repository_location("test")
                 .get_repository("nope")
-                .get_full_external_pipeline("sleepy_pipeline")
+                .get_full_external_job("sleepy_pipeline")
             )
 
             pipeline_run = instance.create_run_for_pipeline(
@@ -117,7 +117,7 @@ def test_terminate_after_shutdown():
             external_pipeline = (
                 workspace.get_repository_location("test")
                 .get_repository("nope")
-                .get_full_external_pipeline("math_diamond")
+                .get_full_external_job("math_diamond")
             )
 
             doomed_to_fail_pipeline_run = instance.create_run_for_pipeline(
@@ -163,7 +163,7 @@ def test_server_down():
                 external_pipeline = (
                     workspace.get_repository_location("test")
                     .get_repository("nope")
-                    .get_full_external_pipeline("sleepy_pipeline")
+                    .get_full_external_job("sleepy_pipeline")
                 )
 
                 pipeline_run = instance.create_run_for_pipeline(

--- a/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_default_run_coordinator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_default_run_coordinator.py
@@ -41,7 +41,7 @@ def test_submit_run(instance, coodinator):  # pylint: disable=redefined-outer-na
         external_pipeline = (
             workspace.get_repository_location("bar_repo_location")
             .get_repository("bar_repo")
-            .get_full_external_pipeline("foo")
+            .get_full_external_job("foo")
         )
 
         run = create_run(instance, external_pipeline, run_id="foo-1")
@@ -60,7 +60,7 @@ def test_submit_run_checks_status(instance, coodinator):  # pylint: disable=rede
         external_pipeline = (
             workspace.get_repository_location("bar_repo_location")
             .get_repository("bar_repo")
-            .get_full_external_pipeline("foo")
+            .get_full_external_job("foo")
         )
 
         run = create_run(

--- a/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_queued_run_coordinator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_queued_run_coordinator.py
@@ -50,7 +50,7 @@ class TestQueuedRunCoordinator:
     @pytest.fixture(name="external_pipeline")
     def external_pipeline_fixture(self, workspace):
         location = workspace.get_repository_location("bar_repo_location")
-        return location.get_repository("bar_repo").get_full_external_pipeline("foo")
+        return location.get_repository("bar_repo").get_full_external_job("foo")
 
     def create_run(
         self, instance, external_pipeline, **kwargs

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -189,7 +189,7 @@ def test_external_diamond_toposort():
             working_directory=None,
         ).create_single_location(instance) as repo_location:
             external_repo = next(iter(repo_location.get_repositories().values()))
-            external_pipeline = next(iter(external_repo.get_all_external_pipelines()))
+            external_pipeline = next(iter(external_repo.get_all_external_jobs()))
             assert external_pipeline.solid_names_in_topological_order == [
                 "A_source",
                 "A",

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -93,7 +93,7 @@ def test_run_status_sensor(caplog, executor, instance, workspace, external_repo)
         time.sleep(1)
 
     with pendulum.test(freeze_datetime):
-        external_pipeline = external_repo.get_full_external_pipeline("failure_pipeline")
+        external_pipeline = external_repo.get_full_external_job("failure_pipeline")
         run = instance.create_run_for_pipeline(
             failure_pipeline,
             external_pipeline_origin=external_pipeline.get_external_origin(),
@@ -133,7 +133,7 @@ def test_run_status_sensor(caplog, executor, instance, workspace, external_repo)
         )
 
     with pendulum.test(freeze_datetime):
-        external_pipeline = external_repo.get_full_external_pipeline("foo_pipeline")
+        external_pipeline = external_repo.get_full_external_job("foo_pipeline")
         run = instance.create_run_for_pipeline(
             foo_pipeline,
             external_pipeline_origin=external_pipeline.get_external_origin(),
@@ -206,7 +206,7 @@ def test_run_failure_sensor(executor, instance, workspace, external_repo):
         time.sleep(1)
 
     with pendulum.test(freeze_datetime):
-        external_pipeline = external_repo.get_full_external_pipeline("failure_pipeline")
+        external_pipeline = external_repo.get_full_external_job("failure_pipeline")
         run = instance.create_run_for_pipeline(
             failure_pipeline,
             external_pipeline_origin=external_pipeline.get_external_origin(),
@@ -261,7 +261,7 @@ def test_run_failure_sensor_that_fails(executor, instance, workspace, external_r
         time.sleep(1)
 
     with pendulum.test(freeze_datetime):
-        external_pipeline = external_repo.get_full_external_pipeline("failure_pipeline")
+        external_pipeline = external_repo.get_full_external_job("failure_pipeline")
         run = instance.create_run_for_pipeline(
             failure_pipeline,
             external_pipeline_origin=external_pipeline.get_external_origin(),
@@ -332,7 +332,7 @@ def test_run_failure_sensor_filtered(executor, instance, workspace, external_rep
         time.sleep(1)
 
     with pendulum.test(freeze_datetime):
-        external_pipeline = external_repo.get_full_external_pipeline("failure_pipeline")
+        external_pipeline = external_repo.get_full_external_job("failure_pipeline")
         run = instance.create_run_for_pipeline(
             failure_pipeline,
             external_pipeline_origin=external_pipeline.get_external_origin(),
@@ -364,7 +364,7 @@ def test_run_failure_sensor_filtered(executor, instance, workspace, external_rep
         time.sleep(1)
 
     with pendulum.test(freeze_datetime):
-        external_pipeline = external_repo.get_full_external_pipeline("failure_graph")
+        external_pipeline = external_repo.get_full_external_job("failure_graph")
         run = instance.create_run_for_pipeline(
             failure_job,
             external_pipeline_origin=external_pipeline.get_external_origin(),
@@ -461,7 +461,7 @@ def test_run_status_sensor_interleave(storage_config_fn, executor):
                 time.sleep(1)
 
             with pendulum.test(freeze_datetime):
-                external_pipeline = external_repo.get_full_external_pipeline("hanging_pipeline")
+                external_pipeline = external_repo.get_full_external_job("hanging_pipeline")
                 # start run 1
                 run1 = instance.create_run_for_pipeline(
                     hanging_pipeline,
@@ -632,7 +632,7 @@ def test_cross_repo_run_status_sensor(executor):
             time.sleep(1)
 
         with pendulum.test(freeze_datetime):
-            external_pipeline = the_other_repo.get_full_external_pipeline("the_pipeline")
+            external_pipeline = the_other_repo.get_full_external_job("the_pipeline")
             run = instance.create_run_for_pipeline(
                 the_pipeline,
                 external_pipeline_origin=external_pipeline.get_external_origin(),
@@ -696,7 +696,7 @@ def test_cross_repo_job_run_status_sensor(executor):
             time.sleep(1)
 
         with pendulum.test(freeze_datetime):
-            external_pipeline = the_other_repo.get_full_external_pipeline("the_pipeline")
+            external_pipeline = the_other_repo.get_full_external_job("the_pipeline")
             run = instance.create_run_for_pipeline(
                 the_pipeline,
                 external_pipeline_origin=external_pipeline.get_external_origin(),
@@ -783,7 +783,7 @@ def test_different_instance_run_status_sensor(executor):
                 time.sleep(1)
 
             with pendulum.test(freeze_datetime):
-                external_pipeline = the_other_repo.get_full_external_pipeline("the_pipeline")
+                external_pipeline = the_other_repo.get_full_external_job("the_pipeline")
                 run = the_other_instance.create_run_for_pipeline(
                     the_pipeline,
                     external_pipeline_origin=external_pipeline.get_external_origin(),

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -172,7 +172,7 @@ def pipeline():
 @pytest.fixture
 def external_pipeline(workspace):
     location = workspace.get_repository_location(workspace.repository_location_names[0])
-    return location.get_repository(repo.repository.__name__).get_full_external_pipeline(
+    return location.get_repository(repo.repository.__name__).get_full_external_job(
         repo.pipeline.__name__
     )
 
@@ -180,7 +180,7 @@ def external_pipeline(workspace):
 @pytest.fixture
 def other_external_pipeline(other_workspace):
     location = other_workspace.get_repository_location(other_workspace.repository_location_names[0])
-    return location.get_repository(repo.repository.__name__).get_full_external_pipeline(
+    return location.get_repository(repo.repository.__name__).get_full_external_job(
         repo.pipeline.__name__
     )
 

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_terminate.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_terminate.py
@@ -68,7 +68,7 @@ def test_terminate_kills_subproc():
             external_pipeline = (
                 workspace.get_repository_location("test")
                 .get_repository("sleepy_repo")
-                .get_full_external_pipeline("sleepy_pipeline")
+                .get_full_external_job("sleepy_pipeline")
             )
             pipeline_run = instance.create_run_for_pipeline(
                 pipeline_def=sleepy_pipeline,


### PR DESCRIPTION

Working from https://github.com/dagster-io/dagster/pull/9563/, this tries to get `ExternalRepository` cleaned up a bit before making changes. Starting from trying to remove the methods on `ExternalRepository` that distinguish `job` from `pipeline` in confusing ways, I ended up cleaning up a lot of CLI code branches that were no longer triggered due to https://github.com/dagster-io/dagster/pull/9170 . I did a set of renames to try to leave things in a reasonable spot. 

### How I Tested These Changes

bk