### PR TITLE
Return last run correclty in job table

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/JobTable.tsx
+++ b/js_modules/dagit/packages/core/src/instance/JobTable.tsx
@@ -97,7 +97,7 @@ export const JobTable = (props: Props) => {
               </td>
               <td>
                 {runs.length ? (
-                  <LastRunSummary run={runs[0]} />
+                  <LastRunSummary run={runs[runs.length - 1]} />
                 ) : (
                   <div style={{color: Colors.Gray500}}>None</div>
                 )}


### PR DESCRIPTION
Summary:
runs[0] is the earliest run, not the latest run

Test Plan:
View the status overview page when there are more than 1 run, latest run tab is now correct

### Summary & Motivation

### How I Tested These Changes
