### PR TITLE
[grpc] use sync request for repository load

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_context.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_context.py
@@ -42,7 +42,7 @@ def test_can_reload_on_external_repository_error():
                 # note it where the function is *used* that needs to mocked, not
                 # where it is defined.
                 # see https://docs.python.org/3/library/unittest.mock.html#where-to-patch
-                "dagster._core.host_representation.repository_location.sync_get_streaming_external_repositories_data_grpc"
+                "dagster._core.host_representation.repository_location.sync_get_external_repositories_data_grpc"
             ) as external_repository_mock:
                 external_repository_mock.side_effect = Exception("get_external_repo_failure")
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reload_repository_location.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reload_repository_location.py
@@ -267,7 +267,7 @@ class TestReloadRepositoriesOutOfProcess(OutOfProcessTestSuite):
                 # note it where the function is *used* that needs to mocked, not
                 # where it is defined.
                 # see https://docs.python.org/3/library/unittest.mock.html#where-to-patch
-                "dagster._core.host_representation.repository_location.sync_get_streaming_external_repositories_data_grpc"
+                "dagster._core.host_representation.repository_location.sync_get_external_repositories_data_grpc"
             ) as external_repository_mock:
 
                 @repository

--- a/python_modules/dagster/dagster/_api/snapshot_repository.py
+++ b/python_modules/dagster/dagster/_api/snapshot_repository.py
@@ -13,8 +13,9 @@ if TYPE_CHECKING:
     from dagster._grpc.client import DagsterGrpcClient
 
 
-def sync_get_streaming_external_repositories_data_grpc(
-    api_client: "DagsterGrpcClient", repository_location: "RepositoryLocation"
+def sync_get_external_repositories_data_grpc(
+    api_client: "DagsterGrpcClient",
+    repository_location: "RepositoryLocation",
 ) -> Mapping[str, ExternalRepositoryData]:
     from dagster._core.host_representation import ExternalRepositoryOrigin, RepositoryLocation
 
@@ -22,22 +23,15 @@ def sync_get_streaming_external_repositories_data_grpc(
 
     repo_datas = {}
     for repository_name in repository_location.repository_names:  # type: ignore
-        external_repository_chunks = list(
-            api_client.streaming_external_repository(
-                external_repository_origin=ExternalRepositoryOrigin(
-                    repository_location.origin,
-                    repository_name,
-                )
-            )
+        response = api_client.external_repository(
+            external_repository_origin=ExternalRepositoryOrigin(
+                repository_location.origin,
+                repository_name,
+            ),
         )
 
         result = deserialize_as(
-            "".join(
-                [
-                    chunk["serialized_external_repository_chunk"]
-                    for chunk in external_repository_chunks
-                ]
-            ),
+            response,
             (ExternalRepositoryData, ExternalRepositoryErrorData),
         )
 

--- a/python_modules/dagster/dagster/_core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/repository_location.py
@@ -17,7 +17,7 @@ from dagster._api.snapshot_partition import (
     sync_get_external_partition_tags_grpc,
 )
 from dagster._api.snapshot_pipeline import sync_get_external_pipeline_subset_grpc
-from dagster._api.snapshot_repository import sync_get_streaming_external_repositories_data_grpc
+from dagster._api.snapshot_repository import sync_get_external_repositories_data_grpc
 from dagster._api.snapshot_schedule import sync_get_external_schedule_execution_data_grpc
 from dagster._api.snapshot_sensor import sync_get_external_sensor_execution_data_grpc
 from dagster._core.code_pointer import CodePointer
@@ -585,7 +585,7 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
 
             self._container_context = list_repositories_response.container_context
 
-            self._external_repositories_data = sync_get_streaming_external_repositories_data_grpc(
+            self._external_repositories_data = sync_get_external_repositories_data_grpc(
                 self.client,
                 self,
             )

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 import pytest
 
 from dagster import repository
-from dagster._api.snapshot_repository import sync_get_streaming_external_repositories_data_grpc
+from dagster._api.snapshot_repository import sync_get_external_repositories_data_grpc
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.host_representation import (
     ExternalRepositoryData,
@@ -19,7 +19,7 @@ from .utils import get_bar_repo_repository_location
 
 def test_streaming_external_repositories_api_grpc(instance):
     with get_bar_repo_repository_location(instance) as repository_location:
-        external_repo_datas = sync_get_streaming_external_repositories_data_grpc(
+        external_repo_datas = sync_get_external_repositories_data_grpc(
             repository_location.client, repository_location
         )
 
@@ -40,7 +40,7 @@ def test_streaming_external_repositories_error(instance):
             DagsterUserCodeProcessError,
             match='Could not find a repository called "does_not_exist"',
         ):
-            sync_get_streaming_external_repositories_data_grpc(
+            sync_get_external_repositories_data_grpc(
                 repository_location.client, repository_location
             )
 
@@ -81,11 +81,12 @@ def get_giant_repo_grpc_repository_location(instance):
 
 
 @pytest.mark.skip("https://github.com/dagster-io/dagster/issues/6940")
-def test_giant_external_repository_streaming_grpc():
+def test_giant_external_repository_grpc():
     with instance_for_test() as instance:
         with get_giant_repo_grpc_repository_location(instance) as repository_location:
-            # Using streaming allows the giant repo to load
-            external_repos_data = sync_get_streaming_external_repositories_data_grpc(
+            # we used to have to stream this - but with grpc settings and compression it
+            # works with a regular request
+            external_repos_data = sync_get_external_repositories_data_grpc(
                 repository_location.client, repository_location
             )
 


### PR DESCRIPTION
We set up this application level streaming before investigating the grpc settings we needed to be able to load large repositories.

The grpc streaming doesn't compress so we end up sending a much larger payload over the network in manual chunks. 


### How I Tested These Changes

pytest python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py::test_giant_external_repository_grpc
