### PR TITLE
[Tooltip] Make tooltip show/hide logic controlled with wrapper div

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/Tooltip.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Tooltip.tsx
@@ -59,7 +59,7 @@ export const Tooltip: React.FC<Props> = (props) => {
 
   if (useDisabledButtonTooltipFix) {
     return (
-      <div onMouseOut={() => setIsOpen(false)} onMouseEnter={() => setIsOpen(true)}>
+      <div onMouseLeave={() => setIsOpen(false)} onMouseEnter={() => setIsOpen(true)}>
         {styledTooltip}
       </div>
     );

--- a/js_modules/dagit/packages/ui/src/components/Tooltip.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Tooltip.tsx
@@ -28,17 +28,17 @@ const overwriteMerge = (destination: any[], source: any[]) => source;
 interface Props extends Tooltip2Props {
   display?: React.CSSProperties['display'];
   canShow?: boolean;
+  useDisabledButtonTooltipFix?: boolean;
 }
 
 export const Tooltip: React.FC<Props> = (props) => {
-  const {children, display, canShow = true, ...rest} = props;
+  const {useDisabledButtonTooltipFix = false, children, display, canShow = true, ...rest} = props;
 
-  if (!canShow) {
-    return <>{children}</>;
-  }
+  const [isOpen, setIsOpen] = React.useState<undefined | boolean>(undefined);
 
-  return (
+  const styledTooltip = (
     <StyledTooltip
+      isOpen={isOpen}
       {...rest}
       minimal
       $display={display}
@@ -52,6 +52,15 @@ export const Tooltip: React.FC<Props> = (props) => {
       {children}
     </StyledTooltip>
   );
+
+  if (useDisabledButtonTooltipFix) {
+    return (
+      <div onMouseOut={() => setIsOpen(false)} onMouseEnter={() => setIsOpen(true)}>
+        {styledTooltip}
+      </div>
+    );
+  }
+  return styledTooltip;
 };
 
 interface StyledTooltipProps {

--- a/js_modules/dagit/packages/ui/src/components/Tooltip.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Tooltip.tsx
@@ -36,6 +36,10 @@ export const Tooltip: React.FC<Props> = (props) => {
 
   const [isOpen, setIsOpen] = React.useState<undefined | boolean>(undefined);
 
+  if (!canShow) {
+    return <>{children}</>;
+  }
+
   const styledTooltip = (
     <StyledTooltip
       isOpen={isOpen}


### PR DESCRIPTION
### Summary & Motivation

Issue: [Blueprint tooltips on disabled buttons stay open ](https://github.com/palantir/blueprint/issues/2779#issuecomment-411446961). 

Solution:
Make tooltip controlled and handle showing/hiding it ourselves. I used a wrapper div with `onMouseLeave` and `onMouseEnter` handlers and the behavior is the same as before (transitions in/out).

I put this behavior under a flag using a prop `useDisabledButtonTooltipFix` so that we can roll this out incrementally and test each call site. We have to do it this way because adding the wrapper div can break CSS so we'll need to test it everywhere that we enable it and potentially fix css


### How I Tested These Changes

I used the attribute in cloud and saw it fixed the issue
