### PR TITLE
context.selected_output_names for graph-backed asset contexts

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -1,3 +1,4 @@
+from platform import node
 import warnings
 from typing import (
     TYPE_CHECKING,
@@ -351,10 +352,6 @@ def asset_key_to_dep_node_handles(
                 dep_nodes_by_asset_key[asset_key].extend(dep_node_handles)
                 dep_node_outputs_by_asset_key[asset_key].extend(dep_node_output_handles)
 
-    for node_handle, outputs in outputs_by_graph_handle.items():
-        for output_name, node_output_handle in outputs.items():
-            node_output_handle.node_handle
-
     # handle internal_asset_deps
     for node_handle, assets_def in assets_defs_by_node_handle.items():
         for asset_key, dep_asset_keys in assets_def.asset_deps.items():
@@ -371,6 +368,12 @@ def asset_key_to_dep_node_handles(
                     node
                     for node in dep_nodes_by_asset_key[asset_key]
                     if node not in dep_asset_key_node_handles
+                ]
+                # TODO test internal asset deps
+                dep_node_outputs_by_asset_key[asset_key] = [
+                    node_output
+                    for node_output in dep_node_outputs_by_asset_key[asset_key]
+                    if node_output.node_handle not in dep_asset_key_node_handles
                 ]
 
     dep_node_set_by_asset_key: Dict[AssetKey, Set[NodeHandle]] = {}

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -341,12 +341,15 @@ def asset_key_to_dep_node_handles(
 
                 dep_node_outputs_by_asset_key[asset_key].extend(dep_node_output_handles)
 
-    # handle internal_asset_deps
+    # handle internal_asset_deps within graph-backed assets
     for _, assets_def in assets_defs_by_node_handle.items():
         for asset_key, dep_asset_keys in assets_def.asset_deps.items():
             if asset_key not in assets_def.keys:
                 continue
             for dep_asset_key in [key for key in dep_asset_keys if key in assets_def.keys]:
+                if len(dep_node_outputs_by_asset_key[asset_key]) == 0:
+                    # This case occurs when the asset is not yielded from a graph-backed asset
+                    continue
                 node_output_handle = dep_node_outputs_by_asset_key[asset_key][
                     0
                 ]  # first item in list is the original node output handle that outputs the asset

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -317,11 +317,23 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
         selected_asset_keys = self.selected_asset_keys
         selected_outputs = set()
         for output_name in self.op.output_dict.keys():
-            asset_info = self.job_def.asset_layer.asset_info_for_output(
-                self.solid_handle, output_name
-            )
-            if asset_info and asset_info.key in selected_asset_keys:
+
+            if any(
+                [
+                    asset_key in selected_asset_keys
+                    for asset_key in self.job_def.asset_layer.downstream_dep_assets(
+                        self.solid_handle, output_name
+                    )
+                ]
+            ):
                 selected_outputs.add(output_name)
+
+            # asset_info = self.job_def.asset_layer.asset_info_for_output(
+            #     self.solid_handle, output_name
+            # )
+            # if asset_info and asset_info.key in selected_asset_keys:
+            #     selected_outputs.add(output_name)
+
         return selected_outputs
 
     @public

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -318,21 +318,18 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
         selected_outputs = set()
         for output_name in self.op.output_dict.keys():
 
-            if any(
+            asset_info = self.job_def.asset_layer.asset_info_for_output(
+                self.solid_handle, output_name
+            )
+            if any(  #  For graph-backed assets, check if a downstream asset is selected
                 [
                     asset_key in selected_asset_keys
                     for asset_key in self.job_def.asset_layer.downstream_dep_assets(
                         self.solid_handle, output_name
                     )
                 ]
-            ):
+            ) or (asset_info and asset_info.key in selected_asset_keys):
                 selected_outputs.add(output_name)
-
-            # asset_info = self.job_def.asset_layer.asset_info_for_output(
-            #     self.solid_handle, output_name
-            # )
-            # if asset_info and asset_info.key in selected_asset_keys:
-            #     selected_outputs.add(output_name)
 
         return selected_outputs
 


### PR DESCRIPTION
Enables op execution contexts within graph-backed assets to access a `selected_output_names` property, allowing optional outputs to be yielded within ops when a subset of asset outputs are selected.

For example:
```
@op(out={"out_1": Out(is_required=False), "out_2": Out(is_required=False)})
def two_outputs_op(context):
    if "out_1" in context.selected_output_names:
        yield Output(1, output_name="out_1")
    if "out_2" in context.selected_output_names:
        yield Output(1, output_name="out_2")

@graph(out={"asset_one": GraphOut(), "asset_two": GraphOut()})
def two_assets():
    out_1, out_2 = two_outputs_op()
    return {"asset_one": out_1, "asset_two": out_2}

AssetsDefinition.from_graph(two_assets, can_subset=True)
```
Adds a `downstream_dep_assets(node_handle, output_name)` method to `AssetLayer` to allow fetching for downstream dependent assets for a given output. In the example above, this method allows `two_outputs_op` to know that `out_2` is an upstream dependency of asset_2 and that `out_1` is an upstream dependency of asset_1.

This PR does this by refactoring the existing `asset_key_to_dep_node_handles` method to also return the upstream node output handle dependencies for each node output handle. This addresses more advanced edge cases, for example:
- Many intermediate ops before yielding an asset
- Nested graph-backed assets
- Reusing an asset output as an input to another asset within the same graph-backed asset