### PR TITLE
[dagit] Fix the asset lineage view scrolling the header offscreen if the graph is large

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
@@ -41,7 +41,10 @@ export const AssetNodeLineage: React.FC<{
   const currentDepth = Math.max(1, Math.min(maxDepth, requestedDepth));
 
   return (
-    <Box style={{width: '100%', height: '100%', position: 'relative'}} flex={{direction: 'column'}}>
+    <Box
+      style={{width: '100%', flex: 1, minHeight: 0, position: 'relative'}}
+      flex={{direction: 'column'}}
+    >
       <Box
         flex={{justifyContent: 'space-between', alignItems: 'center', gap: 12}}
         padding={{left: 24, right: 12, vertical: 12}}


### PR DESCRIPTION
### Summary & Motivation

This is a small fix to a bug that caused clicking the "Lineage" tab to scroll the page down and hide the tabs if the graph was larger than the available space.

### How I Tested These Changes
