### PR TITLE
[dagit] Do not attempt to materialize upstream source assets from lineage tab

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
@@ -2,7 +2,7 @@ import {Box, Button, ButtonGroup, Colors, Icon, JoinedButtons, TextInput} from '
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
-import {GraphData, LiveData} from '../asset-graph/Utils';
+import {GraphData, isSourceAsset, LiveData} from '../asset-graph/Utils';
 import {AssetGraphQueryItem, calculateGraphDistances} from '../asset-graph/useAssetGraphData';
 
 import {AssetLineageScope, AssetNodeLineageGraph} from './AssetNodeLineageGraph';
@@ -64,7 +64,9 @@ export const AssetNodeLineage: React.FC<{
         <div style={{flex: 1}} />
         {Object.values(assetGraphData.nodes).length > 1 ? (
           <LaunchAssetExecutionButton
-            assetKeys={Object.values(assetGraphData.nodes).map((n) => n.assetKey)}
+            assetKeys={Object.values(assetGraphData.nodes)
+              .filter((n) => !isSourceAsset(n.definition))
+              .map((n) => n.assetKey)}
             intent="none"
             context="all"
           />


### PR DESCRIPTION
### Summary & Motivation

This is a small fix for a discussion in Slack here: https://elementl-workspace.slack.com/archives/C0417S941U0/p1662493553260299

When viewing the lineage tab, we show a view of neighboring assets and allow the user to re-materialize everything in the view. In some cases for upstream graphs, this can include source assets. These assets cannot be materialized and should be filtered out before they're sent in a launch request.

This is an issue on the lineage graph because we implemented "materialize everything in the view" by simulating a selection of those asset keys. The main asset group and global asset graph views are not impacted.

Repro case:

```

# pylint: disable=redefined-outer-name
# start_marker
from dagster import AssetKey, SourceAsset, asset, repository

my_source_asset = SourceAsset(key=AssetKey("a_source_asset"))


@asset
def my_derived_asset(a_source_asset):
    return a_source_asset + [4]


# end_marker

@repository
def repo():
    return [my_source_asset, my_derived_asset]


```

### How I Tested These Changes
