### PR TITLE
Use report_dagster_event rather than initializing a DagsterLogManager when logging ASSET_MATERIALIZATION_PLANNED events

### DIFF
--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -465,22 +465,6 @@ class DagsterEvent(
         log_resource_event(log_manager, event)
         return event
 
-    @staticmethod
-    def asset_materialization_planned(
-        pipeline_name: str,
-        asset_key: AssetKey,
-        log_manager: DagsterLogManager,
-    ) -> "DagsterEvent":
-        event = DagsterEvent(
-            event_type_value=DagsterEventType.ASSET_MATERIALIZATION_PLANNED.value,
-            pipeline_name=pipeline_name,
-            message=f"{pipeline_name} intends to materialize asset {asset_key.to_string()}",
-            event_specific_data=AssetMaterializationPlannedData(asset_key),
-        )
-        log_level = logging.DEBUG
-        log_manager.log_dagster_event(level=log_level, msg=event.message or "", dagster_event=event)
-        return event
-
     def __new__(
         cls,
         event_type_value: str,


### PR DESCRIPTION
Summery:
This somewhat unusual event type is logged on run creation, getting around the fact that we have no log manager by creating one. This goes through some logging initialization calls (like dictConfig) that sometimes trigger deadlocks in the daemon when multiple sensors with asset materialization planned events are triggered at once. Get around that by calling report_dagster_event, which is the more typical way that we log events within more of a system context.

Test Plan: BK, test_asset_materialization_planned_event_yielded still passes

### Summary & Motivation

### How I Tested These Changes
