### PR TITLE
[dagster-airbyte] Add config to avoid pulling/forwarding Airbyte logs to compute log

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
@@ -99,7 +99,7 @@ def airbyte_sync_op(context):
     yield Output(
         airbyte_output,
         metadata={
-            _get_attempt(**airbyte_output.job_details.get("attempts", [{}])[-1]).get(
+            **_get_attempt(airbyte_output.job_details.get("attempts", [{}])[-1]).get(
                 "totalStats", {}
             )
         },

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
@@ -1,6 +1,6 @@
 from dagster_airbyte.resources import DEFAULT_POLL_INTERVAL_SECONDS
 from dagster_airbyte.types import AirbyteOutput
-from dagster_airbyte.utils import generate_materializations
+from dagster_airbyte.utils import _get_attempt, generate_materializations
 
 from dagster import Array, Bool, Field, In, Noneable, Nothing, Out, Output, op
 
@@ -99,8 +99,8 @@ def airbyte_sync_op(context):
     yield Output(
         airbyte_output,
         metadata={
-            **airbyte_output.job_details.get("attempts", [{}])[-1]
-            .get("attempt", {})
-            .get("totalStats", {})
+            _get_attempt(**airbyte_output.job_details.get("attempts", [{}])[-1]).get(
+                "totalStats", {}
+            )
         },
     )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -37,6 +37,7 @@ class AirbyteResource:
         request_max_retries: int = 3,
         request_retry_delay: float = 0.25,
         log: logging.Logger = get_dagster_logger(),
+        forward_logs: bool = True,
     ):
         self._host = host
         self._port = port
@@ -45,6 +46,8 @@ class AirbyteResource:
         self._request_retry_delay = request_retry_delay
 
         self._log = log
+
+        self._forward_logs = forward_logs
 
     @property
     def api_base_url(self) -> str:
@@ -96,8 +99,26 @@ class AirbyteResource:
     def cancel_job(self, job_id: int):
         self.make_request(endpoint="/jobs/cancel", data={"id": job_id})
 
-    def get_job_status(self, job_id: int) -> dict:
-        return check.not_none(self.make_request(endpoint="/jobs/get", data={"id": job_id}))
+    def get_job_status(self, connection_id: str, job_id: int) -> dict:
+        if self._forward_logs:
+            return check.not_none(self.make_request(endpoint="/jobs/get", data={"id": job_id}))
+        else:
+            # the "list all jobs" endpoint doesn't return logs, which actually makes it much more
+            # lightweight for long-running syncs with many logs
+            out = check.not_none(
+                self.make_request(
+                    endpoint="/jobs/list",
+                    data={
+                        "configTypes": ["sync"],
+                        "configId": connection_id,
+                        # sync should be the most recent, so pageSize 5 is sufficient
+                        "pagination": {"pageSize": 5},
+                    },
+                )
+            )
+            job = next((job for job in out["jobs"] if job["job"]["id"] == job_id), None)
+
+            return check.not_none(job)
 
     def start_sync(self, connection_id: str) -> Dict[str, object]:
         return check.not_none(
@@ -147,11 +168,11 @@ class AirbyteResource:
                         f"Timeout: Airbyte job {job_id} is not ready after the timeout {poll_timeout} seconds"
                     )
                 time.sleep(poll_interval)
-                job_details = self.get_job_status(job_id)
+                job_details = self.get_job_status(connection_id, job_id)
                 attempts = cast(List, job_details.get("attempts", []))
                 cur_attempt = len(attempts)
                 # spit out the available Airbyte log info
-                if cur_attempt:
+                if cur_attempt and self._forward_logs:
                     log_lines = attempts[logged_attempts].get("logs", {}).get("logLines", [])
 
                     for line in log_lines[logged_lines:]:
@@ -214,6 +235,11 @@ class AirbyteResource:
             default_value=0.25,
             description="Time (in seconds) to wait between each request retry.",
         ),
+        "forward_logs": Field(
+            bool,
+            default_value=True,
+            description="Whether to forward Airbyte logs to the compute log, can be expensive for long-running syncs.",
+        ),
     },
     description="This resource helps manage Airbyte connectors",
 )
@@ -255,4 +281,5 @@ def airbyte_resource(context) -> AirbyteResource:
         request_max_retries=context.resource_config["request_max_retries"],
         request_retry_delay=context.resource_config["request_retry_delay"],
         log=context.log,
+        forward_logs=context.resource_config["forward_logs"],
     )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -116,7 +116,7 @@ class AirbyteResource:
                     },
                 )
             )
-            job = next((job for job in out["jobs"] if job["job"]["id"] == job_id), None)
+            job = next((job for job in cast(List, out["jobs"]) if job["job"]["id"] == job_id), None)
 
             return check.not_none(job)
 
@@ -172,13 +172,14 @@ class AirbyteResource:
                 attempts = cast(List, job_details.get("attempts", []))
                 cur_attempt = len(attempts)
                 # spit out the available Airbyte log info
-                if cur_attempt and self._forward_logs:
-                    log_lines = attempts[logged_attempts].get("logs", {}).get("logLines", [])
+                if cur_attempt:
+                    if self._forward_logs:
+                        log_lines = attempts[logged_attempts].get("logs", {}).get("logLines", [])
 
-                    for line in log_lines[logged_lines:]:
-                        sys.stdout.write(line + "\n")
-                        sys.stdout.flush()
-                    logged_lines = len(log_lines)
+                        for line in log_lines[logged_lines:]:
+                            sys.stdout.write(line + "\n")
+                            sys.stdout.flush()
+                        logged_lines = len(log_lines)
 
                     # if there's a next attempt, this one will have no more log messages
                     if logged_attempts < cur_attempt - 1:

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
@@ -29,6 +29,11 @@ def _materialization_for_stream(
     )
 
 
+def _get_attempt(attempt: dict) -> List:
+    # the attempt field is nested in some API results, and is not in others
+    return attempt.get("attempt") or attempt
+
+
 def generate_materializations(
     output: AirbyteOutput, asset_key_prefix: List[str]
 ) -> Iterator[AssetMaterialization]:
@@ -46,9 +51,7 @@ def generate_materializations(
     # stats for each stream that had data sync'd
     all_stream_stats = {
         s["streamName"]: s.get("stats", {})
-        for s in output.job_details.get("attempts", [{}])[-1]
-        .get("attempt", {})
-        .get("streamStats", [])
+        for s in _get_attempt(output.job_details.get("attempts", [{}])[-1]).get("streamStats", [])
     }
     for stream_name, stream_props in all_stream_props.items():
         yield _materialization_for_stream(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
@@ -29,7 +29,7 @@ def _materialization_for_stream(
     )
 
 
-def _get_attempt(attempt: dict) -> List:
+def _get_attempt(attempt: dict):
     # the attempt field is nested in some API results, and is not in others
     return attempt.get("attempt") or attempt
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
@@ -84,3 +84,33 @@ def get_sample_job_json(schema_prefix=""):
             }
         ],
     }
+
+
+def get_sample_job_list_json(schema_prefix=""):
+    return {
+        "jobs": [
+            {
+                "job": {"id": 1, "status": AirbyteState.SUCCEEDED},
+                "attempts": [
+                    {
+                        "streamStats": [
+                            {
+                                "streamName": schema_prefix + "foo",
+                                "stats": {
+                                    "bytesEmitted": 1234,
+                                    "recordsCommitted": 4321,
+                                },
+                            },
+                            {
+                                "streamName": schema_prefix + "baz",
+                                "stats": {
+                                    "bytesEmitted": 1111,
+                                    "recordsCommitted": 1111,
+                                },
+                            },
+                        ]
+                    }
+                ],
+            }
+        ]
+    }


### PR DESCRIPTION
### Summary & Motivation

Currently, we poll the [`/jobs/get`](https://airbyte-public-api-docs.s3.us-east-2.amazonaws.com/rapidoc-api-docs.html#post-/v1/jobs/get) API endpoint to get the status of our Airbyte sync. Unfortunately, this endpoint pulls all the Airbyte logs, which can mean the API takes several seconds to return for long (hours) running syncs.

This PR introduces an optional config for the Airbyte resource that disables fetching logs. Under the hood, this instead hits the [`/jobs/list`](https://airbyte-public-api-docs.s3.us-east-2.amazonaws.com/rapidoc-api-docs.html#post-/v1/jobs/list) API endpoint, which lists recent syncs but provides us the same info minus logs. This will hopefully be faster for users hitting this limitation (though it's a bit hacky).

### How I Tested These Changes

Added params to existing unit tests, tested locally with both config options.