### PR TITLE
[dagster-airbyte] Support representing normalization-created tables as Assets

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -1,4 +1,5 @@
-from typing import List, Optional
+from itertools import chain
+from typing import List, Mapping, Optional, Set
 
 from dagster_airbyte.utils import generate_materializations
 
@@ -13,6 +14,8 @@ def build_airbyte_assets(
     connection_id: str,
     destination_tables: List[str],
     asset_key_prefix: Optional[List[str]] = None,
+    normalization_tables: Optional[Mapping[str, Set[str]]] = None,
+    upstream_assets: Optional[Set[AssetKey]] = None,
 ) -> List[AssetsDefinition]:
     """
     Builds a set of assets representing the tables created by an Airbyte sync operation.
@@ -23,18 +26,41 @@ def build_airbyte_assets(
         destination_tables (List[str]): The names of the tables that you want to be represented
             in the Dagster asset graph for this sync. This will generally map to the name of the
             stream in Airbyte, unless a stream prefix has been specified in Airbyte.
+        normalization_tables (Optional[Mapping[str, List[str]]]): If you are using Airbyte's
+            normalization feature, you may specify a mapping of destination table to a list of
+            derived tables that will be created by the normalization process.
         asset_key_prefix (Optional[List[str]]): A prefix for the asset keys inside this asset.
             If left blank, assets will have a key of `AssetKey([table_name])`.
+        upstream_assets (Optional[Set[AssetKey]]): A list of assets to add as sources.
     """
 
     asset_key_prefix = check.opt_list_param(asset_key_prefix, "asset_key_prefix", of_type=str)
 
+    # Generate a list of outputs, the set of destination tables plus any affiliated
+    # normalization tables
+    tables = chain.from_iterable(
+        chain([destination_tables], normalization_tables.values() if normalization_tables else [])
+    )
+    outputs = {table: AssetOut(key=AssetKey(asset_key_prefix + [table])) for table in tables}
+
+    internal_deps = {}
+
+    # If normalization tables are specified, we need to add a dependency from the destination table
+    # to the affilitated normalization table
+    if normalization_tables:
+        for base_table, derived_tables in normalization_tables.items():
+            for derived_table in derived_tables:
+                internal_deps[derived_table] = {AssetKey(asset_key_prefix + [base_table])}
+
+    # All non-normalization tables depend on any user-provided upstream assets
+    for table in destination_tables:
+        internal_deps[table] = upstream_assets or set()
+
     @multi_asset(
         name=f"airbyte_sync_{connection_id[:5]}",
-        outs={
-            table: AssetOut(key=AssetKey(asset_key_prefix + [table]))
-            for table in destination_tables
-        },
+        non_argument_deps=upstream_assets or set(),
+        outs=outputs,
+        internal_asset_deps=internal_deps,
         required_resource_keys={"airbyte"},
         compute_kind="airbyte",
     )
@@ -50,6 +76,14 @@ def build_airbyte_assets(
                         entry.label: entry.entry_data for entry in materialization.metadata_entries
                     },
                 )
+                # Also materialize any normalization tables affiliated with this destination
+                # e.g. nested objects, lists etc
+                if normalization_tables:
+                    for dependent_table in normalization_tables.get(table_name, set()):
+                        yield Output(
+                            value=None,
+                            output_name=dependent_table,
+                        )
             else:
                 yield materialization
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
@@ -99,7 +99,7 @@ def airbyte_sync_op(context):
     yield Output(
         airbyte_output,
         metadata={
-            _get_attempt(**airbyte_output.job_details.get("attempts", [{}])[-1]).get(
+            **_get_attempt(airbyte_output.job_details.get("attempts", [{}])[-1]).get(
                 "totalStats", {}
             )
         },

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
@@ -1,6 +1,6 @@
 from dagster_airbyte.resources import DEFAULT_POLL_INTERVAL_SECONDS
 from dagster_airbyte.types import AirbyteOutput
-from dagster_airbyte.utils import generate_materializations
+from dagster_airbyte.utils import _get_attempt, generate_materializations
 
 from dagster import Array, Bool, Field, In, Noneable, Nothing, Out, Output, op
 
@@ -99,8 +99,8 @@ def airbyte_sync_op(context):
     yield Output(
         airbyte_output,
         metadata={
-            **airbyte_output.job_details.get("attempts", [{}])[-1]
-            .get("attempt", {})
-            .get("totalStats", {})
+            _get_attempt(**airbyte_output.job_details.get("attempts", [{}])[-1]).get(
+                "totalStats", {}
+            )
         },
     )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -37,6 +37,7 @@ class AirbyteResource:
         request_max_retries: int = 3,
         request_retry_delay: float = 0.25,
         log: logging.Logger = get_dagster_logger(),
+        forward_logs: bool = True,
     ):
         self._host = host
         self._port = port
@@ -45,6 +46,8 @@ class AirbyteResource:
         self._request_retry_delay = request_retry_delay
 
         self._log = log
+
+        self._forward_logs = forward_logs
 
     @property
     def api_base_url(self) -> str:
@@ -96,8 +99,26 @@ class AirbyteResource:
     def cancel_job(self, job_id: int):
         self.make_request(endpoint="/jobs/cancel", data={"id": job_id})
 
-    def get_job_status(self, job_id: int) -> dict:
-        return check.not_none(self.make_request(endpoint="/jobs/get", data={"id": job_id}))
+    def get_job_status(self, connection_id: str, job_id: int) -> dict:
+        if self._forward_logs:
+            return check.not_none(self.make_request(endpoint="/jobs/get", data={"id": job_id}))
+        else:
+            # the "list all jobs" endpoint doesn't return logs, which actually makes it much more
+            # lightweight for long-running syncs with many logs
+            out = check.not_none(
+                self.make_request(
+                    endpoint="/jobs/list",
+                    data={
+                        "configTypes": ["sync"],
+                        "configId": connection_id,
+                        # sync should be the most recent, so pageSize 5 is sufficient
+                        "pagination": {"pageSize": 5},
+                    },
+                )
+            )
+            job = next((job for job in out["jobs"] if job["job"]["id"] == job_id), None)
+
+            return check.not_none(job)
 
     def start_sync(self, connection_id: str) -> Dict[str, object]:
         return check.not_none(
@@ -147,11 +168,11 @@ class AirbyteResource:
                         f"Timeout: Airbyte job {job_id} is not ready after the timeout {poll_timeout} seconds"
                     )
                 time.sleep(poll_interval)
-                job_details = self.get_job_status(job_id)
+                job_details = self.get_job_status(connection_id, job_id)
                 attempts = cast(List, job_details.get("attempts", []))
                 cur_attempt = len(attempts)
                 # spit out the available Airbyte log info
-                if cur_attempt:
+                if cur_attempt and self._forward_logs:
                     log_lines = attempts[logged_attempts].get("logs", {}).get("logLines", [])
 
                     for line in log_lines[logged_lines:]:
@@ -214,6 +235,11 @@ class AirbyteResource:
             default_value=0.25,
             description="Time (in seconds) to wait between each request retry.",
         ),
+        "forward_logs": Field(
+            bool,
+            default_value=True,
+            description="Whether to forward Airbyte logs to the compute log, can be expensive for long-running syncs.",
+        ),
     },
     description="This resource helps manage Airbyte connectors",
 )
@@ -255,4 +281,5 @@ def airbyte_resource(context) -> AirbyteResource:
         request_max_retries=context.resource_config["request_max_retries"],
         request_retry_delay=context.resource_config["request_retry_delay"],
         log=context.log,
+        forward_logs=context.resource_config["forward_logs"],
     )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -116,7 +116,7 @@ class AirbyteResource:
                     },
                 )
             )
-            job = next((job for job in out["jobs"] if job["job"]["id"] == job_id), None)
+            job = next((job for job in cast(List, out["jobs"]) if job["job"]["id"] == job_id), None)
 
             return check.not_none(job)
 
@@ -172,13 +172,14 @@ class AirbyteResource:
                 attempts = cast(List, job_details.get("attempts", []))
                 cur_attempt = len(attempts)
                 # spit out the available Airbyte log info
-                if cur_attempt and self._forward_logs:
-                    log_lines = attempts[logged_attempts].get("logs", {}).get("logLines", [])
+                if cur_attempt:
+                    if self._forward_logs:
+                        log_lines = attempts[logged_attempts].get("logs", {}).get("logLines", [])
 
-                    for line in log_lines[logged_lines:]:
-                        sys.stdout.write(line + "\n")
-                        sys.stdout.flush()
-                    logged_lines = len(log_lines)
+                        for line in log_lines[logged_lines:]:
+                            sys.stdout.write(line + "\n")
+                            sys.stdout.flush()
+                        logged_lines = len(log_lines)
 
                     # if there's a next attempt, this one will have no more log messages
                     if logged_attempts < cur_attempt - 1:

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
@@ -29,6 +29,11 @@ def _materialization_for_stream(
     )
 
 
+def _get_attempt(attempt: dict) -> List:
+    # the attempt field is nested in some API results, and is not in others
+    return attempt.get("attempt") or attempt
+
+
 def generate_materializations(
     output: AirbyteOutput, asset_key_prefix: List[str]
 ) -> Iterator[AssetMaterialization]:
@@ -46,9 +51,7 @@ def generate_materializations(
     # stats for each stream that had data sync'd
     all_stream_stats = {
         s["streamName"]: s.get("stats", {})
-        for s in output.job_details.get("attempts", [{}])[-1]
-        .get("attempt", {})
-        .get("streamStats", [])
+        for s in _get_attempt(output.job_details.get("attempts", [{}])[-1]).get("streamStats", [])
     }
     for stream_name, stream_props in all_stream_props.items():
         yield _materialization_for_stream(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
@@ -29,7 +29,7 @@ def _materialization_for_stream(
     )
 
 
-def _get_attempt(attempt: dict) -> List:
+def _get_attempt(attempt: dict):
     # the attempt field is nested in some API results, and is not in others
     return attempt.get("attempt") or attempt
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -3,6 +3,7 @@ import responses
 from dagster_airbyte import airbyte_resource, build_airbyte_assets
 
 from dagster import AssetKey, MetadataEntry, TableColumn, TableSchema, build_init_resource_context
+from dagster._core.definitions.source_asset import SourceAsset
 from dagster._legacy import build_assets_job
 
 from .utils import get_sample_connection_json, get_sample_job_json
@@ -91,3 +92,102 @@ def test_assets(schema_prefix):
         )
         in materializations[0].metadata_entries
     )
+
+
+@responses.activate
+@pytest.mark.parametrize("schema_prefix", ["", "the_prefix_"])
+@pytest.mark.parametrize("source_asset", [None, "my_source_asset_key"])
+def test_assets_with_normalization(schema_prefix, source_asset):
+
+    ab_resource = airbyte_resource(
+        build_init_resource_context(
+            config={
+                "host": "some_host",
+                "port": "8000",
+            }
+        )
+    )
+    destination_tables = ["foo", "bar"]
+    if schema_prefix:
+        destination_tables = [schema_prefix + t for t in destination_tables]
+
+    bar_normalization_tables = {schema_prefix + "bar_baz", schema_prefix + "bar_qux"}
+    ab_assets = build_airbyte_assets(
+        "12345",
+        destination_tables=destination_tables,
+        normalization_tables={destination_tables[1]: bar_normalization_tables},
+        asset_key_prefix=["some", "prefix"],
+        upstream_assets={AssetKey(source_asset)} if source_asset else None,
+    )
+
+    assert ab_assets[0].keys == {AssetKey(["some", "prefix", t]) for t in destination_tables} | {
+        AssetKey(["some", "prefix", t]) for t in bar_normalization_tables
+    }
+    assert len(ab_assets[0].op.output_defs) == 4
+
+    responses.add(
+        method=responses.POST,
+        url=ab_resource.api_base_url + "/connections/get",
+        json=get_sample_connection_json(prefix=schema_prefix),
+        status=200,
+    )
+    responses.add(
+        method=responses.POST,
+        url=ab_resource.api_base_url + "/connections/sync",
+        json={"job": {"id": 1}},
+        status=200,
+    )
+    responses.add(
+        method=responses.POST,
+        url=ab_resource.api_base_url + "/jobs/get",
+        json=get_sample_job_json(schema_prefix=schema_prefix),
+        status=200,
+    )
+
+    ab_job = build_assets_job(
+        "ab_job",
+        ab_assets,
+        source_assets=[SourceAsset(AssetKey(source_asset))] if source_asset else None,
+        resource_defs={
+            "airbyte": airbyte_resource.configured(
+                {
+                    "host": "some_host",
+                    "port": "8000",
+                }
+            )
+        },
+    )
+
+    res = ab_job.execute_in_process()
+
+    materializations = [
+        event.event_specific_data.materialization
+        for event in res.events_for_node("airbyte_sync_12345")
+        if event.event_type_value == "ASSET_MATERIALIZATION"
+    ]
+    assert len(materializations) == 5
+    assert {m.asset_key for m in materializations} == {
+        AssetKey(["some", "prefix", schema_prefix + "foo"]),
+        AssetKey(["some", "prefix", schema_prefix + "bar"]),
+        AssetKey(["some", "prefix", schema_prefix + "baz"]),
+        # Normalized materializations are there
+        AssetKey(["some", "prefix", schema_prefix + "bar_baz"]),
+        AssetKey(["some", "prefix", schema_prefix + "bar_qux"]),
+    }
+    assert MetadataEntry("bytesEmitted", value=1234) in materializations[0].metadata_entries
+    assert MetadataEntry("recordsCommitted", value=4321) in materializations[0].metadata_entries
+    assert (
+        MetadataEntry(
+            "schema",
+            value=TableSchema(
+                columns=[
+                    TableColumn(name="a", type="str"),
+                    TableColumn(name="b", type="int"),
+                ]
+            ),
+        )
+        in materializations[0].metadata_entries
+    )
+
+    # No metadata for normalized materializations, for now
+    assert not materializations[3].metadata_entries

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
@@ -84,3 +84,33 @@ def get_sample_job_json(schema_prefix=""):
             }
         ],
     }
+
+
+def get_sample_job_list_json(schema_prefix=""):
+    return {
+        "jobs": [
+            {
+                "job": {"id": 1, "status": AirbyteState.SUCCEEDED},
+                "attempts": [
+                    {
+                        "streamStats": [
+                            {
+                                "streamName": schema_prefix + "foo",
+                                "stats": {
+                                    "bytesEmitted": 1234,
+                                    "recordsCommitted": 4321,
+                                },
+                            },
+                            {
+                                "streamName": schema_prefix + "baz",
+                                "stats": {
+                                    "bytesEmitted": 1111,
+                                    "recordsCommitted": 1111,
+                                },
+                            },
+                        ]
+                    }
+                ],
+            }
+        ]
+    }


### PR DESCRIPTION
## Summary

Adds two new optional parameters to `build_airbyte_assets`.

- `upstream_assets` optionally allows a user to specify one or more upstream `AssetKey`s that the Airbyte assets should depend on, this can be used to e.g. represent the source data dependency.
- `normalization_tables` is a Mapping which maps a destination table to a set of one or more derived tables created by the [Airbyte basic normalization](https://docs.airbyte.com/understanding-airbyte/basic-normalization/#nesting) process. These normalization-generated tables will be shown as Assets downstream of their parent table, and materializations will be triggered by the parent table materializing.

<img width="695" alt="Screen Shot 2022-09-09 at 4 14 47 PM" src="https://user-images.githubusercontent.com/10215173/189457596-99ecde10-982c-4b8f-8019-0c04673b1c67.png">



## Test Plan

Tested locally; new unit test.
