### PR TITLE
infer graph input types from inner input types

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/input.py
+++ b/python_modules/dagster/dagster/_core/definitions/input.py
@@ -118,7 +118,7 @@ class InputDefinition:
         asset_key: Optional[Union[AssetKey, Callable[["InputContext"], AssetKey]]] = None,
         asset_partitions: Optional[Union[Set[str], Callable[["InputContext"], Set[str]]]] = None,
         input_manager_key: Optional[str] = None
-        # when adding new params, make sure to update combine_with_inferred below
+        # when adding new params, make sure to update combine_with_inferred and with_dagster_type below
     ):
         self._name = check_valid_name(name)
 
@@ -316,6 +316,19 @@ class InputDefinition:
             dagster_type=dagster_type,
             description=description,
             default_value=default_value,
+            root_manager_key=self._root_manager_key,
+            metadata=self._metadata,
+            asset_key=self._asset_key,
+            asset_partitions=self._asset_partitions_fn,
+            input_manager_key=self._input_manager_key,
+        )
+
+    def with_dagster_type(self, dagster_type: DagsterType) -> "InputDefinition":
+        return InputDefinition(
+            name=self.name,
+            dagster_type=dagster_type,
+            description=self.description,
+            default_value=self.default_value if self.has_default_value else NoValueSentinel,
             root_manager_key=self._root_manager_key,
             metadata=self._metadata,
             asset_key=self._asset_key,

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -1,7 +1,7 @@
 import enum
 import json
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 import pendulum
 import pytest
@@ -14,7 +14,6 @@ from dagster import (
     DynamicOutput,
     Enum,
     Field,
-    GraphIn,
     In,
     InputMapping,
     Nothing,
@@ -1030,20 +1029,6 @@ def test_graph_top_level_input():
     assert result.output_for_node("my_graph.my_op") == 4
 
 
-def test_nothing_inputs_graph():
-    # Document that there is no way to use Nothing inputs on a top-level graph.
-    @op(ins={"sync_signal": In(Nothing)})
-    def my_op():
-        ...
-
-    @graph(ins={"sync_signal": GraphIn()})
-    def my_pipeline(sync_signal):
-        my_op(sync_signal)
-
-    with pytest.raises(DagsterInvalidConfigError):
-        my_pipeline.execute_in_process()
-
-
 def test_run_id_execute_in_process():
     @graph
     def blank():
@@ -1268,3 +1253,114 @@ def test_graph_with_mapped_out():
     result = mapped_out.execute_in_process()
     assert result.success
     assert result.output_value() == {"num_0": 0, "num_1": 1, "num_2": 2}
+
+
+def test_infer_graph_input_type_from_inner_input():
+    @op(ins={"in1": In(Nothing)})
+    def op1():
+        ...
+
+    @graph
+    def graph1(in1):
+        op1(in1)
+
+    assert graph1.input_defs[0].dagster_type.is_nothing
+
+    assert graph1.execute_in_process().success
+
+
+def test_infer_graph_input_type_from_inner_input_int():
+    @op
+    def op1(in1: int):
+        assert in1 == 5
+
+    @graph
+    def graph1(in1):
+        op1(in1)
+
+    assert graph1.input_defs[0].dagster_type.typing_type == int
+
+    assert graph1.execute_in_process(run_config={"inputs": {"in1": {"value": 5}}}).success
+
+
+def test_infer_graph_input_type_from_inner_input_explicit_any():
+    @op(ins={"in1": In(Nothing)})
+    def op1():
+        ...
+
+    @graph
+    def graph1(in1: Any):
+        op1(in1)
+
+    assert graph1.input_defs[0].dagster_type.is_nothing
+
+    assert graph1.execute_in_process().success
+
+
+def test_infer_graph_input_type_from_inner_input_explicit_graphin_type():
+    @op(ins={"in1": In(Nothing)})
+    def op1():
+        ...
+
+    @graph
+    def graph1(in1: int):
+        op1(in1)
+
+    assert graph1.input_defs[0].dagster_type.typing_type == int
+
+
+def test_infer_graph_input_type_from_multiple_inner_inputs():
+    @op(ins={"in1": In(Nothing)})
+    def op1():
+        ...
+
+    @op(ins={"in2": In(Nothing)})
+    def op2():
+        ...
+
+    @graph
+    def graph1(in1):
+        op1(in1)
+        op2(in1)
+
+    assert graph1.input_defs[0].dagster_type.is_nothing
+
+    assert graph1.execute_in_process().success
+
+
+def test_dont_infer_graph_input_type_from_different_inner_inputs():
+    @op(ins={"in1": In(Nothing)})
+    def op1():
+        ...
+
+    @op
+    def op2(in2):
+        del in2
+
+    @graph
+    def graph1(in1):
+        op1(in1)
+        op2(in1)
+
+    assert not graph1.input_defs[0].dagster_type.is_nothing
+
+    with pytest.raises(DagsterInvalidConfigError):
+        graph1.execute_in_process()
+
+
+def test_infer_graph_input_type_from_inner_inner_input():
+    @op(ins={"in1": In(Nothing)})
+    def op1():
+        ...
+
+    @graph
+    def inner(in1):
+        op1(in1)
+
+    @graph
+    def outer(in1):
+        inner(in1)
+
+    assert outer.input_defs[0].dagster_type.is_nothing
+
+    assert outer.execute_in_process().success


### PR DESCRIPTION
### Summary & Motivation

Makes this possible:
```
from dagster import op, graph, Nothing, In, AssetsDefinition, repository


@op(ins={"in1": In(Nothing)})
def op1():
    ...


@graph
def graph1(in1):
    return op1(in1)


@repository
def repo():
    return [AssetsDefinition.from_graph(graph1)]
```

### How I Tested These Changes
