### PR TITLE
[dagster-airbyte] Add ability to generate Airbyte assets from YAML files

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -318,7 +318,7 @@ def with_group(
     """
     group_name = check.opt_str_param(group_name, "group_name")
     if not group_name:
-        return list(assets_defs)
+        return assets_defs
 
     return [
         assets_def.with_prefix_or_group(

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -192,7 +192,7 @@ def load_assets_from_package_module(
     if key_prefix:
         assets = prefix_assets(assets, key_prefix)
     if group_name:
-        assets = with_group(assets, group_name)
+        assets = list(with_group(assets, group_name))
         source_assets = [asset.with_group_name(group_name) for asset in source_assets]
 
     return [*assets, *source_assets]

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -192,7 +192,7 @@ def load_assets_from_package_module(
     if key_prefix:
         assets = prefix_assets(assets, key_prefix)
     if group_name:
-        assets = group_assets(assets, group_name)
+        assets = with_group(assets, group_name)
         source_assets = [asset.with_group_name(group_name) for asset in source_assets]
 
     return [*assets, *source_assets]
@@ -310,11 +310,11 @@ def prefix_assets(
     return result_assets
 
 
-def group_assets(
+def with_group(
     assets_defs: Sequence[AssetsDefinition], group_name: Optional[str]
-) -> List[AssetsDefinition]:
+) -> Sequence[AssetsDefinition]:
     """
-    Given a list of assets, group them under the group_name.
+    Given a list of assets, groups them under the group_name.
     """
     group_name = check.opt_str_param(group_name, "group_name")
     if not group_name:

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -192,12 +192,7 @@ def load_assets_from_package_module(
     if key_prefix:
         assets = prefix_assets(assets, key_prefix)
     if group_name:
-        assets = [
-            asset.with_prefix_or_group(
-                group_names_by_key={asset_key: group_name for asset_key in asset.keys}
-            )
-            for asset in assets
-        ]
+        assets = group_assets(assets, group_name)
         source_assets = [asset.with_group_name(group_name) for asset in source_assets]
 
     return [*assets, *source_assets]
@@ -313,3 +308,21 @@ def prefix_assets(
             )
         )
     return result_assets
+
+
+def group_assets(
+    assets_defs: Sequence[AssetsDefinition], group_name: Optional[str]
+) -> List[AssetsDefinition]:
+    """
+    Given a list of assets, group them under the group_name.
+    """
+    group_name = check.opt_str_param(group_name, "group_name")
+    if not group_name:
+        return list(assets_defs)
+
+    return [
+        assets_def.with_prefix_or_group(
+            group_names_by_key={asset_key: group_name for asset_key in assets_def.keys}
+        )
+        for assets_def in assets_defs
+    ]

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/__init__.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/__init__.py
@@ -1,6 +1,6 @@
 from dagster._core.utils import check_dagster_package_version
 
-from .asset_defs import build_airbyte_assets
+from .asset_defs import build_airbyte_assets, load_assets_from_airbyte_project
 from .ops import airbyte_sync_op
 from .resources import AirbyteResource, AirbyteState, airbyte_resource
 from .types import AirbyteOutput

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -10,7 +10,7 @@ from dagster import _check as check
 from dagster._annotations import experimental
 from dagster._core.definitions import AssetsDefinition, multi_asset
 from dagster._core.definitions.events import CoercibleToAssetKeyPrefix
-from dagster._core.definitions.load_assets_from_modules import group_assets
+from dagster._core.definitions.load_assets_from_modules import with_group
 from dagster._core.definitions.utils import VALID_NAME_REGEX
 
 
@@ -293,7 +293,7 @@ def load_assets_from_airbyte_project(
         )
 
         if connection_to_group_fn:
-            assets_for_connection = group_assets(
+            assets_for_connection = with_group(
                 assets_for_connection, connection_to_group_fn(connection_name)
             )
         assets.extend(assets_for_connection)

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -1,12 +1,17 @@
+import os
 from itertools import chain
-from typing import List, Mapping, Optional, Set
+from typing import Any, Callable, List, Mapping, NamedTuple, Optional, Sequence, Set
 
+import yaml
 from dagster_airbyte.utils import generate_materializations
 
-from dagster import AssetKey, AssetOut, Output
+from dagster import AssetKey, AssetOut, Output, SourceAsset
 from dagster import _check as check
 from dagster._annotations import experimental
 from dagster._core.definitions import AssetsDefinition, multi_asset
+from dagster._core.definitions.events import CoercibleToAssetKeyPrefix
+from dagster._core.definitions.load_assets_from_modules import group_assets
+from dagster._core.definitions.utils import VALID_NAME_REGEX
 
 
 @experimental
@@ -88,3 +93,197 @@ def build_airbyte_assets(
                 yield materialization
 
     return [_assets]
+
+
+def _get_normalization_tables_for_schema(
+    key: str, schema: Mapping[str, Any], prefix: str = ""
+) -> List[str]:
+    """
+    Recursively traverses a schema, returning a list of table names that will be created by the Airbyte
+    normalization process.
+
+    For example, a table `cars` with a nested object field `limited_editions` will produce the tables
+    `cars` and `cars_limited_editions`.
+
+    For more information on Airbyte's normalization process, see:
+    https://docs.airbyte.com/understanding-airbyte/basic-normalization/#nesting
+    """
+
+    out = []
+    # Object types are broken into a new table, as long as they have children
+    if (
+        schema["type"] == "object"
+        or "object" in schema["type"]
+        and len(schema.get("properties", {})) > 0
+    ):
+        out.append(prefix + key)
+        for k, v in schema["properties"].items():
+            out += _get_normalization_tables_for_schema(k, v, f"{prefix}{key}_")
+    # Array types are also broken into a new table
+    elif schema["type"] == "array" or "array" in schema["type"]:
+        out.append(prefix + key)
+        for k, v in schema["items"]["properties"].items():
+            out += _get_normalization_tables_for_schema(k, v, f"{prefix}{key}_")
+    return out
+
+
+def _clean_name(name: str) -> str:
+    """
+    Cleans an input to be a valid Dagster asset name.
+    """
+    return "".join(c if VALID_NAME_REGEX.match(c) else "_" for c in name)
+
+
+class AirbyteConnection(
+    NamedTuple(
+        "_AirbyteConnection",
+        [
+            ("name", str),
+            ("source_config_path", str),
+            ("stream_prefix", str),
+            ("has_basic_normalization", bool),
+            ("stream_data", List[Mapping[str, Any]]),
+        ],
+    )
+):
+    """
+    Contains information about an Airbyte connection.
+
+    Attributes:
+        name (str): The name of the connection.
+        source_config_path (str): The path to the Airbyte source configuration file.
+        stream_prefix (str): A prefix to add to all stream names.
+        has_basic_normalization (bool): Whether or not the connection has basic normalization enabled.
+        stream_data (List[Mapping[str, Any]]): Unparsed list of dicts with information about each stream.
+    """
+
+    def parse_stream_tables(
+        self, return_normalization_tables: bool = False
+    ) -> Mapping[str, Set[str]]:
+        """
+        Parses the stream data and returns a mapping, with keys representing destination
+        tables associated with each enabled stream and values representing any affiliated
+        tables created by Airbyte's normalization process, if enabled.
+        """
+
+        tables: Mapping[str, Set[str]] = {}
+
+        enabled_streams = [
+            stream for stream in self.stream_data if stream.get("config", {}).get("selected", False)
+        ]
+
+        for stream in enabled_streams:
+            name = stream.get("stream", {}).get("name")
+            prefixed_name = self.stream_prefix + name
+
+            tables[prefixed_name] = set()
+            if self.has_basic_normalization and return_normalization_tables:
+                for k, v in stream["stream"]["json_schema"]["properties"].items():
+                    for normalization_table_name in _get_normalization_tables_for_schema(
+                        k, v, f"{name}_"
+                    ):
+                        prefixed_norm_table_name = self.stream_prefix + normalization_table_name
+                        tables[prefixed_name].add(prefixed_norm_table_name)
+
+        return tables
+
+
+class AirbyteSource(NamedTuple("_AirbyteSource", [("name", str)])):
+    """
+    Contains information about an Airbyte source.
+
+    Attributes:
+        name (str): The name of the source.
+    """
+
+
+def _airbyte_connection_from_config(contents: Mapping[str, Any]) -> AirbyteConnection:
+    config_contents = contents.get("configuration")
+    return AirbyteConnection(
+        name=contents["resource_name"],
+        source_config_path=contents["source_configuration_path"],
+        stream_prefix=config_contents.get("prefix", ""),
+        has_basic_normalization=any(
+            op.get("operator_configuration", {}).get("operator_type") == "normalization"
+            for op in config_contents.get("operations", [])
+        ),
+        stream_data=config_contents.get("sync_catalog", {}).get("streams", []),
+    )
+
+
+def _airbyte_source_from_config(contents: Mapping[str, Any]) -> AirbyteSource:
+    return AirbyteSource(name=contents["resource_name"])
+
+
+@experimental
+def load_assets_from_airbyte_project(
+    project_dir: str,
+    key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
+    source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
+    create_assets_for_normalization_tables: bool = True,
+    connection_to_group_fn: Optional[Callable[[str], Optional[str]]] = _clean_name,
+) -> Sequence[AssetsDefinition]:
+    """
+    Loads an Airbyte project into a set of Dagster assets.
+
+    Point to the root folder of an Airbye project synced using the Octavia CLI. For
+    more information, see https://github.com/airbytehq/airbyte/tree/master/octavia-cli#octavia-import-all.
+
+    Args:
+        project_dir (str): The path to the root of your Airbyte project, containing sources, destinations,
+            and connections folders.
+        key_prefix (Optional[CoercibleToAssetKeyPrefix]): A prefix for the asset keys created.
+        source_key_prefix (Optional[CoercibleToAssetKeyPrefix]): A prefix for the source asset keys produced.
+        create_assets_for_normalization_tables (bool): If True, assets will be created for tables
+            created by Airbyte's normalization feature. If False, only the destination tables
+            will be created.
+        connection_to_group_fn (Optional[Callable[[str], Optional[str]]]): Function which returns an asset
+            group name for a given Airbyte connection name. If None, no groups will be created. Defaults
+            to a basic sanitization function.
+    """
+
+    assets = []
+    source_assets = {}
+
+    connections_dir = os.path.join(project_dir, "connections")
+    for connection_name in os.listdir(connections_dir):
+        connection_dir = os.path.join(connections_dir, connection_name)
+        with open(os.path.join(connection_dir, "configuration.yaml"), encoding="utf-8") as f:
+            connection = _airbyte_connection_from_config(yaml.safe_load(f.read()))
+
+        with open(os.path.join(project_dir, connection.source_config_path), encoding="utf-8") as f:
+            source = _airbyte_source_from_config(yaml.safe_load(f.read()))
+            if source.name not in source_assets:
+                source_asset_key = AssetKey.from_user_string(_clean_name(source.name))
+                source_assets[source.name] = SourceAsset(key=source_asset_key)
+
+        state_file = next(
+            (filename for filename in os.listdir(connection_dir) if filename.startswith("state_")),
+            None,
+        )
+        check.invariant(
+            state_file is not None,
+            "No state file found for connection {} in {}".format(connection_name, connection_dir),
+        )
+
+        with open(os.path.join(connection_dir, state_file), encoding="utf-8") as f:
+            state = yaml.safe_load(f.read())
+            connection_id = state.get("resource_id")
+
+        table_mapping = connection.parse_stream_tables(create_assets_for_normalization_tables)
+
+        assets_for_connection = build_airbyte_assets(
+            connection_id=connection_id,
+            destination_tables=list(table_mapping.keys()),
+            normalization_tables=table_mapping,
+            asset_key_prefix=None,
+            upstream_assets={source_asset_key},
+        )
+
+        if connection_to_group_fn:
+            assets_for_connection = group_assets(
+                assets_for_connection, connection_to_group_fn(connection_name)
+            )
+        assets.extend(assets_for_connection)
+
+    return assets, list(source_assets.values())

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -1,6 +1,6 @@
 import os
 from itertools import chain
-from typing import Any, Callable, List, Mapping, NamedTuple, Optional, Set, Tuple, cast
+from typing import Any, Callable, Dict, List, Mapping, NamedTuple, Optional, Set, Tuple, cast
 
 import yaml
 from dagster_airbyte.utils import generate_materializations
@@ -166,7 +166,7 @@ class AirbyteConnection(
         tables created by Airbyte's normalization process, if enabled.
         """
 
-        tables: Mapping[str, Set[str]] = {}
+        tables: Dict[str, Set[str]] = {}
 
         enabled_streams = [
             stream for stream in self.stream_data if stream.get("config", {}).get("selected", False)
@@ -255,7 +255,7 @@ def load_assets_from_airbyte_project(
     key_prefix = check.list_param(key_prefix or [], "key_prefix", of_type=str)
 
     assets: List[AssetsDefinition] = []
-    source_assets: Mapping[str, SourceAsset] = {}
+    source_assets: Dict[str, SourceAsset] = {}
 
     connections_dir = os.path.join(project_dir, "connections")
     for connection_name in os.listdir(connections_dir):

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -291,8 +291,8 @@ def load_assets_from_airbyte_project(
         )
 
         if connection_to_group_fn:
-            assets_for_connection = with_group(
-                assets_for_connection, connection_to_group_fn(connection_name)
+            assets_for_connection = list(
+                with_group(assets_for_connection, connection_to_group_fn(connection_name))
             )
         assets.extend(assets_for_connection)
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -1,6 +1,6 @@
 import os
 from itertools import chain
-from typing import Any, Callable, Dict, List, Mapping, NamedTuple, Optional, Set, Tuple, cast
+from typing import Any, Callable, Dict, List, Mapping, NamedTuple, Optional, Set, Union, cast
 
 import yaml
 from dagster_airbyte.utils import generate_materializations
@@ -227,7 +227,7 @@ def load_assets_from_airbyte_project(
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     create_assets_for_normalization_tables: bool = True,
     connection_to_group_fn: Optional[Callable[[str], Optional[str]]] = _clean_name,
-) -> Tuple[List[AssetsDefinition], List[SourceAsset]]:
+) -> List[Union[AssetsDefinition, SourceAsset]]:
     """
     Loads an Airbyte project into a set of Dagster assets.
 
@@ -299,4 +299,4 @@ def load_assets_from_airbyte_project(
             )
         assets.extend(assets_for_connection)
 
-    return assets, list(source_assets.values())
+    return assets + list(source_assets.values())

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_airbyte_project/api_http_headers.yaml
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_airbyte_project/api_http_headers.yaml
@@ -1,0 +1,4 @@
+# This file is an example file with API HTTP headers used to pass to the octavia CLI API client.
+# It can be helpful to reach out to secured airbyte instances (ex. proxy auth server)
+headers:
+  Content-Type: application/json

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_airbyte_project/connections/github_snowflake_ben/configuration.yaml
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_airbyte_project/connections/github_snowflake_ben/configuration.yaml
@@ -1,0 +1,6859 @@
+definition_type: connection
+resource_name: GitHub <> snowflake-ben
+source_configuration_path: sources/github_dagster_io_dagster/configuration.yaml
+destination_configuration_path: destinations/snowflake_ben/configuration.yaml
+configuration:
+  sync_catalog:
+    streams:
+    - stream:
+        name: assignees
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            type:
+              type:
+              - 'null'
+              - string
+            login:
+              type:
+              - 'null'
+              - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            gists_url:
+              type:
+              - 'null'
+              - string
+            repos_url:
+              type:
+              - 'null'
+              - string
+            avatar_url:
+              type:
+              - 'null'
+              - string
+            events_url:
+              type:
+              - 'null'
+              - string
+            repository:
+              type:
+              - string
+            site_admin:
+              type:
+              - 'null'
+              - boolean
+            gravatar_id:
+              type:
+              - 'null'
+              - string
+            starred_url:
+              type:
+              - 'null'
+              - string
+            followers_url:
+              type:
+              - 'null'
+              - string
+            following_url:
+              type:
+              - 'null'
+              - string
+            organizations_url:
+              type:
+              - 'null'
+              - string
+            subscriptions_url:
+              type:
+              - 'null'
+              - string
+            received_events_url:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        default_cursor_field: []
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field: []
+        primary_key:
+        - - id
+        alias_name: assignees
+        selected: false
+    - stream:
+        name: branches
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            name:
+              type:
+              - 'null'
+              - string
+            commit:
+              type:
+              - 'null'
+              - object
+              properties:
+                sha:
+                  type:
+                  - 'null'
+                  - string
+                url:
+                  type:
+                  - 'null'
+                  - string
+            protected:
+              type:
+              - 'null'
+              - boolean
+            protection:
+              type:
+              - 'null'
+              - object
+              properties:
+                required_status_checks:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    contexts:
+                      type:
+                      - 'null'
+                      - array
+                      items:
+                        type:
+                        - 'null'
+                        - string
+                    enforcement_level:
+                      type:
+                      - 'null'
+                      - string
+            repository:
+              type:
+              - string
+            protection_url:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        default_cursor_field: []
+        source_defined_primary_key:
+        - - repository
+        - - name
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field: []
+        primary_key:
+        - - repository
+        - - name
+        alias_name: branches
+        selected: false
+    - stream:
+        name: collaborators
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            type:
+              type:
+              - 'null'
+              - string
+            login:
+              type:
+              - 'null'
+              - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            gists_url:
+              type:
+              - 'null'
+              - string
+            repos_url:
+              type:
+              - 'null'
+              - string
+            avatar_url:
+              type:
+              - 'null'
+              - string
+            events_url:
+              type:
+              - 'null'
+              - string
+            repository:
+              type:
+              - string
+            site_admin:
+              type:
+              - 'null'
+              - boolean
+            gravatar_id:
+              type:
+              - 'null'
+              - string
+            permissions:
+              type:
+              - 'null'
+              - object
+              properties:
+                pull:
+                  type:
+                  - 'null'
+                  - boolean
+                push:
+                  type:
+                  - 'null'
+                  - boolean
+                admin:
+                  type:
+                  - 'null'
+                  - boolean
+            starred_url:
+              type:
+              - 'null'
+              - string
+            followers_url:
+              type:
+              - 'null'
+              - string
+            following_url:
+              type:
+              - 'null'
+              - string
+            organizations_url:
+              type:
+              - 'null'
+              - string
+            subscriptions_url:
+              type:
+              - 'null'
+              - string
+            received_events_url:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        default_cursor_field: []
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field: []
+        primary_key:
+        - - id
+        alias_name: collaborators
+        selected: false
+    - stream:
+        name: comments
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            body:
+              type:
+              - 'null'
+              - string
+            user:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            user_id:
+              type:
+              - 'null'
+              - integer
+            html_url:
+              type:
+              - 'null'
+              - string
+            issue_url:
+              type:
+              - 'null'
+              - string
+            created_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            repository:
+              type:
+              - string
+            updated_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            author_association:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - updated_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - updated_at
+        primary_key:
+        - - id
+        alias_name: comments
+        selected: false
+    - stream:
+        name: commit_comment_reactions
+        json_schema:
+          type:
+          - 'null'
+          - object
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            user:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            content:
+              type:
+              - 'null'
+              - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            comment_id:
+              type: integer
+            created_at:
+              type: string
+              format: date-time
+            repository:
+              type: string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - created_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - created_at
+        primary_key:
+        - - id
+        alias_name: commit_comment_reactions
+        selected: false
+    - stream:
+        name: commit_comments
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            body:
+              type:
+              - 'null'
+              - string
+            line:
+              type:
+              - 'null'
+              - integer
+            path:
+              type:
+              - 'null'
+              - string
+            user:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            position:
+              type:
+              - 'null'
+              - integer
+            commit_id:
+              type:
+              - 'null'
+              - string
+            created_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            repository:
+              type:
+              - string
+            updated_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            author_association:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - updated_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - updated_at
+        primary_key:
+        - - id
+        alias_name: commit_comments
+        selected: false
+    - stream:
+        name: commits
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            sha:
+              type:
+              - 'null'
+              - string
+            url:
+              type:
+              - 'null'
+              - string
+            author:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            commit:
+              type:
+              - 'null'
+              - object
+              properties:
+                url:
+                  type:
+                  - 'null'
+                  - string
+                tree:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    sha:
+                      type:
+                      - 'null'
+                      - string
+                    url:
+                      type:
+                      - 'null'
+                      - string
+                author:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    date:
+                      type:
+                      - 'null'
+                      - string
+                      format: date-time
+                    name:
+                      type:
+                      - 'null'
+                      - string
+                    email:
+                      type:
+                      - 'null'
+                      - string
+                message:
+                  type:
+                  - 'null'
+                  - string
+                committer:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    date:
+                      type:
+                      - 'null'
+                      - string
+                      format: date-time
+                    name:
+                      type:
+                      - 'null'
+                      - string
+                    email:
+                      type:
+                      - 'null'
+                      - string
+                verification:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    reason:
+                      type:
+                      - 'null'
+                      - string
+                    payload:
+                      type:
+                      - 'null'
+                      - string
+                    verified:
+                      type:
+                      - 'null'
+                      - boolean
+                    signature:
+                      type:
+                      - 'null'
+                      - string
+                comment_count:
+                  type:
+                  - 'null'
+                  - integer
+            node_id:
+              type:
+              - 'null'
+              - string
+            parents:
+              type:
+              - 'null'
+              - array
+              items:
+                type:
+                - 'null'
+                - object
+                properties:
+                  sha:
+                    type:
+                    - 'null'
+                    - string
+                  url:
+                    type:
+                    - 'null'
+                    - string
+                  html_url:
+                    type:
+                    - 'null'
+                    - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            committer:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            created_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            repository:
+              type:
+              - string
+            comments_url:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - created_at
+        source_defined_primary_key:
+        - - sha
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - created_at
+        primary_key:
+        - - sha
+        alias_name: commits
+        selected: false
+    - stream:
+        name: deployments
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            ref:
+              type:
+              - 'null'
+              - string
+            sha:
+              type:
+              - 'null'
+              - string
+            url:
+              type:
+              - 'null'
+              - string
+            task:
+              type:
+              - 'null'
+              - string
+            creator:
+              type: object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            payload:
+              oneOf:
+              - type: object
+                properties: {}
+                additionalProperties: true
+              - type: string
+              - type: 'null'
+            created_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            repository:
+              type:
+              - 'null'
+              - string
+            updated_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            description:
+              type:
+              - 'null'
+              - string
+            environment:
+              type:
+              - 'null'
+              - string
+            statuses_url:
+              type:
+              - 'null'
+              - string
+            repository_url:
+              type:
+              - 'null'
+              - string
+            original_environment:
+              type:
+              - 'null'
+              - string
+            transient_environment:
+              type:
+              - 'null'
+              - boolean
+            production_environment:
+              type:
+              - 'null'
+              - boolean
+            performed_via_github_app:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - updated_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - updated_at
+        primary_key:
+        - - id
+        alias_name: deployments
+        selected: false
+    - stream:
+        name: events
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - string
+            org:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+            repo:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                name:
+                  type:
+                  - 'null'
+                  - string
+            type:
+              type:
+              - 'null'
+              - string
+            actor:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            public:
+              type:
+              - 'null'
+              - boolean
+            payload:
+              type:
+              - 'null'
+              - object
+              properties: {}
+            created_at:
+              type:
+              - 'null'
+              - string
+            repository:
+              type:
+              - string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - created_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - created_at
+        primary_key:
+        - - id
+        alias_name: events
+        selected: false
+    - stream:
+        name: issue_comment_reactions
+        json_schema:
+          type:
+          - 'null'
+          - object
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            user:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            content:
+              type:
+              - 'null'
+              - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            comment_id:
+              type: integer
+            created_at:
+              type: string
+              format: date-time
+            repository:
+              type: string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - created_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - created_at
+        primary_key:
+        - - id
+        alias_name: issue_comment_reactions
+        selected: false
+    - stream:
+        name: issue_events
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            actor:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            event:
+              type:
+              - 'null'
+              - string
+            issue:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                body:
+                  type:
+                  - 'null'
+                  - string
+                user:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    id:
+                      type:
+                      - 'null'
+                      - integer
+                    url:
+                      type:
+                      - 'null'
+                      - string
+                    type:
+                      type:
+                      - 'null'
+                      - string
+                    login:
+                      type:
+                      - 'null'
+                      - string
+                    node_id:
+                      type:
+                      - 'null'
+                      - string
+                    html_url:
+                      type:
+                      - 'null'
+                      - string
+                    gists_url:
+                      type:
+                      - 'null'
+                      - string
+                    repos_url:
+                      type:
+                      - 'null'
+                      - string
+                    avatar_url:
+                      type:
+                      - 'null'
+                      - string
+                    events_url:
+                      type:
+                      - 'null'
+                      - string
+                    site_admin:
+                      type:
+                      - 'null'
+                      - boolean
+                    gravatar_id:
+                      type:
+                      - 'null'
+                      - string
+                    starred_url:
+                      type:
+                      - 'null'
+                      - string
+                    followers_url:
+                      type:
+                      - 'null'
+                      - string
+                    following_url:
+                      type:
+                      - 'null'
+                      - string
+                    organizations_url:
+                      type:
+                      - 'null'
+                      - string
+                    subscriptions_url:
+                      type:
+                      - 'null'
+                      - string
+                    received_events_url:
+                      type:
+                      - 'null'
+                      - string
+                state:
+                  type:
+                  - 'null'
+                  - string
+                title:
+                  type:
+                  - 'null'
+                  - string
+                number:
+                  type:
+                  - 'null'
+                  - integer
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                labels_url:
+                  type:
+                  - 'null'
+                  - string
+                comments_url:
+                  type:
+                  - 'null'
+                  - string
+                repository_url:
+                  type:
+                  - 'null'
+                  - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            commit_id:
+              type:
+              - 'null'
+              - string
+            commit_url:
+              type:
+              - 'null'
+              - string
+            created_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            repository:
+              type:
+              - string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - created_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - created_at
+        primary_key:
+        - - id
+        alias_name: issue_events
+        selected: false
+    - stream:
+        name: issue_labels
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            name:
+              type:
+              - 'null'
+              - string
+            color:
+              type:
+              - 'null'
+              - string
+            default:
+              type:
+              - 'null'
+              - boolean
+            node_id:
+              type:
+              - 'null'
+              - string
+            repository:
+              type:
+              - string
+            description:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        default_cursor_field: []
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field: []
+        primary_key:
+        - - id
+        alias_name: issue_labels
+        selected: false
+    - stream:
+        name: issue_milestones
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            state:
+              type:
+              - 'null'
+              - string
+            title:
+              type:
+              - 'null'
+              - string
+            due_on:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            number:
+              type:
+              - 'null'
+              - integer
+            creator:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            closed_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            created_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            labels_url:
+              type:
+              - 'null'
+              - string
+            repository:
+              type:
+              - string
+            updated_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            description:
+              type:
+              - 'null'
+              - string
+            open_issues:
+              type:
+              - 'null'
+              - integer
+            closed_issues:
+              type:
+              - 'null'
+              - integer
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - updated_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - updated_at
+        primary_key:
+        - - id
+        alias_name: issue_milestones
+        selected: false
+    - stream:
+        name: issue_reactions
+        json_schema:
+          type:
+          - 'null'
+          - object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            user:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            content:
+              type:
+              - 'null'
+              - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            created_at:
+              type: string
+              format: date-time
+            repository:
+              type: string
+            issue_number:
+              type: integer
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - created_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - created_at
+        primary_key:
+        - - id
+        alias_name: issue_reactions
+        selected: false
+    - stream:
+        name: issues
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            body:
+              type:
+              - 'null'
+              - string
+            user:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            state:
+              type:
+              - 'null'
+              - string
+            title:
+              type:
+              - 'null'
+              - string
+            labels:
+              type:
+              - 'null'
+              - array
+              items:
+                type:
+                - 'null'
+                - object
+                properties:
+                  id:
+                    type:
+                    - 'null'
+                    - integer
+                  url:
+                    type:
+                    - 'null'
+                    - string
+                  name:
+                    type:
+                    - 'null'
+                    - string
+                  color:
+                    type:
+                    - 'null'
+                    - string
+                  default:
+                    type:
+                    - 'null'
+                    - boolean
+                  node_id:
+                    type:
+                    - 'null'
+                    - string
+                  description:
+                    type:
+                    - 'null'
+                    - string
+            locked:
+              type:
+              - 'null'
+              - boolean
+            number:
+              type:
+              - 'null'
+              - integer
+            node_id:
+              type:
+              - 'null'
+              - string
+            user_id:
+              type:
+              - 'null'
+              - integer
+            assignee:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            comments:
+              type:
+              - 'null'
+              - integer
+            html_url:
+              type:
+              - 'null'
+              - string
+            assignees:
+              type:
+              - 'null'
+              - array
+              items:
+                type:
+                - 'null'
+                - object
+                properties:
+                  id:
+                    type:
+                    - 'null'
+                    - integer
+                  url:
+                    type:
+                    - 'null'
+                    - string
+                  type:
+                    type:
+                    - 'null'
+                    - string
+                  login:
+                    type:
+                    - 'null'
+                    - string
+                  node_id:
+                    type:
+                    - 'null'
+                    - string
+                  html_url:
+                    type:
+                    - 'null'
+                    - string
+                  gists_url:
+                    type:
+                    - 'null'
+                    - string
+                  repos_url:
+                    type:
+                    - 'null'
+                    - string
+                  avatar_url:
+                    type:
+                    - 'null'
+                    - string
+                  events_url:
+                    type:
+                    - 'null'
+                    - string
+                  site_admin:
+                    type:
+                    - 'null'
+                    - boolean
+                  gravatar_id:
+                    type:
+                    - 'null'
+                    - string
+                  starred_url:
+                    type:
+                    - 'null'
+                    - string
+                  followers_url:
+                    type:
+                    - 'null'
+                    - string
+                  following_url:
+                    type:
+                    - 'null'
+                    - string
+                  organizations_url:
+                    type:
+                    - 'null'
+                    - string
+                  subscriptions_url:
+                    type:
+                    - 'null'
+                    - string
+                  received_events_url:
+                    type:
+                    - 'null'
+                    - string
+            closed_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            milestone:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                state:
+                  type:
+                  - 'null'
+                  - string
+                title:
+                  type:
+                  - 'null'
+                  - string
+                due_on:
+                  type:
+                  - 'null'
+                  - string
+                  format: date-time
+                number:
+                  type:
+                  - 'null'
+                  - integer
+                creator:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    id:
+                      type:
+                      - 'null'
+                      - integer
+                    url:
+                      type:
+                      - 'null'
+                      - string
+                    type:
+                      type:
+                      - 'null'
+                      - string
+                    login:
+                      type:
+                      - 'null'
+                      - string
+                    node_id:
+                      type:
+                      - 'null'
+                      - string
+                    html_url:
+                      type:
+                      - 'null'
+                      - string
+                    gists_url:
+                      type:
+                      - 'null'
+                      - string
+                    repos_url:
+                      type:
+                      - 'null'
+                      - string
+                    avatar_url:
+                      type:
+                      - 'null'
+                      - string
+                    events_url:
+                      type:
+                      - 'null'
+                      - string
+                    site_admin:
+                      type:
+                      - 'null'
+                      - boolean
+                    gravatar_id:
+                      type:
+                      - 'null'
+                      - string
+                    starred_url:
+                      type:
+                      - 'null'
+                      - string
+                    followers_url:
+                      type:
+                      - 'null'
+                      - string
+                    following_url:
+                      type:
+                      - 'null'
+                      - string
+                    organizations_url:
+                      type:
+                      - 'null'
+                      - string
+                    subscriptions_url:
+                      type:
+                      - 'null'
+                      - string
+                    received_events_url:
+                      type:
+                      - 'null'
+                      - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                closed_at:
+                  type:
+                  - 'null'
+                  - string
+                  format: date-time
+                created_at:
+                  type:
+                  - 'null'
+                  - string
+                  format: date-time
+                labels_url:
+                  type:
+                  - 'null'
+                  - string
+                updated_at:
+                  type:
+                  - 'null'
+                  - string
+                  format: date-time
+                description:
+                  type:
+                  - 'null'
+                  - string
+                open_issues:
+                  type:
+                  - 'null'
+                  - integer
+                closed_issues:
+                  type:
+                  - 'null'
+                  - integer
+            created_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            events_url:
+              type:
+              - 'null'
+              - string
+            labels_url:
+              type:
+              - 'null'
+              - string
+            repository:
+              type:
+              - string
+            updated_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            comments_url:
+              type:
+              - 'null'
+              - string
+            pull_request:
+              type:
+              - 'null'
+              - object
+              properties:
+                url:
+                  type:
+                  - 'null'
+                  - string
+                diff_url:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                patch_url:
+                  type:
+                  - 'null'
+                  - string
+            repository_url:
+              type:
+              - 'null'
+              - string
+            active_lock_reason:
+              type:
+              - 'null'
+              - string
+            author_association:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - updated_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - updated_at
+        primary_key:
+        - - id
+        alias_name: issues
+        selected: false
+    - stream:
+        name: organizations
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            blog:
+              type:
+              - 'null'
+              - string
+            name:
+              type:
+              - 'null'
+              - string
+            plan:
+              type:
+              - 'null'
+              - object
+              properties:
+                name:
+                  type:
+                  - 'null'
+                  - string
+                seats:
+                  type:
+                  - 'null'
+                  - integer
+                space:
+                  type:
+                  - 'null'
+                  - integer
+                filled_seats:
+                  type:
+                  - 'null'
+                  - integer
+                private_repos:
+                  type:
+                  - 'null'
+                  - integer
+            type:
+              type:
+              - 'null'
+              - string
+            email:
+              type:
+              - 'null'
+              - string
+            login:
+              type:
+              - 'null'
+              - string
+            company:
+              type:
+              - 'null'
+              - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            location:
+              type:
+              - 'null'
+              - string
+            followers:
+              type:
+              - 'null'
+              - integer
+            following:
+              type:
+              - 'null'
+              - integer
+            hooks_url:
+              type:
+              - 'null'
+              - string
+            repos_url:
+              type:
+              - 'null'
+              - string
+            avatar_url:
+              type:
+              - 'null'
+              - string
+            created_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            disk_usage:
+              type:
+              - 'null'
+              - integer
+            events_url:
+              type:
+              - 'null'
+              - string
+            issues_url:
+              type:
+              - 'null'
+              - string
+            updated_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            description:
+              type:
+              - 'null'
+              - string
+            is_verified:
+              type:
+              - 'null'
+              - boolean
+            members_url:
+              type:
+              - 'null'
+              - string
+            public_gists:
+              type:
+              - 'null'
+              - integer
+            public_repos:
+              type:
+              - 'null'
+              - integer
+            billing_email:
+              type:
+              - 'null'
+              - string
+            collaborators:
+              type:
+              - 'null'
+              - integer
+            private_gists:
+              type:
+              - 'null'
+              - integer
+            twitter_username:
+              type:
+              - 'null'
+              - string
+            public_members_url:
+              type:
+              - 'null'
+              - string
+            owned_private_repos:
+              type:
+              - 'null'
+              - integer
+            total_private_repos:
+              type:
+              - 'null'
+              - integer
+            has_repository_projects:
+              type:
+              - 'null'
+              - boolean
+            members_can_create_pages:
+              type:
+              - 'null'
+              - boolean
+            has_organization_projects:
+              type:
+              - 'null'
+              - boolean
+            default_repository_permission:
+              type:
+              - 'null'
+              - string
+            two_factor_requirement_enabled:
+              type:
+              - 'null'
+              - boolean
+            members_can_create_public_pages:
+              type:
+              - 'null'
+              - boolean
+            members_can_create_repositories:
+              type:
+              - 'null'
+              - boolean
+            members_can_create_private_pages:
+              type:
+              - 'null'
+              - boolean
+        supported_sync_modes:
+        - full_refresh
+        default_cursor_field: []
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field: []
+        primary_key:
+        - - id
+        alias_name: organizations
+        selected: false
+    - stream:
+        name: project_cards
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            note:
+              type:
+              - 'null'
+              - string
+            creator:
+              type: object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            archived:
+              type:
+              - 'null'
+              - boolean
+            column_id:
+              type:
+              - 'null'
+              - integer
+            column_url:
+              type:
+              - 'null'
+              - string
+            created_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            project_id:
+              type:
+              - 'null'
+              - integer
+            repository:
+              type:
+              - 'null'
+              - string
+            updated_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            project_url:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - updated_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - updated_at
+        primary_key:
+        - - id
+        alias_name: project_cards
+        selected: false
+    - stream:
+        name: project_columns
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            name:
+              type:
+              - 'null'
+              - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            cards_url:
+              type:
+              - 'null'
+              - string
+            created_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            project_id:
+              type:
+              - 'null'
+              - integer
+            repository:
+              type:
+              - 'null'
+              - string
+            updated_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            project_url:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - updated_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - updated_at
+        primary_key:
+        - - id
+        alias_name: project_columns
+        selected: false
+    - stream:
+        name: projects
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            body:
+              type:
+              - 'null'
+              - string
+            name:
+              type:
+              - 'null'
+              - string
+            state:
+              type:
+              - 'null'
+              - string
+            number:
+              type:
+              - 'null'
+              - integer
+            creator:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            owner_url:
+              type:
+              - 'null'
+              - string
+            created_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            repository:
+              type:
+              - string
+            updated_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            columns_url:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - updated_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - updated_at
+        primary_key:
+        - - id
+        alias_name: projects
+        selected: false
+    - stream:
+        name: pull_request_comment_reactions
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            user:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+            content:
+              type:
+              - 'null'
+              - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            comment_id:
+              type: integer
+            created_at:
+              type: string
+              format: date-time
+            repository:
+              type: string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - created_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - created_at
+        primary_key:
+        - - id
+        alias_name: pull_request_comment_reactions
+        selected: false
+    - stream:
+        name: pull_request_commits
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            sha:
+              type:
+              - 'null'
+              - string
+            url:
+              type:
+              - 'null'
+              - string
+            author:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            commit:
+              type: object
+              properties:
+                url:
+                  type:
+                  - 'null'
+                  - string
+                tree:
+                  type: object
+                  properties:
+                    sha:
+                      type:
+                      - 'null'
+                      - string
+                    url:
+                      type:
+                      - 'null'
+                      - string
+                author:
+                  type: object
+                  properties:
+                    date:
+                      type:
+                      - 'null'
+                      - string
+                    name:
+                      type:
+                      - 'null'
+                      - string
+                    email:
+                      type:
+                      - 'null'
+                      - string
+                message:
+                  type:
+                  - 'null'
+                  - string
+                committer:
+                  type: object
+                  properties:
+                    date:
+                      type:
+                      - 'null'
+                      - string
+                    name:
+                      type:
+                      - 'null'
+                      - string
+                    email:
+                      type:
+                      - 'null'
+                      - string
+                verification:
+                  type: object
+                  properties:
+                    reason:
+                      type:
+                      - 'null'
+                      - string
+                    payload:
+                      type:
+                      - 'null'
+                      - string
+                    verified:
+                      type:
+                      - 'null'
+                      - boolean
+                    signature:
+                      type:
+                      - 'null'
+                      - string
+                comment_count:
+                  type:
+                  - 'null'
+                  - integer
+            node_id:
+              type:
+              - 'null'
+              - string
+            parents:
+              type: array
+              items:
+                type: object
+                properties:
+                  sha:
+                    type:
+                    - 'null'
+                    - string
+                  url:
+                    type:
+                    - 'null'
+                    - string
+                  html_url:
+                    type:
+                    - 'null'
+                    - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            committer:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            repository:
+              type:
+              - 'null'
+              - string
+            pull_number:
+              type:
+              - 'null'
+              - integer
+            comments_url:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        default_cursor_field: []
+        source_defined_primary_key:
+        - - sha
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field: []
+        primary_key:
+        - - sha
+        alias_name: pull_request_commits
+        selected: false
+    - stream:
+        name: pull_request_stats
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            merged:
+              type:
+              - 'null'
+              - boolean
+            number:
+              type:
+              - 'null'
+              - integer
+            commits:
+              type:
+              - 'null'
+              - integer
+            node_id:
+              type:
+              - 'null'
+              - string
+            comments:
+              type:
+              - 'null'
+              - integer
+            additions:
+              type:
+              - 'null'
+              - integer
+            deletions:
+              type:
+              - 'null'
+              - integer
+            mergeable:
+              type:
+              - 'null'
+              - string
+            merged_by:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+            repository:
+              type:
+              - string
+            updated_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            changed_files:
+              type:
+              - 'null'
+              - integer
+            can_be_rebased:
+              type:
+              - 'null'
+              - boolean
+            review_comments:
+              type:
+              - 'null'
+              - integer
+            merge_state_status:
+              type:
+              - 'null'
+              - string
+            maintainer_can_modify:
+              type:
+              - 'null'
+              - boolean
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - updated_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - updated_at
+        primary_key:
+        - - id
+        alias_name: pull_request_stats
+        selected: false
+    - stream:
+        name: pull_requests
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            base:
+              type:
+              - 'null'
+              - object
+              properties:
+                ref:
+                  type:
+                  - 'null'
+                  - string
+                sha:
+                  type:
+                  - 'null'
+                  - string
+                label:
+                  type:
+                  - 'null'
+                  - string
+                repo_id:
+                  type:
+                  - 'null'
+                  - integer
+                user_id:
+                  type:
+                  - 'null'
+                  - integer
+            body:
+              type:
+              - 'null'
+              - string
+            head:
+              type:
+              - 'null'
+              - object
+              properties:
+                ref:
+                  type:
+                  - 'null'
+                  - string
+                sha:
+                  type:
+                  - 'null'
+                  - string
+                label:
+                  type:
+                  - 'null'
+                  - string
+                repo_id:
+                  type:
+                  - 'null'
+                  - integer
+                user_id:
+                  type:
+                  - 'null'
+                  - integer
+            user:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            draft:
+              type:
+              - 'null'
+              - boolean
+            state:
+              type:
+              - 'null'
+              - string
+            title:
+              type:
+              - 'null'
+              - string
+            _links:
+              type:
+              - 'null'
+              - object
+              properties:
+                html:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    href:
+                      type:
+                      - 'null'
+                      - string
+                self:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    href:
+                      type:
+                      - 'null'
+                      - string
+                issue:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    href:
+                      type:
+                      - 'null'
+                      - string
+                commits:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    href:
+                      type:
+                      - 'null'
+                      - string
+                comments:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    href:
+                      type:
+                      - 'null'
+                      - string
+                statuses:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    href:
+                      type:
+                      - 'null'
+                      - string
+                review_comment:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    href:
+                      type:
+                      - 'null'
+                      - string
+                review_comments:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    href:
+                      type:
+                      - 'null'
+                      - string
+            labels:
+              type:
+              - 'null'
+              - array
+              items:
+                type:
+                - 'null'
+                - object
+                properties:
+                  id:
+                    type:
+                    - 'null'
+                    - integer
+                  url:
+                    type:
+                    - 'null'
+                    - string
+                  name:
+                    type:
+                    - 'null'
+                    - string
+                  color:
+                    type:
+                    - 'null'
+                    - string
+                  default:
+                    type:
+                    - 'null'
+                    - boolean
+                  node_id:
+                    type:
+                    - 'null'
+                    - string
+                  description:
+                    type:
+                    - 'null'
+                    - string
+            locked:
+              type:
+              - 'null'
+              - boolean
+            number:
+              type:
+              - 'null'
+              - integer
+            node_id:
+              type:
+              - 'null'
+              - string
+            assignee:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            diff_url:
+              type:
+              - 'null'
+              - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            assignees:
+              type:
+              - 'null'
+              - array
+              items:
+                type:
+                - 'null'
+                - object
+                properties:
+                  id:
+                    type:
+                    - 'null'
+                    - integer
+                  url:
+                    type:
+                    - 'null'
+                    - string
+                  type:
+                    type:
+                    - 'null'
+                    - string
+                  login:
+                    type:
+                    - 'null'
+                    - string
+                  node_id:
+                    type:
+                    - 'null'
+                    - string
+                  html_url:
+                    type:
+                    - 'null'
+                    - string
+                  gists_url:
+                    type:
+                    - 'null'
+                    - string
+                  repos_url:
+                    type:
+                    - 'null'
+                    - string
+                  avatar_url:
+                    type:
+                    - 'null'
+                    - string
+                  events_url:
+                    type:
+                    - 'null'
+                    - string
+                  site_admin:
+                    type:
+                    - 'null'
+                    - boolean
+                  gravatar_id:
+                    type:
+                    - 'null'
+                    - string
+                  starred_url:
+                    type:
+                    - 'null'
+                    - string
+                  followers_url:
+                    type:
+                    - 'null'
+                    - string
+                  following_url:
+                    type:
+                    - 'null'
+                    - string
+                  organizations_url:
+                    type:
+                    - 'null'
+                    - string
+                  subscriptions_url:
+                    type:
+                    - 'null'
+                    - string
+                  received_events_url:
+                    type:
+                    - 'null'
+                    - string
+            closed_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            issue_url:
+              type:
+              - 'null'
+              - string
+            merged_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            milestone:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                state:
+                  type:
+                  - 'null'
+                  - string
+                title:
+                  type:
+                  - 'null'
+                  - string
+                due_on:
+                  type:
+                  - 'null'
+                  - string
+                  format: date-time
+                number:
+                  type:
+                  - 'null'
+                  - integer
+                creator:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    id:
+                      type:
+                      - 'null'
+                      - integer
+                    url:
+                      type:
+                      - 'null'
+                      - string
+                    type:
+                      type:
+                      - 'null'
+                      - string
+                    login:
+                      type:
+                      - 'null'
+                      - string
+                    node_id:
+                      type:
+                      - 'null'
+                      - string
+                    html_url:
+                      type:
+                      - 'null'
+                      - string
+                    gists_url:
+                      type:
+                      - 'null'
+                      - string
+                    repos_url:
+                      type:
+                      - 'null'
+                      - string
+                    avatar_url:
+                      type:
+                      - 'null'
+                      - string
+                    events_url:
+                      type:
+                      - 'null'
+                      - string
+                    site_admin:
+                      type:
+                      - 'null'
+                      - boolean
+                    gravatar_id:
+                      type:
+                      - 'null'
+                      - string
+                    starred_url:
+                      type:
+                      - 'null'
+                      - string
+                    followers_url:
+                      type:
+                      - 'null'
+                      - string
+                    following_url:
+                      type:
+                      - 'null'
+                      - string
+                    organizations_url:
+                      type:
+                      - 'null'
+                      - string
+                    subscriptions_url:
+                      type:
+                      - 'null'
+                      - string
+                    received_events_url:
+                      type:
+                      - 'null'
+                      - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                closed_at:
+                  type:
+                  - 'null'
+                  - string
+                  format: date-time
+                created_at:
+                  type:
+                  - 'null'
+                  - string
+                  format: date-time
+                labels_url:
+                  type:
+                  - 'null'
+                  - string
+                updated_at:
+                  type:
+                  - 'null'
+                  - string
+                  format: date-time
+                description:
+                  type:
+                  - 'null'
+                  - string
+                open_issues:
+                  type:
+                  - 'null'
+                  - integer
+                closed_issues:
+                  type:
+                  - 'null'
+                  - integer
+            patch_url:
+              type:
+              - 'null'
+              - string
+            auto_merge:
+              type:
+              - 'null'
+              - object
+              properties:
+                enabled_by:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    id:
+                      type:
+                      - 'null'
+                      - integer
+                    url:
+                      type:
+                      - 'null'
+                      - string
+                    type:
+                      type:
+                      - 'null'
+                      - string
+                    login:
+                      type:
+                      - 'null'
+                      - string
+                    node_id:
+                      type:
+                      - 'null'
+                      - string
+                    html_url:
+                      type:
+                      - 'null'
+                      - string
+                    gists_url:
+                      type:
+                      - 'null'
+                      - string
+                    repos_url:
+                      type:
+                      - 'null'
+                      - string
+                    avatar_url:
+                      type:
+                      - 'null'
+                      - string
+                    events_url:
+                      type:
+                      - 'null'
+                      - string
+                    site_admin:
+                      type:
+                      - 'null'
+                      - boolean
+                    gravatar_id:
+                      type:
+                      - 'null'
+                      - string
+                    starred_url:
+                      type:
+                      - 'null'
+                      - string
+                    followers_url:
+                      type:
+                      - 'null'
+                      - string
+                    following_url:
+                      type:
+                      - 'null'
+                      - string
+                    organizations_url:
+                      type:
+                      - 'null'
+                      - string
+                    subscriptions_url:
+                      type:
+                      - 'null'
+                      - string
+                    received_events_url:
+                      type:
+                      - 'null'
+                      - string
+                commit_title:
+                  type:
+                  - 'null'
+                  - string
+                merge_method:
+                  type:
+                  - 'null'
+                  - string
+                commit_message:
+                  type:
+                  - 'null'
+                  - string
+            created_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            repository:
+              type:
+              - string
+            updated_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            commits_url:
+              type:
+              - 'null'
+              - string
+            comments_url:
+              type:
+              - 'null'
+              - string
+            statuses_url:
+              type:
+              - 'null'
+              - string
+            requested_teams:
+              type:
+              - 'null'
+              - array
+              items:
+                type:
+                - 'null'
+                - object
+                properties:
+                  id:
+                    type:
+                    - 'null'
+                    - integer
+                  url:
+                    type:
+                    - 'null'
+                    - string
+                  name:
+                    type:
+                    - 'null'
+                    - string
+                  slug:
+                    type:
+                    - 'null'
+                    - string
+                  parent:
+                    type:
+                    - 'null'
+                    - object
+                    properties: {}
+                  node_id:
+                    type:
+                    - 'null'
+                    - string
+                  privacy:
+                    type:
+                    - 'null'
+                    - string
+                  html_url:
+                    type:
+                    - 'null'
+                    - string
+                  permission:
+                    type:
+                    - 'null'
+                    - string
+                  description:
+                    type:
+                    - 'null'
+                    - string
+                  members_url:
+                    type:
+                    - 'null'
+                    - string
+                  repositories_url:
+                    type:
+                    - 'null'
+                    - string
+            merge_commit_sha:
+              type:
+              - 'null'
+              - string
+            active_lock_reason:
+              type:
+              - 'null'
+              - string
+            author_association:
+              type:
+              - 'null'
+              - string
+            review_comment_url:
+              type:
+              - 'null'
+              - string
+            requested_reviewers:
+              type:
+              - 'null'
+              - array
+              items:
+                type:
+                - 'null'
+                - object
+                properties:
+                  id:
+                    type:
+                    - 'null'
+                    - integer
+                  url:
+                    type:
+                    - 'null'
+                    - string
+                  type:
+                    type:
+                    - 'null'
+                    - string
+                  login:
+                    type:
+                    - 'null'
+                    - string
+                  node_id:
+                    type:
+                    - 'null'
+                    - string
+                  html_url:
+                    type:
+                    - 'null'
+                    - string
+                  gists_url:
+                    type:
+                    - 'null'
+                    - string
+                  repos_url:
+                    type:
+                    - 'null'
+                    - string
+                  avatar_url:
+                    type:
+                    - 'null'
+                    - string
+                  events_url:
+                    type:
+                    - 'null'
+                    - string
+                  site_admin:
+                    type:
+                    - 'null'
+                    - boolean
+                  gravatar_id:
+                    type:
+                    - 'null'
+                    - string
+                  starred_url:
+                    type:
+                    - 'null'
+                    - string
+                  followers_url:
+                    type:
+                    - 'null'
+                    - string
+                  following_url:
+                    type:
+                    - 'null'
+                    - string
+                  organizations_url:
+                    type:
+                    - 'null'
+                    - string
+                  subscriptions_url:
+                    type:
+                    - 'null'
+                    - string
+                  received_events_url:
+                    type:
+                    - 'null'
+                    - string
+            review_comments_url:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - updated_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - updated_at
+        primary_key:
+        - - id
+        alias_name: pull_requests
+        selected: false
+    - stream:
+        name: releases
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            body:
+              type:
+              - 'null'
+              - string
+            name:
+              type:
+              - 'null'
+              - string
+            draft:
+              type:
+              - 'null'
+              - boolean
+            assets:
+              type:
+              - 'null'
+              - array
+              items:
+                type:
+                - 'null'
+                - object
+                properties:
+                  id:
+                    type:
+                    - 'null'
+                    - integer
+                  url:
+                    type:
+                    - 'null'
+                    - string
+                  name:
+                    type:
+                    - 'null'
+                    - string
+                  size:
+                    type:
+                    - 'null'
+                    - integer
+                  label:
+                    type:
+                    - 'null'
+                    - string
+                  state:
+                    type:
+                    - 'null'
+                    - string
+                  node_id:
+                    type:
+                    - 'null'
+                    - string
+                  created_at:
+                    type:
+                    - 'null'
+                    - string
+                    format: date-time
+                  updated_at:
+                    type:
+                    - 'null'
+                    - string
+                    format: date-time
+                  uploader_id:
+                    type:
+                    - 'null'
+                    - integer
+                  content_type:
+                    type:
+                    - 'null'
+                    - string
+                  download_count:
+                    type:
+                    - 'null'
+                    - integer
+                  browser_download_url:
+                    type:
+                    - 'null'
+                    - string
+            author:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            tag_name:
+              type:
+              - 'null'
+              - string
+            assets_url:
+              type:
+              - 'null'
+              - string
+            created_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            prerelease:
+              type:
+              - 'null'
+              - boolean
+            repository:
+              type:
+              - string
+            upload_url:
+              type:
+              - 'null'
+              - string
+            tarball_url:
+              type:
+              - 'null'
+              - string
+            zipball_url:
+              type:
+              - 'null'
+              - string
+            published_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            target_commitish:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - created_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - created_at
+        primary_key:
+        - - id
+        alias_name: releases
+        selected: true
+    - stream:
+        name: repositories
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            fork:
+              type:
+              - 'null'
+              - boolean
+            name:
+              type:
+              - 'null'
+              - string
+            size:
+              type:
+              - 'null'
+              - integer
+            owner:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            topics:
+              type:
+              - 'null'
+              - array
+              items:
+                type:
+                - 'null'
+                - string
+            git_url:
+              type:
+              - 'null'
+              - string
+            license:
+              type:
+              - 'null'
+              - object
+              properties:
+                key:
+                  type:
+                  - 'null'
+                  - string
+                url:
+                  type:
+                  - 'null'
+                  - string
+                name:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                spdx_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            private:
+              type:
+              - 'null'
+              - boolean
+            ssh_url:
+              type:
+              - 'null'
+              - string
+            svn_url:
+              type:
+              - 'null'
+              - string
+            archived:
+              type:
+              - 'null'
+              - boolean
+            disabled:
+              type:
+              - 'null'
+              - boolean
+            has_wiki:
+              type:
+              - 'null'
+              - boolean
+            homepage:
+              type:
+              - 'null'
+              - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            keys_url:
+              type:
+              - 'null'
+              - string
+            language:
+              type:
+              - 'null'
+              - string
+            tags_url:
+              type:
+              - 'null'
+              - string
+            blobs_url:
+              type:
+              - 'null'
+              - string
+            clone_url:
+              type:
+              - 'null'
+              - string
+            forks_url:
+              type:
+              - 'null'
+              - string
+            full_name:
+              type:
+              - 'null'
+              - string
+            has_pages:
+              type:
+              - 'null'
+              - boolean
+            hooks_url:
+              type:
+              - 'null'
+              - string
+            pulls_url:
+              type:
+              - 'null'
+              - string
+            pushed_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            teams_url:
+              type:
+              - 'null'
+              - string
+            trees_url:
+              type:
+              - 'null'
+              - string
+            created_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            events_url:
+              type:
+              - 'null'
+              - string
+            has_issues:
+              type:
+              - 'null'
+              - boolean
+            issues_url:
+              type:
+              - 'null'
+              - string
+            labels_url:
+              type:
+              - 'null'
+              - string
+            merges_url:
+              type:
+              - 'null'
+              - string
+            mirror_url:
+              type:
+              - 'null'
+              - string
+            updated_at:
+              type: string
+              format: date-time
+            visibility:
+              type:
+              - 'null'
+              - string
+            archive_url:
+              type:
+              - 'null'
+              - string
+            commits_url:
+              type:
+              - 'null'
+              - string
+            compare_url:
+              type:
+              - 'null'
+              - string
+            description:
+              type:
+              - 'null'
+              - string
+            forks_count:
+              type:
+              - 'null'
+              - integer
+            is_template:
+              type:
+              - 'null'
+              - boolean
+            permissions:
+              type:
+              - 'null'
+              - object
+              properties:
+                pull:
+                  type:
+                  - 'null'
+                  - boolean
+                push:
+                  type:
+                  - 'null'
+                  - boolean
+                admin:
+                  type:
+                  - 'null'
+                  - boolean
+            branches_url:
+              type:
+              - 'null'
+              - string
+            comments_url:
+              type:
+              - 'null'
+              - string
+            contents_url:
+              type:
+              - 'null'
+              - string
+            git_refs_url:
+              type:
+              - 'null'
+              - string
+            git_tags_url:
+              type:
+              - 'null'
+              - string
+            has_projects:
+              type:
+              - 'null'
+              - boolean
+            releases_url:
+              type:
+              - 'null'
+              - string
+            statuses_url:
+              type:
+              - 'null'
+              - string
+            assignees_url:
+              type:
+              - 'null'
+              - string
+            downloads_url:
+              type:
+              - 'null'
+              - string
+            has_downloads:
+              type:
+              - 'null'
+              - boolean
+            languages_url:
+              type:
+              - 'null'
+              - string
+            default_branch:
+              type:
+              - 'null'
+              - string
+            milestones_url:
+              type:
+              - 'null'
+              - string
+            stargazers_url:
+              type:
+              - 'null'
+              - string
+            watchers_count:
+              type:
+              - 'null'
+              - integer
+            deployments_url:
+              type:
+              - 'null'
+              - string
+            git_commits_url:
+              type:
+              - 'null'
+              - string
+            subscribers_url:
+              type:
+              - 'null'
+              - string
+            contributors_url:
+              type:
+              - 'null'
+              - string
+            issue_events_url:
+              type:
+              - 'null'
+              - string
+            stargazers_count:
+              type:
+              - 'null'
+              - integer
+            subscription_url:
+              type:
+              - 'null'
+              - string
+            collaborators_url:
+              type:
+              - 'null'
+              - string
+            issue_comment_url:
+              type:
+              - 'null'
+              - string
+            notifications_url:
+              type:
+              - 'null'
+              - string
+            open_issues_count:
+              type:
+              - 'null'
+              - integer
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - updated_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - updated_at
+        primary_key:
+        - - id
+        alias_name: repositories
+        selected: false
+    - stream:
+        name: review_comments
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            body:
+              type:
+              - 'null'
+              - string
+            line:
+              type:
+              - 'null'
+              - integer
+            path:
+              type:
+              - 'null'
+              - string
+            side:
+              type:
+              - 'null'
+              - string
+            user:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            _links:
+              type:
+              - 'null'
+              - object
+              properties:
+                html:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    href:
+                      type:
+                      - 'null'
+                      - string
+                self:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    href:
+                      type:
+                      - 'null'
+                      - string
+                pull_request:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    href:
+                      type:
+                      - 'null'
+                      - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            position:
+              type:
+              - 'null'
+              - integer
+            commit_id:
+              type:
+              - 'null'
+              - string
+            diff_hunk:
+              type:
+              - 'null'
+              - string
+            created_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            repository:
+              type:
+              - string
+            start_line:
+              type:
+              - 'null'
+              - integer
+            start_side:
+              type:
+              - 'null'
+              - string
+            updated_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            original_line:
+              type:
+              - 'null'
+              - integer
+            in_reply_to_id:
+              type:
+              - 'null'
+              - integer
+            pull_request_url:
+              type:
+              - 'null'
+              - string
+            original_position:
+              type:
+              - 'null'
+              - integer
+            author_association:
+              type:
+              - 'null'
+              - string
+            original_commit_id:
+              type:
+              - 'null'
+              - string
+            original_start_line:
+              type:
+              - 'null'
+              - integer
+            pull_request_review_id:
+              type:
+              - 'null'
+              - integer
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - updated_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - updated_at
+        primary_key:
+        - - id
+        alias_name: review_comments
+        selected: false
+    - stream:
+        name: reviews
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            body:
+              type:
+              - 'null'
+              - string
+            user:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+            state:
+              type:
+              - 'null'
+              - string
+            _links:
+              type:
+              - 'null'
+              - object
+              properties:
+                html:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    href:
+                      type:
+                      - 'null'
+                      - string
+                pull_request:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    href:
+                      type:
+                      - 'null'
+                      - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            commit_id:
+              type:
+              - 'null'
+              - string
+            created_at:
+              type: string
+              format: date-time
+            repository:
+              type:
+              - string
+            updated_at:
+              type: string
+              format: date-time
+            submitted_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            pull_request_url:
+              type:
+              - 'null'
+              - string
+            author_association:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - updated_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - updated_at
+        primary_key:
+        - - id
+        alias_name: reviews
+        selected: false
+    - stream:
+        name: stargazers
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            user:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                type:
+                  type:
+                  - 'null'
+                  - string
+                login:
+                  type:
+                  - 'null'
+                  - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                gists_url:
+                  type:
+                  - 'null'
+                  - string
+                repos_url:
+                  type:
+                  - 'null'
+                  - string
+                avatar_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                site_admin:
+                  type:
+                  - 'null'
+                  - boolean
+                gravatar_id:
+                  type:
+                  - 'null'
+                  - string
+                starred_url:
+                  type:
+                  - 'null'
+                  - string
+                followers_url:
+                  type:
+                  - 'null'
+                  - string
+                following_url:
+                  type:
+                  - 'null'
+                  - string
+                organizations_url:
+                  type:
+                  - 'null'
+                  - string
+                subscriptions_url:
+                  type:
+                  - 'null'
+                  - string
+                received_events_url:
+                  type:
+                  - 'null'
+                  - string
+            user_id:
+              type:
+              - 'null'
+              - integer
+            repository:
+              type:
+              - string
+            starred_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - starred_at
+        source_defined_primary_key:
+        - - user_id
+      config:
+        sync_mode: incremental
+        destination_sync_mode: append_dedup
+        cursor_field:
+        - starred_at
+        primary_key:
+        - - user_id
+        alias_name: stargazers
+        selected: false
+    - stream:
+        name: tags
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            name:
+              type:
+              - 'null'
+              - string
+            commit:
+              type:
+              - 'null'
+              - object
+              properties:
+                sha:
+                  type:
+                  - 'null'
+                  - string
+                url:
+                  type:
+                  - 'null'
+                  - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            repository:
+              type:
+              - string
+            tarball_url:
+              type:
+              - 'null'
+              - string
+            zipball_url:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        default_cursor_field: []
+        source_defined_primary_key:
+        - - repository
+        - - name
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field: []
+        primary_key:
+        - - repository
+        - - name
+        alias_name: tags
+        selected: true
+    - stream:
+        name: teams
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            name:
+              type:
+              - 'null'
+              - string
+            slug:
+              type:
+              - 'null'
+              - string
+            parent:
+              type:
+              - 'null'
+              - object
+              properties: {}
+              additionalProperties: true
+            node_id:
+              type:
+              - 'null'
+              - string
+            privacy:
+              type:
+              - 'null'
+              - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            permission:
+              type:
+              - 'null'
+              - string
+            repository:
+              type:
+              - 'null'
+              - string
+            description:
+              type:
+              - 'null'
+              - string
+            members_url:
+              type:
+              - 'null'
+              - string
+            organization:
+              type:
+              - 'null'
+              - string
+            repositories_url:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        default_cursor_field: []
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field: []
+        primary_key:
+        - - id
+        alias_name: teams
+        selected: true
+    - stream:
+        name: team_members
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type: integer
+            url:
+              type:
+              - 'null'
+              - string
+            type:
+              type:
+              - 'null'
+              - string
+            login:
+              type:
+              - 'null'
+              - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            gists_url:
+              type:
+              - 'null'
+              - string
+            repos_url:
+              type:
+              - 'null'
+              - string
+            team_slug:
+              type: string
+            avatar_url:
+              type:
+              - 'null'
+              - string
+            events_url:
+              type:
+              - 'null'
+              - string
+            site_admin:
+              type:
+              - 'null'
+              - boolean
+            gravatar_id:
+              type:
+              - 'null'
+              - string
+            starred_url:
+              type:
+              - 'null'
+              - string
+            organization:
+              type: string
+            followers_url:
+              type:
+              - 'null'
+              - string
+            following_url:
+              type:
+              - 'null'
+              - string
+            organizations_url:
+              type:
+              - 'null'
+              - string
+            subscriptions_url:
+              type:
+              - 'null'
+              - string
+            received_events_url:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        default_cursor_field: []
+        source_defined_primary_key:
+        - - id
+        - - team_slug
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field: []
+        primary_key:
+        - - id
+        - - team_slug
+        alias_name: team_members
+        selected: false
+    - stream:
+        name: users
+        json_schema:
+          type:
+          - 'null'
+          - object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            type:
+              type:
+              - 'null'
+              - string
+            login:
+              type:
+              - 'null'
+              - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            gists_url:
+              type:
+              - 'null'
+              - string
+            repos_url:
+              type:
+              - 'null'
+              - string
+            avatar_url:
+              type:
+              - 'null'
+              - string
+            events_url:
+              type:
+              - 'null'
+              - string
+            site_admin:
+              type:
+              - 'null'
+              - boolean
+            gravatar_id:
+              type:
+              - 'null'
+              - string
+            starred_url:
+              type:
+              - 'null'
+              - string
+            organization:
+              type:
+              - 'null'
+              - string
+            followers_url:
+              type:
+              - 'null'
+              - string
+            following_url:
+              type:
+              - 'null'
+              - string
+            organizations_url:
+              type:
+              - 'null'
+              - string
+            subscriptions_url:
+              type:
+              - 'null'
+              - string
+            received_events_url:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        default_cursor_field: []
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field: []
+        primary_key:
+        - - id
+        alias_name: users
+        selected: false
+    - stream:
+        name: workflows
+        json_schema:
+          type:
+          - 'null'
+          - object
+          $schema: http://json-schema.org/draft-04/schema#
+          properties:
+            id:
+              type: integer
+            url:
+              type:
+              - 'null'
+              - string
+            name:
+              type:
+              - 'null'
+              - string
+            path:
+              type:
+              - 'null'
+              - string
+            state:
+              type:
+              - 'null'
+              - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            badge_url:
+              type:
+              - 'null'
+              - string
+            created_at:
+              type:
+              - 'null'
+              - string
+              format: date-time
+            repository:
+              type: string
+            updated_at:
+              type: string
+              format: date-time
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - updated_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - updated_at
+        primary_key:
+        - - id
+        alias_name: workflows
+        selected: false
+    - stream:
+        name: workflow_runs
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-04/schema#
+          properties:
+            id:
+              type:
+              - 'null'
+              - integer
+            url:
+              type:
+              - 'null'
+              - string
+            name:
+              type:
+              - 'null'
+              - string
+            event:
+              type:
+              - 'null'
+              - string
+            status:
+              type:
+              - 'null'
+              - string
+            node_id:
+              type:
+              - 'null'
+              - string
+            head_sha:
+              type:
+              - 'null'
+              - string
+            html_url:
+              type:
+              - 'null'
+              - string
+            jobs_url:
+              type:
+              - 'null'
+              - string
+            logs_url:
+              type:
+              - 'null'
+              - string
+            rerun_url:
+              type:
+              - 'null'
+              - string
+            cancel_url:
+              type:
+              - 'null'
+              - string
+            conclusion:
+              type:
+              - 'null'
+              - string
+            created_at:
+              type:
+              - 'null'
+              - string
+            repository:
+              type: object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                fork:
+                  type:
+                  - 'null'
+                  - boolean
+                name:
+                  type:
+                  - 'null'
+                  - string
+                owner:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    id:
+                      type:
+                      - 'null'
+                      - integer
+                    url:
+                      type:
+                      - 'null'
+                      - string
+                    type:
+                      type:
+                      - 'null'
+                      - string
+                    login:
+                      type:
+                      - 'null'
+                      - string
+                    node_id:
+                      type:
+                      - 'null'
+                      - string
+                    html_url:
+                      type:
+                      - 'null'
+                      - string
+                    gists_url:
+                      type:
+                      - 'null'
+                      - string
+                    repos_url:
+                      type:
+                      - 'null'
+                      - string
+                    avatar_url:
+                      type:
+                      - 'null'
+                      - string
+                    events_url:
+                      type:
+                      - 'null'
+                      - string
+                    site_admin:
+                      type:
+                      - 'null'
+                      - boolean
+                    gravatar_id:
+                      type:
+                      - 'null'
+                      - string
+                    starred_url:
+                      type:
+                      - 'null'
+                      - string
+                    followers_url:
+                      type:
+                      - 'null'
+                      - string
+                    following_url:
+                      type:
+                      - 'null'
+                      - string
+                    organizations_url:
+                      type:
+                      - 'null'
+                      - string
+                    subscriptions_url:
+                      type:
+                      - 'null'
+                      - string
+                    received_events_url:
+                      type:
+                      - 'null'
+                      - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                private:
+                  type:
+                  - 'null'
+                  - boolean
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                keys_url:
+                  type:
+                  - 'null'
+                  - string
+                tags_url:
+                  type:
+                  - 'null'
+                  - string
+                blobs_url:
+                  type:
+                  - 'null'
+                  - string
+                forks_url:
+                  type:
+                  - 'null'
+                  - string
+                full_name:
+                  type:
+                  - 'null'
+                  - string
+                hooks_url:
+                  type:
+                  - 'null'
+                  - string
+                pulls_url:
+                  type:
+                  - 'null'
+                  - string
+                teams_url:
+                  type:
+                  - 'null'
+                  - string
+                trees_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                issues_url:
+                  type:
+                  - 'null'
+                  - string
+                labels_url:
+                  type:
+                  - 'null'
+                  - string
+                merges_url:
+                  type:
+                  - 'null'
+                  - string
+                archive_url:
+                  type:
+                  - 'null'
+                  - string
+                commits_url:
+                  type:
+                  - 'null'
+                  - string
+                compare_url:
+                  type:
+                  - 'null'
+                  - string
+                description:
+                  type:
+                  - 'null'
+                  - string
+                branches_url:
+                  type:
+                  - 'null'
+                  - string
+                comments_url:
+                  type:
+                  - 'null'
+                  - string
+                contents_url:
+                  type:
+                  - 'null'
+                  - string
+                git_refs_url:
+                  type:
+                  - 'null'
+                  - string
+                git_tags_url:
+                  type:
+                  - 'null'
+                  - string
+                releases_url:
+                  type:
+                  - 'null'
+                  - string
+                statuses_url:
+                  type:
+                  - 'null'
+                  - string
+                assignees_url:
+                  type:
+                  - 'null'
+                  - string
+                downloads_url:
+                  type:
+                  - 'null'
+                  - string
+                languages_url:
+                  type:
+                  - 'null'
+                  - string
+                milestones_url:
+                  type:
+                  - 'null'
+                  - string
+                stargazers_url:
+                  type:
+                  - 'null'
+                  - string
+                deployments_url:
+                  type:
+                  - 'null'
+                  - string
+                git_commits_url:
+                  type:
+                  - 'null'
+                  - string
+                subscribers_url:
+                  type:
+                  - 'null'
+                  - string
+                contributors_url:
+                  type:
+                  - 'null'
+                  - string
+                issue_events_url:
+                  type:
+                  - 'null'
+                  - string
+                subscription_url:
+                  type:
+                  - 'null'
+                  - string
+                collaborators_url:
+                  type:
+                  - 'null'
+                  - string
+                issue_comment_url:
+                  type:
+                  - 'null'
+                  - string
+                notifications_url:
+                  type:
+                  - 'null'
+                  - string
+            run_number:
+              type:
+              - 'null'
+              - integer
+            updated_at:
+              type:
+              - 'null'
+              - string
+            head_branch:
+              type:
+              - 'null'
+              - string
+            head_commit:
+              type: object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - string
+                author:
+                  type: object
+                  properties:
+                    name:
+                      type:
+                      - 'null'
+                      - string
+                    email:
+                      type:
+                      - 'null'
+                      - string
+                message:
+                  type:
+                  - 'null'
+                  - string
+                tree_id:
+                  type:
+                  - 'null'
+                  - string
+                committer:
+                  type: object
+                  properties:
+                    name:
+                      type:
+                      - 'null'
+                      - string
+                    email:
+                      type:
+                      - 'null'
+                      - string
+                timestamp:
+                  type:
+                  - 'null'
+                  - string
+            run_attempt:
+              type:
+              - 'null'
+              - integer
+            workflow_id:
+              type:
+              - 'null'
+              - integer
+            workflow_url:
+              type:
+              - 'null'
+              - string
+            artifacts_url:
+              type:
+              - 'null'
+              - string
+            pull_requests:
+              type: array
+              items:
+                type:
+                - 'null'
+                - object
+                properties: {}
+                additionalProperties: true
+            check_suite_id:
+              type:
+              - 'null'
+              - integer
+            run_started_at:
+              type:
+              - 'null'
+              - string
+            check_suite_url:
+              type:
+              - 'null'
+              - string
+            head_repository:
+              type:
+              - 'null'
+              - object
+              properties:
+                id:
+                  type:
+                  - 'null'
+                  - integer
+                url:
+                  type:
+                  - 'null'
+                  - string
+                fork:
+                  type:
+                  - 'null'
+                  - boolean
+                name:
+                  type:
+                  - 'null'
+                  - string
+                owner:
+                  type:
+                  - 'null'
+                  - object
+                  properties:
+                    id:
+                      type:
+                      - 'null'
+                      - integer
+                    url:
+                      type:
+                      - 'null'
+                      - string
+                    type:
+                      type:
+                      - 'null'
+                      - string
+                    login:
+                      type:
+                      - 'null'
+                      - string
+                    node_id:
+                      type:
+                      - 'null'
+                      - string
+                    html_url:
+                      type:
+                      - 'null'
+                      - string
+                    gists_url:
+                      type:
+                      - 'null'
+                      - string
+                    repos_url:
+                      type:
+                      - 'null'
+                      - string
+                    avatar_url:
+                      type:
+                      - 'null'
+                      - string
+                    events_url:
+                      type:
+                      - 'null'
+                      - string
+                    site_admin:
+                      type:
+                      - 'null'
+                      - boolean
+                    gravatar_id:
+                      type:
+                      - 'null'
+                      - string
+                    starred_url:
+                      type:
+                      - 'null'
+                      - string
+                    followers_url:
+                      type:
+                      - 'null'
+                      - string
+                    following_url:
+                      type:
+                      - 'null'
+                      - string
+                    organizations_url:
+                      type:
+                      - 'null'
+                      - string
+                    subscriptions_url:
+                      type:
+                      - 'null'
+                      - string
+                    received_events_url:
+                      type:
+                      - 'null'
+                      - string
+                node_id:
+                  type:
+                  - 'null'
+                  - string
+                private:
+                  type:
+                  - 'null'
+                  - boolean
+                html_url:
+                  type:
+                  - 'null'
+                  - string
+                keys_url:
+                  type:
+                  - 'null'
+                  - string
+                tags_url:
+                  type:
+                  - 'null'
+                  - string
+                blobs_url:
+                  type:
+                  - 'null'
+                  - string
+                forks_url:
+                  type:
+                  - 'null'
+                  - string
+                full_name:
+                  type:
+                  - 'null'
+                  - string
+                hooks_url:
+                  type:
+                  - 'null'
+                  - string
+                pulls_url:
+                  type:
+                  - 'null'
+                  - string
+                teams_url:
+                  type:
+                  - 'null'
+                  - string
+                trees_url:
+                  type:
+                  - 'null'
+                  - string
+                events_url:
+                  type:
+                  - 'null'
+                  - string
+                issues_url:
+                  type:
+                  - 'null'
+                  - string
+                labels_url:
+                  type:
+                  - 'null'
+                  - string
+                merges_url:
+                  type:
+                  - 'null'
+                  - string
+                archive_url:
+                  type:
+                  - 'null'
+                  - string
+                commits_url:
+                  type:
+                  - 'null'
+                  - string
+                compare_url:
+                  type:
+                  - 'null'
+                  - string
+                description:
+                  type:
+                  - 'null'
+                  - string
+                branches_url:
+                  type:
+                  - 'null'
+                  - string
+                comments_url:
+                  type:
+                  - 'null'
+                  - string
+                contents_url:
+                  type:
+                  - 'null'
+                  - string
+                git_refs_url:
+                  type:
+                  - 'null'
+                  - string
+                git_tags_url:
+                  type:
+                  - 'null'
+                  - string
+                releases_url:
+                  type:
+                  - 'null'
+                  - string
+                statuses_url:
+                  type:
+                  - 'null'
+                  - string
+                assignees_url:
+                  type:
+                  - 'null'
+                  - string
+                downloads_url:
+                  type:
+                  - 'null'
+                  - string
+                languages_url:
+                  type:
+                  - 'null'
+                  - string
+                milestones_url:
+                  type:
+                  - 'null'
+                  - string
+                stargazers_url:
+                  type:
+                  - 'null'
+                  - string
+                deployments_url:
+                  type:
+                  - 'null'
+                  - string
+                git_commits_url:
+                  type:
+                  - 'null'
+                  - string
+                subscribers_url:
+                  type:
+                  - 'null'
+                  - string
+                contributors_url:
+                  type:
+                  - 'null'
+                  - string
+                issue_events_url:
+                  type:
+                  - 'null'
+                  - string
+                subscription_url:
+                  type:
+                  - 'null'
+                  - string
+                collaborators_url:
+                  type:
+                  - 'null'
+                  - string
+                issue_comment_url:
+                  type:
+                  - 'null'
+                  - string
+                notifications_url:
+                  type:
+                  - 'null'
+                  - string
+            check_suite_node_id:
+              type:
+              - 'null'
+              - string
+            previous_attempt_url:
+              type:
+              - 'null'
+              - string
+        supported_sync_modes:
+        - full_refresh
+        - incremental
+        source_defined_cursor: true
+        default_cursor_field:
+        - updated_at
+        source_defined_primary_key:
+        - - id
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field:
+        - updated_at
+        primary_key:
+        - - id
+        alias_name: workflow_runs
+        selected: false
+    - stream:
+        name: team_memberships
+        json_schema:
+          type: object
+          $schema: http://json-schema.org/draft-07/schema#
+          properties:
+            url:
+              type: string
+            role:
+              type:
+              - 'null'
+              - string
+            state:
+              type:
+              - 'null'
+              - string
+            username:
+              type: string
+            team_slug:
+              type: string
+            organization:
+              type: string
+        supported_sync_modes:
+        - full_refresh
+        default_cursor_field: []
+        source_defined_primary_key:
+        - - url
+      config:
+        sync_mode: full_refresh
+        destination_sync_mode: append
+        cursor_field: []
+        primary_key:
+        - - url
+        alias_name: team_memberships
+        selected: false
+  status: active
+  namespace_definition: source
+  namespace_format: ${SOURCE_NAMESPACE}
+  prefix: dagster_
+  schedule_type: manual
+  operations:
+  - name: Normalization
+    operator_configuration:
+      operator_type: normalization
+      normalization:
+        option: basic

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_airbyte_project/connections/github_snowflake_ben/state_b49ed3cd-7bb4-4f11-b8ba-95b4a5f7bc75.yaml
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_airbyte_project/connections/github_snowflake_ben/state_b49ed3cd-7bb4-4f11-b8ba-95b4a5f7bc75.yaml
@@ -1,0 +1,5 @@
+configuration_hash: d54a1c246dcf7bb7187bc1381a961749d01f8fce5f81f25aa91d9377cdeea284
+configuration_path: connections/github_snowflake_ben/configuration.yaml
+generation_timestamp: 1662760830
+resource_id: 87b7fe85-a22c-420e-8d74-b30e7ede77df
+workspace_id: b49ed3cd-7bb4-4f11-b8ba-95b4a5f7bc75

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_airbyte_project/destinations/snowflake_ben/configuration.yaml
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_airbyte_project/destinations/snowflake_ben/configuration.yaml
@@ -1,0 +1,16 @@
+resource_name: snowflake-ben
+definition_type: destination
+definition_id: 424892c4-daac-4491-b35d-c6688ba547ba
+definition_image: airbyte/destination-snowflake
+definition_version: 0.4.35
+configuration:
+  host: XXXXXXX.us-east-1.snowflakecomputing.com
+  role: AIRBYTE
+  schema: BEN_DEMO
+  database: AIRBYTE
+  username: BEN_DEMO
+  warehouse: AIRBYTE
+  credentials:
+    password: '**********'
+  loading_method:
+    method: Internal Staging

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_airbyte_project/destinations/snowflake_ben/state_b49ed3cd-7bb4-4f11-b8ba-95b4a5f7bc75.yaml
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_airbyte_project/destinations/snowflake_ben/state_b49ed3cd-7bb4-4f11-b8ba-95b4a5f7bc75.yaml
@@ -1,0 +1,5 @@
+configuration_hash: 226915349dd13a0339a5e25b83f96589276f9006ff0755108b3e8265dd22d9fa
+configuration_path: destinations/snowflake_ben/configuration.yaml
+generation_timestamp: 1662760824
+resource_id: 028fc82d-3a27-4fef-94a6-a22fbd45bac4
+workspace_id: b49ed3cd-7bb4-4f11-b8ba-95b4a5f7bc75

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_airbyte_project/sources/github_dagster_io_dagster/configuration.yaml
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_airbyte_project/sources/github_dagster_io_dagster/configuration.yaml
@@ -1,0 +1,12 @@
+resource_name: github/dagster-io/dagster
+definition_type: source
+definition_id: ef69ef6e-aa7f-4af1-a01d-ef775033524e
+definition_image: airbyte/source-github
+definition_version: 0.2.46
+configuration:
+  repository: dagster-io/dagster
+  start_date: '2021-03-01T00:00:00Z'
+  credentials:
+    option_title: PAT Credentials
+    personal_access_token: '**********'
+  page_size_for_large_streams: 10

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_airbyte_project/sources/github_dagster_io_dagster/state_b49ed3cd-7bb4-4f11-b8ba-95b4a5f7bc75.yaml
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_airbyte_project/sources/github_dagster_io_dagster/state_b49ed3cd-7bb4-4f11-b8ba-95b4a5f7bc75.yaml
@@ -1,0 +1,5 @@
+configuration_hash: 9bd05448a7e5a17716def2660a261f33a4d6afe22cee0edea19ddf2191e4d9d7
+configuration_path: sources/github_dagster_io_dagster/configuration.yaml
+generation_timestamp: 1662760824
+resource_id: 4b8fc3cc-efce-41d7-8654-05c3fc03485e
+workspace_id: b49ed3cd-7bb4-4f11-b8ba-95b4a5f7bc75

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_project.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_project.py
@@ -1,0 +1,98 @@
+import pytest
+import responses
+from dagster_airbyte import airbyte_resource, load_assets_from_airbyte_project
+
+from dagster import AssetKey, build_init_resource_context
+from dagster._legacy import build_assets_job
+from dagster._utils import file_relative_path
+
+from .utils import get_project_connection_json, get_project_job_json
+
+
+@responses.activate
+@pytest.mark.parametrize("use_normalization_tables", [True, False])
+@pytest.mark.parametrize("connection_to_group_fn", [None, lambda x: f"{x}_group"])
+def test_load_from_project(use_normalization_tables, connection_to_group_fn):
+
+    ab_resource = airbyte_resource(
+        build_init_resource_context(
+            config={
+                "host": "some_host",
+                "port": "8000",
+            }
+        )
+    )
+
+    if connection_to_group_fn:
+        ab_assets, source_assets = load_assets_from_airbyte_project(
+            file_relative_path(__file__, "./test_airbyte_project"),
+            create_assets_for_normalization_tables=use_normalization_tables,
+            connection_to_group_fn=connection_to_group_fn,
+        )
+    else:
+        ab_assets, source_assets = load_assets_from_airbyte_project(
+            file_relative_path(__file__, "./test_airbyte_project"),
+            create_assets_for_normalization_tables=use_normalization_tables,
+        )
+
+    tables = {"dagster_releases", "dagster_tags", "dagster_teams"} | (
+        {"dagster_releases_assets", "dagster_releases_author", "dagster_tags_commit"}
+        if use_normalization_tables
+        else set()
+    )
+    assert ab_assets[0].keys == {AssetKey(t) for t in tables}
+    assert all(
+        [
+            ab_assets[0].group_names_by_key.get(AssetKey(t))
+            == (
+                connection_to_group_fn("github_snowflake_ben")
+                if connection_to_group_fn
+                else "github_snowflake_ben"
+            )
+            for t in tables
+        ]
+    )
+    assert len(ab_assets[0].op.output_defs) == len(tables)
+
+    responses.add(
+        method=responses.POST,
+        url=ab_resource.api_base_url + "/connections/get",
+        json=get_project_connection_json(),
+        status=200,
+    )
+    responses.add(
+        method=responses.POST,
+        url=ab_resource.api_base_url + "/connections/sync",
+        json={"job": {"id": 1}},
+        status=200,
+    )
+    responses.add(
+        method=responses.POST,
+        url=ab_resource.api_base_url + "/jobs/get",
+        json=get_project_job_json(),
+        status=200,
+    )
+
+    ab_job = build_assets_job(
+        "ab_job",
+        ab_assets,
+        source_assets=source_assets,
+        resource_defs={
+            "airbyte": airbyte_resource.configured(
+                {
+                    "host": "some_host",
+                    "port": "8000",
+                }
+            )
+        },
+    )
+
+    res = ab_job.execute_in_process()
+
+    materializations = [
+        event.event_specific_data.materialization
+        for event in res.events_for_node("airbyte_sync_87b7f")
+        if event.event_type_value == "ASSET_MATERIALIZATION"
+    ]
+    assert len(materializations) == len(tables)
+    assert {m.asset_key for m in materializations} == {AssetKey(t) for t in tables}

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
@@ -114,3 +114,227 @@ def get_sample_job_list_json(schema_prefix=""):
             }
         ]
     }
+
+
+def get_project_connection_json(**kwargs):
+    return deep_merge_dicts(
+        {
+            "name": "GitHub <> snowflake-ben",
+            "prefix": "dagster_",
+            "syncCatalog": {
+                "streams": [
+                    {
+                        "stream": {
+                            "name": "releases",
+                            "jsonSchema": {
+                                "type": "object",
+                                "$schema": "http://json-schema.org/draft-07/schema#",
+                                "properties": {
+                                    "id": {"type": ["null", "integer"]},
+                                    "url": {"type": ["null", "string"]},
+                                    "body": {"type": ["null", "string"]},
+                                    "name": {"type": ["null", "string"]},
+                                    "draft": {"type": ["null", "boolean"]},
+                                    "assets": {
+                                        "type": ["null", "array"],
+                                        "items": {
+                                            "type": ["null", "object"],
+                                            "properties": {
+                                                "id": {"type": ["null", "integer"]},
+                                                "url": {"type": ["null", "string"]},
+                                                "name": {"type": ["null", "string"]},
+                                                "size": {"type": ["null", "integer"]},
+                                                "label": {"type": ["null", "string"]},
+                                                "state": {"type": ["null", "string"]},
+                                                "node_id": {"type": ["null", "string"]},
+                                                "created_at": {
+                                                    "type": ["null", "string"],
+                                                    "format": "date-time",
+                                                },
+                                                "updated_at": {
+                                                    "type": ["null", "string"],
+                                                    "format": "date-time",
+                                                },
+                                                "uploader_id": {"type": ["null", "integer"]},
+                                                "content_type": {"type": ["null", "string"]},
+                                                "download_count": {"type": ["null", "integer"]},
+                                                "browser_download_url": {
+                                                    "type": ["null", "string"]
+                                                },
+                                            },
+                                        },
+                                    },
+                                    "author": {
+                                        "type": ["null", "object"],
+                                        "properties": {
+                                            "id": {"type": ["null", "integer"]},
+                                            "url": {"type": ["null", "string"]},
+                                            "type": {"type": ["null", "string"]},
+                                            "login": {"type": ["null", "string"]},
+                                            "node_id": {"type": ["null", "string"]},
+                                            "html_url": {"type": ["null", "string"]},
+                                            "gists_url": {"type": ["null", "string"]},
+                                            "repos_url": {"type": ["null", "string"]},
+                                            "avatar_url": {"type": ["null", "string"]},
+                                            "events_url": {"type": ["null", "string"]},
+                                            "site_admin": {"type": ["null", "boolean"]},
+                                            "gravatar_id": {"type": ["null", "string"]},
+                                            "starred_url": {"type": ["null", "string"]},
+                                            "followers_url": {"type": ["null", "string"]},
+                                            "following_url": {"type": ["null", "string"]},
+                                            "organizations_url": {"type": ["null", "string"]},
+                                            "subscriptions_url": {"type": ["null", "string"]},
+                                            "received_events_url": {"type": ["null", "string"]},
+                                        },
+                                    },
+                                    "node_id": {"type": ["null", "string"]},
+                                    "html_url": {"type": ["null", "string"]},
+                                    "tag_name": {"type": ["null", "string"]},
+                                    "assets_url": {"type": ["null", "string"]},
+                                    "created_at": {
+                                        "type": ["null", "string"],
+                                        "format": "date-time",
+                                    },
+                                    "prerelease": {"type": ["null", "boolean"]},
+                                    "repository": {"type": ["string"]},
+                                    "upload_url": {"type": ["null", "string"]},
+                                    "tarball_url": {"type": ["null", "string"]},
+                                    "zipball_url": {"type": ["null", "string"]},
+                                    "published_at": {
+                                        "type": ["null", "string"],
+                                        "format": "date-time",
+                                    },
+                                    "target_commitish": {"type": ["null", "string"]},
+                                },
+                            },
+                            "supportedSyncModes": ["full_refresh", "incremental"],
+                            "sourceDefinedCursor": True,
+                            "defaultCursorField": ["created_at"],
+                            "sourceDefinedPrimaryKey": [["id"]],
+                        },
+                        "config": {
+                            "syncMode": "full_refresh",
+                            "cursorField": ["created_at"],
+                            "destinationSyncMode": "append",
+                            "primaryKey": [["id"]],
+                            "aliasName": "releases",
+                            "selected": True,
+                        },
+                    },
+                    {
+                        "stream": {
+                            "name": "tags",
+                            "jsonSchema": {
+                                "type": "object",
+                                "$schema": "http://json-schema.org/draft-07/schema#",
+                                "properties": {
+                                    "name": {"type": ["null", "string"]},
+                                    "commit": {
+                                        "type": ["null", "object"],
+                                        "properties": {
+                                            "sha": {"type": ["null", "string"]},
+                                            "url": {"type": ["null", "string"]},
+                                        },
+                                    },
+                                    "node_id": {"type": ["null", "string"]},
+                                    "repository": {"type": ["string"]},
+                                    "tarball_url": {"type": ["null", "string"]},
+                                    "zipball_url": {"type": ["null", "string"]},
+                                },
+                            },
+                            "supportedSyncModes": ["full_refresh"],
+                            "defaultCursorField": [],
+                            "sourceDefinedPrimaryKey": [["repository"], ["name"]],
+                        },
+                        "config": {
+                            "syncMode": "full_refresh",
+                            "cursorField": [],
+                            "destinationSyncMode": "append",
+                            "primaryKey": [["repository"], ["name"]],
+                            "aliasName": "tags",
+                            "selected": True,
+                        },
+                    },
+                    {
+                        "stream": {
+                            "name": "teams",
+                            "jsonSchema": {
+                                "type": "object",
+                                "$schema": "http://json-schema.org/draft-07/schema#",
+                                "properties": {
+                                    "id": {"type": ["null", "integer"]},
+                                    "url": {"type": ["null", "string"]},
+                                    "name": {"type": ["null", "string"]},
+                                    "slug": {"type": ["null", "string"]},
+                                    "parent": {
+                                        "type": ["null", "object"],
+                                        "properties": {},
+                                        "additionalProperties": True,
+                                    },
+                                    "node_id": {"type": ["null", "string"]},
+                                    "privacy": {"type": ["null", "string"]},
+                                    "html_url": {"type": ["null", "string"]},
+                                    "permission": {"type": ["null", "string"]},
+                                    "repository": {"type": ["null", "string"]},
+                                    "description": {"type": ["null", "string"]},
+                                    "members_url": {"type": ["null", "string"]},
+                                    "organization": {"type": ["null", "string"]},
+                                    "repositories_url": {"type": ["null", "string"]},
+                                },
+                            },
+                            "supportedSyncModes": ["full_refresh"],
+                            "defaultCursorField": [],
+                            "sourceDefinedPrimaryKey": [["id"]],
+                        },
+                        "config": {
+                            "syncMode": "full_refresh",
+                            "cursorField": [],
+                            "destinationSyncMode": "append",
+                            "primaryKey": [["id"]],
+                            "aliasName": "teams",
+                            "selected": True,
+                        },
+                    },
+                ]
+            },
+        },
+        kwargs,
+    )
+
+
+def get_project_job_json(schema_prefix=""):
+    return {
+        "job": {"id": 1, "status": AirbyteState.SUCCEEDED},
+        "attempts": [
+            {
+                "attempt": {
+                    "streamStats": [
+                        {
+                            "streamName": "dagster_teams",
+                            "stats": {
+                                "recordsEmitted": 3,
+                                "bytesEmitted": 1493,
+                                "recordsCommitted": 3,
+                            },
+                        },
+                        {
+                            "streamName": "dagster_tags",
+                            "stats": {
+                                "recordsEmitted": 622,
+                                "bytesEmitted": 289815,
+                                "recordsCommitted": 622,
+                            },
+                        },
+                        {
+                            "streamName": "dagster_releases",
+                            "stats": {
+                                "recordsEmitted": 119,
+                                "bytesEmitted": 620910,
+                                "recordsCommitted": 119,
+                            },
+                        },
+                    ],
+                }
+            }
+        ],
+    }

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
@@ -302,7 +302,7 @@ def get_project_connection_json(**kwargs):
     )
 
 
-def get_project_job_json(schema_prefix=""):
+def get_project_job_json():
     return {
         "job": {"id": 1, "status": AirbyteState.SUCCEEDED},
         "attempts": [


### PR DESCRIPTION
## Summary

Adds a new `@experimental` API that lets users load a set of Airbyte assets from an Airbyte project folder containing YAML files pulled using the [Octavia CLI](https://github.com/airbytehq/airbyte/tree/master/octavia-cli#octavia-import-all).

```python
airbyte_assets, source_assets = load_assets_from_airbyte_project(
    AIRBYTE_PROJECT_DIR, 
)
```

<img width="952" alt="Screen Shot 2022-09-12 at 2 53 23 PM" src="https://user-images.githubusercontent.com/10215173/189765266-0a5c0647-35fa-4fb4-b71c-fe23761b1f84.png">

Also provides a few optional config arguments to let users customize the output asset group names, whether or not to show normalization-created tables as separate assets etc.

## Test Plan

Tested locally; new unit test.
