### PR TITLE
Use partition set tag to identify partition set runs (rather than the pipeline_name column)

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -184,8 +184,10 @@ def get_partition_set_partition_statuses(
 
     run_partition_data = graphene_info.context.instance.run_storage.get_run_partition_data(
         runs_filter=RunsFilter(
-            pipeline_name=job_name,
-            tags={REPOSITORY_LABEL_TAG: repository_handle.get_external_origin().get_label()},
+            tags={
+                PARTITION_SET_TAG: partition_set_name,
+                REPOSITORY_LABEL_TAG: repository_handle.get_external_origin().get_label(),
+            },
         )
     )
     names_result = graphene_info.context.get_external_partition_names(


### PR DESCRIPTION
Summary:
We have some evidence that suggests combining a column filter on the runs table (pipeline_name) and a filter on the tags table is very expensive due to join performance. Instead, use another tag to filter runs down to the right partition set.

Once we have a column for repo label, we could switch back to just a query on the runs table - having the condition on both tables seems to be what is causing problems.

Test Plan: Partitions set query that used to take ~20 seconds now takes <1 second

### Summary & Motivation

### How I Tested These Changes
