### PR TITLE
Add option to run EcsRunLauncher without pulling network config from the current ECS task, and kwargs to customize the task config

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
@@ -43,6 +43,11 @@ ECS_CONTAINER_CONTEXT_SCHEMA = {
             "environment variables in the container."
         ),
     ),
+    "task_definition_arn": Field(
+        StringSource,
+        is_required=False,
+        description="ARN of the task definition to use to launch the container.",
+    ),
     **SHARED_ECS_SCHEMA,
 }
 
@@ -54,6 +59,7 @@ class EcsContainerContext(
             ("secrets", List[Any]),
             ("secrets_tags", List[str]),
             ("env_vars", List[str]),
+            ("task_definition_arn", Optional[str]),
         ],
     )
 ):
@@ -64,12 +70,14 @@ class EcsContainerContext(
         secrets: Optional[List[Any]] = None,
         secrets_tags: Optional[List[str]] = None,
         env_vars: Optional[List[str]] = None,
+        task_definition_arn: Optional[str] = None,
     ):
         return super(EcsContainerContext, cls).__new__(
             cls,
             secrets=check.opt_list_param(secrets, "secrets"),
             secrets_tags=check.opt_list_param(secrets_tags, "secrets_tags"),
             env_vars=check.opt_list_param(env_vars, "env_vars"),
+            task_definition_arn=check.opt_str_param(task_definition_arn, "task_definition_arn"),
         )
 
     def merge(self, other: "EcsContainerContext") -> "EcsContainerContext":
@@ -77,6 +85,7 @@ class EcsContainerContext(
             secrets=other.secrets + self.secrets,
             secrets_tags=other.secrets_tags + self.secrets_tags,
             env_vars=other.env_vars + self.env_vars,
+            task_definition_arn=other.task_definition_arn or self.task_definition_arn,
         )
 
     def get_secrets_dict(self, secrets_manager) -> Mapping[str, str]:
@@ -98,6 +107,7 @@ class EcsContainerContext(
                     secrets=run_launcher.secrets,
                     secrets_tags=run_launcher.secrets_tags,
                     env_vars=run_launcher.env_vars,
+                    task_definition_arn=run_launcher.task_definition,  # run launcher converts this from short name to ARN in constructor
                 )
             )
 
@@ -146,5 +156,6 @@ class EcsContainerContext(
                 secrets=processed_context_value.get("secrets"),
                 secrets_tags=processed_context_value.get("secrets_tags"),
                 env_vars=processed_context_value.get("env_vars"),
+                task_definition_arn=processed_context_value.get("task_definition_arn"),
             )
         )

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -1,13 +1,12 @@
 import json
 import warnings
 from collections import namedtuple
-from contextlib import suppress
 from typing import Any, Dict, Optional
 
 import boto3
 from botocore.exceptions import ClientError
 
-from dagster import Array, Field, Noneable, ScalarUnion, StringSource
+from dagster import Array, Field, Noneable, Permissive, ScalarUnion, StringSource
 from dagster import _check as check
 from dagster._core.events import EngineEventData, MetadataEntry
 from dagster._core.launcher.base import (
@@ -22,7 +21,13 @@ from dagster._serdes import ConfigurableClass
 
 from ..secretsmanager import get_secrets_from_arns
 from .container_context import SHARED_ECS_SCHEMA, EcsContainerContext
-from .tasks import default_ecs_task_definition, default_ecs_task_metadata
+from .tasks import (
+    DagsterEcsTaskDefinitionConfig,
+    get_current_ecs_task,
+    get_current_ecs_task_metadata,
+    get_task_definition_dict_from_current_task,
+    get_task_kwargs_from_current_task,
+)
 from .utils import sanitize_family
 
 Tags = namedtuple("Tags", ["arn", "cluster", "cpu", "memory"])
@@ -51,6 +56,8 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         secrets_tag="dagster",
         env_vars=None,
         include_sidecars=False,
+        use_current_ecs_task_config: bool = True,
+        run_task_kwargs: Optional[Dict[str, Any]] = None,
     ):
         self._inst_data = inst_data
         self.ecs = boto3.client("ecs")
@@ -94,6 +101,33 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
                 f"'{self.task_definition}' because the container is not defined.",
             )
             self.task_definition = task_definition["taskDefinition"]["taskDefinitionArn"]
+
+        self.use_current_ecs_task_config = check.opt_bool_param(
+            use_current_ecs_task_config, "use_current_ecs_task_config"
+        )
+
+        self.run_task_kwargs = check.opt_dict_param(run_task_kwargs, "run_task_kwargs")
+        if run_task_kwargs:
+            check.invariant(
+                "taskDefinition" not in run_task_kwargs,
+                "Use the `taskDefinition` config field to pass in a task definition to run.",
+            )
+            check.invariant(
+                "overrides" not in run_task_kwargs,
+                "Task overrides are set by the run launcher and cannot be set in run_task_kwargs.",
+            )
+
+            expected_keys = [
+                key for key in self.ecs.meta.service_model.shape_for("RunTaskRequest").members
+            ]
+
+            for key in run_task_kwargs:
+                check.invariant(
+                    key in expected_keys, f"Found an unexpected key {key} in run_task_kwargs"
+                )
+
+        self._current_task_metadata = None
+        self._current_task = None
 
     @property
     def inst_data(self):
@@ -151,6 +185,33 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
                     "Defaults to False."
                 ),
             ),
+            "use_current_ecs_task_config": Field(
+                bool,
+                is_required=False,
+                default_value=True,
+                description=(
+                    "Whether to use the run launcher's current ECS task in order to determine "
+                    "the cluster and networking configuration for the launched task. Defaults to "
+                    "True. Should only be called if the run launcher is running within an ECS "
+                    "task."
+                ),
+            ),
+            "run_task_kwargs": Field(
+                Permissive(
+                    {
+                        "cluster": Field(
+                            StringSource,
+                            is_required=False,
+                            description="Name of the ECS cluster to launch ECS tasks in.",
+                        ),
+                    }
+                ),
+                is_required=False,
+                description="Additional arguments to include while running the task. See "
+                "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task "
+                "for the available parameters. The overrides and taskDefinition arguments will always "
+                "be set by the run launcher.",
+            ),
             **SHARED_ECS_SCHEMA,
         }
 
@@ -165,9 +226,11 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         except ClientError:
             pass
 
-    def _set_run_tags(self, run_id, task_arn):
-        cluster = self._task_metadata().cluster
-        tags = {"ecs/task_arn": task_arn, "ecs/cluster": cluster}
+    def _set_run_tags(self, run_id: str, cluster: str, task_arn: str):
+        tags = {
+            "ecs/task_arn": task_arn,
+            "ecs/cluster": cluster,
+        }
         self._instance.add_run_tags(run_id, tags)
 
     def _get_run_tags(self, run_id):
@@ -190,18 +253,10 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         docker-compose when you use the Dagster ECS reference deployment.
         """
         run = context.pipeline_run
-        family = sanitize_family(
-            run.external_pipeline_origin.external_repository_origin.repository_location_origin.location_name  # type: ignore
-        )
-
         container_context = EcsContainerContext.create_for_run(run, self)
 
-        metadata = self._task_metadata()
         pipeline_origin = check.not_none(context.pipeline_code_origin)
         image = pipeline_origin.repository_origin.container_image
-        task_definition = self._task_definition(family, metadata, image, container_context)[
-            "family"
-        ]
 
         # ECS limits overrides to 8192 characters including json formatting
         # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html
@@ -224,6 +279,8 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         )
         command = args.get_command_args()
 
+        run_task_kwargs = self._run_task_kwargs(run, image, container_context)
+
         # Set cpu or memory overrides
         # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
         cpu_and_memory_overrides = self.get_cpu_and_memory_overrides(run)
@@ -239,7 +296,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
             }
         ]
 
-        overrides: Dict[str, Any] = {
+        run_task_kwargs["overrides"] = {
             "containerOverrides": container_overrides,
             # taskOverrides expects cpu/memory as strings
             **cpu_and_memory_overrides,
@@ -249,17 +306,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         # Run a task using the same network configuration as this processes's
         # task.
         response = self.ecs.run_task(
-            taskDefinition=task_definition,
-            cluster=metadata.cluster,
-            overrides=overrides,
-            networkConfiguration={
-                "awsvpcConfiguration": {
-                    "subnets": metadata.subnets,
-                    "assignPublicIp": metadata.assign_public_ip,
-                    "securityGroups": metadata.security_groups,
-                }
-            },
-            launchType="FARGATE",
+            **run_task_kwargs,
         )
 
         tasks = response["tasks"]
@@ -275,9 +322,10 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
             raise Exception(exceptions)
 
         arn = tasks[0]["taskArn"]
-        self._set_run_tags(run.run_id, task_arn=arn)
+        cluster_arn = tasks[0]["clusterArn"]
+        self._set_run_tags(run.run_id, cluster=cluster_arn, task_arn=arn)
         self._set_ecs_tags(run.run_id, task_arn=arn)
-        self.report_launch_events(run, arn, metadata.cluster)
+        self.report_launch_events(run, arn, cluster_arn)
 
     def report_launch_events(
         self, run: PipelineRun, arn: Optional[str] = None, cluster: Optional[str] = None
@@ -333,75 +381,102 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         self.ecs.stop_task(task=tags.arn, cluster=tags.cluster)
         return True
 
-    def _task_definition(self, family, metadata, image, container_context):
-        """
-        Return the launcher's task definition if it's configured.
+    def _get_current_task_metadata(self):
+        if self._current_task_metadata == None:
+            self._current_task_metadata = get_current_ecs_task_metadata()
+        return self._current_task_metadata
 
-        Otherwise, a new task definition revision is registered for every run.
-        First, the process that calls this method finds its own task
-        definition. Next, it creates a new task definition based on its own
-        but it overrides the image with the pipeline origin's image.
-        """
-        if self.task_definition:
-            task_definition = self.ecs.describe_task_definition(taskDefinition=self.task_definition)
-            return task_definition["taskDefinition"]
+    def _get_current_task(self):
+        if self._current_task == None:
+            current_task_metadata = self._get_current_task_metadata()
+            self._current_task = get_current_ecs_task(
+                self.ecs, current_task_metadata.task_arn, current_task_metadata.cluster
+            )
 
-        environment = [
+        return self._current_task
+
+    def _run_task_kwargs(self, run, image, container_context) -> Dict[str, Any]:
+        """
+        Return a dictionary of args to launch the ECS task, registering a new task
+        definition if needed.
+        """
+        environment = self._environment(container_context)
+        secrets = self._secrets(container_context)
+
+        if container_context.task_definition_arn:
+            task_definition = container_context.task_definition_arn
+        else:
+            family = sanitize_family(
+                run.external_pipeline_origin.external_repository_origin.repository_location_origin.location_name  # type: ignore
+            )
+            task_definition_dict = get_task_definition_dict_from_current_task(
+                self.ecs,
+                family,
+                self._get_current_task(),
+                image,
+                self.container_name,
+                environment=environment,
+                secrets=secrets if secrets else {},
+                include_sidecars=self.include_sidecars,
+            )
+
+            task_definition_config = DagsterEcsTaskDefinitionConfig.from_task_definition_dict(
+                task_definition_dict,
+                self.container_name,
+            )
+
+            if not self._reuse_task_definition(
+                task_definition_config,
+            ):
+                self.ecs.register_task_definition(**task_definition_dict)
+
+            task_definition = family
+
+        if self.use_current_ecs_task_config:
+            current_task_metadata = get_current_ecs_task_metadata()
+            current_task = get_current_ecs_task(
+                self.ecs, current_task_metadata.task_arn, current_task_metadata.cluster
+            )
+            task_kwargs = get_task_kwargs_from_current_task(
+                self.ec2,
+                current_task_metadata.cluster,
+                current_task,
+            )
+        else:
+            task_kwargs = {}
+
+        return {**task_kwargs, **self.run_task_kwargs, "taskDefinition": task_definition}
+
+    def _reuse_task_definition(
+        self, desired_task_definition_config: DagsterEcsTaskDefinitionConfig
+    ):
+        family = desired_task_definition_config.family
+
+        try:
+            existing_task_definition = self.ecs.describe_task_definition(taskDefinition=family)[
+                "taskDefinition"
+            ]
+        except ClientError:
+            # task definition does not exist, do not reuse
+            return False
+
+        existing_task_definition_config = DagsterEcsTaskDefinitionConfig.from_task_definition_dict(
+            existing_task_definition, self.container_name
+        )
+
+        return existing_task_definition_config == desired_task_definition_config
+
+    def _environment(self, container_context):
+        return [
             {"name": key, "value": value}
             for key, value in container_context.get_environment_dict().items()
         ]
 
+    def _secrets(self, container_context):
         secrets = container_context.get_secrets_dict(self.secrets_manager)
-        secrets_definition = (
-            {"secrets": [{"name": key, "valueFrom": value} for key, value in secrets.items()]}
-            if secrets
-            else {}
+        return (
+            [{"name": key, "valueFrom": value} for key, value in secrets.items()] if secrets else []
         )
-
-        task_definition = {}
-        with suppress(ClientError):
-            task_definition = self.ecs.describe_task_definition(taskDefinition=family)[
-                "taskDefinition"
-            ]
-        secrets = secrets_definition.get("secrets", [])
-        if self._reuse_task_definition(task_definition, metadata, image, secrets, environment):
-            return task_definition
-
-        return default_ecs_task_definition(
-            self.ecs,
-            family,
-            metadata,
-            image,
-            self.container_name,
-            environment=environment,
-            secrets=secrets_definition,
-            include_sidecars=self.include_sidecars,
-        )
-
-    def _reuse_task_definition(self, task_definition, metadata, image, secrets, environment):
-        container_definitions_match = False
-        task_definitions_match = False
-
-        container_definitions = task_definition.get("containerDefinitions", [{}])
-        # Only check for diffs to the primary container. This ignores changes to sidecars.
-        for container_definition in container_definitions:
-            if (
-                container_definition.get("image") == image
-                and container_definition.get("name") == self.container_name
-                and container_definition.get("secrets") == secrets
-                and ((not environment) or container_definition.get("environment") == environment)
-            ):
-                container_definitions_match = True
-
-        if task_definition.get("executionRoleArn") == metadata.task_definition.get(
-            "executionRoleArn"
-        ) and task_definition.get("taskRoleArn") == metadata.task_definition.get("taskRoleArn"):
-            task_definitions_match = True
-
-        return container_definitions_match & task_definitions_match
-
-    def _task_metadata(self):
-        return default_ecs_task_metadata(self.ec2, self.ecs)
 
     @property
     def supports_check_run_worker_health(self):

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
@@ -1,6 +1,5 @@
 import os
-import typing
-from dataclasses import dataclass
+from typing import Any, Dict, List, NamedTuple, Optional
 
 import requests
 
@@ -8,14 +7,58 @@ from dagster._utils import merge_dicts
 from dagster._utils.backoff import backoff
 
 
-@dataclass
-class TaskMetadata:
-    cluster: str
-    subnets: typing.List[str]
-    security_groups: typing.List[str]
-    task_definition: typing.Dict[str, typing.Any]
-    container_definition: typing.Dict[str, typing.Any]
-    assign_public_ip: bool
+class DagsterEcsTaskDefinitionConfig(
+    NamedTuple(
+        "_DagsterEcsTaskDefinitionConfig",
+        [
+            ("family", str),
+            ("image", str),
+            ("container_name", str),
+            ("command", Optional[str]),
+            ("log_configuration", Optional[Dict[str, Any]]),
+            ("secrets", Optional[List[Dict[str, str]]]),
+            ("environment", Optional[List[Dict[str, str]]]),
+            ("execution_role_arn", Optional[str]),
+            ("task_role_arn", Optional[str]),
+            ("sidecars", List[Dict[str, Any]]),
+        ],
+    )
+):
+    """All the information that Dagster needs to compare two task definition to see if they
+    should be reused."""
+
+    @staticmethod
+    def from_task_definition_dict(task_definition_dict, container_name):
+
+        matching_container_defs = [
+            container
+            for container in task_definition_dict["containerDefinitions"]
+            if container["name"] == container_name
+        ]
+
+        if not matching_container_defs:
+            raise Exception(f"No container in task definition with expected name {container_name}")
+
+        container_definition = matching_container_defs[0]
+
+        sidecars = [
+            container
+            for container in task_definition_dict["containerDefinitions"]
+            if container["name"] != container_name
+        ]
+
+        return DagsterEcsTaskDefinitionConfig(
+            family=task_definition_dict["family"],
+            image=container_definition["image"],
+            container_name=container_name,
+            command=container_definition.get("command"),
+            log_configuration=task_definition_dict.get("logConfiguration"),
+            secrets=container_definition.get("secrets"),
+            environment=container_definition.get("environment"),
+            execution_role_arn=task_definition_dict.get("executionRoleArn"),
+            task_role_arn=task_definition_dict.get("taskRoleArn"),
+            sidecars=sidecars,
+        )
 
 
 # 9 retries polls for up to 51.1 seconds with exponential backoff.
@@ -33,10 +76,10 @@ class EcsNoTasksFound(Exception):
     pass
 
 
-def default_ecs_task_definition(
+def get_task_definition_dict_from_current_task(
     ecs,
     family,
-    metadata,
+    current_task,
     image,
     container_name,
     environment,
@@ -44,6 +87,24 @@ def default_ecs_task_definition(
     secrets=None,
     include_sidecars=False,
 ):
+
+    current_container_name = current_ecs_container_name()
+
+    current_task_definition_arn = current_task["taskDefinitionArn"]
+    current_task_definition_dict = ecs.describe_task_definition(
+        taskDefinition=current_task_definition_arn
+    )["taskDefinition"]
+
+    container_definition = next(
+        iter(
+            [
+                container
+                for container in current_task_definition_dict["containerDefinitions"]
+                if container["name"] == current_container_name
+            ]
+        )
+    )
+
     # Start with the current process's task's definition but remove
     # extra keys that aren't useful for creating a new task definition
     # (status, revision, etc.)
@@ -51,9 +112,9 @@ def default_ecs_task_definition(
         key for key in ecs.meta.service_model.shape_for("RegisterTaskDefinitionRequest").members
     ]
     task_definition = dict(
-        (key, metadata.task_definition[key])
+        (key, current_task_definition_dict[key])
         for key in expected_keys
-        if key in metadata.task_definition.keys()
+        if key in current_task_definition_dict.keys()
     )
 
     # The current process might not be running in a container that has the
@@ -66,20 +127,20 @@ def default_ecs_task_definition(
     # https://aws.amazon.com/blogs/opensource/demystifying-entrypoint-cmd-docker/
     new_container_definition = merge_dicts(
         {
-            **metadata.container_definition,
+            **container_definition,
             "name": container_name,
             "image": image,
             "entryPoint": [],
             "command": command if command else [],
         },
         ({"environment": environment} if environment else {}),
-        secrets or {},
+        ({"secrets": secrets} if secrets else {}),
         {} if include_sidecars else {"dependsOn": []},
     )
 
     if include_sidecars:
-        container_definitions = metadata.task_definition.get("containerDefinitions")
-        container_definitions.remove(metadata.container_definition)
+        container_definitions = current_task_definition_dict.get("containerDefinitions")
+        container_definitions.remove(container_definition)
         container_definitions.append(new_container_definition)
     else:
         container_definitions = [new_container_definition]
@@ -90,14 +151,25 @@ def default_ecs_task_definition(
         "containerDefinitions": container_definitions,
     }
 
-    # Register the task overridden task definition as a revision to the
-    # "dagster-run" family.
-    ecs.register_task_definition(**task_definition)
-
     return task_definition
 
 
-def default_ecs_task_metadata(ec2, ecs):
+class CurrentEcsTaskMetadata(
+    NamedTuple("_CurrentEcsTaskMetadata", [("cluster", str), ("task_arn", str)])
+):
+    pass
+
+
+def get_current_ecs_task_metadata() -> CurrentEcsTaskMetadata:
+    task_metadata_uri = _container_metadata_uri() + "/task"
+    response = requests.get(task_metadata_uri).json()
+    cluster = response.get("Cluster")
+    task_arn = response.get("TaskARN")
+
+    return CurrentEcsTaskMetadata(cluster=cluster, task_arn=task_arn)
+
+
+def _container_metadata_uri():
     """
     ECS injects an environment variable into each Fargate task. The value
     of this environment variable is a url that can be queried to introspect
@@ -105,14 +177,14 @@ def default_ecs_task_metadata(ec2, ecs):
 
     https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-metadata-endpoint-v4-fargate.html
     """
-    container_metadata_uri = os.environ.get("ECS_CONTAINER_METADATA_URI_V4")
-    name = requests.get(container_metadata_uri).json()["Name"]
+    return os.environ.get("ECS_CONTAINER_METADATA_URI_V4")
 
-    task_metadata_uri = container_metadata_uri + "/task"
-    response = requests.get(task_metadata_uri).json()
-    cluster = response.get("Cluster")
-    task_arn = response.get("TaskARN")
 
+def current_ecs_container_name():
+    return requests.get(_container_metadata_uri()).json()["Name"]
+
+
+def get_current_ecs_task(ecs, task_arn, cluster):
     def describe_task_or_raise(task_arn, cluster):
         try:
             return ecs.describe_tasks(tasks=[task_arn], cluster=cluster)["tasks"][0]
@@ -129,6 +201,14 @@ def default_ecs_task_metadata(ec2, ecs):
     except EcsNoTasksFound:
         raise EcsEventualConsistencyTimeout
 
+    return task
+
+
+def get_task_kwargs_from_current_task(
+    ec2,
+    cluster,
+    task,
+):
     enis = []
     subnets = []
     for attachment in task["attachments"]:
@@ -147,26 +227,14 @@ def default_ecs_task_metadata(ec2, ecs):
         for group in eni.groups:
             security_groups.append(group["GroupId"])
 
-    task_definition_arn = task["taskDefinitionArn"]
-    task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)[
-        "taskDefinition"
-    ]
-
-    container_definition = next(
-        iter(
-            [
-                container
-                for container in task_definition["containerDefinitions"]
-                if container["name"] == name
-            ]
-        )
-    )
-
-    return TaskMetadata(
-        cluster=cluster,
-        subnets=subnets,
-        security_groups=security_groups,
-        task_definition=task_definition,
-        container_definition=container_definition,
-        assign_public_ip="ENABLED" if public_ip else "DISABLED",
-    )
+    return {
+        "cluster": cluster,
+        "networkConfiguration": {
+            "awsvpcConfiguration": {
+                "subnets": subnets,
+                "assignPublicIp": "ENABLED" if public_ip else "DISABLED",
+                "securityGroups": security_groups,
+            },
+        },
+        "launchType": task.get("launchType") or "FARGATE",
+    }

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -139,6 +139,25 @@ def instance(instance_cm):
 
 
 @pytest.fixture
+def instance_dont_use_current_task(instance_cm, subnet):
+    with instance_cm(
+        config={
+            "use_current_ecs_task_config": False,
+            "run_task_kwargs": {
+                "cluster": "my_cluster",
+                "networkConfiguration": {
+                    "awsvpcConfiguration": {
+                        "subnets": [subnet.id],
+                        "assignPublicIp": "ENABLED",
+                    },
+                },
+            },
+        }
+    ) as dagster_instance:
+        yield dagster_instance
+
+
+@pytest.fixture
 def workspace(instance, image):
     with in_process_test_workspace(
         instance,

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_instance.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_instance.py
@@ -1,0 +1,41 @@
+import pytest
+
+
+def test_default_instance(instance_cm):
+    with instance_cm() as instance:
+        assert instance.run_launcher.use_current_ecs_task_config
+        assert instance.run_launcher.run_task_kwargs == {}
+
+
+def test_run_task_kwargs(instance_cm):
+    run_task_kwargs = {
+        "launchType": "EC2",
+    }
+
+    with instance_cm(
+        config={
+            "run_task_kwargs": run_task_kwargs,
+        }
+    ) as instance:
+        assert instance.run_launcher.run_task_kwargs == run_task_kwargs
+
+
+def test_invalid_kwargs_field(instance_cm):
+
+    with pytest.raises(Exception, match="Found an unexpected key foo in run_task_kwargs"):
+        with instance_cm(config={"run_task_kwargs": {"foo": "bar"}}):
+            pass
+
+    with pytest.raises(Exception):
+        with instance_cm(
+            config={"taskDefinition": "my-task-def"},
+            match="Use the `taskDefinition` config field to pass in a task definition to run",
+        ):
+            pass
+
+    with pytest.raises(Exception):
+        with instance_cm(
+            config={"overrides": {"containerOverrides": {}}},
+            match="Task overrides are set by the run launcher and cannot be set in run_task_kwargs.",
+        ):
+            pass

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
@@ -44,12 +44,12 @@ def stubbed(function):
                 self.stubber.deactivate()
                 self.stubber.assert_no_pending_responses()
             return copy.deepcopy(response)
-        except Exception as ex:
+        except Exception:
             # Exceptions should reset the stubber
             self.stub_count = 0
             self.stubber.deactivate()
             self.stubber = Stubber(self.client)
-            raise ex
+            raise
 
     return wrapper
 


### PR DESCRIPTION
Right now the only way to use the EcsRunLauncher involves pulling permissions and other configuration from the task that is launching the run. This creates a problem in situations where you might want system code to have different IAM roles than user code, or even launch runs from outside of ECS. In Cloud, it creates an awkward situation where the grpc server tasks  are configured based on fields on the instance, but runs are configured by pulling from the current task.

This PR creates a configuration option that lets you pass in all the configuration you need when launching run, with nothing pulled from the current container. The old version is kept as well.