### PR TITLE
Add asset selection flag to run_request_for_partition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -569,6 +569,7 @@ class JobDefinition(PipelineDefinition):
         partition_key: str,
         run_key: Optional[str],
         tags: Optional[Mapping[str, str]] = None,
+        asset_selection: Optional[Sequence[AssetKey]] = None,
     ) -> RunRequest:
         partition_set = self.get_partition_set_def()
         if not partition_set:
@@ -583,7 +584,11 @@ class JobDefinition(PipelineDefinition):
         )
 
         return RunRequest(
-            run_key=run_key, run_config=run_config, tags=run_request_tags, job_name=self.name
+            run_key=run_key,
+            run_config=run_config,
+            tags=run_request_tags,
+            job_name=self.name,
+            asset_selection=asset_selection,
         )
 
     @public

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -3,6 +3,7 @@ from functools import reduce
 from typing import TYPE_CHECKING, Any, Dict, NamedTuple, Optional, Sequence, Union, cast
 
 import dagster._check as check
+from dagster._core.definitions import AssetKey
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.selector.subset_selector import parse_clause
 
@@ -96,6 +97,7 @@ class UnresolvedAssetJobDefinition(
         partition_key: str,
         run_key: Optional[str],
         tags: Optional[Dict[str, str]] = None,
+        asset_selection: Optional[Sequence[AssetKey]] = None,
     ) -> RunRequest:
         partition_set = self.get_partition_set_def()
         if not partition_set:
@@ -109,7 +111,12 @@ class UnresolvedAssetJobDefinition(
             else partition_set.tags_for_partition(partition)
         )
 
-        return RunRequest(run_key=run_key, run_config=run_config, tags=run_request_tags)
+        return RunRequest(
+            run_key=run_key,
+            run_config=run_config,
+            tags=run_request_tags,
+            asset_selection=asset_selection,
+        )
 
     def resolve(
         self,

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -348,7 +348,17 @@ def large_sensor(_context):
 
 @sensor(job=asset_job)
 def asset_selection_sensor(_context):
-    return RunRequest(run_key=None, asset_selection=[AssetKey("a"), AssetKey("b")])
+    yield RunRequest(run_key=None, asset_selection=[AssetKey("a"), AssetKey("b")])
+    yield hourly_asset_job.run_request_for_partition(
+        partition_key="2022-08-01-00:00", run_key=None, asset_selection=[AssetKey("hourly_asset_3")]
+    )
+
+
+@sensor(job=hourly_asset_job)
+def partitioned_asset_selection_sensor(_context):
+    return hourly_asset_job.run_request_for_partition(
+        partition_key="2022-08-01-00:00", run_key=None, asset_selection=[AssetKey("hourly_asset_3")]
+    )
 
 
 @asset_sensor(job_name="the_pipeline", asset_key=AssetKey("foo"))
@@ -495,6 +505,7 @@ def the_repo():
         weekly_asset_job,
         multi_asset_sensor_hourly_to_weekly,
         multi_asset_sensor_hourly_to_hourly,
+        partitioned_asset_selection_sensor,
     ]
 
 
@@ -1489,6 +1500,46 @@ def test_asset_selection_sensor(executor, instance, workspace, external_repo):
             )
         }
         assert planned_asset_keys == {AssetKey("a"), AssetKey("b")}
+
+
+@pytest.mark.parametrize("executor", get_sensor_executors())
+def test_partitioned_asset_selection_sensor(executor, instance, workspace, external_repo):
+    freeze_datetime = to_timezone(
+        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
+        "US/Central",
+    )
+    with pendulum.test(freeze_datetime):
+        external_sensor = external_repo.get_external_sensor("partitioned_asset_selection_sensor")
+        external_origin_id = external_sensor.get_external_origin_id()
+        instance.start_sensor(external_sensor)
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        assert len(ticks) == 0
+
+        evaluate_sensors(instance, workspace, executor)
+
+        assert instance.get_runs_count() == 1
+        run = instance.get_runs()[0]
+        assert run.asset_selection == {AssetKey("hourly_asset_3")}
+        assert run.tags["dagster/partition"] == "2022-08-01-00:00"
+        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        assert len(ticks) == 1
+        validate_tick(
+            ticks[0],
+            external_sensor,
+            freeze_datetime,
+            TickStatus.SUCCESS,
+            [run.run_id],
+        )
+
+        planned_asset_keys = {
+            record.event_log_entry.dagster_event.event_specific_data.asset_key
+            for record in instance.get_event_records(
+                EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION_PLANNED)
+            )
+        }
+        assert planned_asset_keys == {AssetKey("hourly_asset_3")}
 
 
 @pytest.mark.parametrize("executor", get_sensor_executors())

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -349,9 +349,6 @@ def large_sensor(_context):
 @sensor(job=asset_job)
 def asset_selection_sensor(_context):
     yield RunRequest(run_key=None, asset_selection=[AssetKey("a"), AssetKey("b")])
-    yield hourly_asset_job.run_request_for_partition(
-        partition_key="2022-08-01-00:00", run_key=None, asset_selection=[AssetKey("hourly_asset_3")]
-    )
 
 
 @sensor(job=hourly_asset_job)


### PR DESCRIPTION
We already allow an `asset_selection` on a run request. This PR enables a partitioned run request to also contain an asset selection. Adding this in preparation to add docs examples for triggering partitioned runs via `multi_asset_sensor`.