### PR TITLE
[dagster-dbt] fix missing select when using dbt_cli_resource

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
@@ -183,7 +183,7 @@ class DbtCliResource(DbtResource):
             # do not include these arguments if both are True, as these are deprecated in later
             # versions of dbt, and for older versions the functionality is the same regardless of
             # if both are set or neither are set.
-            return self.cli("test", models=models, exclude=exclude, **kwargs)
+            return self.cli("test", models=models, exclude=exclude, select=select, **kwargs)
         return self.cli(
             "test",
             models=models,


### PR DESCRIPTION
### Summary & Motivation

I recently added select as named keyword argument to this method, which messed up this code path. this fixes it.

### How I Tested These Changes
