### PR TITLE
[dagit] Defensively pretty-print JSON in run logs

### DIFF
--- a/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
@@ -10,6 +10,7 @@ import {
   Markdown,
   Tooltip,
   FontFamily,
+  tryPrettyPrintJSON,
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
@@ -87,9 +88,7 @@ export const MetadataEntry: React.FC<{
 
     case 'JsonMetadataEntry':
       return expandSmallValues && entry.jsonString.length < 1000 ? (
-        <div style={{whiteSpace: 'pre-wrap'}}>
-          {JSON.stringify(JSON.parse(entry.jsonString), null, 2)}
-        </div>
+        <div style={{whiteSpace: 'pre-wrap'}}>{tryPrettyPrintJSON(entry.jsonString)}</div>
       ) : (
         <MetadataEntryModalAction
           label={entry.label}
@@ -102,7 +101,7 @@ export const MetadataEntry: React.FC<{
               border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
               style={{whiteSpace: 'pre-wrap', fontFamily: FontFamily.monospace, overflow: 'auto'}}
             >
-              {JSON.stringify(JSON.parse(entry.jsonString), null, 2)}
+              {tryPrettyPrintJSON(entry.jsonString)}
             </Box>
           )}
         >

--- a/js_modules/dagit/packages/ui/src/components/ConfigTypeSchema.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ConfigTypeSchema.tsx
@@ -140,12 +140,14 @@ function renderTypeRecursive(
   return <span>{type.givenName}</span>;
 }
 
-const prettyJsonString = (value: string) => {
+export const tryPrettyPrintJSON = (jsonString: string) => {
   try {
-    const parsed = JSON.parse(value);
-    return JSON.stringify(parsed, null, 2);
-  } catch (e) {
-    return value;
+    return JSON.stringify(JSON.parse(jsonString), null, 2);
+  } catch (err) {
+    // welp, looks like it's not valid JSON. This has happened at least once
+    // in the wild - a user was able to build a metadata entry in Python with
+    // a `NaN` number value: https://github.com/dagster-io/dagster/issues/8959
+    return jsonString;
   }
 };
 
@@ -154,7 +156,7 @@ const ConfigContent = React.memo(({value}: {value: string}) => (
     <ConfigHeader>
       <strong>Default value</strong>
     </ConfigHeader>
-    <ConfigJSON>{prettyJsonString(value)}</ConfigJSON>
+    <ConfigJSON>{tryPrettyPrintJSON(value)}</ConfigJSON>
   </>
 ));
 


### PR DESCRIPTION
### Summary & Motivation

This resolves the issue reported here: https://github.com/dagster-io/dagster/issues/8959

I feel slightly gross exporting the existing helper for this from `@dagster/ui`, but I felt equally gross redefining it in the main app. Curious if maybe that'd be better? Two definitions might not kill us but I wanted to include the comment explaining why it was try-catched.

### How I Tested These Changes
