### PR TITLE
[dagit] Allow collapsing the asset event row that is expanded by default

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetEventsTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventsTable.tsx
@@ -35,7 +35,7 @@ export const AssetEventsTable: React.FC<{
   hasLineage: boolean;
   groups: AssetEventGroup[];
   focused?: AssetEventGroup;
-  setFocused?: (timestamp: AssetEventGroup) => void;
+  setFocused?: (timestamp: AssetEventGroup | undefined) => void;
 }> = ({hasPartitions, hasLineage, groups, focused, setFocused}) => {
   return (
     <Table>
@@ -58,7 +58,7 @@ export const AssetEventsTable: React.FC<{
                 if (e.target instanceof HTMLElement && e.target.closest('a')) {
                   return;
                 }
-                setFocused?.(group);
+                setFocused?.(focused !== group ? group : undefined);
               }}
             >
               <EventGroupRow


### PR DESCRIPTION
### Summary & Motivation

This is a small fix for https://github.com/dagster-io/dagster/issues/9471. It changes the logic used to open the first Asset Event table row by default so that you can explicitly close the first item and not have it re-open.

It's a little tricky because a URL like `/instance/assets/my_derived_asset?view=activity&time=1663123997972` specifies both the "By Timestamp" tab _and_ the expanded item. To allow you to deselect the item while staying on the "By Timestamp" tab, we set the value to an empty string rather than removing it entirely. This is sort of how things were set up already, but allowing you to close the item makes it more explicit and I added a comment to the top of the component.

### How I Tested These Changes
