### PR TITLE
graph_name parameter on define_asset_job

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -790,6 +790,7 @@ def build_asset_selection_job(
     tags: Optional[Mapping[str, Any]] = None,
     asset_selection: Optional[FrozenSet[AssetKey]] = None,
     asset_selection_data: Optional[AssetSelectionData] = None,
+    graph_name: Optional[str] = None,
 ) -> "JobDefinition":
     from dagster._core.definitions import build_assets_job
 
@@ -822,6 +823,7 @@ def build_asset_selection_job(
             partitions_def=partitions_def,
             description=description,
             tags=tags,
+            graph_name=graph_name,
             _asset_selection_data=asset_selection_data,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -37,6 +37,7 @@ def build_assets_job(
     tags: Optional[Mapping[str, object]] = None,
     executor_def: Optional[ExecutorDefinition] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
+    graph_name: Optional[str] = None,
     _asset_selection_data: Optional[AssetSelectionData] = None,
 ) -> JobDefinition:
     """Builds a job that materializes the given assets.
@@ -106,7 +107,7 @@ def build_assets_job(
         deps, assets_defs_by_node_handle = build_node_deps(assets, resolved_asset_deps)
 
     graph = GraphDefinition(
-        name=name,
+        name=graph_name or name,
         node_defs=[asset.node_def for asset in assets],
         dependencies=deps,
         description=description,
@@ -124,6 +125,7 @@ def build_assets_job(
     if _asset_selection_data:
         original_job = _asset_selection_data.parent_job_def
         return graph.to_job(
+            name=name,
             resource_defs=all_resource_defs,
             config=config,
             tags=tags,
@@ -139,6 +141,7 @@ def build_assets_job(
         )
 
     return graph.to_job(
+        name=name,
         resource_defs=all_resource_defs,
         config=config,
         tags=tags,

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -480,6 +480,7 @@ class JobDefinition(PipelineDefinition):
             asset_selection=asset_selection,
             asset_selection_data=asset_selection_data,
             config=self.config_mapping,
+            graph_name=self.graph.name,
         )
         return new_job
 

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -33,6 +33,7 @@ class UnresolvedAssetJobDefinition(
             ("tags", Optional[Dict[str, Any]]),
             ("partitions_def", Optional["PartitionsDefinition"]),
             ("executor_def", Optional["ExecutorDefinition"]),
+            ("graph_name", Optional[str]),
         ],
     )
 ):
@@ -45,6 +46,7 @@ class UnresolvedAssetJobDefinition(
         tags: Optional[Dict[str, Any]] = None,
         partitions_def: Optional["PartitionsDefinition"] = None,
         executor_def: Optional["ExecutorDefinition"] = None,
+        graph_name: Optional[str] = None,
     ):
         from dagster._core.definitions import (
             AssetSelection,
@@ -63,6 +65,7 @@ class UnresolvedAssetJobDefinition(
                 partitions_def, "partitions_def", PartitionsDefinition
             ),
             executor_def=check.opt_inst_param(executor_def, "partitions_def", ExecutorDefinition),
+            graph_name=check.opt_str_param(graph_name, "graph_name"),
         )
 
     def get_partition_set_def(self) -> Optional["PartitionSetDefinition"]:
@@ -130,6 +133,7 @@ class UnresolvedAssetJobDefinition(
             asset_selection=self.selection.resolve([*assets, *source_assets]),
             partitions_def=self.partitions_def,
             executor_def=self.executor_def or default_executor_def,
+            graph_name=self.graph_name,
         )
 
 
@@ -160,6 +164,7 @@ def define_asset_job(
     tags: Optional[Dict[str, Any]] = None,
     partitions_def: Optional["PartitionsDefinition"] = None,
     executor_def: Optional["ExecutorDefinition"] = None,
+    graph_name: Optional[str] = None,
 ) -> UnresolvedAssetJobDefinition:
     """Creates a definition of a job which will materialize a selection of assets. This will only be
     resolved to a JobDefinition once placed in a repository.
@@ -202,7 +207,9 @@ def define_asset_job(
             How this Job will be executed. Defaults to :py:class:`multi_or_in_process_executor`,
             which can be switched between multi-process and in-process modes of execution. The
             default mode of execution is multi-process.
-
+        graph_name (Optional[str]): The name to assign to the underlying graph of the job. Useful in
+            situations where you want to avoid name collisions with other graphs in your repository.
+            If not specified, the job name will be used.
 
     Returns:
         UnresolvedAssetJobDefinition: The job, which can be placed inside a repository.
@@ -260,4 +267,5 @@ def define_asset_job(
         tags=tags,
         partitions_def=partitions_def,
         executor_def=executor_def,
+        graph_name=graph_name,
     )

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -1910,3 +1910,14 @@ def test_resolve_dependency_multi_asset_different_groups():
             warnings.simplefilter("ignore", category=ExperimentalWarning)
 
             materialize_to_memory([upstream, assets])
+
+
+def test_define_asset_job_custom_graph_name():
+    @asset
+    def asset1():
+        ...
+
+    job1 = define_asset_job("abc", graph_name="abc_graph")
+    resolved = job1.resolve([asset1], [])
+    assert resolved.name == "abc"
+    assert resolved.graph.name == "abc_graph"


### PR DESCRIPTION
### Summary & Motivation

I'm hoping to get this in for this week's release, to help out a user.

Without this change, this breaks:
```
from dagster import op, graph, repository, AssetsDefinition, define_asset_job


@op
def op1():
    ...


@graph
def graph1():
    ...


@repository
def repo():
    asset1 = AssetsDefinition.from_graph(graph1)
    return [asset1, define_asset_job("graph1")]
```

with 

```
dagster._core.errors.DagsterInvalidDefinitionError: Conflicting definitions found in repository with name 'graph1'. Op/Graph/Solid definition names must be unique within a repository. GraphDefinition is defined in job '__ASSET_JOB' and in job 'graph1'.
```

### How I Tested These Changes
