### PR TITLE
[dagster-databricks] fix library install version

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -175,15 +175,23 @@ class DatabricksJobRunner:
         libraries = list(run_config.get("libraries", []))
         install_default_libraries = run_config.get("install_default_libraries", True)
         if install_default_libraries:
+            import dagster_databricks
+            import dagster_pyspark
+
             python_libraries = {
                 x["pypi"]["package"].split("==")[0].replace("_", "-")
                 for x in libraries
                 if "pypi" in x
             }
-            for library in ["dagster", "dagster-databricks", "dagster-pyspark"]:
-                if library not in python_libraries:
+
+            for library_name, library in [
+                ("dagster", dagster),
+                ("dagster-databricks", dagster_databricks),
+                ("dagster-pyspark", dagster_pyspark),
+            ]:
+                if library_name not in python_libraries:
                     libraries.append(
-                        {"pypi": {"package": "{}=={}".format(library, dagster.__version__)}}
+                        {"pypi": {"package": "{}=={}".format(library_name, library.__version__)}}
                     )
 
         # Only one task should be able to be chosen really; make sure of that here.

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -1,6 +1,8 @@
 import base64
 import time
 
+import dagster_databricks
+import dagster_pyspark
 import requests.exceptions
 from databricks_api import DatabricksAPI
 
@@ -175,9 +177,6 @@ class DatabricksJobRunner:
         libraries = list(run_config.get("libraries", []))
         install_default_libraries = run_config.get("install_default_libraries", True)
         if install_default_libraries:
-            import dagster_databricks
-            import dagster_pyspark
-
             python_libraries = {
                 x["pypi"]["package"].split("==")[0].replace("_", "-")
                 for x in libraries


### PR DESCRIPTION
### Summary & Motivation

Fix library install version -- the dagster library version is no longer guaranteed to match the dagster-pyspark / dagster-databricks library versions.

### How I Tested These Changes
