### PR TITLE
[dagit] remove mode and graphName from workspace context

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
@@ -79,12 +79,7 @@ const ROOT_WORKSPACE_QUERY = gql`
                   id
                   name
                   isJob
-                  graphName
                   pipelineSnapshotId
-                  modes {
-                    id
-                    name
-                  }
                 }
                 schedules {
                   id

--- a/js_modules/dagit/packages/core/src/workspace/types/RootWorkspaceQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/RootWorkspaceQuery.ts
@@ -15,20 +15,12 @@ export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_d
   value: string;
 }
 
-export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_modes {
-  __typename: "Mode";
-  id: string;
-  name: string;
-}
-
 export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines {
   __typename: "Pipeline";
   id: string;
   name: string;
   isJob: boolean;
-  graphName: string;
   pipelineSnapshotId: string;
-  modes: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_modes[];
 }
 
 export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_scheduleState {


### PR DESCRIPTION
this prevents having to have access to the full job snapshot for all objects in the root workspace query

### How I Tested These Changes

typescript
