### PR TITLE
[dagster-airbyte] Add ability to generate Airbyte assets by pulling config from Airbyte instance

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/__init__.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/__init__.py
@@ -1,6 +1,10 @@
 from dagster._core.utils import check_dagster_package_version
 
-from .asset_defs import build_airbyte_assets, load_assets_from_airbyte_project
+from .asset_defs import (
+    build_airbyte_assets,
+    load_assets_from_airbyte_instance,
+    load_assets_from_airbyte_project,
+)
 from .ops import airbyte_sync_op
 from .resources import AirbyteResource, AirbyteState, airbyte_resource
 from .types import AirbyteOutput

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -314,9 +314,11 @@ def load_assets_from_airbyte_instance(
             )
         assets.extend(assets_for_connection)
 
-    return with_resources(
-        assets,
-        resource_defs={"airbyte": airbyte},
+    return list(
+        with_resources(
+            assets,
+            resource_defs={"airbyte": airbyte},
+        )
     )
 
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -9,6 +9,7 @@ from dagster_airbyte.utils import generate_materializations
 
 from dagster import AssetKey, AssetOut, Output, ResourceDefinition
 from dagster import _check as check
+from dagster import with_resources
 from dagster._annotations import experimental
 from dagster._core.definitions import AssetsDefinition, multi_asset
 from dagster._core.definitions.events import CoercibleToAssetKeyPrefix
@@ -313,7 +314,10 @@ def load_assets_from_airbyte_instance(
             )
         assets.extend(assets_for_connection)
 
-    return assets
+    return with_resources(
+        assets,
+        resource_defs={"airbyte": airbyte},
+    )
 
 
 @experimental

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -3,7 +3,7 @@ import responses
 from dagster_airbyte import airbyte_resource
 from dagster_airbyte.asset_defs import load_assets_from_airbyte_instance
 
-from dagster import AssetKey, build_init_resource_context, materialize, with_resources
+from dagster import AssetKey, build_init_resource_context, materialize
 
 from .utils import (
     get_instance_connections_json,
@@ -102,12 +102,7 @@ def test_load_from_instance(use_normalization_tables, connection_to_group_fn):
         status=200,
     )
 
-    res = materialize(
-        with_resources(
-            ab_assets,
-            resource_defs={"airbyte": ab_instance},
-        )
-    )
+    res = materialize(ab_assets)
 
     materializations = [
         event.event_specific_data.materialization

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
@@ -338,3 +338,222 @@ def get_project_job_json():
             }
         ],
     }
+
+
+def get_instance_workspaces_json():
+    return {
+        "workspaces": [
+            {
+                "workspaceId": "b49ed3cd-7bb4-4f11-b8ba-95b4a5f7bc75",
+            }
+        ]
+    }
+
+
+def get_instance_connections_json():
+    return {
+        "connections": [
+            {
+                "connectionId": "87b7fe85-a22c-420e-8d74-b30e7ede77df",
+                "name": "GitHub <> snowflake-ben",
+                "prefix": "dagster_",
+                "sourceId": "4b8fc3cc-efce-41d7-8654-05c3fc03485e",
+                "destinationId": "028fc82d-3a27-4fef-94a6-a22fbd45bac4",
+                "operationIds": ["f39dbcd0-a6dc-4319-9ae4-28937997b48a"],
+                "syncCatalog": {
+                    "streams": [
+                        {
+                            "stream": {
+                                "name": "releases",
+                                "jsonSchema": {
+                                    "type": "object",
+                                    "$schema": "http://json-schema.org/draft-07/schema#",
+                                    "properties": {
+                                        "id": {"type": ["null", "integer"]},
+                                        "url": {"type": ["null", "string"]},
+                                        "body": {"type": ["null", "string"]},
+                                        "name": {"type": ["null", "string"]},
+                                        "draft": {"type": ["null", "boolean"]},
+                                        "assets": {
+                                            "type": ["null", "array"],
+                                            "items": {
+                                                "type": ["null", "object"],
+                                                "properties": {
+                                                    "id": {"type": ["null", "integer"]},
+                                                    "url": {"type": ["null", "string"]},
+                                                    "name": {"type": ["null", "string"]},
+                                                    "size": {"type": ["null", "integer"]},
+                                                    "label": {"type": ["null", "string"]},
+                                                    "state": {"type": ["null", "string"]},
+                                                    "node_id": {"type": ["null", "string"]},
+                                                    "created_at": {
+                                                        "type": ["null", "string"],
+                                                        "format": "date-time",
+                                                    },
+                                                    "updated_at": {
+                                                        "type": ["null", "string"],
+                                                        "format": "date-time",
+                                                    },
+                                                    "uploader_id": {"type": ["null", "integer"]},
+                                                    "content_type": {"type": ["null", "string"]},
+                                                    "download_count": {"type": ["null", "integer"]},
+                                                    "browser_download_url": {
+                                                        "type": ["null", "string"]
+                                                    },
+                                                },
+                                            },
+                                        },
+                                        "author": {
+                                            "type": ["null", "object"],
+                                            "properties": {
+                                                "id": {"type": ["null", "integer"]},
+                                                "url": {"type": ["null", "string"]},
+                                                "type": {"type": ["null", "string"]},
+                                                "login": {"type": ["null", "string"]},
+                                                "node_id": {"type": ["null", "string"]},
+                                                "html_url": {"type": ["null", "string"]},
+                                                "gists_url": {"type": ["null", "string"]},
+                                                "repos_url": {"type": ["null", "string"]},
+                                                "avatar_url": {"type": ["null", "string"]},
+                                                "events_url": {"type": ["null", "string"]},
+                                                "site_admin": {"type": ["null", "boolean"]},
+                                                "gravatar_id": {"type": ["null", "string"]},
+                                                "starred_url": {"type": ["null", "string"]},
+                                                "followers_url": {"type": ["null", "string"]},
+                                                "following_url": {"type": ["null", "string"]},
+                                                "organizations_url": {"type": ["null", "string"]},
+                                                "subscriptions_url": {"type": ["null", "string"]},
+                                                "received_events_url": {"type": ["null", "string"]},
+                                            },
+                                        },
+                                        "node_id": {"type": ["null", "string"]},
+                                        "html_url": {"type": ["null", "string"]},
+                                        "tag_name": {"type": ["null", "string"]},
+                                        "assets_url": {"type": ["null", "string"]},
+                                        "created_at": {
+                                            "type": ["null", "string"],
+                                            "format": "date-time",
+                                        },
+                                        "prerelease": {"type": ["null", "boolean"]},
+                                        "repository": {"type": ["string"]},
+                                        "upload_url": {"type": ["null", "string"]},
+                                        "tarball_url": {"type": ["null", "string"]},
+                                        "zipball_url": {"type": ["null", "string"]},
+                                        "published_at": {
+                                            "type": ["null", "string"],
+                                            "format": "date-time",
+                                        },
+                                        "target_commitish": {"type": ["null", "string"]},
+                                    },
+                                },
+                                "supportedSyncModes": ["full_refresh", "incremental"],
+                                "sourceDefinedCursor": True,
+                                "defaultCursorField": ["created_at"],
+                                "sourceDefinedPrimaryKey": [["id"]],
+                            },
+                            "config": {
+                                "syncMode": "incremental",
+                                "cursorField": ["created_at"],
+                                "destinationSyncMode": "append_dedup",
+                                "primaryKey": [["id"]],
+                                "aliasName": "releases",
+                                "selected": True,
+                            },
+                        },
+                        {
+                            "stream": {
+                                "name": "tags",
+                                "jsonSchema": {
+                                    "type": "object",
+                                    "$schema": "http://json-schema.org/draft-07/schema#",
+                                    "properties": {
+                                        "name": {"type": ["null", "string"]},
+                                        "commit": {
+                                            "type": ["null", "object"],
+                                            "properties": {
+                                                "sha": {"type": ["null", "string"]},
+                                                "url": {"type": ["null", "string"]},
+                                            },
+                                        },
+                                        "node_id": {"type": ["null", "string"]},
+                                        "repository": {"type": ["string"]},
+                                        "tarball_url": {"type": ["null", "string"]},
+                                        "zipball_url": {"type": ["null", "string"]},
+                                    },
+                                },
+                                "supportedSyncModes": ["full_refresh"],
+                                "defaultCursorField": [],
+                                "sourceDefinedPrimaryKey": [["repository"], ["name"]],
+                            },
+                            "config": {
+                                "syncMode": "full_refresh",
+                                "cursorField": [],
+                                "destinationSyncMode": "append",
+                                "primaryKey": [["repository"], ["name"]],
+                                "aliasName": "tags",
+                                "selected": True,
+                            },
+                        },
+                        {
+                            "stream": {
+                                "name": "teams",
+                                "jsonSchema": {
+                                    "type": "object",
+                                    "$schema": "http://json-schema.org/draft-07/schema#",
+                                    "properties": {
+                                        "id": {"type": ["null", "integer"]},
+                                        "url": {"type": ["null", "string"]},
+                                        "name": {"type": ["null", "string"]},
+                                        "slug": {"type": ["null", "string"]},
+                                        "parent": {
+                                            "type": ["null", "object"],
+                                            "properties": {},
+                                            "additionalProperties": True,
+                                        },
+                                        "node_id": {"type": ["null", "string"]},
+                                        "privacy": {"type": ["null", "string"]},
+                                        "html_url": {"type": ["null", "string"]},
+                                        "permission": {"type": ["null", "string"]},
+                                        "repository": {"type": ["null", "string"]},
+                                        "description": {"type": ["null", "string"]},
+                                        "members_url": {"type": ["null", "string"]},
+                                        "organization": {"type": ["null", "string"]},
+                                        "repositories_url": {"type": ["null", "string"]},
+                                    },
+                                },
+                                "supportedSyncModes": ["full_refresh"],
+                                "defaultCursorField": [],
+                                "sourceDefinedPrimaryKey": [["id"]],
+                            },
+                            "config": {
+                                "syncMode": "full_refresh",
+                                "cursorField": [],
+                                "destinationSyncMode": "append",
+                                "primaryKey": [["id"]],
+                                "aliasName": "teams",
+                                "selected": True,
+                            },
+                        },
+                    ]
+                },
+                "scheduleType": "manual",
+                "status": "active",
+            },
+        ]
+    }
+
+
+def get_instance_operations_json():
+    return {
+        "operations": [
+            {
+                "workspaceId": "b49ed3cd-7bb4-4f11-b8ba-95b4a5f7bc75",
+                "operationId": "f39dbcd0-a6dc-4319-9ae4-28937997b48a",
+                "name": "Normalization",
+                "operatorConfiguration": {
+                    "operatorType": "normalization",
+                    "normalization": {"option": "basic"},
+                },
+            }
+        ]
+    }


### PR DESCRIPTION
## Summary

Adds a new `@experimental` API similar to #9664 that allows users to load Airbyte assets from an Airbyte instance, connecting at initialization-time and pulling connection definitions.

```python
airbyte_instance = airbyte_resource.configured(
    {
        "host": "localhost",
        "port": "8000",
        "forward_logs": False,
    }
)
airbyte_assets = load_assets_from_airbyte_instance(
    airbyte_instance,
)
```

Has the same config options as the 'from project' API.

## Test Plan

Tested locally; new unit tests
