### PR TITLE
[dagit] Virtualized schedules table

### DIFF
--- a/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
@@ -211,6 +211,8 @@ export const TICK_TAG_FRAGMENT = gql`
       ...PythonErrorFragment
     }
   }
+
+  ${PYTHON_ERROR_FRAGMENT}
 `;
 
 const LAUNCHED_RUN_LIST_QUERY = gql`

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesTable.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesTable.tsx
@@ -78,7 +78,7 @@ export const SchedulesTable: React.FC<{
   );
 };
 
-const errorDisplay = (status: InstigationStatus, runningScheduleCount: number) => {
+export const errorDisplay = (status: InstigationStatus, runningScheduleCount: number) => {
   if (status === InstigationStatus.STOPPED && runningScheduleCount === 0) {
     return null;
   } else if (status === InstigationStatus.RUNNING && runningScheduleCount === 1) {

--- a/js_modules/dagit/packages/core/src/ui/VirtualizedTable.tsx
+++ b/js_modules/dagit/packages/core/src/ui/VirtualizedTable.tsx
@@ -1,0 +1,57 @@
+import {Box, Colors} from '@dagster-io/ui';
+import * as React from 'react';
+import styled from 'styled-components/macro';
+
+export const HeaderCell: React.FC = ({children}) => (
+  <Box
+    padding={{vertical: 8, horizontal: 24}}
+    border={{side: 'right', width: 1, color: Colors.KeylineGray}}
+    style={{whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden'}}
+  >
+    {children}
+  </Box>
+);
+
+export const RowCell: React.FC = ({children}) => (
+  <Box
+    padding={{horizontal: 24}}
+    flex={{direction: 'column', justifyContent: 'center'}}
+    style={{color: Colors.Gray500, overflow: 'hidden'}}
+    border={{side: 'right', width: 1, color: Colors.KeylineGray}}
+  >
+    {children}
+  </Box>
+);
+
+export const Container = styled.div`
+  height: 100%;
+  overflow: auto;
+`;
+
+type InnerProps = {
+  $totalHeight: number;
+};
+
+export const Inner = styled.div.attrs<InnerProps>(({$totalHeight}) => ({
+  style: {
+    height: `${$totalHeight}px`,
+  },
+}))<InnerProps>`
+  position: relative;
+  width: 100%;
+`;
+
+type RowProps = {$height: number; $start: number};
+
+export const Row = styled.div.attrs<RowProps>(({$height, $start}) => ({
+  style: {
+    height: `${$height}px`,
+    transform: `translateY(${$start}px)`,
+  },
+}))<RowProps>`
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  overflow: hidden;
+`;

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedJobTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedJobTable.tsx
@@ -13,6 +13,7 @@ import {RunStatusPezList} from '../runs/RunStatusPez';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
 import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
+import {Container, Inner, Row, RowCell} from '../ui/VirtualizedTable';
 import {useRepoExpansionState} from '../ui/useRepoExpansionState';
 
 import {buildPipelineSelector} from './WorkspaceContext';
@@ -234,50 +235,6 @@ const JobRow = (props: JobRowProps) => {
     </Row>
   );
 };
-
-const RowCell: React.FC = ({children}) => (
-  <Box
-    padding={{horizontal: 24}}
-    flex={{direction: 'column', justifyContent: 'center'}}
-    style={{color: Colors.Gray500, overflow: 'hidden'}}
-    border={{side: 'right', width: 1, color: Colors.KeylineGray}}
-  >
-    {children}
-  </Box>
-);
-
-const Container = styled.div`
-  height: 100%;
-  overflow: auto;
-`;
-
-type InnerProps = {
-  $totalHeight: number;
-};
-
-const Inner = styled.div.attrs<InnerProps>(({$totalHeight}) => ({
-  style: {
-    height: `${$totalHeight}px`,
-  },
-}))<InnerProps>`
-  position: relative;
-  width: 100%;
-`;
-
-type RowProps = {$height: number; $start: number};
-
-const Row = styled.div.attrs<RowProps>(({$height, $start}) => ({
-  style: {
-    height: `${$height}px`,
-    transform: `translateY(${$start}px)`,
-  },
-}))<RowProps>`
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-  overflow: hidden;
-`;
 
 const RowGrid = styled(Box)`
   display: grid;

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleTable.tsx
@@ -1,0 +1,336 @@
+import {gql, useLazyQuery} from '@apollo/client';
+import {Box, Button, Caption, Colors, Icon, Menu, Popover, Tag, Tooltip} from '@dagster-io/ui';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+import styled from 'styled-components/macro';
+
+import {LastRunSummary} from '../instance/LastRunSummary';
+import {TickTag, TICK_TAG_FRAGMENT} from '../instigation/InstigationTick';
+import {PipelineReference} from '../pipelines/PipelineReference';
+import {RepoSectionHeader} from '../runs/RepoSectionHeader';
+import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
+import {ScheduleSwitch, SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
+import {errorDisplay} from '../schedules/SchedulesTable';
+import {TimestampDisplay} from '../schedules/TimestampDisplay';
+import {humanCronString} from '../schedules/humanCronString';
+import {InstigationStatus, InstigationType} from '../types/globalTypes';
+import {MenuLink} from '../ui/MenuLink';
+import {Container, Inner, Row, RowCell} from '../ui/VirtualizedTable';
+import {useRepoExpansionState} from '../ui/useRepoExpansionState';
+
+import {isThisThingAJob, useRepository} from './WorkspaceContext';
+import {repoAddressAsString} from './repoAddressAsString';
+import {RepoAddress} from './types';
+import {SingleScheduleQuery, SingleScheduleQueryVariables} from './types/SingleScheduleQuery';
+import {workspacePathFromAddress} from './workspacePath';
+
+type Repository = {
+  repoAddress: RepoAddress;
+  schedules: string[];
+};
+
+interface Props {
+  repos: Repository[];
+}
+
+type RowType =
+  | {type: 'header'; repoAddress: RepoAddress; scheduleCount: number}
+  | {type: 'schedule'; repoAddress: RepoAddress; name: string};
+
+const SCHEDULES_EXPANSION_STATE_STORAGE_KEY = 'schedules-virtualized-expansion-state';
+
+export const VirtualizedScheduleTable: React.FC<Props> = ({repos}) => {
+  const parentRef = React.useRef<HTMLDivElement | null>(null);
+  const {expandedKeys, onToggle} = useRepoExpansionState(SCHEDULES_EXPANSION_STATE_STORAGE_KEY);
+
+  const flattened: RowType[] = React.useMemo(() => {
+    const flat: RowType[] = [];
+    repos.forEach(({repoAddress, schedules}) => {
+      flat.push({type: 'header', repoAddress, scheduleCount: schedules.length});
+      const repoKey = repoAddressAsString(repoAddress);
+      if (expandedKeys.includes(repoKey)) {
+        schedules.forEach((name) => {
+          flat.push({type: 'schedule', repoAddress, name});
+        });
+      }
+    });
+    return flat;
+  }, [repos, expandedKeys]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: flattened.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: (ii: number) => {
+      const row = flattened[ii];
+      return row?.type === 'header' ? 32 : 64;
+    },
+    overscan: 10,
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const items = rowVirtualizer.getVirtualItems();
+
+  return (
+    <Container ref={parentRef}>
+      <Inner $totalHeight={totalHeight}>
+        {items.map(({index, key, size, start}) => {
+          const row: RowType = flattened[index];
+          const type = row!.type;
+          return type === 'header' ? (
+            <RepoRow
+              repoAddress={row.repoAddress}
+              jobCount={row.scheduleCount}
+              key={key}
+              height={size}
+              start={start}
+              onToggle={onToggle}
+            />
+          ) : (
+            <ScheduleRow
+              key={key}
+              name={row.name}
+              repoAddress={row.repoAddress}
+              height={size}
+              start={start}
+            />
+          );
+        })}
+      </Inner>
+    </Container>
+  );
+};
+
+const RepoRow: React.FC<{
+  repoAddress: RepoAddress;
+  jobCount: number;
+  height: number;
+  start: number;
+  onToggle: (repoAddress: RepoAddress) => void;
+}> = ({repoAddress, jobCount, height, start, onToggle}) => {
+  return (
+    <Row $height={height} $start={start}>
+      <RepoSectionHeader
+        repoName={repoAddress.name}
+        repoLocation={repoAddress.location}
+        expanded
+        onClick={() => onToggle(repoAddress)}
+        showLocation={false}
+        rightElement={<Tag intent="primary">{jobCount}</Tag>}
+      />
+    </Row>
+  );
+};
+
+const JOB_QUERY_DELAY = 300;
+
+interface ScheduleRowProps {
+  name: string;
+  repoAddress: RepoAddress;
+  height: number;
+  start: number;
+}
+
+const ScheduleRow = (props: ScheduleRowProps) => {
+  const {name, repoAddress, start, height} = props;
+
+  const repo = useRepository(repoAddress);
+
+  const [queryJob, {data, loading}] = useLazyQuery<
+    SingleScheduleQuery,
+    SingleScheduleQueryVariables
+  >(SINGLE_SCHEDULE_QUERY, {
+    fetchPolicy: 'cache-and-network',
+    variables: {
+      selector: {
+        repositoryName: repoAddress.name,
+        repositoryLocationName: repoAddress.location,
+        scheduleName: name,
+      },
+    },
+  });
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => {
+      queryJob();
+    }, JOB_QUERY_DELAY);
+
+    return () => clearTimeout(timer);
+  }, [queryJob, name]);
+
+  const scheduleData = React.useMemo(() => {
+    if (data?.scheduleOrError.__typename !== 'Schedule') {
+      return null;
+    }
+
+    return data.scheduleOrError;
+  }, [data]);
+
+  const isJob = !!(scheduleData && isThisThingAJob(repo, scheduleData.pipelineName));
+
+  return (
+    <Row $height={height} $start={start}>
+      <RowGrid border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
+        <RowCell>
+          {scheduleData ? (
+            <Box flex={{direction: 'column', gap: 4}}>
+              {/* Keyed so that a new switch is always rendered, otherwise it's reused and animates on/off */}
+              <ScheduleSwitch key={name} repoAddress={repoAddress} schedule={scheduleData} />
+              {errorDisplay(
+                scheduleData.scheduleState.status,
+                scheduleData.scheduleState.runningCount,
+              )}
+            </Box>
+          ) : null}
+        </RowCell>
+        <RowCell>
+          <Box flex={{direction: 'column', gap: 4}}>
+            <span style={{fontWeight: 500}}>
+              <Link to={workspacePathFromAddress(repoAddress, `/schedules/${name}`)}>{name}</Link>
+            </span>
+            {scheduleData ? (
+              <Caption>
+                <PipelineReference
+                  showIcon
+                  size="small"
+                  pipelineName={scheduleData.pipelineName}
+                  pipelineHrefContext={repoAddress}
+                  isJob={isJob}
+                />
+              </Caption>
+            ) : null}
+          </Box>
+        </RowCell>
+        <RowCell>
+          {scheduleData ? (
+            <Box flex={{direction: 'column', gap: 4}}>
+              <Tooltip position="bottom" content={scheduleData.cronSchedule}>
+                <span style={{color: Colors.Dark}}>
+                  {humanCronString(
+                    scheduleData.cronSchedule,
+                    scheduleData.executionTimezone || 'UTC',
+                  )}
+                </span>
+              </Tooltip>
+              <Caption>
+                Next tick:&nbsp;
+                {scheduleData.scheduleState.nextTick &&
+                scheduleData.scheduleState.status === InstigationStatus.RUNNING ? (
+                  <TimestampDisplay
+                    timestamp={scheduleData.scheduleState.nextTick.timestamp}
+                    timezone={scheduleData.executionTimezone}
+                    timeFormat={{showSeconds: false, showTimezone: true}}
+                  />
+                ) : (
+                  'None'
+                )}
+              </Caption>
+            </Box>
+          ) : (
+            <div style={{color: Colors.Gray500}}>{loading && !data ? 'Loading' : 'None'}</div>
+          )}
+        </RowCell>
+        <RowCell>
+          {scheduleData?.scheduleState.ticks.length ? (
+            <div>
+              <TickTag
+                tick={scheduleData.scheduleState.ticks[0]}
+                instigationType={InstigationType.SCHEDULE}
+              />
+            </div>
+          ) : (
+            <div style={{color: Colors.Gray500}}>{loading && !data ? 'Loading' : 'None'}</div>
+          )}
+        </RowCell>
+        <RowCell>
+          {scheduleData?.scheduleState && scheduleData?.scheduleState.runs.length > 0 ? (
+            <LastRunSummary
+              run={scheduleData.scheduleState.runs[0]}
+              name={name}
+              showButton={false}
+              showHover
+            />
+          ) : (
+            <div style={{color: Colors.Gray500}}>{loading && !data ? 'Loading' : 'None'}</div>
+          )}
+        </RowCell>
+        <RowCell>
+          {scheduleData?.partitionSet ? (
+            <Popover
+              content={
+                <Menu>
+                  <MenuLink
+                    text="View partition history"
+                    icon="dynamic_feed"
+                    target="_blank"
+                    to={workspacePathFromAddress(
+                      repoAddress,
+                      `/${isJob ? 'jobs' : 'pipelines'}/${scheduleData.pipelineName}/partitions`,
+                    )}
+                  />
+                  <MenuLink
+                    text="Launch partition backfill"
+                    icon="add_circle"
+                    target="_blank"
+                    to={workspacePathFromAddress(
+                      repoAddress,
+                      `/${isJob ? 'jobs' : 'pipelines'}/${scheduleData.pipelineName}/partitions`,
+                    )}
+                  />
+                </Menu>
+              }
+              position="bottom-left"
+            >
+              <Button icon={<Icon name="expand_more" />} />
+            </Popover>
+          ) : (
+            <div style={{color: Colors.Gray500}}>{loading && !data ? 'Loading' : 'None'}</div>
+          )}
+        </RowCell>
+      </RowGrid>
+    </Row>
+  );
+};
+
+const RowGrid = styled(Box)`
+  display: grid;
+  grid-template-columns: 76px 28% 30% 10% 20% 10%;
+  height: 100%;
+`;
+
+const SINGLE_SCHEDULE_QUERY = gql`
+  query SingleScheduleQuery($selector: ScheduleSelector!) {
+    scheduleOrError(scheduleSelector: $selector) {
+      ... on Schedule {
+        id
+        name
+        pipelineName
+        description
+        scheduleState {
+          id
+          runningCount
+          ticks(limit: 1) {
+            id
+            ...TickTagFragment
+          }
+          runs(limit: 1) {
+            id
+            ...RunTimeFragment
+          }
+          nextTick {
+            timestamp
+          }
+        }
+        partitionSet {
+          id
+          name
+        }
+        ...ScheduleSwitchFragment
+      }
+    }
+  }
+
+  ${SCHEDULE_SWITCH_FRAGMENT}
+  ${TICK_TAG_FRAGMENT}
+  ${RUN_TIME_FRAGMENT}
+`;

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
@@ -14,6 +14,7 @@ import {WorkspaceJobsRoot} from './WorkspaceJobsRoot';
 import {WorkspaceOverviewRoot} from './WorkspaceOverviewRoot';
 import {WorkspacePipelineRoot} from './WorkspacePipelineRoot';
 import {WorkspaceRepoRoot} from './WorkspaceRepoRoot';
+import {WorkspaceSchedulesRoot} from './WorkspaceSchedulesRoot';
 import {repoAddressFromPath} from './repoAddressFromPath';
 
 const RepoRouteContainer = () => {
@@ -123,6 +124,11 @@ export const WorkspaceRoot = () => {
         {flagNewWorkspace ? (
           <Route path="/workspace/jobs" exact>
             <WorkspaceJobsRoot />
+          </Route>
+        ) : null}
+        {flagNewWorkspace ? (
+          <Route path="/workspace/schedules" exact>
+            <WorkspaceSchedulesRoot />
           </Route>
         ) : null}
         <Route path={['/workspace/pipelines/:pipelinePath', '/workspace/jobs/:pipelinePath']}>

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceSchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceSchedulesRoot.tsx
@@ -4,60 +4,42 @@ import * as React from 'react';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {useTrackPageView} from '../app/analytics';
-import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {RepoFilterButton} from '../instance/RepoFilterButton';
-import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {HeaderCell} from '../ui/VirtualizedTable';
 
-import {VirtualizedJobTable} from './VirtualizedJobTable';
+import {VirtualizedScheduleTable} from './VirtualizedScheduleTable';
 import {WorkspaceContext} from './WorkspaceContext';
 import {WorkspaceTabs} from './WorkspaceTabs';
 import {buildRepoAddress} from './buildRepoAddress';
-import {repoAddressAsString} from './repoAddressAsString';
 import {RepoAddress} from './types';
-import {WorkspaceJobsQuery} from './types/WorkspaceJobsQuery';
+import {WorkspaceSchedulesQuery} from './types/WorkspaceSchedulesQuery';
 
-export const WorkspaceJobsRoot = () => {
+export const WorkspaceSchedulesRoot = () => {
   useTrackPageView();
 
   const [searchValue, setSearchValue] = React.useState('');
-  const {allRepos, visibleRepos} = React.useContext(WorkspaceContext);
+  const {allRepos} = React.useContext(WorkspaceContext);
   const repoCount = allRepos.length;
 
-  const queryResultOverview = useQuery<WorkspaceJobsQuery>(WORKSPACE_JOBS_QUERY, {
+  const queryResultOverview = useQuery<WorkspaceSchedulesQuery>(WORKSPACE_SCHEDULES_QUERY, {
     fetchPolicy: 'network-only',
     notifyOnNetworkStatusChange: true,
   });
   const {data, loading} = queryResultOverview;
 
-  // Batch up the data and bucket by repo.
   const repoBuckets = useRepoBuckets(data);
-
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
   const anySearch = sanitizedSearch.length > 0;
 
-  const filteredRepoBuckets = React.useMemo(() => {
-    const visibleRepoKeys = new Set(
-      visibleRepos.map((option) =>
-        repoAddressAsString(
-          buildRepoAddress(option.repository.name, option.repositoryLocation.name),
-        ),
-      ),
-    );
-    return repoBuckets.filter(({repoAddress}) =>
-      visibleRepoKeys.has(repoAddressAsString(repoAddress)),
-    );
-  }, [repoBuckets, visibleRepos]);
-
   const filteredBySearch = React.useMemo(() => {
     const searchToLower = sanitizedSearch.toLocaleLowerCase();
-    return filteredRepoBuckets
-      .map(({repoAddress, jobs}) => ({
+    return repoBuckets
+      .map(({repoAddress, schedules}) => ({
         repoAddress,
-        jobs: jobs.filter(({name}) => name.toLocaleLowerCase().includes(searchToLower)),
+        schedules: schedules.filter((name) => name.toLocaleLowerCase().includes(searchToLower)),
       }))
-      .filter(({jobs}) => jobs.length > 0);
-  }, [filteredRepoBuckets, sanitizedSearch]);
+      .filter(({schedules}) => schedules.length > 0);
+  }, [repoBuckets, sanitizedSearch]);
 
   const content = () => {
     if (loading && !data) {
@@ -65,7 +47,7 @@ export const WorkspaceJobsRoot = () => {
         <Box flex={{direction: 'row', justifyContent: 'center'}} style={{paddingTop: '100px'}}>
           <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
             <Spinner purpose="body-text" />
-            <div style={{color: Colors.Gray600}}>Loading jobs…</div>
+            <div style={{color: Colors.Gray600}}>Loading schedules…</div>
           </Box>
         </Box>
       );
@@ -77,10 +59,10 @@ export const WorkspaceJobsRoot = () => {
           <Box padding={{top: 20}}>
             <NonIdealState
               icon="search"
-              title="No matching jobs"
+              title="No matching schedules"
               description={
                 <div>
-                  No jobs matching <strong>{searchValue}</strong> were found in this workspace
+                  No schedules matching <strong>{searchValue}</strong> were found in this workspace
                 </div>
               }
             />
@@ -92,8 +74,8 @@ export const WorkspaceJobsRoot = () => {
         <Box padding={{top: 20}}>
           <NonIdealState
             icon="search"
-            title="No jobs"
-            description="No jobs were found in this workspace"
+            title="No schedules"
+            description="No schedules were found in this workspace"
           />
         </Box>
       );
@@ -105,20 +87,21 @@ export const WorkspaceJobsRoot = () => {
           border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
           style={{
             display: 'grid',
-            gridTemplateColumns: '34% 30% 20% 8% 8%',
+            gridTemplateColumns: '76px 28% 30% 10% 20% 10%',
             height: '32px',
             fontSize: '12px',
             color: Colors.Gray600,
           }}
         >
+          <HeaderCell />
           <HeaderCell>Job name</HeaderCell>
-          <HeaderCell>Schedules/sensors</HeaderCell>
-          <HeaderCell>Latest run</HeaderCell>
-          <HeaderCell>Run history</HeaderCell>
+          <HeaderCell>Schedule</HeaderCell>
+          <HeaderCell>Last tick</HeaderCell>
+          <HeaderCell>Last run</HeaderCell>
           <HeaderCell>Actions</HeaderCell>
         </Box>
         <div style={{overflow: 'hidden'}}>
-          <VirtualizedJobTable repos={filteredBySearch} />
+          <VirtualizedScheduleTable repos={filteredBySearch} />
         </div>
       </>
     );
@@ -126,17 +109,17 @@ export const WorkspaceJobsRoot = () => {
 
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
-      <PageHeader title={<Heading>Workspace</Heading>} tabs={<WorkspaceTabs tab="jobs" />} />
+      <PageHeader title={<Heading>Workspace</Heading>} tabs={<WorkspaceTabs tab="schedules" />} />
       <Box
         padding={{horizontal: 24, vertical: 16}}
         flex={{direction: 'row', alignItems: 'center', gap: 12, grow: 0}}
       >
-        {repoCount > 1 ? <RepoFilterButton /> : null}
+        {repoCount > 0 ? <RepoFilterButton /> : null}
         <TextInput
           icon="search"
           value={searchValue}
           onChange={(e) => setSearchValue(e.target.value)}
-          placeholder="Filter by job name…"
+          placeholder="Filter by schedule name…"
           style={{width: '340px'}}
         />
       </Box>
@@ -153,13 +136,10 @@ export const WorkspaceJobsRoot = () => {
 
 type RepoBucket = {
   repoAddress: RepoAddress;
-  jobs: {
-    isJob: boolean;
-    name: string;
-  }[];
+  schedules: string[];
 };
 
-const useRepoBuckets = (data?: WorkspaceJobsQuery): RepoBucket[] => {
+const useRepoBuckets = (data?: WorkspaceSchedulesQuery): RepoBucket[] => {
   return React.useMemo(() => {
     if (data?.workspaceOrError.__typename !== 'Workspace') {
       return [];
@@ -175,21 +155,14 @@ const useRepoBuckets = (data?: WorkspaceJobsQuery): RepoBucket[] => {
       }
 
       for (const repo of entry.repositories) {
-        const {name, pipelines} = repo;
+        const {name, schedules} = repo;
         const repoAddress = buildRepoAddress(name, entry.name);
-        const jobs = pipelines
-          .filter(({name}) => !isHiddenAssetGroupJob(name))
-          .map((pipeline) => {
-            return {
-              isJob: pipeline.isJob,
-              name: pipeline.name,
-            };
-          });
+        const scheduleNames = schedules.map(({name}) => name);
 
-        if (jobs.length > 0) {
+        if (scheduleNames.length > 0) {
           buckets.push({
             repoAddress,
-            jobs,
+            schedules: scheduleNames,
           });
         }
       }
@@ -199,8 +172,8 @@ const useRepoBuckets = (data?: WorkspaceJobsQuery): RepoBucket[] => {
   }, [data]);
 };
 
-export const WORKSPACE_JOBS_QUERY = gql`
-  query WorkspaceJobsQuery {
+const WORKSPACE_SCHEDULES_QUERY = gql`
+  query WorkspaceSchedulesQuery {
     workspaceOrError {
       ... on Workspace {
         locationEntries {
@@ -212,10 +185,10 @@ export const WORKSPACE_JOBS_QUERY = gql`
               repositories {
                 id
                 name
-                pipelines {
+                schedules {
                   id
                   name
-                  isJob
+                  description
                 }
               }
             }
@@ -228,40 +201,4 @@ export const WORKSPACE_JOBS_QUERY = gql`
   }
 
   ${PYTHON_ERROR_FRAGMENT}
-`;
-
-export const RECENT_RUNS_PER_JOB_QUERY = gql`
-  query RecentRunsPerJobQuery {
-    workspaceOrError {
-      ... on Workspace {
-        locationEntries {
-          id
-          locationOrLoadError {
-            ... on RepositoryLocation {
-              id
-              name
-              repositories {
-                id
-                name
-                pipelines {
-                  id
-                  name
-                  isJob
-                  runs(limit: 5) {
-                    id
-                    ...RunTimeFragment
-                  }
-                }
-              }
-            }
-            ...PythonErrorFragment
-          }
-        }
-      }
-      ...PythonErrorFragment
-    }
-  }
-
-  ${PYTHON_ERROR_FRAGMENT}
-  ${RUN_TIME_FRAGMENT}
 `;

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceTabs.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceTabs.tsx
@@ -18,8 +18,8 @@ export const WorkspaceTabs = <TData extends Record<string, any>>(props: Props<TD
     <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
       <Tabs selectedTabId={tab}>
         <TabLink id="jobs" title="Jobs" to="/workspace/jobs" />
-        {/* <TabLink id="schedules" title="Schedules" to="/workspace/schedules" />
-        <TabLink id="sensors" title="Sensors" to="/workspace/sensors" />
+        <TabLink id="schedules" title="Schedules" to="/workspace/schedules" />
+        {/* <TabLink id="sensors" title="Sensors" to="/workspace/sensors" />
         <TabLink id="graphs" title="Graphs" to="/workspace/graphs" />
         <TabLink id="ops" title="Ops" to="/workspace/ops" /> */}
       </Tabs>

--- a/js_modules/dagit/packages/core/src/workspace/types/SingleScheduleQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/SingleScheduleQuery.ts
@@ -1,0 +1,92 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { ScheduleSelector, InstigationTickStatus, RunStatus, InstigationStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: SingleScheduleQuery
+// ====================================================
+
+export interface SingleScheduleQuery_scheduleOrError_ScheduleNotFoundError {
+  __typename: "ScheduleNotFoundError" | "PythonError";
+}
+
+export interface SingleScheduleQuery_scheduleOrError_Schedule_scheduleState_ticks_error_causes {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface SingleScheduleQuery_scheduleOrError_Schedule_scheduleState_ticks_error {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  causes: SingleScheduleQuery_scheduleOrError_Schedule_scheduleState_ticks_error_causes[];
+}
+
+export interface SingleScheduleQuery_scheduleOrError_Schedule_scheduleState_ticks {
+  __typename: "InstigationTick";
+  id: string;
+  status: InstigationTickStatus;
+  timestamp: number;
+  skipReason: string | null;
+  runIds: string[];
+  runKeys: string[];
+  error: SingleScheduleQuery_scheduleOrError_Schedule_scheduleState_ticks_error | null;
+}
+
+export interface SingleScheduleQuery_scheduleOrError_Schedule_scheduleState_runs {
+  __typename: "Run";
+  id: string;
+  runId: string;
+  status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
+}
+
+export interface SingleScheduleQuery_scheduleOrError_Schedule_scheduleState_nextTick {
+  __typename: "FutureInstigationTick";
+  timestamp: number;
+}
+
+export interface SingleScheduleQuery_scheduleOrError_Schedule_scheduleState {
+  __typename: "InstigationState";
+  id: string;
+  runningCount: number;
+  ticks: SingleScheduleQuery_scheduleOrError_Schedule_scheduleState_ticks[];
+  runs: SingleScheduleQuery_scheduleOrError_Schedule_scheduleState_runs[];
+  nextTick: SingleScheduleQuery_scheduleOrError_Schedule_scheduleState_nextTick | null;
+  selectorId: string;
+  status: InstigationStatus;
+}
+
+export interface SingleScheduleQuery_scheduleOrError_Schedule_partitionSet {
+  __typename: "PartitionSet";
+  id: string;
+  name: string;
+}
+
+export interface SingleScheduleQuery_scheduleOrError_Schedule {
+  __typename: "Schedule";
+  id: string;
+  name: string;
+  pipelineName: string;
+  description: string | null;
+  scheduleState: SingleScheduleQuery_scheduleOrError_Schedule_scheduleState;
+  partitionSet: SingleScheduleQuery_scheduleOrError_Schedule_partitionSet | null;
+  cronSchedule: string;
+  executionTimezone: string | null;
+}
+
+export type SingleScheduleQuery_scheduleOrError = SingleScheduleQuery_scheduleOrError_ScheduleNotFoundError | SingleScheduleQuery_scheduleOrError_Schedule;
+
+export interface SingleScheduleQuery {
+  scheduleOrError: SingleScheduleQuery_scheduleOrError;
+}
+
+export interface SingleScheduleQueryVariables {
+  selector: ScheduleSelector;
+}

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceSchedulesQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceSchedulesQuery.ts
@@ -1,0 +1,74 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: WorkspaceSchedulesQuery
+// ====================================================
+
+export interface WorkspaceSchedulesQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules {
+  __typename: "Schedule";
+  id: string;
+  name: string;
+  description: string | null;
+}
+
+export interface WorkspaceSchedulesQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories {
+  __typename: "Repository";
+  id: string;
+  name: string;
+  schedules: WorkspaceSchedulesQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules[];
+}
+
+export interface WorkspaceSchedulesQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation {
+  __typename: "RepositoryLocation";
+  id: string;
+  name: string;
+  repositories: WorkspaceSchedulesQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories[];
+}
+
+export interface WorkspaceSchedulesQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError_causes {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface WorkspaceSchedulesQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  causes: WorkspaceSchedulesQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError_causes[];
+}
+
+export type WorkspaceSchedulesQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError = WorkspaceSchedulesQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation | WorkspaceSchedulesQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError;
+
+export interface WorkspaceSchedulesQuery_workspaceOrError_Workspace_locationEntries {
+  __typename: "WorkspaceLocationEntry";
+  id: string;
+  locationOrLoadError: WorkspaceSchedulesQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError | null;
+}
+
+export interface WorkspaceSchedulesQuery_workspaceOrError_Workspace {
+  __typename: "Workspace";
+  locationEntries: WorkspaceSchedulesQuery_workspaceOrError_Workspace_locationEntries[];
+}
+
+export interface WorkspaceSchedulesQuery_workspaceOrError_PythonError_causes {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface WorkspaceSchedulesQuery_workspaceOrError_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  causes: WorkspaceSchedulesQuery_workspaceOrError_PythonError_causes[];
+}
+
+export type WorkspaceSchedulesQuery_workspaceOrError = WorkspaceSchedulesQuery_workspaceOrError_Workspace | WorkspaceSchedulesQuery_workspaceOrError_PythonError;
+
+export interface WorkspaceSchedulesQuery {
+  workspaceOrError: WorkspaceSchedulesQuery_workspaceOrError;
+}


### PR DESCRIPTION
### Summary & Motivation

A first pass at a virtualized Schedules table to new Workspace page.

<img width="1448" alt="Screen Shot 2022-09-15 at 1 21 41 PM" src="https://user-images.githubusercontent.com/2823852/190482447-60c90f0f-0181-48de-a547-9632be1c40cf.png">


### How I Tested These Changes

View Dagit with new workspace page flag enabled, click Workspace, then Schedules. Verify rendering of virtualized table, incuding fanout of individual row queries.
