### PR TITLE
Fixes for multi_asset_sensor

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -409,7 +409,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
                 Mapping of AssetKey to a mapping of partitions to EventLogRecords where the
                 EventLogRecord is the most recent materialization event for the partition.
                 Filters for materializations in partitions after the cursor. The mapping
-                preserves the order of
+                preserves the order that the materializations occurred.
 
         Example:
             .. code-block:: python

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -175,7 +175,8 @@ class TimeWindowPartitionsDefinition(
             else:
                 break
 
-        return result
+        current_partitions = [partition.name for partition in self.get_partitions()]
+        return [partition for partition in result if partition in current_partitions]
 
     @public  # type: ignore
     @property

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
@@ -500,7 +500,7 @@ def test_invalid_partition_mapping():
         ctx = build_multi_asset_sensor_context(
             [july_daily_partitions.key], instance=instance, repository_def=my_repo
         )
-        with pytest.raises(DagsterInvalidInvocationError):
+        with pytest.warns(UserWarning):
             list(asset_sensor(ctx))
 
 


### PR DESCRIPTION
This PR fixes a couple small bugs on the `multi_asset_sensor`:
- Fixes `latest_materialization_records_by_partition` to return materializations in order they occurred
- Fixes `advance_cursor` to not overwrite the entire cursor dictionary and only update provided values
- Updates `get_downstream_partition_keys` to warn instead of error for time window partitions if a partition doesn't exist yet (e.g. Daily partition 9/15/2022 materialized but because the week hasn't ended downstream weekly partition 9/11/2022 does not exist). 