### PR TITLE
making it possible to skip debug log within polling loop

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -251,9 +251,14 @@ class DatabricksJobRunner:
                 time.sleep(waiter_delay)
         log.warn("Could not retrieve cluster logs!")
 
-    def wait_for_run_to_complete(self, log, databricks_run_id):
+    def wait_for_run_to_complete(self, log, databricks_run_id, verbose_logs=True):
         return wait_for_run_to_complete(
-            self.client, log, databricks_run_id, self.poll_interval_sec, self.max_wait_time_sec
+            self.client,
+            log,
+            databricks_run_id,
+            self.poll_interval_sec,
+            self.max_wait_time_sec,
+            verbose_logs,
         )
 
 
@@ -263,6 +268,7 @@ def poll_run_state(
     start_poll_time: float,
     databricks_run_id: int,
     max_wait_time_sec: float,
+    verbose_logs: bool = True,
 ):
     run_state = client.get_run_state(databricks_run_id)
     if run_state.has_terminated():
@@ -278,7 +284,8 @@ def poll_run_state(
             log.error(error_message)
             raise DatabricksError(error_message)
     else:
-        log.debug("Run %s in state %s" % (databricks_run_id, run_state))
+        if verbose_logs:
+            log.debug("Run %s in state %s" % (databricks_run_id, run_state))
     if time.time() - start_poll_time > max_wait_time_sec:
         raise DatabricksError(
             "Job run {} took more than {}s to complete; failing".format(
@@ -288,12 +295,14 @@ def poll_run_state(
     return False
 
 
-def wait_for_run_to_complete(client, log, databricks_run_id, poll_interval_sec, max_wait_time_sec):
+def wait_for_run_to_complete(
+    client, log, databricks_run_id, poll_interval_sec, max_wait_time_sec, verbose_logs=True
+):
     """Wait for a Databricks run to complete."""
     check.int_param(databricks_run_id, "databricks_run_id")
     log.info("Waiting for Databricks run %s to complete..." % databricks_run_id)
     start = time.time()
     while True:
-        if poll_run_state(client, log, start, databricks_run_id, max_wait_time_sec):
+        if poll_run_state(client, log, start, databricks_run_id, max_wait_time_sec, verbose_logs):
             return
         time.sleep(poll_interval_sec)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
@@ -111,7 +111,7 @@ def test_databricks_wait_for_run(mock_submit_run, databricks_run_config):
             return calls["final_state"]
 
     with mock.patch.object(runner.client, "get_run_state", new=new_get_run_state):
-        runner.wait_for_run_to_complete(context.log, databricks_run_id)
+        runner.wait_for_run_to_complete(context.log, databricks_run_id, verbose_logs=True)
 
     calls["num_calls"] = 0
     calls["final_state"] = DatabricksRunState(
@@ -121,5 +121,5 @@ def test_databricks_wait_for_run(mock_submit_run, databricks_run_config):
     )
     with pytest.raises(DatabricksError) as exc_info:
         with mock.patch.object(runner.client, "get_run_state", new=new_get_run_state):
-            runner.wait_for_run_to_complete(context.log, databricks_run_id)
+            runner.wait_for_run_to_complete(context.log, databricks_run_id, verbose_logs=True)
     assert "Run 1 failed with result state" in str(exc_info.value)


### PR DESCRIPTION
### Summary & Motivation

When executing a long-running op or fan-out of ops that use the DatabricksPySparkStepLauncher, a debug log statement that is embedded in the loop that checks the job status and retrieves job events can produce tens of thousands of log messages. When viewing a run, Dagit appears to have to load all log messages regardless of whether or not the 'debug' filter toggle is selected, and slows to a crawl (in some cases completely failing to load). This is particularly a problem when running a fan-out with lots of Databricks jobs running in parallel.

### How I Tested These Changes
1) Ran the included unit tests. 
2) Locally created a wheel from the dagster-databirkcs subpackage, installed it in a local environment and ran a dagster job with 3 ops that used the databricks step launcher with `verbose_logs=False`. This resulted in no debug logs while polling databricks for completion.