### PR TITLE
fix repeat file import

### DIFF
--- a/python_modules/dagster/dagster/_seven/__init__.py
+++ b/python_modules/dagster/dagster/_seven/__init__.py
@@ -38,18 +38,17 @@ def import_module_from_path(module_name: str, path_to_file: str) -> ModuleType:
                 module_name=module_name, path_to_file=path_to_file
             )
         )
-    if (
-        sys.modules.get(spec.name)
-        and spec.origin
-        and sys.modules[spec.name].__file__ == os.path.abspath(spec.origin)
-    ):
-        module = sys.modules[spec.name]
-    else:
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[spec.name] = module
-        assert spec.loader
-        spec.loader.exec_module(module)
 
+    if sys.modules.get(spec.name) and spec.origin:
+        f = sys.modules[spec.name].__file__
+        # __file__ can be relative depending on current working directory
+        if f and os.path.abspath(f) == os.path.abspath(spec.origin):
+            return sys.modules[spec.name]
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader
+    spec.loader.exec_module(module)
     return module
 
 


### PR DESCRIPTION
noticed this during debuging large workspaces seeing repeat repository construction


https://stackoverflow.com/questions/7116889/is-module-file-attribute-absolute-or-relative


### How I Tested These Changes

target.py
```
from dagster import repository

print("loading file")


@repository
def o():
    print("loading repo")
    return []
```

before:
```
(py39) ~/dagster:master$ dagit -f /tmp/target.py
loading file
loading repo
2022-09-16 12:23:58 -0500 - dagit - INFO - Serving dagit on http://127.0.0.1:3000 in process 57298
^C
Aborted!
(py39) ~/dagster:master$ cd /tmp
(py39) /tmp:$ dagit -f target.py
loading file
loading repo
loading file
loading repo

2022-09-16 12:24:07 -0500 - dagit - INFO - Serving dagit on http://127.0.0.1:3000 in process 57312
```

after

```

(py39) /tmp:$ dagit -f target.py
loading file
loading repo
2022-09-16 12:22:48 -0500 - dagit - INFO - Serving dagit on http://127.0.0.1:3000 in process 56682
^C
Aborted!
(py39) /tmp:$ cd
(py39) ~:$ dagit -f /tmp/target.py
loading file
loading repo
2022-09-16 12:23:04 -0500 - dagit - INFO - Serving dagit on http://127.0.0.1:3000 in process 56710
```