### PR TITLE
dbt > dbt Cloud

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -480,7 +480,7 @@
         "path": "/integrations/dbt"
       },
       {
-        "title": "dbt",
+        "title": "dbt Cloud",
         "path": "/integrations/dbt_cloud"
       },
       {


### PR DESCRIPTION
This PR fixes a duplicate entry in the sidenav for `dbt`, which should've been `dbt Cloud`