### PR TITLE
remove output_description

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1044,12 +1044,11 @@ def external_asset_graph_from_defs(
                 or node_def.name,
                 graph_name=graph_name,
                 op_names=op_names_by_asset_key[asset_key],
-                op_description=node_def.description,
+                op_description=node_def.description or output_def.description,
                 node_definition_name=node_def.name,
                 job_names=job_names,
                 partitions_def_data=partitions_def_data,
                 output_name=output_def.name,
-                output_description=output_def.description,
                 metadata_entries=asset_metadata_entries,
                 # assets defined by Out(asset_key="k") do not have any group
                 # name specified we default to DEFAULT_GROUP_NAME here to ensure

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -44,7 +44,6 @@ def test_single_asset_job():
             node_definition_name="asset1",
             job_names=["assets_job"],
             output_name="result",
-            output_description=None,
             group_name=DEFAULT_GROUP_NAME,
         )
     ]
@@ -110,7 +109,6 @@ def test_two_asset_job():
             op_description=None,
             job_names=["assets_job"],
             output_name="result",
-            output_description=None,
             group_name=DEFAULT_GROUP_NAME,
         ),
         ExternalAssetNode(
@@ -124,7 +122,6 @@ def test_two_asset_job():
             op_description=None,
             job_names=["assets_job"],
             output_name="result",
-            output_description=None,
             group_name=DEFAULT_GROUP_NAME,
         ),
     ]
@@ -249,7 +246,6 @@ def test_two_downstream_assets_job():
             op_description=None,
             job_names=["assets_job"],
             output_name="result",
-            output_description=None,
             group_name=DEFAULT_GROUP_NAME,
         ),
         ExternalAssetNode(
@@ -263,7 +259,6 @@ def test_two_downstream_assets_job():
             op_description=None,
             job_names=["assets_job"],
             output_name="result",
-            output_description=None,
             group_name=DEFAULT_GROUP_NAME,
         ),
         ExternalAssetNode(
@@ -277,7 +272,6 @@ def test_two_downstream_assets_job():
             op_description=None,
             job_names=["assets_job"],
             output_name="result",
-            output_description=None,
             group_name=DEFAULT_GROUP_NAME,
         ),
     ]
@@ -310,7 +304,6 @@ def test_cross_job_asset_dependency():
             op_description=None,
             job_names=["assets_job1"],
             output_name="result",
-            output_description=None,
             group_name=DEFAULT_GROUP_NAME,
         ),
         ExternalAssetNode(
@@ -324,7 +317,6 @@ def test_cross_job_asset_dependency():
             op_description=None,
             job_names=["assets_job2"],
             output_name="result",
-            output_description=None,
             group_name=DEFAULT_GROUP_NAME,
         ),
     ]
@@ -352,7 +344,6 @@ def test_same_asset_in_multiple_pipelines():
             op_description=None,
             job_names=["job1", "job2"],
             output_name="result",
-            output_description=None,
             group_name=DEFAULT_GROUP_NAME,
         ),
     ]
@@ -381,10 +372,9 @@ def test_basic_multi_asset():
             node_definition_name="assets",
             graph_name=None,
             op_names=["assets"],
-            op_description=None,
+            op_description=f"foo: {i}",
             job_names=["assets_job"],
             output_name=f"out{i}",
-            output_description=f"foo: {i}",
             group_name=DEFAULT_GROUP_NAME,
         )
         for i in range(10)
@@ -683,7 +673,6 @@ def test_used_source_asset():
             depended_by=[],
             job_names=["job1"],
             output_name="result",
-            output_description=None,
             group_name=DEFAULT_GROUP_NAME,
         ),
     ]
@@ -936,7 +925,6 @@ def test_deps_resolve_group():
             op_description=None,
             job_names=["assets_job"],
             output_name="result",
-            output_description=None,
             group_name=DEFAULT_GROUP_NAME,
         ),
         ExternalAssetNode(
@@ -950,7 +938,6 @@ def test_deps_resolve_group():
             op_description=None,
             job_names=["assets_job"],
             output_name="result",
-            output_description=None,
             group_name=DEFAULT_GROUP_NAME,
         ),
     ]


### PR DESCRIPTION
### Summary & Motivation

This value is not used anywhere and duplicates information that's currently held in the (poorly named) op_description field.

Note: It might look like this PR can change the value of op_description (as op_description is changed in one of the tests), but this actually retains current behavior because the constructor for ExternalAssetNode sets `op_description = op_description or output_description`.

So in that test, setting output_description="foo {i}" sets BOTH op_description and output_description to that value. So the value of op_description is unchanged in this test (only output description changes to None).

### How I Tested These Changes
