### PR TITLE
[dagit] Add unloadable alert to virtualized schedule/sensor pages

### DIFF
--- a/js_modules/dagit/packages/core/src/instigation/Unloadable.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/Unloadable.tsx
@@ -21,14 +21,15 @@ import {InstigationStateFragment} from './types/InstigationStateFragment';
 
 export const UnloadableSensors: React.FC<{
   sensorStates: InstigationStateFragment[];
-}> = ({sensorStates}) => {
+  showSubheading?: boolean;
+}> = ({sensorStates, showSubheading = true}) => {
   if (!sensorStates.length) {
     return null;
   }
   return (
     <>
-      <Box padding={{top: 16, horizontal: 24}}>
-        <Subheading>Unloadable sensors</Subheading>
+      <Box padding={{vertical: 16, horizontal: 20}}>
+        {showSubheading ? <Subheading>Unloadable sensors</Subheading> : null}
         <UnloadableSensorInfo />
       </Box>
       <Table>
@@ -52,14 +53,15 @@ export const UnloadableSensors: React.FC<{
 
 export const UnloadableSchedules: React.FC<{
   scheduleStates: InstigationStateFragment[];
-}> = ({scheduleStates}) => {
+  showSubheading?: boolean;
+}> = ({scheduleStates, showSubheading = true}) => {
   if (!scheduleStates.length) {
     return null;
   }
   return (
     <>
-      <Box padding={{top: 16, horizontal: 24}}>
-        <Subheading>Unloadable schedules</Subheading>
+      <Box padding={{vertical: 16, horizontal: 20}}>
+        {showSubheading ? <Subheading>Unloadable schedules</Subheading> : null}
         <UnloadableScheduleInfo />
       </Box>
       <Table>
@@ -84,43 +86,39 @@ export const UnloadableSchedules: React.FC<{
 };
 
 const UnloadableSensorInfo = () => (
-  <Box margin={{vertical: 20}}>
-    <Alert
-      intent="warning"
-      title={
-        <div>
-          Note: You can turn off any of the following sensors, but you cannot turn them back on.{' '}
-        </div>
-      }
-      description={
-        <div>
-          The following sensors were previously started but now cannot be loaded. They may be part
-          of a different workspace or from a sensor or repository that no longer exists in code. You
-          can turn them off, but you cannot turn them back on since they can’t be loaded.
-        </div>
-      }
-    />
-  </Box>
+  <Alert
+    intent="warning"
+    title={
+      <div>
+        Note: You can turn off any of the following sensors, but you cannot turn them back on.{' '}
+      </div>
+    }
+    description={
+      <div>
+        The following sensors were previously started but now cannot be loaded. They may be part of
+        a different workspace or from a sensor or repository that no longer exists in code. You can
+        turn them off, but you cannot turn them back on since they can’t be loaded.
+      </div>
+    }
+  />
 );
 
 const UnloadableScheduleInfo = () => (
-  <Box margin={{vertical: 20}}>
-    <Alert
-      intent="warning"
-      title={
-        <div>
-          Note: You can turn off any of the following schedules, but you cannot turn them back on.
-        </div>
-      }
-      description={
-        <div>
-          The following schedules were previously started but now cannot be loaded. They may be part
-          of a different workspace or from a schedule or repository that no longer exists in code.
-          You can turn them off, but you cannot turn them back on since they can’t be loaded.
-        </div>
-      }
-    />
-  </Box>
+  <Alert
+    intent="warning"
+    title={
+      <div>
+        Note: You can turn off any of the following schedules, but you cannot turn them back on.
+      </div>
+    }
+    description={
+      <div>
+        The following schedules were previously started but now cannot be loaded. They may be part
+        of a different workspace or from a schedule or repository that no longer exists in code. You
+        can turn them off, but you cannot turn them back on since they can’t be loaded.
+      </div>
+    }
+  />
 );
 
 const SensorStateRow = ({sensorState}: {sensorState: InstigationStateFragment}) => {

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleTable.tsx
@@ -15,7 +15,7 @@ import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {humanCronString} from '../schedules/humanCronString';
 import {InstigationStatus, InstigationType} from '../types/globalTypes';
 import {MenuLink} from '../ui/MenuLink';
-import {Container, Inner, Row, RowCell} from '../ui/VirtualizedTable';
+import {Container, HeaderCell, Inner, Row, RowCell} from '../ui/VirtualizedTable';
 import {findDuplicateRepoNames} from '../ui/findDuplicateRepoNames';
 import {useRepoExpansionState} from '../ui/useRepoExpansionState';
 
@@ -75,42 +75,63 @@ export const VirtualizedScheduleTable: React.FC<Props> = ({repos}) => {
   const items = rowVirtualizer.getVirtualItems();
 
   return (
-    <Container ref={parentRef}>
-      <Inner $totalHeight={totalHeight}>
-        {items.map(({index, key, size, start}) => {
-          const row: RowType = flattened[index];
-          const type = row!.type;
-          return type === 'header' ? (
-            <RepoRow
-              repoAddress={row.repoAddress}
-              key={key}
-              height={size}
-              start={start}
-              onToggle={onToggle}
-              showLocation={duplicateRepoNames.has(row.repoAddress.name)}
-              rightElement={
-                <Tooltip
-                  content={
-                    row.scheduleCount === 1 ? '1 schedule' : `${row.scheduleCount} schedules`
+    <>
+      <Box
+        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '76px 28% 30% 10% 20% 10%',
+          height: '32px',
+          fontSize: '12px',
+          color: Colors.Gray600,
+        }}
+      >
+        <HeaderCell />
+        <HeaderCell>Schedule name</HeaderCell>
+        <HeaderCell>Schedule</HeaderCell>
+        <HeaderCell>Last tick</HeaderCell>
+        <HeaderCell>Last run</HeaderCell>
+        <HeaderCell>Actions</HeaderCell>
+      </Box>
+      <div style={{overflow: 'hidden'}}>
+        <Container ref={parentRef}>
+          <Inner $totalHeight={totalHeight}>
+            {items.map(({index, key, size, start}) => {
+              const row: RowType = flattened[index];
+              const type = row!.type;
+              return type === 'header' ? (
+                <RepoRow
+                  repoAddress={row.repoAddress}
+                  key={key}
+                  height={size}
+                  start={start}
+                  onToggle={onToggle}
+                  showLocation={duplicateRepoNames.has(row.repoAddress.name)}
+                  rightElement={
+                    <Tooltip
+                      content={
+                        row.scheduleCount === 1 ? '1 schedule' : `${row.scheduleCount} schedules`
+                      }
+                      placement="top"
+                    >
+                      <Tag intent="primary">{row.scheduleCount}</Tag>
+                    </Tooltip>
                   }
-                  placement="top"
-                >
-                  <Tag intent="primary">{row.scheduleCount}</Tag>
-                </Tooltip>
-              }
-            />
-          ) : (
-            <ScheduleRow
-              key={key}
-              name={row.name}
-              repoAddress={row.repoAddress}
-              height={size}
-              start={start}
-            />
-          );
-        })}
-      </Inner>
-    </Container>
+                />
+              ) : (
+                <ScheduleRow
+                  key={key}
+                  name={row.name}
+                  repoAddress={row.repoAddress}
+                  height={size}
+                  start={start}
+                />
+              );
+            })}
+          </Inner>
+        </Container>
+      </div>
+    </>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorTable.tsx
@@ -13,7 +13,7 @@ import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {humanizeSensorInterval} from '../sensors/SensorDetails';
 import {SensorSwitch, SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
 import {InstigationType} from '../types/globalTypes';
-import {Container, Inner, Row, RowCell} from '../ui/VirtualizedTable';
+import {Container, HeaderCell, Inner, Row, RowCell} from '../ui/VirtualizedTable';
 import {findDuplicateRepoNames} from '../ui/findDuplicateRepoNames';
 import {useRepoExpansionState} from '../ui/useRepoExpansionState';
 
@@ -73,40 +73,60 @@ export const VirtualizedSensorTable: React.FC<Props> = ({repos}) => {
   const items = rowVirtualizer.getVirtualItems();
 
   return (
-    <Container ref={parentRef}>
-      <Inner $totalHeight={totalHeight}>
-        {items.map(({index, key, size, start}) => {
-          const row: RowType = flattened[index];
-          const type = row!.type;
-          return type === 'header' ? (
-            <RepoRow
-              repoAddress={row.repoAddress}
-              key={key}
-              height={size}
-              start={start}
-              onToggle={onToggle}
-              showLocation={duplicateRepoNames.has(row.repoAddress.name)}
-              rightElement={
-                <Tooltip
-                  content={row.sensorCount === 1 ? '1 sensor' : `${row.sensorCount} sensors`}
-                  placement="top"
-                >
-                  <Tag intent="primary">{row.sensorCount}</Tag>
-                </Tooltip>
-              }
-            />
-          ) : (
-            <SensorRow
-              key={key}
-              name={row.name}
-              repoAddress={row.repoAddress}
-              height={size}
-              start={start}
-            />
-          );
-        })}
-      </Inner>
-    </Container>
+    <>
+      <Box
+        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '76px 38% 30% 10% 20%',
+          height: '32px',
+          fontSize: '12px',
+          color: Colors.Gray600,
+        }}
+      >
+        <HeaderCell />
+        <HeaderCell>Sensor name</HeaderCell>
+        <HeaderCell>Frequency</HeaderCell>
+        <HeaderCell>Last tick</HeaderCell>
+        <HeaderCell>Last run</HeaderCell>
+      </Box>
+      <div style={{overflow: 'hidden'}}>
+        <Container ref={parentRef}>
+          <Inner $totalHeight={totalHeight}>
+            {items.map(({index, key, size, start}) => {
+              const row: RowType = flattened[index];
+              const type = row!.type;
+              return type === 'header' ? (
+                <RepoRow
+                  repoAddress={row.repoAddress}
+                  key={key}
+                  height={size}
+                  start={start}
+                  onToggle={onToggle}
+                  showLocation={duplicateRepoNames.has(row.repoAddress.name)}
+                  rightElement={
+                    <Tooltip
+                      content={row.sensorCount === 1 ? '1 sensor' : `${row.sensorCount} sensors`}
+                      placement="top"
+                    >
+                      <Tag intent="primary">{row.sensorCount}</Tag>
+                    </Tooltip>
+                  }
+                />
+              ) : (
+                <SensorRow
+                  key={key}
+                  name={row.name}
+                  repoAddress={row.repoAddress}
+                  height={size}
+                  start={start}
+                />
+              );
+            })}
+          </Inner>
+        </Container>
+      </div>
+    </>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/workspace/types/UnloadableSchedulesQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/UnloadableSchedulesQuery.ts
@@ -1,0 +1,97 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { InstigationType, InstigationStatus, RunStatus, InstigationTickStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: UnloadableSchedulesQuery
+// ====================================================
+
+export interface UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData_SensorData {
+  __typename: "SensorData";
+  lastRunKey: string | null;
+  lastCursor: string | null;
+}
+
+export interface UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData_ScheduleData {
+  __typename: "ScheduleData";
+  cronSchedule: string;
+}
+
+export type UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData = UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData_SensorData | UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData_ScheduleData;
+
+export interface UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_runs {
+  __typename: "Run";
+  id: string;
+  runId: string;
+  status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
+}
+
+export interface UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error_causes {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  causes: UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error_causes[];
+}
+
+export interface UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks {
+  __typename: "InstigationTick";
+  id: string;
+  cursor: string | null;
+  status: InstigationTickStatus;
+  timestamp: number;
+  skipReason: string | null;
+  runIds: string[];
+  runKeys: string[];
+  error: UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error | null;
+}
+
+export interface UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results {
+  __typename: "InstigationState";
+  id: string;
+  selectorId: string;
+  name: string;
+  instigationType: InstigationType;
+  status: InstigationStatus;
+  repositoryName: string;
+  repositoryLocationName: string;
+  typeSpecificData: UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData | null;
+  runs: UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_runs[];
+  ticks: UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks[];
+  runningCount: number;
+}
+
+export interface UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates {
+  __typename: "InstigationStates";
+  results: UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results[];
+}
+
+export interface UnloadableSchedulesQuery_unloadableInstigationStatesOrError_PythonError_causes {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface UnloadableSchedulesQuery_unloadableInstigationStatesOrError_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  causes: UnloadableSchedulesQuery_unloadableInstigationStatesOrError_PythonError_causes[];
+}
+
+export type UnloadableSchedulesQuery_unloadableInstigationStatesOrError = UnloadableSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates | UnloadableSchedulesQuery_unloadableInstigationStatesOrError_PythonError;
+
+export interface UnloadableSchedulesQuery {
+  unloadableInstigationStatesOrError: UnloadableSchedulesQuery_unloadableInstigationStatesOrError;
+}

--- a/js_modules/dagit/packages/core/src/workspace/types/UnloadableSensorsQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/UnloadableSensorsQuery.ts
@@ -1,0 +1,97 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { InstigationType, InstigationStatus, RunStatus, InstigationTickStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: UnloadableSensorsQuery
+// ====================================================
+
+export interface UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData_SensorData {
+  __typename: "SensorData";
+  lastRunKey: string | null;
+  lastCursor: string | null;
+}
+
+export interface UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData_ScheduleData {
+  __typename: "ScheduleData";
+  cronSchedule: string;
+}
+
+export type UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData = UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData_SensorData | UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData_ScheduleData;
+
+export interface UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_runs {
+  __typename: "Run";
+  id: string;
+  runId: string;
+  status: RunStatus;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
+}
+
+export interface UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error_causes {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  causes: UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error_causes[];
+}
+
+export interface UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks {
+  __typename: "InstigationTick";
+  id: string;
+  cursor: string | null;
+  status: InstigationTickStatus;
+  timestamp: number;
+  skipReason: string | null;
+  runIds: string[];
+  runKeys: string[];
+  error: UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error | null;
+}
+
+export interface UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results {
+  __typename: "InstigationState";
+  id: string;
+  selectorId: string;
+  name: string;
+  instigationType: InstigationType;
+  status: InstigationStatus;
+  repositoryName: string;
+  repositoryLocationName: string;
+  typeSpecificData: UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_typeSpecificData | null;
+  runs: UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_runs[];
+  ticks: UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks[];
+  runningCount: number;
+}
+
+export interface UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates {
+  __typename: "InstigationStates";
+  results: UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results[];
+}
+
+export interface UnloadableSensorsQuery_unloadableInstigationStatesOrError_PythonError_causes {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface UnloadableSensorsQuery_unloadableInstigationStatesOrError_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  causes: UnloadableSensorsQuery_unloadableInstigationStatesOrError_PythonError_causes[];
+}
+
+export type UnloadableSensorsQuery_unloadableInstigationStatesOrError = UnloadableSensorsQuery_unloadableInstigationStatesOrError_InstigationStates | UnloadableSensorsQuery_unloadableInstigationStatesOrError_PythonError;
+
+export interface UnloadableSensorsQuery {
+  unloadableInstigationStatesOrError: UnloadableSensorsQuery_unloadableInstigationStatesOrError;
+}

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceSchedulesQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceSchedulesQuery.ts
@@ -69,6 +69,23 @@ export interface WorkspaceSchedulesQuery_workspaceOrError_PythonError {
 
 export type WorkspaceSchedulesQuery_workspaceOrError = WorkspaceSchedulesQuery_workspaceOrError_Workspace | WorkspaceSchedulesQuery_workspaceOrError_PythonError;
 
+export interface WorkspaceSchedulesQuery_unloadableInstigationStatesOrError_PythonError {
+  __typename: "PythonError";
+}
+
+export interface WorkspaceSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results {
+  __typename: "InstigationState";
+  id: string;
+}
+
+export interface WorkspaceSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates {
+  __typename: "InstigationStates";
+  results: WorkspaceSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results[];
+}
+
+export type WorkspaceSchedulesQuery_unloadableInstigationStatesOrError = WorkspaceSchedulesQuery_unloadableInstigationStatesOrError_PythonError | WorkspaceSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates;
+
 export interface WorkspaceSchedulesQuery {
   workspaceOrError: WorkspaceSchedulesQuery_workspaceOrError;
+  unloadableInstigationStatesOrError: WorkspaceSchedulesQuery_unloadableInstigationStatesOrError;
 }

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceSensorsQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceSensorsQuery.ts
@@ -69,6 +69,23 @@ export interface WorkspaceSensorsQuery_workspaceOrError_PythonError {
 
 export type WorkspaceSensorsQuery_workspaceOrError = WorkspaceSensorsQuery_workspaceOrError_Workspace | WorkspaceSensorsQuery_workspaceOrError_PythonError;
 
+export interface WorkspaceSensorsQuery_unloadableInstigationStatesOrError_PythonError {
+  __typename: "PythonError";
+}
+
+export interface WorkspaceSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results {
+  __typename: "InstigationState";
+  id: string;
+}
+
+export interface WorkspaceSensorsQuery_unloadableInstigationStatesOrError_InstigationStates {
+  __typename: "InstigationStates";
+  results: WorkspaceSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results[];
+}
+
+export type WorkspaceSensorsQuery_unloadableInstigationStatesOrError = WorkspaceSensorsQuery_unloadableInstigationStatesOrError_PythonError | WorkspaceSensorsQuery_unloadableInstigationStatesOrError_InstigationStates;
+
 export interface WorkspaceSensorsQuery {
   workspaceOrError: WorkspaceSensorsQuery_workspaceOrError;
+  unloadableInstigationStatesOrError: WorkspaceSensorsQuery_unloadableInstigationStatesOrError;
 }


### PR DESCRIPTION
### Summary & Motivation

Add unloadable schedules/sensors to the new virtualized table pages. Also do a bit more cleanup.

If there are any unloadable items, show an alert that opens a dialog. The dialog will render the existing schedule or sensor table, because this data is currently quite a bit harder to query per-row.

<img width="1246" alt="Screen Shot 2022-09-19 at 9 53 24 AM" src="https://user-images.githubusercontent.com/2823852/191051576-4969d80c-d000-4fe9-bdb6-2f25aa168373.png">
<img width="1174" alt="Screen Shot 2022-09-19 at 9 53 29 AM" src="https://user-images.githubusercontent.com/2823852/191051579-387b3cbf-d097-4867-8573-f14baa09fb48.png">

### How I Tested These Changes

Turn on a schedule and a sensor, then comment them out in code to make them unloadable. View schedules and sensors pages within Workspace, verify that alerts and dialogs behave as expected.
