### PR TITLE
[dagit] Show ad hoc asset materializations in run timeline

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useMergedRefresh, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
-import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {
   failedStatuses,
   inProgressStatuses,
@@ -167,9 +166,7 @@ export const InstanceOverviewPage = () => {
         (r) =>
           r.repository.name === repoAddress.name &&
           r.repositoryLocation.name === repoAddress.location,
-      ) &&
-      name.toLocaleLowerCase().includes(searchToLower) &&
-      !isHiddenAssetGroupJob(name);
+      ) && name.toLocaleLowerCase().includes(searchToLower);
 
     const {failed, inProgress, queued, succeeded, neverRan} = bucketed;
     return {

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.stories.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.stories.tsx
@@ -3,7 +3,7 @@ import {Meta} from '@storybook/react/types-6-0';
 import faker from 'faker';
 import * as React from 'react';
 
-import {RunTimeline} from '../runs/RunTimeline';
+import {RunTimeline, TimelineJob} from '../runs/RunTimeline';
 import {generateRunMocks} from '../testing/generateRunMocks';
 import {RunStatus} from '../types/globalTypes';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
@@ -21,13 +21,14 @@ export const OneRow = () => {
   const sixHoursAgo = React.useMemo(() => Date.now() - 6 * 60 * 60 * 1000, []);
   const now = React.useMemo(() => Date.now(), []);
 
-  const jobs = React.useMemo(() => {
+  const jobs: TimelineJob[] = React.useMemo(() => {
     const jobKey = faker.random.words(2).split(' ').join('-').toLowerCase();
     const repoAddress = makeRepoAddress();
     return [
       {
         key: jobKey,
         jobName: jobKey,
+        jobType: 'job',
         path: `/${jobKey}`,
         repoAddress,
         runs: generateRunMocks(6, [sixHoursAgo, now]),
@@ -42,7 +43,7 @@ export const RowWithOverlappingRuns = () => {
   const sixHoursAgo = React.useMemo(() => Date.now() - 6 * 60 * 60 * 1000, []);
   const now = React.useMemo(() => Date.now(), []);
 
-  const jobs = React.useMemo(() => {
+  const jobs: TimelineJob[] = React.useMemo(() => {
     const jobKey = faker.random.words(2).split(' ').join('-').toLowerCase();
     const repoAddress = makeRepoAddress();
     const [first, second, third] = generateRunMocks(3, [sixHoursAgo, now]);
@@ -50,6 +51,7 @@ export const RowWithOverlappingRuns = () => {
       {
         key: jobKey,
         jobName: jobKey,
+        jobType: 'job',
         path: `/${jobKey}`,
         repoAddress,
         runs: [{...first}, {...first}, {...second}, {...second}, {...second}, third],
@@ -64,13 +66,14 @@ export const OverlapWithRunning = () => {
   const twoHoursAgo = React.useMemo(() => Date.now() - 2 * 60 * 60 * 1000, []);
   const now = React.useMemo(() => Date.now(), []);
 
-  const jobs = React.useMemo(() => {
+  const jobs: TimelineJob[] = React.useMemo(() => {
     const jobKey = faker.random.words(2).split(' ').join('-').toLowerCase();
     const repoAddress = makeRepoAddress();
     return [
       {
         key: jobKey,
         jobName: jobKey,
+        jobType: 'job',
         path: `/${jobKey}`,
         repoAddress,
         runs: [
@@ -104,7 +107,7 @@ export const ManyRows = () => {
   const sixHoursAgo = React.useMemo(() => Date.now() - 6 * 60 * 60 * 1000, []);
   const now = React.useMemo(() => Date.now(), []);
 
-  const jobs = React.useMemo(() => {
+  const jobs: TimelineJob[] = React.useMemo(() => {
     const repoAddress = makeRepoAddress();
     return [...new Array(12)].reduce((accum) => {
       const jobKey = faker.random.words(3).split(' ').join('-').toLowerCase();
@@ -130,7 +133,7 @@ export const VeryLongRunning = () => {
   const twoDaysAgo = React.useMemo(() => Date.now() - 48 * 60 * 60 * 1000, []);
   const future = React.useMemo(() => Date.now() + 1 * 60 * 60 * 1000, []);
 
-  const jobs = React.useMemo(() => {
+  const jobs: TimelineJob[] = React.useMemo(() => {
     const repoAddress = makeRepoAddress();
     const jobKeyA = faker.random.words(2).split(' ').join('-').toLowerCase();
     const jobKeyB = faker.random.words(2).split(' ').join('-').toLowerCase();
@@ -138,6 +141,7 @@ export const VeryLongRunning = () => {
       {
         key: jobKeyA,
         jobName: jobKeyA,
+        jobType: 'job',
         path: `/${jobKeyA}`,
         repoAddress,
         runs: [
@@ -152,6 +156,7 @@ export const VeryLongRunning = () => {
       {
         key: jobKeyB,
         jobName: jobKeyB,
+        jobType: 'job',
         path: `/${jobKeyB}`,
         repoAddress,
         runs: [

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -1,4 +1,14 @@
-import {Box, Colors, Popover, Mono, FontFamily, Tooltip, Tag, NonIdealState} from '@dagster-io/ui';
+import {
+  Box,
+  Colors,
+  Popover,
+  Mono,
+  FontFamily,
+  Tooltip,
+  Tag,
+  NonIdealState,
+  Icon,
+} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -37,6 +47,7 @@ export type TimelineJob = {
   key: string;
   repoAddress: RepoAddress;
   jobName: string;
+  jobType: 'job' | 'asset';
   path: string;
   runs: TimelineRun[];
 };
@@ -456,7 +467,12 @@ const RunTimelineRow = ({
   return (
     <Row $top={top}>
       <JobName>
-        <Link to={job.path}>{job.jobName}</Link>
+        <Icon name={job.jobType === 'asset' ? 'asset' : 'job'} />
+        {job.jobType === 'asset' ? (
+          <span style={{color: Colors.Gray900}}>{job.jobName}</span>
+        ) : (
+          <Link to={job.path}>{job.jobName}</Link>
+        )}
       </JobName>
       <RunChunks>
         {batched.map((batch) => {
@@ -535,7 +551,8 @@ const JobName = styled.div`
   align-items: center;
   display: flex;
   font-size: 13px;
-  justify-content: space-between;
+  justify-content: flex-start;
+  gap: 8px;
   line-height: 16px;
   overflow: hidden;
   padding: 0 12px 0 24px;


### PR DESCRIPTION
### Summary & Motivation

Resolves #9652.

Show ad hoc asset materialization runs on run timeline.

<img width="1182" alt="Screen Shot 2022-09-19 at 10 54 58 AM" src="https://user-images.githubusercontent.com/2823852/191060611-cf387694-a078-46e0-b892-06da14e48d64.png">

### How I Tested These Changes

Run a handful of jobs, and run a materialization of an asset. Verify that the timeline shows all runs.
