### PR TITLE
[dagit] Don't link to nowhere on Backfill history table

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
@@ -10,10 +10,7 @@ import {
   Popover,
   Table,
   Tag,
-  Mono,
-  stringFromValue,
 } from '@dagster-io/ui';
-import qs from 'qs';
 import * as React from 'react';
 import {useHistory, Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -112,12 +109,12 @@ export const BackfillTable = ({
       <Table>
         <thead>
           <tr>
-            <th style={{width: 120}}>Backfill Id</th>
+            <th style={{width: 120}}>Backfill ID</th>
             <th style={{width: 200}}>Created</th>
-            {showPartitionSet ? <th>Partition Set</th> : null}
+            {showPartitionSet ? <th>Partition set</th> : null}
             {allPartitions ? <th>Requested</th> : null}
-            <th style={{textAlign: 'right', width: 200}}>Backfill Status</th>
-            <th>Run Status</th>
+            <th style={{width: 140}}>Backfill status</th>
+            <th>Run status</th>
             <th style={{width: 80}} />
           </tr>
         </thead>
@@ -179,47 +176,13 @@ const BackfillRow = ({
     },
   ]);
 
-  const repoAddress = backfill.partitionSet
-    ? buildRepoAddress(
-        backfill.partitionSet.repositoryOrigin.repositoryName,
-        backfill.partitionSet.repositoryOrigin.repositoryLocationName,
-      )
-    : null;
-  const repo = useRepository(repoAddress);
-  const isJob = !!(
-    repo &&
-    backfill.partitionSet &&
-    isThisThingAJob(repo, backfill.partitionSet.pipelineName)
-  );
-
-  const partitionSetBackfillUrl = backfill.partitionSet
-    ? workspacePipelinePath({
-        repoName: backfill.partitionSet.repositoryOrigin.repositoryName,
-        repoLocation: backfill.partitionSet.repositoryOrigin.repositoryLocationName,
-        pipelineName: backfill.partitionSet.pipelineName,
-        path: `/partitions?${qs.stringify({
-          partitionSet: backfill.partitionSet.name,
-          q: [stringFromValue([{token: 'tag', value: `dagster/backfill=${backfill.backfillId}`}])],
-        })}`,
-        isJob,
-      })
-    : null;
-
   const canCancelRuns = backfill.partitionStatuses.results.some(
     (r) => r.runStatus === RunStatus.QUEUED || r.runStatus === RunStatus.STARTED,
   );
 
   return (
     <tr>
-      <td style={{width: 120}}>
-        <Mono>
-          {partitionSetBackfillUrl ? (
-            <Link to={partitionSetBackfillUrl}>{backfill.backfillId}</Link>
-          ) : (
-            backfill.backfillId
-          )}
-        </Mono>
-      </td>
+      <td style={{width: 120}}>{backfill.backfillId}</td>
       <td style={{width: 240}}>
         {backfill.timestamp ? <TimestampDisplay timestamp={backfill.timestamp} /> : '-'}
       </td>
@@ -241,7 +204,7 @@ const BackfillRow = ({
           />
         </td>
       ) : null}
-      <td style={{textAlign: 'right', width: 200}}>
+      <td style={{width: 140}}>
         <BackfillStatus backfill={backfill} />
       </td>
       <td>
@@ -283,12 +246,12 @@ const BackfillRow = ({
                 />
               ) : null}
               <MenuItem
-                text="View Backfill Runs"
+                text="View backfill runs"
                 icon="settings_backup_restore"
                 onClick={() => history.push(runsUrl)}
               />
               <MenuItem
-                text="View Step Status"
+                text="View step status"
                 icon="view_list"
                 onClick={() => {
                   onShowStepStatus(backfill);

--- a/js_modules/dagit/packages/core/src/partitions/PartitionGraphSet.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionGraphSet.tsx
@@ -82,7 +82,7 @@ export const PartitionGraphSet: React.FC<{
       <div style={{flex: 1}}>
         <PartitionGraph
           isJob={isJob}
-          title="Execution Time by Partition"
+          title="Execution time by partition"
           yLabel="Execution time (secs)"
           partitionNames={partitionNames}
           jobDataByPartition={jobDurationData}
@@ -92,7 +92,7 @@ export const PartitionGraphSet: React.FC<{
 
         <PartitionGraph
           isJob={isJob}
-          title="Materialization Count by Partition"
+          title="Materialization count by partition"
           yLabel="Number of materializations"
           partitionNames={partitionNames}
           jobDataByPartition={jobMaterializationData}
@@ -101,7 +101,7 @@ export const PartitionGraphSet: React.FC<{
         />
         <PartitionGraph
           isJob={isJob}
-          title="Expectation Successes by Partition"
+          title="Expectation successes by partition"
           yLabel="Number of successes"
           partitionNames={partitionNames}
           jobDataByPartition={jobExpectationSuccessData}
@@ -110,7 +110,7 @@ export const PartitionGraphSet: React.FC<{
         />
         <PartitionGraph
           isJob={isJob}
-          title="Expectation Failures by Partition"
+          title="Expectation failures by partition"
           yLabel="Number of failures"
           partitionNames={partitionNames}
           jobDataByPartition={jobExpectationFailureData}
@@ -119,7 +119,7 @@ export const PartitionGraphSet: React.FC<{
         />
         <PartitionGraph
           isJob={isJob}
-          title="Expectation Rate by Partition"
+          title="Expectation rate by partition"
           yLabel="Rate of success"
           partitionNames={partitionNames}
           jobDataByPartition={jobExpectationRateData}

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
@@ -127,7 +127,6 @@ export const PartitionStepStatus: React.FC<PartitionStepStatusProps> = (props) =
   const [minUnix, maxUnix] = timeboundsOfPartitions(partitionColumns);
   const topLabelHeight = topLabelHeightForLabels(partitionColumns.map((p) => p.name));
 
-  console.log(visibleColumns);
   return (
     <PartitionRunMatrixContainer>
       <Dialog
@@ -154,13 +153,12 @@ export const PartitionStepStatus: React.FC<PartitionStepStatusProps> = (props) =
         style={{
           position: 'relative',
           display: 'flex',
-          borderBottom: `1px solid ${Colors.KeylineGray}`,
         }}
       >
         <GridFloatingContainer floating={props.offset + visibleCount < props.partitionNames.length}>
           <GridColumn disabled style={{flex: 1, flexShrink: 1, overflow: 'hidden'}}>
             <TopLabel style={{height: topLabelHeight}} />
-            <LeftLabel style={{paddingLeft: 24}}>Last Run</LeftLabel>
+            <LeftLabel style={{paddingLeft: 24}}>Last run</LeftLabel>
             <Divider />
             {stepRows.map((step) => (
               <LeftLabel
@@ -384,12 +382,12 @@ const PartitionSquare: React.FC<{
         <Menu>
           <MenuLink
             icon="open_in_new"
-            text="Show Logs From Last Run"
+            text="Show logs from last run"
             to={linkToRunEvent(runs[runs.length - 1], {stepKey: step ? step.name : null})}
           />
           <MenuItem
             icon="settings_backup_restore"
-            text={`View Runs (${runs.length})`}
+            text={`View runs (${runs.length})`}
             onClick={() => setFocused({stepName: step?.name, partitionName})}
           />
         </Menu>

--- a/js_modules/dagit/packages/core/src/partitions/PartitionView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionView.tsx
@@ -9,12 +9,12 @@ import {
   CursorPaginationControls,
   CursorPaginationProps,
   NonIdealState,
+  Subheading,
 } from '@dagster-io/ui';
 import * as React from 'react';
 
 import {usePermissions} from '../app/Permissions';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
-import {OptionsContainer} from '../gantt/VizComponents';
 import {useViewport} from '../gantt/useViewport';
 import {BackfillTable, BACKFILL_TABLE_FRAGMENT} from '../instance/BackfillTable';
 import {RepositorySelector, RunStatus} from '../types/globalTypes';
@@ -178,11 +178,9 @@ const PartitionViewContent: React.FC<{
       <Box
         flex={{justifyContent: 'space-between', direction: 'row', alignItems: 'center'}}
         border={{width: 1, side: 'bottom', color: Colors.KeylineGray}}
-        padding={16}
+        padding={{vertical: 16, horizontal: 24}}
       >
-        <div>
-          <strong>Status</strong>
-        </div>
+        <Subheading>Status</Subheading>
         <Box flex={{gap: 8}}>
           <Button onClick={() => setShowSteps(!showSteps)} active={showBackfillSetup}>
             {showSteps ? 'Hide per-step status' : 'Show per-step status'}
@@ -205,8 +203,9 @@ const PartitionViewContent: React.FC<{
         </Box>
       </Box>
       <Box
-        flex={{justifyContent: 'space-between', direction: 'row', alignItems: 'center'}}
+        flex={{direction: 'row', alignItems: 'center'}}
         border={{width: 1, side: 'bottom', color: Colors.KeylineGray}}
+        padding={{horizontal: 8}}
       >
         <CountBox count={partitionNames.length} label="Total partitions" />
         <CountBox
@@ -223,7 +222,7 @@ const PartitionViewContent: React.FC<{
           label="Missing partitions"
         />
       </Box>
-      <Box margin={16}>
+      <Box padding={{vertical: 16, horizontal: 24}}>
         <div {...containerProps}>
           <PartitionStatus
             partitionNames={partitionNames}
@@ -259,13 +258,16 @@ const PartitionViewContent: React.FC<{
           </Box>
         ) : null}
       </Box>
-      <OptionsContainer>
-        <strong>Run duration</strong>
-      </OptionsContainer>
+      <Box
+        padding={{horizontal: 24, vertical: 16}}
+        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+      >
+        <Subheading>Run duration</Subheading>
+      </Box>
       <Box margin={24}>
         <PartitionGraph
           isJob={true}
-          title="Execution Time by Partition"
+          title="Execution time by partition"
           yLabel="Execution time (secs)"
           partitionNames={showSteps ? selectedPartitions : partitionNames}
           jobDataByPartition={runDurationData}
@@ -273,13 +275,13 @@ const PartitionViewContent: React.FC<{
       </Box>
       {showSteps ? (
         <>
-          <OptionsContainer>
-            <strong>Step duration</strong>
-          </OptionsContainer>
+          <Box padding={{horizontal: 24, vertical: 16}}>
+            <Subheading>Step duration</Subheading>
+          </Box>
           <Box margin={24}>
             <PartitionGraph
               isJob={true}
-              title="Execution Time by Partition"
+              title="Execution time by partition"
               yLabel="Execution time (secs)"
               partitionNames={selectedPartitions}
               stepDataByPartition={stepDurationData}
@@ -287,10 +289,10 @@ const PartitionViewContent: React.FC<{
           </Box>
         </>
       ) : null}
-      <OptionsContainer>
-        <strong>Backfill History</strong>
-      </OptionsContainer>
-      <Box margin={16}>
+      <Box padding={{horizontal: 24, vertical: 16}}>
+        <Subheading>Backfill history</Subheading>
+      </Box>
+      <Box margin={{bottom: 20}}>
         <JobBackfills
           partitionSet={partitionSet}
           repositorySelector={repositorySelector}
@@ -384,12 +386,12 @@ const CountBox: React.FC<{
   count: number;
   label: string;
 }> = ({count, label}) => (
-  <div style={{flex: 1, borderLeft: `1px solid ${Colors.KeylineGray}`, padding: 16}}>
+  <Box padding={16} style={{flex: 1}} border={{side: 'right', width: 1, color: Colors.KeylineGray}}>
     <div style={{fontSize: 18, marginBottom: 4}}>
       <strong>{count}</strong>
     </div>
     <div>{label}</div>
-  </div>
+  </Box>
 );
 
 const PARTITIONS_STATUS_QUERY = gql`


### PR DESCRIPTION
### Summary & Motivation

Resolves #9662.

The backfill history table has links from the backfill ID to nowhere in particular. I believe this was previously linked to a filtered view of the partition tab, which no longer exists.

Instead, just use the menu items in the table row to link to the relevant data.

Also doing some spacing and copy cleanup while I'm in here.

### How I Tested These Changes

View a partition tab on a job. Verify that backfill history table no longer links to nowhere. Verify that the step view dialog now animates correctly, that copy changes are visible, and that spacing and alignment are now tidied up.
