### PR TITLE
[dagit] Avoid skipping subscription for compute log panel

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/useComputeLogs.tsx
+++ b/js_modules/dagit/packages/core/src/runs/useComputeLogs.tsx
@@ -69,19 +69,16 @@ const initialState: State = {
   isLoading: true,
 };
 
-export const useComputeLogs = (runId: string, stepKey?: string) => {
+export const useComputeLogs = (runId: string, stepKey: string) => {
   const [state, dispatch] = React.useReducer(reducer, initialState);
 
   useSubscription<ComputeLogsSubscription, ComputeLogsSubscriptionVariables>(
     COMPUTE_LOGS_SUBSCRIPTION,
     {
       fetchPolicy: 'no-cache',
-      variables: {runId, stepKey: stepKey!, ioType: ComputeIOType.STDOUT, cursor: null},
-      skip: !stepKey,
+      variables: {runId, stepKey, ioType: ComputeIOType.STDOUT, cursor: null},
       onSubscriptionData: ({subscriptionData}) => {
-        if (stepKey) {
-          dispatch({type: 'stdout', stepKey, log: subscriptionData.data?.computeLogs || null});
-        }
+        dispatch({type: 'stdout', stepKey, log: subscriptionData.data?.computeLogs || null});
       },
     },
   );
@@ -90,12 +87,9 @@ export const useComputeLogs = (runId: string, stepKey?: string) => {
     COMPUTE_LOGS_SUBSCRIPTION,
     {
       fetchPolicy: 'no-cache',
-      variables: {runId, stepKey: stepKey!, ioType: ComputeIOType.STDERR, cursor: null},
-      skip: !stepKey,
+      variables: {runId, stepKey, ioType: ComputeIOType.STDERR, cursor: null},
       onSubscriptionData: ({subscriptionData}) => {
-        if (stepKey) {
-          dispatch({type: 'stderr', stepKey, log: subscriptionData.data?.computeLogs || null});
-        }
+        dispatch({type: 'stderr', stepKey, log: subscriptionData.data?.computeLogs || null});
       },
     },
   );


### PR DESCRIPTION
### Summary & Motivation

Try to avoid an issue where the compute log panel on Run views is sometimes unhooking its WebSocket subscription prematurely, leading to compute logs failing to appear.

Our hypothesis is that this is related to using the `skip` value on `useSubscription`, and that this is leading the subscription to send a "stop" event before we have a compute key to query for.

### How I Tested These Changes

Tested with @gibsondan to verify that compute logs appear correctly and reliably.
