### PR TITLE
[dagit] Avoid showing hidden asset jobs on the backfill page

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1704,6 +1704,7 @@ type PartitionBackfill {
   numRequested: Int!
   fromFailure: Boolean!
   reexecutionSteps: [String!]!
+  assetSelection: [AssetKey!]
   partitionSetName: String!
   timestamp: Float!
   partitionSet: PartitionSet

--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
@@ -110,7 +110,7 @@ export const BackfillTable = ({
           <tr>
             <th style={{width: 120}}>Backfill ID</th>
             <th style={{width: 200}}>Created</th>
-            {showBackfillTarget ? <th>Backfill Target</th> : null}
+            {showBackfillTarget ? <th>Backfill target</th> : null}
             {allPartitions ? <th>Requested</th> : null}
             <th style={{width: 140}}>Backfill status</th>
             <th>Run status</th>

--- a/js_modules/dagit/packages/core/src/instance/types/BackfillTableFragment.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/BackfillTableFragment.ts
@@ -38,6 +38,11 @@ export interface BackfillTableFragment_partitionStatuses {
   results: BackfillTableFragment_partitionStatuses_results[];
 }
 
+export interface BackfillTableFragment_assetSelection {
+  __typename: "AssetKey";
+  path: string[];
+}
+
 export interface BackfillTableFragment_error_causes {
   __typename: "PythonError";
   message: string;
@@ -62,5 +67,6 @@ export interface BackfillTableFragment {
   partitionSetName: string;
   partitionSet: BackfillTableFragment_partitionSet | null;
   partitionStatuses: BackfillTableFragment_partitionStatuses;
+  assetSelection: BackfillTableFragment_assetSelection[] | null;
   error: BackfillTableFragment_error | null;
 }

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceBackfillsQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceBackfillsQuery.ts
@@ -51,6 +51,11 @@ export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackf
   results: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionStatuses_results[];
 }
 
+export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_assetSelection {
+  __typename: "AssetKey";
+  path: string[];
+}
+
 export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results {
   __typename: "PartitionBackfill";
   backfillId: string;
@@ -64,6 +69,7 @@ export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackf
   error: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_error | null;
   partitionNames: string[];
   partitionStatuses: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionStatuses;
+  assetSelection: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_assetSelection[] | null;
 }
 
 export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills {

--- a/js_modules/dagit/packages/core/src/partitions/PartitionView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionView.tsx
@@ -371,7 +371,7 @@ const JobBackfills = ({
             <BackfillTable
               backfills={backfills}
               refetch={refetch}
-              showPartitionSet={false}
+              showBackfillTarget={false}
               allPartitions={partitionNames}
             />
             <CursorPaginationControls {...paginationProps} />

--- a/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsQuery.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsQuery.ts
@@ -42,6 +42,11 @@ export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_pa
   results: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionStatuses_results[];
 }
 
+export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_assetSelection {
+  __typename: "AssetKey";
+  path: string[];
+}
+
 export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_error_causes {
   __typename: "PythonError";
   message: string;
@@ -66,6 +71,7 @@ export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills {
   partitionSetName: string;
   partitionSet: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionSet | null;
   partitionStatuses: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_partitionStatuses;
+  assetSelection: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_assetSelection[] | null;
   error: JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills_error | null;
 }
 

--- a/js_modules/dagit/packages/core/src/runs/AssetKeyTagCollection.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/AssetKeyTagCollection.test.tsx
@@ -4,9 +4,9 @@ import * as React from 'react';
 
 import {TestProvider} from '../testing/TestProvider';
 
-import {RunAssetKeyTags} from './RunAssetKeyTags';
+import {AssetKeyTagCollection} from './AssetKeyTagCollection';
 
-describe('RunAssetKeyTags', () => {
+describe('AssetKeyTagCollection', () => {
   const makeKeys = (count: number) => {
     return Array(count)
       .fill(null)
@@ -17,7 +17,7 @@ describe('RunAssetKeyTags', () => {
     await act(async () => {
       render(
         <TestProvider>
-          <RunAssetKeyTags assetKeys={makeKeys(3)} clickableTags />
+          <AssetKeyTagCollection assetKeys={makeKeys(3)} clickableTags />
         </TestProvider>,
       );
     });
@@ -32,7 +32,7 @@ describe('RunAssetKeyTags', () => {
     await act(async () => {
       render(
         <TestProvider>
-          <RunAssetKeyTags assetKeys={makeKeys(5)} clickableTags />
+          <AssetKeyTagCollection assetKeys={makeKeys(5)} clickableTags />
         </TestProvider>,
       );
     });

--- a/js_modules/dagit/packages/core/src/runs/AssetKeyTagCollection.tsx
+++ b/js_modules/dagit/packages/core/src/runs/AssetKeyTagCollection.tsx
@@ -18,10 +18,11 @@ import {AssetKey} from '../assets/types';
 
 const MAX_ASSET_TAGS = 3;
 
-export const RunAssetKeyTags: React.FC<{
+export const AssetKeyTagCollection: React.FC<{
   assetKeys: AssetKey[] | null;
+  modalTitle?: string;
   clickableTags?: boolean;
-}> = React.memo(({assetKeys, clickableTags}) => {
+}> = React.memo(({assetKeys, clickableTags, modalTitle = 'Assets in Run'}) => {
   const [showMore, setShowMore] = React.useState(false);
 
   if (!assetKeys || !assetKeys.length) {
@@ -50,7 +51,7 @@ export const RunAssetKeyTags: React.FC<{
           </ButtonLink>
         )}
         <Dialog
-          title="Assets in Run"
+          title={modalTitle}
           onClose={() => setShowMore(false)}
           style={{minWidth: '400px', maxWidth: '80vw', maxHeight: '70vh'}}
           isOpen={showMore}

--- a/js_modules/dagit/packages/core/src/runs/RunRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunRoot.tsx
@@ -12,8 +12,8 @@ import {isThisThingAJob} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {useRepositoryForRun} from '../workspace/useRepositoryForRun';
 
+import {AssetKeyTagCollection} from './AssetKeyTagCollection';
 import {Run} from './Run';
-import {RunAssetKeyTags} from './RunAssetKeyTags';
 import {RunConfigDialog, RunDetails} from './RunDetails';
 import {RunFragments} from './RunFragments';
 import {RunStatusTag} from './RunStatusTag';
@@ -73,7 +73,7 @@ export const RunRoot = () => {
               <>
                 <RunStatusTag status={run.status} />
                 {isHiddenAssetGroupJob(run.pipelineName) ? (
-                  <RunAssetKeyTags assetKeys={assetKeysForRun(run)} clickableTags />
+                  <AssetKeyTagCollection assetKeys={assetKeysForRun(run)} clickableTags />
                 ) : (
                   <>
                     <Tag icon="run">
@@ -86,7 +86,7 @@ export const RunRoot = () => {
                         isJob={isJob}
                       />
                     </Tag>
-                    <RunAssetKeyTags assetKeys={run.assets.map((a) => a.key)} clickableTags />
+                    <AssetKeyTagCollection assetKeys={run.assets.map((a) => a.key)} clickableTags />
                   </>
                 )}
                 <Box flex={{direction: 'row', alignItems: 'flex-start', gap: 12, wrap: 'wrap'}}>

--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -19,8 +19,8 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {useRepositoryForRun} from '../workspace/useRepositoryForRun';
 import {workspacePipelinePath, workspacePipelinePathGuessRepo} from '../workspace/workspacePath';
 
+import {AssetKeyTagCollection} from './AssetKeyTagCollection';
 import {RunActionsMenu, RunBulkActionsMenu} from './RunActionsMenu';
-import {RunAssetKeyTags} from './RunAssetKeyTags';
 import {RunStatusTagWithStats} from './RunStatusTag';
 import {RunTags} from './RunTags';
 import {
@@ -243,7 +243,7 @@ const RunRow: React.FC<{
       <td>
         <Box flex={{direction: 'column', gap: 5}}>
           {isHiddenAssetGroupJob(run.pipelineName) ? (
-            <RunAssetKeyTags assetKeys={assetKeysForRun(run)} />
+            <AssetKeyTagCollection assetKeys={assetKeysForRun(run)} />
           ) : (
             <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
               <PipelineReference

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -6,6 +6,7 @@ from dagster._core.storage.pipeline_run import FINISHED_STATUSES, PipelineRunSta
 from dagster._core.storage.tags import BACKFILL_ID_TAG
 
 from ..implementation.fetch_partition_sets import partition_statuses_from_run_partition_data
+from .asset_key import GrapheneAssetKey
 from .errors import (
     GrapheneInvalidOutputError,
     GrapheneInvalidStepError,
@@ -109,6 +110,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
     numRequested = graphene.NonNull(graphene.Int)
     fromFailure = graphene.NonNull(graphene.Boolean)
     reexecutionSteps = non_null_list(graphene.String)
+    assetSelection = graphene.List(graphene.NonNull(GrapheneAssetKey))
     partitionSetName = graphene.NonNull(graphene.String)
     timestamp = graphene.NonNull(graphene.Float)
     partitionSet = graphene.Field("dagster_graphql.schema.partition_sets.GraphenePartitionSet")
@@ -139,6 +141,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             reexecutionSteps=backfill_job.reexecution_steps,
             partitionNames=backfill_job.partition_names,
             timestamp=backfill_job.backfill_timestamp,
+            assetSelection=backfill_job.asset_selection,
         )
 
     def _get_partition_set(self, graphene_info):


### PR DESCRIPTION
### Summary & Motivation

This PR adds a GraphQL resolver exposing `backfill.assetSelection` and then renders the asset selection in place of the hidden asset job name in the backfills table.

This uses the same "truncating set of asset tags" that we use for the run table, and offers to show a modal if there are more than three asset keys being backfilled.

I renamed this column in the Backfill table from "Partition Set" to "Backfill Target" because it actually shows the backfill repo, job, and partition set in the `op job` case, and showing a `repo + asset list` in a partition set column felt odd.

Before:

![image](https://user-images.githubusercontent.com/1037212/191128869-03b111a9-d5a7-4eea-b6f2-51c26bba325f.png)

After: 

![image](https://user-images.githubusercontent.com/1037212/191128772-124fd033-8b4d-4ce0-87ec-a20ee1697150.png)


### How I Tested These Changes
