### PR TITLE
Revert "remove dagster cli api subcommand from docs (#9165)"

### DIFF
--- a/docs/sphinx/sections/api/apidocs/cli.rst
+++ b/docs/sphinx/sections/api/apidocs/cli.rst
@@ -56,3 +56,6 @@ Dagster CLI
 
 .. click:: dagster._daemon.cli:debug_heartbeat_dump_command
    :prog: dagster-daemon debug heartbeat-dump
+
+.. click:: dagster._cli.api:grpc_command
+   :prog: dagster api grpc


### PR DESCRIPTION
This reverts commit a4ffdc4c7ab38be32c04be8c71a960eb87815486. We reference this command in the docs when telling users how to run their own grpc server - i may be missing context on why it was removed originally though.

### Summary & Motivation

### How I Tested These Changes
