### PR TITLE
RFC (more like dump prototype) Typed resource ctor:

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/branch_deployments/repository_v2.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/branch_deployments/repository_v2.py
@@ -26,11 +26,12 @@ resource_defs = {
                 "database": f"PRODUCTION_CLONE_{os.getenv('DAGSTER_CLOUD_PULL_REQUEST_ID')}",
             }
         ),
-        "snowflake": snowflake_resource.configured(
-            {
-                **snowflake_config,
-                "database": f"PRODUCTION_CLONE_{os.getenv('DAGSTER_CLOUD_PULL_REQUEST_ID')}",
-            }
+        "snowflake": snowflake_resource(
+            database=f"PRODUCTION_CLONE_{os.getenv('DAGSTER_CLOUD_PULL_REQUEST_ID')}",
+            schema="HACKER_NEWS"
+            account=os.getenv('SNOWFLAKE_ACCOUNT'),
+            user=os.getenv('SNOWFLAKE_USER'),
+            password=os.getenv('SNOWFLAKE_PASSWORD'),
         ),
     },
     "production": {
@@ -40,8 +41,12 @@ resource_defs = {
                 "database": "PRODUCTION",
             }
         ),
-        "snowflake": snowflake_resource.configured(
-            {**snowflake_config, "database": "PRODUCTION"}
+        "snowflake": snowflake_resource(
+            database="PRODUCTION"
+            schema="HACKER_NEWS"
+            account=os.getenv('SNOWFLAKE_ACCOUNT'),
+            user=os.getenv('SNOWFLAKE_USER'),
+            password=os.getenv('SNOWFLAKE_PASSWORD'),
         ),
     },
 }

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_config.py
@@ -1,0 +1,43 @@
+from distutils.command.config import config
+from importlib.resources import Resource
+from re import A
+from dagster import resource, op, job, ResourceDefinition
+from dagster._core.definitions.resource_definition import typed_resource_ctor
+
+@resource(config_schema={"database": str})
+def configurable_some_resource(init_context):
+    return dict(database=init_context.resource_config["database"])
+
+@typed_resource_ctor(configurable_some_resource)
+def some_resource(database: str):
+    return configurable_some_resource.configured({"database": database})
+
+def test_typed_some_resource():
+    configured_inst = some_resource.configured({"database": "foo"})
+    assert isinstance(configured_inst, ResourceDefinition)
+
+    typed_inst = some_resource(database="bar")
+    assert isinstance(typed_inst, ResourceDefinition)
+
+    @op(required_resource_keys={'some_resource'})
+    def use_some_resource(context):
+        return context.resources.some_resource
+
+    @job(resource_defs={'some_resource': configured_inst})
+    def configured_job():
+        use_some_resource()
+
+    assert configured_job.execute_in_process().output_for_node("use_some_resource") == {"database": "foo"}
+
+    @job(resource_defs={'some_resource': typed_inst})
+    def inst_job():
+        use_some_resource()
+
+    assert inst_job.execute_in_process().output_for_node("use_some_resource") == {"database": "bar"}
+
+    @job(resource_defs={'some_resource': some_resource})
+    def trad_job():
+        use_some_resource()
+    
+    assert trad_job.execute_in_process(
+        run_config={'resources': {'some_resource': {'config': {'database': 'baaz'}}}}).output_for_node("use_some_resource") == {"database": "baaz"}

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -154,12 +154,20 @@ class SnowflakeConnection:
 
         self.execute_queries(sql_queries)
 
+from dagster._core.definitions.resource_definition import typed_resource_ctor
+
+@typed_resource_ctor
+# TODO actually type
+# Natural extension would be to generate config schema from this function signature
+# (Good intern project)
+def snowflake_resource(**kwargs):
+    return configurable_snowflake_resource.configured(**kwargs)
 
 @resource(
     config_schema=define_snowflake_config(),
     description="This resource is for connecting to the Snowflake data warehouse",
 )
-def snowflake_resource(context):
+def configurable_snowflake_resource(context):
     """A resource for connecting to the Snowflake data warehouse.
 
     A simple example of loading data into Snowflake and subsequently querying that data is shown below:


### PR DESCRIPTION
This is more of a pattern rather than real technology. I banged this out very quickly so it is not fleshed out. The idea here is to make it norm to provide typed constructors for resources as opposed to configured. The configurable resource is still available for advanced cases.

The big drawback here is that this breaks direct resource invocation. However I think for the spin-up/simple use case this is *far* more self-explantory.

Additionally a natural extension would be to generate config schema from the python types on the typed signature if that is desirable.