### PR TITLE
[dagit] Virtualized table for assets

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetLatestInfoFragment.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetLatestInfoFragment.ts
@@ -1,0 +1,30 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { AssetComputeStatus, RunStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL fragment: AssetLatestInfoFragment
+// ====================================================
+
+export interface AssetLatestInfoFragment_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface AssetLatestInfoFragment_latestRun {
+  __typename: "Run";
+  status: RunStatus;
+  id: string;
+}
+
+export interface AssetLatestInfoFragment {
+  __typename: "AssetLatestInfo";
+  assetKey: AssetLatestInfoFragment_assetKey;
+  computeStatus: AssetComputeStatus;
+  unstartedRunIds: string[];
+  inProgressRunIds: string[];
+  latestRun: AssetLatestInfoFragment_latestRun | null;
+}

--- a/js_modules/dagit/packages/core/src/asset-graph/useLiveDataForAssetKeys.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useLiveDataForAssetKeys.tsx
@@ -34,6 +34,21 @@ export function useLiveDataForAssetKeys(assetKeys: AssetKeyInput[]) {
   };
 }
 
+export const ASSET_LATEST_INFO_FRAGMENT = gql`
+  fragment AssetLatestInfoFragment on AssetLatestInfo {
+    assetKey {
+      path
+    }
+    computeStatus
+    unstartedRunIds
+    inProgressRunIds
+    latestRun {
+      status
+      id
+    }
+  }
+`;
+
 const ASSETS_GRAPH_LIVE_QUERY = gql`
   query AssetGraphLiveQuery($assetKeys: [AssetKeyInput!]!) {
     assetNodes(assetKeys: $assetKeys, loadMaterializations: true) {
@@ -41,17 +56,10 @@ const ASSETS_GRAPH_LIVE_QUERY = gql`
       ...AssetNodeLiveFragment
     }
     assetsLatestInfo(assetKeys: $assetKeys) {
-      assetKey {
-        path
-      }
-      computeStatus
-      unstartedRunIds
-      inProgressRunIds
-      latestRun {
-        status
-        id
-      }
+      ...AssetLatestInfoFragment
     }
   }
+
   ${ASSET_NODE_LIVE_FRAGMENT}
+  ${ASSET_LATEST_INFO_FRAGMENT}
 `;

--- a/js_modules/dagit/packages/core/src/assets/AssetActionMenu.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetActionMenu.tsx
@@ -1,0 +1,72 @@
+import {Button, Icon, Menu, MenuItem, Popover} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {usePermissions} from '../app/Permissions';
+import {MenuLink} from '../ui/MenuLink';
+import {RepoAddress} from '../workspace/types';
+import {workspacePathFromAddress} from '../workspace/workspacePath';
+
+import {assetDetailsPathForKey} from './assetDetailsPathForKey';
+import {AssetTableFragment} from './types/AssetTableFragment';
+
+interface Props {
+  repoAddress: RepoAddress | null;
+  asset: AssetTableFragment;
+  onWipe?: (assets: AssetTableFragment[]) => void;
+}
+
+export const AssetActionMenu: React.FC<Props> = (props) => {
+  const {repoAddress, asset, onWipe} = props;
+  const {canWipeAssets} = usePermissions();
+  const {path} = asset.key;
+
+  return (
+    <Popover
+      position="bottom-right"
+      content={
+        <Menu>
+          <MenuLink
+            text="Show in group"
+            to={
+              repoAddress && asset.definition?.groupName
+                ? workspacePathFromAddress(
+                    repoAddress,
+                    `/asset-groups/${asset.definition.groupName}`,
+                  )
+                : ''
+            }
+            disabled={!asset?.definition}
+            icon="asset_group"
+          />
+          <MenuLink
+            text="View neighbors"
+            to={assetDetailsPathForKey({path}, {view: 'lineage', lineageScope: 'neighbors'})}
+            disabled={!asset?.definition}
+            icon="graph_neighbors"
+          />
+          <MenuLink
+            text="View upstream assets"
+            to={assetDetailsPathForKey({path}, {view: 'lineage', lineageScope: 'upstream'})}
+            disabled={!asset?.definition}
+            icon="graph_upstream"
+          />
+          <MenuLink
+            text="View downstream assets"
+            to={assetDetailsPathForKey({path}, {view: 'lineage', lineageScope: 'downstream'})}
+            disabled={!asset?.definition}
+            icon="graph_downstream"
+          />
+          <MenuItem
+            text="Wipe materializations"
+            icon="delete"
+            disabled={!onWipe || !canWipeAssets.enabled}
+            intent="danger"
+            onClick={() => canWipeAssets.enabled && onWipe && onWipe([asset])}
+          />
+        </Menu>
+      }
+    >
+      <Button icon={<Icon name="expand_more" />} />
+    </Popover>
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/AssetLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetLink.tsx
@@ -13,9 +13,9 @@ export const AssetLink: React.FC<{
   const linkUrl = url ? url : assetDetailsPathForKey({path});
 
   return (
-    <Box flex={{direction: 'row', alignItems: 'center', display: 'inline-flex'}}>
+    <Box flex={{direction: 'row', alignItems: 'flex-start', display: 'inline-flex'}}>
       {icon ? (
-        <Box margin={{right: 8}}>
+        <Box margin={{right: 8, top: 1}}>
           <Icon name={icon} color={Colors.Gray400} />
         </Box>
       ) : null}

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -28,11 +28,11 @@ import {useSelectionReducer} from '../hooks/useSelectionReducer';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {AnchorButton} from '../ui/AnchorButton';
-import {MenuLink} from '../ui/MenuLink';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
+import {AssetActionMenu} from './AssetActionMenu';
 import {AssetLink} from './AssetLink';
 import {AssetWipeDialog} from './AssetWipeDialog';
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
@@ -64,7 +64,6 @@ export const AssetTable = ({
   requery?: RefetchQueriesFunction;
 }) => {
   const [toWipe, setToWipe] = React.useState<AssetKey[] | undefined>();
-  const {canWipeAssets} = usePermissions();
 
   const groupedByFirstComponent: {[pathComponent: string]: Asset[]} = {};
 
@@ -151,7 +150,6 @@ export const AssetTable = ({
                   isSelected={checkedPaths.has(pathStr)}
                   onToggleChecked={onToggleFactory(pathStr)}
                   onWipe={(assets: Asset[]) => setToWipe(assets.map((asset) => asset.key))}
-                  canWipe={canWipeAssets.enabled}
                 />
               );
             })
@@ -191,9 +189,8 @@ const AssetEntryRow: React.FC<{
   assets: Asset[];
   liveDataByNode: LiveData;
   onWipe: (assets: Asset[]) => void;
-  canWipe?: boolean;
 }> = React.memo(
-  ({prefixPath, path, assets, isSelected, onToggleChecked, onWipe, canWipe, liveDataByNode}) => {
+  ({prefixPath, path, assets, isSelected, onToggleChecked, onWipe, liveDataByNode}) => {
     const fullPath = [...prefixPath, ...path];
     const linkUrl = assetDetailsPathForKey({path: fullPath});
 
@@ -290,62 +287,7 @@ const AssetEntryRow: React.FC<{
           {asset ? (
             <Box flex={{gap: 8, alignItems: 'center'}}>
               <AnchorButton to={assetDetailsPathForKey({path})}>View details</AnchorButton>
-              <Popover
-                position="bottom-right"
-                content={
-                  <Menu>
-                    <MenuLink
-                      text="Show in group"
-                      to={
-                        repoAddress && asset.definition?.groupName
-                          ? workspacePathFromAddress(
-                              repoAddress,
-                              `/asset-groups/${asset.definition.groupName}`,
-                            )
-                          : ''
-                      }
-                      disabled={!asset?.definition}
-                      icon="asset_group"
-                    />
-                    <MenuLink
-                      text="View neighbors"
-                      to={assetDetailsPathForKey(
-                        {path},
-                        {view: 'lineage', lineageScope: 'neighbors'},
-                      )}
-                      disabled={!asset?.definition}
-                      icon="graph_neighbors"
-                    />
-                    <MenuLink
-                      text="View upstream assets"
-                      to={assetDetailsPathForKey(
-                        {path},
-                        {view: 'lineage', lineageScope: 'upstream'},
-                      )}
-                      disabled={!asset?.definition}
-                      icon="graph_upstream"
-                    />
-                    <MenuLink
-                      text="View downstream assets"
-                      to={assetDetailsPathForKey(
-                        {path},
-                        {view: 'lineage', lineageScope: 'downstream'},
-                      )}
-                      disabled={!asset?.definition}
-                      icon="graph_downstream"
-                    />
-                    <MenuItem
-                      text="Wipe materializations"
-                      icon="delete"
-                      disabled={!canWipe}
-                      intent="danger"
-                      onClick={() => canWipe && onWipe(assets)}
-                    />
-                  </Menu>
-                }
-              >
-                <Button icon={<Icon name="expand_more" />} />
-              </Popover>
+              <AssetActionMenu repoAddress={repoAddress} asset={asset} onWipe={onWipe} />
             </Box>
           ) : (
             <span />

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
@@ -17,7 +17,6 @@ import styled from 'styled-components/macro';
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useMergedRefresh, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment';
-import {tokenForAssetKey} from '../asset-graph/Utils';
 import {useLiveDataForAssetKeys} from '../asset-graph/useLiveDataForAssetKeys';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {AssetGroupSelector} from '../types/globalTypes';
@@ -39,6 +38,7 @@ import {
   AssetCatalogTableQuery_assetsOrError_AssetConnection_nodes,
 } from './types/AssetCatalogTableQuery';
 import {AssetTableFragment} from './types/AssetTableFragment';
+import {useAssetSearch} from './useAssetSearch';
 import {AssetViewType, useAssetView} from './useAssetView';
 
 const PAGE_SIZE = 50;
@@ -110,14 +110,12 @@ export const AssetsCatalogTable: React.FC<AssetCatalogTableProps> = ({
     .trim();
 
   const {assets, query, error} = useAllAssets(groupSelector);
+  const pathMatches = useAssetSearch(searchPath, assets || []);
+
   const filtered = React.useMemo(
     () =>
-      (assets || []).filter((a) => {
-        const groupMatch = !searchGroup || isEqual(buildAssetGroupSelector(a), searchGroup);
-        const pathMatch = !searchPath || tokenForAssetKey(a.key).toLowerCase().includes(searchPath);
-        return groupMatch && pathMatch;
-      }),
-    [assets, searchPath, searchGroup],
+      pathMatches.filter((a) => !searchGroup || isEqual(buildAssetGroupSelector(a), searchGroup)),
+    [pathMatches, searchGroup],
   );
 
   const {displayPathForAsset, displayed, nextCursor, prevCursor} =

--- a/js_modules/dagit/packages/core/src/assets/useAssetSearch.tsx
+++ b/js_modules/dagit/packages/core/src/assets/useAssetSearch.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+import {tokenForAssetKey} from '../asset-graph/Utils';
+
+const useSanitizedAssetSearch = (searchValue: string) => {
+  return React.useMemo(() => {
+    return (searchValue || '')
+      .replace(/(( ?> ?)|\.|\/)/g, '/')
+      .toLowerCase()
+      .trim();
+  }, [searchValue]);
+};
+
+export const useAssetSearch = <A extends {key: {path: string[]}}>(
+  searchValue: string,
+  assets: A[],
+): A[] => {
+  const sanitizedSearch = useSanitizedAssetSearch(searchValue);
+  return React.useMemo(() => {
+    // If there is no search value, match everything.
+    if (!sanitizedSearch) {
+      return assets;
+    }
+    return assets.filter((a) => tokenForAssetKey(a.key).toLowerCase().includes(sanitizedSearch));
+  }, [assets, sanitizedSearch]);
+};
+
+export const useAssetNodeSearch = <A extends {assetKey: {path: string[]}}>(
+  searchValue: string,
+  assetNodes: A[],
+): A[] => {
+  const sanitizedSearch = useSanitizedAssetSearch(searchValue);
+
+  return React.useMemo(() => {
+    // If there is no search value, match everything.
+    if (!sanitizedSearch) {
+      return assetNodes;
+    }
+    return assetNodes.filter((a) =>
+      tokenForAssetKey(a.assetKey).toLowerCase().includes(sanitizedSearch),
+    );
+  }, [assetNodes, sanitizedSearch]);
+};

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
@@ -1,0 +1,377 @@
+import {gql, useLazyQuery} from '@apollo/client';
+import {Box, Caption, Colors, Icon, IconWrapper, Tag} from '@dagster-io/ui';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+import styled from 'styled-components/macro';
+
+import {AppContext} from '../app/AppContext';
+import {
+  AssetLatestRunWithNotices,
+  AssetRunLink,
+  ASSET_NODE_LIVE_FRAGMENT,
+  ComputeStatusNotice,
+} from '../asset-graph/AssetNode';
+import {buildLiveDataForNode} from '../asset-graph/Utils';
+import {ASSET_LATEST_INFO_FRAGMENT} from '../asset-graph/useLiveDataForAssetKeys';
+import {AssetActionMenu} from '../assets/AssetActionMenu';
+import {AssetLink} from '../assets/AssetLink';
+import {ASSET_TABLE_FRAGMENT} from '../assets/AssetTable';
+import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
+import {TimestampDisplay} from '../schedules/TimestampDisplay';
+import {Container, HeaderCell, Inner, Row, RowCell} from '../ui/VirtualizedTable';
+
+import {LoadingOrNone, useDelayedRowQuery} from './VirtualizedWorkspaceTable';
+import {repoAddressAsString} from './repoAddressAsString';
+import {RepoAddress} from './types';
+import {SingleAssetQuery, SingleAssetQueryVariables} from './types/SingleAssetQuery';
+import {workspacePathFromAddress} from './workspacePath';
+
+type Asset = {id: string; groupName: string | null; assetKey: {path: string[]}};
+
+interface Props {
+  repoAddress: RepoAddress;
+  assets: Asset[];
+}
+
+type RowType =
+  | {type: 'group'; name: string; assetCount: number}
+  | {type: 'asset'; id: string; path: string[]};
+
+const UNGROUPED_NAME = 'UNGROUPED';
+const ASSET_GROUPS_EXPANSION_STATE_STORAGE_KEY = 'assets-virtualized-expansion-state';
+
+export const VirtualizedAssetTable: React.FC<Props> = ({repoAddress, assets}) => {
+  const parentRef = React.useRef<HTMLDivElement | null>(null);
+  const repoKey = repoAddressAsString(repoAddress);
+  const {expandedKeys, onToggle} = useAssetGroupExpansionState(
+    `${repoKey}-${ASSET_GROUPS_EXPANSION_STATE_STORAGE_KEY}`,
+  );
+
+  const grouped: {[key: string]: Asset[]} = React.useMemo(() => {
+    const groups = {};
+    for (const asset of assets) {
+      const groupName = asset.groupName || UNGROUPED_NAME;
+      const assetsForGroup = groups[groupName] || [];
+      groups[groupName] = [...assetsForGroup, asset];
+    }
+    return groups;
+  }, [assets]);
+
+  const flattened: RowType[] = React.useMemo(() => {
+    const flat: RowType[] = [];
+    Object.keys(grouped).forEach((groupName) => {
+      const assetsForGroup = grouped[groupName];
+      flat.push({type: 'group', name: groupName, assetCount: assetsForGroup.length});
+      if (expandedKeys.includes(groupName)) {
+        assetsForGroup.forEach(({id, assetKey}) => {
+          flat.push({type: 'asset', id, path: assetKey.path});
+        });
+      }
+    });
+    return flat;
+  }, [grouped, expandedKeys]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: flattened.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: (ii: number) => {
+      const row = flattened[ii];
+      return row?.type === 'group' ? 48 : 64;
+    },
+    overscan: 10,
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const items = rowVirtualizer.getVirtualItems();
+
+  return (
+    <>
+      <Box
+        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '40% 30% 20% 10%',
+          height: '32px',
+          fontSize: '12px',
+          color: Colors.Gray600,
+        }}
+      >
+        <HeaderCell>Asset name</HeaderCell>
+        <HeaderCell>Materialized</HeaderCell>
+        <HeaderCell>Latest run</HeaderCell>
+        <HeaderCell>Actions</HeaderCell>
+      </Box>
+      <div style={{overflow: 'hidden'}}>
+        <Container ref={parentRef}>
+          <Inner $totalHeight={totalHeight}>
+            {items.map(({index, key, size, start}) => {
+              const row: RowType = flattened[index];
+              const type = row!.type;
+              return type === 'group' ? (
+                <GroupNameRow
+                  repoAddress={repoAddress}
+                  groupName={row.name}
+                  assetCount={row.assetCount}
+                  expanded={expandedKeys.includes(row.name)}
+                  key={key}
+                  height={size}
+                  start={start}
+                  onToggle={onToggle}
+                />
+              ) : (
+                <AssetRow
+                  key={key}
+                  path={row.path}
+                  repoAddress={repoAddress}
+                  height={size}
+                  start={start}
+                />
+              );
+            })}
+          </Inner>
+        </Container>
+      </div>
+    </>
+  );
+};
+
+interface JobRowProps {
+  path: string[];
+  repoAddress: RepoAddress;
+  height: number;
+  start: number;
+}
+
+const AssetRow = (props: JobRowProps) => {
+  const {path, repoAddress, start, height} = props;
+
+  const [queryAsset, queryResult] = useLazyQuery<SingleAssetQuery, SingleAssetQueryVariables>(
+    SINGLE_ASSET_QUERY,
+    {
+      fetchPolicy: 'cache-and-network',
+      variables: {input: {path}},
+    },
+  );
+
+  useDelayedRowQuery(queryAsset);
+  const {data} = queryResult;
+
+  const asset = React.useMemo(() => {
+    if (data?.assetOrError.__typename === 'Asset') {
+      return data.assetOrError;
+    }
+    return null;
+  }, [data]);
+
+  const liveData = React.useMemo(() => {
+    if (asset?.definition && data?.assetsLatestInfo) {
+      const latestInfoForAsset = data.assetsLatestInfo[0];
+      if (latestInfoForAsset) {
+        return buildLiveDataForNode(asset.definition, latestInfoForAsset);
+      }
+    }
+    return null;
+  }, [data, asset]);
+
+  const linkUrl = assetDetailsPathForKey({path});
+
+  return (
+    <Row $height={height} $start={start}>
+      <RowGrid border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
+        <RowCell>
+          <AssetLink path={path} url={linkUrl} isGroup={false} icon="asset" />
+          <div
+            style={{
+              maxWidth: '100%',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            <Caption
+              style={{
+                color: Colors.Gray500,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {asset?.definition?.description}
+            </Caption>
+          </div>
+        </RowCell>
+        <RowCell>
+          {liveData?.lastMaterialization ? (
+            <Box flex={{gap: 8, alignItems: 'center'}}>
+              <>
+                <AssetRunLink
+                  runId={liveData.lastMaterialization.runId}
+                  event={{
+                    stepKey: liveData.stepKey,
+                    timestamp: liveData.lastMaterialization.timestamp,
+                  }}
+                >
+                  <TimestampDisplay
+                    timestamp={Number(liveData.lastMaterialization.timestamp) / 1000}
+                    timeFormat={{showSeconds: false, showTimezone: false}}
+                  />
+                </AssetRunLink>
+              </>
+              <ComputeStatusNotice computeStatus={liveData?.computeStatus} />
+            </Box>
+          ) : (
+            <LoadingOrNone queryResult={queryResult} />
+          )}
+        </RowCell>
+        <RowCell>
+          {liveData ? (
+            <AssetLatestRunWithNotices liveData={liveData} />
+          ) : (
+            <LoadingOrNone queryResult={queryResult} />
+          )}
+        </RowCell>
+        <RowCell>
+          {asset ? (
+            <div>
+              <AssetActionMenu repoAddress={repoAddress} asset={asset} />
+            </div>
+          ) : null}
+        </RowCell>
+      </RowGrid>
+    </Row>
+  );
+};
+
+export const GroupNameRow: React.FC<{
+  repoAddress: RepoAddress;
+  groupName: string;
+  assetCount: number;
+  expanded: boolean;
+  height: number;
+  start: number;
+  onToggle: (groupName: string) => void;
+}> = ({repoAddress, groupName, assetCount, expanded, height, start, onToggle}) => {
+  return (
+    <Row $height={height} $start={start}>
+      <Box
+        background={Colors.Gray50}
+        flex={{direction: 'row', alignItems: 'center', gap: 8, justifyContent: 'space-between'}}
+        padding={{horizontal: 24}}
+        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        style={{height: '100%'}}
+      >
+        <Box flex={{alignItems: 'center', gap: 8}}>
+          <Icon name="asset_group" />
+          {groupName === UNGROUPED_NAME ? (
+            <div>Ungrouped assets</div>
+          ) : (
+            <>
+              <strong>{groupName}</strong>
+              {groupName !== UNGROUPED_NAME ? (
+                <Box margin={{left: 12}}>
+                  <Link to={workspacePathFromAddress(repoAddress, `/asset-groups/${groupName}`)}>
+                    <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+                      <span>View lineage</span>
+                      <Icon name="open_in_new" size={16} color={Colors.Link} />
+                    </Box>
+                  </Link>
+                </Box>
+              ) : null}
+            </>
+          )}
+        </Box>
+        <Box flex={{direction: 'row', alignItems: 'center', gap: 12}}>
+          <Tag intent="primary">{assetCount === 1 ? '1 asset' : `${assetCount} assets`}</Tag>
+          <ExpandButton onClick={() => onToggle(groupName)} $open={expanded}>
+            <Icon name="arrow_drop_down" size={20} />
+          </ExpandButton>
+        </Box>
+      </Box>
+    </Row>
+  );
+};
+
+const RowGrid = styled(Box)`
+  display: grid;
+  grid-template-columns: 40% 30% 20% 10%;
+  height: 100%;
+`;
+
+const ExpandButton = styled.button<{$open: boolean}>`
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 8px;
+  margin: -8px;
+
+  :focus,
+  :active {
+    outline: none;
+  }
+
+  ${IconWrapper}[aria-label="arrow_drop_down"] {
+    transition: transform 100ms linear;
+    ${({$open}) => ($open ? null : `transform: rotate(-90deg);`)}
+  }
+`;
+
+const SINGLE_ASSET_QUERY = gql`
+  query SingleAssetQuery($input: AssetKeyInput!) {
+    assetOrError(assetKey: $input) {
+      ... on Asset {
+        id
+        assetMaterializations(limit: 1) {
+          runId
+          timestamp
+        }
+        ...AssetTableFragment
+        definition {
+          id
+          ...AssetNodeLiveFragment
+        }
+      }
+    }
+    assetsLatestInfo(assetKeys: [$input]) {
+      ...AssetLatestInfoFragment
+    }
+  }
+
+  ${ASSET_TABLE_FRAGMENT}
+  ${ASSET_NODE_LIVE_FRAGMENT}
+  ${ASSET_LATEST_INFO_FRAGMENT}
+`;
+
+const validateExpandedKeys = (parsed: unknown) => (Array.isArray(parsed) ? parsed : []);
+
+/**
+ * Use localStorage to persist the expanded/collapsed visual state of asset groups.
+ */
+export const useAssetGroupExpansionState = (storageKey: string) => {
+  const {basePath} = React.useContext(AppContext);
+  const [expandedKeys, setExpandedKeys] = useStateWithStorage<string[]>(
+    `${basePath}:dagit.${storageKey}`,
+    validateExpandedKeys,
+  );
+
+  const onToggle = React.useCallback(
+    (groupName: string) => {
+      setExpandedKeys((current) => {
+        const nextExpandedKeys = new Set(current || []);
+        if (nextExpandedKeys.has(groupName)) {
+          nextExpandedKeys.delete(groupName);
+        } else {
+          nextExpandedKeys.add(groupName);
+        }
+        return Array.from(nextExpandedKeys);
+      });
+    },
+    [setExpandedKeys],
+  );
+
+  return React.useMemo(
+    () => ({
+      expandedKeys,
+      onToggle,
+    }),
+    [expandedKeys, onToggle],
+  );
+};

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceAssetsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceAssetsRoot.tsx
@@ -1,0 +1,128 @@
+import {gql, useQuery} from '@apollo/client';
+import {Box, Colors, NonIdealState, Spinner, TextInput} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {useTrackPageView} from '../app/analytics';
+import {useAssetNodeSearch} from '../assets/useAssetSearch';
+
+import {VirtualizedAssetTable} from './VirtualizedAssetTable';
+import {WorkspaceHeader} from './WorkspaceHeader';
+import {repoAddressToSelector} from './repoAddressToSelector';
+import {RepoAddress} from './types';
+import {WorkspaceAssetsQuery, WorkspaceAssetsQueryVariables} from './types/WorkspaceAssetsQuery';
+
+export const WorkspaceAssetsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
+  useTrackPageView();
+
+  const [searchValue, setSearchValue] = React.useState('');
+  const selector = repoAddressToSelector(repoAddress);
+
+  const queryResultOverview = useQuery<WorkspaceAssetsQuery, WorkspaceAssetsQueryVariables>(
+    WORKSPACE_ASSETS_QUERY,
+    {
+      fetchPolicy: 'network-only',
+      notifyOnNetworkStatusChange: true,
+      variables: {selector},
+    },
+  );
+  const {data, loading} = queryResultOverview;
+
+  const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
+  const anySearch = sanitizedSearch.length > 0;
+
+  const assetNodes = React.useMemo(() => {
+    if (data?.repositoryOrError.__typename === 'Repository') {
+      return data.repositoryOrError.assetNodes;
+    }
+    return [];
+  }, [data]);
+
+  const filteredBySearch = useAssetNodeSearch(searchValue, assetNodes);
+
+  const content = () => {
+    if (loading && !data) {
+      return (
+        <Box flex={{direction: 'row', justifyContent: 'center'}} style={{paddingTop: '100px'}}>
+          <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
+            <Spinner purpose="body-text" />
+            <div style={{color: Colors.Gray600}}>Loading assets…</div>
+          </Box>
+        </Box>
+      );
+    }
+
+    if (!filteredBySearch.length) {
+      if (anySearch) {
+        return (
+          <Box padding={{top: 20}}>
+            <NonIdealState
+              icon="search"
+              title="No matching assets"
+              description={
+                <div>
+                  No assets matching <strong>{searchValue}</strong> were found in this repository
+                </div>
+              }
+            />
+          </Box>
+        );
+      }
+
+      return (
+        <Box padding={{top: 20}}>
+          <NonIdealState
+            icon="search"
+            title="No assets"
+            description="No assets were found in this repository"
+          />
+        </Box>
+      );
+    }
+
+    return <VirtualizedAssetTable repoAddress={repoAddress} assets={filteredBySearch} />;
+  };
+
+  return (
+    <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
+      <WorkspaceHeader repoAddress={repoAddress} tab="assets" />
+      <Box padding={{horizontal: 24, vertical: 16}}>
+        <TextInput
+          icon="search"
+          value={searchValue}
+          onChange={(e) => setSearchValue(e.target.value)}
+          placeholder="Filter by asset name…"
+          style={{width: '340px'}}
+        />
+      </Box>
+      {loading && !data ? (
+        <Box padding={64}>
+          <Spinner purpose="page" />
+        </Box>
+      ) : (
+        content()
+      )}
+    </Box>
+  );
+};
+
+const WORKSPACE_ASSETS_QUERY = gql`
+  query WorkspaceAssetsQuery($selector: RepositorySelector!) {
+    repositoryOrError(repositorySelector: $selector) {
+      ... on Repository {
+        id
+        name
+        assetNodes {
+          id
+          assetKey {
+            path
+          }
+          groupName
+        }
+      }
+      ...PythonErrorFragment
+    }
+  }
+
+  ${PYTHON_ERROR_FRAGMENT}
+`;

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
@@ -9,6 +9,7 @@ import {ScheduleRoot} from '../schedules/ScheduleRoot';
 import {SensorRoot} from '../sensors/SensorRoot';
 
 import {GraphRoot} from './GraphRoot';
+import {WorkspaceAssetsRoot} from './WorkspaceAssetsRoot';
 import {WorkspaceContext} from './WorkspaceContext';
 import {WorkspaceJobsRoot} from './WorkspaceJobsRoot';
 import {WorkspaceOverviewRoot} from './WorkspaceOverviewRoot';
@@ -79,6 +80,11 @@ const RepoRouteContainer = () => {
 
   return (
     <Switch>
+      {flagNewWorkspace ? (
+        <Route path="/workspace/:repoPath/assets" exact>
+          <WorkspaceAssetsRoot repoAddress={addressForPath} />
+        </Route>
+      ) : null}
       {flagNewWorkspace ? (
         <Route path="/workspace/:repoPath/jobs" exact>
           <WorkspaceJobsRoot repoAddress={addressForPath} />

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceTabs.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceTabs.tsx
@@ -21,6 +21,7 @@ export const WorkspaceTabs = <TData extends Record<string, any>>(props: Props<TD
   return (
     <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
       <Tabs selectedTabId={tab}>
+        <TabLink id="assets" title="Assets" to={workspacePathFromAddress(repoAddress, '/assets')} />
         <TabLink id="jobs" title="Jobs" to={workspacePathFromAddress(repoAddress, '/jobs')} />
         <TabLink
           id="schedules"

--- a/js_modules/dagit/packages/core/src/workspace/types/SingleAssetQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/SingleAssetQuery.ts
@@ -1,0 +1,100 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { AssetKeyInput, AssetComputeStatus, RunStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: SingleAssetQuery
+// ====================================================
+
+export interface SingleAssetQuery_assetOrError_AssetNotFoundError {
+  __typename: "AssetNotFoundError";
+}
+
+export interface SingleAssetQuery_assetOrError_Asset_assetMaterializations {
+  __typename: "MaterializationEvent";
+  runId: string;
+  timestamp: string;
+}
+
+export interface SingleAssetQuery_assetOrError_Asset_key {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface SingleAssetQuery_assetOrError_Asset_definition_repository_location {
+  __typename: "RepositoryLocation";
+  id: string;
+  name: string;
+}
+
+export interface SingleAssetQuery_assetOrError_Asset_definition_repository {
+  __typename: "Repository";
+  id: string;
+  name: string;
+  location: SingleAssetQuery_assetOrError_Asset_definition_repository_location;
+}
+
+export interface SingleAssetQuery_assetOrError_Asset_definition_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface SingleAssetQuery_assetOrError_Asset_definition_assetMaterializations {
+  __typename: "MaterializationEvent";
+  timestamp: string;
+  runId: string;
+}
+
+export interface SingleAssetQuery_assetOrError_Asset_definition {
+  __typename: "AssetNode";
+  id: string;
+  groupName: string | null;
+  partitionDefinition: string | null;
+  description: string | null;
+  repository: SingleAssetQuery_assetOrError_Asset_definition_repository;
+  opNames: string[];
+  assetKey: SingleAssetQuery_assetOrError_Asset_definition_assetKey;
+  assetMaterializations: SingleAssetQuery_assetOrError_Asset_definition_assetMaterializations[];
+}
+
+export interface SingleAssetQuery_assetOrError_Asset {
+  __typename: "Asset";
+  id: string;
+  assetMaterializations: SingleAssetQuery_assetOrError_Asset_assetMaterializations[];
+  key: SingleAssetQuery_assetOrError_Asset_key;
+  definition: SingleAssetQuery_assetOrError_Asset_definition | null;
+}
+
+export type SingleAssetQuery_assetOrError = SingleAssetQuery_assetOrError_AssetNotFoundError | SingleAssetQuery_assetOrError_Asset;
+
+export interface SingleAssetQuery_assetsLatestInfo_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface SingleAssetQuery_assetsLatestInfo_latestRun {
+  __typename: "Run";
+  status: RunStatus;
+  id: string;
+}
+
+export interface SingleAssetQuery_assetsLatestInfo {
+  __typename: "AssetLatestInfo";
+  assetKey: SingleAssetQuery_assetsLatestInfo_assetKey;
+  computeStatus: AssetComputeStatus;
+  unstartedRunIds: string[];
+  inProgressRunIds: string[];
+  latestRun: SingleAssetQuery_assetsLatestInfo_latestRun | null;
+}
+
+export interface SingleAssetQuery {
+  assetOrError: SingleAssetQuery_assetOrError;
+  assetsLatestInfo: SingleAssetQuery_assetsLatestInfo[];
+}
+
+export interface SingleAssetQueryVariables {
+  input: AssetKeyInput;
+}

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceAssetsQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceAssetsQuery.ts
@@ -1,0 +1,56 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { RepositorySelector } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: WorkspaceAssetsQuery
+// ====================================================
+
+export interface WorkspaceAssetsQuery_repositoryOrError_RepositoryNotFoundError {
+  __typename: "RepositoryNotFoundError";
+}
+
+export interface WorkspaceAssetsQuery_repositoryOrError_Repository_assetNodes_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface WorkspaceAssetsQuery_repositoryOrError_Repository_assetNodes {
+  __typename: "AssetNode";
+  id: string;
+  assetKey: WorkspaceAssetsQuery_repositoryOrError_Repository_assetNodes_assetKey;
+  groupName: string | null;
+}
+
+export interface WorkspaceAssetsQuery_repositoryOrError_Repository {
+  __typename: "Repository";
+  id: string;
+  name: string;
+  assetNodes: WorkspaceAssetsQuery_repositoryOrError_Repository_assetNodes[];
+}
+
+export interface WorkspaceAssetsQuery_repositoryOrError_PythonError_causes {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface WorkspaceAssetsQuery_repositoryOrError_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  causes: WorkspaceAssetsQuery_repositoryOrError_PythonError_causes[];
+}
+
+export type WorkspaceAssetsQuery_repositoryOrError = WorkspaceAssetsQuery_repositoryOrError_RepositoryNotFoundError | WorkspaceAssetsQuery_repositoryOrError_Repository | WorkspaceAssetsQuery_repositoryOrError_PythonError;
+
+export interface WorkspaceAssetsQuery {
+  repositoryOrError: WorkspaceAssetsQuery_repositoryOrError;
+}
+
+export interface WorkspaceAssetsQueryVariables {
+  selector: RepositorySelector;
+}


### PR DESCRIPTION
### Summary & Motivation

Add a virtualized table for Assets within a repo. I'm trying to repurpose a bunch of existing Asset table code for this.

Asset groups are collapsible within the table. A bit of a yolo design here, so let's iterate further.


<img width="1353" alt="Screen Shot 2022-09-21 at 1 44 15 PM" src="https://user-images.githubusercontent.com/2823852/191586217-4c082ee3-47e8-4c99-9614-416e6c86ffee.png">

### How I Tested These Changes

View asset tab for a repo in the new Workspace section, verify proper rendering, fetching, collapsing.
