### PR TITLE
Add launch_type config to EcsRunLauncher

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -1,13 +1,12 @@
 import json
 import warnings
 from collections import namedtuple
-from contextlib import suppress
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import boto3
 from botocore.exceptions import ClientError
 
-from dagster import Array, Field, Noneable, ScalarUnion, StringSource
+from dagster import Array, Field, Noneable, Permissive, ScalarUnion, StringSource
 from dagster import _check as check
 from dagster._core.events import EngineEventData, MetadataEntry
 from dagster._core.launcher.base import (
@@ -22,8 +21,15 @@ from dagster._serdes import ConfigurableClass
 
 from ..secretsmanager import get_secrets_from_arns
 from .container_context import SHARED_ECS_SCHEMA, EcsContainerContext
-from .tasks import default_ecs_task_definition, default_ecs_task_metadata
-from .utils import sanitize_family
+from .tasks import (
+    DagsterEcsTaskConfig,
+    DagsterEcsTaskDefinitionConfig,
+    get_current_ecs_task,
+    get_current_ecs_task_metadata,
+    get_task_config_from_current_task,
+    get_task_definition_dict_from_current_task,
+)
+from .utils import sanitize_family, should_assign_public_ip
 
 Tags = namedtuple("Tags", ["arn", "cluster", "cpu", "memory"])
 
@@ -51,6 +57,14 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         secrets_tag="dagster",
         env_vars=None,
         include_sidecars=False,
+        use_current_ecs_task=True,
+        cluster: Optional[str] = None,
+        subnets: Optional[List[str]] = None,
+        security_group_ids: Optional[List[str]] = None,
+        execution_role_arn: Optional[str] = None,
+        task_role_arn: Optional[str] = None,
+        log_group: Optional[str] = None,
+        sidecar_container_definitions: Optional[List[Dict[str, Any]]] = None,
     ):
         self._inst_data = inst_data
         self.ecs = boto3.client("ecs")
@@ -82,6 +96,8 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         self.secrets_tags = [secrets_tag] if secrets_tag else []
         self.include_sidecars = include_sidecars
 
+        self.use_current_ecs_task = check.bool_param(use_current_ecs_task, "use_current_ecs_task")
+
         if self.task_definition:
             task_definition = self.ecs.describe_task_definition(taskDefinition=task_definition)
             container_names = [
@@ -94,6 +110,34 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
                 f"'{self.task_definition}' because the container is not defined.",
             )
             self.task_definition = task_definition["taskDefinition"]["taskDefinitionArn"]
+
+        self.cluster = check.opt_str_param(cluster, "cluster")
+        self.subnets = check.opt_list_param(subnets, "subnets")
+        self.security_group_ids = check.opt_list_param(security_group_ids, "security_group_ids")
+        self.execution_role_arn = check.opt_str_param(execution_role_arn, "execution_role_arn")
+        self.task_role_arn = check.opt_str_param(task_role_arn, "task_role_arn")
+        self.log_group = check.opt_str_param(log_group, "log_group")
+        self.sidecar_container_definitions = check.opt_list_param(
+            sidecar_container_definitions, "sidecar_container_definitions"
+        )
+
+        if not self.use_current_ecs_task:
+            check.invariant(
+                self.cluster,
+                "Must set a cluster if not pulling from current task definition",
+            )
+            check.invariant(
+                self.subnets,
+                "Must set subnets if not pulling from current task definition",
+            )
+            check.invariant(
+                self.execution_role_arn,
+                "Must set execution_role_arn if not pulling from current task definition",
+            )
+            check.invariant(
+                not self.include_sidecars,
+                "can only set include_sidecars if use_current_ecs_task is True",
+            )
 
     @property
     def inst_data(self):
@@ -151,6 +195,61 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
                     "Defaults to False."
                 ),
             ),
+            "use_current_ecs_task": Field(
+                bool,
+                is_required=False,
+                default_value=True,
+                description=(
+                    "Whether to use the current task to configure the task definition and task"
+                    "for the launched run - allows you to launch a run without specifying the "
+                    "cluster/subnets/roles/etc. Requires that the launcher is running within an ECS "
+                    "cluster. Individual fields like cluster or subnets can still be overriden "
+                    "while this field is true."
+                ),
+            ),
+            "cluster": Field(
+                StringSource,
+                is_required=False,
+                description="Name of the ECS cluster to launch ECS tasks in.",
+            ),
+            "subnets": Field(
+                Array(StringSource),
+                is_required=False,
+                description="List of subnets to use for the launched ECS task.",
+            ),
+            "security_group_ids": Field(
+                Array(StringSource),
+                is_required=False,
+                description="Security group IDs to use for the launched ECS tasks.",
+            ),
+            "execution_role_arn": Field(
+                StringSource,
+                is_required=False,
+                description=(
+                    "IAM role that grants permissions to start the containers "
+                    "defined in the launched ECS task."
+                ),
+            ),
+            "task_role_arn": Field(
+                StringSource,
+                is_required=False,
+                description="IAM role for the code within the launched ECS task.",
+            ),
+            "log_group": Field(
+                StringSource,
+                is_required=False,
+                description="AWS log group for the launched ECS task.",
+            ),
+            "sidecar_container_definitions": Field(
+                Array(Permissive({})),
+                is_required=False,
+                description=(
+                    "List of container definitions to be included in the launched task in addition "
+                    "to the main Dagster container. See the containerDefinitions argument to "
+                    "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.register_task_definition"
+                    " for the expected format."
+                ),
+            ),
             **SHARED_ECS_SCHEMA,
         }
 
@@ -165,9 +264,11 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         except ClientError:
             pass
 
-    def _set_run_tags(self, run_id, task_arn):
-        cluster = self._task_metadata().cluster
-        tags = {"ecs/task_arn": task_arn, "ecs/cluster": cluster}
+    def _set_run_tags(self, run_id: str, cluster: str, task_arn: str):
+        tags = {
+            "ecs/task_arn": task_arn,
+            "ecs/cluster": cluster,
+        }
         self._instance.add_run_tags(run_id, tags)
 
     def _get_run_tags(self, run_id):
@@ -190,18 +291,10 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         docker-compose when you use the Dagster ECS reference deployment.
         """
         run = context.pipeline_run
-        family = sanitize_family(
-            run.external_pipeline_origin.external_repository_origin.repository_location_origin.location_name  # type: ignore
-        )
-
         container_context = EcsContainerContext.create_for_run(run, self)
 
-        metadata = self._task_metadata()
         pipeline_origin = check.not_none(context.pipeline_code_origin)
         image = pipeline_origin.repository_origin.container_image
-        task_definition = self._task_definition(family, metadata, image, container_context)[
-            "family"
-        ]
 
         # ECS limits overrides to 8192 characters including json formatting
         # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html
@@ -223,6 +316,8 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
             instance_ref=self._instance.get_ref(),
         )
         command = args.get_command_args()
+
+        task_config = self._task_config(run, image, container_context)
 
         # Set cpu or memory overrides
         # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
@@ -249,16 +344,10 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         # Run a task using the same network configuration as this processes's
         # task.
         response = self.ecs.run_task(
-            taskDefinition=task_definition,
-            cluster=metadata.cluster,
+            taskDefinition=task_config.task_definition,
+            cluster=task_config.cluster,
             overrides=overrides,
-            networkConfiguration={
-                "awsvpcConfiguration": {
-                    "subnets": metadata.subnets,
-                    "assignPublicIp": metadata.assign_public_ip,
-                    "securityGroups": metadata.security_groups,
-                }
-            },
+            networkConfiguration=task_config.network_configuration,
             launchType="FARGATE",
         )
 
@@ -275,9 +364,10 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
             raise Exception(exceptions)
 
         arn = tasks[0]["taskArn"]
-        self._set_run_tags(run.run_id, task_arn=arn)
+        cluster_arn = tasks[0]["clusterArn"]
+        self._set_run_tags(run.run_id, cluster=cluster_arn, task_arn=arn)
         self._set_ecs_tags(run.run_id, task_arn=arn)
-        self.report_launch_events(run, arn, metadata.cluster)
+        self.report_launch_events(run, arn, cluster_arn)
 
     def report_launch_events(
         self, run: PipelineRun, arn: Optional[str] = None, cluster: Optional[str] = None
@@ -333,75 +423,142 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         self.ecs.stop_task(task=tags.arn, cluster=tags.cluster)
         return True
 
-    def _task_definition(self, family, metadata, image, container_context):
+    def _task_config(self, run, image, container_context) -> DagsterEcsTaskConfig:
         """
-        Return the launcher's task definition if it's configured.
+        Return a DagsterEcsTaskConfig to use to launch the ECS task, registering a new task
+        definition if needed.
+        """
+        environment = self._environment(container_context)
+        secrets = self._secrets(container_context)
 
-        Otherwise, a new task definition revision is registered for every run.
-        First, the process that calls this method finds its own task
-        definition. Next, it creates a new task definition based on its own
-        but it overrides the image with the pipeline origin's image.
-        """
         if self.task_definition:
+            # Use the passed in task definition as a basis for the launched task (using the current
+            # ECS task to determine network configuration and security groups)
+            current_task_metadata = get_current_ecs_task_metadata()
+            current_task = get_current_ecs_task(
+                self.ecs, current_task_metadata.task_arn, current_task_metadata.cluster
+            )
             task_definition = self.ecs.describe_task_definition(taskDefinition=self.task_definition)
-            return task_definition["taskDefinition"]
 
-        environment = [
+            return get_task_config_from_current_task(
+                self.ec2,
+                current_task_metadata.cluster,
+                current_task,
+                task_definition["taskDefinition"]["family"],
+            )
+
+        family = sanitize_family(
+            run.external_pipeline_origin.external_repository_origin.repository_location_origin.location_name  # type: ignore
+        )
+
+        if self.use_current_ecs_task:
+            # Create a new task definition based on the launcher's task definition (re-using a
+            # previous task with the same family if the configuration hasn't changed). Then
+            # substitute in any configuration that was explicitly set on the run launcher
+            current_task_metadata = get_current_ecs_task_metadata()
+            current_task = get_current_ecs_task(
+                self.ecs, current_task_metadata.task_arn, current_task_metadata.cluster
+            )
+
+            task_definition_dict = get_task_definition_dict_from_current_task(
+                self.ecs,
+                family,
+                current_task,
+                image,
+                self.container_name,
+                environment=environment,
+                execution_role_arn=self.execution_role_arn,
+                task_role_arn=self.task_role_arn,
+                log_group=self.log_group,
+                secrets=secrets if secrets else {},
+                include_sidecars=self.include_sidecars,
+                sidecar_container_definitions=self.sidecar_container_definitions,
+            )
+
+            task_definition_config = DagsterEcsTaskDefinitionConfig.from_task_definition_dict(
+                task_definition_dict,
+                self.container_name,
+            )
+
+            if not self._reuse_task_definition(
+                task_definition_config,
+            ):
+                self.ecs.register_task_definition(**task_definition_dict)
+
+            return get_task_config_from_current_task(
+                self.ec2,
+                self.cluster or current_task_metadata.cluster,
+                current_task,
+                family,
+                self.subnets,
+                self.security_group_ids,
+            )
+        else:
+            # Don't use the current task at all - purely derive the task to launch based on
+            # the launcher config
+            task_definition_config = DagsterEcsTaskDefinitionConfig(
+                family=family,
+                image=image,
+                container_name=self.container_name,
+                command=None,
+                log_configuration={
+                    "logDriver": "awslogs",
+                    "options": {
+                        "awslogs-group": self.log_group,
+                        "awslogs-region": self.ecs.meta.region_name,
+                        "awslogs-stream-prefix": family,
+                    },
+                },
+                secrets=secrets,
+                environment=environment,
+                execution_role_arn=self.execution_role_arn,
+                task_role_arn=self.task_role_arn,
+                sidecars=self.sidecar_container_definitions,
+            )
+            if not self._reuse_task_definition(task_definition_config):
+                task_definition_dict = task_definition_config.task_definition_dict()
+                # Register the task overridden task definition as a revision to the
+                # "dagster-run" family.
+                self.ecs.register_task_definition(**task_definition_dict)
+
+            return DagsterEcsTaskConfig(
+                task_definition=family,
+                cluster=check.not_none(self.cluster),
+                subnets=check.not_none(self.subnets),
+                security_groups=self.security_group_ids,
+                assign_public_ip=should_assign_public_ip(self.ec2, self.subnets),
+            )
+
+    def _reuse_task_definition(
+        self, desired_task_definition_config: DagsterEcsTaskDefinitionConfig
+    ):
+        family = desired_task_definition_config.family
+
+        try:
+            existing_task_definition = self.ecs.describe_task_definition(taskDefinition=family)[
+                "taskDefinition"
+            ]
+        except ClientError:
+            # task definition does not exist, do not reuse
+            return False
+
+        existing_task_definition_config = DagsterEcsTaskDefinitionConfig.from_task_definition_dict(
+            existing_task_definition, self.container_name
+        )
+
+        return existing_task_definition_config == desired_task_definition_config
+
+    def _environment(self, container_context):
+        return [
             {"name": key, "value": value}
             for key, value in container_context.get_environment_dict().items()
         ]
 
+    def _secrets(self, container_context):
         secrets = container_context.get_secrets_dict(self.secrets_manager)
-        secrets_definition = (
-            {"secrets": [{"name": key, "valueFrom": value} for key, value in secrets.items()]}
-            if secrets
-            else {}
+        return (
+            [{"name": key, "valueFrom": value} for key, value in secrets.items()] if secrets else []
         )
-
-        task_definition = {}
-        with suppress(ClientError):
-            task_definition = self.ecs.describe_task_definition(taskDefinition=family)[
-                "taskDefinition"
-            ]
-        secrets = secrets_definition.get("secrets", [])
-        if self._reuse_task_definition(task_definition, metadata, image, secrets, environment):
-            return task_definition
-
-        return default_ecs_task_definition(
-            self.ecs,
-            family,
-            metadata,
-            image,
-            self.container_name,
-            environment=environment,
-            secrets=secrets_definition,
-            include_sidecars=self.include_sidecars,
-        )
-
-    def _reuse_task_definition(self, task_definition, metadata, image, secrets, environment):
-        container_definitions_match = False
-        task_definitions_match = False
-
-        container_definitions = task_definition.get("containerDefinitions", [{}])
-        # Only check for diffs to the primary container. This ignores changes to sidecars.
-        for container_definition in container_definitions:
-            if (
-                container_definition.get("image") == image
-                and container_definition.get("name") == self.container_name
-                and container_definition.get("secrets") == secrets
-                and ((not environment) or container_definition.get("environment") == environment)
-            ):
-                container_definitions_match = True
-
-        if task_definition.get("executionRoleArn") == metadata.task_definition.get(
-            "executionRoleArn"
-        ) and task_definition.get("taskRoleArn") == metadata.task_definition.get("taskRoleArn"):
-            task_definitions_match = True
-
-        return container_definitions_match & task_definitions_match
-
-    def _task_metadata(self):
-        return default_ecs_task_metadata(self.ec2, self.ecs)
 
     @property
     def supports_check_run_worker_health(self):

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
@@ -1,6 +1,5 @@
 import os
-import typing
-from dataclasses import dataclass
+from typing import Any, Dict, List, NamedTuple, Optional
 
 import requests
 
@@ -8,14 +7,117 @@ from dagster._utils import merge_dicts
 from dagster._utils.backoff import backoff
 
 
-@dataclass
-class TaskMetadata:
-    cluster: str
-    subnets: typing.List[str]
-    security_groups: typing.List[str]
-    task_definition: typing.Dict[str, typing.Any]
-    container_definition: typing.Dict[str, typing.Any]
-    assign_public_ip: bool
+class DagsterEcsTaskDefinitionConfig(
+    NamedTuple(
+        "_DagsterEcsTaskDefinitionConfig",
+        [
+            ("family", str),
+            ("image", str),
+            ("container_name", str),
+            ("command", Optional[str]),
+            ("log_configuration", Optional[Dict[str, Any]]),
+            ("secrets", Optional[List[Dict[str, str]]]),
+            ("environment", Optional[List[Dict[str, str]]]),
+            ("execution_role_arn", Optional[str]),
+            ("task_role_arn", Optional[str]),
+            ("sidecars", List[Dict[str, Any]]),
+        ],
+    )
+):
+    """All the information that Dagster needs to compare two task definition to see if they
+    should be reused."""
+
+    @staticmethod
+    def from_task_definition_dict(task_definition_dict, container_name):
+
+        container_definition = next(
+            iter(
+                [
+                    container
+                    for container in task_definition_dict["containerDefinitions"]
+                    if container["name"] == container_name
+                ]
+            )
+        )
+
+        sidecars = [
+            container
+            for container in task_definition_dict["containerDefinitions"]
+            if container["name"] != container_name
+        ]
+
+        return DagsterEcsTaskDefinitionConfig(
+            family=task_definition_dict["family"],
+            image=container_definition["image"],
+            container_name=container_name,
+            command=container_definition.get("command"),
+            log_configuration=task_definition_dict.get("logConfiguration"),
+            secrets=container_definition.get("secrets"),
+            environment=container_definition.get("environment"),
+            execution_role_arn=container_definition.get("executionRoleArn"),
+            task_role_arn=container_definition.get("taskRoleArn"),
+            sidecars=sidecars,
+        )
+
+    def task_definition_dict(self):
+        kwargs = dict(
+            family=self.family,
+            requiresCompatibilities=["FARGATE"],
+            networkMode="awsvpc",
+            containerDefinitions=[
+                merge_dicts(
+                    {
+                        "name": self.container_name,
+                        "image": self.image,
+                    },
+                    (
+                        {"logConfiguration": self.log_configuration}
+                        if self.log_configuration
+                        else {}
+                    ),
+                    ({"command": self.command} if self.command else {}),
+                    ({"secrets": self.secrets} if self.secrets else {}),
+                    ({"environment": self.environment} if self.environment else {}),
+                ),
+                *self.sidecars,
+            ],
+            # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
+            cpu="256",
+            memory="512",
+        )
+
+        if self.execution_role_arn:
+            kwargs.update(dict(executionRoleArn=self.execution_role_arn))
+
+        if self.task_role_arn:
+            kwargs.update(dict(taskRoleArn=self.task_role_arn))
+
+        return kwargs
+
+
+class DagsterEcsTaskConfig(
+    NamedTuple(
+        "_DagsterEcsTaskConfig",
+        [
+            ("task_definition", str),  # family or family:revision
+            ("cluster", str),
+            ("subnets", List[str]),
+            ("security_groups", Optional[List[str]]),
+            ("assign_public_ip", bool),
+        ],
+    )
+):
+    """All the information needs that Dagster needs to launch an ECS task."""
+
+    @property
+    def network_configuration(self):
+        return {
+            "awsvpcConfiguration": {
+                "subnets": self.subnets,
+                "assignPublicIp": self.assign_public_ip,
+                "securityGroups": self.security_groups or [],
+            }
+        }
 
 
 # 9 retries polls for up to 51.1 seconds with exponential backoff.
@@ -33,17 +135,39 @@ class EcsNoTasksFound(Exception):
     pass
 
 
-def default_ecs_task_definition(
+def get_task_definition_dict_from_current_task(
     ecs,
     family,
-    metadata,
+    current_task,
     image,
     container_name,
     environment,
+    execution_role_arn,
+    task_role_arn,
+    log_group,
+    sidecar_container_definitions,
     command=None,
     secrets=None,
     include_sidecars=False,
 ):
+
+    current_container_name = current_ecs_container_name()
+
+    current_task_definition_arn = current_task["taskDefinitionArn"]
+    current_task_definition_dict = ecs.describe_task_definition(
+        taskDefinition=current_task_definition_arn
+    )["taskDefinition"]
+
+    container_definition = next(
+        iter(
+            [
+                container
+                for container in current_task_definition_dict["containerDefinitions"]
+                if container["name"] == current_container_name
+            ]
+        )
+    )
+
     # Start with the current process's task's definition but remove
     # extra keys that aren't useful for creating a new task definition
     # (status, revision, etc.)
@@ -51,9 +175,9 @@ def default_ecs_task_definition(
         key for key in ecs.meta.service_model.shape_for("RegisterTaskDefinitionRequest").members
     ]
     task_definition = dict(
-        (key, metadata.task_definition[key])
+        (key, current_task_definition_dict[key])
         for key in expected_keys
-        if key in metadata.task_definition.keys()
+        if key in current_task_definition_dict.keys()
     )
 
     # The current process might not be running in a container that has the
@@ -66,20 +190,34 @@ def default_ecs_task_definition(
     # https://aws.amazon.com/blogs/opensource/demystifying-entrypoint-cmd-docker/
     new_container_definition = merge_dicts(
         {
-            **metadata.container_definition,
+            **container_definition,
             "name": container_name,
             "image": image,
             "entryPoint": [],
             "command": command if command else [],
         },
         ({"environment": environment} if environment else {}),
-        secrets or {},
+        ({"secrets": secrets} if secrets else {}),
         {} if include_sidecars else {"dependsOn": []},
+        (
+            {
+                "logConfiguration": {
+                    "logDriver": "awslogs",
+                    "options": {
+                        "awslogs-group": log_group,
+                        "awslogs-region": ecs.meta.region_name,
+                        "awslogs-stream-prefix": family,
+                    },
+                }
+            }
+            if log_group
+            else {}
+        ),
     )
 
     if include_sidecars:
-        container_definitions = metadata.task_definition.get("containerDefinitions")
-        container_definitions.remove(metadata.container_definition)
+        container_definitions = current_task_definition_dict.get("containerDefinitions")
+        container_definitions.remove(container_definition)
         container_definitions.append(new_container_definition)
     else:
         container_definitions = [new_container_definition]
@@ -87,17 +225,30 @@ def default_ecs_task_definition(
     task_definition = {
         **task_definition,
         "family": family,
-        "containerDefinitions": container_definitions,
+        "containerDefinitions": container_definitions + sidecar_container_definitions,
+        **({"executionRoleArn": execution_role_arn} if execution_role_arn else {}),
+        **({"taskRoleArn": task_role_arn} if task_role_arn else {}),
     }
-
-    # Register the task overridden task definition as a revision to the
-    # "dagster-run" family.
-    ecs.register_task_definition(**task_definition)
 
     return task_definition
 
 
-def default_ecs_task_metadata(ec2, ecs):
+class CurrentEcsTaskMetadata(
+    NamedTuple("_CurrentEcsTaskMetadata", [("cluster", str), ("task_arn", str)])
+):
+    pass
+
+
+def get_current_ecs_task_metadata() -> CurrentEcsTaskMetadata:
+    task_metadata_uri = _container_metadata_uri() + "/task"
+    response = requests.get(task_metadata_uri).json()
+    cluster = response.get("Cluster")
+    task_arn = response.get("TaskARN")
+
+    return CurrentEcsTaskMetadata(cluster=cluster, task_arn=task_arn)
+
+
+def _container_metadata_uri():
     """
     ECS injects an environment variable into each Fargate task. The value
     of this environment variable is a url that can be queried to introspect
@@ -105,14 +256,14 @@ def default_ecs_task_metadata(ec2, ecs):
 
     https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-metadata-endpoint-v4-fargate.html
     """
-    container_metadata_uri = os.environ.get("ECS_CONTAINER_METADATA_URI_V4")
-    name = requests.get(container_metadata_uri).json()["Name"]
+    return os.environ.get("ECS_CONTAINER_METADATA_URI_V4")
 
-    task_metadata_uri = container_metadata_uri + "/task"
-    response = requests.get(task_metadata_uri).json()
-    cluster = response.get("Cluster")
-    task_arn = response.get("TaskARN")
 
+def current_ecs_container_name():
+    return requests.get(_container_metadata_uri()).json()["Name"]
+
+
+def get_current_ecs_task(ecs, task_arn, cluster):
     def describe_task_or_raise(task_arn, cluster):
         try:
             return ecs.describe_tasks(tasks=[task_arn], cluster=cluster)["tasks"][0]
@@ -129,8 +280,19 @@ def default_ecs_task_metadata(ec2, ecs):
     except EcsNoTasksFound:
         raise EcsEventualConsistencyTimeout
 
+    return task
+
+
+def get_task_config_from_current_task(
+    ec2,
+    cluster,
+    task,
+    family,
+    subnets=None,
+    security_groups=None,
+):
     enis = []
-    subnets = []
+    subnets = subnets.copy() if subnets else []
     for attachment in task["attachments"]:
         if attachment["type"] == "ElasticNetworkInterface":
             for detail in attachment["details"]:
@@ -140,33 +302,17 @@ def default_ecs_task_metadata(ec2, ecs):
                     enis.append(ec2.NetworkInterface(detail["value"]))
 
     public_ip = False
-    security_groups = []
+    security_groups = security_groups.copy() if security_groups else []
     for eni in enis:
         if (eni.association_attribute or {}).get("PublicIp"):
             public_ip = True
         for group in eni.groups:
             security_groups.append(group["GroupId"])
 
-    task_definition_arn = task["taskDefinitionArn"]
-    task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)[
-        "taskDefinition"
-    ]
-
-    container_definition = next(
-        iter(
-            [
-                container
-                for container in task_definition["containerDefinitions"]
-                if container["name"] == name
-            ]
-        )
-    )
-
-    return TaskMetadata(
+    return DagsterEcsTaskConfig(
+        task_definition=family,
         cluster=cluster,
         subnets=subnets,
         security_groups=security_groups,
-        task_definition=task_definition,
-        container_definition=container_definition,
         assign_public_ip="ENABLED" if public_ip else "DISABLED",
     )

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/utils.py
@@ -4,3 +4,20 @@ import re
 def sanitize_family(family):
     # Trim the location name and remove special characters
     return re.sub(r"[^\w^\-]", "", family)[:255]
+
+
+def should_assign_public_ip(ec2, subnet_ids):
+    # https://docs.aws.amazon.com/AmazonECS/latest/userguide/fargate-task-networking.html
+    # Assign a public IP if any of the subnets are public
+    route_tables = ec2.route_tables.filter(
+        Filters=[
+            {"Name": "association.subnet-id", "Values": subnet_ids},
+        ]
+    )
+
+    # Consider a subnet to be public if it has a route that targets
+    # an internet gateway; private subnets have routes that target NAT gateways
+    for route_table in route_tables:
+        if any(route.nat_gateway_id for route in route_table.routes):
+            return "DISABLED"
+    return "ENABLED"

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -139,6 +139,21 @@ def instance(instance_cm):
 
 
 @pytest.fixture
+def instance_dont_use_current_task_definition(instance_cm, subnet):
+    with instance_cm(
+        config={
+            "use_current_ecs_task": False,
+            "cluster": "my_cluster",
+            "subnets": [subnet.id],
+            "execution_role_arn": "fake-role",
+            "log_group": "my_log_group",
+            "env_vars": ["FOO=bar"],
+        }
+    ) as dagster_instance:
+        yield dagster_instance
+
+
+@pytest.fixture
 def workspace(instance, image):
     with in_process_test_workspace(
         instance,

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_instance.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_instance.py
@@ -1,0 +1,34 @@
+def test_default_instance(instance_cm):
+    with instance_cm() as instance:
+        assert instance.run_launcher.use_current_ecs_task
+
+
+def test_dont_use_current_task_definition(instance_cm):
+
+    sidecars = [
+        {
+            "name": "DatadogAgent",
+            "image": "public.ecr.aws/datadog/agent:latest",
+            "environment": [
+                {"name": "ECS_FARGATE", "value": "true"},
+            ],
+        }
+    ]
+
+    with instance_cm(
+        config={
+            "use_current_ecs_task": False,
+            "cluster": "my-ecs-cluster",
+            "subnets": ["subnet1", "subnet2"],
+            "execution_role_arn": "fake-role",
+            "task_role_arn": "other-fake-role",
+            "log_group": "my_log_group",
+            "sidecar_container_definitions": sidecars,
+        }
+    ) as instance:
+        launcher = instance.run_launcher
+        assert launcher.cluster == "my-ecs-cluster"
+        assert launcher.subnets == ["subnet1", "subnet2"]
+        assert launcher.execution_role_arn == "fake-role"
+        assert launcher.log_group == "my_log_group"
+        assert launcher.sidecar_container_definitions == sidecars

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -1,13 +1,12 @@
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
-import copy
 
 import dagster_aws
 import pytest
 from botocore.exceptions import ClientError
 from dagster_aws.ecs import EcsEventualConsistencyTimeout
 from dagster_aws.ecs.launcher import RUNNING_STATUSES, STOPPED_STATUSES
-from dagster_aws.ecs.tasks import TaskMetadata
+from dagster_aws.ecs.tasks import DagsterEcsTaskDefinitionConfig
 
 from dagster._check import CheckError
 from dagster._core.code_pointer import FileCodePointer
@@ -54,11 +53,12 @@ def test_default_launcher(
     assert container_definition["image"] == image
     assert not container_definition.get("entryPoint")
     assert not container_definition.get("dependsOn")
-    # But other stuff is inhereted from the parent task definition
+    # But other stuff is inherited from the parent task definition
     assert container_definition["environment"] == environment
 
     # A new task is launched
     tasks = ecs.list_tasks()["taskArns"]
+
     assert len(tasks) == len(initial_tasks) + 1
     task_arn = list(set(tasks).difference(initial_tasks))[0]
     task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
@@ -98,6 +98,93 @@ def test_default_launcher(
     # check status and stop task
     assert instance.run_launcher.check_run_worker_health(run).status == WorkerStatus.RUNNING
     ecs.stop_task(task=task_arn)
+
+
+def test_launcher_dont_use_task_definition(
+    ecs,
+    instance_dont_use_current_task_definition,
+    workspace,
+    external_pipeline,
+    pipeline,
+    subnet,
+    image,
+    environment,
+):
+    instance = instance_dont_use_current_task_definition
+    run = instance.create_run_for_pipeline(
+        pipeline,
+        external_pipeline_origin=external_pipeline.get_external_origin(),
+        pipeline_code_origin=external_pipeline.get_python_origin(),
+    )
+
+    cluster = instance.run_launcher.cluster
+
+    assert not run.tags
+
+    initial_task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
+    initial_tasks = ecs.list_tasks(cluster=cluster)["taskArns"]
+
+    instance.launch_run(run.run_id, workspace)
+
+    # A new task definition is created
+    task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
+    assert len(task_definitions) == len(initial_task_definitions) + 1
+    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
+    task_definition = task_definition["taskDefinition"]
+
+    assert instance.run_launcher.check_run_worker_health(run).status == WorkerStatus.RUNNING
+
+    # It has a new family, name, and image
+    # We get the family name from the location name. With the InProcessExecutor that we use in tests,
+    # the location name is always <<in_process>>. And we sanitize it so it's compatible with the ECS API.
+    assert task_definition["family"] == "in_process"
+    assert len(task_definition["containerDefinitions"]) == 1
+    container_definition = task_definition["containerDefinitions"][0]
+    assert container_definition["name"] == "run"
+    assert container_definition["image"] == image
+    assert not container_definition.get("entryPoint")
+    assert not container_definition.get("dependsOn")
+    # It takes in the environment configured on the instance
+    assert container_definition["environment"] == environment
+
+    # A new task is launched
+    tasks = ecs.list_tasks(cluster=cluster)["taskArns"]
+
+    assert len(tasks) == len(initial_tasks) + 1
+    task_arn = list(set(tasks).difference(initial_tasks))[0]
+    task = ecs.describe_tasks(cluster=cluster, tasks=[task_arn])["tasks"][0]
+    assert subnet.id in str(task)
+    assert task["taskDefinitionArn"] == task_definition["taskDefinitionArn"]
+
+    # The run is tagged with info about the ECS task
+    assert instance.get_run_by_id(run.run_id).tags["ecs/task_arn"] == task_arn
+    cluster_arn = ecs._cluster_arn(cluster)
+    assert instance.get_run_by_id(run.run_id).tags["ecs/cluster"] == cluster_arn
+
+    assert ecs.list_tags_for_resource(resourceArn=task_arn)["tags"][0]["key"] == "dagster/run_id"
+    assert ecs.list_tags_for_resource(resourceArn=task_arn)["tags"][0]["value"] == run.run_id
+
+    # We set pipeline-specific overides
+    overrides = task["overrides"]["containerOverrides"]
+    assert len(overrides) == 1
+    override = overrides[0]
+    assert override["name"] == "run"
+    assert "execute_run" in override["command"]
+    assert run.run_id in str(override["command"])
+
+    # And we log
+    events = instance.event_log_storage.get_logs_for_run(run.run_id)
+    latest_event = events[-1]
+    assert latest_event.message == "[EcsRunLauncher] Launching run in ECS task"
+    event_metadata = latest_event.dagster_event.engine_event_data.metadata_entries
+    assert MetadataEntry("ECS Task ARN", value=task_arn) in event_metadata
+    assert MetadataEntry("ECS Cluster", value=cluster_arn) in event_metadata
+    assert MetadataEntry("Run ID", value=run.run_id) in event_metadata
+
+    # check status and stop task
+    assert instance.run_launcher.check_run_worker_health(run).status == WorkerStatus.RUNNING
+    ecs.stop_task(cluster=cluster, task=task_arn)
 
 
 def test_task_definition_registration(
@@ -148,90 +235,65 @@ def test_task_definition_registration(
     assert len(ecs.list_task_definitions()["taskDefinitionArns"]) == len(task_definitions) + 1
 
 
-def test_reuse_task_definition(instance):
-    image = "image"
-    secrets = []
+def test_reuse_task_definition(instance, ecs):
+    family = "my-location-family"
+    image = "hello_world:latest"
+    secrets = [
+        {
+            "name": "FOO",
+            "valueFrom": "arn:aws:secretsmanager:us-west-2:111122223333:secret:aes128-1a2b3c",
+        },
+    ]
     environment = [
         {
             "name": "MY_ENV_VAR",
             "value": "MY_VALUE",
         }
     ]
-    original_task_definition = {
-        "containerDefinitions": [
-            {
-                "image": image,
-                "name": instance.run_launcher.container_name,
-                "secrets": secrets,
-                "environment": environment,
-            },
-        ],
-    }
-    metadata = TaskMetadata(
-        cluster="cluster",
-        subnets=[],
-        security_groups=[],
-        task_definition=original_task_definition,
-        container_definition={},
-        assign_public_ip=True,
+    container_name = instance.run_launcher.container_name
+
+    brand_new_task_definition_config = DagsterEcsTaskDefinitionConfig(
+        family="my-location-family",
+        image=image,
+        container_name=container_name,
+        command=None,
+        log_configuration=None,
+        secrets=secrets,
+        environment=environment,
+        execution_role_arn=None,
+        task_role_arn=None,
+        sidecars=[],
     )
 
-    # The same task definition passes
-    task_definition = copy.deepcopy(original_task_definition)
-    assert instance.run_launcher._reuse_task_definition(
-        task_definition, metadata, image, secrets, environment
-    )
+    # New task definition not re-used since it is new
+    assert not instance.run_launcher._reuse_task_definition(brand_new_task_definition_config)
+
+    # Once it's registered, it is re-used
+    ecs.register_task_definition(**brand_new_task_definition_config.task_definition_dict())
+    assert instance.run_launcher._reuse_task_definition(brand_new_task_definition_config)
 
     # Changed image fails
-    task_definition = copy.deepcopy(original_task_definition)
-    task_definition["containerDefinitions"][0]["image"] = "new-image"
+
     assert not instance.run_launcher._reuse_task_definition(
-        task_definition, metadata, image, secrets, environment
+        brand_new_task_definition_config._replace(image="new-image")
     )
 
     # Changed container name fails
-    task_definition = copy.deepcopy(original_task_definition)
-    task_definition["containerDefinitions"][0]["name"] = "new-container"
     assert not instance.run_launcher._reuse_task_definition(
-        task_definition, metadata, image, secrets, environment
+        brand_new_task_definition_config._replace(container_name="new-container")
     )
 
     # Changed secrets fails
-    task_definition = copy.deepcopy(original_task_definition)
-    task_definition["containerDefinitions"][0]["secrets"].append("new-secrets")
     assert not instance.run_launcher._reuse_task_definition(
-        task_definition, metadata, image, secrets, environment
-    )
-
-    # Changed environment fails
-
-    task_definition = copy.deepcopy(original_task_definition)
-    task_definition["containerDefinitions"][0]["environment"].append(
-        {"name": "MY_ENV_VAR", "value": "MY_ENV_VALUE"}
-    )
-    assert not instance.run_launcher._reuse_task_definition(
-        task_definition, metadata, image, secrets, environment
-    )
-
-    # Changed execution role fails
-    task_definition = copy.deepcopy(original_task_definition)
-    task_definition["executionRoleArn"] = "new-role"
-    assert not instance.run_launcher._reuse_task_definition(
-        task_definition, metadata, image, secrets, environment
-    )
-
-    # Changed task role fails
-    task_definition = copy.deepcopy(original_task_definition)
-    task_definition["taskRoleArn"] = "new-role"
-    assert not instance.run_launcher._reuse_task_definition(
-        task_definition, metadata, image, secrets, environment
-    )
-
-    # Any other diff passes
-    task_definition = copy.deepcopy(original_task_definition)
-    task_definition["somethingElse"] = "boom"
-    assert instance.run_launcher._reuse_task_definition(
-        task_definition, metadata, image, secrets, environment
+        brand_new_task_definition_config._replace(
+            secrets=[
+                *secrets,
+                {
+                    "name": "BAR",
+                    "valueFrom": "arn:aws:secretsmanager:us-west-2:111122223333:secret:aes192-4D5e6F",
+                },
+            ]
+        )
     )
 
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -269,7 +269,7 @@ def test_reuse_task_definition(instance, ecs):
     assert not instance.run_launcher._reuse_task_definition(brand_new_task_definition_config)
 
     # Once it's registered, it is re-used
-    ecs.register_task_definition(**brand_new_task_definition_config.task_definition_dict())
+    ecs.register_task_definition(**brand_new_task_definition_config.task_definition_dict("FARGATE"))
     assert instance.run_launcher._reuse_task_definition(brand_new_task_definition_config)
 
     # Changed image fails

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
@@ -369,6 +369,9 @@ class StubbedEcs:
                     "memory": task_definition["memory"],
                 }
 
+                if "launchType" in kwargs:
+                    task["launchType"] = kwargs["launchType"]
+
                 if vpc_configuration:
                     for subnet in vpc_configuration["subnets"]:
                         ec2 = boto3.resource("ec2", region_name=self.client.meta.region_name)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
@@ -44,12 +44,12 @@ def stubbed(function):
                 self.stubber.deactivate()
                 self.stubber.assert_no_pending_responses()
             return copy.deepcopy(response)
-        except Exception as ex:
+        except Exception:
             # Exceptions should reset the stubber
             self.stub_count = 0
             self.stubber.deactivate()
             self.stubber = Stubber(self.client)
-            raise ex
+            raise
 
     return wrapper
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_tasks.py
@@ -40,7 +40,7 @@ def test_create_dagster_task_definition_dict():
         ],
     )
 
-    assert task_config.task_definition_dict() == {
+    assert task_config.task_definition_dict("FARGATE") == {
         "family": "my_task",
         "requiresCompatibilities": ["FARGATE"],
         "networkMode": "awsvpc",
@@ -73,3 +73,5 @@ def test_create_dagster_task_definition_dict():
         "memory": "512",
         "taskRoleArn": "fake-task-role",
     }
+
+    assert task_config.task_definition_dict("EC2")["requiresCompatibilities"] == []

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_tasks.py
@@ -1,0 +1,75 @@
+from dagster_aws.ecs.tasks import DagsterEcsTaskDefinitionConfig
+
+
+def test_create_dagster_task_definition_dict():
+    task_config = DagsterEcsTaskDefinitionConfig(
+        family="my_task",
+        image="foo_image:bar",
+        container_name="run",
+        command=["dagster", "api", "execute_run"],
+        execution_role_arn="fake-role",
+        log_configuration={
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-group": "my-log-group",
+                "awslogs-region": "us_east_=",
+                "awslogs-stream-prefix": "my_task",
+            },
+        },
+        task_role_arn="fake-task-role",
+        environment=[
+            {
+                "name": "FOO_ENV_VAR",
+                "value": "BAR_VALUE",
+            }
+        ],
+        secrets=[
+            {
+                "name": "FOO_SECRET",
+                "valueFrom": "BAR_SECRET_VALUE",
+            }
+        ],
+        sidecars=[
+            {
+                "name": "DatadogAgent",
+                "image": "public.ecr.aws/datadog/agent:latest",
+                "environment": [
+                    {"name": "ECS_FARGATE", "value": "true"},
+                ],
+            }
+        ],
+    )
+
+    assert task_config.task_definition_dict() == {
+        "family": "my_task",
+        "requiresCompatibilities": ["FARGATE"],
+        "networkMode": "awsvpc",
+        "containerDefinitions": [
+            {
+                "name": "run",
+                "image": "foo_image:bar",
+                "environment": [{"name": "FOO_ENV_VAR", "value": "BAR_VALUE"}],
+                "command": ["dagster", "api", "execute_run"],
+                "logConfiguration": {
+                    "logDriver": "awslogs",
+                    "options": {
+                        "awslogs-group": "my-log-group",
+                        "awslogs-region": "us_east_=",
+                        "awslogs-stream-prefix": "my_task",
+                    },
+                },
+                "secrets": [{"name": "FOO_SECRET", "valueFrom": "BAR_SECRET_VALUE"}],
+            },
+            {
+                "name": "DatadogAgent",
+                "image": "public.ecr.aws/datadog/agent:latest",
+                "environment": [
+                    {"name": "ECS_FARGATE", "value": "true"},
+                ],
+            },
+        ],
+        "executionRoleArn": "fake-role",
+        "cpu": "256",
+        "memory": "512",
+        "taskRoleArn": "fake-task-role",
+    }


### PR DESCRIPTION
Summary:
Lets you configure that the EcsRunLauncher should run using EC2, rather than just FARGATE.