### PR TITLE
[dagster-dbt] fix star issue

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -22,7 +22,8 @@ def _resource_type(unique_id: str) -> str:
 
 
 def _get_input_name(node_info: Mapping[str, Any]) -> str:
-    return node_info["unique_id"].replace(".", "_")
+    # * can be present when sources are sharded tables
+    return node_info["unique_id"].replace(".", "_").replace("*", "_star")
 
 
 def _get_output_name(node_info: Mapping[str, Any]) -> str:


### PR DESCRIPTION
### Summary & Motivation

Sharded tables for certain connector types (e.g. Bigquery) can be expressed as sources with `some_table_*`. We then try to automatically generate an input name from that source name (really, the unique id), which fails because it has a star in it. This replaces any "*" characters in the table name with "star", so that we'll have a valid python identifier in these cases.

### How I Tested These Changes

Local dbt project that had a source with a * in it failed before, succeeded after.