### PR TITLE
[dagster-airbyte] Generate airbyte assets from API, using cached assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
@@ -40,7 +40,6 @@ class AssetsDefinitionCacheableData(
         can_subset: bool = False,
         extra_metadata: Optional[Mapping[Any, Any]] = None,
     ):
-<<<<<<< HEAD
 
         keys_by_input_name = check.opt_nullable_mapping_param(
             keys_by_input_name, "keys_by_input_name", key_type=str, value_type=AssetKey
@@ -67,20 +66,6 @@ class AssetsDefinitionCacheableData(
         except TypeError:
             check.failed("Value for `extra_metadata` is not JSON serializable.")
 
-=======
-        #     asset_deps = check.opt_nullable_dict_param(
-        #         asset_deps, "asset_deps", key_type=AssetKey, value_type=set
-        #     )
-        group_names_by_key = check.opt_nullable_dict_param(
-            group_names_by_key, "group_names_by_key", key_type=AssetKey, value_type=str
-        )
-        # metadata_by_key = check.opt_nullable_dict_param(
-        #     metadata_by_key,
-        #     "metadata_by_key",
-        #     key_type=AssetKey,
-        #     value_type=MetadataUserInput,
-        # )
->>>>>>> 29cdf2aac1 (fix 3)
         return super().__new__(
             cls,
             keys_by_input_name=frozendict(keys_by_input_name) if keys_by_input_name else None,

--- a/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
@@ -40,6 +40,7 @@ class AssetsDefinitionCacheableData(
         can_subset: bool = False,
         extra_metadata: Optional[Mapping[Any, Any]] = None,
     ):
+<<<<<<< HEAD
 
         keys_by_input_name = check.opt_nullable_mapping_param(
             keys_by_input_name, "keys_by_input_name", key_type=str, value_type=AssetKey
@@ -66,6 +67,20 @@ class AssetsDefinitionCacheableData(
         except TypeError:
             check.failed("Value for `extra_metadata` is not JSON serializable.")
 
+=======
+        #     asset_deps = check.opt_nullable_dict_param(
+        #         asset_deps, "asset_deps", key_type=AssetKey, value_type=set
+        #     )
+        group_names_by_key = check.opt_nullable_dict_param(
+            group_names_by_key, "group_names_by_key", key_type=AssetKey, value_type=str
+        )
+        # metadata_by_key = check.opt_nullable_dict_param(
+        #     metadata_by_key,
+        #     "metadata_by_key",
+        #     key_type=AssetKey,
+        #     value_type=MetadataUserInput,
+        # )
+>>>>>>> 29cdf2aac1 (fix 3)
         return super().__new__(
             cls,
             keys_by_input_name=frozendict(keys_by_input_name) if keys_by_input_name else None,

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/__init__.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/__init__.py
@@ -1,6 +1,10 @@
 from dagster._core.utils import check_dagster_package_version
 
-from .asset_defs import build_airbyte_assets, load_assets_from_airbyte_project
+from .asset_defs import (
+    build_airbyte_assets,
+    load_assets_from_airbyte_instance,
+    load_assets_from_airbyte_project,
+)
 from .ops import airbyte_sync_op
 from .resources import AirbyteResource, AirbyteState, airbyte_resource
 from .types import AirbyteOutput

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -314,9 +314,11 @@ def load_assets_from_airbyte_instance(
             )
         assets.extend(assets_for_connection)
 
-    return with_resources(
-        assets,
-        resource_defs={"airbyte": airbyte},
+    return list(
+        with_resources(
+            assets,
+            resource_defs={"airbyte": airbyte},
+        )
     )
 
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -53,7 +53,7 @@ def _build_airbyte_asset_defn_metadata(
             )
         )
     )
-    outputs = FrozenSet({AssetKey(asset_key_prefix + [table]) for table in tables})
+    outputs = frozenset({AssetKey(asset_key_prefix + [table]) for table in tables})
 
     internal_deps = {}
 
@@ -66,17 +66,17 @@ def _build_airbyte_asset_defn_metadata(
     if normalization_tables:
         for base_table, derived_tables in normalization_tables.items():
             for derived_table in derived_tables:
-                internal_deps[derived_table] = FrozenSet(
+                internal_deps[derived_table] = frozenset(
                     {AssetKey(asset_key_prefix + [base_table])}
                 )
 
     # All non-normalization tables depend on any user-provided upstream assets
     for table in destination_tables:
-        internal_deps[table] = upstream_assets or FrozenSet()
+        internal_deps[table] = upstream_assets or frozenset()
 
     first_asset_key = AssetKey(asset_key_prefix + [tables[0]])
     return AssetsDefinitionMetadata(
-        input_keys=FrozenSet(),
+        input_keys=frozenset(),
         output_keys=outputs,
         asset_deps=internal_deps,
         group_names_by_key={table: group_name for table in tables} if group_name else None,

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -79,7 +79,9 @@ def _build_airbyte_asset_defn_metadata(
         input_keys=frozenset(),
         output_keys=outputs,
         asset_deps=internal_deps,
-        group_names_by_key={table: group_name for table in tables} if group_name else None,
+        group_names_by_key={AssetKey(asset_key_prefix + [table]): group_name for table in tables}
+        if group_name
+        else None,
         metadata_by_key={
             first_asset_key: {
                 "connection_id": connection_id,
@@ -427,7 +429,7 @@ class AirbyteInstanceCacheableAssetsDefintion(CacheableAssetsDefinition):
                 destination_tables=list(table_mapping.keys()),
                 normalization_tables=table_mapping,
                 asset_key_prefix=self._key_prefix,
-                group_name=self._connection_to_group_fn(connection_id)
+                group_name=self._connection_to_group_fn(connection.name)
                 if self._connection_to_group_fn
                 else None,
             )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -9,6 +9,7 @@ from dagster_airbyte.utils import generate_materializations
 
 from dagster import AssetKey, AssetOut, Output, ResourceDefinition
 from dagster import _check as check
+from dagster import with_resources
 from dagster._annotations import experimental
 from dagster._core.definitions import AssetsDefinition, multi_asset
 from dagster._core.definitions.events import CoercibleToAssetKeyPrefix
@@ -313,7 +314,10 @@ def load_assets_from_airbyte_instance(
             )
         assets.extend(assets_for_connection)
 
-    return assets
+    return with_resources(
+        assets,
+        resource_defs={"airbyte": airbyte},
+    )
 
 
 @experimental

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -94,18 +94,19 @@ def _build_airbyte_assets_from_metadata(
     assets_defn_meta: AssetsDefinitionMetadata,
 ) -> AssetsDefinition:
 
-    connection_id = cast(str, assets_defn_meta.extra_metadata["connection_id"])
-    group_name = cast(Optional[str], assets_defn_meta.extra_metadata["group_name"])
-    destination_tables = cast(List[str], assets_defn_meta.extra_metadata["destination_tables"])
-    normalization_tables = cast(
-        Mapping[str, List[str]], assets_defn_meta.extra_metadata["normalization_tables"]
-    )
+    metadata = cast(Mapping[str, Any], assets_defn_meta.extra_metadata)
+    connection_id = cast(str, metadata["connection_id"])
+    group_name = cast(Optional[str], metadata["group_name"])
+    destination_tables = cast(List[str], metadata["destination_tables"])
+    normalization_tables = cast(Mapping[str, List[str]], metadata["normalization_tables"])
 
     @multi_asset(
         name=f"airbyte_sync_{connection_id[:5]}",
         non_argument_deps=set((assets_defn_meta.keys_by_input_name or {}).values()),
         outs={k: AssetOut(key=v) for k, v in (assets_defn_meta.keys_by_output_name or {}).items()},
-        internal_asset_deps={k: set(v) for k, v in assets_defn_meta.internal_asset_deps.items()},
+        internal_asset_deps={
+            k: set(v) for k, v in (assets_defn_meta.internal_asset_deps or {}).items()
+        },
         required_resource_keys={"airbyte"},
         compute_kind="airbyte",
         group_name=group_name,

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import re
 from itertools import chain
@@ -15,7 +16,6 @@ from typing import (
     cast,
 )
 
-import hashlib
 import yaml
 from dagster_airbyte.resources import AirbyteResource
 from dagster_airbyte.utils import generate_materializations
@@ -26,8 +26,8 @@ from dagster import with_resources
 from dagster._annotations import experimental
 from dagster._core.definitions import AssetsDefinition, multi_asset
 from dagster._core.definitions.cacheable_assets import (
-    CacheableAssetsDefinition,
     AssetsDefinitionCacheableData,
+    CacheableAssetsDefinition,
 )
 from dagster._core.definitions.events import CoercibleToAssetKeyPrefix
 from dagster._core.definitions.load_assets_from_modules import with_group

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -3,7 +3,7 @@ import responses
 from dagster_airbyte import airbyte_resource
 from dagster_airbyte.asset_defs import load_assets_from_airbyte_instance
 
-from dagster import AssetKey, build_init_resource_context, materialize, with_resources
+from dagster import AssetKey, build_init_resource_context, materialize
 
 from .utils import (
     get_instance_connections_json,
@@ -102,12 +102,7 @@ def test_load_from_instance(use_normalization_tables, connection_to_group_fn):
         status=200,
     )
 
-    res = materialize(
-        with_resources(
-            ab_assets,
-            resource_defs={"airbyte": ab_instance},
-        )
-    )
+    res = materialize(ab_assets)
 
     materializations = [
         event.event_specific_data.materialization

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -53,16 +53,17 @@ def test_load_from_instance(use_normalization_tables, connection_to_group_fn):
         status=200,
     )
     if connection_to_group_fn:
-        ab_assets = load_assets_from_airbyte_instance(
+        ab_cacheable_assets = load_assets_from_airbyte_instance(
             ab_instance,
             create_assets_for_normalization_tables=use_normalization_tables,
             connection_to_group_fn=connection_to_group_fn,
         )
     else:
-        ab_assets = load_assets_from_airbyte_instance(
+        ab_cacheable_assets = load_assets_from_airbyte_instance(
             ab_instance,
             create_assets_for_normalization_tables=use_normalization_tables,
         )
+    ab_assets = ab_cacheable_assets.get_definitions(ab_cacheable_assets.get_metadata())
 
     tables = {"dagster_releases", "dagster_tags", "dagster_teams"} | (
         {"dagster_releases_assets", "dagster_releases_author", "dagster_tags_commit"}

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -63,7 +63,7 @@ def test_load_from_instance(use_normalization_tables, connection_to_group_fn):
             ab_instance,
             create_assets_for_normalization_tables=use_normalization_tables,
         )
-    ab_assets = ab_cacheable_assets.get_definitions(ab_cacheable_assets.get_cached_data())
+    ab_assets = ab_cacheable_assets.build_definitions(ab_cacheable_assets.compute_cacheable_data())
 
     tables = {"dagster_releases", "dagster_tags", "dagster_teams"} | (
         {"dagster_releases_assets", "dagster_releases_author", "dagster_tags_commit"}

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -63,7 +63,7 @@ def test_load_from_instance(use_normalization_tables, connection_to_group_fn):
             ab_instance,
             create_assets_for_normalization_tables=use_normalization_tables,
         )
-    ab_assets = ab_cacheable_assets.get_definitions(ab_cacheable_assets.get_metadata())
+    ab_assets = ab_cacheable_assets.get_definitions(ab_cacheable_assets.get_cached_data())
 
     tables = {"dagster_releases", "dagster_tags", "dagster_teams"} | (
         {"dagster_releases_assets", "dagster_releases_author", "dagster_tags_commit"}

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
@@ -338,3 +338,222 @@ def get_project_job_json():
             }
         ],
     }
+
+
+def get_instance_workspaces_json():
+    return {
+        "workspaces": [
+            {
+                "workspaceId": "b49ed3cd-7bb4-4f11-b8ba-95b4a5f7bc75",
+            }
+        ]
+    }
+
+
+def get_instance_connections_json():
+    return {
+        "connections": [
+            {
+                "connectionId": "87b7fe85-a22c-420e-8d74-b30e7ede77df",
+                "name": "GitHub <> snowflake-ben",
+                "prefix": "dagster_",
+                "sourceId": "4b8fc3cc-efce-41d7-8654-05c3fc03485e",
+                "destinationId": "028fc82d-3a27-4fef-94a6-a22fbd45bac4",
+                "operationIds": ["f39dbcd0-a6dc-4319-9ae4-28937997b48a"],
+                "syncCatalog": {
+                    "streams": [
+                        {
+                            "stream": {
+                                "name": "releases",
+                                "jsonSchema": {
+                                    "type": "object",
+                                    "$schema": "http://json-schema.org/draft-07/schema#",
+                                    "properties": {
+                                        "id": {"type": ["null", "integer"]},
+                                        "url": {"type": ["null", "string"]},
+                                        "body": {"type": ["null", "string"]},
+                                        "name": {"type": ["null", "string"]},
+                                        "draft": {"type": ["null", "boolean"]},
+                                        "assets": {
+                                            "type": ["null", "array"],
+                                            "items": {
+                                                "type": ["null", "object"],
+                                                "properties": {
+                                                    "id": {"type": ["null", "integer"]},
+                                                    "url": {"type": ["null", "string"]},
+                                                    "name": {"type": ["null", "string"]},
+                                                    "size": {"type": ["null", "integer"]},
+                                                    "label": {"type": ["null", "string"]},
+                                                    "state": {"type": ["null", "string"]},
+                                                    "node_id": {"type": ["null", "string"]},
+                                                    "created_at": {
+                                                        "type": ["null", "string"],
+                                                        "format": "date-time",
+                                                    },
+                                                    "updated_at": {
+                                                        "type": ["null", "string"],
+                                                        "format": "date-time",
+                                                    },
+                                                    "uploader_id": {"type": ["null", "integer"]},
+                                                    "content_type": {"type": ["null", "string"]},
+                                                    "download_count": {"type": ["null", "integer"]},
+                                                    "browser_download_url": {
+                                                        "type": ["null", "string"]
+                                                    },
+                                                },
+                                            },
+                                        },
+                                        "author": {
+                                            "type": ["null", "object"],
+                                            "properties": {
+                                                "id": {"type": ["null", "integer"]},
+                                                "url": {"type": ["null", "string"]},
+                                                "type": {"type": ["null", "string"]},
+                                                "login": {"type": ["null", "string"]},
+                                                "node_id": {"type": ["null", "string"]},
+                                                "html_url": {"type": ["null", "string"]},
+                                                "gists_url": {"type": ["null", "string"]},
+                                                "repos_url": {"type": ["null", "string"]},
+                                                "avatar_url": {"type": ["null", "string"]},
+                                                "events_url": {"type": ["null", "string"]},
+                                                "site_admin": {"type": ["null", "boolean"]},
+                                                "gravatar_id": {"type": ["null", "string"]},
+                                                "starred_url": {"type": ["null", "string"]},
+                                                "followers_url": {"type": ["null", "string"]},
+                                                "following_url": {"type": ["null", "string"]},
+                                                "organizations_url": {"type": ["null", "string"]},
+                                                "subscriptions_url": {"type": ["null", "string"]},
+                                                "received_events_url": {"type": ["null", "string"]},
+                                            },
+                                        },
+                                        "node_id": {"type": ["null", "string"]},
+                                        "html_url": {"type": ["null", "string"]},
+                                        "tag_name": {"type": ["null", "string"]},
+                                        "assets_url": {"type": ["null", "string"]},
+                                        "created_at": {
+                                            "type": ["null", "string"],
+                                            "format": "date-time",
+                                        },
+                                        "prerelease": {"type": ["null", "boolean"]},
+                                        "repository": {"type": ["string"]},
+                                        "upload_url": {"type": ["null", "string"]},
+                                        "tarball_url": {"type": ["null", "string"]},
+                                        "zipball_url": {"type": ["null", "string"]},
+                                        "published_at": {
+                                            "type": ["null", "string"],
+                                            "format": "date-time",
+                                        },
+                                        "target_commitish": {"type": ["null", "string"]},
+                                    },
+                                },
+                                "supportedSyncModes": ["full_refresh", "incremental"],
+                                "sourceDefinedCursor": True,
+                                "defaultCursorField": ["created_at"],
+                                "sourceDefinedPrimaryKey": [["id"]],
+                            },
+                            "config": {
+                                "syncMode": "incremental",
+                                "cursorField": ["created_at"],
+                                "destinationSyncMode": "append_dedup",
+                                "primaryKey": [["id"]],
+                                "aliasName": "releases",
+                                "selected": True,
+                            },
+                        },
+                        {
+                            "stream": {
+                                "name": "tags",
+                                "jsonSchema": {
+                                    "type": "object",
+                                    "$schema": "http://json-schema.org/draft-07/schema#",
+                                    "properties": {
+                                        "name": {"type": ["null", "string"]},
+                                        "commit": {
+                                            "type": ["null", "object"],
+                                            "properties": {
+                                                "sha": {"type": ["null", "string"]},
+                                                "url": {"type": ["null", "string"]},
+                                            },
+                                        },
+                                        "node_id": {"type": ["null", "string"]},
+                                        "repository": {"type": ["string"]},
+                                        "tarball_url": {"type": ["null", "string"]},
+                                        "zipball_url": {"type": ["null", "string"]},
+                                    },
+                                },
+                                "supportedSyncModes": ["full_refresh"],
+                                "defaultCursorField": [],
+                                "sourceDefinedPrimaryKey": [["repository"], ["name"]],
+                            },
+                            "config": {
+                                "syncMode": "full_refresh",
+                                "cursorField": [],
+                                "destinationSyncMode": "append",
+                                "primaryKey": [["repository"], ["name"]],
+                                "aliasName": "tags",
+                                "selected": True,
+                            },
+                        },
+                        {
+                            "stream": {
+                                "name": "teams",
+                                "jsonSchema": {
+                                    "type": "object",
+                                    "$schema": "http://json-schema.org/draft-07/schema#",
+                                    "properties": {
+                                        "id": {"type": ["null", "integer"]},
+                                        "url": {"type": ["null", "string"]},
+                                        "name": {"type": ["null", "string"]},
+                                        "slug": {"type": ["null", "string"]},
+                                        "parent": {
+                                            "type": ["null", "object"],
+                                            "properties": {},
+                                            "additionalProperties": True,
+                                        },
+                                        "node_id": {"type": ["null", "string"]},
+                                        "privacy": {"type": ["null", "string"]},
+                                        "html_url": {"type": ["null", "string"]},
+                                        "permission": {"type": ["null", "string"]},
+                                        "repository": {"type": ["null", "string"]},
+                                        "description": {"type": ["null", "string"]},
+                                        "members_url": {"type": ["null", "string"]},
+                                        "organization": {"type": ["null", "string"]},
+                                        "repositories_url": {"type": ["null", "string"]},
+                                    },
+                                },
+                                "supportedSyncModes": ["full_refresh"],
+                                "defaultCursorField": [],
+                                "sourceDefinedPrimaryKey": [["id"]],
+                            },
+                            "config": {
+                                "syncMode": "full_refresh",
+                                "cursorField": [],
+                                "destinationSyncMode": "append",
+                                "primaryKey": [["id"]],
+                                "aliasName": "teams",
+                                "selected": True,
+                            },
+                        },
+                    ]
+                },
+                "scheduleType": "manual",
+                "status": "active",
+            },
+        ]
+    }
+
+
+def get_instance_operations_json():
+    return {
+        "operations": [
+            {
+                "workspaceId": "b49ed3cd-7bb4-4f11-b8ba-95b4a5f7bc75",
+                "operationId": "f39dbcd0-a6dc-4319-9ae4-28937997b48a",
+                "name": "Normalization",
+                "operatorConfiguration": {
+                    "operatorType": "normalization",
+                    "normalization": {"option": "basic"},
+                },
+            }
+        ]
+    }


### PR DESCRIPTION
## Summary

Rework of #9702, using the new cached assets API that Owen implemented in #9761 

Adds a new `@experimental` API similar to #9664 that allows users to load Airbyte assets from an Airbyte instance, connecting at initialization-time and pulling connection definitions. The initialization-time configuration is cached, so it's not re-fetched in future repo loads.

```python
airbyte_instance = airbyte_resource.configured(
    {
        "host": "localhost",
        "port": "8000",
        "forward_logs": False,
    }
)
airbyte_assets = load_assets_from_airbyte_instance(
    airbyte_instance,
)
```

Has the same config options as the 'from project' API.

## Test Plan

Tested locally; new unit tests
