### PR TITLE
[fixit] Add library versions to docs

### DIFF
--- a/docs/next/components/Link.tsx
+++ b/docs/next/components/Link.tsx
@@ -7,7 +7,7 @@ import {normalizeVersionPath, useVersion} from '../util/useVersion';
 
 interface LinkProps {
   href: string;
-  children: JSX.Element;
+  children: React.ReactNode;
   version?: string;
   passHref?: boolean;
 }

--- a/docs/next/components/VersionDropdown.tsx
+++ b/docs/next/components/VersionDropdown.tsx
@@ -70,14 +70,17 @@ export default function VersionDropdown() {
                 >
                   <div className="px-4 py-3">
                     <p className="text-sm leading-5">
-                      You are currently viewing the docs for Dagster{' '}
+                      You&apos;re currently viewing the docs for Dagster{' '}
                       <span className="text-sm font-medium leading-5 text-gray-900">
                         {currentVersion}
                       </span>
-                      . You can select a different version below. Note that prior to 1.0, all
-                      Dagster packages shared the same version. After 1.0, separate version tracks
-                      were adopted for mature Dagster packages and less mature integration
-                      libraries.
+                      . Select a different version below. Note that prior to 1.0, all Dagster
+                      packages shared the same version. After 1.0, we adopted separate version
+                      tracks to differentiate less mature integration libraries.{' '}
+                      <Link href="/getting-started/releases#dagster-integration-libraries">
+                        <span className="hover:underline cursor-pointer">Learn more</span>
+                      </Link>
+                      .
                     </p>
                   </div>
 

--- a/docs/next/components/VersionDropdown.tsx
+++ b/docs/next/components/VersionDropdown.tsx
@@ -11,14 +11,16 @@ function getLibraryVersion(coreVersion) {
   return parseInt(major) < 1 ? coreVersion : ['0', 16 + parseInt(minor), patch].join('.');
 }
 
+function getLibraryVersionText(coreVersion) {
+  const libraryVersion = coreVersion === 'master' ? 'master' : getLibraryVersion(coreVersion);
+  return libraryVersion === 'master' || coreVersion === libraryVersion
+    ? ''
+    : `/ ${libraryVersion} (libs)`;
+}
+
 export default function VersionDropdown() {
   const {latestVersion, version: currentVersion, versions, asPath} = useVersion();
-  const libraryVersion = currentVersion === 'master' ? 'master' : getLibraryVersion(currentVersion);
-  const libraryVersionText =
-    libraryVersion === 'master' || currentVersion === libraryVersion
-      ? ''
-      : `/ ${libraryVersion} (libs)`;
-
+  const libraryVersionText = getLibraryVersionText(currentVersion);
   return (
     <div className="z-20 relative inline-flex text-left w-full">
       <div className="relative block text-left w-full">
@@ -72,12 +74,16 @@ export default function VersionDropdown() {
                       <span className="text-sm font-medium leading-5 text-gray-900">
                         {currentVersion}
                       </span>
-                      . You can select a different version below.
+                      . You can select a different version below. Note that prior to 1.0, all
+                      Dagster packages shared the same version. After 1.0, separate version tracks
+                      were adopted for mature Dagster packages and less mature integration
+                      libraries.
                     </p>
                   </div>
 
                   <div className="py-1">
                     {versions.map((version) => {
+                      const libraryVersionText = getLibraryVersionText(version);
                       return (
                         <Link key={version} href={asPath} version={version}>
                           <Menu.Item>
@@ -87,7 +93,7 @@ export default function VersionDropdown() {
                                   active ? 'bg-gray-100 text-gray-900' : 'text-gray-700'
                                 } flex cursor-pointer justify-between w-full px-4 py-2 text-sm leading-5 text-left`}
                               >
-                                {version}
+                                {version} {libraryVersionText}
                               </a>
                             )}
                           </Menu.Item>

--- a/docs/next/components/VersionDropdown.tsx
+++ b/docs/next/components/VersionDropdown.tsx
@@ -6,8 +6,18 @@ import {useVersion} from '../util/useVersion';
 
 import Link from './Link';
 
+function getLibraryVersion(coreVersion) {
+  const [major, minor, patch] = coreVersion.split('.');
+  return parseInt(major) < 1 ? coreVersion : ['0', 16 + parseInt(minor), patch].join('.');
+}
+
 export default function VersionDropdown() {
   const {latestVersion, version: currentVersion, versions, asPath} = useVersion();
+  const libraryVersion = currentVersion === 'master' ? 'master' : getLibraryVersion(currentVersion);
+  const libraryVersionText =
+    libraryVersion === 'master' || currentVersion === libraryVersion
+      ? ''
+      : `/ ${libraryVersion} (libs)`;
 
   return (
     <div className="z-20 relative inline-flex text-left w-full">
@@ -16,13 +26,16 @@ export default function VersionDropdown() {
           {({open}) => (
             <>
               <div>
-                <Menu.Button className="group w-24 lg:w-32 rounded-full px-2 lg:px-4 lg:py-2 text-gray-400 border border-gray-300 hover:bg-white transition-colors duration-200">
+                <Menu.Button className="group rounded-full px-2 lg:px-4 lg:py-2 text-gray-400 border border-gray-300 hover:bg-white transition-colors duration-200">
                   <span className="flex w-full justify-between items-center">
                     <span className="flex min-w-0 items-center justify-between space-x-3">
-                      <span className="flex-1 min-w-0">
-                        <span className="text-gray-900 dark:text-gray-300 text-xs lg:text-sm truncate">
-                          {currentVersion} {currentVersion === latestVersion && '(latest)'}
+                      <span className="flex-1 min-w-0 text-gray-900 dark:text-gray-300 text-xs lg:text-sm truncate space-x-1">
+                        <span>
+                          {currentVersion} {libraryVersionText}
                         </span>
+                        {currentVersion === latestVersion ? (
+                          <span className="bg-lavender rounded-full px-2 py-1">latest</span>
+                        ) : null}
                       </span>
                     </span>
                     {/* Heroicon name: selector */}

--- a/docs/next/scripts/mdx-transform.ts
+++ b/docs/next/scripts/mdx-transform.ts
@@ -5,22 +5,23 @@ import frontmatter from 'remark-frontmatter';
 import mdx from 'remark-mdx';
 import {read, write} from 'to-vfile';
 import {parse as yaml} from 'yaml';
-import preset from "../.remarkrc.js";
-import codeTransformer, { CodeBlockStats } from "../util/codeBlockTransformer";
-import imageTransformer, { ImageStats } from "../util/imageTransformer";
+
+import preset from '../.remarkrc.js';
+import codeTransformer, {CodeBlockStats} from '../util/codeBlockTransformer';
+import imageTransformer, {ImageStats} from '../util/imageTransformer';
 
 // Main
 (async () => {
   const stream = fg.stream(['../content/**/*.mdx']);
 
-  let stats: CodeBlockStats & ImageStats = {
+  const stats: CodeBlockStats & ImageStats = {
     totalCodeBlocks: 0,
     updatedCodeBlocks: [],
     totalImages: 0,
     updatedImages: [],
   };
   const setCodeBlockStats = (newStats: CodeBlockStats) => {
-    const { totalCodeBlocks, updatedCodeBlocks } = newStats;
+    const {totalCodeBlocks, updatedCodeBlocks} = newStats;
     stats.totalCodeBlocks += totalCodeBlocks;
     stats.updatedCodeBlocks = stats.updatedCodeBlocks.concat(updatedCodeBlocks);
   };
@@ -35,8 +36,8 @@ import imageTransformer, { ImageStats } from "../util/imageTransformer";
       .use(frontmatter)
       .use(extract, {yaml})
       .use(mdx)
-      .use(codeTransformer, { setCodeBlockStats })
-      .use(imageTransformer, { setImageStats })
+      .use(codeTransformer, {setCodeBlockStats})
+      .use(imageTransformer, {setImageStats})
       .use(preset)
       .process(file);
 
@@ -49,7 +50,7 @@ import imageTransformer, { ImageStats } from "../util/imageTransformer";
   console.log(`✅ ${stats.totalCodeBlocks} code blocks parsed`);
   if (stats.updatedCodeBlocks.length) {
     console.log(`⚡️ ${stats.updatedCodeBlocks.length} updated:`);
-    console.log(`\t${stats.updatedCodeBlocks.join("\n\t")}`);
+    console.log(`\t${stats.updatedCodeBlocks.join('\n\t')}`);
   } else {
     console.log(`✨ No code blocks were updated`);
   }

--- a/docs/next/util/codeBlockTransformer.ts
+++ b/docs/next/util/codeBlockTransformer.ts
@@ -20,78 +20,81 @@ interface CodeTransformerOptions {
 }
 
 const normalizeOptionValue = (value: string): string | boolean => {
-  if (value === 'true') { return true; }
-  else if (value === 'false') { return false; }
-  else { return value; }
-}
-
-export default ({ setCodeBlockStats: setCodeBlockStats }: CodeTransformerOptions) => async (
-  tree: Node
-) => {
-  const codes: [Node, number][] = [];
-  visit(tree, "code", (node, index) => {
-    codes.push([node, index]);
-  });
-
-  const optionKeys = ["lines", "startafter", "endbefore", "dedent", "trim"];
-
-  const stats: CodeBlockStats = {
-    totalCodeBlocks: 0,
-    updatedCodeBlocks: [],
-  };
-
-  for (const [node] of codes) {
-    const meta = ((node["meta"] as string) || "").split(" ");
-    const fileMeta = meta.find((m) => m.startsWith("file="));
-    if (!fileMeta) {
-      continue;
-    }
-
-    const metaOptions: {
-      lines?: string;
-      dedent?: string;
-      startafter?: string;
-      endbefore?: string;
-      trim?: boolean;
-    } = {
-      trim: true,
-    };
-
-    for (const option of optionKeys) {
-      const needle = `${option}=`;
-      const value = meta.find((m) => m.startsWith(needle));
-      if (value) {
-        metaOptions[option] = normalizeOptionValue(value.slice(needle.length));
-      }
-    }
-
-    const filePath = fileMeta.slice("file=".length);
-    const fileAbsPath = path.join(DOCS_SNIPPET, filePath);
-    try {
-      const content = await fs.readFile(fileAbsPath, "utf8");
-      let contentWithLimit = limitSnippetLines(
-        content,
-        metaOptions.lines,
-        metaOptions.dedent,
-        metaOptions.startafter,
-        metaOptions.endbefore
-      );
-
-      if (metaOptions.trim) {
-        contentWithLimit = contentWithLimit.trim();
-      }
-
-      stats.totalCodeBlocks++;
-      if (node["value"] !== contentWithLimit) {
-        stats.updatedCodeBlocks.push(node["meta"] as string);
-        node["value"] = `${contentWithLimit}`;
-      }
-    } catch (err) {
-      node["value"] = err.message;
-    }
-  }
-
-  if (setCodeBlockStats) {
-    setCodeBlockStats(stats);
+  if (value === 'true') {
+    return true;
+  } else if (value === 'false') {
+    return false;
+  } else {
+    return value;
   }
 };
+
+export default ({setCodeBlockStats: setCodeBlockStats}: CodeTransformerOptions) =>
+  async (tree: Node) => {
+    const codes: [Node, number][] = [];
+    visit(tree, 'code', (node, index) => {
+      codes.push([node, index]);
+    });
+
+    const optionKeys = ['lines', 'startafter', 'endbefore', 'dedent', 'trim'];
+
+    const stats: CodeBlockStats = {
+      totalCodeBlocks: 0,
+      updatedCodeBlocks: [],
+    };
+
+    for (const [node] of codes) {
+      const meta = ((node['meta'] as string) || '').split(' ');
+      const fileMeta = meta.find((m) => m.startsWith('file='));
+      if (!fileMeta) {
+        continue;
+      }
+
+      const metaOptions: {
+        lines?: string;
+        dedent?: string;
+        startafter?: string;
+        endbefore?: string;
+        trim?: boolean;
+      } = {
+        trim: true,
+      };
+
+      for (const option of optionKeys) {
+        const needle = `${option}=`;
+        const value = meta.find((m) => m.startsWith(needle));
+        if (value) {
+          metaOptions[option] = normalizeOptionValue(value.slice(needle.length));
+        }
+      }
+
+      const filePath = fileMeta.slice('file='.length);
+      const fileAbsPath = path.join(DOCS_SNIPPET, filePath);
+      try {
+        const content = await fs.readFile(fileAbsPath, 'utf8');
+        let contentWithLimit = limitSnippetLines(
+          content,
+          metaOptions.lines,
+          metaOptions.dedent,
+          metaOptions.startafter,
+          metaOptions.endbefore,
+        );
+
+        if (metaOptions.trim) {
+          contentWithLimit = contentWithLimit.trim();
+        }
+
+        stats.totalCodeBlocks++;
+        if (node['value'] !== contentWithLimit) {
+          stats.updatedCodeBlocks.push(node['meta'] as string);
+          node['value'] = `${contentWithLimit}`;
+        }
+      } catch (err) {
+        node['value'] = err.message;
+      }
+    }
+
+    if (setCodeBlockStats) {
+      setCodeBlockStats(stats);
+    }
+  };


### PR DESCRIPTION
### Summary & Motivation

Shows library versions in addition to core version in docs.

- If core version is >= 1.0, then version dropdown will show e.g. "1.0.9 /0.16.9 (libs)"
- If core version is < 1.0, only one version is shown
- Changed display of `(latest)` for latest version to drop the parentheses and use a lavender background. This was necessary because of the new `(libs)` text.

### How I Tested These Changes

Browsed dev site locally.
