### PR TITLE
[dagit] Prefill default job config when materializing assets

### DIFF
--- a/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
@@ -229,13 +229,16 @@ export const useInitialDataForMode = (
   pipeline: LaunchpadSessionPipelineFragment,
   partitionSets: LaunchpadSessionPartitionSetsFragment,
 ) => {
-  const {isJob, presets} = pipeline;
+  const {isJob, isAssetJob, presets} = pipeline;
   const partitionSetsForMode = partitionSets.results;
 
   return React.useMemo(() => {
     const presetsForMode = isJob ? (presets.length ? [presets[0]] : []) : presets;
 
-    if (presetsForMode.length === 1 && partitionSetsForMode.length === 0) {
+    // I believe that partition sets in asset jobs do not provide config (at least right now),
+    // so even in the presence of a partition set we want to use config from the
+    // `default` preset
+    if (presetsForMode.length === 1 && (isAssetJob || partitionSetsForMode.length === 0)) {
       return {
         base: {presetName: presetsForMode[0].name, tags: null},
         runConfigYaml: presetsForMode[0].runConfigYaml,

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
@@ -195,6 +195,7 @@ const EXECUTION_SESSION_CONTAINER_PIPELINE_FRAGMENT = gql`
   fragment LaunchpadSessionPipelineFragment on Pipeline {
     id
     isJob
+    isAssetJob
     ...ConfigEditorGeneratorPipelineFragment
     modes {
       id

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadTransientSessionContainer.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadTransientSessionContainer.tsx
@@ -4,6 +4,7 @@ import {
   createSingleSession,
   IExecutionSession,
   IExecutionSessionChanges,
+  useInitialDataForMode,
 } from '../app/ExecutionSessionStorage';
 import {RepoAddress} from '../workspace/types';
 
@@ -23,7 +24,12 @@ interface Props {
 export const LaunchpadTransientSessionContainer = (props: Props) => {
   const {launchpadType, pipeline, partitionSets, repoAddress, sessionPresets} = props;
 
-  const initialSessionComplete = createSingleSession(sessionPresets);
+  const initialData = useInitialDataForMode(pipeline, partitionSets);
+  const initialSessionComplete = createSingleSession({
+    ...sessionPresets,
+    runConfigYaml: initialData.runConfigYaml,
+  });
+
   const [session, setSession] = React.useState<IExecutionSession>(initialSessionComplete);
 
   const onSaveSession = (changes: IExecutionSessionChanges) => {

--- a/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadRootQuery.ts
@@ -61,6 +61,7 @@ export interface LaunchpadRootQuery_pipelineOrError_Pipeline {
   __typename: "Pipeline";
   id: string;
   isJob: boolean;
+  isAssetJob: boolean;
   name: string;
   presets: LaunchpadRootQuery_pipelineOrError_Pipeline_presets[];
   tags: LaunchpadRootQuery_pipelineOrError_Pipeline_tags[];

--- a/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadSessionPipelineFragment.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadSessionPipelineFragment.ts
@@ -39,6 +39,7 @@ export interface LaunchpadSessionPipelineFragment {
   __typename: "Pipeline";
   id: string;
   isJob: boolean;
+  isAssetJob: boolean;
   name: string;
   presets: LaunchpadSessionPipelineFragment_presets[];
   tags: LaunchpadSessionPipelineFragment_tags[];


### PR DESCRIPTION
### Summary & Motivation

This is a small PR that addresses an issue raised in Slack here: https://dagster.slack.com/archives/C01U5LFUZJS/p1663617996204489

When you shift-click the Materialize button for an asset job that has config, we now show the default config in the launchpad. This is consistent with how it works in op jobs in the old launchpad tab.

There's a bit of follow-up work we may want to tackle in the future -- jobs started in this method retain the runConfigYaml in full, not just the defaults you choose to override. This means that opening the launchpad and clicking Run produces slightly different run metadata than starting the run with the same default config without  opening the launchpad. This is now the case with both op and asset jobs though, and seems low priority.

### How I Tested These Changes
