### PR TITLE
[dagit] Fetch isAssetJob in WorkspaceContext, rm Launchpad tab flicker

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/JobMetadata.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/JobMetadata.test.tsx
@@ -5,7 +5,7 @@ import * as Flags from '../app/Flags';
 import {TestProvider} from '../testing/TestProvider';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
-import {JobMetadata, useJobNavMetadata} from './JobMetadata';
+import {JobMetadata} from './JobMetadata';
 
 jest.mock('../app/Flags');
 
@@ -70,10 +70,7 @@ describe('JobMetadata', () => {
   };
 
   const JobMetadataContainer = () => {
-    const metadata = useJobNavMetadata(REPO_ADDRESS, PIPELINE_NAME);
-    return (
-      <JobMetadata metadata={metadata} pipelineName={PIPELINE_NAME} repoAddress={REPO_ADDRESS} />
-    );
+    return <JobMetadata pipelineName={PIPELINE_NAME} repoAddress={REPO_ADDRESS} />;
   };
 
   const renderWithMocks = (mocks?: any) => {

--- a/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
@@ -67,11 +67,11 @@ export function useJobNavMetadata(repoAddress: RepoAddress, pipelineName: string
 interface Props {
   pipelineName: string;
   repoAddress: RepoAddress;
-  metadata: JobMetadata;
 }
 
 export const JobMetadata: React.FC<Props> = (props) => {
-  const {metadata, pipelineName, repoAddress} = props;
+  const {pipelineName, repoAddress} = props;
+  const metadata = useJobNavMetadata(repoAddress, pipelineName);
 
   return (
     <>

--- a/js_modules/dagit/packages/core/src/nav/PipelineNav.tsx
+++ b/js_modules/dagit/packages/core/src/nav/PipelineNav.tsx
@@ -92,8 +92,8 @@ export const PipelineNav: React.FC<Props> = (props) => {
   const repoJobEntry = repo?.repository.pipelines.find(
     (pipelineOrJob) => pipelineOrJob.name === pipelineName,
   );
-  const isJob = repoJobEntry?.isJob || false;
-  const isAssetJob = repoJobEntry?.isAssetJob || false;
+  const isJob = !!repoJobEntry?.isJob;
+  const isAssetJob = !!repoJobEntry?.isAssetJob;
 
   // If using pipeline:mode tuple (crag flag), check for partition sets that are for this specific
   // pipeline:mode tuple. Otherwise, just check for a pipeline name match.

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
@@ -79,6 +79,7 @@ const ROOT_WORKSPACE_QUERY = gql`
                   id
                   name
                   isJob
+                  isAssetJob
                   pipelineSnapshotId
                 }
                 schedules {

--- a/js_modules/dagit/packages/core/src/workspace/types/RootWorkspaceQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/RootWorkspaceQuery.ts
@@ -20,6 +20,7 @@ export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_l
   id: string;
   name: string;
   isJob: boolean;
+  isAssetJob: boolean;
   pipelineSnapshotId: string;
 }
 


### PR DESCRIPTION
### Summary & Motivation

This PR addresses a "flicker" users have reported, where the Launchpad tab appears briefly and then disappears when the asset node metadata loads and we realize it's an Asset job.

I originally avoided adding isAssetJob to the workspace context because I thought the implementation of the resolver looked expensive, but it's actually cheap because the data it references is already loaded. Pre-fetching that value lets us hide/show tabs correctly synchronously.

I think this would also let us use different icons for asset and op jobs, which might be a nice touch sometime soon. 

### How I Tested These Changes
