### PR TITLE
[dagit] Multi-colored run batch backgrounds

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.stories.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.stories.tsx
@@ -215,3 +215,56 @@ export const BucketByRepo = () => {
     </Group>
   );
 };
+
+export const CandyStriping = () => {
+  const twoHoursAgo = React.useMemo(() => Date.now() - 2 * 60 * 60 * 1000, []);
+  const now = React.useMemo(() => Date.now(), []);
+
+  const jobs: TimelineJob[] = React.useMemo(() => {
+    const jobKey = faker.random.words(2).split(' ').join('-').toLowerCase();
+    const repoAddress = makeRepoAddress();
+    return [
+      {
+        key: jobKey,
+        jobName: jobKey,
+        jobType: 'job',
+        path: `/${jobKey}`,
+        repoAddress,
+        runs: [
+          {
+            id: faker.datatype.uuid(),
+            status: RunStatus.SUCCESS,
+            startTime: twoHoursAgo + 20 * 60 * 1000,
+            endTime: twoHoursAgo + 95 * 60 * 1000,
+          },
+          {
+            id: faker.datatype.uuid(),
+            status: RunStatus.SUCCESS,
+            startTime: twoHoursAgo + 90 * 60 * 1000,
+            endTime: twoHoursAgo + 110 * 60 * 1000,
+          },
+          {
+            id: faker.datatype.uuid(),
+            status: RunStatus.FAILURE,
+            startTime: twoHoursAgo + 60 * 60 * 1000,
+            endTime: now,
+          },
+          {
+            id: faker.datatype.uuid(),
+            status: RunStatus.SUCCESS,
+            startTime: twoHoursAgo + 60 * 60 * 1000,
+            endTime: now,
+          },
+          {
+            id: faker.datatype.uuid(),
+            status: RunStatus.STARTED,
+            startTime: twoHoursAgo + 60 * 60 * 1000,
+            endTime: now,
+          },
+        ],
+      },
+    ];
+  }, [twoHoursAgo, now]);
+
+  return <RunTimeline jobs={jobs} range={[twoHoursAgo, now]} />;
+};

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -25,9 +25,10 @@ import {RepoAddress} from '../workspace/types';
 
 import {RepoSectionHeader, SECTION_HEADER_HEIGHT} from './RepoSectionHeader';
 import {RunStatusDot} from './RunStatusDots';
-import {failedStatuses, inProgressStatuses, queuedStatuses, successStatuses} from './RunStatuses';
+import {failedStatuses, inProgressStatuses, successStatuses} from './RunStatuses';
 import {TimeElapsed} from './TimeElapsed';
 import {batchRunsForTimeline, RunBatch} from './batchRunsForTimeline';
+import {mergeStatusToBackground} from './mergeStatusToBackground';
 
 const ROW_HEIGHT = 32;
 const TIME_HEADER_HEIGHT = 42;
@@ -387,46 +388,6 @@ const NowMarker = styled.div`
   user-select: none;
 `;
 
-const mergeStatusToColor = (runs: TimelineRun[]) => {
-  let anyInProgress = false;
-  let anyQueued = false;
-  let anyFailed = false;
-  let anySucceeded = false;
-  let anyScheduled = false;
-
-  runs.forEach(({status}) => {
-    if (status === 'SCHEDULED') {
-      anyScheduled = true;
-    } else if (queuedStatuses.has(status)) {
-      anyQueued = true;
-    } else if (inProgressStatuses.has(status)) {
-      anyInProgress = true;
-    } else if (failedStatuses.has(status)) {
-      anyFailed = true;
-    } else if (successStatuses.has(status)) {
-      anySucceeded = true;
-    }
-  });
-
-  if (anyQueued) {
-    return Colors.Blue200;
-  }
-  if (anyInProgress) {
-    return Colors.Blue500;
-  }
-  if (anyFailed) {
-    return Colors.Red500;
-  }
-  if (anySucceeded) {
-    return Colors.Green500;
-  }
-  if (anyScheduled) {
-    return Colors.Blue200;
-  }
-
-  return Colors.Gray500;
-};
-
 const MIN_CHUNK_WIDTH = 2;
 const MIN_WIDTH_FOR_MULTIPLE = 16;
 
@@ -481,7 +442,7 @@ const RunTimelineRow = ({
           return (
             <RunChunk
               key={batch.runs[0].id}
-              $color={mergeStatusToColor(batch.runs)}
+              $background={mergeStatusToBackground(batch.runs)}
               $multiple={runCount > 1}
               style={{
                 left: `${left}px`,
@@ -568,13 +529,13 @@ const RunChunks = styled.div`
 `;
 
 interface ChunkProps {
-  $color: string;
+  $background: string;
   $multiple: boolean;
 }
 
 const RunChunk = styled.div<ChunkProps>`
   align-items: center;
-  background-color: ${({$color}) => $color};
+  background: ${({$background}) => $background};
   border-radius: 2px;
   height: ${ROW_HEIGHT - 4}px;
   position: absolute;
@@ -594,7 +555,8 @@ const BatchCount = styled.div`
   color: ${Colors.White};
   cursor: default;
   font-family: ${FontFamily.monospace};
-  font-size: 12px;
+  font-size: 14px;
+  font-weight: 600;
   user-select: none;
 `;
 

--- a/js_modules/dagit/packages/core/src/runs/mergeStatusToBackground.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/mergeStatusToBackground.test.tsx
@@ -1,0 +1,86 @@
+import {Colors} from '@dagster-io/ui';
+
+import {RunStatus} from '../types/globalTypes';
+
+import {TimelineRun} from './RunTimeline';
+import {mergeStatusToBackground} from './mergeStatusToBackground';
+
+describe('mergeStatusToBackground', () => {
+  const failedA = {id: 'failed-a', status: RunStatus.FAILURE, startTime: 10, endTime: 50};
+  const failedB = {id: 'failed-b', status: RunStatus.FAILURE, startTime: 10, endTime: 50};
+  const succeededA = {id: 'succeeded-a', status: RunStatus.SUCCESS, startTime: 10, endTime: 50};
+  const succeededB = {id: 'succeeded-b', status: RunStatus.SUCCESS, startTime: 10, endTime: 50};
+  const inProgressA = {id: 'inProgress-a', status: RunStatus.STARTED, startTime: 10, endTime: 50};
+  const inProgressB = {id: 'inProgress-b', status: RunStatus.STARTED, startTime: 10, endTime: 50};
+  const queuedA = {id: 'queued-a', status: RunStatus.QUEUED, startTime: 10, endTime: 50};
+  const queuedB = {id: 'queued-b', status: RunStatus.QUEUED, startTime: 10, endTime: 50};
+  const scheduledA: TimelineRun = {
+    id: 'scheduled-a',
+    status: 'SCHEDULED',
+    startTime: 10,
+    endTime: 50,
+  };
+  const scheduledB: TimelineRun = {
+    id: 'scheduled-b',
+    status: 'SCHEDULED',
+    startTime: 10,
+    endTime: 50,
+  };
+
+  it('uses a single color if all runs are the same status', () => {
+    expect(mergeStatusToBackground([failedA, failedB])).toBe(Colors.Red500);
+    expect(mergeStatusToBackground([succeededA, succeededB])).toBe(Colors.Green500);
+    expect(mergeStatusToBackground([inProgressA, inProgressB])).toBe(Colors.Blue500);
+    expect(mergeStatusToBackground([queuedA, queuedB])).toBe(Colors.Blue200);
+    expect(mergeStatusToBackground([scheduledA, scheduledB])).toBe(Colors.Blue200);
+  });
+
+  it('splits the background if there are two statuses, in order', () => {
+    const failedSucceeded = mergeStatusToBackground([failedA, succeededA]);
+    expect(failedSucceeded).toBe(
+      `linear-gradient(to right, ${Colors.Red500} 50.0%, ${Colors.Green500} 50.0%)`,
+    );
+    const succeededFailed = mergeStatusToBackground([succeededA, failedA]);
+    expect(succeededFailed).toBe(
+      `linear-gradient(to right, ${Colors.Red500} 50.0%, ${Colors.Green500} 50.0%)`,
+    );
+    const succeededInProgress = mergeStatusToBackground([succeededA, inProgressA]);
+    expect(succeededInProgress).toBe(
+      `linear-gradient(to right, ${Colors.Green500} 50.0%, ${Colors.Blue500} 50.0%)`,
+    );
+
+    // More than two runs
+    const failFailSuccess = mergeStatusToBackground([failedA, failedB, succeededA]);
+    expect(failFailSuccess).toBe(
+      `linear-gradient(to right, ${Colors.Red500} 66.7%, ${Colors.Green500} 66.7%)`,
+    );
+  });
+
+  it('splits the background if there are 3+ statuses, in order', () => {
+    const succeedFailInProgress = mergeStatusToBackground([succeededA, failedA, inProgressA]);
+    expect(succeedFailInProgress).toBe(
+      `linear-gradient(to right, ${Colors.Red500} 33.3%, ${Colors.Green500} 33.3% 66.7%, ${Colors.Blue500} 66.7%)`,
+    );
+
+    const succeed2xFailInProgress = mergeStatusToBackground([
+      succeededA,
+      succeededB,
+      failedA,
+      inProgressA,
+    ]);
+    expect(succeed2xFailInProgress).toBe(
+      `linear-gradient(to right, ${Colors.Red500} 25.0%, ${Colors.Green500} 25.0% 75.0%, ${Colors.Blue500} 75.0%)`,
+    );
+
+    const allOfTheAbove = mergeStatusToBackground([
+      succeededA,
+      failedA,
+      inProgressA,
+      queuedA,
+      scheduledA,
+    ]);
+    expect(allOfTheAbove).toBe(
+      `linear-gradient(to right, ${Colors.Red500} 20.0%, ${Colors.Green500} 20.0% 40.0%, ${Colors.Blue500} 40.0% 60.0%, ${Colors.Blue200} 60.0% 80.0%, ${Colors.Blue200} 80.0%)`,
+    );
+  });
+});

--- a/js_modules/dagit/packages/core/src/runs/mergeStatusToBackground.tsx
+++ b/js_modules/dagit/packages/core/src/runs/mergeStatusToBackground.tsx
@@ -1,0 +1,92 @@
+import {Colors} from '@dagster-io/ui';
+
+import {queuedStatuses, inProgressStatuses, failedStatuses, successStatuses} from './RunStatuses';
+import {TimelineRun} from './RunTimeline';
+
+type BackgroundStatus = 'inProgress' | 'queued' | 'failed' | 'succeeded' | 'scheduled';
+
+const statusToColor = (status: BackgroundStatus) => {
+  switch (status) {
+    case 'queued':
+      return Colors.Blue200;
+    case 'inProgress':
+      return Colors.Blue500;
+    case 'failed':
+      return Colors.Red500;
+    case 'succeeded':
+      return Colors.Green500;
+    case 'scheduled':
+      return Colors.Blue200;
+  }
+};
+
+export const mergeStatusToBackground = (runs: TimelineRun[]) => {
+  const counts = {
+    scheduled: 0,
+    queued: 0,
+    inProgress: 0,
+    failed: 0,
+    succeeded: 0,
+  };
+
+  runs.forEach(({status}) => {
+    if (status === 'SCHEDULED') {
+      counts.scheduled++;
+    } else if (queuedStatuses.has(status)) {
+      counts.queued++;
+    } else if (inProgressStatuses.has(status)) {
+      counts.inProgress++;
+    } else if (failedStatuses.has(status)) {
+      counts.failed++;
+    } else if (successStatuses.has(status)) {
+      counts.succeeded++;
+    }
+  });
+
+  const statusArr = Object.keys(counts).filter(
+    (status) => counts[status] > 0,
+  ) as BackgroundStatus[];
+
+  if (statusArr.length === 1) {
+    const [element] = statusArr;
+    return statusToColor(element);
+  }
+
+  // const colorList = statusArr.map(statusToColor);
+  const runCount = runs.length;
+
+  const colors = [
+    counts.failed > 0 ? {status: 'failed', pct: (counts.failed * 100) / runCount} : null,
+    counts.succeeded > 0 ? {status: 'succeeded', pct: (counts.succeeded * 100) / runCount} : null,
+    counts.inProgress > 0
+      ? {status: 'inProgress', pct: (counts.inProgress * 100) / runCount}
+      : null,
+    counts.queued > 0 ? {status: 'queued', pct: (counts.queued * 100) / runCount} : null,
+    counts.scheduled > 0 ? {status: 'scheduled', pct: (counts.scheduled * 100) / runCount} : null,
+  ].filter(Boolean);
+
+  let colorString = '';
+  let nextPct = 0;
+  let pctSoFar = 0;
+
+  for (let ii = 0; ii < colors.length; ii++) {
+    const value = colors[ii];
+    if (!value) {
+      continue;
+    }
+
+    const {status, pct} = value;
+    pctSoFar = nextPct;
+    nextPct += pct;
+    const colorForStatus = statusToColor(status as BackgroundStatus);
+    if (ii === 0) {
+      colorString += `${colorForStatus} ${pct.toFixed(1)}%, `;
+    } else if (ii === colors.length - 1) {
+      colorString += `${colorForStatus} ${pctSoFar.toFixed(1)}%`;
+    } else {
+      colorString += `${colorForStatus} ${pctSoFar.toFixed(1)}% ${nextPct.toFixed(1)}%, `;
+    }
+  }
+
+  return `linear-gradient(to right, ${colorString})`;
+};


### PR DESCRIPTION
### Summary & Motivation

Update run batch backgrounds for the run timeline, in situations where the batch contains runs of different statuses.

Specifically, show proportional backgrounds for the different statuses. For example, if a batch as two failed runs and three successful runs, show a background that is 40% red and 60% green, in that order. If a batch as a failed run, a successful run, an in-progress run, and a queued run, show each background color at 25%.

The goal here is to provide better insight into what the batches contain, instead of blowing away all context and just showing a single color.

<img width="294" alt="Screen Shot 2022-09-22 at 2 10 05 PM" src="https://user-images.githubusercontent.com/2823852/191843974-0b443232-a874-496e-a0fc-895f33e03271.png">
<img width="1077" alt="Screen Shot 2022-09-22 at 2 19 22 PM" src="https://user-images.githubusercontent.com/2823852/191844006-282c0563-bfa0-43c6-a55f-f8e8508e9329.png">

### How I Tested These Changes

Storybook examples, jest test. View a real run timeline with batches, verify that rendering looks correct.
