### PR TITLE
[dagit] Virtualized graphs table, reuse ops view

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedGraphTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedGraphTable.tsx
@@ -1,0 +1,144 @@
+import {gql, useLazyQuery} from '@apollo/client';
+import {Box, Caption, Colors} from '@dagster-io/ui';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+import styled from 'styled-components/macro';
+
+import {Container, HeaderCell, Inner, Row, RowCell} from '../ui/VirtualizedTable';
+
+import {useDelayedRowQuery} from './VirtualizedWorkspaceTable';
+import {RepoAddress} from './types';
+import {SingleGraphQuery, SingleGraphQueryVariables} from './types/SingleGraphQuery';
+import {workspacePathFromAddress} from './workspacePath';
+
+export type Graph = {name: string; path: string; description: string | null};
+
+interface Props {
+  graphs: Graph[];
+  repoAddress: RepoAddress;
+}
+
+export const VirtualizedGraphTable: React.FC<Props> = ({repoAddress, graphs}) => {
+  const parentRef = React.useRef<HTMLDivElement | null>(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: graphs.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 64,
+    overscan: 10,
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const items = rowVirtualizer.getVirtualItems();
+
+  return (
+    <>
+      <Box
+        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '100%',
+          height: '32px',
+          fontSize: '12px',
+          color: Colors.Gray600,
+        }}
+      >
+        <HeaderCell>Graph</HeaderCell>
+      </Box>
+      <div style={{overflow: 'hidden'}}>
+        <Container ref={parentRef}>
+          <Inner $totalHeight={totalHeight}>
+            {items.map(({index, key, size, start}) => {
+              const row: Graph = graphs[index];
+              return (
+                <GraphRow
+                  key={key}
+                  name={row.name}
+                  description={row.description}
+                  path={row.path}
+                  repoAddress={repoAddress}
+                  height={size}
+                  start={start}
+                />
+              );
+            })}
+          </Inner>
+        </Container>
+      </div>
+    </>
+  );
+};
+
+interface GraphRowProps {
+  name: string;
+  path: string;
+  description: string | null;
+  repoAddress: RepoAddress;
+  height: number;
+  start: number;
+}
+
+const GraphRow = (props: GraphRowProps) => {
+  const {name, path, description, repoAddress, start, height} = props;
+
+  const [queryGraph, queryResult] = useLazyQuery<SingleGraphQuery, SingleGraphQueryVariables>(
+    SINGLE_GRAPH_QUERY,
+    {
+      fetchPolicy: 'cache-and-network',
+      variables: {
+        selector: {
+          repositoryName: repoAddress.name,
+          repositoryLocationName: repoAddress.location,
+          graphName: name,
+        },
+      },
+    },
+  );
+
+  useDelayedRowQuery(queryGraph);
+  const {data} = queryResult;
+
+  const displayedDescription = React.useMemo(() => {
+    if (description) {
+      return description;
+    }
+    if (data?.graphOrError.__typename === 'Graph') {
+      return data.graphOrError.description;
+    }
+    return null;
+  }, [data, description]);
+
+  return (
+    <Row $height={height} $start={start}>
+      <RowGrid border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
+        <RowCell>
+          <Box flex={{direction: 'column', gap: 4}}>
+            <span style={{fontWeight: 500}}>
+              <Link to={workspacePathFromAddress(repoAddress, path)}>{name}</Link>
+            </span>
+            {displayedDescription ? <Caption>{displayedDescription}</Caption> : null}
+          </Box>
+        </RowCell>
+      </RowGrid>
+    </Row>
+  );
+};
+
+const RowGrid = styled(Box)`
+  display: grid;
+  grid-template-columns: 100%;
+  height: 100%;
+`;
+
+const SINGLE_GRAPH_QUERY = gql`
+  query SingleGraphQuery($selector: GraphSelector!) {
+    graphOrError(selector: $selector) {
+      ... on Graph {
+        id
+        name
+        description
+      }
+    }
+  }
+`;

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceGraphsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceGraphsRoot.tsx
@@ -1,0 +1,172 @@
+import {gql, useQuery} from '@apollo/client';
+import {Box, Colors, NonIdealState, Spinner, TextInput} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {useTrackPageView} from '../app/analytics';
+import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
+
+import {Graph, VirtualizedGraphTable} from './VirtualizedGraphTable';
+import {WorkspaceHeader} from './WorkspaceHeader';
+import {repoAddressToSelector} from './repoAddressToSelector';
+import {RepoAddress} from './types';
+import {WorkspaceGraphsQuery, WorkspaceGraphsQueryVariables} from './types/WorkspaceGraphsQuery';
+
+export const WorkspaceGraphsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
+  useTrackPageView();
+
+  const [searchValue, setSearchValue] = React.useState('');
+  const selector = repoAddressToSelector(repoAddress);
+
+  const queryResultOverview = useQuery<WorkspaceGraphsQuery, WorkspaceGraphsQueryVariables>(
+    WROSKPACE_GRAPHS_QUERY,
+    {
+      fetchPolicy: 'network-only',
+      notifyOnNetworkStatusChange: true,
+      variables: {selector},
+    },
+  );
+  const {data, loading} = queryResultOverview;
+
+  const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
+  const anySearch = sanitizedSearch.length > 0;
+
+  const graphs = React.useMemo(() => {
+    const repo = data?.repositoryOrError;
+    if (!repo || repo.__typename !== 'Repository') {
+      return [];
+    }
+
+    const jobGraphNames = new Set<string>(
+      repo.pipelines
+        .filter((p) => p.isJob && !isHiddenAssetGroupJob(p.name))
+        .map((p) => p.graphName),
+    );
+
+    const items: Graph[] = Array.from(jobGraphNames).map((graphName) => ({
+      name: graphName,
+      path: `/graphs/${graphName}`,
+      description: null,
+    }));
+
+    repo.usedSolids.forEach((s) => {
+      if (s.definition.__typename === 'CompositeSolidDefinition') {
+        items.push({
+          name: s.definition.name,
+          path: `/graphs/${s.invocations[0].pipeline.name}/${s.invocations[0].solidHandle.handleID}/`,
+          description: s.definition.description,
+        });
+      }
+    });
+
+    return items.sort((a, b) => a.name.localeCompare(b.name));
+  }, [data]);
+
+  const filteredBySearch = React.useMemo(() => {
+    const searchToLower = sanitizedSearch.toLocaleLowerCase();
+    return graphs.filter(({name}) => name.toLocaleLowerCase().includes(searchToLower));
+  }, [graphs, sanitizedSearch]);
+
+  const content = () => {
+    if (loading && !data) {
+      return (
+        <Box flex={{direction: 'row', justifyContent: 'center'}} style={{paddingTop: '100px'}}>
+          <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
+            <Spinner purpose="body-text" />
+            <div style={{color: Colors.Gray600}}>Loading graphs…</div>
+          </Box>
+        </Box>
+      );
+    }
+
+    if (!filteredBySearch.length) {
+      if (anySearch) {
+        return (
+          <Box padding={{top: 20}}>
+            <NonIdealState
+              icon="search"
+              title="No matching graphs"
+              description={
+                <div>
+                  No graphs matching <strong>{searchValue}</strong> were found in this repository
+                </div>
+              }
+            />
+          </Box>
+        );
+      }
+
+      return (
+        <Box padding={{top: 20}}>
+          <NonIdealState
+            icon="search"
+            title="No graphs"
+            description="No graphs were found in this repository"
+          />
+        </Box>
+      );
+    }
+
+    return <VirtualizedGraphTable repoAddress={repoAddress} graphs={filteredBySearch} />;
+  };
+
+  return (
+    <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
+      <WorkspaceHeader repoAddress={repoAddress} tab="graphs" />
+      <Box padding={{horizontal: 24, vertical: 16}}>
+        <TextInput
+          icon="search"
+          value={searchValue}
+          onChange={(e) => setSearchValue(e.target.value)}
+          placeholder="Filter by graph name…"
+          style={{width: '340px'}}
+        />
+      </Box>
+      {loading && !data ? (
+        <Box padding={64}>
+          <Spinner purpose="page" />
+        </Box>
+      ) : (
+        content()
+      )}
+    </Box>
+  );
+};
+
+const WROSKPACE_GRAPHS_QUERY = gql`
+  query WorkspaceGraphsQuery($selector: RepositorySelector!) {
+    repositoryOrError(repositorySelector: $selector) {
+      ... on Repository {
+        id
+        usedSolids {
+          definition {
+            __typename
+            ... on CompositeSolidDefinition {
+              id
+              name
+              description
+            }
+          }
+          invocations {
+            pipeline {
+              id
+              name
+            }
+            solidHandle {
+              handleID
+            }
+          }
+        }
+        pipelines {
+          id
+          name
+          isJob
+          graphName
+        }
+      }
+      ...PythonErrorFragment
+    }
+  }
+
+  ${PYTHON_ERROR_FRAGMENT}
+`;

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceOpsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceOpsRoot.tsx
@@ -1,0 +1,18 @@
+import {Box} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {useTrackPageView} from '../app/analytics';
+import {OpsRoot} from '../ops/OpsRoot';
+
+import {WorkspaceHeader} from './WorkspaceHeader';
+import {RepoAddress} from './types';
+
+export const WorkspaceOpsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
+  useTrackPageView();
+  return (
+    <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
+      <WorkspaceHeader repoAddress={repoAddress} tab="ops" />
+      <OpsRoot repoAddress={repoAddress} />
+    </Box>
+  );
+};

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
@@ -11,7 +11,9 @@ import {SensorRoot} from '../sensors/SensorRoot';
 import {GraphRoot} from './GraphRoot';
 import {WorkspaceAssetsRoot} from './WorkspaceAssetsRoot';
 import {WorkspaceContext} from './WorkspaceContext';
+import {WorkspaceGraphsRoot} from './WorkspaceGraphsRoot';
 import {WorkspaceJobsRoot} from './WorkspaceJobsRoot';
+import {WorkspaceOpsRoot} from './WorkspaceOpsRoot';
 import {WorkspaceOverviewRoot} from './WorkspaceOverviewRoot';
 import {WorkspacePipelineRoot} from './WorkspacePipelineRoot';
 import {WorkspaceRepoRoot} from './WorkspaceRepoRoot';
@@ -98,6 +100,16 @@ const RepoRouteContainer = () => {
       {flagNewWorkspace ? (
         <Route path="/workspace/:repoPath/sensors" exact>
           <WorkspaceSensorsRoot repoAddress={addressForPath} />
+        </Route>
+      ) : null}
+      {flagNewWorkspace ? (
+        <Route path="/workspace/:repoPath/graphs" exact>
+          <WorkspaceGraphsRoot repoAddress={addressForPath} />
+        </Route>
+      ) : null}
+      {flagNewWorkspace ? (
+        <Route path="/workspace/:repoPath/ops/:name?" exact>
+          <WorkspaceOpsRoot repoAddress={addressForPath} />
         </Route>
       ) : null}
       <Route path="/workspace/:repoPath/graphs/(/?.*)">

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceTabs.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceTabs.tsx
@@ -33,8 +33,8 @@ export const WorkspaceTabs = <TData extends Record<string, any>>(props: Props<TD
           title="Sensors"
           to={workspacePathFromAddress(repoAddress, '/sensors')}
         />
-        {/* <TabLink id="graphs" title="Graphs" to="/workspace/graphs" />
-        <TabLink id="ops" title="Ops" to="/workspace/ops" /> */}
+        <TabLink id="graphs" title="Graphs" to={workspacePathFromAddress(repoAddress, '/graphs')} />
+        <TabLink id="ops" title="Ops" to={workspacePathFromAddress(repoAddress, '/ops')} />
       </Tabs>
       {refreshState ? (
         <Box padding={{bottom: 8}}>

--- a/js_modules/dagit/packages/core/src/workspace/types/SingleGraphQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/SingleGraphQuery.ts
@@ -1,0 +1,31 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { GraphSelector } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: SingleGraphQuery
+// ====================================================
+
+export interface SingleGraphQuery_graphOrError_GraphNotFoundError {
+  __typename: "GraphNotFoundError" | "PythonError";
+}
+
+export interface SingleGraphQuery_graphOrError_Graph {
+  __typename: "Graph";
+  id: string;
+  name: string;
+  description: string | null;
+}
+
+export type SingleGraphQuery_graphOrError = SingleGraphQuery_graphOrError_GraphNotFoundError | SingleGraphQuery_graphOrError_Graph;
+
+export interface SingleGraphQuery {
+  graphOrError: SingleGraphQuery_graphOrError;
+}
+
+export interface SingleGraphQueryVariables {
+  selector: GraphSelector;
+}

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceGraphsQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceGraphsQuery.ts
@@ -1,0 +1,88 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { RepositorySelector } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: WorkspaceGraphsQuery
+// ====================================================
+
+export interface WorkspaceGraphsQuery_repositoryOrError_RepositoryNotFoundError {
+  __typename: "RepositoryNotFoundError";
+}
+
+export interface WorkspaceGraphsQuery_repositoryOrError_Repository_usedSolids_definition_SolidDefinition {
+  __typename: "SolidDefinition";
+}
+
+export interface WorkspaceGraphsQuery_repositoryOrError_Repository_usedSolids_definition_CompositeSolidDefinition {
+  __typename: "CompositeSolidDefinition";
+  id: string;
+  name: string;
+  description: string | null;
+}
+
+export type WorkspaceGraphsQuery_repositoryOrError_Repository_usedSolids_definition = WorkspaceGraphsQuery_repositoryOrError_Repository_usedSolids_definition_SolidDefinition | WorkspaceGraphsQuery_repositoryOrError_Repository_usedSolids_definition_CompositeSolidDefinition;
+
+export interface WorkspaceGraphsQuery_repositoryOrError_Repository_usedSolids_invocations_pipeline {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+}
+
+export interface WorkspaceGraphsQuery_repositoryOrError_Repository_usedSolids_invocations_solidHandle {
+  __typename: "SolidHandle";
+  handleID: string;
+}
+
+export interface WorkspaceGraphsQuery_repositoryOrError_Repository_usedSolids_invocations {
+  __typename: "NodeInvocationSite";
+  pipeline: WorkspaceGraphsQuery_repositoryOrError_Repository_usedSolids_invocations_pipeline;
+  solidHandle: WorkspaceGraphsQuery_repositoryOrError_Repository_usedSolids_invocations_solidHandle;
+}
+
+export interface WorkspaceGraphsQuery_repositoryOrError_Repository_usedSolids {
+  __typename: "UsedSolid";
+  definition: WorkspaceGraphsQuery_repositoryOrError_Repository_usedSolids_definition;
+  invocations: WorkspaceGraphsQuery_repositoryOrError_Repository_usedSolids_invocations[];
+}
+
+export interface WorkspaceGraphsQuery_repositoryOrError_Repository_pipelines {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+  isJob: boolean;
+  graphName: string;
+}
+
+export interface WorkspaceGraphsQuery_repositoryOrError_Repository {
+  __typename: "Repository";
+  id: string;
+  usedSolids: WorkspaceGraphsQuery_repositoryOrError_Repository_usedSolids[];
+  pipelines: WorkspaceGraphsQuery_repositoryOrError_Repository_pipelines[];
+}
+
+export interface WorkspaceGraphsQuery_repositoryOrError_PythonError_causes {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface WorkspaceGraphsQuery_repositoryOrError_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  causes: WorkspaceGraphsQuery_repositoryOrError_PythonError_causes[];
+}
+
+export type WorkspaceGraphsQuery_repositoryOrError = WorkspaceGraphsQuery_repositoryOrError_RepositoryNotFoundError | WorkspaceGraphsQuery_repositoryOrError_Repository | WorkspaceGraphsQuery_repositoryOrError_PythonError;
+
+export interface WorkspaceGraphsQuery {
+  repositoryOrError: WorkspaceGraphsQuery_repositoryOrError;
+}
+
+export interface WorkspaceGraphsQueryVariables {
+  selector: RepositorySelector;
+}


### PR DESCRIPTION
### Summary & Motivation

Create a virtualized Graph table and reuse the existing Ops view, in the new Workspace section behind the feature flag.

There's not much in the Graph table right now.

### How I Tested These Changes

View a repo in the new Workspace section, verify correct rendering and behavior of Graphs and Ops tabs.
