### PR TITLE
[dagster-dbt] remove logs and raw output from dbt errors

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
@@ -136,14 +136,10 @@ def execute_cli(
     raw_output = "\n\n".join(raw_output)
 
     if return_code == 2:
-        raise DagsterDbtCliFatalRuntimeError(
-            logs=json_lines, raw_output=raw_output, messages=messages
-        )
+        raise DagsterDbtCliFatalRuntimeError(messages=messages)
 
     if return_code == 1 and not ignore_handled_error:
-        raise DagsterDbtCliHandledRuntimeError(
-            logs=json_lines, raw_output=raw_output, messages=messages
-        )
+        raise DagsterDbtCliHandledRuntimeError(messages=messages)
 
     run_results = (
         parse_run_results(flags_dict["project-dir"], target_path)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
@@ -44,7 +44,7 @@ class DagsterDbtCliRuntimeError(DagsterDbtError, ABC):
             warnings.warn(
                 "`raw_output` is a deprecated argument to DagsterDbtCliRuntimeError and will be discarded"
             )
-        metadata_entries = [MetadataEntry("Parsed CLI Messages", value="\n".join(messages))]
+        metadata_entries = [MetadataEntry("Parsed CLI Messages", value="\n".join(messages or ""))]
         super().__init__(description, metadata_entries)
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
@@ -1,5 +1,6 @@
+import warnings
 from abc import ABC
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping, Optional, Sequence
 
 from dagster import Failure, MetadataEntry
 from dagster import _check as check
@@ -31,38 +32,43 @@ class DagsterDbtCliRuntimeError(DagsterDbtError, ABC):
     def __init__(
         self,
         description: str,
-        logs: Sequence[Mapping[str, Any]],
-        raw_output: str,
-        messages: Sequence[str],
+        logs: Optional[Sequence[Mapping[str, Any]]] = None,
+        raw_output: Optional[str] = None,
+        messages: Optional[Sequence[str]] = None,
     ):
-        metadata_entries = [
-            MetadataEntry(
-                "Parsed CLI Output (JSON)",
-                value={"logs": logs},
-            ),
-            MetadataEntry(
-                "Parsed CLI Messages",
-                value="\n".join(messages),
-            ),
-            MetadataEntry(
-                "Raw CLI Output",
-                value=raw_output,
-            ),
-        ]
+        if logs is not None:
+            warnings.warn(
+                "`logs` is a deprecated argument to DagsterDbtCliRuntimeError and will be discarded"
+            )
+        if raw_output is not None:
+            warnings.warn(
+                "`raw_output` is a deprecated argument to DagsterDbtCliRuntimeError and will be discarded"
+            )
+        metadata_entries = [MetadataEntry("Parsed CLI Messages", value="\n".join(messages))]
         super().__init__(description, metadata_entries)
 
 
 class DagsterDbtCliHandledRuntimeError(DagsterDbtCliRuntimeError):
     """Represents a model error reported by the dbt CLI at runtime (return code 1)."""
 
-    def __init__(self, logs: Sequence[Mapping[str, Any]], raw_output: str, messages: Sequence[str]):
+    def __init__(
+        self,
+        logs: Optional[Sequence[Mapping[str, Any]]] = None,
+        raw_output: Optional[str] = None,
+        messages: Optional[Sequence[str]] = None,
+    ):
         super().__init__("Handled error in the dbt CLI (return code 1)", logs, raw_output, messages)
 
 
 class DagsterDbtCliFatalRuntimeError(DagsterDbtCliRuntimeError):
     """Represents a fatal error in the dbt CLI (return code 2)."""
 
-    def __init__(self, logs: Sequence[Mapping[str, Any]], raw_output: str, messages: Sequence[str]):
+    def __init__(
+        self,
+        logs: Optional[Sequence[Mapping[str, Any]]] = None,
+        raw_output: Optional[str] = None,
+        messages: Optional[Sequence[str]] = None,
+    ):
         super().__init__(
             "Fatal error in the dbt CLI (return code 2): " + " ".join(messages),
             logs,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
@@ -70,7 +70,7 @@ class DagsterDbtCliFatalRuntimeError(DagsterDbtCliRuntimeError):
         messages: Optional[Sequence[str]] = None,
     ):
         super().__init__(
-            "Fatal error in the dbt CLI (return code 2): " + " ".join(messages),
+            "Fatal error in the dbt CLI (return code 2): " + " ".join(messages or []),
             logs,
             raw_output,
             messages,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
@@ -44,7 +44,7 @@ class DagsterDbtCliRuntimeError(DagsterDbtError, ABC):
             warnings.warn(
                 "`raw_output` is a deprecated argument to DagsterDbtCliRuntimeError and will be discarded"
             )
-        metadata_entries = [MetadataEntry("Parsed CLI Messages", value="\n".join(messages or ""))]
+        metadata_entries = [MetadataEntry("Parsed CLI Messages", value="\n".join(messages or []))]
         super().__init__(description, metadata_entries)
 
 


### PR DESCRIPTION
### Summary & Motivation

These fields provide negligible value and take up a lot of room in the database.

Keeping them around on the constructor because technically these errors are exported from the top level so we probably shouldn't break them (even if it's unlikely anyone else is using them)

### How I Tested These Changes
