### PR TITLE
[dagster-airflow] Add DagsterOperator and associated airflow abstractions

### DIFF
--- a/docs/content/integrations/airflow.mdx
+++ b/docs/content/integrations/airflow.mdx
@@ -19,6 +19,8 @@ Dagster is a fully-featured orchestrator and does not require a system like Airf
 You can orchestrate Dagster job runs from airflow by using the `DagsterCloudOperator` or `DagsterOperator` operators in your existing airflow dags. For example, here's an airflow Dag:
 
 ```python file=/integrations/airflow/operator.py
+# pylint: disable=unused-variable
+
 from datetime import datetime
 
 from airflow import DAG
@@ -34,9 +36,10 @@ with DAG(
         task_id='new_dagster_assets',
         repostitory_location_name="example_location",
         repository_name="my_dagster_project",
-        job_name="all_assets_job"
+        job_name="all_assets_job",
     )
 ```
+
 In airflow 2.0+ you can create a dagster connection type to store configuration related to your dagster cloud organization, you can also pass this directly to the operator if you're using airflow 1.0.
 
 ## Exporting Dagster jobs to Airflow

--- a/docs/content/integrations/airflow.mdx
+++ b/docs/content/integrations/airflow.mdx
@@ -7,12 +7,37 @@ description: The dagster-airflow package allows you to export Dagster jobs as Ai
 
 <CodeReferenceLink filePath="examples/with_airflow" />
 
-The [`dagster-airflow`](/\_apidocs/libraries/dagster-airflow) package allows you to export Dagster jobs as Airflow DAGs, as well as to import Airflow DAGs into Dagster jobs.
+The [`dagster-airflow`](/\_apidocs/libraries/dagster-airflow) package allows you to orchestrate Dagster from Airflow, export Dagster jobs as Airflow DAGs, and import Airflow DAGs into Dagster jobs.
 
 Dagster is a fully-featured orchestrator and does not require a system like Airflow to deploy, execute, or schedule jobs. The main scenarios for using Dagster with Airflow are:
 
 - You have an existing Airflow setup that's too difficult to migrate away from, but you want to use Dagster for local development.
 - You want to migrate from Airflow to Dagster in an incremental fashion.
+
+## Orchestrating Dagster jobs from Airflow
+
+You can orchestrate Dagster job runs from airflow by using the `DagsterCloudOperator` or `DagsterOperator` operators in your existing airflow dags. For example, here's an airflow Dag:
+
+```python file=/integrations/airflow/operator.py
+from datetime import datetime
+
+from airflow import DAG
+from dagster_airflow import DagsterCloudOperator
+
+with DAG(
+    dag_id='dagster_cloud',
+    start_date=datetime(2022, 5, 28),
+    schedule_interval='*/5 * * * *',
+    catchup=False,
+) as dag:
+    run_dagster = DagsterCloudOperator(
+        task_id='new_dagster_assets',
+        repostitory_location_name="example_location",
+        repository_name="my_dagster_project",
+        job_name="all_assets_job"
+    )
+```
+In airflow 2.0+ you can create a dagster connection type to store configuration related to your dagster cloud organization, you can also pass this directly to the operator if you're using airflow 1.0.
 
 ## Exporting Dagster jobs to Airflow
 

--- a/docs/content/integrations/airflow.mdx
+++ b/docs/content/integrations/airflow.mdx
@@ -25,13 +25,13 @@ from airflow import DAG
 from dagster_airflow import DagsterCloudOperator
 
 with DAG(
-    dag_id='dagster_cloud',
+    dag_id="dagster_cloud",
     start_date=datetime(2022, 5, 28),
-    schedule_interval='*/5 * * * *',
+    schedule_interval="*/5 * * * *",
     catchup=False,
 ) as dag:
     DagsterCloudOperator(
-        task_id='new_dagster_assets',
+        task_id="new_dagster_assets",
         repostitory_location_name="example_location",
         repository_name="my_dagster_project",
         job_name="all_assets_job",

--- a/docs/content/integrations/airflow.mdx
+++ b/docs/content/integrations/airflow.mdx
@@ -19,8 +19,6 @@ Dagster is a fully-featured orchestrator and does not require a system like Airf
 You can orchestrate Dagster job runs from airflow by using the `DagsterCloudOperator` or `DagsterOperator` operators in your existing airflow dags. For example, here's an airflow Dag:
 
 ```python file=/integrations/airflow/operator.py
-# pylint: disable=unused-variable
-
 from datetime import datetime
 
 from airflow import DAG
@@ -32,7 +30,7 @@ with DAG(
     schedule_interval='*/5 * * * *',
     catchup=False,
 ) as dag:
-    run_dagster = DagsterCloudOperator(
+    DagsterCloudOperator(
         task_id='new_dagster_assets',
         repostitory_location_name="example_location",
         repository_name="my_dagster_project",

--- a/examples/docs_snippets/docs_snippets/integrations/airflow/operator.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airflow/operator.py
@@ -4,13 +4,13 @@ from airflow import DAG
 from dagster_airflow import DagsterCloudOperator
 
 with DAG(
-    dag_id='dagster_cloud',
+    dag_id="dagster_cloud",
     start_date=datetime(2022, 5, 28),
-    schedule_interval='*/5 * * * *',
+    schedule_interval="*/5 * * * *",
     catchup=False,
 ) as dag:
     DagsterCloudOperator(
-        task_id='new_dagster_assets',
+        task_id="new_dagster_assets",
         repostitory_location_name="example_location",
         repository_name="my_dagster_project",
         job_name="all_assets_job",

--- a/examples/docs_snippets/docs_snippets/integrations/airflow/operator.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airflow/operator.py
@@ -1,5 +1,3 @@
-# pylint: disable=unused-variable
-
 from datetime import datetime
 
 from airflow import DAG
@@ -11,7 +9,7 @@ with DAG(
     schedule_interval='*/5 * * * *',
     catchup=False,
 ) as dag:
-    run_dagster = DagsterCloudOperator(
+    DagsterCloudOperator(
         task_id='new_dagster_assets',
         repostitory_location_name="example_location",
         repository_name="my_dagster_project",

--- a/examples/docs_snippets/docs_snippets/integrations/airflow/operator.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airflow/operator.py
@@ -1,0 +1,19 @@
+# pylint: disable=unused-variable
+
+from datetime import datetime
+
+from airflow import DAG
+from dagster_airflow import DagsterCloudOperator
+
+with DAG(
+    dag_id='dagster_cloud',
+    start_date=datetime(2022, 5, 28),
+    schedule_interval='*/5 * * * *',
+    catchup=False,
+) as dag:
+    run_dagster = DagsterCloudOperator(
+        task_id='new_dagster_assets',
+        repostitory_location_name="example_location",
+        repository_name="my_dagster_project",
+        job_name="all_assets_job",
+    )

--- a/python_modules/libraries/dagster-airflow/MANIFEST.in
+++ b/python_modules/libraries/dagster-airflow/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
 include LICENSE
 include dagster_airflow/py.typed
+recursive-include dagster_airflow *.py

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/__init__.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/__init__.py
@@ -1,3 +1,5 @@
+from airflow.plugins_manager import AirflowPlugin
+
 from dagster._core.utils import check_dagster_package_version
 
 from .dagster_job_factory import make_dagster_job_from_airflow_dag
@@ -7,7 +9,10 @@ from .dagster_pipeline_factory import (
     make_dagster_repo_from_airflow_example_dags,
 )
 from .factory import make_airflow_dag, make_airflow_dag_containerized, make_airflow_dag_for_operator
+from .hooks.dagster_hook import DagsterHook
+from .links.dagster_link import DagsterLink
 from .operators.airflow_operator_to_op import airflow_operator_to_op
+from .operators.dagster_operator import DagsterCloudOperator, DagsterOperator
 from .version import __version__
 
 check_dagster_package_version("dagster-airflow", __version__)
@@ -21,3 +26,24 @@ __all__ = [
     "make_dagster_job_from_airflow_dag",
     "airflow_operator_to_op",
 ]
+
+class DagsterAirflowPlugin(AirflowPlugin):
+    name = "dagster_airflow"
+    hooks = [DagsterHook]
+    operators = [DagsterOperator, DagsterCloudOperator]
+    operator_extra_links = [
+        DagsterLink(),
+    ]
+
+def get_provider_info():
+    return {
+        "package-name": "dagster-airflow",
+        "name": "Dagster Airflow",
+        "description": "`Dagster <https://docs.dagster.io>`__",
+        "hook-class-names": ["dagster_airflow.hooks.dagster_hook.DagsterHook"],
+        "connection-types": [{
+            "connection-type": "dagster",
+            "hook-class-name": "dagster_airflow.hooks.dagster_hook.DagsterHook",
+        }],
+        "versions": [__version__]
+    }

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/__init__.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/__init__.py
@@ -24,8 +24,13 @@ __all__ = [
     "make_dagster_repo_from_airflow_dags_path",
     "make_dagster_repo_from_airflow_dag_bag",
     "make_dagster_job_from_airflow_dag",
+    "DagsterHook",
+    "DagsterLink",
+    "DagsterOperator",
+    "DagsterCloudOperator",
     "airflow_operator_to_op",
 ]
+
 
 class DagsterAirflowPlugin(AirflowPlugin):
     name = "dagster_airflow"
@@ -35,15 +40,18 @@ class DagsterAirflowPlugin(AirflowPlugin):
         DagsterLink(),
     ]
 
+
 def get_provider_info():
     return {
         "package-name": "dagster-airflow",
         "name": "Dagster Airflow",
         "description": "`Dagster <https://docs.dagster.io>`__",
         "hook-class-names": ["dagster_airflow.hooks.dagster_hook.DagsterHook"],
-        "connection-types": [{
-            "connection-type": "dagster",
-            "hook-class-name": "dagster_airflow.hooks.dagster_hook.DagsterHook",
-        }],
-        "versions": [__version__]
+        "connection-types": [
+            {
+                "connection-type": "dagster",
+                "hook-class-name": "dagster_airflow.hooks.dagster_hook.DagsterHook",
+            }
+        ],
+        "versions": [__version__],
     }

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/hooks/dagster_hook.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/hooks/dagster_hook.py
@@ -1,0 +1,252 @@
+import json
+import time
+from typing import Any, Dict, Optional
+
+import requests
+from airflow.exceptions import AirflowException
+from airflow.hooks.base_hook import BaseHook
+from airflow.models import Connection
+
+from dagster._core.storage.pipeline_run import PipelineRunStatus
+
+
+class DagsterHook(BaseHook):
+
+    conn_name_attr = "dagster_conn_id"
+    default_conn_name = "dagster_default"
+    conn_type = "dagster"
+    hook_name = "Dagster"
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict[str, Any]:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['port', 'schema', 'extra'],
+            "relabeling": {
+                'description': 'Dagster Cloud Organization ID',
+                'host': 'Dagster Cloud Deployment Name',
+                'login': 'Dagster URL',
+                'password': 'Dagster Cloud User Token',
+            },
+            "placeholders": {
+                'password': '',
+                'login': "https://dagster.cloud/",
+                'description': '',
+                'host': 'prod',
+            },
+        }
+
+    def __init__(self, dagster_conn_id: Optional[str] = "dagster_default", url: Optional[str] = None, user_token: Optional[str] = None) -> None:
+        super().__init__()
+        self.url = url
+        self.user_token = user_token
+        if dagster_conn_id is not None:
+            conn = self.get_connection(dagster_conn_id)
+            base_url = conn.login if conn.login else "https://dagster.cloud/"
+            if base_url == "https://dagster.cloud/":
+              self.set_hook_for_cloud(conn)
+            else:
+              self.set_hook_for_oss(conn)
+
+        if self.user_token is None:
+            raise AirflowException('Cannot get user_token: No valid user_token or dagster_conn_id supplied.')
+
+        if self.url is None:
+            raise AirflowException('Cannot get dagster url: No valid url or dagster_conn_id supplied.')
+
+    def set_hook_for_cloud(self, conn: Connection):
+      self.organization_id = conn.description
+      self.deployment_name = conn.host
+      self.user_token = conn.get_password()
+      base_url = conn.login if conn.login else "https://dagster.cloud/"
+      if self.organization_id is None or self.deployment_name is None:
+        raise AirflowException("Dagster Cloud connection requires organization_id and deployment_name to be set")
+      self.url = f"{base_url}{self.organization_id}/{self.deployment_name}/graphql"
+
+    def set_hook_for_oss(self, conn: Connection):
+      self.url = conn.login
+
+    def launch_run(
+        self,
+        repository_name:str = "my_dagster_project",
+        repostitory_location_name:str = "example_location",
+        job_name:str = "all_assets_job",
+        run_config: Optional[Dict[str, Any]] = {},
+    ) -> str:
+        query = """
+mutation LaunchJobExecution($executionParams: ExecutionParams!) {
+  launchPipelineExecution(executionParams: $executionParams) {
+    __typename
+    ... on LaunchRunSuccess {
+      run {
+        id
+        __typename
+      }
+      __typename
+    }
+    ... on PipelineNotFoundError {
+      message
+      __typename
+    }
+    ... on InvalidSubsetError {
+      message
+      __typename
+    }
+    ... on RunConfigValidationInvalid {
+      errors {
+        message
+        __typename
+      }
+      __typename
+    }
+    ...PythonErrorFragment
+  }
+}
+
+fragment PythonErrorFragment on PythonError {
+  __typename
+  message
+  stack
+  causes {
+    message
+    stack
+    __typename
+  }
+}
+        """
+        variables = {
+            "executionParams":{
+                "runConfigData": json.dumps(run_config),
+                "selector":{
+                    "repositoryName": repository_name,
+                    "repositoryLocationName": repostitory_location_name,
+                    "jobName": job_name
+                },
+                "mode":"default",
+                "executionMetadata":{
+                    "tags":[
+                        {"key":"dagster/solid_selection","value":"*"}
+                    ]
+                }
+            }
+        }
+        headers = {'Dagster-Cloud-Api-Token': self.user_token}
+        response = requests.post(url=self.url, json={'query': query, 'variables': variables}, headers=headers)
+        response.raise_for_status()
+        response_json = response.json()
+        if response_json['data']['launchPipelineExecution']['__typename'] == 'LaunchRunSuccess':
+            run = response_json['data']['launchPipelineExecution']['run']
+            print(f"Run {run['id']} launched successfully")
+            return run['id']
+        else :
+            raise AirflowException(f'Error launching run: {response_json["data"]["launchPipelineExecution"]["message"]}')
+
+    def wait_for_run(
+        self,
+        run_id: str,
+    ) -> None:
+      query = """
+query RunQuery($runId: ID!) {
+	runOrError(runId: $runId) {
+		__typename
+		...PythonErrorFragment
+		...NotFoundFragment
+		... on Run {
+			id
+			status
+			__typename
+		}
+	}
+}
+fragment NotFoundFragment on RunNotFoundError {
+	__typename
+	message
+}
+fragment PythonErrorFragment on PythonError {
+	__typename
+	message
+	stack
+	causes {
+		message
+		stack
+		__typename
+	}
+}
+      """
+      variables = {
+          "runId": run_id
+      }
+      headers = {'Dagster-Cloud-Api-Token': self.user_token}
+      status = ''
+      while status not in [PipelineRunStatus.SUCCESS.value, PipelineRunStatus.FAILURE.value, PipelineRunStatus.CANCELED.value]:
+        response = requests.post(url=self.url, json={'query': query, 'variables': variables}, headers=headers)
+        response.raise_for_status()
+        response_json = response.json()
+
+        if response_json['data']['runOrError']['__typename'] == 'Run':
+            status = response_json['data']['runOrError']['status']
+        else :
+            raise AirflowException(f'Error fetching run status: {response_json["data"]["runOrError"]["message"]}')
+
+        if status == PipelineRunStatus.SUCCESS.value:
+          print(f"Run {run_id} completed successfully")
+        elif status == PipelineRunStatus.FAILURE.value:
+          raise AirflowException(f'Run {run_id} failed')
+        elif status == PipelineRunStatus.CANCELED.value:
+          raise AirflowException(f'Run {run_id} was cancelled')
+        time.sleep(5)
+
+    def terminate_run(
+      self,
+      run_id: str,
+    ):
+      query = """
+mutation Terminate($runId: String!, $terminatePolicy: TerminateRunPolicy) {
+  terminatePipelineExecution(runId: $runId, terminatePolicy: $terminatePolicy) {
+    __typename
+    ... on TerminateRunFailure {
+      message
+      __typename
+    }
+    ... on RunNotFoundError {
+      message
+      __typename
+    }
+    ... on TerminateRunSuccess {
+      run {
+        id
+        runId
+        canTerminate
+        __typename
+      }
+      __typename
+    }
+    ... on UnauthorizedError {
+      message
+      __typename
+    }
+    ...PythonErrorFragment
+  }
+}
+fragment PythonErrorFragment on PythonError {
+  __typename
+  message
+  stack
+  causes {
+    message
+    stack
+    __typename
+  }
+}
+      """
+      variables = {
+          "runId": run_id,
+          "terminatePolicy": "MARK_AS_CANCELED_IMMEDIATELY"
+      }
+      headers = {'Dagster-Cloud-Api-Token': self.user_token}
+      response = requests.post(url=self.url, json={'query': query, 'variables': variables}, headers=headers)
+      response.raise_for_status()
+      response_json = response.json()
+
+      if response_json['data']['terminatePipelineExecution']['__typename'] != 'TerminateRunSuccess':
+          raise AirflowException(f'Error terminating run: {response_json["data"]["terminatePipelineExecution"]["message"]}')

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/hooks/dagster_hook.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/hooks/dagster_hook.py
@@ -3,6 +3,7 @@ import time
 from typing import Any, Dict, Optional
 
 import requests
+from airflow import __version__ as airflow_version
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
 from airflow.models import Connection
@@ -21,56 +22,75 @@ class DagsterHook(BaseHook):
     def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
-            "hidden_fields": ['port', 'schema', 'extra'],
+            "hidden_fields": ["port", "schema", "extra"],
             "relabeling": {
-                'description': 'Dagster Cloud Organization ID',
-                'host': 'Dagster Cloud Deployment Name',
-                'login': 'Dagster URL',
-                'password': 'Dagster Cloud User Token',
+                "description": "Dagster Cloud Organization ID",
+                "host": "Dagster Cloud Deployment Name",
+                "login": "Dagster URL",
+                "password": "Dagster Cloud User Token",
             },
             "placeholders": {
-                'password': '',
-                'login': "https://dagster.cloud/",
-                'description': '',
-                'host': 'prod',
+                "password": "",
+                "login": "https://dagster.cloud/",
+                "description": "",
+                "host": "prod",
             },
         }
 
-    def __init__(self, dagster_conn_id: Optional[str] = "dagster_default", url: Optional[str] = None, user_token: Optional[str] = None) -> None:
-        super().__init__()
+    def __init__(
+        self,
+        dagster_conn_id: Optional[str] = "dagster_default",
+        organization_id: Optional[str] = None,
+        deployment_name: Optional[str] = None,
+        url: str = "",
+        user_token: Optional[str] = None,
+    ) -> None:
+        super().__init__(source=None)
         self.url = url
         self.user_token = user_token
-        if dagster_conn_id is not None:
+        self.organization_id = organization_id
+        self.deployment_name = deployment_name
+        if (deployment_name or organization_id) and dagster_conn_id:
+            raise AirflowException(
+                "Cannot set both dagster_conn_id and organization_id/deployment_name"
+            )
+        if dagster_conn_id is not None and airflow_version >= "2.0.0":
             conn = self.get_connection(dagster_conn_id)
             base_url = conn.login if conn.login else "https://dagster.cloud/"
             if base_url == "https://dagster.cloud/":
-              self.set_hook_for_cloud(conn)
+                self.set_hook_for_cloud(conn)
             else:
-              self.set_hook_for_oss(conn)
+                self.set_hook_for_oss(conn)
 
         if self.user_token is None:
-            raise AirflowException('Cannot get user_token: No valid user_token or dagster_conn_id supplied.')
+            raise AirflowException(
+                "Cannot get user_token: No valid user_token or dagster_conn_id supplied."
+            )
 
-        if self.url is None:
-            raise AirflowException('Cannot get dagster url: No valid url or dagster_conn_id supplied.')
+        if self.url == "":
+            raise AirflowException(
+                "Cannot get dagster url: No valid url or dagster_conn_id supplied."
+            )
 
     def set_hook_for_cloud(self, conn: Connection):
-      self.organization_id = conn.description
-      self.deployment_name = conn.host
-      self.user_token = conn.get_password()
-      base_url = conn.login if conn.login else "https://dagster.cloud/"
-      if self.organization_id is None or self.deployment_name is None:
-        raise AirflowException("Dagster Cloud connection requires organization_id and deployment_name to be set")
-      self.url = f"{base_url}{self.organization_id}/{self.deployment_name}/graphql"
+        self.organization_id = conn.description
+        self.deployment_name = conn.host
+        self.user_token = conn.get_password()
+        base_url = conn.login if conn.login else "https://dagster.cloud/"
+        if self.organization_id is None or self.deployment_name is None:
+            raise AirflowException(
+                "Dagster Cloud connection requires organization_id and deployment_name to be set"
+            )
+        self.url = f"{base_url}{self.organization_id}/{self.deployment_name}/graphql"
 
     def set_hook_for_oss(self, conn: Connection):
-      self.url = conn.login
+        self.url = conn.login
 
     def launch_run(
         self,
-        repository_name:str = "my_dagster_project",
-        repostitory_location_name:str = "example_location",
-        job_name:str = "all_assets_job",
+        repository_name: str = "my_dagster_project",
+        repostitory_location_name: str = "example_location",
+        job_name: str = "all_assets_job",
         run_config: Optional[Dict[str, Any]] = {},
     ) -> str:
         query = """
@@ -115,37 +135,37 @@ fragment PythonErrorFragment on PythonError {
 }
         """
         variables = {
-            "executionParams":{
+            "executionParams": {
                 "runConfigData": json.dumps(run_config),
-                "selector":{
+                "selector": {
                     "repositoryName": repository_name,
                     "repositoryLocationName": repostitory_location_name,
-                    "jobName": job_name
+                    "jobName": job_name,
                 },
-                "mode":"default",
-                "executionMetadata":{
-                    "tags":[
-                        {"key":"dagster/solid_selection","value":"*"}
-                    ]
-                }
+                "mode": "default",
+                "executionMetadata": {"tags": [{"key": "dagster/solid_selection", "value": "*"}]},
             }
         }
-        headers = {'Dagster-Cloud-Api-Token': self.user_token}
-        response = requests.post(url=self.url, json={'query': query, 'variables': variables}, headers=headers)
+        headers = {"Dagster-Cloud-Api-Token": self.user_token if self.user_token else ""}
+        response = requests.post(
+            url=self.url, json={"query": query, "variables": variables}, headers=headers
+        )
         response.raise_for_status()
         response_json = response.json()
-        if response_json['data']['launchPipelineExecution']['__typename'] == 'LaunchRunSuccess':
-            run = response_json['data']['launchPipelineExecution']['run']
+        if response_json["data"]["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess":
+            run = response_json["data"]["launchPipelineExecution"]["run"]
             print(f"Run {run['id']} launched successfully")
-            return run['id']
-        else :
-            raise AirflowException(f'Error launching run: {response_json["data"]["launchPipelineExecution"]["message"]}')
+            return run["id"]
+        else:
+            raise AirflowException(
+                f'Error launching run: {response_json["data"]["launchPipelineExecution"]["message"]}'
+            )
 
     def wait_for_run(
         self,
         run_id: str,
     ) -> None:
-      query = """
+        query = """
 query RunQuery($runId: ID!) {
 	runOrError(runId: $runId) {
 		__typename
@@ -173,34 +193,40 @@ fragment PythonErrorFragment on PythonError {
 	}
 }
       """
-      variables = {
-          "runId": run_id
-      }
-      headers = {'Dagster-Cloud-Api-Token': self.user_token}
-      status = ''
-      while status not in [PipelineRunStatus.SUCCESS.value, PipelineRunStatus.FAILURE.value, PipelineRunStatus.CANCELED.value]:
-        response = requests.post(url=self.url, json={'query': query, 'variables': variables}, headers=headers)
-        response.raise_for_status()
-        response_json = response.json()
+        variables = {"runId": run_id}
+        headers = {"Dagster-Cloud-Api-Token": self.user_token if self.user_token else ""}
+        status = ""
+        while status not in [
+            PipelineRunStatus.SUCCESS.value,
+            PipelineRunStatus.FAILURE.value,
+            PipelineRunStatus.CANCELED.value,
+        ]:
+            response = requests.post(
+                url=self.url, json={"query": query, "variables": variables}, headers=headers
+            )
+            response.raise_for_status()
+            response_json = response.json()
 
-        if response_json['data']['runOrError']['__typename'] == 'Run':
-            status = response_json['data']['runOrError']['status']
-        else :
-            raise AirflowException(f'Error fetching run status: {response_json["data"]["runOrError"]["message"]}')
+            if response_json["data"]["runOrError"]["__typename"] == "Run":
+                status = response_json["data"]["runOrError"]["status"]
+            else:
+                raise AirflowException(
+                    f'Error fetching run status: {response_json["data"]["runOrError"]["message"]}'
+                )
 
-        if status == PipelineRunStatus.SUCCESS.value:
-          print(f"Run {run_id} completed successfully")
-        elif status == PipelineRunStatus.FAILURE.value:
-          raise AirflowException(f'Run {run_id} failed')
-        elif status == PipelineRunStatus.CANCELED.value:
-          raise AirflowException(f'Run {run_id} was cancelled')
-        time.sleep(5)
+            if status == PipelineRunStatus.SUCCESS.value:
+                print(f"Run {run_id} completed successfully")
+            elif status == PipelineRunStatus.FAILURE.value:
+                raise AirflowException(f"Run {run_id} failed")
+            elif status == PipelineRunStatus.CANCELED.value:
+                raise AirflowException(f"Run {run_id} was cancelled")
+            time.sleep(5)
 
     def terminate_run(
-      self,
-      run_id: str,
+        self,
+        run_id: str,
     ):
-      query = """
+        query = """
 mutation Terminate($runId: String!, $terminatePolicy: TerminateRunPolicy) {
   terminatePipelineExecution(runId: $runId, terminatePolicy: $terminatePolicy) {
     __typename
@@ -239,14 +265,18 @@ fragment PythonErrorFragment on PythonError {
   }
 }
       """
-      variables = {
-          "runId": run_id,
-          "terminatePolicy": "MARK_AS_CANCELED_IMMEDIATELY"
-      }
-      headers = {'Dagster-Cloud-Api-Token': self.user_token}
-      response = requests.post(url=self.url, json={'query': query, 'variables': variables}, headers=headers)
-      response.raise_for_status()
-      response_json = response.json()
+        variables = {"runId": run_id, "terminatePolicy": "MARK_AS_CANCELED_IMMEDIATELY"}
+        headers = {"Dagster-Cloud-Api-Token": self.user_token if self.user_token else ""}
+        response = requests.post(
+            url=self.url, json={"query": query, "variables": variables}, headers=headers
+        )
+        response.raise_for_status()
+        response_json = response.json()
 
-      if response_json['data']['terminatePipelineExecution']['__typename'] != 'TerminateRunSuccess':
-          raise AirflowException(f'Error terminating run: {response_json["data"]["terminatePipelineExecution"]["message"]}')
+        if (
+            response_json["data"]["terminatePipelineExecution"]["__typename"]
+            != "TerminateRunSuccess"
+        ):
+            raise AirflowException(
+                f'Error terminating run: {response_json["data"]["terminatePipelineExecution"]["message"]}'
+            )

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/links/dagster_link.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/links/dagster_link.py
@@ -1,0 +1,19 @@
+from airflow.models import BaseOperatorLink, TaskInstance
+
+LINK_FMT = "https://dagster.cloud/{organization_id}/{deployment_name}/instance/runs/{run_id}"
+
+class DagsterLink(BaseOperatorLink):
+    name = "Dagster Cloud"
+
+    def get_link(self, operator, dttm):
+        ti = TaskInstance(task=operator, execution_date=dttm)
+        run_id = ti.xcom_pull(task_ids=operator.task_id, key="run_id")
+        organization_id = ti.xcom_pull(task_ids=operator.task_id, key="organization_id")
+        deployment_name = ti.xcom_pull(task_ids=operator.task_id, key="deployment_name")
+
+        if run_id and organization_id and deployment_name:
+            return LINK_FMT.format(
+                organization_id=organization_id, deployment_name=deployment_name, run_id=run_id
+            )
+        else:
+            return ""

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/links/dagster_link.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/links/dagster_link.py
@@ -2,6 +2,7 @@ from airflow.models import BaseOperatorLink, TaskInstance
 
 LINK_FMT = "https://dagster.cloud/{organization_id}/{deployment_name}/instance/runs/{run_id}"
 
+
 class DagsterLink(BaseOperatorLink):
     name = "Dagster Cloud"
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/operators/dagster_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/operators/dagster_operator.py
@@ -1,0 +1,103 @@
+import json
+
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+from dagster_airflow.hooks.dagster_hook import DagsterHook
+from dagster_airflow.links.dagster_link import LINK_FMT, DagsterLink
+
+
+class DagsterOperator(BaseOperator):
+    template_fields = ["run_config"]
+    template_ext = (".yaml", ".yml", ".json")
+    ui_color = "#663399"
+    ui_fgcolor = "#e0e3fc"
+    operator_extra_links = (DagsterLink(),)
+
+    @apply_defaults
+    def __init__(
+        self,
+        dagster_conn_id="dagster_default",
+        run_config=None,
+        repository_name="",
+        repostitory_location_name="",
+        job_name="",
+        # params for airflow < 2.0.0 were custom connections aren't supported
+        deployment_name="prod",
+        user_token=None,
+        organization_id="",
+        url="https://dagster.cloud/",
+        *args,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.run_id = None
+        self.dagster_conn_id = dagster_conn_id
+        self.run_config = run_config or {}
+        self.repository_name = repository_name
+        self.repostitory_location_name = repostitory_location_name
+        self.job_name = job_name
+
+        self.user_token = user_token
+        self.url = url
+        self.organization_id = organization_id
+        self.deployment_name = deployment_name
+
+        self.hook = DagsterHook(
+            dagster_conn_id=self.dagster_conn_id,
+            user_token=self.user_token,
+            url=f"{self.url}{self.organization_id}/{self.deployment_name}/graphql"
+        )
+
+    def _is_json(self, blob):
+        try:
+            json.loads(blob)
+        except ValueError:
+            return False
+        return True
+
+    def pre_execute(self, context):
+        # force re-rendering to ensure run_config renders any templated
+        # content from run_config that couldn't be accessed on init
+        setattr(
+            self,
+            "run_config",
+            self.render_template(self.run_config, context),
+        )
+
+    def post_execute(self, context, result):
+        pass
+
+    def on_kill(self):
+        self.log.info("Terminating Run")
+        self.hook.terminate_run(
+            run_id=self.run_id,
+        )
+
+    def execute(self, context):
+        try:
+            return self._execute(context)
+        except Exception as e:
+            raise e
+
+    def _execute(self, context):
+        self.run_id = self.hook.launch_run(
+            repository_name=self.repository_name,
+            repostitory_location_name=self.repostitory_location_name,
+            job_name=self.job_name,
+            run_config=self.run_config,
+        )
+        # save relevant info in xcom for use in links
+        context["task_instance"].xcom_push(key="run_id", value=self.run_id)
+        context["task_instance"].xcom_push(key="organization_id", value=self.hook.organization_id)
+        context["task_instance"].xcom_push(key="deployment_name", value=self.hook.deployment_name)
+
+        self.log.info("Run Starting....")
+        self.log.info("Run tracking: %s", LINK_FMT.format(organization_id=self.hook.organization_id, deployment_name=self.hook.deployment_name, run_id=self.run_id))
+        self.hook.wait_for_run(
+            run_id=self.run_id,
+        )
+
+
+class DagsterCloudOperator(DagsterOperator):
+    # expose specific cloud operator for clarity
+    pass

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/operators/dagster_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/operators/dagster_operator.py
@@ -139,6 +139,3 @@ class DagsterCloudOperator(DagsterOperator):
         deployment_name (Optional[str]): the name of the dagster cloud deployment
         user_token (Optional[str]): the dagster cloud user token to use
     """
-
-    # expose specific cloud operator for clarity
-    pass

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_operator.py
@@ -1,0 +1,56 @@
+import unittest
+from datetime import datetime
+from unittest import mock
+
+import pytest
+from airflow import DAG
+from airflow import __version__ as airflow_version
+from airflow.models import Connection, TaskInstance
+from dagster_airflow import DagsterCloudOperator
+from dagster_airflow_tests.marks import requires_airflow_db
+
+
+@requires_airflow_db
+class TestDagsterOperator(unittest.TestCase):
+    @mock.patch("dagster_airflow.hooks.dagster_hook.DagsterHook.launch_run", return_value="run_id")
+    @mock.patch("dagster_airflow.hooks.dagster_hook.DagsterHook.wait_for_run")
+    def test_operator(self, launch_run, wait_for_run):
+        dag = DAG(dag_id="anydag", start_date=datetime.now())
+        run_config = {"foo": "bar"}
+        task = DagsterCloudOperator(
+            dag=dag,
+            task_id="anytask",
+            job_name="anyjob",
+            run_config=run_config,
+            user_token="token",
+            organization_id="test-org",
+        )
+        ti = TaskInstance(task=task, execution_date=datetime.now())
+        ctx = ti.get_template_context()
+        task.execute(ctx)
+        launch_run.assert_called_once()
+        wait_for_run.assert_called_once()
+
+    @mock.patch("dagster_airflow.hooks.dagster_hook.DagsterHook.launch_run")
+    @mock.patch("dagster_airflow.hooks.dagster_hook.DagsterHook.wait_for_run")
+    @mock.patch("dagster_airflow.hooks.dagster_hook.DagsterHook.get_connection")
+    @pytest.mark.skipif(airflow_version < "2.0.0", reason="dagster connection requires airflow 2")
+    def test_operator_with_connection(self, launch_run, wait_for_run, mock_get_conn):
+        mock_connection = Connection(
+            conn_type="dagster",
+            host="prod",
+            password="test-token",
+            description="test-org",
+        )
+        mock_get_conn.return_value = mock_connection
+
+        dag = DAG(dag_id="anydag", start_date=datetime.now())
+        run_config = {"foo": "bar"}
+        task = DagsterCloudOperator(
+            dag=dag, task_id="anytask", job_name="anyjob", run_config=run_config
+        )
+        ti = TaskInstance(task=task, execution_date=datetime.now())
+        ctx = ti.get_template_context()
+        task.execute(ctx)
+        launch_run.assert_called_once()
+        wait_for_run.assert_called_once()

--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -40,6 +40,10 @@ if __name__ == "__main__":
             # https://issues.apache.org/jira/browse/AIRFLOW-6854
             'typing_extensions; python_version>="3.8"',
         ],
+        project_urls={
+            # airflow will embed a link this in the providers page UI
+            "project-url/documentation": "https://docs.dagster.io",
+        },
         extras_require={
             "kubernetes": ["kubernetes>=3.0.0", "cryptography>=2.0.0"],
             "test": [
@@ -59,5 +63,14 @@ if __name__ == "__main__":
                 "markupsafe<=2.0.1",
             ],
         },
-        entry_points={"console_scripts": ["dagster-airflow = dagster_airflow.cli:main"]},
+        entry_points={
+            "console_scripts": ["dagster-airflow = dagster_airflow.cli:main"],
+            # airflow 1.0/2.0 plugin format
+            "airflow.plugins": ["dagster_airflow = dagster_airflow:DagsterAirflowPlugin"],
+            # airflow 2.0 provider format
+            "apache_airflow_provider": [
+                "provider_info=dagster_airflow.__init__:get_provider_info"
+            ]
+        },
+
     )

--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -66,11 +66,8 @@ if __name__ == "__main__":
         entry_points={
             "console_scripts": ["dagster-airflow = dagster_airflow.cli:main"],
             # airflow 1.0/2.0 plugin format
-            "airflow.plugins": ["dagster_airflow = dagster_airflow:DagsterAirflowPlugin"],
+            "airflow.plugins": ["dagster_airflow = dagster_airflow.__init__:DagsterAirflowPlugin"],
             # airflow 2.0 provider format
-            "apache_airflow_provider": [
-                "provider_info=dagster_airflow.__init__:get_provider_info"
-            ]
+            "apache_airflow_provider": ["provider_info=dagster_airflow.__init__:get_provider_info"],
         },
-
     )

--- a/python_modules/libraries/dagster-airflow/tox.ini
+++ b/python_modules/libraries/dagster-airflow/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}-{default,requiresairflowdb},pylint
+envlist = py{39,38,37,36}-{unix,windows}-{default,requiresairflowdb}-airflow{1.10.15,2.4.1},pylint
 
 [testenv]
 usedevelop = true
@@ -22,6 +22,8 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  airflow1.10.15: pip install apache-airflow==1.10.15
+  airflow2.4.1: pip install apache-airflow==2.4.1
   requiresairflowdb: airflow initdb
   !requiresairflowdb: pytest -m "not requires_airflow_db" -vv --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report= {posargs}
   requiresairflowdb: pytest -m requires_airflow_db -vv --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report= {posargs}


### PR DESCRIPTION
### Summary & Motivation

This PR defines an airflow plugin(1.0.0+) and provider(2.0.0+ only) that provides the following to users building airflow dags

The plugin:
- provides a DagsterOperator and DagsterAirflowOperator that allow users to orchestrate dagster jobs from their airflow dag
- A DagsterLink that will direct link to the UI for each task instance of the operators
- A DagsterHook that can be used for defining other custom operators

The provider:
- defines a custom Dagster connection type that makes configuring (Organization ID, deployment name, user token, dagit url) much easier, if users are using airflow 1.0.0 they will need to pass these things to the operator instead.

This operator is mainly designed to work with dagster cloud but can work with OSS dagit so long as there is networking available between the dagit and airflow instances.

### How I Tested These Changes

I've been running local airflow/dagit

### Todos

- [x] add a testing harness for running this on airflow 1 and 2, with and without an oss dagit
