### PR TITLE
[perf] resolve lru_cache usage issues

### DIFF
--- a/python_modules/dagster/dagster/_api/snapshot_execution_plan.py
+++ b/python_modules/dagster/dagster/_api/snapshot_execution_plan.py
@@ -34,7 +34,7 @@ def sync_get_external_execution_plan_grpc(
     check.inst_param(api_client, "api_client", DagsterGrpcClient)
     check.inst_param(pipeline_origin, "pipeline_origin", ExternalPipelineOrigin)
     solid_selection = check.opt_list_param(solid_selection, "solid_selection", of_type=str)
-    asset_selection = check.opt_set_param(asset_selection, "asset_selection", of_type=AssetKey)
+    check.opt_set_param(asset_selection, "asset_selection", of_type=AssetKey)
     run_config = check.dict_param(run_config, "run_config", key_type=str)
     check.str_param(mode, "mode")
     check.opt_nullable_list_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -77,7 +77,6 @@ class ReconstructableRepository(
             ),
         )
 
-    @lru_cache(maxsize=1)
     def get_definition(self):
         return repository_def_from_pointer(self.pointer)
 
@@ -172,26 +171,15 @@ class ReconstructablePipeline(
     def solid_selection(self) -> Optional[List[str]]:
         return seven.json.loads(self.solid_selection_str) if self.solid_selection_str else None
 
+    # Keep the most recent 1 definition (globally since this is a NamedTuple method)
+    # This allows repeated calls to get_definition in execution paths to not reload the job
     @lru_cache(maxsize=1)
     def get_definition(self):
-        from dagster._core.definitions.job_definition import JobDefinition
-
-        defn = self.repository.get_definition().get_pipeline(self.pipeline_name)
-
-        if isinstance(defn, JobDefinition):
-            return (
-                self.repository.get_definition()
-                .get_pipeline(self.pipeline_name)
-                .get_job_def_for_subset_selection(self.solid_selection, self.asset_selection)
-            )
-
-        check.invariant(
-            self.asset_selection is None, "Asset selection cannot be provided with a pipeline"
-        )
-        return (
-            self.repository.get_definition().get_pipeline(self.pipeline_name)
-            # pipelines use post-resolved selection
-            .get_pipeline_subset_def(self.solids_to_execute)
+        return self.repository.get_definition().get_maybe_subset_job_def(
+            self.pipeline_name,
+            self.solid_selection,
+            self.asset_selection,
+            self.solids_to_execute,
         )
 
     def get_reconstructable_repository(self):

--- a/python_modules/dagster/dagster/_core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/repository_location.py
@@ -22,6 +22,7 @@ from dagster._api.snapshot_schedule import sync_get_external_schedule_execution_
 from dagster._api.snapshot_sensor import sync_get_external_sensor_execution_data_grpc
 from dagster._core.code_pointer import CodePointer
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
+from dagster._core.definitions.repository_definition import RepositoryDefinition
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.plan.state import KnownExecutionState
@@ -286,15 +287,8 @@ class InProcessRepositoryLocation(RepositoryLocation):
 
         self._repository_code_pointer_dict = self._loaded_repositories.code_pointers_by_repo_name
 
-        self._recon_repos = {
-            repo_name: self._loaded_repositories.get_recon_repo(repo_name)
-            for repo_name in self._repository_code_pointer_dict
-        }
-
-        self._repositories = {}
-        for repo_name in self._repository_code_pointer_dict:
-            recon_repo = self._loaded_repositories.get_recon_repo(repo_name)
-            repo_def = recon_repo.get_definition()
+        self._repositories: Dict[str, ExternalRepository] = {}
+        for repo_name, repo_def in self._loaded_repositories.definitions_by_name.items():
             self._repositories[repo_name] = external_repo_from_def(
                 repo_def,
                 RepositoryHandle(repository_name=repo_name, repository_location=self),
@@ -331,7 +325,12 @@ class InProcessRepositoryLocation(RepositoryLocation):
     def get_reconstructable_pipeline(
         self, repository_name: str, name: str
     ) -> ReconstructablePipeline:
-        return self._recon_repos[repository_name].get_reconstructable_pipeline(name)
+        return self._loaded_repositories.reconstructables_by_name[
+            repository_name
+        ].get_reconstructable_pipeline(name)
+
+    def _get_repo_def(self, name: str) -> RepositoryDefinition:
+        return self._loaded_repositories.definitions_by_name[name]
 
     def get_repository(self, name: str) -> ExternalRepository:
         return self._repositories[name]
@@ -356,7 +355,8 @@ class InProcessRepositoryLocation(RepositoryLocation):
         from dagster._grpc.impl import get_external_pipeline_subset_result
 
         return get_external_pipeline_subset_result(
-            self.get_reconstructable_pipeline(selector.repository_name, selector.pipeline_name),
+            self._get_repo_def(selector.repository_name),
+            selector.pipeline_name,
             selector.solid_selection,
             selector.asset_selection,
         )
@@ -404,7 +404,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
         check.str_param(partition_name, "partition_name")
 
         return get_partition_config(
-            recon_repo=self._recon_repos[repository_handle.repository_name],
+            self._get_repo_def(repository_handle.repository_name),
             partition_set_name=partition_set_name,
             partition_name=partition_name,
         )
@@ -417,7 +417,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
         check.str_param(partition_name, "partition_name")
 
         return get_partition_tags(
-            recon_repo=self._recon_repos[repository_handle.repository_name],
+            self._get_repo_def(repository_handle.repository_name),
             partition_set_name=partition_set_name,
             partition_name=partition_name,
         )
@@ -435,7 +435,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
             )
 
         return get_partition_names(
-            recon_repo=self._recon_repos[external_partition_set.repository_handle],
+            self._get_repo_def(external_partition_set.repository_handle),
             partition_set_name=external_partition_set.name,
         )
 
@@ -452,7 +452,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
         check.opt_inst_param(scheduled_execution_time, "scheduled_execution_time", PendulumDateTime)
 
         return get_external_schedule_execution(
-            recon_repo=self._recon_repos[repository_handle.repository_name],
+            self._get_repo_def(repository_handle.repository_name),
             instance_ref=instance.get_ref(),
             schedule_name=schedule_name,
             scheduled_execution_timestamp=scheduled_execution_time.timestamp()
@@ -473,7 +473,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
         cursor: Optional[str],
     ) -> Union["SensorExecutionData", "ExternalSensorExecutionErrorData"]:
         return get_external_sensor_execution(
-            self._recon_repos[repository_handle.repository_name],
+            self._get_repo_def(repository_handle.repository_name),
             instance.get_ref(),
             name,
             last_completion_time,
@@ -492,7 +492,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
         check.list_param(partition_names, "partition_names", of_type=str)
 
         return get_partition_set_execution_param_data(
-            recon_repo=self._recon_repos[repository_handle.repository_name],
+            self._get_repo_def(repository_handle.repository_name),
             partition_set_name=partition_set_name,
             partition_names=partition_names,
         )

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -373,7 +373,8 @@ def parse_op_selection(job_def: "JobDefinition", op_selection: List[str]) -> Dic
 
 
 def parse_solid_selection(
-    pipeline_def: "PipelineDefinition", solid_selection: List[str]
+    pipeline_def: "PipelineDefinition",
+    solid_selection: Sequence[str],
 ) -> FrozenSet[str]:
     """Take pipeline definition and a list of solid selection queries (inlcuding names of solid
         invocations. See syntax examples below) and return a set of the qualified solid names.

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -3,14 +3,15 @@
 import os
 import sys
 from contextlib import ExitStack
-from typing import Generator, List, Optional
+from typing import Generator, List, Optional, Sequence
 
 import pendulum
 
 import dagster._check as check
 from dagster._core.definitions import ScheduleEvaluationContext
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.reconstruct import ReconstructablePipeline, ReconstructableRepository
+from dagster._core.definitions.reconstruct import ReconstructablePipeline
+from dagster._core.definitions.repository_definition import RepositoryDefinition
 from dagster._core.definitions.sensor_definition import (
     MultiAssetSensorDefinition,
     MultiAssetSensorEvaluationContext,
@@ -39,6 +40,7 @@ from dagster._core.host_representation.external_data import (
     ExternalSensorExecutionErrorData,
 )
 from dagster._core.instance import DagsterInstance
+from dagster._core.instance.ref import InstanceRef
 from dagster._core.snap.execution_plan_snapshot import (
     ExecutionPlanSnapshotErrorData,
     snapshot_from_execution_plan,
@@ -215,44 +217,33 @@ def start_run_in_subprocess(
 
 
 def get_external_pipeline_subset_result(
-    recon_pipeline: ReconstructablePipeline,
+    repo_def: RepositoryDefinition,
+    job_name: str,
     solid_selection: Optional[List[str]],
     asset_selection: Optional[List[AssetKey]],
 ):
-    check.inst_param(recon_pipeline, "recon_pipeline", ReconstructablePipeline)
-    check.opt_list_param(solid_selection, "solid_selection", str)
-    check.opt_list_param(asset_selection, "asset_selection", AssetKey)
-    if solid_selection or asset_selection:
-        try:
-            sub_pipeline = recon_pipeline.subset_for_execution(
-                solid_selection=solid_selection,
-                asset_selection=frozenset(asset_selection) if asset_selection else None,
-            )
-            definition = sub_pipeline.get_definition()
-        except Exception:
-            return ExternalPipelineSubsetResult(
-                success=False, error=serializable_error_info_from_exc_info(sys.exc_info())
-            )
-    else:
-        definition = recon_pipeline.get_definition()
+    try:
+        definition = repo_def.get_maybe_subset_job_def(
+            job_name,
+            op_selection=solid_selection,
+            asset_selection=frozenset(asset_selection) if asset_selection else None,
+        )
+    except Exception:
+        return ExternalPipelineSubsetResult(
+            success=False, error=serializable_error_info_from_exc_info(sys.exc_info())
+        )
     external_pipeline_data = external_pipeline_data_from_def(definition)
     return ExternalPipelineSubsetResult(success=True, external_pipeline_data=external_pipeline_data)
 
 
 def get_external_schedule_execution(
-    recon_repo,
-    instance_ref,
-    schedule_name,
-    scheduled_execution_timestamp,
-    scheduled_execution_timezone,
+    repo_def: RepositoryDefinition,
+    instance_ref: Optional[InstanceRef],
+    schedule_name: str,
+    scheduled_execution_timestamp: float,
+    scheduled_execution_timezone: str,
 ):
-    check.inst_param(
-        recon_repo,
-        "recon_repo",
-        ReconstructableRepository,
-    )
-    definition = recon_repo.get_definition()
-    schedule_def = definition.get_schedule_def(schedule_name)
+    schedule_def = repo_def.get_schedule_def(schedule_name)
     scheduled_execution_time = (
         pendulum.from_timestamp(
             scheduled_execution_timestamp,
@@ -277,16 +268,14 @@ def get_external_schedule_execution(
 
 
 def get_external_sensor_execution(
-    recon_repo, instance_ref, sensor_name, last_completion_timestamp, last_run_key, cursor
+    repo_def: RepositoryDefinition,
+    instance_ref: Optional[InstanceRef],
+    sensor_name: str,
+    last_completion_timestamp: Optional[float],
+    last_run_key: Optional[str],
+    cursor: Optional[str],
 ):
-    check.inst_param(
-        recon_repo,
-        "recon_repo",
-        ReconstructableRepository,
-    )
-
-    definition = recon_repo.get_definition()
-    sensor_def = definition.get_sensor_def(sensor_name)
+    sensor_def = repo_def.get_sensor_def(sensor_name)
 
     with ExitStack() as stack:
 
@@ -297,8 +286,8 @@ def get_external_sensor_execution(
                     last_completion_time=last_completion_timestamp,
                     last_run_key=last_run_key,
                     cursor=cursor,
-                    repository_name=recon_repo.get_definition().name,
-                    repository_def=definition,
+                    repository_name=repo_def.name,
+                    repository_def=repo_def,
                     asset_keys=sensor_def.asset_keys,
                 )
             )
@@ -309,7 +298,7 @@ def get_external_sensor_execution(
                     last_completion_time=last_completion_timestamp,
                     last_run_key=last_run_key,
                     cursor=cursor,
-                    repository_name=recon_repo.get_definition().name,
+                    repository_name=repo_def.name,
                 )
             )
 
@@ -326,9 +315,13 @@ def get_external_sensor_execution(
             )
 
 
-def get_partition_config(recon_repo, partition_set_name, partition_name):
-    definition = recon_repo.get_definition()
-    partition_set_def = definition.get_partition_set_def(partition_set_name)
+def get_partition_config(
+    repo_def: RepositoryDefinition,
+    partition_set_name: str,
+    partition_name: str,
+):
+
+    partition_set_def = repo_def.get_partition_set_def(partition_set_name)
     partition = partition_set_def.get_partition(partition_name)
     try:
         with user_code_error_boundary(
@@ -353,9 +346,11 @@ def _get_target_for_partition_execution_error(partition_set_def):
         return f"partition set '{partition_set_def.name}'"
 
 
-def get_partition_names(recon_repo, partition_set_name):
-    definition = recon_repo.get_definition()
-    partition_set_def = definition.get_partition_set_def(partition_set_name)
+def get_partition_names(
+    repo_def: RepositoryDefinition,
+    partition_set_name: str,
+):
+    partition_set_def = repo_def.get_partition_set_def(partition_set_name)
     try:
         with user_code_error_boundary(
             PartitionExecutionError,
@@ -371,9 +366,12 @@ def get_partition_names(recon_repo, partition_set_name):
         )
 
 
-def get_partition_tags(recon_repo, partition_set_name, partition_name):
-    definition = recon_repo.get_definition()
-    partition_set_def = definition.get_partition_set_def(partition_set_name)
+def get_partition_tags(
+    repo_def: RepositoryDefinition,
+    partition_set_name: str,
+    partition_name: str,
+):
+    partition_set_def = repo_def.get_partition_set_def(partition_set_name)
     partition = partition_set_def.get_partition(partition_name)
     try:
         with user_code_error_boundary(
@@ -389,21 +387,21 @@ def get_partition_tags(recon_repo, partition_set_name, partition_name):
         )
 
 
-def get_external_execution_plan_snapshot(recon_pipeline, args):
-    check.inst_param(recon_pipeline, "recon_pipeline", ReconstructablePipeline)
-    check.inst_param(args, "args", ExecutionPlanSnapshotArgs)
-
+def get_external_execution_plan_snapshot(
+    repo_def: RepositoryDefinition,
+    job_name: str,
+    args: ExecutionPlanSnapshotArgs,
+):
     try:
-        pipeline = recon_pipeline
-
-        if args.solid_selection or args.asset_selection:
-            pipeline = pipeline.subset_for_execution(
-                solid_selection=args.solid_selection, asset_selection=args.asset_selection
-            )
+        job_def = repo_def.get_maybe_subset_job_def(
+            job_name,
+            op_selection=args.solid_selection,
+            asset_selection=args.asset_selection,
+        )
 
         return snapshot_from_execution_plan(
             create_execution_plan(
-                pipeline=pipeline,
+                job_def,
                 run_config=args.run_config,
                 mode=args.mode,
                 step_keys_to_execute=args.step_keys_to_execute,
@@ -418,8 +416,11 @@ def get_external_execution_plan_snapshot(recon_pipeline, args):
         )
 
 
-def get_partition_set_execution_param_data(recon_repo, partition_set_name, partition_names):
-    repo_definition = recon_repo.get_definition()
+def get_partition_set_execution_param_data(
+    repo_definition: RepositoryDefinition,
+    partition_set_name: str,
+    partition_names: Sequence[str],
+):
     partition_set_def = repo_definition.get_partition_set_def(partition_set_name)
     try:
         with user_code_error_boundary(

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -7,9 +7,10 @@ import threading
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from multiprocessing.synchronize import Event as MPEvent
 from threading import Event as ThreadingEventType
 from time import sleep
-from typing import NamedTuple
+from typing import Dict, List, NamedTuple, Optional, Tuple
 
 import grpc
 from grpc_health.v1 import health, health_pb2, health_pb2_grpc
@@ -18,24 +19,18 @@ import dagster._check as check
 import dagster._seven as seven
 from dagster._core.code_pointer import CodePointer
 from dagster._core.definitions.reconstruct import ReconstructableRepository
+from dagster._core.definitions.repository_definition import RepositoryDefinition
 from dagster._core.errors import DagsterUserCodeUnreachableError
 from dagster._core.host_representation.external_data import (
     ExternalRepositoryErrorData,
     external_pipeline_data_from_def,
     external_repository_data_from_def,
 )
-from dagster._core.host_representation.origin import (
-    ExternalPipelineOrigin,
-    ExternalRepositoryOrigin,
-)
+from dagster._core.host_representation.origin import ExternalRepositoryOrigin
 from dagster._core.instance import DagsterInstance
 from dagster._core.origin import DEFAULT_DAGSTER_ENTRY_POINT, get_python_environment_entry_point
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._serdes import (
-    deserialize_json_to_dagster_namedtuple,
-    serialize_dagster_namedtuple,
-    whitelist_for_serdes,
-)
+from dagster._serdes import deserialize_as, serialize_dagster_namedtuple, whitelist_for_serdes
 from dagster._serdes.ipc import IPCErrorMessage, ipc_write_stream, open_ipc_subprocess
 from dagster._utils import find_free_port, frozenlist, safe_tempfile_path_unmanaged
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
@@ -89,14 +84,21 @@ class CouldNotBindGrpcServerToAddress(Exception):
 
 
 class LoadedRepositories:
-    def __init__(self, loadable_target_origin, entry_point, container_image=None):
+    def __init__(
+        self,
+        loadable_target_origin: Optional[LoadableTargetOrigin],
+        entry_point: List[str],
+        container_image: Optional[str] = None,
+    ):
         self._loadable_target_origin = loadable_target_origin
 
-        self._code_pointers_by_repo_name = {}
-        self._recon_repos_by_name = {}
-        self._loadable_repository_symbols = []
+        self._code_pointers_by_repo_name: Dict[str, CodePointer] = {}
+        self._recon_repos_by_name: Dict[str, ReconstructableRepository] = {}
+        self._repo_defs_by_name: Dict[str, RepositoryDefinition] = {}
+        self._loadable_repository_symbols: List[LoadableRepositorySymbol] = []
 
         if not loadable_target_origin:
+            # empty workspace
             return
 
         loadable_targets = get_loadable_targets(
@@ -122,6 +124,7 @@ class LoadedRepositories:
 
             self._code_pointers_by_repo_name[repo_def.name] = pointer
             self._recon_repos_by_name[repo_def.name] = recon_repo
+            self._repo_defs_by_name[repo_def.name] = repo_def
             self._loadable_repository_symbols.append(
                 LoadableRepositorySymbol(
                     attribute=loadable_target.attribute,
@@ -137,12 +140,13 @@ class LoadedRepositories:
     def code_pointers_by_repo_name(self):
         return self._code_pointers_by_repo_name
 
-    def get_recon_repo(self, name: str) -> ReconstructableRepository:
+    @property
+    def definitions_by_name(self) -> Dict[str, RepositoryDefinition]:
+        return self._repo_defs_by_name
 
-        if name not in self._recon_repos_by_name:
-            raise Exception(f'Could not find a repository called "{name}"')
-
-        return self._recon_repos_by_name[name]
+    @property
+    def reconstructables_by_name(self) -> Dict[str, ReconstructableRepository]:
+        return self._recon_repos_by_name
 
 
 def _get_code_pointer(loadable_target_origin, loadable_repository_symbol):
@@ -172,15 +176,15 @@ class DagsterApiServer(DagsterApiServicer):
     # the target passed in here instead of passing in a target in the argument.
     def __init__(
         self,
-        server_termination_event,
-        loadable_target_origin=None,
-        heartbeat=False,
-        heartbeat_timeout=30,
-        lazy_load_user_code=False,
-        fixed_server_id=None,
-        entry_point=None,
-        container_image=None,
-        container_context=None,
+        server_termination_event: ThreadingEventType,
+        loadable_target_origin: Optional[LoadableTargetOrigin] = None,
+        heartbeat: bool = False,
+        heartbeat_timeout: int = 30,
+        lazy_load_user_code: bool = False,
+        fixed_server_id: Optional[str] = None,
+        entry_point: Optional[List[str]] = None,
+        container_image: Optional[str] = None,
+        container_context: Optional[dict] = None,
     ):
         super(DagsterApiServer, self).__init__()
 
@@ -206,11 +210,9 @@ class DagsterApiServer(DagsterApiServicer):
         # termination event once all current executions have finished, which will stop the server)
         self._shutdown_once_executions_finish_event = threading.Event()
 
-        # Dict[str, (multiprocessing.Process, DagsterInstance)]
-        self._executions = {}
-        # Dict[str, multiprocessing.Event]
-        self._termination_events = {}
-        self._termination_times = {}
+        self._executions: Dict[str, Tuple[multiprocessing.Process, DagsterInstance]] = {}
+        self._termination_events: Dict[str, MPEvent] = {}
+        self._termination_times: Dict[str, float] = {}
         self._execution_lock = threading.Lock()
 
         self._serializable_load_error = None
@@ -225,7 +227,7 @@ class DagsterApiServer(DagsterApiServicer):
         self._container_context = check.opt_dict_param(container_context, "container_context")
 
         try:
-            self._loaded_repositories = LoadedRepositories(
+            self._loaded_repositories: Optional[LoadedRepositories] = LoadedRepositories(
                 loadable_target_origin,
                 self._entry_point,
                 self._container_image,
@@ -238,7 +240,7 @@ class DagsterApiServer(DagsterApiServicer):
 
         self.__last_heartbeat_time = time.time()
         if heartbeat:
-            self.__heartbeat_thread = threading.Thread(
+            self.__heartbeat_thread: Optional[threading.Thread] = threading.Thread(
                 target=self._heartbeat_thread,
                 args=(heartbeat_timeout,),
                 name="grpc-server-heartbeat",
@@ -314,17 +316,16 @@ class DagsterApiServer(DagsterApiServicer):
         if run_id in self._termination_times:
             del self._termination_times[run_id]
 
-    def _recon_repository_from_origin(
-        self, external_repository_origin: ExternalRepositoryOrigin
-    ) -> ReconstructableRepository:
-        # could assert against external_repository_origin.repository_location_origin
-        return self._loaded_repositories.get_recon_repo(external_repository_origin.repository_name)
-
-    def _recon_pipeline_from_origin(self, external_pipeline_origin: ExternalPipelineOrigin):
-        recon_repo = self._recon_repository_from_origin(
-            external_pipeline_origin.external_repository_origin
-        )
-        return recon_repo.get_reconstructable_pipeline(external_pipeline_origin.pipeline_name)
+    def _get_repo_for_origin(
+        self,
+        external_repo_origin: ExternalRepositoryOrigin,
+    ) -> RepositoryDefinition:
+        loaded_repos = check.not_none(self._loaded_repositories)
+        if external_repo_origin.repository_name not in loaded_repos.definitions_by_name:
+            raise Exception(
+                f'Could not find a repository called "{external_repo_origin.repository_name}"'
+            )
+        return loaded_repos.definitions_by_name[external_repo_origin.repository_name]
 
     def Ping(self, request, _context):
         echo = request.echo
@@ -345,14 +346,17 @@ class DagsterApiServer(DagsterApiServicer):
         return api_pb2.GetServerIdReply(server_id=self._server_id)
 
     def ExecutionPlanSnapshot(self, request, _context):
-        execution_plan_args = deserialize_json_to_dagster_namedtuple(
-            request.serialized_execution_plan_snapshot_args
+        execution_plan_args = deserialize_as(
+            request.serialized_execution_plan_snapshot_args,
+            ExecutionPlanSnapshotArgs,
         )
 
-        check.inst_param(execution_plan_args, "execution_plan_args", ExecutionPlanSnapshotArgs)
-        recon_pipeline = self._recon_pipeline_from_origin(execution_plan_args.pipeline_origin)
         execution_plan_snapshot_or_error = get_external_execution_plan_snapshot(
-            recon_pipeline, execution_plan_args
+            self._get_repo_for_origin(
+                execution_plan_args.pipeline_origin.external_repository_origin
+            ),
+            execution_plan_args.pipeline_origin.pipeline_name,
+            execution_plan_args,
         )
         return api_pb2.ExecutionPlanSnapshotReply(
             serialized_execution_plan_snapshot=serialize_dagster_namedtuple(
@@ -384,18 +388,14 @@ class DagsterApiServer(DagsterApiServicer):
         )
 
     def ExternalPartitionNames(self, request, _context):
-        partition_names_args = deserialize_json_to_dagster_namedtuple(
-            request.serialized_partition_names_args
+        partition_names_args = deserialize_as(
+            request.serialized_partition_names_args,
+            PartitionNamesArgs,
         )
-
-        check.inst_param(partition_names_args, "partition_names_args", PartitionNamesArgs)
-
-        recon_repo = self._recon_repository_from_origin(partition_names_args.repository_origin)
-
         return api_pb2.ExternalPartitionNamesReply(
             serialized_external_partition_names_or_external_partition_execution_error=serialize_dagster_namedtuple(
                 get_partition_names(
-                    recon_repo,
+                    self._get_repo_for_origin(partition_names_args.repository_origin),
                     partition_names_args.partition_set_name,
                 )
             )
@@ -407,20 +407,14 @@ class DagsterApiServer(DagsterApiServicer):
         return api_pb2.ExternalNotebookDataReply(content=get_notebook_data(notebook_path))
 
     def ExternalPartitionSetExecutionParams(self, request, _context):
-        args = deserialize_json_to_dagster_namedtuple(
-            request.serialized_partition_set_execution_param_args
-        )
-
-        check.inst_param(
-            args,
-            "args",
+        args = deserialize_as(
+            request.serialized_partition_set_execution_param_args,
             PartitionSetExecutionParamArgs,
         )
 
-        recon_repo = self._recon_repository_from_origin(args.repository_origin)
         serialized_data = serialize_dagster_namedtuple(
             get_partition_set_execution_param_data(
-                recon_repo=recon_repo,
+                self._get_repo_for_origin(args.repository_origin),
                 partition_set_name=args.partition_set_name,
                 partition_names=args.partition_names,
             )
@@ -429,48 +423,44 @@ class DagsterApiServer(DagsterApiServicer):
         yield from self._split_serialized_data_into_chunk_events(serialized_data)
 
     def ExternalPartitionConfig(self, request, _context):
-        args = deserialize_json_to_dagster_namedtuple(request.serialized_partition_args)
-
-        check.inst_param(args, "args", PartitionArgs)
-
-        recon_repo = self._recon_repository_from_origin(args.repository_origin)
+        args = deserialize_as(request.serialized_partition_args, PartitionArgs)
 
         return api_pb2.ExternalPartitionConfigReply(
             serialized_external_partition_config_or_external_partition_execution_error=serialize_dagster_namedtuple(
-                get_partition_config(recon_repo, args.partition_set_name, args.partition_name)
+                get_partition_config(
+                    self._get_repo_for_origin(args.repository_origin),
+                    args.partition_set_name,
+                    args.partition_name,
+                )
             )
         )
 
     def ExternalPartitionTags(self, request, _context):
-        partition_args = deserialize_json_to_dagster_namedtuple(request.serialized_partition_args)
-
-        check.inst_param(partition_args, "partition_args", PartitionArgs)
-
-        recon_repo = self._recon_repository_from_origin(partition_args.repository_origin)
+        partition_args = deserialize_as(request.serialized_partition_args, PartitionArgs)
 
         return api_pb2.ExternalPartitionTagsReply(
             serialized_external_partition_tags_or_external_partition_execution_error=serialize_dagster_namedtuple(
                 get_partition_tags(
-                    recon_repo, partition_args.partition_set_name, partition_args.partition_name
+                    self._get_repo_for_origin(partition_args.repository_origin),
+                    partition_args.partition_set_name,
+                    partition_args.partition_name,
                 )
             )
         )
 
     def ExternalPipelineSubsetSnapshot(self, request, _context):
-        pipeline_subset_snapshot_args = deserialize_json_to_dagster_namedtuple(
-            request.serialized_pipeline_subset_snapshot_args
-        )
-
-        check.inst_param(
-            pipeline_subset_snapshot_args,
-            "pipeline_subset_snapshot_args",
+        pipeline_subset_snapshot_args = deserialize_as(
+            request.serialized_pipeline_subset_snapshot_args,
             PipelineSubsetSnapshotArgs,
         )
 
         return api_pb2.ExternalPipelineSubsetSnapshotReply(
             serialized_external_pipeline_subset_result=serialize_dagster_namedtuple(
                 get_external_pipeline_subset_result(
-                    self._recon_pipeline_from_origin(pipeline_subset_snapshot_args.pipeline_origin),
+                    self._get_repo_for_origin(
+                        pipeline_subset_snapshot_args.pipeline_origin.external_repository_origin
+                    ),
+                    pipeline_subset_snapshot_args.pipeline_origin.pipeline_name,
                     pipeline_subset_snapshot_args.solid_selection,
                     pipeline_subset_snapshot_args.asset_selection,
                 )
@@ -479,15 +469,14 @@ class DagsterApiServer(DagsterApiServicer):
 
     def _get_serialized_external_repository_data(self, request):
         try:
-            repository_origin = deserialize_json_to_dagster_namedtuple(
-                request.serialized_repository_python_origin
+            repository_origin = deserialize_as(
+                request.serialized_repository_python_origin,
+                ExternalRepositoryOrigin,
             )
 
-            check.inst_param(repository_origin, "repository_origin", ExternalRepositoryOrigin)
-            recon_repo = self._recon_repository_from_origin(repository_origin)
             return serialize_dagster_namedtuple(
                 external_repository_data_from_def(
-                    recon_repo.get_definition(),
+                    self._get_repo_for_origin(repository_origin),
                     defer_snapshots=request.defer_snapshots,
                 )
             )
@@ -504,13 +493,12 @@ class DagsterApiServer(DagsterApiServicer):
 
     def ExternalJob(self, request, _context):
         try:
-            repository_origin = deserialize_json_to_dagster_namedtuple(
-                request.serialized_repository_origin
+            repository_origin = deserialize_as(
+                request.serialized_repository_origin,
+                ExternalRepositoryOrigin,
             )
 
-            check.inst_param(repository_origin, "repository_origin", ExternalRepositoryOrigin)
-            recon_repo = self._recon_repository_from_origin(repository_origin)
-            job_def = recon_repo.get_definition().get_pipeline(request.job_name)
+            job_def = self._get_repo_for_origin(repository_origin).get_pipeline(request.job_name)
             ser_job_data = serialize_dagster_namedtuple(external_pipeline_data_from_def(job_def))
             return api_pb2.ExternalJobReply(serialized_job_data=ser_job_data)
         except Exception:
@@ -556,20 +544,13 @@ class DagsterApiServer(DagsterApiServicer):
             )
 
     def ExternalScheduleExecution(self, request, _context):
-        args = deserialize_json_to_dagster_namedtuple(
-            request.serialized_external_schedule_execution_args
-        )
-
-        check.inst_param(
-            args,
-            "args",
+        args = deserialize_as(
+            request.serialized_external_schedule_execution_args,
             ExternalScheduleExecutionArgs,
         )
-
-        recon_repo = self._recon_repository_from_origin(args.repository_origin)
         serialized_schedule_data = serialize_dagster_namedtuple(
             get_external_schedule_execution(
-                recon_repo,
+                self._get_repo_for_origin(args.repository_origin),
                 args.instance_ref,
                 args.schedule_name,
                 args.scheduled_execution_timestamp,
@@ -580,16 +561,14 @@ class DagsterApiServer(DagsterApiServicer):
         yield from self._split_serialized_data_into_chunk_events(serialized_schedule_data)
 
     def ExternalSensorExecution(self, request, _context):
-        args = deserialize_json_to_dagster_namedtuple(
-            request.serialized_external_sensor_execution_args
+        args = deserialize_as(
+            request.serialized_external_sensor_execution_args,
+            SensorExecutionArgs,
         )
 
-        check.inst_param(args, "args", SensorExecutionArgs)
-
-        recon_repo = self._recon_repository_from_origin(args.repository_origin)
         serialized_sensor_data = serialize_dagster_namedtuple(
             get_external_sensor_execution(
-                recon_repo,
+                self._get_repo_for_origin(args.repository_origin),
                 args.instance_ref,
                 args.sensor_name,
                 args.last_completion_time,
@@ -625,8 +604,8 @@ class DagsterApiServer(DagsterApiServicer):
         message = None
         serializable_error_info = None
         try:
-            cancel_execution_request = check.inst(
-                deserialize_json_to_dagster_namedtuple(request.serialized_cancel_execution_request),
+            cancel_execution_request = deserialize_as(
+                request.serialized_cancel_execution_request,
                 CancelExecutionRequest,
             )
             with self._execution_lock:
@@ -649,8 +628,8 @@ class DagsterApiServer(DagsterApiServicer):
         )
 
     def CanCancelExecution(self, request, _context):
-        can_cancel_execution_request = check.inst(
-            deserialize_json_to_dagster_namedtuple(request.serialized_can_cancel_execution_request),
+        can_cancel_execution_request = deserialize_as(
+            request.serialized_can_cancel_execution_request,
             CanCancelExecutionRequest,
         )
         with self._execution_lock:
@@ -678,13 +657,18 @@ class DagsterApiServer(DagsterApiServicer):
             )
 
         try:
-            execute_external_pipeline_args = check.inst(
-                deserialize_json_to_dagster_namedtuple(request.serialized_execute_run_args),
+            execute_external_pipeline_args = deserialize_as(
+                request.serialized_execute_run_args,
                 ExecuteExternalPipelineArgs,
             )
             run_id = execute_external_pipeline_args.pipeline_run_id
-            recon_pipeline = self._recon_pipeline_from_origin(
-                execute_external_pipeline_args.pipeline_origin
+
+            # reconstructable required for handing execution off to subprocess
+            recon_repo = check.not_none(self._loaded_repositories).reconstructables_by_name[
+                execute_external_pipeline_args.pipeline_origin.external_repository_origin.repository_name
+            ]
+            recon_pipeline = recon_repo.get_reconstructable_pipeline(
+                execute_external_pipeline_args.pipeline_origin.pipeline_name
             )
 
         except:

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -60,7 +60,7 @@ class ExecutionPlanSnapshotArgs(
             pipeline_snapshot_id=check.str_param(pipeline_snapshot_id, "pipeline_snapshot_id"),
             known_state=check.opt_inst_param(known_state, "known_state", KnownExecutionState),
             instance_ref=check.opt_inst_param(instance_ref, "instance_ref", InstanceRef),
-            asset_selection=check.opt_set_param(
+            asset_selection=check.opt_nullable_set_param(
                 asset_selection, "asset_selection", of_type=AssetKey
             ),
         )


### PR DESCRIPTION
`@lru_cache(maxsize=...)` does not work as one may intuitively expect for `NamedTuple`. Since there are no object instance to bind to for the tuples, the cache ends up as a process global with the tuple itself being used as the key.

* For the op signature ones i dropped the caches since those were basically not doing anything. The appropriate place to cache that work is probably as close the the fn inspect call as possible.

* For `ReconstructablePipeline` I added a clarifying comment for what the global cache of 1 actually helps with, and a test to go with it. 

* For `ReconstructableRepository` i removed the cache and added explicit holding in `LoadedRepositories`. To pass these already loaded definitions in to grpc server implementations involved cascading changes. I cleaned up the types while i was there.

### How I Tested These Changes

added test
