### PR TITLE
[dagit] Top tooltip for backfill segments

### DIFF
--- a/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
@@ -183,6 +183,7 @@ export const PartitionStatus: React.FC<{
             ) : (
               <Tooltip
                 display="block"
+                position="top"
                 content={
                   tooltipMessage
                     ? tooltipMessage


### PR DESCRIPTION
### Summary & Motivation

The left tooltip looks weird on the backfill segments. Put it on top of the segment instead.

<img width="285" alt="Screen Shot 2022-09-23 at 3 57 19 PM" src="https://user-images.githubusercontent.com/2823852/192055399-d04447a4-3fc6-446e-90da-4a858673ded8.png">


### How I Tested These Changes

Hover on backfill segment.
