### PR TITLE
Extend ECS stub to include new cpu/mem

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
@@ -496,5 +496,7 @@ class StubbedEcs:
             "1024": [str(i) for i in range(2048, 8192 + 1, 1024)],
             "2048": [str(i) for i in range(4096, 16384 + 1, 1024)],
             "4096": [str(i) for i in range(8192, 30720 + 1, 1024)],
+            "8192": [str(i) for i in range(16384, 61440 + 1, 4096)],
+            "16384": [str(i) for i in range(32768, 122880 + 1, 8192)],
         }
         return bool(memory in constraints.get(cpu, []))


### PR DESCRIPTION
https://aws.amazon.com/about-aws/whats-new/2022/09/aws-fargate-increases-compute-memory-resource-configurations-4x/