### PR TITLE
[dagit] Add reload button to WorkspaceHeader

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/ReloadRepositoryLocationButton.tsx
+++ b/js_modules/dagit/packages/core/src/nav/ReloadRepositoryLocationButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import {AppContext} from '../app/AppContext';
+import {useFeatureFlags} from '../app/Flags';
 import {RepositoryLocationErrorDialog} from '../workspace/RepositoryLocationErrorDialog';
 
 import {buildReloadFnForLocation, useRepositoryLocationReload} from './useRepositoryLocationReload';
@@ -20,6 +21,7 @@ export const ReloadRepositoryLocationButton: React.FC<Props> = (props) => {
   const [shown, setShown] = React.useState(false);
 
   const {basePath} = React.useContext(AppContext);
+  const {flagNewWorkspace} = useFeatureFlags();
 
   const reloadFn = React.useMemo(() => buildReloadFnForLocation(location), [location]);
   const {reloading, error, tryReload} = useRepositoryLocationReload({
@@ -43,7 +45,9 @@ export const ReloadRepositoryLocationButton: React.FC<Props> = (props) => {
           // is presented to the user, and so that if the user was previously viewing
           // an object in a failed repo location, they aren't staring at a blank page.
           setShown(false);
-          window.location.href = `${basePath}/workspace`;
+          window.location.href = flagNewWorkspace
+            ? `${basePath}/instance/code-locations`
+            : `${basePath}/workspace`;
         }}
       />
     </>

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceHeader.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceHeader.tsx
@@ -1,6 +1,8 @@
-import {PageHeader, Box, Heading, Colors} from '@dagster-io/ui';
+import {PageHeader, Box, Heading, Colors, Button, Icon} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
+
+import {ReloadRepositoryLocationButton} from '../nav/ReloadRepositoryLocationButton';
 
 import {WorkspaceTabs} from './WorkspaceTabs';
 import {repoAddressAsString} from './repoAddressAsString';
@@ -24,6 +26,21 @@ export const WorkspaceHeader: React.FC<{repoAddress: RepoAddress; tab: string}> 
         </Box>
       }
       tabs={<WorkspaceTabs repoAddress={repoAddress} tab={tab} />}
+      right={
+        <ReloadRepositoryLocationButton location={repoAddress.location}>
+          {({tryReload, reloading}) => {
+            return (
+              <Button
+                onClick={() => tryReload()}
+                loading={reloading}
+                icon={<Icon name="refresh" />}
+              >
+                Reload repository location
+              </Button>
+            );
+          }}
+        </ReloadRepositoryLocationButton>
+      }
     />
   );
 };


### PR DESCRIPTION
### Summary & Motivation

Add a "Reload repository location" button to WorkspaceHeader, which is used on all the new Workspace virtualized table pages.

### How I Tested These Changes

View a repo in the new sections, click to reload. Verify proper rendering, loading behavior, reload confirmation.
