### PR TITLE
load asset values outside of a run

### DIFF
--- a/docs/content/concepts/assets/software-defined-assets.mdx
+++ b/docs/content/concepts/assets/software-defined-assets.mdx
@@ -488,6 +488,28 @@ def test_uses_context():
 
 ---
 
+## Loading asset values outside of Dagster runs
+
+It's sometimes useful to load an asset as a Python object outside of a Dagster run, e.g. if you want to do exploratory data analysis on it inside a Jupyter notebook. For this, you can use <PyObject object="RepositoryDefinition" method="load_asset_value" />:
+
+```python file=/concepts/assets/load_asset_values.py startafter=single_asset_start_marker endbefore=single_asset_end_marker dedent=4
+@repository
+def repo():
+    return [load_assets_from_current_module()]
+
+asset1_value = repo.load_asset_value(AssetKey("asset1"))
+```
+
+If you want to load the values of multiple assets, it's more efficient to use <PyObject object="RepositoryDefinition" method="load_asset_value" />, which avoids spinning up resources separately for each asset:
+
+```python file=/concepts/assets/load_asset_values.py startafter=multiple_asset_start_marker endbefore=multiple_asset_end_marker dedent=4
+with repo.get_asset_value_loader() as loader:
+    asset1_value = loader.load_asset_value(AssetKey("asset1"))
+    asset2_value = loader.load_asset_value(AssetKey("asset2"))
+```
+
+---
+
 ## Examples
 
 - [Multi-component asset keys](#multi-component-asset-keys)

--- a/examples/docs_snippets/docs_snippets/concepts/assets/load_asset_values.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/load_asset_values.py
@@ -1,0 +1,68 @@
+from dagster import (
+    AssetKey,
+    IOManager,
+    IOManagerDefinition,
+    asset,
+    load_assets_from_current_module,
+    repository,
+    with_resources,
+)
+
+
+class MyIOManager(IOManager):
+    def handle_output(self, context, obj):
+        assert False
+
+    def load_input(self, context):
+        return 5
+
+
+def get_assets():
+    @asset
+    def asset1():
+        ...
+
+    @asset
+    def asset2():
+        ...
+
+    return with_resources(
+        [asset1, asset2],
+        resource_defs={
+            "io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())
+        },
+    )
+
+
+assets = get_assets()
+
+
+def load_single_asset_value():
+    # single_asset_start_marker
+
+    @repository
+    def repo():
+        return [load_assets_from_current_module()]
+
+    asset1_value = repo.load_asset_value(AssetKey("asset1"))
+
+    # single_asset_end_marker
+
+    del asset1_value
+
+
+def load_multiple_asset_values():
+    @repository
+    def repo():
+        return [load_assets_from_current_module()]
+
+    # multiple_asset_start_marker
+
+    with repo.get_asset_value_loader() as loader:
+        asset1_value = loader.load_asset_value(AssetKey("asset1"))
+        asset2_value = loader.load_asset_value(AssetKey("asset2"))
+
+    # multiple_asset_end_marker
+
+    del asset1_value
+    del asset2_value

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_load_asset_values.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_load_asset_values.py
@@ -1,0 +1,9 @@
+from docs_snippets.concepts.assets.load_asset_values import (
+    load_multiple_asset_values,
+    load_single_asset_value,
+)
+
+
+def test():
+    load_single_asset_value()
+    load_multiple_asset_values()

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -746,6 +746,15 @@ class AssetsDefinition(ResourceAddable):
 
             return result
 
+    def get_io_manager_key_for_asset_key(self, key: AssetKey) -> str:
+        for output_name, asset_key in self.keys_by_output_name.items():
+            if key == asset_key:
+                return self.node_def.resolve_output_to_origin(
+                    output_name, NodeHandle(self.node_def.name, parent=None)
+                )[0].io_manager_key
+
+        check.failed(f"Asset key {key.to_user_string()} not found in AssetsDefinition")
+
     def get_resource_requirements(self) -> Iterator[ResourceRequirement]:
         yield from self.node_def.get_resource_requirements()  # type: ignore[attr-defined]
         for source_key, resource_def in self.resource_defs.items():

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition.py
@@ -22,10 +22,11 @@ from typing import (
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
+from dagster._core.instance import DagsterInstance
 from dagster._core.selector import parse_solid_selection
 from dagster._utils import merge_dicts
 
-from .events import AssetKey
+from .events import AssetKey, CoercibleToAssetKey
 from .executor_definition import ExecutorDefinition
 from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .job_definition import JobDefinition
@@ -40,6 +41,7 @@ from .utils import check_valid_name
 
 if TYPE_CHECKING:
     from dagster._core.definitions import AssetGroup, AssetsDefinition
+    from dagster._core.storage.asset_value_loader import AssetValueLoader
 
 VALID_REPOSITORY_DATA_DICT_KEYS = {
     "pipelines",
@@ -1319,6 +1321,57 @@ class RepositoryDefinition:
             solids_to_execute = parse_solid_selection(defn, op_selection)
 
         return defn.get_pipeline_subset_def(solids_to_execute)
+
+    @public
+    def load_asset_value(
+        self,
+        asset_key: CoercibleToAssetKey,
+        python_type: Optional[Type] = None,
+        instance: Optional[DagsterInstance] = None,
+    ) -> object:
+        """
+        Loads the contents of an asset as a Python object.
+
+        Invokes `load_input` on the :py:class:`IOManager` associated with the asset.
+
+        If you want to load the values of multiple assets, it's more efficient to use
+        `get_asset_value_loader`, which avoids spinning up resources separately for each asset.
+
+        Args:
+            asset_key (Union[AssetKey, Sequence[str], str]): The key of the asset to load.
+            python_type (Optional[Type]): The python type to load the asset as. This is what will
+                be returned inside `load_input` by `context.dagster_type.typing_type`.
+
+        Returns:
+            The contents of an asset as a Python object.
+        """
+        from dagster._core.storage.asset_value_loader import AssetValueLoader
+
+        with AssetValueLoader(self._assets_defs_by_key, instance=instance) as loader:
+            return loader.load_asset_value(asset_key, python_type=python_type)
+
+    @public
+    def get_asset_value_loader(
+        self, instance: Optional[DagsterInstance] = None
+    ) -> "AssetValueLoader":
+        """
+        Returns an object that can load the contents of assets as Python objects.
+
+        Invokes `load_input` on the :py:class:`IOManager` associated with the assets. Avoids
+        spinning up resources separately for each asset.
+
+        Usage:
+
+            .. code-block:: python
+
+                with my_repo.get_asset_value_loader() as loader:
+                    asset1 = loader.load_asset_value()
+                    asset1 = loader.load_asset_value()
+
+        """
+        from dagster._core.storage.asset_value_loader import AssetValueLoader
+
+        return AssetValueLoader(self._assets_defs_by_key, instance=instance)
 
     # If definition comes from the @repository decorator, then the __call__ method will be
     # overwritten. Therefore, we want to maintain the call-ability of repository definitions.

--- a/python_modules/dagster/dagster/_core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/build_resources.py
@@ -21,7 +21,7 @@ from .api import ephemeral_instance_if_missing
 from .context_creation_pipeline import initialize_console_manager
 
 
-def _get_mapped_resource_config(
+def get_mapped_resource_config(
     resource_defs: Mapping[str, ResourceDefinition], resource_config: Mapping[str, Any]
 ) -> Mapping[str, ResourceConfig]:
     resource_config_schema = define_resource_dictionary_cls(
@@ -89,7 +89,7 @@ def build_resources(
     resource_config = check.opt_dict_param(resource_config, "resource_config", key_type=str)
     log_manager = check.opt_inst_param(log_manager, "log_manager", DagsterLogManager)
     resource_defs = wrap_resources_for_execution(resources)
-    mapped_resource_config = _get_mapped_resource_config(resource_defs, resource_config)
+    mapped_resource_config = get_mapped_resource_config(resource_defs, resource_config)
 
     with ephemeral_instance_if_missing(instance) as dagster_instance:
         resources_manager = resource_initialization_manager(

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -73,6 +73,7 @@ class InputContext:
         resources: Optional[Union["Resources", Dict[str, Any]]] = None,
         step_context: Optional["StepExecutionContext"] = None,
         op_def: Optional["OpDefinition"] = None,
+        asset_key: Optional[AssetKey] = None,
     ):
         from dagster._core.definitions.resource_definition import IContainsGenerator, Resources
         from dagster._core.execution.build_resources import build_resources
@@ -90,6 +91,7 @@ class InputContext:
         self._log = log_manager
         self._resource_config = resource_config
         self._step_context = step_context
+        self._asset_key = asset_key
 
         if isinstance(resources, Resources):
             self._resources_cm = None
@@ -232,27 +234,17 @@ class InputContext:
     @public  # type: ignore
     @property
     def has_asset_key(self) -> bool:
-        return (
-            self._step_context is not None
-            and self._name is not None
-            and self._step_context.pipeline_def.asset_layer.asset_key_for_input(
-                node_handle=self.step_context.solid_handle, input_name=self._name
-            )
-            is not None
-        )
+        return self._asset_key is not None
 
     @public  # type: ignore
     @property
     def asset_key(self) -> AssetKey:
-        result = self.step_context.pipeline_def.asset_layer.asset_key_for_input(
-            node_handle=self.step_context.solid_handle, input_name=self.name
-        )
-        if result is None:
+        if self._asset_key is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access asset_key, but no asset is associated with this input"
             )
 
-        return result
+        return self._asset_key
 
     @public  # type: ignore
     @property
@@ -480,6 +472,7 @@ def build_input_context(
     resources: Optional[Dict[str, Any]] = None,
     op_def: Optional["OpDefinition"] = None,
     step_context: Optional["StepExecutionContext"] = None,
+    asset_key: Optional["AssetKey"] = None,
 ) -> "InputContext":
     """Builds input context from provided parameters.
 
@@ -528,6 +521,7 @@ def build_input_context(
     resources = check.opt_dict_param(resources, "resources", key_type=str)
     op_def = check.opt_inst_param(op_def, "op_def", OpDefinition)
     step_context = check.opt_inst_param(step_context, "step_context", StepExecutionContext)
+    asset_key = check.opt_inst_param(asset_key, "asset_key", AssetKey)
 
     return InputContext(
         name=name,
@@ -541,4 +535,5 @@ def build_input_context(
         resources=resources,
         step_context=step_context,
         op_def=op_def,
+        asset_key=asset_key,
     )

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -564,6 +564,9 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             step_context=self,
             resource_config=resource_config,
             resources=resources,
+            asset_key=self.pipeline_def.asset_layer.asset_key_for_input(
+                node_handle=self.solid_handle, input_name=name
+            ),
         )
 
     def for_hook(self, hook_def: HookDefinition) -> "HookContext":

--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -1,0 +1,99 @@
+from contextlib import ExitStack
+from typing import Dict, Mapping, Optional, Type, cast
+
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
+from dagster._core.definitions.resource_definition import ResourceDefinition
+from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
+from dagster._core.execution.build_resources import build_resources, get_mapped_resource_config
+from dagster._core.execution.context.input import build_input_context
+from dagster._core.execution.context.output import build_output_context
+from dagster._core.instance import DagsterInstance
+from dagster._core.types.dagster_type import resolve_dagster_type
+from dagster._utils import merge_dicts
+
+from .fs_io_manager import fs_io_manager
+from .io_manager import IOManager
+
+
+class AssetValueLoader:
+    """Caches resource definitions that are used to load asset values across multiple load
+    invocations"""
+
+    def __init__(
+        self,
+        assets_defs_by_key: Mapping[AssetKey, AssetsDefinition],
+        instance: Optional[DagsterInstance] = None,
+    ):
+        self._assets_defs_by_key = assets_defs_by_key
+        self._resource_instance_cache: Dict[str, object] = {}
+        self._instance = instance
+        self._exit_stack: ExitStack = ExitStack().__enter__()
+
+    def _ensure_resource_instances_in_cache(self, resource_defs: Mapping[str, ResourceDefinition]):
+        for built_resource_key, built_resource in (
+            self._exit_stack.enter_context(
+                build_resources(
+                    resources={
+                        resource_key: self._resource_instance_cache.get(resource_key, resource_def)
+                        for resource_key, resource_def in resource_defs.items()
+                    },
+                    instance=self._instance,
+                )
+            )
+            ._asdict()
+            .items()
+        ):
+            self._resource_instance_cache[built_resource_key] = built_resource
+
+    def load_asset_value(
+        self,
+        asset_key: CoercibleToAssetKey,
+        python_type: Optional[Type] = None,
+    ) -> object:
+        """
+        Loads the contents of an asset as a Python object.
+
+        Invokes `load_input` on the :py:class:`IOManager` associated with the asset.
+
+        Args:
+            asset_key (Union[AssetKey, Sequence[str], str]): The key of the asset to load.
+            python_type (Optional[Type]): The python type to load the asset as. This is what will
+                be returned inside `load_input` by `context.dagster_type.typing_type`.
+
+        Returns:
+            The contents of an asset as a Python object.
+        """
+        asset_key = AssetKey.from_coerceable(asset_key)
+
+        assets_def = self._assets_defs_by_key[asset_key]
+        resource_defs = merge_dicts(
+            {DEFAULT_IO_MANAGER_KEY: fs_io_manager}, assets_def.resource_defs
+        )
+        io_manager_key = assets_def.get_io_manager_key_for_asset_key(asset_key)
+        io_manager_def = resource_defs[io_manager_key]
+        required_resource_keys = io_manager_def.required_resource_keys | {io_manager_key}
+
+        self._ensure_resource_instances_in_cache(
+            {k: v for k, v in resource_defs.items() if k in required_resource_keys}
+        )
+        io_manager = cast(IOManager, self._resource_instance_cache[io_manager_key])
+
+        io_manager_config = get_mapped_resource_config({io_manager_key: io_manager_def}, {})
+
+        input_context = build_input_context(
+            name=None,
+            asset_key=asset_key,
+            dagster_type=resolve_dagster_type(python_type),
+            upstream_output=build_output_context(metadata=assets_def.metadata_by_key[asset_key]),
+            resources=self._resource_instance_cache,
+            resource_config=io_manager_config[io_manager_key].config,
+        )
+
+        return io_manager.load_input(input_context)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self._exit_stack.close()

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_asset_value_loader.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_asset_value_loader.py
@@ -1,0 +1,158 @@
+from contextlib import contextmanager
+
+from dagster import (
+    AssetKey,
+    DagsterInstance,
+    IOManager,
+    ResourceDefinition,
+    asset,
+    io_manager,
+    materialize,
+    repository,
+    resource,
+    with_resources,
+)
+
+
+def test_single_asset():
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            assert False
+
+        def load_input(self, context):
+            assert context.asset_key == AssetKey("asset1")
+            assert context.upstream_output.metadata["a"] == "b"
+            assert context.dagster_type.typing_type == int
+            return 5
+
+    @asset(io_manager_key="my_io_manager", metadata={"a": "b"})
+    def asset1():
+        ...
+
+    happenings = set()
+
+    @io_manager
+    @contextmanager
+    def my_io_manager():
+        try:
+            happenings.add("resource_inited")
+            yield MyIOManager()
+        finally:
+            happenings.add("torn_down")
+
+    @repository
+    def repo():
+        return with_resources([asset1], resource_defs={"my_io_manager": my_io_manager})
+
+    with repo.get_asset_value_loader() as loader:
+        assert "resource_inited" not in happenings
+        assert "torn_down" not in happenings
+        value = loader.load_asset_value(AssetKey("asset1"), python_type=int)
+        assert "resource_inited" in happenings
+        assert "torn_down" not in happenings
+        assert value == 5
+
+    assert "torn_down" in happenings
+
+    assert repo.load_asset_value(AssetKey("asset1"), python_type=int) == 5
+
+
+def test_resource_dependencies_and_config():
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            assert False
+
+        def load_input(self, context):
+            assert context.resources.other_resource == "apple"
+            assert context.resource_config["config_key"] == "config_val"
+            return 5
+
+    @io_manager(required_resource_keys={"other_resource"}, config_schema={"config_key": str})
+    def my_io_manager():
+        return MyIOManager()
+
+    @asset(io_manager_key="my_io_manager")
+    def asset1():
+        ...
+
+    @repository
+    def repo():
+        return with_resources(
+            [asset1],
+            resource_defs={
+                "my_io_manager": my_io_manager.configured({"config_key": "config_val"}),
+                "other_resource": ResourceDefinition.hardcoded_resource("apple"),
+            },
+        )
+
+    with repo.get_asset_value_loader() as loader:
+        value = loader.load_asset_value(AssetKey("asset1"))
+        assert value == 5
+
+
+def test_two_io_managers_same_resource_dep():
+    happenings = set()
+
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            assert False
+
+        def load_input(self, context):
+            assert context.resources.other_resource == "apple"
+            return context.asset_key.path[-1] + "_5"
+
+    @io_manager(required_resource_keys={"other_resource"})
+    def io_manager1():
+        return MyIOManager()
+
+    @io_manager(required_resource_keys={"other_resource"})
+    def io_manager2():
+        return MyIOManager()
+
+    @resource
+    def other_resource():
+        assert "other_resource_inited" not in happenings
+        happenings.add("other_resource_inited")
+        return "apple"
+
+    @asset(io_manager_key="io_manager1")
+    def asset1():
+        ...
+
+    @asset(io_manager_key="io_manager2")
+    def asset2():
+        ...
+
+    @repository
+    def repo():
+        return with_resources(
+            [asset1, asset2],
+            resource_defs={
+                "io_manager1": io_manager1,
+                "io_manager2": io_manager2,
+                "other_resource": other_resource,
+            },
+        )
+
+    with repo.get_asset_value_loader() as loader:
+        assert loader.load_asset_value(AssetKey("asset1")) == "asset1_5"
+        assert loader.load_asset_value(AssetKey("asset2")) == "asset2_5"
+
+
+def test_default_io_manager():
+    @asset
+    def asset1():
+        return 5
+
+    @repository
+    def repo():
+        return [asset1]
+
+    with DagsterInstance.ephemeral() as instance:
+        materialize([asset1], instance=instance)
+
+        with repo.get_asset_value_loader(instance=instance) as loader:
+            value = loader.load_asset_value(AssetKey("asset1"), python_type=int)
+            assert value == 5
+
+    assert repo.load_asset_value(AssetKey("asset1"), python_type=int, instance=instance) == 5


### PR DESCRIPTION
### Summary & Motivation

Fixes #9524.

In a notebook, or in an op, you might want to load an asset to inspect it. Imagine if you could do something like this:

```
from my_module import my_repo

my_repo.load_asset_value("asset_abc")
```

It would call the IO manager associated with the asset and load it.

### How I Tested These Changes

added tests
