### PR TITLE
Add clearer logging when daemon is in the process of shutting down

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/test_dagster_daemon_health.py
+++ b/integration_tests/test_suites/daemon-test-suite/test_dagster_daemon_health.py
@@ -142,7 +142,7 @@ def test_thread_die_daemon(monkeypatch):
                         controller.check_daemon_threads()  # Should eventually throw since the sensor thread is interrupted
                     except Exception as e:
                         assert (
-                            "Stopping dagster-daemon process since the following threads are no longer running: ['SENSOR']"
+                            "Stopped dagster-daemon process due to threads no longer running"
                             in str(e)
                         )
                         break
@@ -175,7 +175,7 @@ def test_transient_heartbeat_failure(mocker):
 
             with pytest.raises(
                 Exception,
-                match="Stopping dagster-daemon process since the following threads are no longer sending heartbeats",
+                match="Stopped dagster-daemon process due to thread heartbeat failure",
             ):
                 controller.check_daemon_heartbeats()
 


### PR DESCRIPTION
Summary:
Came up while debugging last week - we don't log anything on shutdown until the join finishes which can be quite slow. Log something as soon as we start shutting down instead.

### Summary & Motivation

### How I Tested These Changes
