### PR TITLE
[dagit] Add top-level polling to virtualized table pages

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceAssetsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceAssetsRoot.tsx
@@ -3,6 +3,7 @@ import {Box, Colors, NonIdealState, Spinner, TextInput} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {useAssetNodeSearch} from '../assets/useAssetSearch';
 
@@ -27,6 +28,7 @@ export const WorkspaceAssetsRoot = ({repoAddress}: {repoAddress: RepoAddress}) =
     },
   );
   const {data, loading} = queryResultOverview;
+  const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
   const anySearch = sanitizedSearch.length > 0;
@@ -85,7 +87,12 @@ export const WorkspaceAssetsRoot = ({repoAddress}: {repoAddress: RepoAddress}) =
 
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
-      <WorkspaceHeader repoAddress={repoAddress} tab="assets" />
+      <WorkspaceHeader
+        repoAddress={repoAddress}
+        tab="assets"
+        refreshState={refreshState}
+        queryData={queryResultOverview}
+      />
       <Box padding={{horizontal: 24, vertical: 16}}>
         <TextInput
           icon="search"

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceGraphsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceGraphsRoot.tsx
@@ -3,6 +3,7 @@ import {Box, Colors, NonIdealState, Spinner, TextInput} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 
@@ -27,6 +28,7 @@ export const WorkspaceGraphsRoot = ({repoAddress}: {repoAddress: RepoAddress}) =
     },
   );
   const {data, loading} = queryResultOverview;
+  const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
   const anySearch = sanitizedSearch.length > 0;
@@ -112,7 +114,12 @@ export const WorkspaceGraphsRoot = ({repoAddress}: {repoAddress: RepoAddress}) =
 
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
-      <WorkspaceHeader repoAddress={repoAddress} tab="graphs" />
+      <WorkspaceHeader
+        repoAddress={repoAddress}
+        tab="graphs"
+        refreshState={refreshState}
+        queryData={queryResultOverview}
+      />
       <Box padding={{horizontal: 24, vertical: 16}}>
         <TextInput
           icon="search"

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceHeader.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceHeader.tsx
@@ -1,17 +1,25 @@
+import {QueryResult} from '@apollo/client';
 import {PageHeader, Box, Heading, Colors, Button, Icon} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
+import {QueryRefreshState} from '../app/QueryRefresh';
 import {ReloadRepositoryLocationButton} from '../nav/ReloadRepositoryLocationButton';
 
 import {WorkspaceTabs} from './WorkspaceTabs';
 import {repoAddressAsString} from './repoAddressAsString';
 import {RepoAddress} from './types';
 
-export const WorkspaceHeader: React.FC<{repoAddress: RepoAddress; tab: string}> = ({
-  repoAddress,
-  tab,
-}) => {
+interface Props<TData> {
+  repoAddress: RepoAddress;
+  tab: string;
+  refreshState?: QueryRefreshState;
+  queryData?: QueryResult<TData, any>;
+}
+
+export const WorkspaceHeader = <TData extends Record<string, any>>(props: Props<TData>) => {
+  const {repoAddress, tab, refreshState, queryData} = props;
+
   return (
     <PageHeader
       title={
@@ -25,7 +33,14 @@ export const WorkspaceHeader: React.FC<{repoAddress: RepoAddress; tab: string}> 
           <Heading style={{color: Colors.Gray600}}>{repoAddressAsString(repoAddress)}</Heading>
         </Box>
       }
-      tabs={<WorkspaceTabs repoAddress={repoAddress} tab={tab} />}
+      tabs={
+        <WorkspaceTabs
+          repoAddress={repoAddress}
+          tab={tab}
+          refreshState={refreshState}
+          queryData={queryData}
+        />
+      }
       right={
         <ReloadRepositoryLocationButton location={repoAddress.location}>
           {({tryReload, reloading}) => {

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceJobsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceJobsRoot.tsx
@@ -3,6 +3,7 @@ import {Box, Colors, NonIdealState, Spinner, TextInput} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
@@ -29,6 +30,7 @@ export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => 
     },
   );
   const {data, loading} = queryResultOverview;
+  const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
   const anySearch = sanitizedSearch.length > 0;
@@ -92,7 +94,12 @@ export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => 
 
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
-      <WorkspaceHeader repoAddress={repoAddress} tab="jobs" />
+      <WorkspaceHeader
+        repoAddress={repoAddress}
+        tab="jobs"
+        refreshState={refreshState}
+        queryData={queryResultOverview}
+      />
       <Box padding={{horizontal: 24, vertical: 16}}>
         <TextInput
           icon="search"

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceSchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceSchedulesRoot.tsx
@@ -3,6 +3,7 @@ import {Box, Colors, NonIdealState, Spinner, TextInput} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 
 import {VirtualizedScheduleTable} from './VirtualizedScheduleTable';
@@ -29,6 +30,7 @@ export const WorkspaceSchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}
     },
   );
   const {data, loading} = queryResultOverview;
+  const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
   const anySearch = sanitizedSearch.length > 0;
@@ -90,7 +92,12 @@ export const WorkspaceSchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}
 
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
-      <WorkspaceHeader repoAddress={repoAddress} tab="schedules" />
+      <WorkspaceHeader
+        repoAddress={repoAddress}
+        tab="schedules"
+        refreshState={refreshState}
+        queryData={queryResultOverview}
+      />
       <Box padding={{horizontal: 24, vertical: 16}}>
         <TextInput
           icon="search"

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceSensorsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceSensorsRoot.tsx
@@ -3,6 +3,7 @@ import {Box, Colors, NonIdealState, Spinner, TextInput} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 
 import {VirtualizedSensorTable} from './VirtualizedSensorTable';
@@ -26,6 +27,7 @@ export const WorkspaceSensorsRoot = ({repoAddress}: {repoAddress: RepoAddress}) 
     },
   );
   const {data, loading} = queryResultOverview;
+  const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
   const anySearch = sanitizedSearch.length > 0;
@@ -87,7 +89,12 @@ export const WorkspaceSensorsRoot = ({repoAddress}: {repoAddress: RepoAddress}) 
 
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
-      <WorkspaceHeader repoAddress={repoAddress} tab="sensors" />
+      <WorkspaceHeader
+        repoAddress={repoAddress}
+        tab="sensors"
+        refreshState={refreshState}
+        queryData={queryResultOverview}
+      />
       <Box padding={{horizontal: 24, vertical: 16}}>
         <TextInput
           icon="search"

--- a/js_modules/dagit/packages/ui/src/components/RefreshableCountdown.tsx
+++ b/js_modules/dagit/packages/ui/src/components/RefreshableCountdown.tsx
@@ -24,7 +24,7 @@ export const RefreshableCountdown = (props: Props) => {
           ? `Refreshing ${dataDescription}…`
           : `0:${seconds < 10 ? `0${seconds}` : seconds}`}
       </span>
-      <Tooltip content={<span style={{whiteSpace: 'nowrap'}}>Refresh now</span>} position="bottom">
+      <Tooltip content={<span style={{whiteSpace: 'nowrap'}}>Refresh now</span>} position="top">
         <RefreshButton onClick={onRefresh}>
           <Icon name="refresh" color={Colors.Gray400} />
         </RefreshButton>


### PR DESCRIPTION
### Summary & Motivation

Add polling and refresh to virtualized Workspace list pages.

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/2823852/192374051-91ff42cf-4617-4d3e-9cd4-5860e839f82c.png">


### How I Tested These Changes

View each list page for a repo, verify that the polling/refresh behavior is correct.
