### PR TITLE
[dagit] Align virtualized table cells to top

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/VirtualizedTable.tsx
+++ b/js_modules/dagit/packages/core/src/ui/VirtualizedTable.tsx
@@ -14,8 +14,8 @@ export const HeaderCell: React.FC = ({children}) => (
 
 export const RowCell: React.FC = ({children}) => (
   <Box
-    padding={{horizontal: 24}}
-    flex={{direction: 'column', justifyContent: 'center'}}
+    padding={{horizontal: 24, vertical: 12}}
+    flex={{direction: 'column', justifyContent: 'flex-start'}}
     style={{color: Colors.Gray500, overflow: 'hidden'}}
     border={{side: 'right', width: 1, color: Colors.KeylineGray}}
   >

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
@@ -181,7 +181,16 @@ const AssetRow = (props: JobRowProps) => {
     <Row $height={height} $start={start}>
       <RowGrid border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
         <RowCell>
-          <AssetLink path={path} url={linkUrl} isGroup={false} icon="asset" />
+          <div
+            style={{
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              fontWeight: 500,
+            }}
+          >
+            <AssetLink path={path} url={linkUrl} isGroup={false} icon="asset" />
+          </div>
           <div
             style={{
               maxWidth: '100%',

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedGraphTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedGraphTable.tsx
@@ -113,11 +113,28 @@ const GraphRow = (props: GraphRowProps) => {
     <Row $height={height} $start={start}>
       <RowGrid border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
         <RowCell>
-          <Box flex={{direction: 'column', gap: 4}}>
-            <span style={{fontWeight: 500}}>
+          <Box flex={{direction: 'column'}}>
+            <div style={{whiteSpace: 'nowrap', fontWeight: 500}}>
               <Link to={workspacePathFromAddress(repoAddress, path)}>{name}</Link>
-            </span>
-            {displayedDescription ? <Caption>{displayedDescription}</Caption> : null}
+            </div>
+            {displayedDescription ? (
+              <div
+                style={{
+                  maxWidth: '100%',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                <Caption
+                  style={{
+                    color: Colors.Gray500,
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {displayedDescription}
+                </Caption>
+              </div>
+            ) : null}
           </Box>
         </RowCell>
       </RowGrid>

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedJobTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedJobTable.tsx
@@ -127,7 +127,7 @@ const JobRow = (props: JobRowProps) => {
     <Row $height={height} $start={start}>
       <RowGrid border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
         <RowCell>
-          <div style={{whiteSpace: 'nowrap'}}>
+          <div style={{whiteSpace: 'nowrap', fontWeight: 500}}>
             <Link to={workspacePathFromAddress(repoAddress, `/jobs/${name}`)}>{name}</Link>
           </div>
           <div
@@ -172,7 +172,9 @@ const JobRow = (props: JobRowProps) => {
         </RowCell>
         <RowCell>
           {latestRuns.length ? (
-            <RunStatusPezList jobName={name} runs={[...latestRuns].reverse()} fade />
+            <Box margin={{top: 4}}>
+              <RunStatusPezList jobName={name} runs={[...latestRuns].reverse()} fade />
+            </Box>
           ) : (
             <LoadingOrNone queryResult={queryResult} />
           )}

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleTable.tsx
@@ -159,14 +159,16 @@ const ScheduleRow = (props: ScheduleRowProps) => {
         <RowCell>
           {scheduleData ? (
             <Box flex={{direction: 'column', gap: 4}}>
-              <Tooltip position="bottom" content={scheduleData.cronSchedule}>
-                <span style={{color: Colors.Dark}}>
-                  {humanCronString(
-                    scheduleData.cronSchedule,
-                    scheduleData.executionTimezone || 'UTC',
-                  )}
-                </span>
-              </Tooltip>
+              <div>
+                <Tooltip position="top" content={scheduleData.cronSchedule}>
+                  <span style={{color: Colors.Dark}}>
+                    {humanCronString(
+                      scheduleData.cronSchedule,
+                      scheduleData.executionTimezone || 'UTC',
+                    )}
+                  </span>
+                </Tooltip>
+              </div>
               <Caption>
                 Next tick:&nbsp;
                 {scheduleData.scheduleState.nextTick &&
@@ -238,9 +240,7 @@ const ScheduleRow = (props: ScheduleRowProps) => {
             >
               <Button icon={<Icon name="expand_more" />} />
             </Popover>
-          ) : (
-            <LoadingOrNone queryResult={queryResult} />
-          )}
+          ) : null}
         </RowCell>
       </RowGrid>
     </Row>


### PR DESCRIPTION
### Summary & Motivation

Align table cells to the top. Additionally, use higher font-weight on the object names on all tables.

<img width="1264" alt="Screen Shot 2022-09-27 at 3 18 02 PM" src="https://user-images.githubusercontent.com/2823852/192629843-0bce77fc-ba5a-4a78-b222-0c8c6c724435.png">


### How I Tested These Changes

View Workspace with flag turned on, verify correct rendering and alignment.
