### PR TITLE
Specify platform to build in deploy_ecs example

### DIFF
--- a/examples/deploy_ecs/docker-compose.yml
+++ b/examples/deploy_ecs/docker-compose.yml
@@ -8,6 +8,7 @@ services:
   # dagit will be put on a queue and later dequeued and launched by
   # the dagster-daemon service.
   dagit:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: ./Dockerfile
@@ -46,6 +47,7 @@ services:
   # taking runs off of the queue and launching them, as well as creating
   # runs from schedules or sensors.
   daemon:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: ./Dockerfile
@@ -92,6 +94,7 @@ services:
   # Multiple containers like this can be deployed separately - each needs to
   # run on its own port and have its own entry in the workspace.yaml file.
   user_code:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: ./Dockerfile


### PR DESCRIPTION
Summary:
So that users building on M1 macs will still build with the right architecture.

Test Plan:
I don't have an M1, but verify that the deploy_ecs example still deploys - check with somebody who has an M1 to try as well.

### Summary & Motivation

### How I Tested These Changes
