### PR TITLE
[dagit] Hover/active state for top nav items

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
@@ -1,6 +1,6 @@
 import {Box, Colors, Icon, IconWrapper, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
-import {Link, useHistory} from 'react-router-dom';
+import {Link, NavLink, useHistory} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {InstanceWarningIcon} from '../nav/InstanceWarningIcon';
@@ -49,7 +49,7 @@ export const AppTopNav: React.FC<Props> = ({
             shortcutLabel="⌥2"
             shortcutFilter={(e) => e.code === 'Digit2' && e.altKey}
           >
-            <TopNavLink to="/instance/assets" data-cy="AppTopNav_AssetsLink">
+            <TopNavLink to="/instance/assets" data-cy="AppTopNav_AssetsLink" exact={false}>
               Assets
             </TopNavLink>
           </ShortcutHandler>
@@ -58,7 +58,18 @@ export const AppTopNav: React.FC<Props> = ({
             shortcutLabel="⌥3"
             shortcutFilter={(e) => e.code === 'Digit3' && e.altKey}
           >
-            <TopNavLink to="/instance" data-cy="AppTopNav_StatusLink">
+            <TopNavLink
+              to="/instance"
+              data-cy="AppTopNav_StatusLink"
+              isActive={(_, location) => {
+                const {pathname} = location;
+                return (
+                  pathname.startsWith('/instance') &&
+                  !pathname.startsWith('/instance/runs') &&
+                  !pathname.startsWith('/instance/assets')
+                );
+              }}
+            >
               <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
                 Status
                 {showStatusWarningIcon ? <InstanceWarningIcon /> : null}
@@ -180,14 +191,20 @@ const DaggyTooltip = styled(Tooltip)`
   }
 `;
 
-export const TopNavLink = styled(Link)`
-  color: ${Colors.Gray200};
+export const TopNavLink = styled(NavLink)`
+  color: ${Colors.Gray400};
   font-weight: 600;
   transition: color 50ms linear;
   padding: 24px 0;
+  text-decoration: none;
 
-  :hover,
-  :active {
+  :hover {
+    color: ${Colors.Gray300};
+    text-decoration: none;
+  }
+
+  :active,
+  &.active {
     color: ${Colors.White};
     text-decoration: none;
   }


### PR DESCRIPTION
### Summary & Motivation

Resolves #9806.

Make the active top nav item more obvious. Dim the default color a bit, add a hover state, and use active states to indicate where the user is in the app. This leans on react-router-dom's `NavLink`.

"Workspace" is the active link:

<img width="306" alt="Screen Shot 2022-09-28 at 9 37 22 AM" src="https://user-images.githubusercontent.com/2823852/192808834-860dd7ec-d2a9-492c-8736-32993fc59594.png">

Hovering over "Assets":

<img width="291" alt="Screen Shot 2022-09-28 at 9 37 28 AM" src="https://user-images.githubusercontent.com/2823852/192808837-385e7d44-267c-4596-b3f4-da4415e3b4d6.png">


### How I Tested These Changes

View Dagit, click around and verify that the correct top nav item is highlighted depending on where I am in the app.
