### PR TITLE
[dagit] Update homepage and top nav for new workspace flag

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
@@ -8,6 +8,7 @@ import {VersionNumber} from '../nav/VersionNumber';
 import {WorkspaceStatus} from '../nav/WorkspaceStatus';
 import {SearchDialog} from '../search/SearchDialog';
 
+import {useFeatureFlags} from './Flags';
 import {LayoutContext} from './LayoutProvider';
 import {ShortcutHandler} from './ShortcutHandler';
 import {WebSocketStatus} from './WebSocketProvider';
@@ -25,6 +26,8 @@ export const AppTopNav: React.FC<Props> = ({
   showStatusWarningIcon = true,
 }) => {
   const history = useHistory();
+  const {flagNewWorkspace} = useFeatureFlags();
+  const runHref = flagNewWorkspace ? '/instance/runs/timeline' : '/instance/runs';
 
   return (
     <AppTopNavContainer>
@@ -36,11 +39,11 @@ export const AppTopNav: React.FC<Props> = ({
       <Box flex={{direction: 'row', alignItems: 'center'}}>
         <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
           <ShortcutHandler
-            onShortcut={() => history.push('/instance/runs')}
+            onShortcut={() => history.push(runHref)}
             shortcutLabel="⌥1"
             shortcutFilter={(e) => e.code === 'Digit1' && e.altKey}
           >
-            <TopNavLink to="/instance/runs" data-cy="AppTopNav_RunsLink">
+            <TopNavLink to={runHref} data-cy="AppTopNav_RunsLink">
               Runs
             </TopNavLink>
           </ShortcutHandler>

--- a/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
@@ -6,6 +6,8 @@ import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {DagsterRepoOption, WorkspaceContext} from '../workspace/WorkspaceContext';
 import {workspacePath, workspacePipelinePath} from '../workspace/workspacePath';
 
+import {useFeatureFlags} from './Flags';
+
 const InstanceRedirect = () => {
   const location = useLocation();
   const path = `${location.pathname}${location.search}`;
@@ -34,6 +36,8 @@ const getVisibleJobs = (r: DagsterRepoOption) =>
 const FinalRedirectOrLoadingRoot = () => {
   const workspaceContext = React.useContext(WorkspaceContext);
   const {allRepos, loading, locationEntries} = workspaceContext;
+
+  const {flagNewWorkspace} = useFeatureFlags();
 
   if (loading) {
     return (
@@ -88,7 +92,7 @@ const FinalRedirectOrLoadingRoot = () => {
 
   // If we have more than one repo with a job, route to the instance overview
   if (reposWithVisibleJobs.length > 0) {
-    return <Redirect to="/instance" />;
+    return <Redirect to={flagNewWorkspace ? '/instance/runs/timeline' : '/instance'} />;
   }
 
   const repoWithNoJob = allRepos[0];

--- a/js_modules/dagit/packages/core/src/instance/InstanceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceRoot.tsx
@@ -51,7 +51,12 @@ export const InstanceRoot = () => {
         <Route path="/instance/:tab">
           <InstanceStatusRoot />
         </Route>
-        <Route path="*" render={() => <Redirect to="/instance/overview" />} />
+        <Route
+          path="*"
+          render={() => (
+            <Redirect to={flagNewWorkspace ? '/instance/code-locations' : '/instance/overview'} />
+          )}
+        />
       </Switch>
     </MainContent>
   );

--- a/js_modules/dagit/packages/core/src/instance/InstanceStatusRoot.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceStatusRoot.tsx
@@ -2,6 +2,8 @@ import {Page} from '@dagster-io/ui';
 import * as React from 'react';
 import {Redirect, Route, Switch} from 'react-router-dom';
 
+import {useFeatureFlags} from '../app/Flags';
+
 import {InstanceBackfills} from './InstanceBackfills';
 import {InstanceConfig} from './InstanceConfig';
 import {InstanceHealthPage} from './InstanceHealthPage';
@@ -11,33 +13,38 @@ import {InstanceSensors} from './InstanceSensors';
 
 const CodeLocationsPage = React.lazy(() => import('./CodeLocationsPage'));
 
-export const InstanceStatusRoot = () => (
-  <Page>
-    <Switch>
-      <Route path="/instance/overview">
-        <InstanceOverviewPage />
-      </Route>
-      <Route path="/instance/health">
-        <InstanceHealthPage />
-      </Route>
-      <Route path="/instance/schedules">
-        <InstanceSchedules />
-      </Route>
-      <Route path="/instance/sensors">
-        <InstanceSensors />
-      </Route>
-      <Route path="/instance/backfills">
-        <InstanceBackfills />
-      </Route>
-      <Route path="/instance/config">
-        <InstanceConfig />
-      </Route>
-      <Route path="/instance/code-locations">
-        <React.Suspense fallback={<div />}>
-          <CodeLocationsPage />
-        </React.Suspense>
-      </Route>
-      <Route path="*" render={() => <Redirect to="/instance" />} />
-    </Switch>
-  </Page>
-);
+export const InstanceStatusRoot = () => {
+  const {flagNewWorkspace} = useFeatureFlags();
+  return (
+    <Page>
+      <Switch>
+        {flagNewWorkspace ? null : (
+          <Route path="/instance/overview">
+            <InstanceOverviewPage />
+          </Route>
+        )}
+        <Route path="/instance/health">
+          <InstanceHealthPage />
+        </Route>
+        <Route path="/instance/schedules">
+          <InstanceSchedules />
+        </Route>
+        <Route path="/instance/sensors">
+          <InstanceSensors />
+        </Route>
+        <Route path="/instance/backfills">
+          <InstanceBackfills />
+        </Route>
+        <Route path="/instance/config">
+          <InstanceConfig />
+        </Route>
+        <Route path="/instance/code-locations">
+          <React.Suspense fallback={<div />}>
+            <CodeLocationsPage />
+          </React.Suspense>
+        </Route>
+        <Route path="*" render={() => <Redirect to="/instance" />} />
+      </Switch>
+    </Page>
+  );
+};

--- a/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
@@ -28,13 +28,17 @@ export const InstanceTabs = <TData extends Record<string, any>>(props: Props<TDa
   return (
     <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
       <Tabs selectedTabId={tab}>
-        <TabLink id="overview" title="Overview" to="/instance/overview" />
+        {flagNewWorkspace ? null : (
+          <TabLink id="overview" title="Overview" to="/instance/overview" />
+        )}
         {flagNewWorkspace ? (
           <TabLink id="code-locations" title="Code locations" to="/instance/code-locations" />
         ) : null}
         <TabLink id="health" title={healthTitle} to="/instance/health" />
-        <TabLink id="schedules" title="Schedules" to="/instance/schedules" />
-        <TabLink id="sensors" title="Sensors" to="/instance/sensors" />
+        {flagNewWorkspace ? null : (
+          <TabLink id="schedules" title="Schedules" to="/instance/schedules" />
+        )}
+        {flagNewWorkspace ? null : <TabLink id="sensors" title="Sensors" to="/instance/sensors" />}
         {flagNewWorkspace ? null : (
           <TabLink id="backfills" title="Backfills" to="/instance/backfills" />
         )}


### PR DESCRIPTION
### Summary & Motivation

If the user is in the new workspace page flag, set their `/` redirect "homepage" to the Run timeline. Also update the "Status" page (soon to be "Deployment") to hide Instance Overview (now split apart) and Schedules/Sensors tabs (now visible on Workspace).

### How I Tested These Changes

With flag enabled, verify changes described above. With flag disabled, verify that everything is the same as current.
