### PR TITLE
Add metadata hooks for making grpc client calls

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/repository_location.py
@@ -3,7 +3,7 @@ import sys
 import threading
 from abc import abstractmethod
 from contextlib import AbstractContextManager
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Union, cast
 
 import dagster._check as check
 from dagster._api.get_server_id import sync_get_server_id
@@ -523,6 +523,7 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
         heartbeat: Optional[bool] = False,
         watch_server: Optional[bool] = True,
         grpc_server_registry: Optional[GrpcServerRegistry] = None,
+        grpc_metadata: Optional[List[Tuple[str, str]]] = None,
     ):
         from dagster._grpc.client import DagsterGrpcClient, client_heartbeat_thread
 
@@ -564,6 +565,7 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
                 socket=self._socket,
                 host=self._host,
                 use_ssl=self._use_ssl,
+                metadata=grpc_metadata,
             )
             list_repositories_response = sync_list_repositories_grpc(self.client)
 

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -996,6 +996,9 @@ def open_server_process(
     heartbeat_timeout=30,
     fixed_server_id=None,
     startup_timeout=20,
+    cwd=None,
+    log_level="WARNING",  # don't log INFO messages for automatically spun up servers
+    env=None,
 ):
     check.invariant((port or socket) and not (port and socket), "Set only port or socket")
     check.opt_inst_param(loadable_target_origin, "loadable_target_origin", LoadableTargetOrigin)
@@ -1018,7 +1021,7 @@ def open_server_process(
         + (["--heartbeat-timeout", str(heartbeat_timeout)] if heartbeat_timeout else [])
         + (["--fixed-server-id", fixed_server_id] if fixed_server_id else [])
         + (["--override-system-timezone", mocked_system_timezone] if mocked_system_timezone else [])
-        + (["--log-level", "WARNING"])  # don't log INFO messages for automatically spun up servers
+        + (["--log-level", log_level])
         # only use the Python environment if it has been explicitly set in the workspace
         + (["--use-python-environment-entry-point"] if executable_path else [])
     )
@@ -1026,7 +1029,7 @@ def open_server_process(
     if loadable_target_origin:
         subprocess_args += loadable_target_origin.get_cli_args()
 
-    server_process = open_ipc_subprocess(subprocess_args)
+    server_process = open_ipc_subprocess(subprocess_args, cwd=cwd, env=env)
 
     from dagster._grpc.client import DagsterGrpcClient
 
@@ -1054,6 +1057,9 @@ def open_server_process_on_dynamic_port(
     heartbeat_timeout=30,
     fixed_server_id=None,
     startup_timeout=20,
+    cwd=None,
+    log_level="WARNING",
+    env=None,
 ):
     server_process = None
     retries = 0
@@ -1069,6 +1075,9 @@ def open_server_process_on_dynamic_port(
                 heartbeat_timeout=heartbeat_timeout,
                 fixed_server_id=fixed_server_id,
                 startup_timeout=startup_timeout,
+                cwd=cwd,
+                log_level=log_level,
+                env=env,
             )
         except CouldNotBindGrpcServerToAddress:
             pass
@@ -1089,6 +1098,9 @@ class GrpcServerProcess:
         heartbeat_timeout=30,
         fixed_server_id=None,
         startup_timeout=20,
+        cwd=None,
+        log_level="WARNING",
+        env=None,
     ):
         self.port = None
         self.socket = None
@@ -1120,6 +1132,9 @@ class GrpcServerProcess:
                 heartbeat_timeout=heartbeat_timeout,
                 fixed_server_id=fixed_server_id,
                 startup_timeout=startup_timeout,
+                cwd=cwd,
+                log_level=log_level,
+                env=env,
             )
         else:
             self.socket = safe_tempfile_path_unmanaged()
@@ -1133,6 +1148,9 @@ class GrpcServerProcess:
                 heartbeat_timeout=heartbeat_timeout,
                 fixed_server_id=fixed_server_id,
                 startup_timeout=startup_timeout,
+                cwd=cwd,
+                log_level=log_level,
+                env=env,
             )
 
         if self.server_process is None:


### PR DESCRIPTION
Summary:
One could imagine a multiplexing gRPC server passign through metadata for routing information to say which server the multiplex should route to. Also provide a utlity _get_response method that can be used to easily pass through requests.

### Summary & Motivation

### How I Tested These Changes
