### PR TITLE
[dagster-dbt] Support dbt 1.3 raw_code schema change

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -142,7 +142,7 @@ def _get_node_group_name(node_info: Mapping[str, Any]) -> Optional[str]:
 
 
 def _get_node_description(node_info):
-    code_block = textwrap.indent(node_info["raw_sql"], "    ")
+    code_block = textwrap.indent(node_info.get("raw_sql") or node_info.get("raw_code", ""), "    ")
     description_sections = [
         node_info["description"] or f"dbt {node_info['resource_type']} {node_info['name']}",
         f"#### Raw SQL:\n```\n{code_block}\n```",


### PR DESCRIPTION
### Summary & Motivation

dbt 1.3 supports python models, so they changed this field from raw_sql to raw_code

### How I Tested These Changes
