### PR TITLE
[dagit] Use a consistent partition selection UI for op / asset backfills

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -87,9 +87,8 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
   assetJobName,
   upstreamAssetKeys,
 }) => {
-  const data = usePartitionHealthData(
-    assets.filter((a) => !!a.partitionDefinition).map((a) => a.assetKey),
-  );
+  const partitionedAssets = assets.filter((a) => !!a.partitionDefinition);
+  const data = usePartitionHealthData(partitionedAssets.map((a) => a.assetKey));
   const upstreamData = usePartitionHealthData(upstreamAssetKeys);
 
   const allKeys = React.useMemo(() => (data[0] ? data[0].keys : []), [data]);
@@ -276,28 +275,25 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
           flex={{direction: 'column', gap: 8}}
           style={{marginTop: 16, overflowY: 'auto', overflowX: 'visible', maxHeight: '50vh'}}
         >
-          {assets
-            .filter((a) => !!a.partitionDefinition)
-            .slice(0, previewCount)
-            .map((a) => (
-              <PartitionHealthSummary
-                assetKey={a.assetKey}
-                showAssetKey
-                key={displayNameForAssetKey(a.assetKey)}
-                data={data}
-                selected={selected}
-              />
-            ))}
+          {partitionedAssets.slice(0, previewCount).map((a) => (
+            <PartitionHealthSummary
+              assetKey={a.assetKey}
+              showAssetKey
+              key={displayNameForAssetKey(a.assetKey)}
+              data={data}
+              selected={selected}
+            />
+          ))}
           {previewCount === 0 ? (
             <Box margin={{vertical: 8}}>
               <ButtonLink onClick={() => setPreviewCount(5)}>
                 Show per-Asset partition health
               </ButtonLink>
             </Box>
-          ) : previewCount < assets.length ? (
+          ) : previewCount < partitionedAssets.length ? (
             <Box margin={{vertical: 8}}>
-              <ButtonLink onClick={() => setPreviewCount(assets.length)}>
-                Show {assets.length - previewCount} more previews
+              <ButtonLink onClick={() => setPreviewCount(partitionedAssets.length)}>
+                Show {partitionedAssets.length - previewCount} more previews
               </ButtonLink>
             </Box>
           ) : undefined}

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -89,7 +89,9 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
   assetJobName,
   upstreamAssetKeys,
 }) => {
-  const data = usePartitionHealthData(assets.map((a) => a.assetKey));
+  const data = usePartitionHealthData(
+    assets.filter((a) => !!a.partitionDefinition).map((a) => a.assetKey),
+  );
   const upstreamData = usePartitionHealthData(upstreamAssetKeys);
 
   const allKeys = data[0] ? data[0].keys : [];
@@ -283,15 +285,18 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
           flex={{direction: 'column', gap: 8}}
           style={{marginTop: 16, overflowY: 'auto', overflowX: 'visible', maxHeight: '50vh'}}
         >
-          {assets.slice(0, previewCount).map((a) => (
-            <PartitionHealthSummary
-              assetKey={a.assetKey}
-              showAssetKey
-              key={displayNameForAssetKey(a.assetKey)}
-              data={data}
-              selected={selected}
-            />
-          ))}
+          {assets
+            .filter((a) => !!a.partitionDefinition)
+            .slice(0, previewCount)
+            .map((a) => (
+              <PartitionHealthSummary
+                assetKey={a.assetKey}
+                showAssetKey
+                key={displayNameForAssetKey(a.assetKey)}
+                data={data}
+                selected={selected}
+              />
+            ))}
           {previewCount < assets.length ? (
             <Box margin={{vertical: 8}}>
               <ButtonLink onClick={() => setPreviewCount(assets.length)}>
@@ -325,7 +330,12 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
         <Button intent="none" onClick={() => setOpen(false)}>
           Cancel
         </Button>
-        <Button intent="primary" onClick={onLaunch}>
+        <Button
+          intent="primary"
+          onClick={onLaunch}
+          disabled={selected.length === 0}
+          loading={launching}
+        >
           {launching
             ? 'Launching...'
             : selected.length !== 1

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -30,11 +30,9 @@ import {
   ConfigPartitionSelectionQuery,
   ConfigPartitionSelectionQueryVariables,
 } from '../launchpad/types/ConfigPartitionSelectionQuery';
-import {
-  assembleIntoSpans,
-  PartitionRangeInput,
-  stringForSpan,
-} from '../partitions/PartitionRangeInput';
+import {assembleIntoSpans, stringForSpan} from '../partitions/PartitionRangeInput';
+import {PartitionRangeWizard} from '../partitions/PartitionRangeWizard';
+import {PartitionState} from '../partitions/PartitionStatus';
 import {showBackfillErrorToast, showBackfillSuccessToast} from '../partitions/PartitionsBackfill';
 import {RepoAddress} from '../workspace/types';
 
@@ -94,17 +92,12 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
   );
   const upstreamData = usePartitionHealthData(upstreamAssetKeys);
 
-  const allKeys = data[0] ? data[0].keys : [];
+  const allKeys = React.useMemo(() => (data[0] ? data[0].keys : []), [data]);
   const mostRecentKey = allKeys[allKeys.length - 1];
 
   const [selected, setSelected] = React.useState<string[]>([]);
-  const [previewCount, setPreviewCount] = React.useState(4);
+  const [previewCount, setPreviewCount] = React.useState(0);
   const [launching, setLaunching] = React.useState(false);
-
-  const setMostRecent = () => setSelected([mostRecentKey]);
-  const setAll = () => setSelected([...allKeys]);
-  const setMissing = () =>
-    setSelected(allKeys.filter((key) => data.every((d) => !d.statusByPartition[key])));
 
   React.useEffect(() => {
     setSelected([mostRecentKey]);
@@ -257,29 +250,27 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
     setSelected(reject(selected, upstreamUnavailable));
   };
 
+  const partitionData = React.useMemo(() => {
+    const result: {[partitionName: string]: PartitionState} = {};
+    allKeys.forEach((partitionName) => {
+      const success = data.every((d) => d.statusByPartition[partitionName]);
+      result[partitionName] = success ? PartitionState.SUCCESS : PartitionState.MISSING;
+    });
+    return result;
+  }, [allKeys, data]);
+
   return (
     <>
       <DialogBody>
         <Box flex={{direction: 'column', gap: 8}}>
           <Subheading style={{flex: 1}}>Partition Keys</Subheading>
-          <Box flex={{direction: 'row', gap: 8, alignItems: 'baseline'}}>
-            <Box flex={{direction: 'column'}} style={{flex: 1}}>
-              <PartitionRangeInput
-                value={selected}
-                onChange={setSelected}
-                partitionNames={allKeys}
-              />
-            </Box>
-            <Button small onClick={setMostRecent}>
-              Most Recent
-            </Button>
-            <Button small onClick={setMissing}>
-              Missing
-            </Button>
-            <Button small onClick={setAll}>
-              All
-            </Button>
-          </Box>
+
+          <PartitionRangeWizard
+            all={allKeys}
+            selected={selected}
+            setSelected={setSelected}
+            partitionData={partitionData}
+          />
         </Box>
         <Box
           flex={{direction: 'column', gap: 8}}
@@ -297,7 +288,13 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
                 selected={selected}
               />
             ))}
-          {previewCount < assets.length ? (
+          {previewCount === 0 ? (
+            <Box margin={{vertical: 8}}>
+              <ButtonLink onClick={() => setPreviewCount(5)}>
+                Show per-Asset partition health
+              </ButtonLink>
+            </Box>
+          ) : previewCount < assets.length ? (
             <Box margin={{vertical: 8}}>
               <ButtonLink onClick={() => setPreviewCount(assets.length)}>
                 Show {assets.length - previewCount} more previews

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRangeWizard.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRangeWizard.tsx
@@ -1,0 +1,96 @@
+import {Box, Button, Checkbox, Icon} from '@dagster-io/ui';
+import groupBy from 'lodash/groupBy';
+import * as React from 'react';
+
+import {PartitionRangeInput} from './PartitionRangeInput';
+import {PartitionState, PartitionStatus} from './PartitionStatus';
+
+export const PartitionRangeWizard: React.FC<{
+  selected: string[];
+  setSelected: (selected: string[]) => void;
+  all: string[];
+  partitionData: {[name: string]: PartitionState};
+}> = ({selected, setSelected, all, partitionData}) => {
+  const byState = React.useMemo(() => {
+    return groupBy(Object.keys(partitionData), (name) => partitionData[name]);
+  }, [partitionData]);
+
+  const successPartitions = byState[PartitionState.SUCCESS] || [];
+  const failedPartitions = byState[PartitionState.FAILURE] || [];
+  const missingPartitions = byState[PartitionState.MISSING] || [];
+
+  return (
+    <>
+      <Box>
+        Select the set of partitions to include in the backfill. You can specify a range using the
+        text selector, or by dragging a range selection in the status indicator.
+      </Box>
+      <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}>
+        <Box flex={{direction: 'row', alignItems: 'center', gap: 12}}>
+          {successPartitions.length ? (
+            <Checkbox
+              style={{marginBottom: 0, marginLeft: 10}}
+              checked={successPartitions.every((x) => selected.includes(x))}
+              label="Succeeded"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                if (e.target.checked) {
+                  setSelected(Array.from(new Set(selected.concat(successPartitions))));
+                } else {
+                  setSelected(selected.filter((x) => !successPartitions.includes(x)));
+                }
+              }}
+            />
+          ) : null}
+          {failedPartitions.length ? (
+            <Checkbox
+              style={{marginBottom: 0, marginLeft: 10}}
+              checked={failedPartitions.every((x) => selected.includes(x))}
+              label="Failed"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                if (e.target.checked) {
+                  setSelected(Array.from(new Set(selected.concat(failedPartitions))));
+                } else {
+                  setSelected(selected.filter((x) => !failedPartitions.includes(x)));
+                }
+              }}
+            />
+          ) : null}
+          {missingPartitions.length ? (
+            <Checkbox
+              style={{marginBottom: 0, marginLeft: 10}}
+              checked={missingPartitions.every((x) => selected.includes(x))}
+              label="Missing"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                if (e.target.checked) {
+                  setSelected(Array.from(new Set(selected.concat(missingPartitions))));
+                } else {
+                  setSelected(selected.filter((x) => !missingPartitions.includes(x)));
+                }
+              }}
+            />
+          ) : null}
+        </Box>
+        <Button
+          icon={<Icon name="close" />}
+          disabled={!all.length}
+          style={{marginBottom: 0, marginLeft: 10}}
+          small={true}
+          onClick={() => {
+            setSelected([]);
+          }}
+        >
+          Clear selection
+        </Button>
+      </Box>
+      <PartitionRangeInput value={selected} partitionNames={all} onChange={setSelected} />
+      <Box margin={{top: 8}}>
+        <PartitionStatus
+          partitionNames={all}
+          partitionData={partitionData}
+          selected={selected}
+          onSelect={setSelected}
+        />
+      </Box>
+    </>
+  );
+};

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
@@ -13,9 +13,34 @@ type SelectionRange = {
 
 const MIN_SPAN_WIDTH = 8;
 
+export enum PartitionState {
+  MISSING = 'missing',
+  SUCCESS = 'success',
+  FAILURE = 'failure',
+  QUEUED = 'queued',
+  STARTED = 'started',
+}
+
+export const runStatusToPartitionState = (runStatus: RunStatus | null) => {
+  switch (runStatus) {
+    case RunStatus.CANCELED:
+    case RunStatus.CANCELING:
+    case RunStatus.FAILURE:
+      return PartitionState.FAILURE;
+    case RunStatus.STARTED:
+      return PartitionState.STARTED;
+    case RunStatus.SUCCESS:
+      return PartitionState.SUCCESS;
+    case RunStatus.QUEUED:
+      return PartitionState.QUEUED;
+    default:
+      return PartitionState.MISSING;
+  }
+};
+
 export const PartitionStatus: React.FC<{
   partitionNames: string[];
-  partitionData: {[name: string]: RunStatus | null};
+  partitionData: {[name: string]: PartitionState};
   selected?: string[];
   small?: boolean;
   onClick?: (partitionName: string) => void;
@@ -153,6 +178,7 @@ export const PartitionStatus: React.FC<{
           borderRadius: 4,
           overflow: 'hidden',
           cursor: 'pointer',
+          background: Colors.Gray200,
         }}
         ref={ref}
         onClick={_onClick}
@@ -164,9 +190,14 @@ export const PartitionStatus: React.FC<{
             style={{
               left: `min(calc(100% - 2px), ${indexToPct(s.startIdx)})`,
               width: indexToPct(s.endIdx - s.startIdx + 1),
-              minWidth: s.status ? 2 : undefined,
+              minWidth: s.status && s.status !== PartitionState.MISSING ? 2 : undefined,
               position: 'absolute',
-              zIndex: s.startIdx === 0 || s.endIdx === highestIndex ? 3 : s.status ? 2 : 1, //End-caps, then statuses, then missing
+              zIndex:
+                s.startIdx === 0 || s.endIdx === highestIndex
+                  ? 3
+                  : s.status && s.status !== PartitionState.MISSING
+                  ? 2
+                  : 1, //End-caps, then statuses, then missing
               top: 0,
             }}
           >
@@ -329,11 +360,12 @@ export const PartitionStatus: React.FC<{
   );
 };
 
-function _partitionsToSpans(keys: string[], keyStatus: {[key: string]: RunStatus | null}) {
-  const spans: {startIdx: number; endIdx: number; status: RunStatus | null}[] = [];
+function _partitionsToSpans(keys: string[], keyStatus: {[key: string]: PartitionState}) {
+  const spans: {startIdx: number; endIdx: number; status: PartitionState}[] = [];
 
   for (let ii = 0; ii < keys.length; ii++) {
-    const status: RunStatus | null = keys[ii] in keyStatus ? keyStatus[keys[ii]] : null;
+    const status: PartitionState =
+      keys[ii] in keyStatus ? keyStatus[keys[ii]] : PartitionState.MISSING;
     if (!spans.length || spans[spans.length - 1].status !== status) {
       spans.push({startIdx: ii, endIdx: ii, status});
     } else {
@@ -344,34 +376,30 @@ function _partitionsToSpans(keys: string[], keyStatus: {[key: string]: RunStatus
   return spans;
 }
 
-const _statusToColor = (status: RunStatus | null) => {
+const _statusToColor = (status: PartitionState) => {
   switch (status) {
-    case RunStatus.SUCCESS:
+    case PartitionState.SUCCESS:
       return Colors.Green500;
-    case RunStatus.CANCELED:
-    case RunStatus.CANCELING:
-    case RunStatus.FAILURE:
+    case PartitionState.FAILURE:
       return Colors.Red500;
-    case RunStatus.STARTED:
+    case PartitionState.STARTED:
       return Colors.Blue500;
-    case RunStatus.QUEUED:
+    case PartitionState.QUEUED:
       return Colors.Blue200;
     default:
       return Colors.Gray200;
   }
 };
 
-const _statusToText = (status: RunStatus | null) => {
+const _statusToText = (status: PartitionState) => {
   switch (status) {
-    case RunStatus.SUCCESS:
+    case PartitionState.SUCCESS:
       return 'complete';
-    case RunStatus.CANCELED:
-    case RunStatus.CANCELING:
-    case RunStatus.FAILURE:
+    case PartitionState.FAILURE:
       return 'failed';
-    case RunStatus.STARTED:
+    case PartitionState.STARTED:
       return 'in progress';
-    case RunStatus.QUEUED:
+    case PartitionState.QUEUED:
       return 'queued';
     default:
       return 'missing';

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -175,7 +175,7 @@ class JobDefinition(PipelineDefinition):
         if partitions_def:
             check.invariant(
                 not isinstance(config, ConfigMapping),
-                "Can't supply a ConfigMappi/ng for 'config' when 'partitions_def' is supplied.",
+                "Can't supply a ConfigMapping for 'config' when 'partitions_def' is supplied.",
             )
 
             if isinstance(config, PartitionedConfig):


### PR DESCRIPTION
### Summary & Motivation

This PR fixes two issues with the "Materialize" button used to launch partitioned asset runs:

- This UI was slightly different from the version used by op jobs (and less nice, @prha's iteration on top of it added more features!) I refactored them to use the same component so you can click+drag to select partitions.  https://github.com/dagster-io/dagster/issues/9028

- You could attempt to submit the dialog with no partitions selected

Before:
![Screen Shot 2022-09-23 at 4 00 00 PM](https://user-images.githubusercontent.com/1037212/193085169-004325e4-7e8b-4774-88b7-40b4f3cf9fc8.png)

After:
![Screen Shot 2022-09-23 at 3 59 14 PM](https://user-images.githubusercontent.com/1037212/193085208-c1902231-e309-4c71-b754-6a582cf3d673.png)



### How I Tested These Changes
