### PR TITLE
Add partition key field to build_input_context

### DIFF
--- a/examples/docs_snippets/docs_snippets/concepts/io_management/test_build_io_context.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/test_build_io_context.py
@@ -115,7 +115,16 @@ def test_context_logging_metadata():
     assert [entry.label for entry in context.get_logged_metadata_entries()] == ["foo"]
 
 
-def test_context_partition_key():
+def test_output_context_partition_key():
     context = build_output_context(partition_key="foo")
     assert context.partition_key == "foo"
     assert context.has_partition_key
+
+
+def test_input_context_partition_key():
+    context = build_input_context(partition_key="foo")
+    assert context.partition_key == "foo"
+    assert context.has_partition_key
+
+    context = build_input_context()
+    assert not context.has_partition_key


### PR DESCRIPTION
Inspired by a conversation with a user [here](https://dagster.slack.com/archives/C01U954MEER/p1664373710531919).

`build_output_context` currently has the `partition_key` field for testing. This PR brings `build_input_context` to parity with `build_output_context` by adding the same functionality.