### PR TITLE
[dagit] Switch “View Run” toasts to open run details in new tab

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
@@ -84,11 +84,13 @@ export function handleLaunchResult(
   if (obj.__typename === 'LaunchRunSuccess') {
     const pathname = `/instance/runs/${obj.run.runId}`;
     const search = options.preserveQuerystring ? history.location.search : '';
+    const openInNewTab = () => window.open(history.createHref({pathname, search}), '_blank');
+    const openInSameTab = () => history.push({pathname, search});
 
     if (options.behavior === 'open-in-new-tab') {
-      window.open(history.createHref({pathname, search}), '_blank');
+      openInNewTab();
     } else if (options.behavior === 'open') {
-      history.push({pathname, search});
+      openInSameTab();
     } else {
       SharedToaster.show({
         intent: 'success',
@@ -99,7 +101,7 @@ export function handleLaunchResult(
         ),
         action: {
           text: 'View',
-          onClick: () => history.push({pathname, search}),
+          onClick: () => openInNewTab(),
         },
       });
     }


### PR DESCRIPTION
### Summary & Motivation
Small fix related to the slack discussion here:
https://elementl-workspace.slack.com/archives/C03CCE471E0/p1664470710262119

![image](https://user-images.githubusercontent.com/1037212/193138460-a98f0333-5c91-49aa-a04a-70ed226dd070.png)

![image](https://user-images.githubusercontent.com/1037212/193138479-d871846b-cddc-4ea0-b5f8-665208f72914.png)

### How I Tested These Changes
