### PR TITLE
[dagit] Run timeline pagination

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/QueryfulRunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/QueryfulRunTimeline.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import {useFeatureFlags} from '../app/Flags';
 import {RunsFilter} from '../types/globalTypes';
-import {LoadingSpinner} from '../ui/Loading';
 
 import {RunTimeline} from './RunTimeline';
 import {useRunsForTimeline} from './useRunsForTimeline';
@@ -23,9 +22,12 @@ export const QueryfulRunTimeline = (props: Props) => {
     visibleJobKeys,
   ]);
 
-  if (loading) {
-    return <LoadingSpinner purpose="section" />;
-  }
-
-  return <RunTimeline range={range} jobs={visibleJobs} bucketByRepo={flagRunBucketing} />;
+  return (
+    <RunTimeline
+      loading={loading}
+      range={range}
+      jobs={visibleJobs}
+      bucketByRepo={flagRunBucketing}
+    />
+  );
 };

--- a/js_modules/dagit/packages/core/src/runs/RunTimelineRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimelineRoot.tsx
@@ -1,4 +1,4 @@
-import {Page, PageHeader, Heading, Box, TextInput, ButtonGroup} from '@dagster-io/ui';
+import {Page, PageHeader, Heading, Box, TextInput, ButtonGroup, Button} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {useTrackPageView} from '../app/analytics';
@@ -16,6 +16,19 @@ const LOOKAHEAD_HOURS = 1;
 const ONE_HOUR = 60 * 60 * 1000;
 const POLL_INTERVAL = 60 * 1000;
 
+const hourWindowToOffset = (hourWindow: HourWindow) => {
+  switch (hourWindow) {
+    case '1':
+      return ONE_HOUR;
+    case '6':
+      return 6 * ONE_HOUR;
+    case '12':
+      return 12 * ONE_HOUR;
+    case '24':
+      return 24 * ONE_HOUR;
+  }
+};
+
 export const RunTimelineRoot = () => {
   useTrackPageView();
   useDocumentTitle('Runs');
@@ -25,6 +38,7 @@ export const RunTimelineRoot = () => {
   const [searchValue, setSearchValue] = React.useState('');
   const [hourWindow, setHourWindow] = useHourWindow('12');
   const [now, setNow] = React.useState(() => Date.now());
+  const [offsetMsec, setOffsetMsec] = React.useState(() => 0);
 
   React.useEffect(() => {
     setNow(Date.now());
@@ -37,9 +51,24 @@ export const RunTimelineRoot = () => {
     };
   }, [hourWindow]);
 
+  const onPageEarlier = React.useCallback(() => {
+    setOffsetMsec((current) => current - hourWindowToOffset(hourWindow));
+  }, [hourWindow]);
+
+  const onPageLater = React.useCallback(() => {
+    setOffsetMsec((current) => current + hourWindowToOffset(hourWindow));
+  }, [hourWindow]);
+
+  const onPageNow = React.useCallback(() => {
+    setOffsetMsec(0);
+  }, []);
+
   const range: [number, number] = React.useMemo(
-    () => [now - Number(hourWindow) * ONE_HOUR, now + LOOKAHEAD_HOURS * ONE_HOUR],
-    [hourWindow, now],
+    () => [
+      now - Number(hourWindow) * ONE_HOUR + offsetMsec,
+      now + LOOKAHEAD_HOURS * ONE_HOUR + offsetMsec,
+    ],
+    [hourWindow, now, offsetMsec],
   );
 
   const visibleJobKeys = React.useMemo(() => {
@@ -57,7 +86,7 @@ export const RunTimelineRoot = () => {
     <Page>
       <PageHeader title={<Heading>Runs</Heading>} tabs={<RunListTabs />} />
       <Box
-        padding={{horizontal: 24, top: 16}}
+        padding={{horizontal: 24, vertical: 16}}
         flex={{alignItems: 'center', justifyContent: 'space-between'}}
       >
         <Box flex={{direction: 'row', alignItems: 'center', gap: 12, grow: 0}}>
@@ -67,19 +96,26 @@ export const RunTimelineRoot = () => {
             value={searchValue}
             onChange={(e) => setSearchValue(e.target.value)}
             placeholder="Filter by job name…"
-            style={{width: '340px'}}
+            style={{width: '200px'}}
           />
         </Box>
-        <ButtonGroup<HourWindow>
-          activeItems={new Set([hourWindow])}
-          buttons={[
-            {id: '1', label: '1hr'},
-            {id: '6', label: '6hr'},
-            {id: '12', label: '12hr'},
-            {id: '24', label: '24hr'},
-          ]}
-          onClick={(hrWindow: HourWindow) => setHourWindow(hrWindow)}
-        />
+        <Box flex={{direction: 'row', gap: 16, alignItems: 'center'}}>
+          <ButtonGroup<HourWindow>
+            activeItems={new Set([hourWindow])}
+            buttons={[
+              {id: '1', label: '1hr'},
+              {id: '6', label: '6hr'},
+              {id: '12', label: '12hr'},
+              {id: '24', label: '24hr'},
+            ]}
+            onClick={(hrWindow: HourWindow) => setHourWindow(hrWindow)}
+          />
+          <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+            <Button onClick={onPageEarlier}>&larr;</Button>
+            <Button onClick={onPageNow}>Now</Button>
+            <Button onClick={onPageLater}>&rarr;</Button>
+          </Box>
+        </Box>
       </Box>
       <QueryfulRunTimeline range={range} visibleJobKeys={visibleJobKeys} />
     </Page>

--- a/js_modules/dagit/packages/core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/useRunsForTimeline.tsx
@@ -167,7 +167,7 @@ export const useRunsForTimeline = (range: [number, number], runsFilter: RunsFilt
 
   return {
     jobs: jobsWithRuns,
-    loading: loading && !data && !previousData,
+    loading: loading && !data,
   };
 };
 


### PR DESCRIPTION
### Summary & Motivation

Make some updates to the Run timeline.

- Add pagination to the Timeline tab on Runs, as flagged behind "New workspace". Users can page forward/backward, and return to "Now".
- Improve loading state and empty state.
- Show date above time. This gives the user context for where they are while paginating.

<img width="1122" alt="Screen Shot 2022-09-29 at 3 31 33 PM" src="https://user-images.githubusercontent.com/2823852/193135976-7ed12c73-f850-4830-8852-3e089b767ffb.png">


### How I Tested These Changes

With flag enabled, view Runs > Timeline page.

- Verify that I can page forward/backward, and that loading/empty states are correct.
- Verify that the dates shown above the timeline are correct, and align properly with midnight markers.
- Change timezone, verify same.
