### PR TITLE
[dagit] Fix rendering of run details sidebar on tiny screens

### DIFF
--- a/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
@@ -207,7 +207,7 @@ const Elapsed = styled.div`
 `;
 
 const EmptyNotice = styled.div`
-  height: 32px;
+  min-height: 32px;
   font-size: 12px;
   padding: 8px 24px;
   color: ${Colors.Gray400};

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarComponents.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarComponents.tsx
@@ -24,7 +24,7 @@ export const SidebarSection: React.FC<ISidebarSectionProps> = (props) => {
   return (
     <>
       <CollapsingHeaderBar onClick={onToggle}>
-        {title}
+        <SidebarTitleTextWrap>{title}</SidebarTitleTextWrap>
         <Icon
           size={24}
           name="arrow_drop_down"
@@ -37,6 +37,13 @@ export const SidebarSection: React.FC<ISidebarSectionProps> = (props) => {
     </>
   );
 };
+
+export const SidebarTitleTextWrap = styled.div`
+  overflow: hidden;
+  min-width: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
 
 export const SidebarTitle = styled.h3`
   font-family: ${FontFamily.monospace};


### PR DESCRIPTION
### Summary & Motivation

This is a small bit of polish that came out of this slack post: https://elementl-workspace.slack.com/archives/C03CCE471E0/p1664335074452669

![image](https://user-images.githubusercontent.com/1037212/193138296-6ecfef1d-b043-46f9-8a83-a7de1d5a0687.png)

### How I Tested These Changes
