### PR TITLE
[perf] Run logs - Move useSubscription to component that returns null to avoid re-rendering children

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -257,8 +257,8 @@ const LogsProviderWithSubscription: React.FC<LogsProviderProps> = (props) => {
   const state = useLogsProviderWithSubscription(props.runId);
   return (
     <>
-      {props.children(state)}
       {state.subscriptionComponent}
+      {props.children(state)}
     </>
   );
 };


### PR DESCRIPTION
### Summary & Motivation

[Per](https://github.com/dagster-io/dagster/pull/9795#pullrequestreview-1126021119) @alangenfeld 
https://stackoverflow.com/questions/61876931/how-to-prevent-re-rendering-with-usesubscription
https://medium.com/@seniv/improve-performance-of-your-react-apollo-application-440692e37026

### How I Tested These Changes

I loaded a run and made sure the logs still loaded