### PR TITLE
fix api docs for python graphql client

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -7,8 +7,9 @@ from gql.transport import Transport
 from gql.transport.requests import RequestsHTTPTransport
 
 import dagster._check as check
+from dagster import DagsterRunStatus
+from dagster._annotations import public
 from dagster._core.definitions.utils import validate_tags
-from dagster._core.storage.pipeline_run import PipelineRunStatus
 from dagster._utils.backcompat import experimental_class_warning
 
 from .client_queries import (
@@ -269,6 +270,7 @@ class DagsterGraphQLClient:
             is_using_job_op_graph_apis=False,
         )
 
+    @public
     def submit_job_execution(
         self,
         job_name: str,
@@ -321,7 +323,8 @@ class DagsterGraphQLClient:
             is_using_job_op_graph_apis=True,
         )
 
-    def get_run_status(self, run_id: str) -> PipelineRunStatus:
+    @public
+    def get_run_status(self, run_id: str) -> DagsterRunStatus:
         """Get the status of a given Pipeline Run
 
         Args:
@@ -332,7 +335,7 @@ class DagsterGraphQLClient:
             DagsterGraphQLClientError("PythonError", message): on internal framework errors
 
         Returns:
-            PipelineRunStatus: returns a status Enum describing the state of the requested pipeline run
+            DagsterRunStatus: returns a status Enum describing the state of the requested pipeline run
         """
         check.str_param(run_id, "run_id")
 
@@ -342,10 +345,11 @@ class DagsterGraphQLClient:
         query_result: Dict[str, Any] = res_data["pipelineRunOrError"]
         query_result_type: str = query_result["__typename"]
         if query_result_type == "PipelineRun" or query_result_type == "Run":
-            return PipelineRunStatus(query_result["status"])
+            return DagsterRunStatus(query_result["status"])
         else:
             raise DagsterGraphQLClientError(query_result_type, query_result["message"])
 
+    @public
     def reload_repository_location(
         self, repository_location_name: str
     ) -> ReloadRepositoryLocationInfo:
@@ -387,6 +391,7 @@ class DagsterGraphQLClient:
                 message=query_result["message"],
             )
 
+    @public
     def shutdown_repository_location(
         self, repository_location_name: str
     ) -> ShutdownRepositoryLocationInfo:


### PR DESCRIPTION
Summary:
We link to these methods in the docs but the links do not work. Now, they should.

Test Plan:
Build API docs locally, should see the linked methods on https://docs.dagster.io/concepts/dagit/graphql-client#overview

### Summary & Motivation

### How I Tested These Changes
