### PR TITLE
[dagit] Use a filterable Select for compute logs toolbar

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/LogsToolbar.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsToolbar.tsx
@@ -148,6 +148,7 @@ const ComputeLogToolbar = ({
   const logCaptureSteps =
     metadata.logCaptureSteps || extractLogCaptureStepsFromLegacySteps(Object.keys(metadata.steps));
   const isValidStepSelection = computeLogKey && logCaptureSteps[computeLogKey];
+
   const logKeyText = (logKey?: string) => {
     if (!logKey || !logCaptureSteps[logKey]) {
       return null;
@@ -171,6 +172,9 @@ const ComputeLogToolbar = ({
         <Select
           disabled={!steps.length}
           items={Object.keys(logCaptureSteps)}
+          itemPredicate={(query, item) =>
+            item.toLocaleLowerCase().includes(query.toLocaleLowerCase())
+          }
           itemRenderer={(item: string, options: {handleClick: any; modifiers: any}) => (
             <MenuItem
               key={item}
@@ -180,7 +184,6 @@ const ComputeLogToolbar = ({
             />
           )}
           activeItem={computeLogKey}
-          filterable={false}
           onItemSelect={(logKey) => {
             onSetComputeLogKey(logKey);
           }}


### PR DESCRIPTION
### Summary & Motivation

Use a filterable Select instead of the current non-filterable one in the compute log toolbar step selection control.

<img width="411" alt="image" src="https://user-images.githubusercontent.com/2823852/193316202-a21daf23-2905-4eed-8c03-d4cd84d0fff7.png">


Keyboard behavior with this thing seems pretty broken, so I'll need to figure out what's going on there. It's already broken, though, so this won't make it worse.

### How I Tested These Changes

View a run, open compute log toolbar. Search for a step, verify that it filters and selects correctly.
