### PR TITLE
[dagit] Rename "Status" to "Deployment"

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppProvider.tsx
@@ -163,8 +163,8 @@ export const AppProvider: React.FC<AppProviderProps> = (props) => {
   const analytics = React.useMemo(() => dummyAnalytics(), []);
   const instancePageValue = React.useMemo(
     () => ({
-      pageTitle: 'Instance status',
-      healthTitle: 'Health',
+      pageTitle: 'Deployment',
+      healthTitle: 'Daemons',
     }),
     [],
   );

--- a/js_modules/dagit/packages/core/src/app/AppTopNav.test.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.test.tsx
@@ -58,7 +58,7 @@ describe('AppTopNav', () => {
       const runsLink = screen.getByRole('link', {name: /runs/i});
       expect(runsLink.closest('a')).toHaveAttribute('href', '/instance/runs');
       expect(screen.getByText('Assets').closest('a')).toHaveAttribute('href', '/instance/assets');
-      expect(screen.getByText('Status').closest('a')).toHaveAttribute('href', '/instance');
+      expect(screen.getByText('Deployment').closest('a')).toHaveAttribute('href', '/instance');
       expect(screen.getByText('RightOfSearchBar')).toBeVisible();
     });
   });
@@ -145,11 +145,11 @@ describe('AppTopNav', () => {
       });
 
       expect(screen.getByText(/workspace/i)).toBeVisible();
-      const link = screen.getByRole('link', {name: /status/i});
+      const link = screen.getByRole('link', {name: /deployment/i});
       expect(within(link).queryByText(/warning/i)).toBeNull();
     });
 
-    it('shows status warning icon by default, if there are errors', async () => {
+    it('shows deployment warning icon by default, if there are errors', async () => {
       await act(async () => {
         render(
           <TestProvider
@@ -161,13 +161,13 @@ describe('AppTopNav', () => {
       });
 
       const link = screen.getByRole('link', {
-        name: /status warning/i,
+        name: /deployment warning/i,
       });
 
-      expect(within(link).getByText(/status/i)).toBeVisible();
+      expect(within(link).getByText(/deployment/i)).toBeVisible();
     });
 
-    it('does not show status warning icon if `showStatusWarningIcon` is false, even with errors', async () => {
+    it('does not show deployment warning icon if `showStatusWarningIcon` is false, even with errors', async () => {
       await act(async () => {
         render(
           <TestProvider
@@ -179,7 +179,7 @@ describe('AppTopNav', () => {
       });
 
       expect(screen.getByText(/workspace/i)).toBeVisible();
-      const link = screen.getByRole('link', {name: /status/i});
+      const link = screen.getByRole('link', {name: /deployment/i});
       expect(within(link).queryByText(/warning/i)).toBeNull();
     });
   });

--- a/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
@@ -74,7 +74,7 @@ export const AppTopNav: React.FC<Props> = ({
               }}
             >
               <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
-                Status
+                Deployment
                 {showStatusWarningIcon ? <InstanceWarningIcon /> : null}
               </Box>
             </TopNavLink>

--- a/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
@@ -15,9 +15,6 @@ interface Props<TData> {
   tab: string;
 }
 
-// todo dish: Delete this once Cloud is switched to use `InstancePageContext`.
-export const InstanceTabContext = React.createContext({healthTitle: 'Daemons'});
-
 export const InstanceTabs = <TData extends Record<string, any>>(props: Props<TData>) => {
   const {refreshState, tab} = props;
 


### PR DESCRIPTION
### Summary & Motivation

In top nav and elsewhere, rename "Status" to "Deployment". This will also apply in Cloud.

In followups, we should migrate URL paths from `/instance` to `/deployment`.

### How I Tested These Changes

View Dagit, verify top nav and header changes.
