### PR TITLE
[dagit] Consolidate top nav warning icons for flagged users

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {Link, NavLink, useHistory} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import {InstanceWarningIcon} from '../nav/InstanceWarningIcon';
+import {DeploymentStatusIcon} from '../nav/DeploymentStatus';
 import {VersionNumber} from '../nav/VersionNumber';
 import {WorkspaceStatus} from '../nav/WorkspaceStatus';
 import {SearchDialog} from '../search/SearchDialog';
@@ -19,15 +19,53 @@ interface Props {
   showStatusWarningIcon?: boolean;
 }
 
-export const AppTopNav: React.FC<Props> = ({
-  children,
-  rightOfSearchBar,
-  searchPlaceholder,
-  showStatusWarningIcon = true,
-}) => {
+export const AppTopNav: React.FC<Props> = ({children, rightOfSearchBar, searchPlaceholder}) => {
   const history = useHistory();
   const {flagNewWorkspace} = useFeatureFlags();
   const runHref = flagNewWorkspace ? '/instance/runs/timeline' : '/instance/runs';
+
+  const deploymentItem = (
+    <ShortcutHandler
+      key="deployment"
+      onShortcut={() => history.push('/instance')}
+      shortcutLabel="⌥3"
+      shortcutFilter={(e) => e.code === 'Digit3' && e.altKey}
+    >
+      <TopNavLink
+        to="/instance"
+        data-cy="AppTopNav_StatusLink"
+        isActive={(_, location) => {
+          const {pathname} = location;
+          return (
+            pathname.startsWith('/instance') &&
+            !pathname.startsWith('/instance/runs') &&
+            !pathname.startsWith('/instance/assets')
+          );
+        }}
+      >
+        <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
+          Deployment
+          <DeploymentStatusIcon />
+        </Box>
+      </TopNavLink>
+    </ShortcutHandler>
+  );
+
+  const workspaceItem = (
+    <ShortcutHandler
+      key="workspace"
+      onShortcut={() => history.push('/workspace')}
+      shortcutLabel="⌥4"
+      shortcutFilter={(e) => e.code === 'Digit4' && e.altKey}
+    >
+      <TopNavLink to="/workspace" data-cy="AppTopNav_WorkspaceLink">
+        <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
+          Workspace
+          {flagNewWorkspace ? null : <WorkspaceStatus />}
+        </Box>
+      </TopNavLink>
+    </ShortcutHandler>
+  );
 
   return (
     <AppTopNavContainer>
@@ -56,41 +94,7 @@ export const AppTopNav: React.FC<Props> = ({
               Assets
             </TopNavLink>
           </ShortcutHandler>
-          <ShortcutHandler
-            onShortcut={() => history.push('/instance')}
-            shortcutLabel="⌥3"
-            shortcutFilter={(e) => e.code === 'Digit3' && e.altKey}
-          >
-            <TopNavLink
-              to="/instance"
-              data-cy="AppTopNav_StatusLink"
-              isActive={(_, location) => {
-                const {pathname} = location;
-                return (
-                  pathname.startsWith('/instance') &&
-                  !pathname.startsWith('/instance/runs') &&
-                  !pathname.startsWith('/instance/assets')
-                );
-              }}
-            >
-              <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
-                Deployment
-                {showStatusWarningIcon ? <InstanceWarningIcon /> : null}
-              </Box>
-            </TopNavLink>
-          </ShortcutHandler>
-          <ShortcutHandler
-            onShortcut={() => history.push('/workspace')}
-            shortcutLabel="⌥4"
-            shortcutFilter={(e) => e.code === 'Digit4' && e.altKey}
-          >
-            <TopNavLink to="/workspace" data-cy="AppTopNav_WorkspaceLink">
-              <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
-                Workspace
-                <WorkspaceStatus />
-              </Box>
-            </TopNavLink>
-          </ShortcutHandler>
+          {flagNewWorkspace ? [workspaceItem, deploymentItem] : [deploymentItem, workspaceItem]}
         </Box>
         {children}
       </Box>

--- a/js_modules/dagit/packages/core/src/nav/DeploymentStatus.tsx
+++ b/js_modules/dagit/packages/core/src/nav/DeploymentStatus.tsx
@@ -1,0 +1,47 @@
+import {Box, Colors, Icon, Spinner, Tooltip} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {useFeatureFlags} from '../app/Flags';
+
+import {InstanceWarningIcon, useDeploymentStatus} from './InstanceWarningIcon';
+import {WarningTooltip} from './WarningTooltip';
+import {useWorkspaceStatus} from './WorkspaceStatus';
+
+export const DeploymentStatusIcon = React.memo(() => {
+  const {flagNewWorkspace} = useFeatureFlags();
+  return flagNewWorkspace ? <CombinedStatusIcon /> : <InstanceWarningIcon />;
+});
+
+const CombinedStatusIcon = React.memo(() => {
+  const deploymentStatus = useDeploymentStatus();
+  const workspaceStatus = useWorkspaceStatus();
+
+  if (workspaceStatus?.type === 'spinner') {
+    return (
+      <Tooltip content={workspaceStatus.content} placement="bottom">
+        <Spinner purpose="body-text" fillColor={Colors.Gray300} />
+      </Tooltip>
+    );
+  }
+
+  const anyWarning = deploymentStatus?.type === 'warning' || workspaceStatus?.type === 'warning';
+
+  if (anyWarning) {
+    return (
+      <WarningTooltip
+        content={
+          <Box flex={{direction: 'column', gap: 4}}>
+            {deploymentStatus?.content}
+            {workspaceStatus?.content}
+          </Box>
+        }
+        position="bottom"
+        modifiers={{offset: {enabled: true, options: {offset: [0, 28]}}}}
+      >
+        <Icon name="warning" color={Colors.Yellow500} />
+      </WarningTooltip>
+    );
+  }
+
+  return <div style={{width: '16px'}} />;
+});

--- a/js_modules/dagit/packages/core/src/nav/InstanceWarningIcon.tsx
+++ b/js_modules/dagit/packages/core/src/nav/InstanceWarningIcon.tsx
@@ -9,7 +9,7 @@ import {useRepositoryOptions} from '../workspace/WorkspaceContext';
 import {WarningTooltip} from './WarningTooltip';
 import {InstanceWarningQuery} from './types/InstanceWarningQuery';
 
-export const InstanceWarningIcon = React.memo(() => {
+export const useDeploymentStatus = () => {
   const {options} = useRepositoryOptions();
   const queryResult = useQuery<InstanceWarningQuery>(INSTANCE_WARNING_QUERY, {
     fetchPolicy: 'cache-and-network',
@@ -78,22 +78,35 @@ export const InstanceWarningIcon = React.memo(() => {
   }, [anySchedules, anySensors, healthData]);
 
   if (visibleErrorCount) {
-    return (
-      <WarningTooltip
-        content={
-          <div>{`${visibleErrorCount} ${
-            visibleErrorCount === 1 ? 'daemon not running' : 'daemons not running'
-          }`}</div>
-        }
-        position="bottom"
-        modifiers={{offset: {enabled: true, options: {offset: [0, 28]}}}}
-      >
-        <Icon name="warning" color={Colors.Yellow500} />
-      </WarningTooltip>
-    );
+    return {
+      type: 'warning',
+      content: (
+        <div style={{whiteSpace: 'nowrap'}}>{`${visibleErrorCount} ${
+          visibleErrorCount === 1 ? 'daemon not running' : 'daemons not running'
+        }`}</div>
+      ),
+    };
   }
 
   return null;
+};
+
+export const InstanceWarningIcon = React.memo(() => {
+  const status = useDeploymentStatus();
+
+  if (!status) {
+    return null;
+  }
+
+  return (
+    <WarningTooltip
+      content={status.content}
+      position="bottom"
+      modifiers={{offset: {enabled: true, options: {offset: [0, 28]}}}}
+    >
+      <Icon name="warning" color={Colors.Yellow500} />
+    </WarningTooltip>
+  );
 });
 
 const INSTANCE_WARNING_QUERY = gql`


### PR DESCRIPTION
### Summary & Motivation

For users in the new Workspace page flag, consolidate the top nav status icons for Workspace and Deployment (formerly Status) to be only on the Deployment nav item.

To accomplish this, I'm exporting hooks that encapsulate the relevant querying and state management.

I also swapped the order of these two items for flagged users, to keep the status icon to the right.

Flagged:

<img width="404" alt="Screen Shot 2022-09-30 at 3 01 11 PM" src="https://user-images.githubusercontent.com/2823852/193348967-31a618b4-86cd-40e5-b154-eec35768e35f.png">

Not flagged:

<img width="443" alt="Screen Shot 2022-09-30 at 3 01 23 PM" src="https://user-images.githubusercontent.com/2823852/193348978-940f1e8f-70c6-45cd-a7fd-3940e89228d6.png">


### How I Tested These Changes

With flag on and off, verify rendering of the top nav items with daemons running/disabled, and with/without code location errors.
