### PR TITLE
[Performance] Stop recreating PipelineRunLogsSubscription on every render 

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -244,9 +244,10 @@ const SubscriptionComponent = ({
     return {
       runId,
       cursor,
-      lostWebsocket,
     };
     // Don't add cursor to memo otherwise subscription gets recreated
+    // Add lostWebSocket to dependency so that we record the cursor we're at
+    // for when the status comes back
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runId, lostWebsocket]);
 

--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -237,11 +237,24 @@ const SubscriptionComponent = ({
   cursor: string | null;
   onSubscriptionData: (options: OnSubscriptionDataOptions<PipelineRunLogsSubscription>) => void;
 }) => {
+  const {availability, disabled, status} = React.useContext(WebSocketContext);
+  const lostWebsocket = !disabled && availability === 'available' && status === WebSocket.CLOSED;
+
+  const variables = React.useMemo(() => {
+    return {
+      runId,
+      cursor,
+      lostWebsocket,
+    };
+    // Don't add cursor to memo otherwise subscription gets recreated
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runId, lostWebsocket]);
+
   useSubscription<PipelineRunLogsSubscription, PipelineRunLogsSubscriptionVariables>(
     PIPELINE_RUN_LOGS_SUBSCRIPTION,
     {
       fetchPolicy: 'no-cache',
-      variables: {runId, cursor},
+      variables,
       onSubscriptionData,
     },
   );

--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -192,11 +192,28 @@ const useLogsProviderWithSubscription = (runId: string) => {
 
   const {nodes, counts, cursor, loading} = state;
 
+  const {availability, disabled, status} = React.useContext(WebSocketContext);
+  const lostWebsocket = !disabled && availability === 'available' && status === WebSocket.CLOSED;
+  const currentInitialCursorRef = React.useRef<string | null>(cursor);
+
+  if (lostWebsocket) {
+    // Record the cursor we're at when disconnecting so that our subscription
+    // picks up where we left off.
+    currentInitialCursorRef.current = cursor;
+  }
+  const currentInitialCursor = currentInitialCursorRef.current;
+
+  const variables = React.useMemo(() => {
+    return {
+      runId,
+      cursor: currentInitialCursor,
+    };
+  }, [runId, currentInitialCursor]);
+
   const subscriptionComponent = React.useMemo(
     () => (
       <SubscriptionComponent
-        runId={runId}
-        cursor={cursor}
+        variables={variables}
         onSubscriptionData={({subscriptionData}) => {
           const logs = subscriptionData.data?.pipelineRunLogs;
           if (!logs || logs.__typename === 'PipelineRunLogsSubscriptionFailure') {
@@ -211,7 +228,7 @@ const useLogsProviderWithSubscription = (runId: string) => {
         }}
       />
     ),
-    [runId, cursor, throttledSetNodes],
+    [variables, throttledSetNodes],
   );
 
   return React.useMemo(
@@ -229,28 +246,15 @@ const useLogsProviderWithSubscription = (runId: string) => {
  * https://stackoverflow.com/questions/61876931/how-to-prevent-re-rendering-with-usesubscription
  */
 const SubscriptionComponent = ({
-  runId,
-  cursor,
+  variables,
   onSubscriptionData,
 }: {
-  runId: string;
-  cursor: string | null;
+  variables: {
+    runId: string;
+    cursor: string | null;
+  };
   onSubscriptionData: (options: OnSubscriptionDataOptions<PipelineRunLogsSubscription>) => void;
 }) => {
-  const {availability, disabled, status} = React.useContext(WebSocketContext);
-  const lostWebsocket = !disabled && availability === 'available' && status === WebSocket.CLOSED;
-
-  const variables = React.useMemo(() => {
-    return {
-      runId,
-      cursor,
-    };
-    // Don't add cursor to memo otherwise subscription gets recreated
-    // Add lostWebSocket to dependency so that we record the cursor we're at
-    // for when the status comes back
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [runId, lostWebsocket]);
-
   useSubscription<PipelineRunLogsSubscription, PipelineRunLogsSubscriptionVariables>(
     PIPELINE_RUN_LOGS_SUBSCRIPTION,
     {


### PR DESCRIPTION
### Summary & Motivation

This PR fixes an issue arising due to the variables of our `useSubscription` changing on every render. By changing the variables we cause apollo-graphql to recreate the subscription from scratch on every render.  This is a problem because the python server fetches chunks for the subscription in a while loop and queues up all of the results but the client closes the subscription after it receives just one message. The result is that we end up overfetching and throwing away the work.

### Test Plan

Left side: Passing the cursor (start/stop multiple times) 
Right side: Without passing cursor (no start/stop multiple times)
![image](https://user-images.githubusercontent.com/2286579/193365633-7679ec47-12e6-4159-aca6-4e6d46aee391.png)



