### PR TITLE
Fix bug with multiprocess execution, dynamic outputs, and retries

### DIFF
--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -559,6 +559,11 @@ class DagsterEvent(
 
     @public  # type: ignore
     @property
+    def is_resource_init_failure(self) -> bool:
+        return self.event_type == DagsterEventType.RESOURCE_INIT_FAILURE
+
+    @public  # type: ignore
+    @property
     def is_step_skipped(self) -> bool:
         return self.event_type == DagsterEventType.STEP_SKIPPED
 

--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -790,7 +790,11 @@ def reexecute_pipeline(
             solids_to_execute=parent_pipeline_run.solids_to_execute,
             root_run_id=parent_pipeline_run.root_run_id or parent_pipeline_run.run_id,
             parent_run_id=parent_pipeline_run.run_id,
-            pipeline_code_origin=parent_pipeline_run.pipeline_code_origin,
+            pipeline_code_origin=(
+                pipeline.get_python_origin()
+                if isinstance(pipeline, ReconstructablePipeline)
+                else None
+            ),
             repository_load_data=repository_load_data,
         )
 
@@ -1080,6 +1084,8 @@ def pipeline_execution_iterator(
     try:
         for event in pipeline_context.executor.execute(pipeline_context, execution_plan):
             if event.is_step_failure:
+                failed_steps.append(event.step_key)
+            elif event.is_resource_init_failure and event.step_key:
                 failed_steps.append(event.step_key)
 
             yield event

--- a/python_modules/dagster/dagster/_core/execution/execution_result.py
+++ b/python_modules/dagster/dagster/_core/execution/execution_result.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Callable, List, Sequence, Union, cast
+from typing import AbstractSet, Any, Callable, List, Sequence, Union, cast
 
 import dagster._check as check
 from dagster._core.definitions import JobDefinition, NodeHandle
@@ -162,6 +162,16 @@ class ExecutionResult(ABC):
 
     def get_step_success_events(self) -> Sequence[DagsterEvent]:
         return [event for event in self.all_events if event.is_step_success]
+
+    def get_failed_step_keys(self) -> AbstractSet[str]:
+        failure_events = self.filter_events(
+            lambda event: event.is_step_failure or event.is_resource_init_failure
+        )
+        keys = set()
+        for event in failure_events:
+            if event.step_key:
+                keys.add(event.step_key)
+        return keys
 
     def compute_events_for_handle(self, handle: NodeHandle) -> Sequence[DagsterEvent]:
         return [

--- a/python_modules/dagster/dagster/_core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/active.py
@@ -398,6 +398,15 @@ class ActiveExecution:
         step_key = cast(str, dagster_event.step_key)
         if dagster_event.is_step_failure:
             self.mark_failed(step_key)
+        elif dagster_event.is_resource_init_failure:
+            # Resources are only initialized without a step key in the
+            # in-process case, and resource initalization happens before the
+            # ActiveExecution object is created.
+            check.invariant(
+                dagster_event.step_key is not None,
+                "Resource init failure was reported during execution without a step key.",
+            )
+            self.mark_failed(step_key)
         elif dagster_event.is_step_success:
             self.mark_success(step_key)
         elif dagster_event.is_step_skipped:

--- a/python_modules/dagster/dagster/_core/execution/plan/resume_retry.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/resume_retry.py
@@ -50,6 +50,7 @@ def get_retry_steps_from_parent_run(
             DagsterEventType.STEP_FAILURE,
             DagsterEventType.STEP_SUCCESS,
             DagsterEventType.STEP_SKIPPED,
+            DagsterEventType.RESOURCE_INIT_FAILURE,
         },
     )
 
@@ -79,6 +80,9 @@ def get_retry_steps_from_parent_run(
             _update_tracking_dict(all_steps_in_parent_run_logs, step_handle)
 
             if record.dagster_event_type == DagsterEventType.STEP_FAILURE:
+                _update_tracking_dict(failed_steps_in_parent_run_logs, step_handle)
+
+            if record.dagster_event_type == DagsterEventType.RESOURCE_INIT_FAILURE:
                 _update_tracking_dict(failed_steps_in_parent_run_logs, step_handle)
 
             if record.dagster_event_type == DagsterEventType.STEP_SUCCESS:

--- a/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
@@ -218,7 +218,11 @@ class StepDelegatingExecutor(Executor):
                         active_execution.verify_complete(plan_context, dagster_event.step_key)
                     else:
                         active_execution.handle_event(dagster_event)
-                        if dagster_event.is_step_success or dagster_event.is_step_failure:
+                        if (
+                            dagster_event.is_step_success
+                            or dagster_event.is_step_failure
+                            or dagster_event.is_resource_init_failure
+                        ):
                             assert isinstance(dagster_event.step_key, str)
                             del running_steps[dagster_event.step_key]
                             active_execution.verify_complete(plan_context, dagster_event.step_key)

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/retry_jobs.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/retry_jobs.py
@@ -1,0 +1,176 @@
+# pylint: disable=unused-argument
+import os
+import pickle
+import re
+from tempfile import TemporaryDirectory
+from typing import Any, Callable, Dict, Tuple
+
+from dagster import (
+    DynamicOut,
+    DynamicOutput,
+    ExecutorDefinition,
+    JobDefinition,
+    ReexecutionOptions,
+    execute_job,
+    job,
+    op,
+    reconstructable,
+    resource,
+)
+from dagster._core.test_utils import instance_for_test
+
+
+def get_dynamic_job_resource_init_failure(
+    executor_def: ExecutorDefinition,
+) -> Tuple[JobDefinition, Callable[[str, int, int], Dict[str, Any]]]:
+    # Induces failure state where among a series of dynamic steps induced from
+    # upstream dynamic outputs, some of those steps fail during resource
+    # initialization time. Since resource initialization is happening across
+    # multiple processes, it is necessary to track the total number of
+    # initializations that have already occurred within an external file
+    # (count.pkl) so that state can be shared. In multiprocessing case, race
+    # conditions are avoided by setting max concurrency to 1.
+    @op(out=DynamicOut(), config_schema={"num_dynamic_steps": int})
+    def source(context):
+        for i in range(context.op_config["num_dynamic_steps"]):
+            yield DynamicOutput(i, mapping_key=str(i))
+
+    @resource(config_schema={"path": str, "allowed_initializations": int})
+    def resource_for_dynamic_step(init_context):
+
+        # Get the count of successful initializations. If it is already at the
+        # allowed initialization number, fail.
+        with open(os.path.join(init_context.resource_config["path"], "count.pkl"), "rb") as f:
+            init_count = pickle.load(f)
+            if init_count == init_context.resource_config["allowed_initializations"]:
+                raise Exception("too many initializations.")
+
+        # We have not yet reached the allowed initializaton number, allow
+        # initialization to complete and add to total init number.
+        with open(os.path.join(init_context.resource_config["path"], "count.pkl"), "wb") as f:
+            init_count += 1
+            pickle.dump(init_count, f)
+        return None
+
+    @op(required_resource_keys={"foo"})
+    def mapped_op(x):
+        pass
+
+    @op
+    def consumer(x):
+        pass
+
+    @job(resource_defs={"foo": resource_for_dynamic_step}, executor_def=executor_def)
+    def the_job():
+        consumer(source().map(mapped_op).collect())
+
+    return (
+        the_job,
+        lambda temp_dir, init_count, dynamic_steps: {
+            "resources": {
+                "foo": {"config": {"path": temp_dir, "allowed_initializations": init_count}}
+            },
+            "ops": {"source": {"config": {"num_dynamic_steps": dynamic_steps}}},
+        },
+    )
+
+
+def get_dynamic_job_op_failure(
+    executor_def: ExecutorDefinition,
+) -> Tuple[JobDefinition, Callable[[str, int, int], Dict[str, Any]]]:
+    # Induces failure state where among a series of dynamic steps induced from
+    # upstream dynamic outputs, some of those steps fail during op runtime.
+    # Since step runs are happening across multiple processes, it is necessary
+    # to track the total number of initializations that have already occurred
+    # within an external file (count.pkl) so that state can be shared. In
+    # multiprocessing case, race conditions are avoided by setting max
+    # concurrency to 1.
+    @op(out=DynamicOut())
+    def source():
+        for i in range(3):
+            yield DynamicOutput(i, mapping_key=str(i))
+
+    @op(config_schema={"path": str, "allowed_runs": int})
+    def mapped_op(context, x):
+
+        # Get the count of successful initializations. If it is already at the
+        # allowed initialization number, fail.
+        with open(os.path.join(context.op_config["path"], "count.pkl"), "rb") as f:
+            run_count = pickle.load(f)
+            if run_count == context.op_config["allowed_runs"]:
+                raise Exception("oof")
+
+        # We have not yet reached the allowed initializaton number, allow
+        # initialization to complete and add to total init number.
+        with open(os.path.join(context.op_config["path"], "count.pkl"), "wb") as f:
+            run_count += 1
+            pickle.dump(run_count, f)
+
+    @op
+    def consumer(x):
+        return 4
+
+    @job
+    def the_job():
+        consumer(source().map(mapped_op).collect())
+
+    return (
+        the_job,
+        lambda temp_dir, run_count, dynamic_steps: {
+            "ops": {
+                "mapped_op": {"config": {"path": temp_dir, "allowed_runs": run_count}},
+                "source": {"config": {"num_dynamic_steps": dynamic_steps}},
+            }
+        },
+    )
+
+
+def _regexes_match(regexes, the_list):
+    return all([re.match(regex, item) for regex, item in zip(regexes, the_list)])
+
+
+def _write_blank_count(path):
+    with open(os.path.join(path, "count.pkl"), "wb") as f:
+        pickle.dump(0, f)
+
+
+def assert_expected_failure_behavior(job_fn, config_fn):
+    num_dynamic_steps = 3
+    with TemporaryDirectory() as temp_dir:
+        with instance_for_test(temp_dir=temp_dir) as instance:
+            _write_blank_count(temp_dir)
+            result = execute_job(
+                reconstructable(job_fn),
+                instance,
+                run_config=config_fn(
+                    temp_dir, 1, num_dynamic_steps
+                ),  # Only allow one dynamic step to pass
+            )
+            assert not result.success
+            assert len(result.get_step_success_events()) == 2
+            assert _regexes_match(
+                [r"source", r"mapped_op\[\d\]"],
+                [event.step_key for event in result.get_step_success_events()],
+            )
+            assert len(result.get_failed_step_keys()) == 2
+            assert _regexes_match(
+                [r"mapped_op\[\d\]", r"mapped_op\[\d\]"],
+                list(result.get_failed_step_keys()),
+            )
+            _write_blank_count(temp_dir)
+            retry_result = execute_job(
+                reconstructable(job_fn),
+                instance,
+                run_config=config_fn(
+                    temp_dir, num_dynamic_steps, num_dynamic_steps
+                ),  # Allows all dynamic steps to pass
+                reexecution_options=ReexecutionOptions.from_failure(
+                    run_id=result.run_id, instance=instance
+                ),
+            )
+            assert retry_result.success
+            assert len(retry_result.get_step_success_events()) == 3
+            assert _regexes_match(
+                [r"mapped_op\[\d\]", r"mapped_op\[\d\]", "consumer"],
+                [event.step_key for event in retry_result.get_step_success_events()],
+            )


### PR DESCRIPTION
### Summary & Motivation
Fixes a bug with out-of-process execution and dynamic execution where, if a dynamic step fails during initialization of resources, subsequent retries of the job will ignore the dynamic steps that did not execute. Now, resource initialization failures during step execution are treated as failures, and the re-execution machinery will pick up steps that failed during resource initialization.
