### PR TITLE
Remove extra "_tests" suffix

### DIFF
--- a/docs/content/getting-started/create-new-project.mdx
+++ b/docs/content/getting-started/create-new-project.mdx
@@ -100,7 +100,7 @@ You can specify new Python dependencies in `setup.py`.
 Tests can be added in the `my_dagster_project_tests` directory and you can run tests using `pytest`:
 
 ```bash
-pytest my_dagster_project_tests_tests
+pytest my_dagster_project_tests
 ```
 
 ### Schedules and sensors


### PR DESCRIPTION


### Summary & Motivation
The name of the tests directory in the "getting started" documentation has an extra "_tests" suffix.  Presumably this is a copy-and-paste error

