### PR TITLE
Reference correct method in "loading asset values outside of Dagster runs" example

### DIFF
--- a/docs/content/concepts/assets/software-defined-assets.mdx
+++ b/docs/content/concepts/assets/software-defined-assets.mdx
@@ -500,7 +500,7 @@ def repo():
 asset1_value = repo.load_asset_value(AssetKey("asset1"))
 ```
 
-If you want to load the values of multiple assets, it's more efficient to use <PyObject object="RepositoryDefinition"" method="get_asset_value_loader" />, which avoids spinning up resources separately for each asset:
+If you want to load the values of multiple assets, it's more efficient to use <PyObject object="RepositoryDefinition" method="get_asset_value_loader" />, which avoids spinning up resources separately for each asset:
 
 ```python file=/concepts/assets/load_asset_values.py startafter=multiple_asset_start_marker endbefore=multiple_asset_end_marker dedent=4
 with repo.get_asset_value_loader() as loader:

--- a/docs/content/concepts/assets/software-defined-assets.mdx
+++ b/docs/content/concepts/assets/software-defined-assets.mdx
@@ -500,7 +500,7 @@ def repo():
 asset1_value = repo.load_asset_value(AssetKey("asset1"))
 ```
 
-If you want to load the values of multiple assets, it's more efficient to use <PyObject object="RepositoryDefinition" method="load_asset_value" />, which avoids spinning up resources separately for each asset:
+If you want to load the values of multiple assets, it's more efficient to use <PyObject object="AssetValueLoader" method="load_asset_value" />, which avoids spinning up resources separately for each asset:
 
 ```python file=/concepts/assets/load_asset_values.py startafter=multiple_asset_start_marker endbefore=multiple_asset_end_marker dedent=4
 with repo.get_asset_value_loader() as loader:

--- a/docs/content/concepts/assets/software-defined-assets.mdx
+++ b/docs/content/concepts/assets/software-defined-assets.mdx
@@ -500,7 +500,7 @@ def repo():
 asset1_value = repo.load_asset_value(AssetKey("asset1"))
 ```
 
-If you want to load the values of multiple assets, it's more efficient to use <PyObject object="AssetValueLoader" method="load_asset_value" />, which avoids spinning up resources separately for each asset:
+If you want to load the values of multiple assets, it's more efficient to use <PyObject object="RepositoryDefinition"" method="get_asset_value_loader" />, which avoids spinning up resources separately for each asset:
 
 ```python file=/concepts/assets/load_asset_values.py startafter=multiple_asset_start_marker endbefore=multiple_asset_end_marker dedent=4
 with repo.get_asset_value_loader() as loader:


### PR DESCRIPTION
### Summary & Motivation
In the section "Loading asset values outside of Dagster runs" of the concepts documentation for software-defined assets, two  examples of loading assets are presented, one of which uses `load_asset_value`, and one of which uses `get_asset_value_loader`.  However, the text describing both examples cites `load_asset_value`, which seems like a mistake.