### PR TITLE
[dagit] Rearrange top nav

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
@@ -22,82 +22,123 @@ interface Props {
 export const AppTopNav: React.FC<Props> = ({children, rightOfSearchBar, searchPlaceholder}) => {
   const history = useHistory();
   const {flagNewWorkspace} = useFeatureFlags();
-  const runHref = flagNewWorkspace ? '/instance/runs/timeline' : '/instance/runs';
 
-  const deploymentItem = (
-    <ShortcutHandler
-      key="deployment"
-      onShortcut={() => history.push('/instance')}
-      shortcutLabel="⌥3"
-      shortcutFilter={(e) => e.code === 'Digit3' && e.altKey}
-    >
-      <TopNavLink
-        to="/instance"
-        data-cy="AppTopNav_StatusLink"
-        isActive={(_, location) => {
-          const {pathname} = location;
-          return (
-            pathname.startsWith('/instance') &&
-            !pathname.startsWith('/instance/runs') &&
-            !pathname.startsWith('/instance/assets')
-          );
-        }}
+  const navLinks = () => {
+    const runHref = flagNewWorkspace ? '/instance/runs/timeline' : '/instance/runs';
+
+    const deploymentItem = (
+      <ShortcutHandler
+        key="deployment"
+        onShortcut={() => history.push('/instance')}
+        shortcutLabel={flagNewWorkspace ? '⌥4' : '⌥3'}
+        shortcutFilter={(e) =>
+          flagNewWorkspace ? e.code === 'Digit4' && e.altKey : e.code === 'Digit3' && e.altKey
+        }
       >
-        <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
-          Deployment
-          <DeploymentStatusIcon />
-        </Box>
-      </TopNavLink>
-    </ShortcutHandler>
-  );
+        <TopNavLink
+          to="/instance"
+          data-cy="AppTopNav_StatusLink"
+          isActive={(_, location) => {
+            const {pathname} = location;
+            return (
+              pathname.startsWith('/instance') &&
+              !pathname.startsWith('/instance/runs') &&
+              !pathname.startsWith('/instance/assets')
+            );
+          }}
+        >
+          <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
+            Deployment
+            <DeploymentStatusIcon />
+          </Box>
+        </TopNavLink>
+      </ShortcutHandler>
+    );
 
-  const workspaceItem = (
-    <ShortcutHandler
-      key="workspace"
-      onShortcut={() => history.push('/workspace')}
-      shortcutLabel="⌥4"
-      shortcutFilter={(e) => e.code === 'Digit4' && e.altKey}
-    >
-      <TopNavLink to="/workspace" data-cy="AppTopNav_WorkspaceLink">
-        <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
-          Workspace
-          {flagNewWorkspace ? null : <WorkspaceStatus />}
-        </Box>
-      </TopNavLink>
-    </ShortcutHandler>
-  );
+    const workspaceItem = (
+      <ShortcutHandler
+        key="workspace"
+        onShortcut={() => history.push('/workspace')}
+        shortcutLabel={flagNewWorkspace ? '⌥3' : '⌥4'}
+        shortcutFilter={(e) =>
+          flagNewWorkspace ? e.code === 'Digit3' && e.altKey : e.code === 'Digit4' && e.altKey
+        }
+      >
+        <TopNavLink to="/workspace" data-cy="AppTopNav_WorkspaceLink">
+          <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
+            Workspace
+            {flagNewWorkspace ? null : <WorkspaceStatus />}
+          </Box>
+        </TopNavLink>
+      </ShortcutHandler>
+    );
 
-  return (
-    <AppTopNavContainer>
+    return (
+      <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
+        <ShortcutHandler
+          onShortcut={() => history.push(runHref)}
+          shortcutLabel="⌥1"
+          shortcutFilter={(e) => e.code === 'Digit1' && e.altKey}
+        >
+          <TopNavLink to={runHref} data-cy="AppTopNav_RunsLink">
+            Runs
+          </TopNavLink>
+        </ShortcutHandler>
+        <ShortcutHandler
+          onShortcut={() => history.push('/instance/assets')}
+          shortcutLabel="⌥2"
+          shortcutFilter={(e) => e.code === 'Digit2' && e.altKey}
+        >
+          <TopNavLink to="/instance/assets" data-cy="AppTopNav_AssetsLink" exact={false}>
+            Assets
+          </TopNavLink>
+        </ShortcutHandler>
+        {flagNewWorkspace ? [workspaceItem, deploymentItem] : [deploymentItem, workspaceItem]}
+      </Box>
+    );
+  };
+
+  const left = () => {
+    if (flagNewWorkspace) {
+      return (
+        <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
+          <AppTopNavLogo />
+          <Box margin={{left: 8}}>{navLinks()}</Box>
+          {rightOfSearchBar}
+        </Box>
+      );
+    }
+    return (
       <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
         <AppTopNavLogo />
         <SearchDialog searchPlaceholder={searchPlaceholder} />
         {rightOfSearchBar}
       </Box>
-      <Box flex={{direction: 'row', alignItems: 'center'}}>
-        <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
-          <ShortcutHandler
-            onShortcut={() => history.push(runHref)}
-            shortcutLabel="⌥1"
-            shortcutFilter={(e) => e.code === 'Digit1' && e.altKey}
-          >
-            <TopNavLink to={runHref} data-cy="AppTopNav_RunsLink">
-              Runs
-            </TopNavLink>
-          </ShortcutHandler>
-          <ShortcutHandler
-            onShortcut={() => history.push('/instance/assets')}
-            shortcutLabel="⌥2"
-            shortcutFilter={(e) => e.code === 'Digit2' && e.altKey}
-          >
-            <TopNavLink to="/instance/assets" data-cy="AppTopNav_AssetsLink" exact={false}>
-              Assets
-            </TopNavLink>
-          </ShortcutHandler>
-          {flagNewWorkspace ? [workspaceItem, deploymentItem] : [deploymentItem, workspaceItem]}
+    );
+  };
+
+  const right = () => {
+    if (flagNewWorkspace) {
+      return (
+        <Box flex={{direction: 'row', alignItems: 'center'}}>
+          <SearchDialog searchPlaceholder={searchPlaceholder} />
+          {children}
         </Box>
+      );
+    }
+
+    return (
+      <Box flex={{direction: 'row', alignItems: 'center'}}>
+        {navLinks()}
         {children}
       </Box>
+    );
+  };
+
+  return (
+    <AppTopNavContainer>
+      {left()}
+      {right()}
     </AppTopNavContainer>
   );
 };


### PR DESCRIPTION
### Summary & Motivation

Rearrange the top navigation items in Dagit, behind the "New workspace" feature flag.

- The nav links are moved to the left.
- The search bar and other children are on the right.

The right side will be consolidated a bit further.

<img width="1092" alt="Screen Shot 2022-10-03 at 10 15 41 AM" src="https://user-images.githubusercontent.com/2823852/193615034-a24b0541-3384-4477-9aeb-a5ab8fd1ed4d.png">


### How I Tested These Changes

With flag on and off, verify rendering of top nav items. Test keyboard shortcuts.

Repeat in Cloud, verify that everything looks correct.
