### PR TITLE
[docs] - Fix formatting in note

### DIFF
--- a/docs/content/concepts/configuration/config-schema.mdx
+++ b/docs/content/concepts/configuration/config-schema.mdx
@@ -48,8 +48,8 @@ def resource_using_config(context):
 
 <Note>
   It is technically possible to access <pre>context.op_config</pre> inside ops
-  (not assets) without defining a <pre>config_schema</pre>. However, this is
-  not recommended.
+  (not assets) without defining a <pre>config_schema</pre>. However, this is not
+  recommended.
 </Note>
 
 You can also build config into jobs, as described in [the Jobs documentation](/concepts/ops-jobs-graphs/jobs#configuring-jobs).

--- a/docs/content/concepts/configuration/config-schema.mdx
+++ b/docs/content/concepts/configuration/config-schema.mdx
@@ -47,8 +47,8 @@ def resource_using_config(context):
 ```
 
 <Note>
-  It is technically possible to access <code>context.op_config</code> inside ops
-  (not assets) without defining a <code>config_schema</code>. However, this is
+  It is technically possible to access <pre>context.op_config</pre> inside ops
+  (not assets) without defining a <pre>config_schema</pre>. However, this is
   not recommended.
 </Note>
 


### PR DESCRIPTION
This PR fixes some formatting in a Note component, to correctly use `pre` instead of `code`