### PR TITLE
Explicitly error when retries are exceeded if raise_on_error is set

### DIFF
--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -389,6 +389,29 @@ class DagsterUserCodeProcessError(DagsterError):
         super(DagsterUserCodeProcessError, self).__init__(*args, **kwargs)
 
 
+class DagsterMaxRetriesExceededError(DagsterError):
+    """Raised when raise_on_error is true, and retries were exceeded, this error should be raised."""
+
+    def __init__(self, *args, **kwargs):
+        from dagster._utils.error import SerializableErrorInfo
+
+        self.user_code_process_error_infos = check.list_param(
+            kwargs.pop("user_code_process_error_infos"),
+            "user_code_process_error_infos",
+            SerializableErrorInfo,
+        )
+        super(DagsterMaxRetriesExceededError, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    def from_error_info(error_info):
+        from dagster._utils.error import SerializableErrorInfo
+
+        check.inst_param(error_info, "error_info", SerializableErrorInfo)
+        return DagsterMaxRetriesExceededError(
+            error_info.to_string(), user_code_process_error_infos=[error_info]
+        )
+
+
 class DagsterRepositoryLocationNotFoundError(DagsterError):
     pass
 

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
@@ -7,6 +7,7 @@ from dagster._core.definitions import Failure, HookExecutionResult, RetryRequest
 from dagster._core.errors import (
     DagsterError,
     DagsterExecutionInterruptedError,
+    DagsterMaxRetriesExceededError,
     DagsterUserCodeExecutionError,
     HookExecutionError,
     user_code_error_boundary,
@@ -259,6 +260,8 @@ def dagster_event_sequence_for_step(
                         error_source=ErrorSource.USER_CODE_ERROR if fail_err.cause else None,
                     ),
                 )
+                if step_context.raise_on_error:
+                    raise DagsterMaxRetriesExceededError.from_error_info(fail_err)
             else:
                 yield DagsterEvent.step_retry_event(
                     step_context,

--- a/python_modules/dagster/dagster_tests/execution_tests/test_execute_in_process.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_execute_in_process.py
@@ -9,7 +9,9 @@ from dagster import (
     DynamicOutput,
     Out,
     Output,
+    RetryRequested,
     daily_partitioned_config,
+    graph,
     job,
     op,
     resource,
@@ -17,6 +19,7 @@ from dagster import (
 from dagster._check import CheckError
 from dagster._core.definitions.decorators.graph_decorator import graph
 from dagster._core.definitions.output import GraphOut
+from dagster._core.errors import DagsterMaxRetriesExceededError
 from dagster._legacy import solid
 
 
@@ -352,3 +355,29 @@ def test_execute_in_process_input_values():
     result = requires_input_graph.to_job().execute_in_process(input_values={"x": 5})
     assert result.success
     assert result.output_value() == 6
+
+
+def test_retries_exceeded():
+    called = []
+
+    @op
+    def always_fail():
+        exception = Exception("I have failed.")
+        called.append("yes")
+        raise RetryRequested(max_retries=2) from exception
+
+    @graph
+    def fail():
+        always_fail()
+
+    with pytest.raises(DagsterMaxRetriesExceededError, match="Exceeded max_retries of 2"):
+        fail.execute_in_process()
+
+    result = fail.execute_in_process(raise_on_error=False)
+    assert not result.success
+    assert (
+        "Exception: I have failed"
+        in result.filter_events(lambda evt: evt.is_step_failure)[
+            0
+        ].event_specific_data.error_display_string
+    )


### PR DESCRIPTION
### Summary & Motivation
In reference to https://github.com/dagster-io/dagster/issues/9790 - explicitly raises an error in the case of retries exceeded, and raise_on_error is enabled.

Adds a new error class for maximum retries being exceeded.

### How I Tested These Changes
Added a unit test to show the behavior with execute_in_process in both raise_on_error cases.
