### PR TITLE
Add threading to scheduler daemon

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -225,6 +225,16 @@ def sensors_daemon_config():
     )
 
 
+def schedules_daemon_config():
+    return Field(
+        {
+            "use_threads": Field(Bool, is_required=False, default_value=False),
+            "num_workers": Field(int, is_required=False),
+        },
+        is_required=False,
+    )
+
+
 def dagster_instance_config_schema():
     return {
         "local_artifact_storage": config_field_for_configurable_class(),
@@ -264,4 +274,5 @@ def dagster_instance_config_schema():
         ),
         "retention": retention_config_schema(),
         "sensors": sensors_daemon_config(),
+        "schedules": schedules_daemon_config(),
     }


### PR DESCRIPTION
### Summary & Motivation
Adds a threadpool to the scheduler daemon for launching off ticks of schedules. This was implemented mostly by cargo cult-ing the sensor daemon's thread pool, and making some modifications for schedule specific use cases.

### How I Tested These Changes
Parameterized the scheduler test suite based on executor, so each test is run in both synchronous and multithreaded mode.
