### PR TITLE
Return each Python PackageSpec's distribution

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -1,5 +1,5 @@
 import os
-from distutils.core import run_setup
+from distutils.core import run_setup  # pylint: disable=deprecated-module
 from pathlib import Path
 from typing import Callable, List, Mapping, NamedTuple, Optional, Union
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -1,5 +1,9 @@
 import os
+from distutils.core import run_setup
+from pathlib import Path
 from typing import Callable, List, Mapping, NamedTuple, Optional, Union
+
+from setuptools.dist import Distribution
 
 from .python_version import AvailablePythonVersion
 from .step_builder import BuildkiteQueue
@@ -263,3 +267,11 @@ class PackageSpec(
                 steps=steps,
             )
         ]
+
+    @property
+    def distribution(self):
+        setup = Path(self.directory) / "setup.py"
+        if setup.exists():
+            return run_setup(Path(self.directory) / "setup.py")
+        else:
+            return Distribution()

--- a/examples/assets_dbt_python/setup.py
+++ b/examples/assets_dbt_python/setup.py
@@ -1,20 +1,19 @@
 from setuptools import find_packages, setup
 
-if __name__ == "__main__":
-    setup(
-        name="assets_dbt_python",
-        packages=find_packages(exclude=["assets_dbt_python_tests"]),
-        package_data={"assets_dbt_python": ["dbt_project/*"]},
-        install_requires=[
-            "dagster",
-            "dagster-dbt",
-            "pandas",
-            "numpy",
-            "scipy",
-            "dbt-core",
-            "dbt-duckdb",
-            "dagster-duckdb",
-            "dagster-duckdb-pandas",
-        ],
-        extras_require={"dev": ["dagit", "pytest"]},
-    )
+setup(
+    name="assets_dbt_python",
+    packages=find_packages(exclude=["assets_dbt_python_tests"]),
+    package_data={"assets_dbt_python": ["dbt_project/*"]},
+    install_requires=[
+        "dagster",
+        "dagster-dbt",
+        "pandas",
+        "numpy",
+        "scipy",
+        "dbt-core",
+        "dbt-duckdb",
+        "dagster-duckdb",
+        "dagster-duckdb-pandas",
+    ],
+    extras_require={"dev": ["dagit", "pytest"]},
+)

--- a/examples/assets_modern_data_stack/setup.py
+++ b/examples/assets_modern_data_stack/setup.py
@@ -1,20 +1,19 @@
 from setuptools import find_packages, setup
 
-if __name__ == "__main__":
-    setup(
-        name="assets_modern_data_stack",
-        packages=find_packages(exclude=["assets_modern_data_stack_tests"]),
-        package_data={"assets_modern_data_stack": ["dbt_project/*"]},
-        install_requires=[
-            "dagster",
-            "dagster-airbyte",
-            "dagster-dbt",
-            "dagster-postgres",
-            "pandas",
-            "numpy",
-            "scipy",
-            "dbt-core",
-            "dbt-postgres",
-        ],
-        extras_require={"dev": ["dagit", "pytest"]},
-    )
+setup(
+    name="assets_modern_data_stack",
+    packages=find_packages(exclude=["assets_modern_data_stack_tests"]),
+    package_data={"assets_modern_data_stack": ["dbt_project/*"]},
+    install_requires=[
+        "dagster",
+        "dagster-airbyte",
+        "dagster-dbt",
+        "dagster-postgres",
+        "pandas",
+        "numpy",
+        "scipy",
+        "dbt-core",
+        "dbt-postgres",
+    ],
+    extras_require={"dev": ["dagit", "pytest"]},
+)

--- a/examples/assets_pandas_pyspark/setup.py
+++ b/examples/assets_pandas_pyspark/setup.py
@@ -1,17 +1,16 @@
 from setuptools import find_packages, setup
 
-if __name__ == "__main__":
-    setup(
-        name="assets_pandas_pyspark",
-        packages=find_packages(exclude=["assets_pandas_pyspark_tests"]),
-        install_requires=[
-            "dagster",
-            "pandas",
-            "pyspark",
-            # "pyarrow",
-        ],
-        extras_require={
-            "dev": ["dagit", "pytest"],
-            "test": ["pandas", "pyarrow; python_version < '3.9'", "pyspark"],
-        },
-    )
+setup(
+    name="assets_pandas_pyspark",
+    packages=find_packages(exclude=["assets_pandas_pyspark_tests"]),
+    install_requires=[
+        "dagster",
+        "pandas",
+        "pyspark",
+        # "pyarrow",
+    ],
+    extras_require={
+        "dev": ["dagit", "pytest"],
+        "test": ["pandas", "pyarrow; python_version < '3.9'", "pyspark"],
+    },
+)

--- a/examples/assets_pandas_type_metadata/setup.py
+++ b/examples/assets_pandas_type_metadata/setup.py
@@ -1,17 +1,16 @@
 from setuptools import find_packages, setup
 
-if __name__ == "__main__":
-    setup(
-        name="assets_pandas_type_metadata",
-        packages=find_packages(exclude=["assets_pandas_type_metadata_tests"]),
-        install_requires=[
-            "dagster",
-            "dagster-pandera",
-            "jupyterlab",
-            "matplotlib",
-            "seaborn",
-            "pandera",
-            "pandas",
-        ],
-        extras_require={"dev": ["dagit", "pytest"]},
-    )
+setup(
+    name="assets_pandas_type_metadata",
+    packages=find_packages(exclude=["assets_pandas_type_metadata_tests"]),
+    install_requires=[
+        "dagster",
+        "dagster-pandera",
+        "jupyterlab",
+        "matplotlib",
+        "seaborn",
+        "pandera",
+        "pandas",
+    ],
+    extras_require={"dev": ["dagit", "pytest"]},
+)

--- a/examples/assets_smoke_test/setup.py
+++ b/examples/assets_smoke_test/setup.py
@@ -1,19 +1,18 @@
 from setuptools import find_packages, setup
 
-if __name__ == "__main__":
-    setup(
-        name="assets_smoke_test",
-        packages=find_packages(exclude=["assets_smoke_test_tests"]),
-        package_data={"assets_smoke_test": ["dbt_project/*"]},
-        install_requires=[
-            "dagster",
-            "dagster-pandas",
-            "dagster-dbt",
-            "pandas",
-            "dbt-core",
-            "dbt-snowflake",
-            "dagster-snowflake",
-            "dagster-snowflake-pandas",
-        ],
-        extras_require={"dev": ["dagit", "pytest"]},
-    )
+setup(
+    name="assets_smoke_test",
+    packages=find_packages(exclude=["assets_smoke_test_tests"]),
+    package_data={"assets_smoke_test": ["dbt_project/*"]},
+    install_requires=[
+        "dagster",
+        "dagster-pandas",
+        "dagster-dbt",
+        "pandas",
+        "dbt-core",
+        "dbt-snowflake",
+        "dagster-snowflake",
+        "dagster-snowflake-pandas",
+    ],
+    extras_require={"dev": ["dagit", "pytest"]},
+)

--- a/examples/docs_snippets/setup.py
+++ b/examples/docs_snippets/setup.py
@@ -1,56 +1,55 @@
 from setuptools import find_packages, setup
 
-if __name__ == "__main__":
-    setup(
-        name="docs_snippets",
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        url="https://github.com/dagster-io/dagster/tree/master/examples/docs_snippets",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["test"]),
-        install_requires=[
-            "dagit",
-            "dagster",
-            "dagstermill",
-            "dagster-airbyte",
-            "dagster-airflow",
-            "dagster-aws",
-            "dagster-celery",
-            "dagster-dbt",
-            "dagster-dask",
-            "dagster-gcp",
-            "dagster-graphql",
-            "dagster-k8s",
-            "dagster-postgres",
-            "dagster-slack",
-        ],
-        extras_require={
-            "full": [
-                "click",
-                "matplotlib",
-                # matplotlib-inline 0.1.5 is causing mysterious
-                # "'NoneType' object has no attribute 'canvas'" errors in the tests that involve
-                # Jupyter notebooks
-                "matplotlib-inline<=0.1.3",
-                "moto==1.3.16",
-                "numpy",
-                "pandas",
-                "pandera",
-                "pytest",
-                "requests",
-                "seaborn",
-                "scikit-learn",
-                "slack_sdk",
-                "snapshottest",
-                "dagit[test]",
-            ]
-        },
-    )
+setup(
+    name="docs_snippets",
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    url="https://github.com/dagster-io/dagster/tree/master/examples/docs_snippets",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["test"]),
+    install_requires=[
+        "dagit",
+        "dagster",
+        "dagstermill",
+        "dagster-airbyte",
+        "dagster-airflow",
+        "dagster-aws",
+        "dagster-celery",
+        "dagster-dbt",
+        "dagster-dask",
+        "dagster-gcp",
+        "dagster-graphql",
+        "dagster-k8s",
+        "dagster-postgres",
+        "dagster-slack",
+    ],
+    extras_require={
+        "full": [
+            "click",
+            "matplotlib",
+            # matplotlib-inline 0.1.5 is causing mysterious
+            # "'NoneType' object has no attribute 'canvas'" errors in the tests that involve
+            # Jupyter notebooks
+            "matplotlib-inline<=0.1.3",
+            "moto==1.3.16",
+            "numpy",
+            "pandas",
+            "pandera",
+            "pytest",
+            "requests",
+            "seaborn",
+            "scikit-learn",
+            "slack_sdk",
+            "snapshottest",
+            "dagit[test]",
+        ]
+    },
+)

--- a/examples/feature_graph_backed_assets/setup.py
+++ b/examples/feature_graph_backed_assets/setup.py
@@ -1,19 +1,18 @@
 from setuptools import find_packages, setup
 
-if __name__ == "__main__":
-    setup(
-        name="feature_graph_backed_assets",
-        packages=find_packages(exclude=["feature_graph_backed_assets_tests"]),
-        install_requires=["dagster", "pandas"],
-        license="Apache-2.0",
-        description="Dagster example of op and graph-backed assets.",
-        url="https://github.com/dagster-io/dagster/tree/master/examples/feature_graph_backed_assets",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        extras_require={"dev": ["dagit", "pytest"]},
-    )
+setup(
+    name="feature_graph_backed_assets",
+    packages=find_packages(exclude=["feature_graph_backed_assets_tests"]),
+    install_requires=["dagster", "pandas"],
+    license="Apache-2.0",
+    description="Dagster example of op and graph-backed assets.",
+    url="https://github.com/dagster-io/dagster/tree/master/examples/feature_graph_backed_assets",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    extras_require={"dev": ["dagit", "pytest"]},
+)

--- a/examples/with_airflow/setup.py
+++ b/examples/with_airflow/setup.py
@@ -1,16 +1,15 @@
 from setuptools import find_packages, setup
 
-if __name__ == "__main__":
-    setup(
-        name="with_airflow",
-        packages=find_packages(exclude=["with_airflow_tests"]),
-        install_requires=[
-            "dagster",
-            "dagster_airflow",
-            # See https://github.com/dagster-io/dagster/issues/2701
-            "apache-airflow==1.10.10",
-            # Conflicts with `Jinja2` which is used in dagster cli that dagster_airflow depends on
-            "markupsafe<=2.0.1",
-        ],
-        extras_require={"dev": ["dagit", "pytest"]},
-    )
+setup(
+    name="with_airflow",
+    packages=find_packages(exclude=["with_airflow_tests"]),
+    install_requires=[
+        "dagster",
+        "dagster_airflow",
+        # See https://github.com/dagster-io/dagster/issues/2701
+        "apache-airflow==1.10.10",
+        # Conflicts with `Jinja2` which is used in dagster cli that dagster_airflow depends on
+        "markupsafe<=2.0.1",
+    ],
+    extras_require={"dev": ["dagit", "pytest"]},
+)

--- a/examples/with_great_expectations/setup.py
+++ b/examples/with_great_expectations/setup.py
@@ -1,13 +1,12 @@
 from setuptools import find_packages, setup
 
-if __name__ == "__main__":
-    setup(
-        name="with_great_expectations",
-        packages=find_packages(exclude=["with_great_expectations_tests"]),
-        install_requires=[
-            "dagster",
-            "dagster-ge",
-            "great_expectations>=0.14.12",  # pinned because pip is using the cached wheel for 0.13.14
-        ],
-        extras_require={"dev": ["dagit", "pytest"]},
-    )
+setup(
+    name="with_great_expectations",
+    packages=find_packages(exclude=["with_great_expectations_tests"]),
+    install_requires=[
+        "dagster",
+        "dagster-ge",
+        "great_expectations>=0.14.12",  # pinned because pip is using the cached wheel for 0.13.14
+    ],
+    extras_require={"dev": ["dagit", "pytest"]},
+)

--- a/examples/with_pyspark/setup.py
+++ b/examples/with_pyspark/setup.py
@@ -1,13 +1,12 @@
 from setuptools import find_packages, setup
 
-if __name__ == "__main__":
-    setup(
-        name="with_pyspark",
-        packages=find_packages(exclude=["with_pyspark_tests"]),
-        install_requires=[
-            "dagster",
-            "dagster-spark",
-            "dagster-pyspark",
-        ],
-        extras_require={"dev": ["dagit", "pytest"]},
-    )
+setup(
+    name="with_pyspark",
+    packages=find_packages(exclude=["with_pyspark_tests"]),
+    install_requires=[
+        "dagster",
+        "dagster-spark",
+        "dagster-pyspark",
+    ],
+    extras_require={"dev": ["dagit", "pytest"]},
+)

--- a/examples/with_pyspark_emr/setup.py
+++ b/examples/with_pyspark_emr/setup.py
@@ -1,13 +1,12 @@
 from setuptools import find_packages, setup
 
-if __name__ == "__main__":
-    setup(
-        name="with_pyspark_emr",
-        packages=find_packages(exclude=["with_pyspark_emr_tests"]),
-        install_requires=[
-            "dagster",
-            "dagster-aws",
-            "dagster-pyspark",
-        ],
-        extras_require={"dev": ["dagit", "pytest"]},
-    )
+setup(
+    name="with_pyspark_emr",
+    packages=find_packages(exclude=["with_pyspark_emr_tests"]),
+    install_requires=[
+        "dagster",
+        "dagster-aws",
+        "dagster-pyspark",
+    ],
+    extras_require={"dev": ["dagit", "pytest"]},
+)

--- a/integration_tests/python_modules/dagster-k8s-test-infra/setup.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/setup.py
@@ -1,22 +1,21 @@
 from setuptools import find_packages, setup  # type: ignore
 
-if __name__ == "__main__":
-    setup(
-        name="dagster-k8s-test-infra",
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="A Dagster integration for k8s-test-infra",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-k8s-test-infra",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["test"]),
-        install_requires=["dagster", "docker", "dagster-aws"],
-        zip_safe=False,
-    )
+setup(
+    name="dagster-k8s-test-infra",
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="A Dagster integration for k8s-test-infra",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-k8s-test-infra",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["test"]),
+    install_requires=["dagster", "docker", "dagster-aws"],
+    zip_safe=False,
+)

--- a/python_modules/dagit/setup.py
+++ b/python_modules/dagit/setup.py
@@ -11,53 +11,50 @@ def long_description():
 
 def get_version():
     version = {}
-    with open("dagit/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagit/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagit",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Web UI for dagster.",
-        long_description=long_description(),
-        long_description_content_type="text/markdown",
-        url="https://github.com/dagster-io/dagster",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagit_tests*"]),
-        include_package_data=True,
-        install_requires=[
-            "PyYAML",
-            # cli
-            "click>=7.0,<9.0",
-            f"dagster{pin}",
-            f"dagster-graphql{pin}",
-            "requests",
-            # watchdog
-            "watchdog>=0.8.3",
-            "starlette",
-            "uvicorn[standard]",
-        ],
-        extras_require={
-            "notebook": ["nbconvert"],  # notebooks support
-            "test": ["starlette[full]"],  # TestClient deps in full
-        },
-        entry_points={
-            "console_scripts": ["dagit = dagit.cli:main", "dagit-debug = dagit.debug:main"]
-        },
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagit",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Web UI for dagster.",
+    long_description=long_description(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/dagster-io/dagster",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagit_tests*"]),
+    include_package_data=True,
+    install_requires=[
+        "PyYAML",
+        # cli
+        "click>=7.0,<9.0",
+        f"dagster{pin}",
+        f"dagster-graphql{pin}",
+        "requests",
+        # watchdog
+        "watchdog>=0.8.3",
+        "starlette",
+        "uvicorn[standard]",
+    ],
+    extras_require={
+        "notebook": ["nbconvert"],  # notebooks support
+        "test": ["starlette[full]"],  # TestClient deps in full
+    },
+    entry_points={"console_scripts": ["dagit = dagit.cli:main", "dagit-debug = dagit.debug:main"]},
+)

--- a/python_modules/dagit/setup.py
+++ b/python_modules/dagit/setup.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from setuptools import find_packages, setup
 

--- a/python_modules/dagster-graphql/setup.py
+++ b/python_modules/dagster-graphql/setup.py
@@ -11,33 +11,32 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-graphql",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="The GraphQL frontend to python dagster.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/dagster-graphql",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_graphql_tests*"]),
-        install_requires=[
-            f"dagster{pin}",
-            "graphene>=2.1.3,<3",  # compatability with graphql-ws in dagit
-            "graphql-core>=2.1,<3",  # compatability with graphql-ws in dagit
-            "requests",
-            "gql<3",  # compatibility with graphql-core pin above
-        ],
-        entry_points={"console_scripts": ["dagster-graphql = dagster_graphql.cli:main"]},
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-graphql",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="The GraphQL frontend to python dagster.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/dagster-graphql",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_graphql_tests*"]),
+    install_requires=[
+        f"dagster{pin}",
+        "graphene>=2.1.3,<3",  # compatability with graphql-ws in dagit
+        "graphql-core>=2.1,<3",  # compatability with graphql-ws in dagit
+        "requests",
+        "gql<3",  # compatibility with graphql-core pin above
+    ],
+    entry_points={"console_scripts": ["dagster-graphql = dagster_graphql.cli:main"]},
+)

--- a/python_modules/dagster-graphql/setup.py
+++ b/python_modules/dagster-graphql/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_graphql/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_graphql/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -25,119 +25,118 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    setup(
-        name="dagster",
-        version=get_version(),
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="The data orchestration platform built for productivity.",
-        long_description=get_description(),
-        long_description_content_type="text/markdown",
-        url="https://github.com/dagster-io/dagster",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
+setup(
+    name="dagster",
+    version=get_version(),
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="The data orchestration platform built for productivity.",
+    long_description=get_description(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/dagster-io/dagster",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_tests*"]),
+    include_package_data=True,
+    install_requires=[
+        # cli
+        "click>=5.0",
+        "coloredlogs>=6.1, <=14.0",
+        "contextvars; python_version < '3.7'",
+        "Jinja2",
+        "PyYAML>=5.1",
+        # core (not explicitly expressed atm)
+        # pin around issues in specific versions of alembic that broke our migrations
+        "alembic>=1.2.1,!=1.6.3,!=1.7.0",
+        "croniter>=0.3.34",
+        # grpcio 1.48.1 has hanging/crashing issues: https://github.com/grpc/grpc/issues/30843
+        # ensure version we require is >= that with which we generated the grpc code (set in dev-requirements)
+        "grpcio>=1.32.0,<1.48.1",
+        "grpcio-health-checking>=1.32.0,<1.44.0",
+        "packaging>=20.9",
+        "pendulum",
+        "protobuf>=3.13.0,<4",  # ensure version we require is >= that with which we generated the proto code (set in dev-requirements)
+        "python-dateutil",
+        "pytz",
+        "requests",
+        "rx>=1.6,<2",  # https://github.com/dagster-io/dagster/issues/4089
+        "setuptools",
+        "tabulate",
+        "tqdm",
+        "typing_compat",
+        "typing_extensions>=4.0.1",
+        "sqlalchemy>=1.0",
+        "toposort>=1.0",
+        "watchdog>=0.8.3",
+        'psutil >= 1.0; platform_system=="Windows"',
+        # https://github.com/mhammond/pywin32/issues/1439
+        'pywin32 != 226; platform_system=="Windows"',
+        "docstring-parser",
+    ],
+    extras_require={
+        "docker": ["docker"],
+        "test": [
+            "buildkite-test-collector ; python_version>='3.8'",
+            "coverage==5.3",
+            "docker",
+            "grpcio-tools>=1.32.0,<1.44.0",  # related to above grpcio pins
+            "mock==3.0.5",
+            "objgraph",
+            "protobuf==3.13.0",  # without this, pip will install the most up-to-date protobuf
+            "pytest-cov==2.10.1",
+            "pytest-dependency==0.5.1",
+            "pytest-mock==3.3.1",
+            "pytest-rerunfailures==10.0",
+            "pytest-runner==5.2",
+            "pytest-xdist==2.1.0",
+            "pytest==7.0.1",  # last version supporting python 3.6
+            "responses==0.10.*",
+            "snapshottest==0.6.0",
+            "tox==3.25.0",
+            "yamllint",
+            "astroid",  # let pylint determine the version
+            "pylint==2.13.7",
         ],
-        packages=find_packages(exclude=["dagster_tests*"]),
-        include_package_data=True,
-        install_requires=[
-            # cli
-            "click>=5.0",
-            "coloredlogs>=6.1, <=14.0",
-            "contextvars; python_version < '3.7'",
-            "Jinja2",
-            "PyYAML>=5.1",
-            # core (not explicitly expressed atm)
-            # pin around issues in specific versions of alembic that broke our migrations
-            "alembic>=1.2.1,!=1.6.3,!=1.7.0",
-            "croniter>=0.3.34",
-            # grpcio 1.48.1 has hanging/crashing issues: https://github.com/grpc/grpc/issues/30843
-            # ensure version we require is >= that with which we generated the grpc code (set in dev-requirements)
-            "grpcio>=1.32.0,<1.48.1",
-            "grpcio-health-checking>=1.32.0,<1.44.0",
-            "packaging>=20.9",
-            "pendulum",
-            "protobuf>=3.13.0,<4",  # ensure version we require is >= that with which we generated the proto code (set in dev-requirements)
-            "python-dateutil",
-            "pytz",
-            "requests",
-            "rx>=1.6,<2",  # https://github.com/dagster-io/dagster/issues/4089
-            "setuptools",
-            "tabulate",
-            "tqdm",
-            "typing_compat",
-            "typing_extensions>=4.0.1",
-            "sqlalchemy>=1.0",
-            "toposort>=1.0",
-            "watchdog>=0.8.3",
-            'psutil >= 1.0; platform_system=="Windows"',
-            # https://github.com/mhammond/pywin32/issues/1439
-            'pywin32 != 226; platform_system=="Windows"',
-            "docstring-parser",
+        "black": [
+            "black[jupyter]==22.3.0",
         ],
-        extras_require={
-            "docker": ["docker"],
-            "test": [
-                "buildkite-test-collector ; python_version>='3.8'",
-                "coverage==5.3",
-                "docker",
-                "grpcio-tools>=1.32.0,<1.44.0",  # related to above grpcio pins
-                "mock==3.0.5",
-                "objgraph",
-                "protobuf==3.13.0",  # without this, pip will install the most up-to-date protobuf
-                "pytest-cov==2.10.1",
-                "pytest-dependency==0.5.1",
-                "pytest-mock==3.3.1",
-                "pytest-rerunfailures==10.0",
-                "pytest-runner==5.2",
-                "pytest-xdist==2.1.0",
-                "pytest==7.0.1",  # last version supporting python 3.6
-                "responses==0.10.*",
-                "snapshottest==0.6.0",
-                "tox==3.25.0",
-                "yamllint",
-                "astroid",  # let pylint determine the version
-                "pylint==2.13.7",
-            ],
-            "black": [
-                "black[jupyter]==22.3.0",
-            ],
-            "isort": [
-                "isort==5.10.1",
-            ],
-            "mypy": [
-                "mypy==0.950",
-                "types-backports",  # version will be resolved against backports
-                "types-certifi",  # version will be resolved against certifi
-                "types-chardet",  # chardet is a 2+-order dependency of some Dagster libs
-                "types-croniter",  # version will be resolved against croniter
-                "types-cryptography",  # version will be resolved against cryptography
-                "types-mock",  # version will be resolved against mock
-                "types-paramiko",  # version will be resolved against paramiko
-                "types-pkg-resources",  # version will be resolved against setuptools (contains pkg_resources)
-                "types-protobuf<=3.19.21",  # version will be resolved against protobuf (3.19.22 introduced breaking change)
-                "types-pyOpenSSL",  # version will be resolved against pyOpenSSL
-                "types-python-dateutil",  # version will be resolved against python-dateutil
-                "types-PyYAML",  # version will be resolved against PyYAML
-                "types-pytz",  # version will be resolved against pytz
-                "types-requests",  # version will be resolved against requests
-                "types-simplejson",  # version will be resolved against simplejson
-                "types-six",  # needed but not specified by grpcio
-                "types-tabulate",  # version will be resolved against tabulate
-                "types-tzlocal",  # version will be resolved against tzlocal
-                "types-toml",  # version will be resolved against toml
-            ],
-        },
-        entry_points={
-            "console_scripts": [
-                "dagster = dagster.cli:main",
-                "dagster-daemon = dagster.daemon.cli:main",
-            ]
-        },
-    )
+        "isort": [
+            "isort==5.10.1",
+        ],
+        "mypy": [
+            "mypy==0.950",
+            "types-backports",  # version will be resolved against backports
+            "types-certifi",  # version will be resolved against certifi
+            "types-chardet",  # chardet is a 2+-order dependency of some Dagster libs
+            "types-croniter",  # version will be resolved against croniter
+            "types-cryptography",  # version will be resolved against cryptography
+            "types-mock",  # version will be resolved against mock
+            "types-paramiko",  # version will be resolved against paramiko
+            "types-pkg-resources",  # version will be resolved against setuptools (contains pkg_resources)
+            "types-protobuf<=3.19.21",  # version will be resolved against protobuf (3.19.22 introduced breaking change)
+            "types-pyOpenSSL",  # version will be resolved against pyOpenSSL
+            "types-python-dateutil",  # version will be resolved against python-dateutil
+            "types-PyYAML",  # version will be resolved against PyYAML
+            "types-pytz",  # version will be resolved against pytz
+            "types-requests",  # version will be resolved against requests
+            "types-simplejson",  # version will be resolved against simplejson
+            "types-six",  # needed but not specified by grpcio
+            "types-tabulate",  # version will be resolved against tabulate
+            "types-tzlocal",  # version will be resolved against tzlocal
+            "types-toml",  # version will be resolved against toml
+        ],
+    },
+    entry_points={
+        "console_scripts": [
+            "dagster = dagster.cli:main",
+            "dagster-daemon = dagster.daemon.cli:main",
+        ]
+    },
+)

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -19,7 +19,7 @@ def get_description() -> str:
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-airbyte/setup.py
+++ b/python_modules/libraries/dagster-airbyte/setup.py
@@ -5,35 +5,34 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_airbyte/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_airbyte/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-airbyte",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for integrating Airbyte with Dagster.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-airbyte",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_airbyte_tests*"]),
-        install_requires=[
-            f"dagster{pin}",
-            "requests",
-        ],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-airbyte",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for integrating Airbyte with Dagster.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-airbyte",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_airbyte_tests*"]),
+    install_requires=[
+        f"dagster{pin}",
+        "requests",
+    ],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-airbyte/setup.py
+++ b/python_modules/libraries/dagster-airbyte/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup

--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_airflow/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_airflow/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -11,63 +11,62 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-airflow",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Airflow plugin for Dagster",
-        url="https://github.com/dagster-io/dagster",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-airflow",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Airflow plugin for Dagster",
+    url="https://github.com/dagster-io/dagster",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_airflow_tests*"]),
+    install_requires=[
+        f"dagster{pin}",
+        "docker",
+        "python-dateutil>=2.8.0",
+        "lazy_object_proxy",
+        # https://issues.apache.org/jira/browse/AIRFLOW-6854
+        'typing_extensions; python_version>="3.8"',
+    ],
+    project_urls={
+        # airflow will embed a link this in the providers page UI
+        "project-url/documentation": "https://docs.dagster.io",
+    },
+    extras_require={
+        "kubernetes": ["kubernetes>=3.0.0", "cryptography>=2.0.0"],
+        "test": [
+            # Airflow should be provided by the end user, not us. For example, GCP Cloud
+            # Composer ships a fork of Airflow; we don't want to override it with our install.
+            # See https://github.com/dagster-io/dagster/issues/2701
+            "apache-airflow==1.10.10",
+            # https://github.com/dagster-io/dagster/issues/3858
+            "sqlalchemy>=1.0,<1.4.0",
+            "marshmallow-sqlalchemy<0.26.0",
+            "boto3==1.9.*",
+            "kubernetes==10.0.1",
+            # New WTForms release breaks the version of airflow used by tests
+            "WTForms<3.0.0",
+            # pinned based on certain incompatible versions of Jinja2, which is itself pinned
+            # by apache-airflow==1.10.10
+            "markupsafe<=2.0.1",
         ],
-        packages=find_packages(exclude=["dagster_airflow_tests*"]),
-        install_requires=[
-            f"dagster{pin}",
-            "docker",
-            "python-dateutil>=2.8.0",
-            "lazy_object_proxy",
-            # https://issues.apache.org/jira/browse/AIRFLOW-6854
-            'typing_extensions; python_version>="3.8"',
-        ],
-        project_urls={
-            # airflow will embed a link this in the providers page UI
-            "project-url/documentation": "https://docs.dagster.io",
-        },
-        extras_require={
-            "kubernetes": ["kubernetes>=3.0.0", "cryptography>=2.0.0"],
-            "test": [
-                # Airflow should be provided by the end user, not us. For example, GCP Cloud
-                # Composer ships a fork of Airflow; we don't want to override it with our install.
-                # See https://github.com/dagster-io/dagster/issues/2701
-                "apache-airflow==1.10.10",
-                # https://github.com/dagster-io/dagster/issues/3858
-                "sqlalchemy>=1.0,<1.4.0",
-                "marshmallow-sqlalchemy<0.26.0",
-                "boto3==1.9.*",
-                "kubernetes==10.0.1",
-                # New WTForms release breaks the version of airflow used by tests
-                "WTForms<3.0.0",
-                # pinned based on certain incompatible versions of Jinja2, which is itself pinned
-                # by apache-airflow==1.10.10
-                "markupsafe<=2.0.1",
-            ],
-        },
-        entry_points={
-            "console_scripts": ["dagster-airflow = dagster_airflow.cli:main"],
-            # airflow 1.0/2.0 plugin format
-            "airflow.plugins": ["dagster_airflow = dagster_airflow.__init__:DagsterAirflowPlugin"],
-            # airflow 2.0 provider format
-            "apache_airflow_provider": ["provider_info=dagster_airflow.__init__:get_provider_info"],
-        },
-    )
+    },
+    entry_points={
+        "console_scripts": ["dagster-airflow = dagster_airflow.cli:main"],
+        # airflow 1.0/2.0 plugin format
+        "airflow.plugins": ["dagster_airflow = dagster_airflow.__init__:DagsterAirflowPlugin"],
+        # airflow 2.0 provider format
+        "apache_airflow_provider": ["provider_info=dagster_airflow.__init__:get_provider_info"],
+    },
+)

--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -11,42 +11,41 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-aws",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for AWS-specific Dagster framework solid and resource components.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-aws",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-aws",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for AWS-specific Dagster framework solid and resource components.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-aws",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_aws_tests*"]),
+    include_package_data=True,
+    install_requires=[
+        "boto3",
+        f"dagster{pin}",
+        "packaging",
+        "requests",
+    ],
+    extras_require={
+        "redshift": ["psycopg2-binary"],
+        "pyspark": ["dagster-pyspark"],
+        "test": [
+            "moto>=2.2.8",
+            "requests-mock",
+            "xmltodict==0.12.0",  # pinned until moto>=3.1.9 (https://github.com/spulec/moto/issues/5112)
         ],
-        packages=find_packages(exclude=["dagster_aws_tests*"]),
-        include_package_data=True,
-        install_requires=[
-            "boto3",
-            f"dagster{pin}",
-            "packaging",
-            "requests",
-        ],
-        extras_require={
-            "redshift": ["psycopg2-binary"],
-            "pyspark": ["dagster-pyspark"],
-            "test": [
-                "moto>=2.2.8",
-                "requests-mock",
-                "xmltodict==0.12.0",  # pinned until moto>=3.1.9 (https://github.com/spulec/moto/issues/5112)
-            ],
-        },
-        zip_safe=False,
-    )
+    },
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_aws/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_aws/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-azure/setup.py
+++ b/python_modules/libraries/dagster-azure/setup.py
@@ -11,34 +11,33 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-azure",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for Azure-specific Dagster framework op and resource components.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-azure",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_azure_tests*"]),
-        include_package_data=True,
-        install_requires=[
-            "azure-core<2.0.0,>=1.7.0",
-            "azure-storage-blob<13.0.0,>=12.5.0",
-            "azure-storage-file-datalake<13.0.0,>=12.5",
-            f"dagster{pin}",
-        ],
-        entry_points={"console_scripts": ["dagster-azure = dagster_azure.cli.cli:main"]},
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-azure",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for Azure-specific Dagster framework op and resource components.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-azure",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_azure_tests*"]),
+    include_package_data=True,
+    install_requires=[
+        "azure-core<2.0.0,>=1.7.0",
+        "azure-storage-blob<13.0.0,>=12.5.0",
+        "azure-storage-file-datalake<13.0.0,>=12.5",
+        f"dagster{pin}",
+    ],
+    entry_points={"console_scripts": ["dagster-azure = dagster_azure.cli.cli:main"]},
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-azure/setup.py
+++ b/python_modules/libraries/dagster-azure/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_azure/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_azure/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-celery-docker/setup.py
+++ b/python_modules/libraries/dagster-celery-docker/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_celery_docker/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_celery_docker/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-celery-docker/setup.py
+++ b/python_modules/libraries/dagster-celery-docker/setup.py
@@ -11,31 +11,30 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-celery-docker",
-        version=ver,
-        author="Elementl",
-        license="Apache-2.0",
-        description="A Dagster integration for celery-docker",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-celery-docker",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_celery_docker_tests*"]),
-        install_requires=[
-            f"dagster{pin}",
-            f"dagster-celery{pin}",
-            f"dagster-graphql{pin}",
-            "docker",
-        ],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-celery-docker",
+    version=ver,
+    author="Elementl",
+    license="Apache-2.0",
+    description="A Dagster integration for celery-docker",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-celery-docker",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_celery_docker_tests*"]),
+    install_requires=[
+        f"dagster{pin}",
+        f"dagster-celery{pin}",
+        f"dagster-graphql{pin}",
+        "docker",
+    ],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-celery-k8s/setup.py
+++ b/python_modules/libraries/dagster-celery-k8s/setup.py
@@ -11,30 +11,29 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-celery-k8s",
-        version=ver,
-        author="Elementl",
-        license="Apache-2.0",
-        description="A Dagster integration for celery-k8s-executor",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-celery-k8s",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_celery_k8s_tests*"]),
-        install_requires=[
-            f"dagster{pin}",
-            f"dagster-k8s{pin}",
-            f"dagster-celery{pin}",
-        ],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-celery-k8s",
+    version=ver,
+    author="Elementl",
+    license="Apache-2.0",
+    description="A Dagster integration for celery-k8s-executor",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-celery-k8s",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_celery_k8s_tests*"]),
+    install_requires=[
+        f"dagster{pin}",
+        f"dagster-k8s{pin}",
+        f"dagster-celery{pin}",
+    ],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-celery-k8s/setup.py
+++ b/python_modules/libraries/dagster-celery-k8s/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_celery_k8s/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_celery_k8s/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-celery/setup.py
+++ b/python_modules/libraries/dagster-celery/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_celery/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_celery/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-celery/setup.py
+++ b/python_modules/libraries/dagster-celery/setup.py
@@ -11,39 +11,38 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-celery",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for using Celery as Dagster's execution engine.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-celery",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_celery_tests*"]),
-        entry_points={"console_scripts": ["dagster-celery = dagster_celery.cli:main"]},
-        install_requires=[
-            f"dagster{pin}",
-            "celery>=4.3.0",
-            "click>=5.0,<9.0",
-            "importlib_metadata<5.0.0; python_version<'3.8'",  # https://github.com/celery/celery/issues/7783
-        ],
-        extras_require={
-            "flower": ["flower"],
-            "redis": ["redis"],
-            "kubernetes": ["kubernetes"],
-            "test": ["docker"],
-        },
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-celery",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for using Celery as Dagster's execution engine.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-celery",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_celery_tests*"]),
+    entry_points={"console_scripts": ["dagster-celery = dagster_celery.cli:main"]},
+    install_requires=[
+        f"dagster{pin}",
+        "celery>=4.3.0",
+        "click>=5.0,<9.0",
+        "importlib_metadata<5.0.0; python_version<'3.8'",  # https://github.com/celery/celery/issues/7783
+    ],
+    extras_require={
+        "flower": ["flower"],
+        "redis": ["redis"],
+        "kubernetes": ["kubernetes"],
+        "test": ["docker"],
+    },
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-census/setup.py
+++ b/python_modules/libraries/dagster-census/setup.py
@@ -11,27 +11,26 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-census",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for integrating Census with Dagster.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-census",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_census_tests*"]),
-        install_requires=[f"dagster{pin}"],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-census",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for integrating Census with Dagster.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-census",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_census_tests*"]),
+    install_requires=[f"dagster{pin}"],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-census/setup.py
+++ b/python_modules/libraries/dagster-census/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_census/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_census/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-dask/setup.py
+++ b/python_modules/libraries/dagster-dask/setup.py
@@ -11,39 +11,38 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-dask",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for using Dask as Dagster's execution engine.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-dask",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_dask_tests*"]),
-        install_requires=[
-            "bokeh",
-            f"dagster{pin}",
-            "dask[dataframe]>=1.2.2",
-            "distributed>=1.28.1",
-        ],
-        extras_require={
-            "yarn": ["dask-yarn"],
-            "pbs": ["dask-jobqueue"],
-            "kube": ["dask-kubernetes<=2022.9.0"],
-            # we need `pyarrow` for testing read/write parquet files.
-            "test": ["pyarrow"],
-        },
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-dask",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for using Dask as Dagster's execution engine.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-dask",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_dask_tests*"]),
+    install_requires=[
+        "bokeh",
+        f"dagster{pin}",
+        "dask[dataframe]>=1.2.2",
+        "distributed>=1.28.1",
+    ],
+    extras_require={
+        "yarn": ["dask-yarn"],
+        "pbs": ["dask-jobqueue"],
+        "kube": ["dask-kubernetes<=2022.9.0"],
+        # we need `pyarrow` for testing read/write parquet files.
+        "test": ["pyarrow"],
+    },
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-dask/setup.py
+++ b/python_modules/libraries/dagster-dask/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_dask/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_dask/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-databricks/setup.py
+++ b/python_modules/libraries/dagster-databricks/setup.py
@@ -11,32 +11,31 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-databricks",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for Databricks-specific Dagster framework solid and resource components.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-databricks",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_databricks_tests*"]),
-        include_package_data=True,
-        install_requires=[
-            f"dagster{pin}",
-            f"dagster-pyspark{pin}",
-            "databricks_api",
-        ],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-databricks",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for Databricks-specific Dagster framework solid and resource components.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-databricks",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_databricks_tests*"]),
+    include_package_data=True,
+    install_requires=[
+        f"dagster{pin}",
+        f"dagster-pyspark{pin}",
+        "databricks_api",
+    ],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-databricks/setup.py
+++ b/python_modules/libraries/dagster-databricks/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_databricks/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_databricks/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-datadog/setup.py
+++ b/python_modules/libraries/dagster-datadog/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_datadog/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_datadog/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-datadog/setup.py
+++ b/python_modules/libraries/dagster-datadog/setup.py
@@ -11,27 +11,26 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-datadog",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for datadog Dagster framework components.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-datadog",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_datadog_tests*"]),
-        install_requires=[f"dagster{pin}", "datadog"],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-datadog",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for datadog Dagster framework components.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-datadog",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_datadog_tests*"]),
+    install_requires=[f"dagster{pin}", "datadog"],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-datahub/setup.py
+++ b/python_modules/libraries/dagster-datahub/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_datahub/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_datahub/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-datahub/setup.py
+++ b/python_modules/libraries/dagster-datahub/setup.py
@@ -11,34 +11,33 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-datahub",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for Datahub-specific Dagster framework solid and resource components.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-datahub",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_datahub_tests*"]),
-        include_package_data=True,
-        install_requires=[
-            "acryl-datahub[datahub-rest, datahub-kafka]<0.8.41.2",
-            f"dagster{pin}",
-            "packaging",
-            "requests",
-        ],
-        extras_require={},
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-datahub",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for Datahub-specific Dagster framework solid and resource components.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-datahub",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_datahub_tests*"]),
+    include_package_data=True,
+    install_requires=[
+        "acryl-datahub[datahub-rest, datahub-kafka]<0.8.41.2",
+        f"dagster{pin}",
+        "packaging",
+        "requests",
+    ],
+    extras_require={},
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_dbt/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_dbt/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -11,41 +11,40 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-dbt",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="A Dagster integration for dbt",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-dbt",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_dbt_tests*"]),
-        install_requires=[
-            f"dagster{pin}",
-            "dbt-core",
-            "requests",
-            "attrs",
-            "agate",
-        ],
-        extras_require={
-            "test": [
-                "Jinja2",
-                "dbt-rpc",
-                "dbt-postgres",
-                "matplotlib",
-            ]
-        },
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-dbt",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="A Dagster integration for dbt",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-dbt",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_dbt_tests*"]),
+    install_requires=[
+        f"dagster{pin}",
+        "dbt-core",
+        "requests",
+        "attrs",
+        "agate",
+    ],
+    extras_require={
+        "test": [
+            "Jinja2",
+            "dbt-rpc",
+            "dbt-postgres",
+            "matplotlib",
+        ]
+    },
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-docker/setup.py
+++ b/python_modules/libraries/dagster-docker/setup.py
@@ -11,27 +11,26 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-docker",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="A Dagster integration for docker",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-docker",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_docker_tests*"]),
-        install_requires=[f"dagster{pin}", "docker", "docker-image-py"],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-docker",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="A Dagster integration for docker",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-docker",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_docker_tests*"]),
+    install_requires=[f"dagster{pin}", "docker", "docker-image-py"],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-docker/setup.py
+++ b/python_modules/libraries/dagster-docker/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_docker/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_docker/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-fivetran/setup.py
+++ b/python_modules/libraries/dagster-fivetran/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_fivetran/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_fivetran/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-fivetran/setup.py
+++ b/python_modules/libraries/dagster-fivetran/setup.py
@@ -11,27 +11,26 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-fivetran",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for integrating Fivetran with Dagster.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-fivetran",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_fivetran_tests*"]),
-        install_requires=[f"dagster{pin}"],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-fivetran",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for integrating Fivetran with Dagster.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-fivetran",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_fivetran_tests*"]),
+    install_requires=[f"dagster{pin}"],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-gcp/setup.py
+++ b/python_modules/libraries/dagster-gcp/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_gcp/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_gcp/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-gcp/setup.py
+++ b/python_modules/libraries/dagster-gcp/setup.py
@@ -11,38 +11,37 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-gcp",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for GCP-specific Dagster framework op and resource components.",
-        # pylint: disable=line-too-long
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-gcp",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_gcp_tests*"]),
-        install_requires=[
-            f"dagster{pin}",
-            f"dagster_pandas{pin}",
-            "db-dtypes",  # Required as per https://github.com/googleapis/python-bigquery/issues/1188
-            "google-api-python-client",
-            "google-cloud-bigquery",
-            "google-cloud-storage",
-            "oauth2client",
-        ],
-        # we need `pyarrow` for testing read/write parquet files.
-        extras_require={"pyarrow": ["pyarrow"]},
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-gcp",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for GCP-specific Dagster framework op and resource components.",
+    # pylint: disable=line-too-long
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-gcp",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_gcp_tests*"]),
+    install_requires=[
+        f"dagster{pin}",
+        f"dagster_pandas{pin}",
+        "db-dtypes",  # Required as per https://github.com/googleapis/python-bigquery/issues/1188
+        "google-api-python-client",
+        "google-cloud-bigquery",
+        "google-cloud-storage",
+        "oauth2client",
+    ],
+    # we need `pyarrow` for testing read/write parquet files.
+    extras_require={"pyarrow": ["pyarrow"]},
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-ge/setup.py
+++ b/python_modules/libraries/dagster-ge/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_ge/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_ge/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-ge/setup.py
+++ b/python_modules/libraries/dagster-ge/setup.py
@@ -11,31 +11,30 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-ge",
-        version=ver,
-        author="Elementl",
-        license="Apache-2.0",
-        description="Package for GE-specific Dagster framework op and resource components.",
-        # pylint: disable=line-too-long
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-ge",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_ge_tests*"]),
-        install_requires=[
-            f"dagster{pin}",
-            f"dagster-pandas{pin}",
-            "pandas",
-            "great_expectations >=0.11.9, !=0.12.8, !=0.13.17, !=0.13.27",
-        ],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-ge",
+    version=ver,
+    author="Elementl",
+    license="Apache-2.0",
+    description="Package for GE-specific Dagster framework op and resource components.",
+    # pylint: disable=line-too-long
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-ge",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_ge_tests*"]),
+    install_requires=[
+        f"dagster{pin}",
+        f"dagster-pandas{pin}",
+        "pandas",
+        "great_expectations >=0.11.9, !=0.12.8, !=0.13.17, !=0.13.27",
+    ],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-github/setup.py
+++ b/python_modules/libraries/dagster-github/setup.py
@@ -11,34 +11,33 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-github",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="A Github client resource for interacting with the github API with a github App",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-github",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_github_tests*"]),
-        install_requires=[
-            f"dagster{pin}",
-            # Using a Github app requires signing your own JWT :(
-            # https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/
-            "pyjwt[crypto]",
-            # No officially supported python sdk for github :(
-            "requests",
-        ],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-github",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="A Github client resource for interacting with the github API with a github App",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-github",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_github_tests*"]),
+    install_requires=[
+        f"dagster{pin}",
+        # Using a Github app requires signing your own JWT :(
+        # https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/
+        "pyjwt[crypto]",
+        # No officially supported python sdk for github :(
+        "requests",
+    ],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-github/setup.py
+++ b/python_modules/libraries/dagster-github/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_github/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_github/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-k8s/setup.py
+++ b/python_modules/libraries/dagster-k8s/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_k8s/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_k8s/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-k8s/setup.py
+++ b/python_modules/libraries/dagster-k8s/setup.py
@@ -11,27 +11,26 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-k8s",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="A Dagster integration for k8s",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-k8s",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_k8s_tests*"]),
-        install_requires=[f"dagster{pin}", "kubernetes"],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-k8s",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="A Dagster integration for k8s",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-k8s",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_k8s_tests*"]),
+    install_requires=[f"dagster{pin}", "kubernetes"],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-mlflow/setup.py
+++ b/python_modules/libraries/dagster-mlflow/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_mlflow/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_mlflow/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-mlflow/setup.py
+++ b/python_modules/libraries/dagster-mlflow/setup.py
@@ -11,28 +11,27 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    setup(
-        name="dagster-mlflow",
-        version=get_version(),
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for mlflow Dagster framework components.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-mlflow",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_mlflow_tests*"]),
-        install_requires=[
-            "dagster",
-            "mlflow<=1.26.0",  # https://github.com/mlflow/mlflow/issues/5968
-            "pandas",
-        ],
-        zip_safe=False,
-    )
+setup(
+    name="dagster-mlflow",
+    version=get_version(),
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for mlflow Dagster framework components.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-mlflow",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_mlflow_tests*"]),
+    install_requires=[
+        "dagster",
+        "mlflow<=1.26.0",  # https://github.com/mlflow/mlflow/issues/5968
+        "pandas",
+    ],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-msteams/setup.py
+++ b/python_modules/libraries/dagster-msteams/setup.py
@@ -9,27 +9,26 @@ def get_version():
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    setup(
-        name="dagster-msteams",
-        version=get_version(),
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="A Microsoft Teams client resource for posting to Microsoft Teams",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-msteams",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_msteams_tests*"]),
-        install_requires=[
-            "dagster",
-            "requests>=2,<3",
-        ],
-        zip_safe=False,
-    )
+setup(
+    name="dagster-msteams",
+    version=get_version(),
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="A Microsoft Teams client resource for posting to Microsoft Teams",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-msteams",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_msteams_tests*"]),
+    install_requires=[
+        "dagster",
+        "requests>=2,<3",
+    ],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-msteams/setup.py
+++ b/python_modules/libraries/dagster-msteams/setup.py
@@ -1,9 +1,11 @@
+from pathlib import Path
+
 from setuptools import find_packages, setup
 
 
 def get_version():
     version = {}
-    with open("dagster_msteams/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_msteams/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-mysql/setup.py
+++ b/python_modules/libraries/dagster-mysql/setup.py
@@ -1,9 +1,11 @@
+from pathlib import Path
+
 from setuptools import find_packages, setup
 
 
 def get_version():
     version = {}
-    with open("dagster_mysql/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_mysql/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-mysql/setup.py
+++ b/python_modules/libraries/dagster-mysql/setup.py
@@ -9,33 +9,32 @@ def get_version():
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-mysql",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="A Dagster integration for MySQL",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-mysql",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_mysql_tests*"]),
-        package_data={
-            "dagster-mysql": [
-                "dagster_mysql/alembic/*",
-            ]
-        },
-        include_package_data=True,
-        install_requires=[f"dagster{pin}", "mysql-connector-python"],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-mysql",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="A Dagster integration for MySQL",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-mysql",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_mysql_tests*"]),
+    package_data={
+        "dagster-mysql": [
+            "dagster_mysql/alembic/*",
+        ]
+    },
+    include_package_data=True,
+    install_requires=[f"dagster{pin}", "mysql-connector-python"],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-pagerduty/setup.py
+++ b/python_modules/libraries/dagster-pagerduty/setup.py
@@ -11,27 +11,26 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-pagerduty",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for pagerduty Dagster framework components.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-pagerduty",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_pagerduty_tests*"]),
-        install_requires=[f"dagster{pin}", "pypd"],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-pagerduty",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for pagerduty Dagster framework components.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-pagerduty",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_pagerduty_tests*"]),
+    install_requires=[f"dagster{pin}", "pypd"],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-pagerduty/setup.py
+++ b/python_modules/libraries/dagster-pagerduty/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_pagerduty/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_pagerduty/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-pandas/setup.py
+++ b/python_modules/libraries/dagster-pandas/setup.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -12,7 +13,7 @@ def long_description() -> str:
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_pandas/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_pandas/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-pandas/setup.py
+++ b/python_modules/libraries/dagster-pandas/setup.py
@@ -18,32 +18,31 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-pandas",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description=(
-            "Utilities and examples for working with pandas and dagster, an opinionated "
-            "framework for expressing data pipelines"
-        ),
-        long_description=long_description(),
-        long_description_content_type="text/markdown",
-        url="https://github.com/dagster-io/dagster",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_pandas_tests*"]),
-        include_package_data=True,
-        install_requires=[f"dagster{pin}", "pandas"],
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-pandas",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description=(
+        "Utilities and examples for working with pandas and dagster, an opinionated "
+        "framework for expressing data pipelines"
+    ),
+    long_description=long_description(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/dagster-io/dagster",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_pandas_tests*"]),
+    include_package_data=True,
+    install_requires=[f"dagster{pin}", "pandas"],
+)

--- a/python_modules/libraries/dagster-pandera/setup.py
+++ b/python_modules/libraries/dagster-pandera/setup.py
@@ -11,31 +11,30 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-pandera",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description=("Integration layer for dagster and pandera."),
-        url="https://github.com/dagster-io/dagster",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-pandera",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description=("Integration layer for dagster and pandera."),
+    url="https://github.com/dagster-io/dagster",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_pandera_tests*"]),
+    include_package_data=True,
+    install_requires=[f"dagster{pin}", "pandas", "pandera>=0.9.0"],
+    extras_require={
+        "test": [
+            "pytest",
         ],
-        packages=find_packages(exclude=["dagster_pandera_tests*"]),
-        include_package_data=True,
-        install_requires=[f"dagster{pin}", "pandas", "pandera>=0.9.0"],
-        extras_require={
-            "test": [
-                "pytest",
-            ],
-        },
-    )
+    },
+)

--- a/python_modules/libraries/dagster-pandera/setup.py
+++ b/python_modules/libraries/dagster-pandera/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_pandera/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_pandera/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=exec-used
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-papertrail/setup.py
+++ b/python_modules/libraries/dagster-papertrail/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_papertrail/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_papertrail/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-papertrail/setup.py
+++ b/python_modules/libraries/dagster-papertrail/setup.py
@@ -11,27 +11,26 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-papertrail",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for papertrail Dagster framework components.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-papertrail",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_papertrail_tests*"]),
-        install_requires=[f"dagster{pin}"],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-papertrail",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for papertrail Dagster framework components.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-papertrail",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_papertrail_tests*"]),
+    install_requires=[f"dagster{pin}"],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-postgres/setup.py
+++ b/python_modules/libraries/dagster-postgres/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_postgres/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_postgres/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-postgres/setup.py
+++ b/python_modules/libraries/dagster-postgres/setup.py
@@ -11,33 +11,32 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-postgres",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="A Dagster integration for postgres",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-postgres",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_postgres_tests*"]),
-        package_data={
-            "dagster-postgres": [
-                "dagster_postgres/alembic/*",
-            ]
-        },
-        include_package_data=True,
-        install_requires=[f"dagster{pin}", "psycopg2-binary"],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-postgres",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="A Dagster integration for postgres",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-postgres",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_postgres_tests*"]),
+    package_data={
+        "dagster-postgres": [
+            "dagster_postgres/alembic/*",
+        ]
+    },
+    include_package_data=True,
+    install_requires=[f"dagster{pin}", "psycopg2-binary"],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-prometheus/setup.py
+++ b/python_modules/libraries/dagster-prometheus/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_prometheus/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_prometheus/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-prometheus/setup.py
+++ b/python_modules/libraries/dagster-prometheus/setup.py
@@ -11,27 +11,26 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-prometheus",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="A Dagster integration for prometheus",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-prometheus",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_prometheus_tests*"]),
-        install_requires=[f"dagster{pin}", "prometheus_client"],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-prometheus",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="A Dagster integration for prometheus",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-prometheus",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_prometheus_tests*"]),
+    install_requires=[f"dagster{pin}", "prometheus_client"],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-pyspark/setup.py
+++ b/python_modules/libraries/dagster-pyspark/setup.py
@@ -11,33 +11,32 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-pyspark",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for PySpark Dagster framework components.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/dagster-framework/pyspark",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_pyspark_tests*"]),
-        install_requires=[
-            f"dagster{pin}",
-            f"dagster_spark{pin}",
-            # Pyspark 2.x is incompatible with Python 3.8+
-            'pyspark>=3.0.0; python_version >= "3.8"',
-            'pyspark>=2.0.2; python_version < "3.8"',
-        ],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-pyspark",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for PySpark Dagster framework components.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/dagster-framework/pyspark",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_pyspark_tests*"]),
+    install_requires=[
+        f"dagster{pin}",
+        f"dagster_spark{pin}",
+        # Pyspark 2.x is incompatible with Python 3.8+
+        'pyspark>=3.0.0; python_version >= "3.8"',
+        'pyspark>=2.0.2; python_version < "3.8"',
+    ],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-pyspark/setup.py
+++ b/python_modules/libraries/dagster-pyspark/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_pyspark/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_pyspark/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-shell/setup.py
+++ b/python_modules/libraries/dagster-shell/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_shell/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_shell/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-shell/setup.py
+++ b/python_modules/libraries/dagster-shell/setup.py
@@ -11,28 +11,27 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-shell",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for Dagster shell ops.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-shell",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_shell_tests*"]),
-        install_requires=[f"dagster{pin}"],
-        extras_require={"test": ["psutil"]},
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-shell",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for Dagster shell ops.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-shell",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_shell_tests*"]),
+    install_requires=[f"dagster{pin}"],
+    extras_require={"test": ["psutil"]},
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-slack/setup.py
+++ b/python_modules/libraries/dagster-slack/setup.py
@@ -9,30 +9,29 @@ def get_version():
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-slack",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="A Slack client resource for posting to Slack",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-slack",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_slack_tests*"]),
-        install_requires=[
-            f"dagster{pin}",
-            "slack_sdk",
-        ],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-slack",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="A Slack client resource for posting to Slack",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-slack",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_slack_tests*"]),
+    install_requires=[
+        f"dagster{pin}",
+        "slack_sdk",
+    ],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-slack/setup.py
+++ b/python_modules/libraries/dagster-slack/setup.py
@@ -1,9 +1,11 @@
+from pathlib import Path
+
 from setuptools import find_packages, setup
 
 
 def get_version():
     version = {}
-    with open("dagster_slack/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_slack/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-snowflake-pandas/setup.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_snowflake_pandas/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_snowflake_pandas/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-snowflake-pandas/setup.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/setup.py
@@ -11,34 +11,33 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-snowflake-pandas",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for integrating Snowflake and Pandas with Dagster.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-snowflake-pandas",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_snowflake_pandas_tests*"]),
-        install_requires=[
-            f"dagster{pin}",
-            f"dagster-snowflake{pin}",
-            "pandas",
-            "requests",
-            "snowflake-connector-python[pandas]",
-            "snowflake-sqlalchemy",
-        ],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-snowflake-pandas",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for integrating Snowflake and Pandas with Dagster.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-snowflake-pandas",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_snowflake_pandas_tests*"]),
+    install_requires=[
+        f"dagster{pin}",
+        f"dagster-snowflake{pin}",
+        "pandas",
+        "requests",
+        "snowflake-connector-python[pandas]",
+        "snowflake-sqlalchemy",
+    ],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-snowflake/setup.py
+++ b/python_modules/libraries/dagster-snowflake/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_snowflake/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_snowflake/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-snowflake/setup.py
+++ b/python_modules/libraries/dagster-snowflake/setup.py
@@ -11,30 +11,29 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-snowflake",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for Snowflake Dagster framework components.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-snowflake",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_snowflake_tests*"]),
-        install_requires=[f"dagster{pin}", "snowflake-connector-python>=2.1.0"],
-        extras_require={
-            "snowflake.sqlalchemy": ["sqlalchemy", "snowflake-sqlalchemy"],
-            "pandas": ["pandas"],
-        },
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-snowflake",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for Snowflake Dagster framework components.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-snowflake",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_snowflake_tests*"]),
+    install_requires=[f"dagster{pin}", "snowflake-connector-python>=2.1.0"],
+    extras_require={
+        "snowflake.sqlalchemy": ["sqlalchemy", "snowflake-sqlalchemy"],
+        "pandas": ["pandas"],
+    },
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-spark/setup.py
+++ b/python_modules/libraries/dagster-spark/setup.py
@@ -11,27 +11,26 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-spark",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for Spark Dagster framework components.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-spark",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_spark_tests*"]),
-        install_requires=[f"dagster{pin}"],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-spark",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for Spark Dagster framework components.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-spark",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_spark_tests*"]),
+    install_requires=[f"dagster{pin}"],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-spark/setup.py
+++ b/python_modules/libraries/dagster-spark/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_spark/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_spark/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-ssh/setup.py
+++ b/python_modules/libraries/dagster-ssh/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_ssh/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_ssh/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-ssh/setup.py
+++ b/python_modules/libraries/dagster-ssh/setup.py
@@ -11,28 +11,27 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-ssh",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="Package for ssh Dagster framework components.",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-ssh",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_ssh_tests*"]),
-        install_requires=[f"dagster{pin}", "sshtunnel", "paramiko"],
-        extras_require={"test": ["cryptography==2.6.1", "pytest-sftpserver==1.2.0"]},
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-ssh",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="Package for ssh Dagster framework components.",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-ssh",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_ssh_tests*"]),
+    install_requires=[f"dagster{pin}", "sshtunnel", "paramiko"],
+    extras_require={"test": ["cryptography==2.6.1", "pytest-sftpserver==1.2.0"]},
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagster-twilio/setup.py
+++ b/python_modules/libraries/dagster-twilio/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_twilio/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_twilio/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-twilio/setup.py
+++ b/python_modules/libraries/dagster-twilio/setup.py
@@ -11,27 +11,26 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagster-twilio",
-        version=ver,
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        description="A Dagster integration for twilio",
-        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-twilio",
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        packages=find_packages(exclude=["dagster_twilio_tests*"]),
-        install_requires=[f"dagster{pin}", "twilio"],
-        zip_safe=False,
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagster-twilio",
+    version=ver,
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    description="A Dagster integration for twilio",
+    url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-twilio",
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_packages(exclude=["dagster_twilio_tests*"]),
+    install_requires=[f"dagster{pin}", "twilio"],
+    zip_safe=False,
+)

--- a/python_modules/libraries/dagstermill/setup.py
+++ b/python_modules/libraries/dagstermill/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagstermill/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagstermill/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagstermill/setup.py
+++ b/python_modules/libraries/dagstermill/setup.py
@@ -11,50 +11,49 @@ def get_version() -> str:
     return version["__version__"]
 
 
-if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "0+dev" else f"=={ver}"
-    setup(
-        name="dagstermill",
-        version=ver,
-        description="run notebooks using the Dagster tools",
-        author="Elementl",
-        author_email="hello@elementl.com",
-        license="Apache-2.0",
-        packages=find_packages(exclude=["dagstermill_tests*"]),
-        classifiers=[
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: OS Independent",
-        ],
-        install_requires=[
-            f"dagster{pin}",
-            # ipykernel 5.4.0 and 5.4.1 broke papermill
-            # see https://github.com/dagster-io/dagster/issues/3401,
-            # https://github.com/nteract/papermill/issues/519,
-            # https://github.com/ipython/ipykernel/issues/568
-            "ipykernel>=4.9.0,!=5.4.0,!=5.4.1",
-            # See: https://github.com/mu-editor/mu/pull/1844
-            # ipykernel<6 depends on ipython_genutils, but it isn't explicitly
-            # declared as a dependency. It also depends on traitlets, which
-            # incidentally brought ipython_genutils, but in v5.1 it was dropped, so as
-            # a workaround we need to manually specify it here
-            "ipython_genutils>=0.2.0",
-            "packaging>=20.5",
-            "papermill>=1.0.0",
-            "scrapbook>=0.5.0",
-        ],
-        extras_require={
-            "test": [
-                "matplotlib",
-                "nbconvert",
-                "scikit-learn>=0.19.0",
-                "tqdm<=4.48",  # https://github.com/tqdm/tqdm/issues/1049
-            ]
-        },
-        entry_points={"console_scripts": ["dagstermill = dagstermill.cli:main"]},
-    )
+ver = get_version()
+# dont pin dev installs to avoid pip dep resolver issues
+pin = "" if ver == "0+dev" else f"=={ver}"
+setup(
+    name="dagstermill",
+    version=ver,
+    description="run notebooks using the Dagster tools",
+    author="Elementl",
+    author_email="hello@elementl.com",
+    license="Apache-2.0",
+    packages=find_packages(exclude=["dagstermill_tests*"]),
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    install_requires=[
+        f"dagster{pin}",
+        # ipykernel 5.4.0 and 5.4.1 broke papermill
+        # see https://github.com/dagster-io/dagster/issues/3401,
+        # https://github.com/nteract/papermill/issues/519,
+        # https://github.com/ipython/ipykernel/issues/568
+        "ipykernel>=4.9.0,!=5.4.0,!=5.4.1",
+        # See: https://github.com/mu-editor/mu/pull/1844
+        # ipykernel<6 depends on ipython_genutils, but it isn't explicitly
+        # declared as a dependency. It also depends on traitlets, which
+        # incidentally brought ipython_genutils, but in v5.1 it was dropped, so as
+        # a workaround we need to manually specify it here
+        "ipython_genutils>=0.2.0",
+        "packaging>=20.5",
+        "papermill>=1.0.0",
+        "scrapbook>=0.5.0",
+    ],
+    extras_require={
+        "test": [
+            "matplotlib",
+            "nbconvert",
+            "scikit-learn>=0.19.0",
+            "tqdm<=4.48",  # https://github.com/tqdm/tqdm/issues/1049
+        ]
+    },
+    entry_points={"console_scripts": ["dagstermill = dagstermill.cli:main"]},
+)


### PR DESCRIPTION
To limit each build's scope, we want to begin only running tests
affected by the change.

We can assume a package's tests need to run if:

- The package's tests change
- The package changes
- Any of the package's dependencies change (package code only - not
  their tests)

This change modifies PackageSpec to parse each package's setup.py file.
Using a combination of a git diff and the distribution's
`install_requires` and `extras_require` attributes, we should be able to
pinpoint the exact packages that are affected by each change.

`distutils.core.run_setup` does the heavy lifting here:

https://docs.python.org/3/distutils/apiref.html#distutils.core.run_setup

> Run a setup script in a somewhat controlled environment, and return
> the distutils.dist.Distribution instance that drives things. This is
> useful if you need to find out the distribution meta-data (passed as
> keyword args from script to setup()), or the contents of the config
> files or command-line.

A build tool like pants can do a lot of the heavy lifting of this exercise
for us, but we want to explore how far we can get without introducing
a new framework first.

This only exposes the metadata we'll need; subsequent PRs will work
on implementing the behavioral changes we want.