### PR TITLE
[dagster-airbyte] require port in the config

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -217,7 +217,7 @@ class AirbyteResource:
         ),
         "port": Field(
             StringSource,
-            is_required=False,
+            is_required=True,
             description="Port for the Airbyte Server.",
         ),
         "use_https": Field(


### PR DESCRIPTION
### Summary & Motivation

If you don't supply it, we'll error when constructing the class, so it should be required.

### How I Tested These Changes
