### PR TITLE
Fix loading head texture in subroutes on docs site

### DIFF
--- a/docs/next/layouts/MainLayout.tsx
+++ b/docs/next/layouts/MainLayout.tsx
@@ -17,7 +17,7 @@ const Layout: React.FC = ({children}) => {
       <div
         style={{
           minHeight: '100vh',
-          backgroundImage: 'url("_next/image?url=/assets/head-texture.jpg&w=3840&q=100")',
+          backgroundImage: 'url("/_next/image?url=/assets/head-texture.jpg&w=3840&q=100")',
           backgroundRepeat: 'no-repeat',
           backgroundPosition: 'top middle',
           backgroundSize: 'fit',


### PR DESCRIPTION
### Summary & Motivation
Missing head texture if we load a subroute directly (eg: load https://docs.dagster.io/concepts/assets/multi-assets directly and notice the top texture is missing, but load https://docs.dagster.io/ and then manually navigate to the same route and you can see the texture shows up correctly.)

### How I Tested These Changes

<img width="2056" alt="Screen Shot 2022-10-05 at 1 41 38 PM" src="https://user-images.githubusercontent.com/2286579/194126126-01c5f42c-e0a6-47e7-a11d-2c6f4693ab9b.png">



vercel preview