### PR TITLE
Only add buildkite steps for affected changes

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -275,3 +275,13 @@ class PackageSpec(
             return run_setup(Path(self.directory) / "setup.py")
         else:
             return Distribution()
+
+    @property
+    def requirements(self):
+        extras = [
+            requirement
+            for requirements in self.distribution.extras_require.values()
+            for requirement in requirements
+        ]
+        install = self.distribution.install_requires
+        return extras + install

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -1,5 +1,6 @@
 import os
 from glob import glob
+from pathlib import Path
 from typing import List, Optional
 
 from dagster_buildkite.defines import GCP_CREDS_LOCAL_FILE, GIT_REPO_ROOT
@@ -12,7 +13,9 @@ from dagster_buildkite.steps.test_project import (
 from dagster_buildkite.utils import (
     BuildkiteStep,
     connect_sibling_docker_container,
+    get_changed_files,
     network_buildkite_container,
+    safe_getenv,
 )
 
 
@@ -56,13 +59,61 @@ def build_dagit_screenshot_steps() -> List[BuildkiteStep]:
 
 
 def _build_steps_from_package_specs(package_specs: List[PackageSpec]) -> List[BuildkiteStep]:
+    changed_files = get_changed_files()
+
     steps: List[BuildkiteStep] = []
     all_packages = sorted(
         package_specs,
         key=lambda p: f"{_PACKAGE_TYPE_ORDER.index(p.package_type)} {p.name}",
     )
+
+    packages_with_changes = [
+        package
+        for package in all_packages
+        if any(
+            path
+            for path in changed_files
+            # A file in our git diff exists in the package directory
+            if path in Path(package.directory).rglob("*")
+            # The file can alter behavior - exclude things like README changes
+            and path.suffix in [".py", ".cfg", ".toml"]
+            # The file is not part of a test
+            and not any(part.endswith("tests") for part in path.parts)
+        )
+    ]
+
+    packages_with_changed_tests = [
+        package
+        for package in all_packages
+        if any(
+            path
+            for path in changed_files
+            # A file in our git diff exists in the package directory
+            if path in Path(package.directory).rglob("*")
+            # The file can alter behavior - exclude things like README changes
+            and path.suffix in [".py", ".cfg", ".toml"]
+            # The file is part of a test
+            and any(part.endswith("tests") for part in path.parts)
+        )
+    ]
+
     for pkg in all_packages:
-        steps += pkg.build_steps()
+        if (
+            # On all pushes to main
+            safe_getenv("BUILDKITE_BRANCH") == "master"
+            # Or if any of the package's tests change
+            or pkg in packages_with_changed_tests
+            # Or if any of the package's implemention changes
+            or pkg in packages_with_changes
+            # Or if the package requires any package which implementation has changed
+            or any(
+                requirement in [package.name for package in packages_with_changes]
+                for requirement in pkg.requirements
+            )
+        ):
+            print(pkg.name)
+            steps += pkg.build_steps()
+
     return steps
 
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -111,7 +111,6 @@ def _build_steps_from_package_specs(package_specs: List[PackageSpec]) -> List[Bu
                 for requirement in pkg.requirements
             )
         ):
-            print(pkg.name)
             steps += pkg.build_steps()
 
     return steps

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 import packaging.version
@@ -176,3 +177,13 @@ def parse_package_version(version_str: str) -> packaging.version.Version:
         parsed_version, packaging.version.Version
     ), f"Found LegacyVersion: {version_str}"
     return parsed_version
+
+
+def get_changed_files():
+    paths = (
+        subprocess.check_output(["git", "diff", "origin/master...HEAD", "--name-only"])
+        .decode("utf-8")
+        .strip()
+        .split("\n")
+    )
+    return [Path(path) for path in paths]

--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -6,7 +5,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open(Path(__file__).parent / "dagster_airflow/version.py", encoding="utf8") as fp:
+    with open("dagster_airflow/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-dask/setup.py
+++ b/python_modules/libraries/dagster-dask/setup.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -6,7 +5,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open(Path(__file__).parent / "dagster_dask/version.py", encoding="utf8") as fp:
+    with open("dagster_dask/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -6,7 +5,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open(Path(__file__).parent / "dagster_dbt/version.py", encoding="utf8") as fp:
+    with open("dagster_dbt/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-gcp/setup.py
+++ b/python_modules/libraries/dagster-gcp/setup.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -6,7 +5,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open(Path(__file__).parent / "dagster_gcp/version.py", encoding="utf8") as fp:
+    with open("dagster_gcp/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]


### PR DESCRIPTION
This will benefit from some refactoring once I play around with it a bit
more.

We're still going to see a lot of tests run on a lot of PRs because
almost everything requires dagster.

Right now, this doesn't build the steps at all. We might also want to
experiment with somehow marking the steps as skipped so it's obvious
what did and didn't run on a PR.