### PR TITLE
Fix #5737

### DIFF
--- a/python_modules/libraries/dagstermill/dagstermill/translator.py
+++ b/python_modules/libraries/dagstermill/dagstermill/translator.py
@@ -30,7 +30,8 @@ context = __dm_dagstermill._reconstitute_pipeline_context(
 
 class DagsterTranslator(papermill.translators.PythonTranslator):
     @classmethod
-    def codify(cls, parameters):  # pylint: disable=arguments-differ
+    def codify(cls, parameters, comment=None):
+        # comment is not used but is a required argument on newer versions of papermill
         assert "__dm_context" in parameters
         assert "__dm_executable_dict" in parameters
         assert "__dm_pipeline_run_dict" in parameters


### PR DESCRIPTION
### Summary & Motivation

When developing https://github.com/noteable-io/papermill-origami we ran into the same issue as described in #5737.
We fixed the issue by creating our own implementation of the `DagsterTranslator` https://github.com/noteable-io/papermill-origami/blob/main/papermill_origami/noteable_dagstermill/translator.py#L38

### How I Tested These Changes
Our own implementation https://github.com/noteable-io/papermill-origami/blob/main/papermill_origami/noteable_dagstermill/translator.py#L38 works and by having this change upstream we won't need to maintain our own implementation.