### PR TITLE
[dagit] Create Overview root

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
@@ -24,16 +24,25 @@ export const AppTopNav: React.FC<Props> = ({children, rightOfSearchBar, searchPl
   const {flagNewWorkspace} = useFeatureFlags();
 
   const navLinks = () => {
-    const runHref = flagNewWorkspace ? '/instance/runs/timeline' : '/instance/runs';
+    const overviewItem = flagNewWorkspace ? (
+      <ShortcutHandler
+        key="overview"
+        onShortcut={() => history.push('/overview')}
+        shortcutLabel="⌥1"
+        shortcutFilter={(e) => e.code === 'Digit1' && e.altKey}
+      >
+        <TopNavLink to="/overview" data-cy="AppTopNav_StatusLink">
+          Overview
+        </TopNavLink>
+      </ShortcutHandler>
+    ) : null;
 
     const deploymentItem = (
       <ShortcutHandler
         key="deployment"
         onShortcut={() => history.push('/instance')}
-        shortcutLabel={flagNewWorkspace ? '⌥4' : '⌥3'}
-        shortcutFilter={(e) =>
-          flagNewWorkspace ? e.code === 'Digit4' && e.altKey : e.code === 'Digit3' && e.altKey
-        }
+        shortcutLabel={flagNewWorkspace ? '⌥5' : '⌥3'}
+        shortcutFilter={(e) => e.altKey && e.code === (flagNewWorkspace ? 'Digit5' : 'Digit3')}
       >
         <TopNavLink
           to="/instance"
@@ -59,10 +68,8 @@ export const AppTopNav: React.FC<Props> = ({children, rightOfSearchBar, searchPl
       <ShortcutHandler
         key="workspace"
         onShortcut={() => history.push('/workspace')}
-        shortcutLabel={flagNewWorkspace ? '⌥3' : '⌥4'}
-        shortcutFilter={(e) =>
-          flagNewWorkspace ? e.code === 'Digit3' && e.altKey : e.code === 'Digit4' && e.altKey
-        }
+        shortcutLabel="⌥4"
+        shortcutFilter={(e) => e.code === 'Digit4' && e.altKey}
       >
         <TopNavLink to="/workspace" data-cy="AppTopNav_WorkspaceLink">
           <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
@@ -75,19 +82,20 @@ export const AppTopNav: React.FC<Props> = ({children, rightOfSearchBar, searchPl
 
     return (
       <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
+        {flagNewWorkspace ? overviewItem : null}
         <ShortcutHandler
-          onShortcut={() => history.push(runHref)}
-          shortcutLabel="⌥1"
-          shortcutFilter={(e) => e.code === 'Digit1' && e.altKey}
+          onShortcut={() => history.push('/instance/runs')}
+          shortcutLabel={flagNewWorkspace ? '⌥2' : '⌥1'}
+          shortcutFilter={(e) => e.altKey && e.code === (flagNewWorkspace ? 'Digit2' : 'Digit1')}
         >
-          <TopNavLink to={runHref} data-cy="AppTopNav_RunsLink">
+          <TopNavLink to="/instance/runs" data-cy="AppTopNav_RunsLink">
             Runs
           </TopNavLink>
         </ShortcutHandler>
         <ShortcutHandler
           onShortcut={() => history.push('/instance/assets')}
-          shortcutLabel="⌥2"
-          shortcutFilter={(e) => e.code === 'Digit2' && e.altKey}
+          shortcutLabel={flagNewWorkspace ? '⌥3' : '⌥2'}
+          shortcutFilter={(e) => e.altKey && e.code === (flagNewWorkspace ? 'Digit3' : 'Digit2')}
         >
           <TopNavLink to="/instance/assets" data-cy="AppTopNav_AssetsLink" exact={false}>
             Assets

--- a/js_modules/dagit/packages/core/src/app/ContentRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/ContentRoot.tsx
@@ -4,6 +4,7 @@ import {Route, Switch} from 'react-router-dom';
 const InstanceRoot = React.lazy(() => import('../instance/InstanceRoot'));
 const UserSettingsRoot = React.lazy(() => import('./UserSettingsRoot'));
 const WorkspaceRoot = React.lazy(() => import('../workspace/WorkspaceRoot'));
+const OverviewRoot = React.lazy(() => import('../overview/OverviewRoot'));
 const FallthroughRoot = React.lazy(() => import('./FallthroughRoot'));
 
 export const ContentRoot = React.memo(() => (
@@ -21,6 +22,11 @@ export const ContentRoot = React.memo(() => (
     <Route path="/settings">
       <React.Suspense fallback={<div />}>
         <UserSettingsRoot />
+      </React.Suspense>
+    </Route>
+    <Route path="/overview">
+      <React.Suspense fallback={<div />}>
+        <OverviewRoot />
       </React.Suspense>
     </Route>
     <Route path="*">

--- a/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
@@ -92,7 +92,7 @@ const FinalRedirectOrLoadingRoot = () => {
 
   // If we have more than one repo with a job, route to the instance overview
   if (reposWithVisibleJobs.length > 0) {
-    return <Redirect to={flagNewWorkspace ? '/instance/runs/timeline' : '/instance'} />;
+    return <Redirect to={flagNewWorkspace ? '/overview' : '/instance'} />;
   }
 
   const repoWithNoJob = allRepos[0];

--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -14,7 +14,7 @@ import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
-import {RunListTabs} from '../runs/RunListTabs';
+import {OverviewTabs} from '../overview/OverviewTabs';
 import {useCursorPaginatedQuery} from '../runs/useCursorPaginatedQuery';
 import {Loading} from '../ui/Loading';
 
@@ -59,10 +59,10 @@ export const InstanceBackfills = () => {
   return (
     <>
       <PageHeader
-        title={<Heading>{flagNewWorkspace ? 'Runs' : pageTitle}</Heading>}
+        title={<Heading>{flagNewWorkspace ? 'Overview' : pageTitle}</Heading>}
         tabs={
           flagNewWorkspace ? (
-            <RunListTabs />
+            <OverviewTabs tab="backfills" refreshState={refreshState} />
           ) : (
             <InstanceTabs tab="backfills" refreshState={refreshState} />
           )

--- a/js_modules/dagit/packages/core/src/instance/InstanceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceRoot.tsx
@@ -6,7 +6,6 @@ import {useFeatureFlags} from '../app/Flags';
 import {AssetsCatalogRoot} from '../assets/AssetsCatalogRoot';
 import {AssetsGroupsGlobalGraphRoot} from '../assets/AssetsGroupsGlobalGraphRoot';
 import {RunRoot} from '../runs/RunRoot';
-import {RunTimelineRoot} from '../runs/RunTimelineRoot';
 import {RunsRoot} from '../runs/RunsRoot';
 import {ScheduledRunListRoot} from '../runs/ScheduledRunListRoot';
 import {SnapshotRoot} from '../snapshots/SnapshotRoot';
@@ -34,11 +33,6 @@ export const InstanceRoot = () => {
         <Route path="/instance/runs" exact>
           <RunsRoot />
         </Route>
-        {flagNewWorkspace ? (
-          <Route path="/instance/runs/timeline" exact>
-            <RunTimelineRoot />
-          </Route>
-        ) : null}
         <Route path="/instance/runs/scheduled" exact>
           <ScheduledRunListRoot />
         </Route>

--- a/js_modules/dagit/packages/core/src/instance/InstanceSchedules.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceSchedules.tsx
@@ -2,11 +2,13 @@ import {gql, useQuery} from '@apollo/client';
 import {Box, Colors, Group, NonIdealState, PageHeader, Heading, Subheading} from '@dagster-io/ui';
 import * as React from 'react';
 
+import {useFeatureFlags} from '../app/Flags';
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {INSTIGATION_STATE_FRAGMENT} from '../instigation/InstigationUtils';
 import {UnloadableSchedules} from '../instigation/Unloadable';
+import {OverviewTabs} from '../overview/OverviewTabs';
 import {SCHEDULE_FRAGMENT} from '../schedules/ScheduleUtils';
 import {SchedulerInfo} from '../schedules/SchedulerInfo';
 import {SchedulesTable} from '../schedules/SchedulesTable';
@@ -22,6 +24,7 @@ import {InstanceSchedulesQuery} from './types/InstanceSchedulesQuery';
 
 export const InstanceSchedules = React.memo(() => {
   useTrackPageView();
+  const {flagNewWorkspace} = useFeatureFlags();
 
   const {pageTitle} = React.useContext(InstancePageContext);
   const queryData = useQuery<InstanceSchedulesQuery>(INSTANCE_SCHEDULES_QUERY, {
@@ -33,8 +36,14 @@ export const InstanceSchedules = React.memo(() => {
   return (
     <>
       <PageHeader
-        title={<Heading>{pageTitle}</Heading>}
-        tabs={<InstanceTabs tab="schedules" refreshState={refreshState} />}
+        title={<Heading>{flagNewWorkspace ? 'Overview' : pageTitle}</Heading>}
+        tabs={
+          flagNewWorkspace ? (
+            <OverviewTabs tab="schedules" />
+          ) : (
+            <InstanceTabs tab="schedules" refreshState={refreshState} />
+          )
+        }
       />
       <Loading queryResult={queryData} allowStaleData={true}>
         {(data) => <AllSchedules data={data} />}

--- a/js_modules/dagit/packages/core/src/instance/InstanceSensors.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceSensors.tsx
@@ -2,11 +2,13 @@ import {gql, useQuery} from '@apollo/client';
 import {Box, Colors, NonIdealState, PageHeader, Heading, Subheading} from '@dagster-io/ui';
 import * as React from 'react';
 
+import {useFeatureFlags} from '../app/Flags';
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {INSTIGATION_STATE_FRAGMENT} from '../instigation/InstigationUtils';
 import {UnloadableSensors} from '../instigation/Unloadable';
+import {OverviewTabs} from '../overview/OverviewTabs';
 import {SENSOR_FRAGMENT} from '../sensors/SensorFragment';
 import {SensorInfo} from '../sensors/SensorInfo';
 import {SensorsTable} from '../sensors/SensorsTable';
@@ -21,6 +23,7 @@ import {InstanceSensorsQuery} from './types/InstanceSensorsQuery';
 
 export const InstanceSensors = React.memo(() => {
   useTrackPageView();
+  const {flagNewWorkspace} = useFeatureFlags();
 
   const {pageTitle} = React.useContext(InstancePageContext);
   const queryData = useQuery<InstanceSensorsQuery>(INSTANCE_SENSORS_QUERY, {
@@ -32,8 +35,14 @@ export const InstanceSensors = React.memo(() => {
   return (
     <>
       <PageHeader
-        title={<Heading>{pageTitle}</Heading>}
-        tabs={<InstanceTabs tab="sensors" refreshState={refreshState} />}
+        title={<Heading>{flagNewWorkspace ? 'Overview' : pageTitle}</Heading>}
+        tabs={
+          flagNewWorkspace ? (
+            <OverviewTabs tab="sensors" />
+          ) : (
+            <InstanceTabs tab="sensors" refreshState={refreshState} />
+          )
+        }
       />
       <Loading queryResult={queryData} allowStaleData={true}>
         {(data) => <AllSensors data={data} />}

--- a/js_modules/dagit/packages/core/src/overview/OverviewRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewRoot.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import {Redirect, Route, Switch} from 'react-router-dom';
+
+import {useFeatureFlags} from '../app/Flags';
+import {InstanceBackfills} from '../instance/InstanceBackfills';
+import {InstanceSchedules} from '../instance/InstanceSchedules';
+import {InstanceSensors} from '../instance/InstanceSensors';
+
+import {OverviewTimelineRoot} from './OverviewTimelineRoot';
+
+export const OverviewRoot = () => {
+  const {flagNewWorkspace} = useFeatureFlags();
+
+  if (!flagNewWorkspace) {
+    return <Redirect to="/instance/overview" />;
+  }
+
+  return (
+    <Switch>
+      <Route path="/overview/timeline">
+        <OverviewTimelineRoot />
+      </Route>
+      <Route path="/overview/schedules">
+        <InstanceSchedules />
+      </Route>
+      <Route path="/overview/sensors">
+        <InstanceSensors />
+      </Route>
+      <Route path="/overview/backfills">
+        <InstanceBackfills />
+      </Route>
+      <Route path="*" render={() => <Redirect to="/overview/timeline" />} />
+    </Switch>
+  );
+};
+
+// Imported via React.lazy, which requires a default export.
+// eslint-disable-next-line import/no-default-export
+export default OverviewRoot;

--- a/js_modules/dagit/packages/core/src/overview/OverviewTabs.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewTabs.tsx
@@ -1,0 +1,32 @@
+import {QueryResult} from '@apollo/client';
+import {Box, Tabs} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
+import {TabLink} from '../ui/TabLink';
+
+interface Props<TData> {
+  refreshState?: QueryRefreshState;
+  queryData?: QueryResult<TData, any>;
+  tab: string;
+}
+
+export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TData>) => {
+  const {refreshState, tab} = props;
+  return (
+    <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
+      <Tabs selectedTabId={tab}>
+        <TabLink id="timeline" title="Timeline" to="/overview/timeline" />
+        {/* <TabLink id="jobs" title="Jobs" to="/overview/jobs" /> */}
+        <TabLink id="schedules" title="Schedules" to="/overview/schedules" />
+        <TabLink id="sensors" title="Sensors" to="/overview/sensors" />
+        <TabLink id="backfills" title="Backfills" to="/overview/backfills" />
+      </Tabs>
+      {refreshState ? (
+        <Box padding={{bottom: 8}}>
+          <QueryRefreshCountdown refreshState={refreshState} />
+        </Box>
+      ) : null}
+    </Box>
+  );
+};

--- a/js_modules/dagit/packages/core/src/overview/OverviewTimelineRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewTimelineRoot.tsx
@@ -1,16 +1,16 @@
-import {Page, PageHeader, Heading, Box, TextInput, ButtonGroup, Button} from '@dagster-io/ui';
+import {Page, PageHeader, Heading, Box, TextInput, Button, ButtonGroup} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {RepoFilterButton} from '../instance/RepoFilterButton';
+import {QueryfulRunTimeline} from '../runs/QueryfulRunTimeline';
+import {useHourWindow, HourWindow} from '../runs/useHourWindow';
+import {makeJobKey} from '../runs/useRunsForTimeline';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
-import {QueryfulRunTimeline} from './QueryfulRunTimeline';
-import {RunListTabs} from './RunListTabs';
-import {HourWindow, useHourWindow} from './useHourWindow';
-import {makeJobKey} from './useRunsForTimeline';
+import {OverviewTabs} from './OverviewTabs';
 
 const LOOKAHEAD_HOURS = 1;
 const ONE_HOUR = 60 * 60 * 1000;
@@ -29,7 +29,7 @@ const hourWindowToOffset = (hourWindow: HourWindow) => {
   }
 };
 
-export const RunTimelineRoot = () => {
+export const OverviewTimelineRoot = () => {
   useTrackPageView();
   useDocumentTitle('Runs');
 
@@ -84,7 +84,7 @@ export const RunTimelineRoot = () => {
 
   return (
     <Page>
-      <PageHeader title={<Heading>Runs</Heading>} tabs={<RunListTabs />} />
+      <PageHeader title={<Heading>Overview</Heading>} tabs={<OverviewTabs tab="timeline" />} />
       <Box
         padding={{horizontal: 24, vertical: 16}}
         flex={{alignItems: 'center', justifyContent: 'space-between'}}

--- a/js_modules/dagit/packages/core/src/runs/RunListTabs.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunListTabs.tsx
@@ -4,7 +4,6 @@ import isEqual from 'lodash/isEqual';
 import * as React from 'react';
 import {useLocation} from 'react-router-dom';
 
-import {useFeatureFlags} from '../app/Flags';
 import {RunStatus} from '../types/globalTypes';
 import {TabLink} from '../ui/TabLink';
 
@@ -17,7 +16,6 @@ import {
 import {RunTabsCountQuery, RunTabsCountQueryVariables} from './types/RunTabsCountQuery';
 
 export const RunListTabs = React.memo(() => {
-  const {flagNewWorkspace} = useFeatureFlags();
   const [filterTokens] = useQueryPersistedRunFilters();
   const runsFilter = runsFilterForSearchTokens(filterTokens);
 
@@ -45,9 +43,6 @@ export const RunListTabs = React.memo(() => {
 
   return (
     <Tabs selectedTabId={selectedTab} id="run-tabs">
-      {flagNewWorkspace ? (
-        <TabLink title="Timeline" to="/instance/runs/timeline" id="timeline" />
-      ) : null}
       <TabLink title="All runs" to={urlForStatus([])} id="all" />
       <TabLink
         title="Queued"
@@ -63,9 +58,6 @@ export const RunListTabs = React.memo(() => {
       />
       <TabLink title="Done" to={urlForStatus(Array.from(doneStatuses))} id="done" />
       <TabLink title="Scheduled" to="/instance/runs/scheduled" id="scheduled" />
-      {flagNewWorkspace ? (
-        <TabLink title="Backfills" to="/instance/backfills" id="backfills" />
-      ) : null}
     </Tabs>
   );
 });


### PR DESCRIPTION
### Summary & Motivation

After talking through the current "New workspace page" flagged changes with @braunjj, we're going to try adding an "Overview" root page that contains the run timeline and virtualized cross-deployment jobs, schedules, and sensors tables.

In this PR I'm just repurposing the existing schedules and sensors pages from "Status", but in a follow up I'll replace them with the virtualized versions, and also add the Jobs tab to the page.

The idea here is to keep Instance Overview features that users get a lot of value from, but try to unify things a little bit better and, of course, improve query/render perf.

"Overview" will be a top nav item, which will hopefully make it a bit more of an obvious home page for the app, instead of being oddly underneath "Status".

<img width="1020" alt="Screen Shot 2022-10-06 at 9 01 19 AM" src="https://user-images.githubusercontent.com/2823852/194333257-9d12d066-8f2c-4902-b9eb-4aa95c6d054a.png">

### How I Tested These Changes

With flag turned off, verify that the nav and routing remain the same as current non-flagged state.

With flag turned on, verify:

- "Overview" item is added to top nav
- Overview tabs and pages render correctly
- Click Daggy, verify that I am directed to /overview
