### PR TITLE
[dagit] Run timeline: reduce scheduled tick width, reduce chunk min width

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.stories.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.stories.tsx
@@ -216,7 +216,7 @@ export const BucketByRepo = () => {
   );
 };
 
-export const CandyStriping = () => {
+export const MultipleStatusesBatched = () => {
   const twoHoursAgo = React.useMemo(() => Date.now() - 2 * 60 * 60 * 1000, []);
   const now = React.useMemo(() => Date.now(), []);
 
@@ -267,4 +267,69 @@ export const CandyStriping = () => {
   }, [twoHoursAgo, now]);
 
   return <RunTimeline jobs={jobs} range={[twoHoursAgo, now]} />;
+};
+
+export const BatchThresholdTesting = () => {
+  const threeHoursAgo = React.useMemo(() => Date.now() - 3 * 60 * 60 * 1000, []);
+  const now = React.useMemo(() => Date.now(), []);
+
+  const jobs: TimelineJob[] = React.useMemo(() => {
+    const jobKey = faker.random.words(2).split(' ').join('-').toLowerCase();
+    const repoAddress = makeRepoAddress();
+    return [
+      {
+        key: jobKey,
+        jobName: jobKey,
+        jobType: 'job',
+        path: `/${jobKey}`,
+        repoAddress,
+        runs: [
+          {
+            id: faker.datatype.uuid(),
+            status: 'SCHEDULED',
+            startTime: now,
+            endTime: now + 5 * 1000,
+          },
+          {
+            id: faker.datatype.uuid(),
+            status: 'SCHEDULED',
+            startTime: now + 60 * 2 * 1000,
+            endTime: now + 60 * 2 * 1000 + 5 * 1000,
+          },
+          {
+            id: faker.datatype.uuid(),
+            status: 'SCHEDULED',
+            startTime: now + 60 * 4 * 1000,
+            endTime: now + 60 * 4 * 1000 + 5 * 1000,
+          },
+          {
+            id: faker.datatype.uuid(),
+            status: 'SCHEDULED',
+            startTime: now + 60 * 6 * 1000,
+            endTime: now + 60 * 6 * 1000 + 5 * 1000,
+          },
+          {
+            id: faker.datatype.uuid(),
+            status: 'SCHEDULED',
+            startTime: now + 60 * 8 * 1000,
+            endTime: now + 60 * 8 * 1000 + 5 * 1000,
+          },
+          {
+            id: faker.datatype.uuid(),
+            status: RunStatus.SUCCESS,
+            startTime: threeHoursAgo + 24 * 60 * 1000,
+            endTime: threeHoursAgo + 26 * 60 * 1000,
+          },
+          {
+            id: faker.datatype.uuid(),
+            status: RunStatus.FAILURE,
+            startTime: threeHoursAgo + 28 * 60 * 1000,
+            endTime: threeHoursAgo + 30 * 60 * 1000,
+          },
+        ],
+      },
+    ];
+  }, [threeHoursAgo, now]);
+
+  return <RunTimeline jobs={jobs} range={[threeHoursAgo, now + 60 * 60 * 1000]} />;
 };

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -495,7 +495,7 @@ const NowMarker = styled.div`
 `;
 
 const MIN_CHUNK_WIDTH = 2;
-const MIN_WIDTH_FOR_MULTIPLE = 16;
+const MIN_WIDTH_FOR_MULTIPLE = 12;
 
 const RunTimelineRow = ({
   job,

--- a/js_modules/dagit/packages/core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/useRunsForTimeline.tsx
@@ -126,7 +126,7 @@ export const useRunsForTimeline = (range: [number, number], runsFilter: RunsFilt
                     id: `${schedule.pipelineName}-future-run-${timestamp}`,
                     status: 'SCHEDULED',
                     startTime,
-                    endTime: startTime + 10 * 1000,
+                    endTime: startTime + 5 * 1000,
                   });
                 }
               });


### PR DESCRIPTION
### Summary & Motivation

In an effort to reduce how often high-firing scheduled ticks are batched together in the run timeline:

- Reduce the "duration" of scheduled ticks to 5 seconds (instead of 10) to make them a bit narrower
- Reduce the minimum chunk width to 12px, which should hopefully keep some runs/ticks separate that are currently being batched.

These are probably fairly subtle changes, but maybe they make some of the current batching slightly less confusing.

### How I Tested These Changes

View storybook example with scheduled ticks shown, view a run timeline in Dagit with lots of batching and verify that the batching is slightly less aggressive.
