### PR TITLE
Pin dask-kubernetes until we switch KubeCluster

### DIFF
--- a/python_modules/libraries/dagster-dask/setup.py
+++ b/python_modules/libraries/dagster-dask/setup.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
         extras_require={
             "yarn": ["dask-yarn"],
             "pbs": ["dask-jobqueue"],
-            "kube": ["dask-kubernetes"],
+            "kube": ["dask-kubernetes<=2022.9.0"],
             # we need `pyarrow` for testing read/write parquet files.
             "test": ["pyarrow"],
         },


### PR DESCRIPTION
We use `KubeCluster` but it was just deprecated in dask-kuberenetes=2022.10.0:

https://github.com/dask/dask-kubernetes/commit/3fe8e28479825d05bb3f8dcd9ff1c7f5a5c4795a

I haven't looked into what it'll take to upgrade/remain backward compatible but I'm pinning for now to prevent an invalid import statement.
