### PR TITLE
[dagit] Fix run tab counts not updating with poll interval

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunsPageHeader.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsPageHeader.tsx
@@ -1,0 +1,65 @@
+import {useQuery} from '@apollo/client';
+import {PageHeader, Heading, Box} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {
+  FIFTEEN_SECONDS,
+  QueryRefreshCountdown,
+  QueryRefreshState,
+  useMergedRefresh,
+  useQueryRefreshAtInterval,
+} from '../app/QueryRefresh';
+
+import {RunListTabs, RUN_TABS_COUNT_QUERY} from './RunListTabs';
+import {inProgressStatuses, queuedStatuses} from './RunStatuses';
+import {runsFilterForSearchTokens, useQueryPersistedRunFilters} from './RunsFilterInput';
+import {RunTabsCountQuery, RunTabsCountQueryVariables} from './types/RunTabsCountQuery';
+
+interface Props {
+  refreshStates: QueryRefreshState[];
+}
+
+export const RunsPageHeader = (props: Props) => {
+  const {refreshStates} = props;
+
+  const [filterTokens] = useQueryPersistedRunFilters();
+  const filter = runsFilterForSearchTokens(filterTokens);
+
+  const runCountResult = useQuery<RunTabsCountQuery, RunTabsCountQueryVariables>(
+    RUN_TABS_COUNT_QUERY,
+    {
+      variables: {
+        queuedFilter: {...filter, statuses: Array.from(queuedStatuses)},
+        inProgressFilter: {...filter, statuses: Array.from(inProgressStatuses)},
+      },
+    },
+  );
+
+  const {data: countData} = runCountResult;
+  const {queuedCount, inProgressCount} = React.useMemo(() => {
+    return {
+      queuedCount:
+        countData?.queuedCount?.__typename === 'Runs' ? countData.queuedCount.count : null,
+      inProgressCount:
+        countData?.inProgressCount?.__typename === 'Runs' ? countData.inProgressCount.count : null,
+    };
+  }, [countData]);
+
+  const countRefreshState = useQueryRefreshAtInterval(runCountResult, FIFTEEN_SECONDS);
+
+  const refreshState = useMergedRefresh(countRefreshState, ...refreshStates);
+
+  return (
+    <PageHeader
+      title={<Heading>Runs</Heading>}
+      tabs={
+        <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
+          <RunListTabs queuedCount={queuedCount} inProgressCount={inProgressCount} />
+          <Box padding={{bottom: 8}}>
+            <QueryRefreshCountdown refreshState={refreshState} />
+          </Box>
+        </Box>
+      }
+    />
+  );
+};

--- a/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
@@ -6,9 +6,7 @@ import {
   CursorHistoryControls,
   NonIdealState,
   Page,
-  PageHeader,
   Tag,
-  Heading,
   tokenToString,
 } from '@dagster-io/ui';
 import partition from 'lodash/partition';
@@ -16,11 +14,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
-import {
-  FIFTEEN_SECONDS,
-  QueryRefreshCountdown,
-  useQueryRefreshAtInterval,
-} from '../app/QueryRefresh';
+import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {InstancePageContext} from '../instance/InstancePageContext';
@@ -28,7 +22,7 @@ import {useCanSeeConfig} from '../instance/useCanSeeConfig';
 import {Loading} from '../ui/Loading';
 import {StickyTableContainer} from '../ui/StickyTableContainer';
 
-import {RunListTabs, useSelectedRunsTab} from './RunListTabs';
+import {useSelectedRunsTab} from './RunListTabs';
 import {RunTable, RUN_TABLE_RUN_FRAGMENT} from './RunTable';
 import {RunsQueryRefetchContext} from './RunUtils';
 import {
@@ -38,6 +32,7 @@ import {
   useQueryPersistedRunFilters,
   RunFilterToken,
 } from './RunsFilterInput';
+import {RunsPageHeader} from './RunsPageHeader';
 import {QueueDaemonStatusQuery} from './types/QueueDaemonStatusQuery';
 import {RunsRootQuery, RunsRootQueryVariables} from './types/RunsRootQuery';
 import {useCursorPaginatedQuery} from './useCursorPaginatedQuery';
@@ -74,6 +69,7 @@ export const RunsRoot = () => {
     query: RUNS_ROOT_QUERY,
     pageSize: PAGE_SIZE,
   });
+
   const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
 
   const currentTab = useSelectedRunsTab(filterTokens);
@@ -123,17 +119,7 @@ export const RunsRoot = () => {
 
   return (
     <Page>
-      <PageHeader
-        title={<Heading>Runs</Heading>}
-        tabs={
-          <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
-            <RunListTabs />
-            <Box padding={{bottom: 8}}>
-              <QueryRefreshCountdown refreshState={refreshState} />
-            </Box>
-          </Box>
-        }
-      />
+      <RunsPageHeader refreshStates={[refreshState]} />
       {currentTab === 'queued' && canSeeConfig ? (
         <Box
           flex={{direction: 'column', gap: 8}}

--- a/js_modules/dagit/packages/core/src/runs/ScheduledRunListRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ScheduledRunListRoot.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Page, PageHeader, Heading, Alert, ButtonLink, Colors, Group} from '@dagster-io/ui';
+import {Page, Alert, ButtonLink, Colors, Group} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
@@ -13,7 +13,7 @@ import {SchedulerInfo} from '../schedules/SchedulerInfo';
 import {SchedulesNextTicks} from '../schedules/SchedulesNextTicks';
 import {Loading} from '../ui/Loading';
 
-import {RunListTabs} from './RunListTabs';
+import {RunsPageHeader} from './RunsPageHeader';
 import {SchedulerInfoQuery} from './types/SchedulerInfoQuery';
 
 export const ScheduledRunListRoot = () => {
@@ -26,11 +26,11 @@ export const ScheduledRunListRoot = () => {
     notifyOnNetworkStatusChange: true,
   });
 
-  useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
+  const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
 
   return (
     <Page>
-      <PageHeader title={<Heading>Runs</Heading>} tabs={<RunListTabs />} />
+      <RunsPageHeader refreshStates={[refreshState]} />
       <Loading queryResult={queryResult}>
         {(result) => {
           const {repositoriesOrError, instance} = result;
@@ -60,10 +60,13 @@ export const ScheduledRunListRoot = () => {
             );
           }
           return (
-            <Group direction="column" spacing={24}>
-              <SchedulerInfo daemonHealth={instance.daemonHealth} />
+            <>
+              <SchedulerInfo
+                daemonHealth={instance.daemonHealth}
+                padding={{vertical: 16, horizontal: 24}}
+              />
               <SchedulesNextTicks repos={repositoriesOrError.nodes} />
-            </Group>
+            </>
           );
         }}
       </Loading>


### PR DESCRIPTION
### Summary & Motivation

The `RunTabs` component queries for counts, but not on a polling basis. This means that the counts never update when other queries on the Runs page refresh.

Create a `RunsPageHeader` component that uses merged refresh state to accept an outer refresh state (e.g. the list of runs or scheduled ticks) and merge it with the counts query.

### How I Tested These Changes

Load Dagit, view Runs page. Kick off some runs, verify that the counts for queued and in-progress tabs update automatically with the polled queries.
