### PR TITLE
[dagster-airbyte] Support union types while generating normalization tables

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -66,7 +66,12 @@ def test_load_from_instance(use_normalization_tables, connection_to_group_fn):
     ab_assets = ab_cacheable_assets.build_definitions(ab_cacheable_assets.compute_cacheable_data())
 
     tables = {"dagster_releases", "dagster_tags", "dagster_teams"} | (
-        {"dagster_releases_assets", "dagster_releases_author", "dagster_tags_commit"}
+        {
+            "dagster_releases_assets",
+            "dagster_releases_author",
+            "dagster_tags_commit",
+            "dagster_releases_foo",
+        }
         if use_normalization_tables
         else set()
     )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
@@ -205,6 +205,18 @@ def get_project_connection_json(**kwargs):
                                         "format": "date-time",
                                     },
                                     "target_commitish": {"type": ["null", "string"]},
+                                    "foo": {
+                                        "oneOf": [
+                                            {
+                                                "type": ["null", "object"],
+                                                "properties": {"bar": {"type": "string"}},
+                                            },
+                                            {
+                                                "type": ["null", "object"],
+                                                "properties": {"baz": {"type": "string"}},
+                                            },
+                                        ]
+                                    },
                                 },
                             },
                             "supportedSyncModes": ["full_refresh", "incremental"],
@@ -444,6 +456,18 @@ def get_instance_connections_json():
                                             "format": "date-time",
                                         },
                                         "target_commitish": {"type": ["null", "string"]},
+                                        "foo": {
+                                            "oneOf": [
+                                                {
+                                                    "types": ["null", "object"],
+                                                    "properties": {"bar": {"type": "string"}},
+                                                },
+                                                {
+                                                    "type": ["null", "object"],
+                                                    "properties": {"baz": {"type": "string"}},
+                                                },
+                                            ]
+                                        },
                                     },
                                 },
                                 "supportedSyncModes": ["full_refresh", "incremental"],


### PR DESCRIPTION
## Summary

Allows our normalization-table-generating logic to correctly handle [union types](https://docs.airbyte.com/understanding-airbyte/supported-data-types/), which appear in some connection definitions.

Also added support for the `types` field, which I have seen appear (perhaps erroneously) instead of `type` in some connectors.

## Test Plan

Added unit test.
