### PR TITLE
[dagster-airbyte] Generate schema metadata at load time when loading from project or instance

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/table.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Type, Union, 
 import dagster._check as check
 from dagster._annotations import PublicAttr, experimental, public
 from dagster._serdes.serdes import DefaultNamedTupleSerializer, whitelist_for_serdes
+from dagster._utils import frozenlist
 
 # ########################
 # ##### TABLE RECORD
@@ -115,7 +116,7 @@ class TableSchema(
     ):
         return super(TableSchema, cls).__new__(
             cls,
-            columns=check.list_param(columns, "columns", of_type=TableColumn),
+            columns=frozenlist(check.list_param(columns, "columns", of_type=TableColumn)),
             constraints=check.opt_inst_param(
                 constraints, "constraints", TableConstraints, default=_DEFAULT_TABLE_CONSTRAINTS
             ),
@@ -162,7 +163,7 @@ class TableConstraints(
     ):
         return super(TableConstraints, cls).__new__(
             cls,
-            other=check.list_param(other, "other", of_type=str),
+            other=frozenlist(check.list_param(other, "other", of_type=str)),
         )
 
 
@@ -260,7 +261,7 @@ class TableColumnConstraints(
             cls,
             nullable=check.bool_param(nullable, "nullable"),
             unique=check.bool_param(unique, "unique"),
-            other=check.opt_list_param(other, "other"),
+            other=frozenlist(check.opt_list_param(other, "other")),
         )
 
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -91,7 +91,7 @@ def _build_airbyte_asset_defn_metadata(
         key_prefix=asset_key_prefix,
         can_subset=False,
         metadata_by_output_name={
-            table: {"schema": MetadataValue.table_schema(schema_by_table_name[table])}
+            table: {"table_schema": MetadataValue.table_schema(schema_by_table_name[table])}
             for table in tables
         }
         if schema_by_table_name
@@ -201,7 +201,7 @@ def build_airbyte_assets(
     outputs = {
         table: AssetOut(
             key=AssetKey(asset_key_prefix + [table]),
-            metadata={"schema": MetadataValue.table_schema(schema_by_table_name[table])}
+            metadata={"table_schema": MetadataValue.table_schema(schema_by_table_name[table])}
             if schema_by_table_name
             else None,
         )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -36,7 +36,6 @@ from dagster._core.definitions.load_assets_from_modules import with_group
 from dagster._core.definitions.metadata import MetadataValue, TableSchemaMetadataValue
 from dagster._core.definitions.metadata.table import TableSchema
 from dagster._core.execution.context.init import build_init_resource_context
-from dagster._serdes.serdes import deserialize_as, serialize_dagster_namedtuple
 from dagster._utils import merge_dicts
 
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -91,11 +91,7 @@ def _build_airbyte_asset_defn_metadata(
         key_prefix=asset_key_prefix,
         can_subset=False,
         metadata_by_output_name={
-            table: {
-                "schema": serialize_dagster_namedtuple(
-                    MetadataValue.table_schema(schema_by_table_name[table])
-                )
-            }
+            table: {"schema": MetadataValue.table_schema(schema_by_table_name[table])}
             for table in tables
         }
         if schema_by_table_name
@@ -126,7 +122,7 @@ def _build_airbyte_assets_from_metadata(
             k: AssetOut(
                 key=v,
                 metadata={
-                    k: deserialize_as(cast(str, v), TableSchemaMetadataValue)
+                    k: cast(TableSchemaMetadataValue, v)
                     for k, v in assets_defn_meta.metadata_by_output_name.get(k, {}).items()
                 }
                 if assets_defn_meta.metadata_by_output_name
@@ -282,7 +278,7 @@ def _get_normalization_tables_for_schema(
     key: str, schema: Mapping[str, Any], prefix: str = ""
 ) -> Dict[str, AirbyteTableMetadata]:
     """
-    Recursively traverses a schema, returning a list of table names that will be created by the Airbyte
+    Recursively traverses a schema, returning metadata for the tables that will be created by the Airbyte
     normalization process.
 
     For example, a table `cars` with a nested object field `limited_editions` will produce the tables

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -19,7 +19,8 @@ from typing import (
 
 import yaml
 from dagster_airbyte.resources import AirbyteResource
-from dagster_airbyte.utils import generate_materializations
+from dagster_airbyte.types import AirbyteStreamMetadata
+from dagster_airbyte.utils import generate_materializations, generate_table_schema
 
 from dagster import AssetKey, AssetOut, Output, ResourceDefinition
 from dagster import _check as check
@@ -32,7 +33,14 @@ from dagster._core.definitions.cacheable_assets import (
 )
 from dagster._core.definitions.events import CoercibleToAssetKeyPrefix
 from dagster._core.definitions.load_assets_from_modules import with_group
+from dagster._core.definitions.metadata import MetadataValue
+from dagster._core.definitions.metadata.table import TableSchema
 from dagster._core.execution.context.init import build_init_resource_context
+from dagster._serdes.serdes import (
+    deserialize_json_to_dagster_namedtuple,
+    serialize_dagster_namedtuple,
+)
+from dagster._utils import merge_dicts
 
 
 def _build_airbyte_asset_defn_metadata(
@@ -42,6 +50,7 @@ def _build_airbyte_asset_defn_metadata(
     normalization_tables: Optional[Mapping[str, Set[str]]] = None,
     upstream_assets: Optional[Iterable[AssetKey]] = None,
     group_name: Optional[str] = None,
+    schema_by_table_name: Optional[Mapping[str, TableSchema]] = None,
 ) -> AssetsDefinitionCacheableData:
 
     asset_key_prefix = check.opt_list_param(asset_key_prefix, "asset_key_prefix", of_type=str) or []
@@ -55,6 +64,7 @@ def _build_airbyte_asset_defn_metadata(
             )
         )
     )
+
     outputs = {table: AssetKey(asset_key_prefix + [table]) for table in tables}
 
     internal_deps: Dict[str, Set[AssetKey]] = {}
@@ -83,6 +93,16 @@ def _build_airbyte_asset_defn_metadata(
         group_name=group_name,
         key_prefix=asset_key_prefix,
         can_subset=False,
+        metadata_by_output_name={
+            table: {
+                "schema": serialize_dagster_namedtuple(
+                    MetadataValue.table_schema(schema_by_table_name[table])
+                )
+            }
+            for table in tables
+        }
+        if schema_by_table_name
+        else None,
         extra_metadata={
             "connection_id": connection_id,
             "group_name": group_name,
@@ -105,7 +125,18 @@ def _build_airbyte_assets_from_metadata(
     @multi_asset(
         name=f"airbyte_sync_{connection_id[:5]}",
         non_argument_deps=set((assets_defn_meta.keys_by_input_name or {}).values()),
-        outs={k: AssetOut(key=v) for k, v in (assets_defn_meta.keys_by_output_name or {}).items()},
+        outs={
+            k: AssetOut(
+                key=v,
+                metadata={
+                    k: deserialize_json_to_dagster_namedtuple(v)
+                    for k, v in assets_defn_meta.metadata_by_output_name.get(k, {}).items()
+                }
+                if assets_defn_meta.metadata_by_output_name
+                else None,
+            )
+            for k, v in (assets_defn_meta.keys_by_output_name or {}).items()
+        },
         internal_asset_deps={
             k: set(v) for k, v in (assets_defn_meta.internal_asset_deps or {}).items()
         },
@@ -148,6 +179,7 @@ def build_airbyte_assets(
     asset_key_prefix: Optional[List[str]] = None,
     normalization_tables: Optional[Mapping[str, Set[str]]] = None,
     upstream_assets: Optional[Set[AssetKey]] = None,
+    schema_by_table_name: Optional[Mapping[str, TableSchema]] = None,
 ) -> List[AssetsDefinition]:
     """
     Builds a set of assets representing the tables created by an Airbyte sync operation.
@@ -173,7 +205,15 @@ def build_airbyte_assets(
     tables = chain.from_iterable(
         chain([destination_tables], normalization_tables.values() if normalization_tables else [])
     )
-    outputs = {table: AssetOut(key=AssetKey(asset_key_prefix + [table])) for table in tables}
+    outputs = {
+        table: AssetOut(
+            key=AssetKey(asset_key_prefix + [table]),
+            metadata={"schema": MetadataValue.table_schema(schema_by_table_name[table])}
+            if schema_by_table_name
+            else None,
+        )
+        for table in tables
+    }
 
     internal_deps = {}
 
@@ -243,7 +283,7 @@ def _get_sub_schemas(schema: Mapping[str, Any]) -> List[Mapping[str, Any]]:
 
 def _get_normalization_tables_for_schema(
     key: str, schema: Mapping[str, Any], prefix: str = ""
-) -> List[str]:
+) -> Dict[str, AirbyteStreamMetadata]:
     """
     Recursively traverses a schema, returning a list of table names that will be created by the Airbyte
     normalization process.
@@ -255,7 +295,7 @@ def _get_normalization_tables_for_schema(
     https://docs.airbyte.com/understanding-airbyte/basic-normalization/#nesting
     """
 
-    out = []
+    out: Dict[str, AirbyteStreamMetadata] = {}
     # Object types are broken into a new table, as long as they have children
 
     sub_schemas = _get_sub_schemas(schema)
@@ -266,15 +306,23 @@ def _get_normalization_tables_for_schema(
             continue
 
         if "object" in schema_types and len(sub_schema.get("properties", {})) > 0:
-            out.append(prefix + key)
+            out[prefix + key] = AirbyteStreamMetadata(
+                schema=generate_table_schema(sub_schema.get("properties", {}))
+            )
             for k, v in sub_schema["properties"].items():
-                out += _get_normalization_tables_for_schema(k, v, f"{prefix}{key}_")
+                out = merge_dicts(
+                    out, _get_normalization_tables_for_schema(k, v, f"{prefix}{key}_")
+                )
         # Array types are also broken into a new table
         elif "array" in schema_types:
-            out.append(prefix + key)
+            out[prefix + key] = AirbyteStreamMetadata(
+                schema=generate_table_schema(sub_schema.get("items", {}).get("properties", {}))
+            )
             if sub_schema.get("items", {}).get("properties"):
                 for k, v in sub_schema["items"]["properties"].items():
-                    out += _get_normalization_tables_for_schema(k, v, f"{prefix}{key}_")
+                    out = merge_dicts(
+                        out, _get_normalization_tables_for_schema(k, v, f"{prefix}{key}_")
+                    )
 
     return out
 
@@ -344,14 +392,14 @@ class AirbyteConnectionMetadata(
 
     def parse_stream_tables(
         self, return_normalization_tables: bool = False
-    ) -> Mapping[str, Set[str]]:
+    ) -> Mapping[str, AirbyteStreamMetadata]:
         """
         Parses the stream data and returns a mapping, with keys representing destination
         tables associated with each enabled stream and values representing any affiliated
         tables created by Airbyte's normalization process, if enabled.
         """
 
-        tables: Dict[str, Set[str]] = {}
+        tables: Dict[str, AirbyteStreamMetadata] = {}
 
         enabled_streams = [
             stream for stream in self.stream_data if stream.get("config", {}).get("selected", False)
@@ -361,19 +409,23 @@ class AirbyteConnectionMetadata(
             name = cast(str, stream.get("stream", {}).get("name"))
             prefixed_name = f"{self.stream_prefix}{name}"
 
-            tables[prefixed_name] = set()
+            schema = (
+                stream["stream"]["json_schema"]
+                if "json_schema" in stream["stream"]
+                else stream["stream"]["jsonSchema"]
+            )
+            normalization_tables: Dict[str, AirbyteStreamMetadata] = {}
             if self.has_basic_normalization and return_normalization_tables:
-                schema = (
-                    stream["stream"]["json_schema"]
-                    if "json_schema" in stream["stream"]
-                    else stream["stream"]["jsonSchema"]
-                )
                 for k, v in schema["properties"].items():
-                    for normalization_table_name in _get_normalization_tables_for_schema(
+                    for normalization_table_name, meta in _get_normalization_tables_for_schema(
                         k, v, f"{name}_"
-                    ):
+                    ).items():
                         prefixed_norm_table_name = f"{self.stream_prefix}{normalization_table_name}"
-                        tables[prefixed_name].add(prefixed_norm_table_name)
+                        normalization_tables[prefixed_norm_table_name] = meta
+            tables[prefixed_name] = AirbyteStreamMetadata(
+                schema=generate_table_schema(schema["properties"]),
+                normalization_tables=normalization_tables,
+            )
 
         return tables
 
@@ -451,18 +503,33 @@ class AirbyteInstanceCacheableAssetsDefintion(CacheableAssetsDefinition):
             if self._connection_filter and not self._connection_filter(connection):
                 continue
 
-            table_mapping = connection.parse_stream_tables(
+            stream_table_metadata = connection.parse_stream_tables(
                 self._create_assets_for_normalization_tables
+            )
+            schema_by_table_name: Mapping[str, TableSchema] = dict(
+                chain.from_iterable(
+                    chain(
+                        [[(k, v.schema) for k, v in stream_table_metadata.items()]],
+                        [
+                            [(k, v.schema) for k, v in meta.normalization_tables.items()]
+                            for meta in stream_table_metadata.values()
+                        ],
+                    )
+                )
             )
 
             asset_data_for_conn = _build_airbyte_asset_defn_metadata(
                 connection_id=connection_id,
-                destination_tables=list(table_mapping.keys()),
-                normalization_tables=table_mapping,
+                destination_tables=list(stream_table_metadata.keys()),
+                normalization_tables={
+                    table: metadata.normalization_tables
+                    for table, metadata in stream_table_metadata.items()
+                },
                 asset_key_prefix=self._key_prefix,
                 group_name=self._connection_to_group_fn(connection.name)
                 if self._connection_to_group_fn
                 else None,
+                schema_by_table_name=schema_by_table_name,
             )
 
             asset_defn_data.append(asset_data_for_conn)
@@ -654,13 +721,30 @@ def load_assets_from_airbyte_project(
             state = yaml.safe_load(f.read())
             connection_id = state.get("resource_id")
 
-        table_mapping = connection.parse_stream_tables(create_assets_for_normalization_tables)
+        stream_table_metadata = connection.parse_stream_tables(
+            create_assets_for_normalization_tables
+        )
+        schema_by_table_name: Mapping[str, TableSchema] = dict(
+            chain.from_iterable(
+                chain(
+                    [[(k, v.schema) for k, v in stream_table_metadata.items()]],
+                    [
+                        [(k, v.schema) for k, v in meta.normalization_tables.items()]
+                        for meta in stream_table_metadata.values()
+                    ],
+                )
+            )
+        )
 
         assets_for_connection = build_airbyte_assets(
             connection_id=connection_id,
-            destination_tables=list(table_mapping.keys()),
-            normalization_tables=table_mapping,
+            destination_tables=list(stream_table_metadata.keys()),
+            normalization_tables={
+                table: metadata.normalization_tables
+                for table, metadata in stream_table_metadata.items()
+            },
             asset_key_prefix=key_prefix,
+            schema_by_table_name=schema_by_table_name,
         )
 
         if connection_to_group_fn:

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -19,7 +19,7 @@ from typing import (
 
 import yaml
 from dagster_airbyte.resources import AirbyteResource
-from dagster_airbyte.types import AirbyteStreamMetadata
+from dagster_airbyte.types import AirbyteTableMetadata
 from dagster_airbyte.utils import generate_materializations, generate_table_schema
 
 from dagster import AssetKey, AssetOut, Output, ResourceDefinition
@@ -280,7 +280,7 @@ def _get_sub_schemas(schema: Mapping[str, Any]) -> List[Mapping[str, Any]]:
 
 def _get_normalization_tables_for_schema(
     key: str, schema: Mapping[str, Any], prefix: str = ""
-) -> Dict[str, AirbyteStreamMetadata]:
+) -> Dict[str, AirbyteTableMetadata]:
     """
     Recursively traverses a schema, returning a list of table names that will be created by the Airbyte
     normalization process.
@@ -292,7 +292,7 @@ def _get_normalization_tables_for_schema(
     https://docs.airbyte.com/understanding-airbyte/basic-normalization/#nesting
     """
 
-    out: Dict[str, AirbyteStreamMetadata] = {}
+    out: Dict[str, AirbyteTableMetadata] = {}
     # Object types are broken into a new table, as long as they have children
 
     sub_schemas = _get_sub_schemas(schema)
@@ -303,7 +303,7 @@ def _get_normalization_tables_for_schema(
             continue
 
         if "object" in schema_types and len(sub_schema.get("properties", {})) > 0:
-            out[prefix + key] = AirbyteStreamMetadata(
+            out[prefix + key] = AirbyteTableMetadata(
                 schema=generate_table_schema(sub_schema.get("properties", {}))
             )
             for k, v in sub_schema["properties"].items():
@@ -312,7 +312,7 @@ def _get_normalization_tables_for_schema(
                 )
         # Array types are also broken into a new table
         elif "array" in schema_types:
-            out[prefix + key] = AirbyteStreamMetadata(
+            out[prefix + key] = AirbyteTableMetadata(
                 schema=generate_table_schema(sub_schema.get("items", {}).get("properties", {}))
             )
             if sub_schema.get("items", {}).get("properties"):
@@ -389,14 +389,14 @@ class AirbyteConnectionMetadata(
 
     def parse_stream_tables(
         self, return_normalization_tables: bool = False
-    ) -> Mapping[str, AirbyteStreamMetadata]:
+    ) -> Mapping[str, AirbyteTableMetadata]:
         """
         Parses the stream data and returns a mapping, with keys representing destination
         tables associated with each enabled stream and values representing any affiliated
         tables created by Airbyte's normalization process, if enabled.
         """
 
-        tables: Dict[str, AirbyteStreamMetadata] = {}
+        tables: Dict[str, AirbyteTableMetadata] = {}
 
         enabled_streams = [
             stream for stream in self.stream_data if stream.get("config", {}).get("selected", False)
@@ -411,7 +411,7 @@ class AirbyteConnectionMetadata(
                 if "json_schema" in stream["stream"]
                 else stream["stream"]["jsonSchema"]
             )
-            normalization_tables: Dict[str, AirbyteStreamMetadata] = {}
+            normalization_tables: Dict[str, AirbyteTableMetadata] = {}
             if self.has_basic_normalization and return_normalization_tables:
                 for k, v in schema["properties"].items():
                     for normalization_table_name, meta in _get_normalization_tables_for_schema(
@@ -419,7 +419,7 @@ class AirbyteConnectionMetadata(
                     ).items():
                         prefixed_norm_table_name = f"{self.stream_prefix}{normalization_table_name}"
                         normalization_tables[prefixed_norm_table_name] = meta
-            tables[prefixed_name] = AirbyteStreamMetadata(
+            tables[prefixed_name] = AirbyteTableMetadata(
                 schema=generate_table_schema(schema["properties"]),
                 normalization_tables=normalization_tables,
             )
@@ -428,7 +428,7 @@ class AirbyteConnectionMetadata(
 
 
 def _get_schema_by_table_name(
-    stream_table_metadata: Mapping[str, AirbyteStreamMetadata]
+    stream_table_metadata: Mapping[str, AirbyteTableMetadata]
 ) -> Dict[str, TableSchema]:
 
     schema_by_base_table_name = [(k, v.schema) for k, v in stream_table_metadata.items()]
@@ -438,7 +438,7 @@ def _get_schema_by_table_name(
                 [
                     (k, v.schema)
                     for k, v in cast(
-                        Dict[str, AirbyteStreamMetadata], meta.normalization_tables
+                        Dict[str, AirbyteTableMetadata], meta.normalization_tables
                     ).items()
                 ]
                 for meta in stream_table_metadata.values()

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/types.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/types.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, NamedTuple
+from typing import Any, Dict, NamedTuple
 
 from dagster._core.definitions.metadata.table import TableSchema
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/types.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/types.py
@@ -1,4 +1,14 @@
-from typing import Any, Dict, NamedTuple
+from typing import Any, Dict, List, NamedTuple
+
+from dagster._core.definitions.metadata.table import TableSchema
+
+
+class AirbyteStreamMetadata:
+    def __init__(
+        self, schema: TableSchema, normalization_tables: Dict[str, "AirbyteStreamMetadata"] = None
+    ):
+        self.schema = schema
+        self.normalization_tables = normalization_tables
 
 
 class AirbyteOutput(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/types.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/types.py
@@ -1,14 +1,16 @@
-from typing import Any, Dict, NamedTuple
+from typing import Any, Dict, NamedTuple, Optional
 
 from dagster._core.definitions.metadata.table import TableSchema
 
 
 class AirbyteStreamMetadata:
     def __init__(
-        self, schema: TableSchema, normalization_tables: Dict[str, "AirbyteStreamMetadata"] = None
+        self,
+        schema: TableSchema,
+        normalization_tables: Optional[Dict[str, "AirbyteStreamMetadata"]] = None,
     ):
         self.schema = schema
-        self.normalization_tables = normalization_tables
+        self.normalization_tables = normalization_tables or dict()
 
 
 class AirbyteOutput(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/types.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/types.py
@@ -3,12 +3,15 @@ from typing import Any, Dict, NamedTuple, Optional
 from dagster._core.definitions.metadata.table import TableSchema
 
 
-class AirbyteStreamMetadata:
+class AirbyteTableMetadata:
     def __init__(
         self,
         schema: TableSchema,
-        normalization_tables: Optional[Dict[str, "AirbyteStreamMetadata"]] = None,
+        normalization_tables: Optional[Dict[str, "AirbyteTableMetadata"]] = None,
     ):
+        """
+        Contains metadata about an Airbyte table, including its schema and any created normalization tables.
+        """
         self.schema = schema
         self.normalization_tables = normalization_tables or dict()
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Iterator, List, Mapping
 
-from dagster_airbyte.types import AirbyteOutput, AirbyteStreamMetadata
+from dagster_airbyte.types import AirbyteOutput
 
 from dagster import AssetMaterialization, MetadataValue
 from dagster._core.definitions.metadata.table import TableColumn, TableSchema

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
@@ -1,9 +1,21 @@
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, Iterator, List, Mapping
 
-from dagster_airbyte.types import AirbyteOutput
+from dagster_airbyte.types import AirbyteOutput, AirbyteStreamMetadata
 
 from dagster import AssetMaterialization, MetadataValue
 from dagster._core.definitions.metadata.table import TableColumn, TableSchema
+
+
+def generate_table_schema(stream_schema_props: Mapping[str, Any]) -> TableSchema:
+    return TableSchema(
+        columns=sorted(
+            [
+                TableColumn(name=name, type=str(info.get("type", "unknown")))
+                for name, info in stream_schema_props.items()
+            ],
+            key=lambda col: col.name,
+        )
+    )
 
 
 def _materialization_for_stream(
@@ -16,14 +28,7 @@ def _materialization_for_stream(
     return AssetMaterialization(
         asset_key=asset_key_prefix + [name],
         metadata={
-            "schema": MetadataValue.table_schema(
-                TableSchema(
-                    columns=[
-                        TableColumn(name=name, type=str(info.get("type", "unknown")))
-                        for name, info in stream_schema_props.items()
-                    ]
-                )
-            ),
+            "schema": MetadataValue.table_schema(generate_table_schema(stream_schema_props)),
             **{k: v for k, v in stream_stats.items() if v is not None},
         },
     )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -88,7 +88,7 @@ def test_load_from_instance(use_normalization_tables, connection_to_group_fn, fi
     # Check schema metadata is added correctly to asset def
 
     assert any(
-        out.metadata.get("schema")
+        out.metadata.get("table_schema")
         == MetadataValue.table_schema(
             TableSchema(
                 columns=[
@@ -106,7 +106,7 @@ def test_load_from_instance(use_normalization_tables, connection_to_group_fn, fi
     # Check schema metadata works for normalization tables too
     if use_normalization_tables:
         assert any(
-            out.metadata.get("schema")
+            out.metadata.get("table_schema")
             == MetadataValue.table_schema(
                 TableSchema(
                     columns=[


### PR DESCRIPTION
## Summary

Generates schema metadata for Airbyte asset definitions when loading from a project or instance, so that users can browse output tables & their schemas from Dagit without having to first materialize an asset.

## Test Plan

Added unit test, tested locally.