### PR TITLE
rename logKey to fileKey / logFileKey for disambiguation with new API

### DIFF
--- a/docs/screenshots/concepts/dagit.yaml
+++ b/docs/screenshots/concepts/dagit.yaml
@@ -40,7 +40,7 @@
 
 - id: re-execution.png
   base_url: https://demo.elementl.show
-  route: /instance/runs/57ea168a-3e2d-4137-8a4c-beb93122c684?logKey=build_comment_stories&logs=query%3Arecommender_model_perf&selection=recommender_model_perf
+  route: /instance/runs/57ea168a-3e2d-4137-8a4c-beb93122c684?logFileKey=build_comment_stories&logs=query%3Arecommender_model_perf&selection=recommender_model_perf
   vetted: false
 
 - id: asset.png

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1240,6 +1240,7 @@ type LogsCapturedEvent implements MessageEvent {
   stepKey: String
   solidHandleID: String
   eventType: DagsterEventType
+  fileKey: String!
   logKey: String!
   stepKeys: [String!]
   pid: Int

--- a/js_modules/dagit/packages/core/src/runs/LogsRow.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRow.tsx
@@ -182,7 +182,7 @@ export const LOGS_ROW_STRUCTURED_FRAGMENT = gql`
       upstreamStepKey
     }
     ... on LogsCapturedEvent {
-      logKey
+      fileKey
       stepKeys
     }
   }

--- a/js_modules/dagit/packages/core/src/runs/LogsRowStructuredContent.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRowStructuredContent.tsx
@@ -215,7 +215,7 @@ export const LogsRowStructuredContent: React.FC<IStructuredContentProps> = ({nod
       return <DefaultContent message={node.message} />;
     case 'LogsCapturedEvent':
       const currentQuery = qs.parse(location.search, {ignoreQueryPrefix: true});
-      const updatedQuery = {...currentQuery, logType: 'stdout', logKey: node.stepKey};
+      const updatedQuery = {...currentQuery, logType: 'stdout', logFileKey: node.stepKey};
       const rawLogsUrl = `${location.pathname}?${qs.stringify(updatedQuery)}`;
       const rawLogsLink = (
         <Link to={rawLogsUrl} style={{color: 'inherit'}}>

--- a/js_modules/dagit/packages/core/src/runs/LogsToolbar.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsToolbar.tsx
@@ -149,18 +149,18 @@ const ComputeLogToolbar = ({
     metadata.logCaptureSteps || extractLogCaptureStepsFromLegacySteps(Object.keys(metadata.steps));
   const isValidStepSelection = computeLogKey && logCaptureSteps[computeLogKey];
 
-  const logKeyText = (logKey?: string) => {
-    if (!logKey || !logCaptureSteps[logKey]) {
+  const fileKeyText = (fileKey?: string) => {
+    if (!fileKey || !logCaptureSteps[fileKey]) {
       return null;
     }
-    const captureInfo = logCaptureSteps[logKey];
-    if (captureInfo.stepKeys.length === 1 && logKey === captureInfo.stepKeys[0]) {
-      return logKey;
+    const captureInfo = logCaptureSteps[fileKey];
+    if (captureInfo.stepKeys.length === 1 && fileKey === captureInfo.stepKeys[0]) {
+      return fileKey;
     }
     if (captureInfo.pid) {
       return `pid: ${captureInfo.pid} (${captureInfo.stepKeys.length} steps)`;
     }
-    return `${logKey} (${captureInfo.stepKeys.length} steps)`;
+    return `${fileKey} (${captureInfo.stepKeys.length} steps)`;
   };
 
   return (
@@ -179,17 +179,17 @@ const ComputeLogToolbar = ({
             <MenuItem
               key={item}
               onClick={options.handleClick}
-              text={logKeyText(item)}
+              text={fileKeyText(item)}
               active={options.modifiers.active}
             />
           )}
           activeItem={computeLogKey}
-          onItemSelect={(logKey) => {
-            onSetComputeLogKey(logKey);
+          onItemSelect={(fileKey) => {
+            onSetComputeLogKey(fileKey);
           }}
         >
           <Button disabled={!steps.length} rightIcon={<Icon name="expand_more" />}>
-            {logKeyText(computeLogKey) || 'Select a step...'}
+            {fileKeyText(computeLogKey) || 'Select a step...'}
           </Button>
         </Select>
         {isValidStepSelection ? (

--- a/js_modules/dagit/packages/core/src/runs/Run.tsx
+++ b/js_modules/dagit/packages/core/src/runs/Run.tsx
@@ -164,7 +164,7 @@ const RunWithData: React.FC<RunWithDataProps> = ({
   });
 
   const [computeLogKey, setComputeLogKey] = useQueryPersistedState<string>({
-    queryKey: 'logKey',
+    queryKey: 'logFileKey',
   });
 
   const logType = logTypeFromQuery(queryLogType);
@@ -188,14 +188,15 @@ const RunWithData: React.FC<RunWithDataProps> = ({
     }
 
     if (metadata.logCaptureSteps) {
-      const logKeys = Object.keys(metadata.logCaptureSteps);
-      const selectedLogKey = logKeys.find((logKey) => {
+      const logFileKeys = Object.keys(metadata.logCaptureSteps);
+      const selectedLogKey = logFileKeys.find((logFileKey) => {
         return selectionStepKeys.every(
           (stepKey) =>
-            metadata.logCaptureSteps && metadata.logCaptureSteps[logKey].stepKeys.includes(stepKey),
+            metadata.logCaptureSteps &&
+            metadata.logCaptureSteps[logFileKey].stepKeys.includes(stepKey),
         );
       });
-      setComputeLogKey(selectedLogKey || logKeys[0]);
+      setComputeLogKey(selectedLogKey || logFileKeys[0]);
     } else if (!stepKeys.includes(computeLogKey)) {
       setComputeLogKey(selectionStepKeys.length === 1 ? selectionStepKeys[0] : stepKeys[0]);
     } else if (selectionStepKeys.length === 1 && computeLogKey !== selectionStepKeys[0]) {
@@ -203,8 +204,8 @@ const RunWithData: React.FC<RunWithDataProps> = ({
     }
   }, [stepKeys, computeLogKey, selectionStepKeys, metadata.logCaptureSteps, setComputeLogKey]);
 
-  const onSetComputeLogKey = (logKey: string) => {
-    setComputeLogKey(logKey);
+  const onSetComputeLogKey = (logFileKey: string) => {
+    setComputeLogKey(logFileKey);
   };
 
   const logsFilterStepKeys = runtimeGraph

--- a/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
@@ -61,7 +61,7 @@ export interface IStepMetadata {
 }
 
 export interface ILogCaptureInfo {
-  logKey: string;
+  fileKey: string;
   stepKeys: string[];
   pid?: string;
 }
@@ -79,7 +79,7 @@ export interface IRunMetadataDict {
     [stepKey: string]: IStepMetadata;
   };
   logCaptureSteps?: {
-    [logKey: string]: ILogCaptureInfo;
+    [fileKey: string]: ILogCaptureInfo;
   };
 }
 
@@ -93,7 +93,7 @@ export const EMPTY_RUN_METADATA: IRunMetadataDict = {
 export const extractLogCaptureStepsFromLegacySteps = (stepKeys: string[]) => {
   const logCaptureSteps = {};
   stepKeys.forEach(
-    (stepKey) => (logCaptureSteps[stepKey] = {logKey: stepKey, stepKeys: [stepKey]}),
+    (stepKey) => (logCaptureSteps[stepKey] = {fileKey: stepKey, stepKeys: [stepKey]}),
   );
   return logCaptureSteps;
 };
@@ -238,8 +238,8 @@ export function extractMetadataFromLogs(
       if (!metadata.logCaptureSteps) {
         metadata.logCaptureSteps = {};
       }
-      metadata.logCaptureSteps[log.logKey] = {
-        logKey: log.logKey,
+      metadata.logCaptureSteps[log.fileKey] = {
+        fileKey: log.fileKey,
         stepKeys: log.stepKeys || [],
         pid: String(log.pid),
       };
@@ -356,7 +356,7 @@ export const RUN_METADATA_PROVIDER_MESSAGE_FRAGMENT = gql`
       }
     }
     ... on LogsCapturedEvent {
-      logKey
+      fileKey
       stepKeys
       pid
     }

--- a/js_modules/dagit/packages/core/src/runs/types/LogsRowStructuredFragment.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/LogsRowStructuredFragment.ts
@@ -2157,7 +2157,7 @@ export interface LogsRowStructuredFragment_LogsCapturedEvent {
   timestamp: string;
   level: LogLevel;
   stepKey: string | null;
-  logKey: string;
+  fileKey: string;
   stepKeys: string[] | null;
 }
 

--- a/js_modules/dagit/packages/core/src/runs/types/LogsScrollingTableMessageFragment.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/LogsScrollingTableMessageFragment.ts
@@ -2157,7 +2157,7 @@ export interface LogsScrollingTableMessageFragment_LogsCapturedEvent {
   timestamp: string;
   level: LogLevel;
   stepKey: string | null;
-  logKey: string;
+  fileKey: string;
   stepKeys: string[] | null;
 }
 

--- a/js_modules/dagit/packages/core/src/runs/types/PipelineRunLogsSubscription.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/PipelineRunLogsSubscription.ts
@@ -2171,7 +2171,7 @@ export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubs
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  logKey: string;
+  fileKey: string;
   stepKeys: string[] | null;
   pid: number | null;
 }

--- a/js_modules/dagit/packages/core/src/runs/types/RunDagsterRunEventFragment.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunDagsterRunEventFragment.ts
@@ -2157,7 +2157,7 @@ export interface RunDagsterRunEventFragment_LogsCapturedEvent {
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  logKey: string;
+  fileKey: string;
   stepKeys: string[] | null;
   pid: number | null;
 }

--- a/js_modules/dagit/packages/core/src/runs/types/RunLogsQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunLogsQuery.ts
@@ -2189,7 +2189,7 @@ export interface RunLogsQuery_logsForRun_EventConnection_events_LogsCapturedEven
   level: LogLevel;
   stepKey: string | null;
   eventType: DagsterEventType | null;
-  logKey: string;
+  fileKey: string;
   stepKeys: string[] | null;
   pid: number | null;
 }

--- a/js_modules/dagit/packages/core/src/runs/types/RunMetadataProviderMessageFragment.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunMetadataProviderMessageFragment.ts
@@ -202,7 +202,7 @@ export interface RunMetadataProviderMessageFragment_LogsCapturedEvent {
   message: string;
   timestamp: string;
   stepKey: string | null;
-  logKey: string;
+  fileKey: string;
   stepKeys: string[] | null;
   pid: number | null;
 }

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -365,7 +365,8 @@ def from_dagster_event_record(event_record: EventLogEntry, pipeline_name: str) -
         )
     elif dagster_event.event_type == DagsterEventType.LOGS_CAPTURED:
         return GrapheneLogsCapturedEvent(
-            logKey=dagster_event.logs_captured_data.log_key,
+            fileKey=dagster_event.logs_captured_data.file_key,
+            logKey=dagster_event.logs_captured_data.file_key,
             stepKeys=dagster_event.logs_captured_data.step_keys,
             pid=dagster_event.pid,
             **basic_params,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
@@ -289,6 +289,9 @@ class GrapheneLogsCapturedEvent(graphene.ObjectType):
         interfaces = (GrapheneMessageEvent,)
         name = "LogsCapturedEvent"
 
+    fileKey = graphene.NonNull(graphene.String)
+    # legacy name for compute log file key... required for back-compat reasons, but has been
+    # renamed to fileKey for newer versions of dagit
     logKey = graphene.NonNull(graphene.String)
     stepKeys = graphene.List(graphene.NonNull(graphene.String))
     pid = graphene.Int()


### PR DESCRIPTION
### Summary & Motivation
The existing captured log event used the variable `log_key` to describe the filename of the compute log file.  This replaces the `step_key` field for process-based captured compute logs.

However, the proposed captured log API introduces `log_key` to be a list of strings, including the filename.  So this renames (for the captured log event) log_key => log_file_key.

### How I Tested These Changes
Existing graphql tests.
