### PR TITLE
Enable sensor/schedule unstructured logging on top of captured log manager

### DIFF
--- a/js_modules/dagit/packages/core/src/TickLogDialog.tsx
+++ b/js_modules/dagit/packages/core/src/TickLogDialog.tsx
@@ -1,0 +1,141 @@
+import {gql, useQuery} from '@apollo/client';
+import {Box, Button, DialogFooter, Dialog, Colors, DialogBody} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {TickHistoryQuery_instigationStateOrError_InstigationState_ticks} from './instigation/types/TickHistoryQuery';
+import {EventTypeColumn, TimestampColumn, Row} from './runs/LogsRowComponents';
+import {
+  ColumnWidthsProvider,
+  ColumnWidthsContext,
+  HeadersContainer,
+  HeaderContainer,
+  Header,
+} from './runs/LogsScrollingTableHeader';
+import {TimestampDisplay} from './schedules/TimestampDisplay';
+import {
+  TickLogEventsQuery,
+  TickLogEventsQueryVariables,
+  TickLogEventsQuery_instigationStateOrError_InstigationState_tick_logEvents_events,
+} from './types/TickLogEventsQuery';
+import {InstigationSelector} from './types/globalTypes';
+
+type InstigationTick = TickHistoryQuery_instigationStateOrError_InstigationState_ticks;
+type LogEvent = TickLogEventsQuery_instigationStateOrError_InstigationState_tick_logEvents_events;
+
+export const TickLogDialog: React.FC<{
+  tick: InstigationTick;
+  instigationSelector: InstigationSelector;
+  onClose: () => void;
+}> = ({tick, instigationSelector, onClose}) => {
+  const {data} = useQuery<TickLogEventsQuery, TickLogEventsQueryVariables>(TICK_LOG_EVENTS_QUERY, {
+    variables: {instigationSelector, timestamp: tick.timestamp},
+    fetchPolicy: 'cache-and-network',
+    partialRefetch: true,
+    notifyOnNetworkStatusChange: true,
+  });
+
+  const events =
+    data?.instigationStateOrError.__typename === 'InstigationState' &&
+    data?.instigationStateOrError.tick
+      ? data?.instigationStateOrError.tick.logEvents.events
+      : undefined;
+
+  return (
+    <Dialog
+      isOpen={!!events}
+      onClose={onClose}
+      style={{width: '70vw', display: 'flex'}}
+      title={tick ? <TimestampDisplay timestamp={tick.timestamp} /> : null}
+    >
+      <DialogBody>
+        {events && events.length ? (
+          <TickLogsTable events={events} />
+        ) : (
+          <Box
+            flex={{justifyContent: 'center', alignItems: 'center'}}
+            style={{flex: 1, color: Colors.Gray600}}
+          >
+            No logs available
+          </Box>
+        )}
+      </DialogBody>
+      <DialogFooter>
+        <Button intent="primary" onClick={onClose}>
+          OK
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  );
+};
+
+const TickLogsTable: React.FC<{events: LogEvent[]}> = ({events}) => {
+  return (
+    <div style={{overflow: 'hidden', borderBottom: '0.5px solid #ececec', flex: 1}}>
+      <ColumnWidthsProvider onWidthsChanged={() => {}}>
+        <Headers />
+        {events.map((event, idx) => (
+          <TickLogRow event={event} key={idx} />
+        ))}
+      </ColumnWidthsProvider>
+    </div>
+  );
+};
+
+const Headers = () => {
+  const widths = React.useContext(ColumnWidthsContext);
+  return (
+    <HeadersContainer>
+      <Header
+        width={widths.eventType}
+        onResize={(width) => widths.onChange({...widths, eventType: width})}
+      >
+        Event Type
+      </Header>
+      <HeaderContainer style={{flex: 1}}>Info</HeaderContainer>
+      <Header
+        handleSide="left"
+        width={widths.timestamp}
+        onResize={(width) => widths.onChange({...widths, timestamp: width})}
+      >
+        Timestamp
+      </Header>
+    </HeadersContainer>
+  );
+};
+
+const TickLogRow: React.FC<{event: LogEvent}> = ({event}) => {
+  return (
+    <Row level={event.level} highlighted={false}>
+      <EventTypeColumn>
+        <span style={{marginLeft: 8}}>{event.level}</span>
+      </EventTypeColumn>
+      <Box padding={{horizontal: 12}} style={{flex: 1}}>
+        {event.message}
+      </Box>
+      <TimestampColumn time={event.timestamp} />
+    </Row>
+  );
+};
+
+const TICK_LOG_EVENTS_QUERY = gql`
+  query TickLogEventsQuery($instigationSelector: InstigationSelector!, $timestamp: Float!) {
+    instigationStateOrError(instigationSelector: $instigationSelector) {
+      __typename
+      ... on InstigationState {
+        id
+        tick(timestamp: $timestamp) {
+          id
+          status
+          timestamp
+          logEvents {
+            events {
+              message
+              timestamp
+              level
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/js_modules/dagit/packages/core/src/app/Flags.tsx
+++ b/js_modules/dagit/packages/core/src/app/Flags.tsx
@@ -10,6 +10,7 @@ export const FeatureFlag = {
   flagDebugConsoleLogging: 'flagDebugConsoleLogging' as const,
   flagDisableWebsockets: 'flagDisableWebsockets' as const,
   flagAssetGraphExperimentalZoom: 'flagAssetGraphExperimentalZoom' as const,
+  flagSensorScheduleLogging: 'flagSensorScheduleLogging' as const,
 };
 export type FeatureFlagType = keyof typeof FeatureFlag;
 

--- a/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
@@ -135,6 +135,16 @@ export function getFeatureFlagRows(
         />
       ),
     },
+    {
+      key: 'Experimental schedule/sensor logging view',
+      value: (
+        <Checkbox
+          format="switch"
+          checked={flags.includes(FeatureFlag.flagSensorScheduleLogging)}
+          onChange={() => toggleFlag(FeatureFlag.flagSensorScheduleLogging)}
+        />
+      ),
+    },
   ];
 }
 

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2429,6 +2429,20 @@ type InstigationTick {
   cursor: String
   runs: [Run!]!
   originRunIds: [String!]!
+  logKey: [String!]
+  logEvents: InstigationEventConnection!
+}
+
+type InstigationEventConnection {
+  events: [InstigationEvent!]!
+  cursor: String!
+  hasMore: Boolean!
+}
+
+type InstigationEvent {
+  message: String!
+  timestamp: String!
+  level: LogLevel!
 }
 
 type ScheduleData {

--- a/js_modules/dagit/packages/core/src/instigation/types/TickHistoryQuery.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/TickHistoryQuery.ts
@@ -49,6 +49,7 @@ export interface TickHistoryQuery_instigationStateOrError_InstigationState_ticks
   runs: TickHistoryQuery_instigationStateOrError_InstigationState_ticks_runs[];
   originRunIds: string[];
   error: TickHistoryQuery_instigationStateOrError_InstigationState_ticks_error | null;
+  logKey: string[] | null;
   runKeys: string[];
 }
 

--- a/js_modules/dagit/packages/core/src/runs/LogsScrollingTableHeader.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsScrollingTableHeader.tsx
@@ -59,7 +59,7 @@ interface HeaderState {
   screenX: number;
 }
 
-class Header extends React.Component<HeaderProps, HeaderState> {
+export class Header extends React.Component<HeaderProps, HeaderState> {
   state = {
     isDragging: false,
     width: 0,
@@ -143,7 +143,7 @@ export const Headers = () => {
   );
 };
 
-const HeadersContainer = styled.div`
+export const HeadersContainer = styled.div`
   display: flex;
   color: ${Colors.Gray400};
   text-transform: uppercase;
@@ -152,7 +152,7 @@ const HeadersContainer = styled.div`
   z-index: 2;
 `;
 
-const HeaderContainer = styled.div`
+export const HeaderContainer = styled.div`
   flex-shrink: 0;
   position: relative;
   user-select: none;

--- a/js_modules/dagit/packages/core/src/types/TickLogEventsQuery.ts
+++ b/js_modules/dagit/packages/core/src/types/TickLogEventsQuery.ts
@@ -1,0 +1,51 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { InstigationSelector, InstigationTickStatus, LogLevel } from "./globalTypes";
+
+// ====================================================
+// GraphQL query operation: TickLogEventsQuery
+// ====================================================
+
+export interface TickLogEventsQuery_instigationStateOrError_InstigationStateNotFoundError {
+  __typename: "InstigationStateNotFoundError" | "PythonError";
+}
+
+export interface TickLogEventsQuery_instigationStateOrError_InstigationState_tick_logEvents_events {
+  __typename: "InstigationEvent";
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+}
+
+export interface TickLogEventsQuery_instigationStateOrError_InstigationState_tick_logEvents {
+  __typename: "InstigationEventConnection";
+  events: TickLogEventsQuery_instigationStateOrError_InstigationState_tick_logEvents_events[];
+}
+
+export interface TickLogEventsQuery_instigationStateOrError_InstigationState_tick {
+  __typename: "InstigationTick";
+  id: string;
+  status: InstigationTickStatus;
+  timestamp: number;
+  logEvents: TickLogEventsQuery_instigationStateOrError_InstigationState_tick_logEvents;
+}
+
+export interface TickLogEventsQuery_instigationStateOrError_InstigationState {
+  __typename: "InstigationState";
+  id: string;
+  tick: TickLogEventsQuery_instigationStateOrError_InstigationState_tick | null;
+}
+
+export type TickLogEventsQuery_instigationStateOrError = TickLogEventsQuery_instigationStateOrError_InstigationStateNotFoundError | TickLogEventsQuery_instigationStateOrError_InstigationState;
+
+export interface TickLogEventsQuery {
+  instigationStateOrError: TickLogEventsQuery_instigationStateOrError;
+}
+
+export interface TickLogEventsQueryVariables {
+  instigationSelector: InstigationSelector;
+  timestamp: number;
+}

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -21,10 +21,12 @@ from dagster._seven.compat.pendulum import to_timezone
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 from dagster._utils.yaml_utils import dump_run_config_yaml
 
+from ..implementation.fetch_instigators import get_tick_log_events
 from ..implementation.fetch_schedules import get_schedule_next_tick
 from ..implementation.fetch_sensors import get_sensor_next_tick
 from ..implementation.loader import RepositoryScopedBatchLoader
 from .errors import GrapheneError, GraphenePythonError
+from .logs.log_level import GrapheneLogLevel
 from .repository_origin import GrapheneRepositoryOrigin
 from .tags import GraphenePipelineTag
 from .util import non_null_list
@@ -94,6 +96,24 @@ class GrapheneInstigationTypeSpecificData(graphene.Union):
         name = "InstigationTypeSpecificData"
 
 
+class GrapheneInstigationEvent(graphene.ObjectType):
+    class Meta:
+        name = "InstigationEvent"
+
+    message = graphene.NonNull(graphene.String)
+    timestamp = graphene.NonNull(graphene.String)
+    level = graphene.NonNull(GrapheneLogLevel)
+
+
+class GrapheneInstigationEventConnection(graphene.ObjectType):
+    class Meta:
+        name = "InstigationEventConnection"
+
+    events = non_null_list(GrapheneInstigationEvent)
+    cursor = graphene.NonNull(graphene.String)
+    hasMore = graphene.NonNull(graphene.Boolean)
+
+
 class GrapheneInstigationTick(graphene.ObjectType):
     id = graphene.NonNull(graphene.ID)
     status = graphene.NonNull(GrapheneInstigationTickStatus)
@@ -105,6 +125,8 @@ class GrapheneInstigationTick(graphene.ObjectType):
     cursor = graphene.String()
     runs = non_null_list("dagster_graphql.schema.pipelines.pipeline.GrapheneRun")
     originRunIds = non_null_list(graphene.String)
+    logKey = graphene.List(graphene.NonNull(graphene.String))
+    logEvents = graphene.Field(graphene.NonNull(GrapheneInstigationEventConnection))
 
     class Meta:
         name = "InstigationTick"
@@ -121,6 +143,7 @@ class GrapheneInstigationTick(graphene.ObjectType):
             skipReason=tick.skip_reason,
             originRunIds=tick.origin_run_ids,
             cursor=tick.cursor,
+            logKey=tick.log_key,
         )
 
     def resolve_id(self, _):
@@ -140,6 +163,9 @@ class GrapheneInstigationTick(graphene.ObjectType):
         }
 
         return [GrapheneRun(records_by_id[run_id]) for run_id in run_ids if run_id in records_by_id]
+
+    def resolve_logEvents(self, graphene_info):
+        return get_tick_log_events(graphene_info, self._tick)
 
 
 class GrapheneFutureInstigationTick(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1319,6 +1319,11 @@ def define_sensors():
             tags={"test": "1234"},
         )
 
+    @sensor(job_name="no_config_pipeline")
+    def logging_sensor(context):
+        context.log.info("hello hello")
+        return SkipReason()
+
     return [
         always_no_config_sensor,
         once_no_config_sensor,
@@ -1326,6 +1331,7 @@ def define_sensors():
         multi_no_config_sensor,
         custom_interval_sensor,
         running_in_code_sensor,
+        logging_sensor,
     ]
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_sensors.py
@@ -7,72 +7,6 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['TestSensors.test_get_sensor[non_launchable_in_memory_instance_lazy_repository] 1'] = {
-    '__typename': 'Sensor',
-    'minIntervalSeconds': 30,
-    'name': 'always_no_config_sensor',
-    'nextTick': None,
-    'sensorState': {
-        'runs': [
-        ],
-        'runsCount': 0,
-        'status': 'STOPPED',
-        'ticks': [
-        ]
-    },
-    'targets': [
-        {
-            'mode': 'default',
-            'pipelineName': 'no_config_pipeline',
-            'solidSelection': None
-        }
-    ]
-}
-
-snapshots['TestSensors.test_get_sensor[non_launchable_in_memory_instance_managed_grpc_env] 1'] = {
-    '__typename': 'Sensor',
-    'minIntervalSeconds': 30,
-    'name': 'always_no_config_sensor',
-    'nextTick': None,
-    'sensorState': {
-        'runs': [
-        ],
-        'runsCount': 0,
-        'status': 'STOPPED',
-        'ticks': [
-        ]
-    },
-    'targets': [
-        {
-            'mode': 'default',
-            'pipelineName': 'no_config_pipeline',
-            'solidSelection': None
-        }
-    ]
-}
-
-snapshots['TestSensors.test_get_sensor[non_launchable_in_memory_instance_multi_location] 1'] = {
-    '__typename': 'Sensor',
-    'minIntervalSeconds': 30,
-    'name': 'always_no_config_sensor',
-    'nextTick': None,
-    'sensorState': {
-        'runs': [
-        ],
-        'runsCount': 0,
-        'status': 'STOPPED',
-        'ticks': [
-        ]
-    },
-    'targets': [
-        {
-            'mode': 'default',
-            'pipelineName': 'no_config_pipeline',
-            'solidSelection': None
-        }
-    ]
-}
-
 snapshots['TestSensors.test_get_sensor[non_launchable_postgres_instance_lazy_repository] 1'] = {
     '__typename': 'Sensor',
     'minIntervalSeconds': 30,
@@ -227,375 +161,6 @@ snapshots['TestSensors.test_get_sensor[non_launchable_sqlite_instance_multi_loca
     ]
 }
 
-snapshots['TestSensors.test_get_sensors[non_launchable_in_memory_instance_lazy_repository] 1'] = [
-    {
-        'description': None,
-        'minIntervalSeconds': 30,
-        'name': 'always_no_config_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'STOPPED',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    },
-    {
-        'description': None,
-        'minIntervalSeconds': 60,
-        'name': 'custom_interval_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'STOPPED',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    },
-    {
-        'description': None,
-        'minIntervalSeconds': 30,
-        'name': 'multi_no_config_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'STOPPED',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    },
-    {
-        'description': None,
-        'minIntervalSeconds': 30,
-        'name': 'never_no_config_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'STOPPED',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    },
-    {
-        'description': None,
-        'minIntervalSeconds': 30,
-        'name': 'once_no_config_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'STOPPED',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    },
-    {
-        'description': None,
-        'minIntervalSeconds': 30,
-        'name': 'running_in_code_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'RUNNING',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    }
-]
-
-snapshots['TestSensors.test_get_sensors[non_launchable_in_memory_instance_managed_grpc_env] 1'] = [
-    {
-        'description': None,
-        'minIntervalSeconds': 30,
-        'name': 'always_no_config_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'STOPPED',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    },
-    {
-        'description': None,
-        'minIntervalSeconds': 60,
-        'name': 'custom_interval_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'STOPPED',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    },
-    {
-        'description': None,
-        'minIntervalSeconds': 30,
-        'name': 'multi_no_config_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'STOPPED',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    },
-    {
-        'description': None,
-        'minIntervalSeconds': 30,
-        'name': 'never_no_config_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'STOPPED',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    },
-    {
-        'description': None,
-        'minIntervalSeconds': 30,
-        'name': 'once_no_config_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'STOPPED',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    },
-    {
-        'description': None,
-        'minIntervalSeconds': 30,
-        'name': 'running_in_code_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'RUNNING',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    }
-]
-
-snapshots['TestSensors.test_get_sensors[non_launchable_in_memory_instance_multi_location] 1'] = [
-    {
-        'description': None,
-        'minIntervalSeconds': 30,
-        'name': 'always_no_config_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'STOPPED',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    },
-    {
-        'description': None,
-        'minIntervalSeconds': 60,
-        'name': 'custom_interval_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'STOPPED',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    },
-    {
-        'description': None,
-        'minIntervalSeconds': 30,
-        'name': 'multi_no_config_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'STOPPED',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    },
-    {
-        'description': None,
-        'minIntervalSeconds': 30,
-        'name': 'never_no_config_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'STOPPED',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    },
-    {
-        'description': None,
-        'minIntervalSeconds': 30,
-        'name': 'once_no_config_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'STOPPED',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    },
-    {
-        'description': None,
-        'minIntervalSeconds': 30,
-        'name': 'running_in_code_sensor',
-        'sensorState': {
-            'runs': [
-            ],
-            'runsCount': 0,
-            'status': 'RUNNING',
-            'ticks': [
-            ]
-        },
-        'targets': [
-            {
-                'mode': 'default',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    }
-]
-
 snapshots['TestSensors.test_get_sensors[non_launchable_postgres_instance_lazy_repository] 1'] = [
     {
         'description': None,
@@ -621,6 +186,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_postgres_instance_lazy_re
         'description': None,
         'minIntervalSeconds': 60,
         'name': 'custom_interval_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'logging_sensor',
         'sensorState': {
             'runs': [
             ],
@@ -763,6 +348,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_postgres_instance_managed
     {
         'description': None,
         'minIntervalSeconds': 30,
+        'name': 'logging_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
         'name': 'multi_no_config_sensor',
         'sensorState': {
             'runs': [
@@ -867,6 +472,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_postgres_instance_multi_l
         'description': None,
         'minIntervalSeconds': 60,
         'name': 'custom_interval_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'logging_sensor',
         'sensorState': {
             'runs': [
             ],
@@ -1009,6 +634,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_deployed_
     {
         'description': None,
         'minIntervalSeconds': 30,
+        'name': 'logging_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
         'name': 'multi_no_config_sensor',
         'sensorState': {
             'runs': [
@@ -1113,6 +758,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_lazy_repo
         'description': None,
         'minIntervalSeconds': 60,
         'name': 'custom_interval_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'logging_sensor',
         'sensorState': {
             'runs': [
             ],
@@ -1255,6 +920,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_managed_g
     {
         'description': None,
         'minIntervalSeconds': 30,
+        'name': 'logging_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
         'name': 'multi_no_config_sensor',
         'sensorState': {
             'runs': [
@@ -1359,6 +1044,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_multi_loc
         'description': None,
         'minIntervalSeconds': 60,
         'name': 'custom_interval_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'logging_sensor',
         'sensorState': {
             'runs': [
             ],

--- a/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
+++ b/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
@@ -1,0 +1,151 @@
+import json
+import logging
+from contextlib import ExitStack
+from typing import IO, Any, List, Mapping, Optional, Sequence
+
+from dagster import _seven
+from dagster._core.instance import DagsterInstance
+from dagster._core.log_manager import DAGSTER_META_KEY
+from dagster._core.storage.captured_log_manager import CapturedLogManager
+from dagster._core.storage.compute_log_manager import ComputeIOType
+from dagster._core.utils import coerce_valid_log_level
+from dagster._utils.log import create_console_logger
+
+
+class DispatchingLogHandler(logging.Handler):
+    """
+    Proxies logging records to a set of downstream loggers which themselves will route to their own
+    set of handlers.  Needed to bridge to the set of dagster logging utilities which were
+    implemented as loggers rather than log handlers.
+    """
+
+    def __init__(self, downstream_loggers: List[logging.Logger]):
+        self._should_capture = True
+        self._downstream_loggers = [*downstream_loggers]
+        super().__init__()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return self._should_capture
+
+    def emit(self, record: logging.LogRecord):
+        """For any received record, add metadata, and have handlers handle it"""
+
+        try:
+            self._should_capture = False
+            for logger in self._downstream_loggers:
+                logger.handle(record)
+        finally:
+            self._should_capture = True
+
+
+class CapturedLogHandler(logging.Handler):
+    """
+    Persist logging records to an IO stream controlled by the CapturedLogManager
+    """
+
+    def __init__(self, write_stream: IO):
+        self._write_stream = write_stream
+        self._has_logged = False
+        super().__init__()
+
+    @property
+    def has_logged(self):
+        return self._has_logged
+
+    def emit(self, record: logging.LogRecord):
+        self._has_logged = True
+        self._write_stream.write(_seven.json.dumps(record.__dict__) + "\n")
+
+
+class InstigationLogger(logging.Logger):
+    """
+    Logger exposed on the evaluation context of sensor/schedule evaluation functions.  This is tied
+    to the Python logging system by setting up a custom logging handler that writes JSON payloads
+    representing the log events to the dagster-managed captured log manager.  These log events are
+    persisted, using the given log_key, which is stored on the sensor/schedule tick. These logs can
+    then be retrieved using the log_key through captured log manager's API.
+
+    The instigation logger also adds a console logger to emit the logs in a structured way from the
+    evaluation process.
+    """
+
+    def __init__(
+        self,
+        log_key: Optional[List[str]] = None,
+        instance: Optional[DagsterInstance] = None,
+        repository_name: Optional[str] = None,
+        name: Optional[str] = None,
+        level: int = logging.NOTSET,
+    ):
+        super().__init__(name="dagster", level=coerce_valid_log_level(level))
+        self._log_key = log_key
+        self._instance = instance
+        self._repository_name = repository_name
+        self._name = name
+        self._exit_stack = ExitStack()
+        self._capture_handler = None
+        self.addHandler(DispatchingLogHandler([create_console_logger("dagster", logging.INFO)]))
+
+    def __enter__(self):
+        if (
+            self._log_key
+            and self._instance
+            and isinstance(self._instance.compute_log_manager, CapturedLogManager)
+        ):
+            write_stream = self._exit_stack.enter_context(
+                self._instance.compute_log_manager.open_log_stream(
+                    self._log_key, ComputeIOType.STDERR
+                )
+            )
+            if write_stream:
+                self._capture_handler = CapturedLogHandler(write_stream)
+                self.addHandler(self._capture_handler)
+        return self
+
+    def __exit__(self, _exception_type, _exception_value, _traceback):
+        self._exit_stack.close()
+
+    def _annotate_record(self, record) -> logging.LogRecord:
+        if self._repository_name and self._name:
+            message = record.getMessage()
+            setattr(
+                record,
+                DAGSTER_META_KEY,
+                {
+                    "repository_name": self._repository_name,
+                    "name": self._name,
+                    "orig_message": message,
+                },
+            )
+            record.msg = " - ".join([self._repository_name, self._name, message])
+        return record
+
+    def makeRecord(  # pylint: disable=signature-differs
+        self, name, level, fn, lno, msg, args, exc_info, func, extra, sinfo
+    ):
+        record = super().makeRecord(name, level, fn, lno, msg, args, exc_info, func, extra, sinfo)
+        return self._annotate_record(record)
+
+    def has_captured_logs(self):
+        return self._capture_handler and self._capture_handler.has_logged
+
+
+def get_instigation_log_records(
+    instance: DagsterInstance, log_key: Sequence[str]
+) -> Sequence[Mapping[str, Any]]:
+    if not isinstance(instance.compute_log_manager, CapturedLogManager):
+        return []
+
+    log_data = instance.compute_log_manager.get_log_data(log_key)
+    raw_logs = log_data.stderr.decode("utf-8") if log_data.stderr else ""
+
+    records = []
+    for line in raw_logs.split("\n"):
+        if not line:
+            continue
+
+        try:
+            records.append(_seven.json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return records

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 from contextlib import ExitStack
 from datetime import datetime
 from enum import Enum
@@ -21,6 +22,7 @@ from typing_extensions import TypeAlias, TypeGuard
 
 import dagster._check as check
 from dagster._annotations import public
+from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils import ensure_gen, merge_dicts
 from dagster._utils.schedules import is_valid_cron_schedule
@@ -104,10 +106,23 @@ class ScheduleEvaluationContext:
 
     """
 
-    __slots__ = ["_instance_ref", "_scheduled_execution_time", "_exit_stack", "_instance"]
+    __slots__ = [
+        "_instance_ref",
+        "_scheduled_execution_time",
+        "_exit_stack",
+        "_instance",
+        "_log_key",
+        "_logger",
+        "_repository_name",
+        "_schedule_name",
+    ]
 
     def __init__(
-        self, instance_ref: Optional[InstanceRef], scheduled_execution_time: Optional[datetime]
+        self,
+        instance_ref: Optional[InstanceRef],
+        scheduled_execution_time: Optional[datetime],
+        repository_name: Optional[str] = None,
+        schedule_name: Optional[str] = None,
     ):
         self._exit_stack = ExitStack()
         self._instance = None
@@ -116,12 +131,25 @@ class ScheduleEvaluationContext:
         self._scheduled_execution_time = check.opt_inst_param(
             scheduled_execution_time, "scheduled_execution_time", datetime
         )
+        self._log_key = (
+            [
+                repository_name,
+                schedule_name,
+                scheduled_execution_time.strftime("%Y%m%d_%H%M%S"),
+            ]
+            if repository_name and schedule_name and scheduled_execution_time
+            else None
+        )
+        self._logger = None
+        self._repository_name = repository_name
+        self._schedule_name = schedule_name
 
     def __enter__(self):
         return self
 
     def __exit__(self, _exception_type, _exception_value, _traceback):
         self._exit_stack.close()
+        self._logger = None
 
     @public  # type: ignore
     @property
@@ -142,6 +170,37 @@ class ScheduleEvaluationContext:
     @property
     def scheduled_execution_time(self) -> Optional[datetime]:
         return self._scheduled_execution_time
+
+    @property
+    def log(self) -> logging.Logger:
+        if self._logger:
+            return self._logger
+
+        if not self._instance_ref:
+            self._logger = self._exit_stack.enter_context(
+                InstigationLogger(
+                    self._log_key,
+                    repository_name=self._repository_name,
+                    name=self._schedule_name,
+                )
+            )
+
+        self._logger = self._exit_stack.enter_context(
+            InstigationLogger(
+                self._log_key,
+                self.instance,
+                repository_name=self._repository_name,
+                name=self._schedule_name,
+            )
+        )
+        return cast(InstigationLogger, self._logger)
+
+    def has_captured_logs(self):
+        return self._logger and self._logger.has_captured_logs()
+
+    @property
+    def log_key(self) -> Optional[List[str]]:
+        return self._log_key
 
 
 class DecoratedScheduleFunction(NamedTuple):
@@ -195,6 +254,7 @@ def build_schedule_context(
 class ScheduleExecutionData(NamedTuple):
     run_requests: Optional[Sequence[RunRequest]]
     skip_message: Optional[str]
+    captured_log_key: Optional[Sequence[str]]
 
 
 class ScheduleDefinition:
@@ -542,7 +602,9 @@ class ScheduleDefinition:
         ]
 
         return ScheduleExecutionData(
-            run_requests=run_requests_with_schedule_tags, skip_message=skip_message
+            run_requests=run_requests_with_schedule_tags,
+            skip_message=skip_message,
+            captured_log_key=context.log_key if context.has_captured_logs() else None,
         )
 
     def has_loadable_target(self):

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -251,10 +251,34 @@ def build_schedule_context(
 
 
 @whitelist_for_serdes
-class ScheduleExecutionData(NamedTuple):
-    run_requests: Optional[Sequence[RunRequest]]
-    skip_message: Optional[str]
-    captured_log_key: Optional[Sequence[str]]
+class ScheduleExecutionData(
+    NamedTuple(
+        "_ScheduleExecutionData",
+        [
+            ("run_requests", Optional[Sequence[RunRequest]]),
+            ("skip_message", Optional[str]),
+            ("captured_log_key", Optional[Sequence[str]]),
+        ],
+    )
+):
+    def __new__(
+        cls,
+        run_requests: Optional[Sequence[RunRequest]] = None,
+        skip_message: Optional[str] = None,
+        captured_log_key: Optional[Sequence[str]] = None,
+    ):
+        check.opt_sequence_param(run_requests, "run_requests", RunRequest)
+        check.opt_str_param(skip_message, "skip_message")
+        check.opt_list_param(captured_log_key, "captured_log_key", str)
+        check.invariant(
+            not (run_requests and skip_message), "Found both skip data and run request data"
+        )
+        return super(ScheduleExecutionData, cls).__new__(
+            cls,
+            run_requests=run_requests,
+            skip_message=skip_message,
+            captured_log_key=captured_log_key,
+        )
 
 
 class ScheduleDefinition:

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from inspect import Parameter
-from typing import Any, Dict, Mapping, NamedTuple, Optional, Sequence, Type, Union
+from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Sequence, Type, Union
 
 import dagster._check as check
 from dagster._core.definitions.run_request import InstigatorType
@@ -343,6 +343,9 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
     def with_origin_run(self, origin_run_id):
         return self._replace(tick_data=self.tick_data.with_origin_run(origin_run_id))
 
+    def with_log_key(self, log_key):
+        return self._replace(tick_data=self.tick_data.with_log_key(log_key))
+
     @property
     def instigator_origin_id(self):
         return self.tick_data.instigator_origin_id
@@ -394,6 +397,10 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
     @property
     def failure_count(self) -> int:
         return self.tick_data.failure_count
+
+    @property
+    def log_key(self) -> Optional[List[str]]:
+        return self.tick_data.log_key
 
 
 register_serdes_tuple_fallbacks({"JobTick": InstigatorTick})
@@ -468,6 +475,7 @@ class TickData(
             ("origin_run_ids", Sequence[str]),
             ("failure_count", int),
             ("selector_id", Optional[str]),
+            ("log_key", Optional[List[str]]),
         ],
     )
 ):
@@ -506,8 +514,10 @@ class TickData(
         origin_run_ids: Optional[Sequence[str]] = None,
         failure_count: Optional[int] = None,
         selector_id: Optional[str] = None,
+        log_key: Optional[List[str]] = None,
     ):
         _validate_tick_args(instigator_type, status, run_ids, error, skip_reason)
+        check.opt_list_param(log_key, "log_key", of_type=str)
         return super(TickData, cls).__new__(
             cls,
             check.str_param(instigator_origin_id, "instigator_origin_id"),
@@ -523,6 +533,7 @@ class TickData(
             origin_run_ids=check.opt_sequence_param(origin_run_ids, "origin_run_ids", of_type=str),
             failure_count=check.opt_int_param(failure_count, "failure_count", 0),
             selector_id=check.opt_str_param(selector_id, "selector_id"),
+            log_key=log_key,
         )
 
     def with_status(self, status, error=None, timestamp=None, failure_count=None):
@@ -589,6 +600,14 @@ class TickData(
             **merge_dicts(
                 self._asdict(),
                 {"origin_run_ids": [*self.origin_run_ids, origin_run_id]},
+            )
+        )
+
+    def with_log_key(self, log_key):
+        return TickData(
+            **merge_dicts(
+                self._asdict(),
+                {"log_key": check.list_param(log_key, "log_key", of_type=str)},
             )
         )
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -524,6 +524,8 @@ class SqlEventLogStorage(EventLogStorage):
     def delete_events(self, run_id):
         with self.run_connection(run_id) as conn:
             self.delete_events_for_run(conn, run_id)
+        with self.index_connection() as conn:
+            self.delete_events_for_run(conn, run_id)
 
     def delete_events_for_run(self, conn, run_id):
         check.str_param(run_id, "run_id")

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -122,6 +122,9 @@ class SensorLaunchContext:
     def add_run_info(self, run_id=None, run_key=None):
         self._tick = self._tick.with_run_info(run_id, run_key)
 
+    def add_log_info(self, log_key):
+        self._tick = self._tick.with_log_key(log_key)
+
     def set_should_update_cursor_on_failure(self, should_update_cursor_on_failure: bool):
         self._should_update_cursor_on_failure = should_update_cursor_on_failure
 
@@ -550,6 +553,9 @@ def _evaluate_sensor(
     )
 
     yield
+
+    if sensor_runtime_data.captured_log_key:
+        context.add_log_info(sensor_runtime_data.captured_log_key)
 
     assert isinstance(sensor_runtime_data, SensorExecutionData)
     if not sensor_runtime_data.run_requests:

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -276,7 +276,9 @@ def get_external_schedule_execution(
         else None
     )
 
-    with ScheduleEvaluationContext(instance_ref, scheduled_execution_time) as schedule_context:
+    with ScheduleEvaluationContext(
+        instance_ref, scheduled_execution_time, repo_def.name, schedule_name
+    ) as schedule_context:
         try:
             with user_code_error_boundary(
                 ScheduleExecutionError,
@@ -309,6 +311,7 @@ def get_external_sensor_execution(
                 cursor=cursor,
                 repository_name=repo_def.name,
                 repository_def=repo_def,
+                sensor_name=sensor_name,
             )
         )
 

--- a/python_modules/dagster/dagster/_loggers/__init__.py
+++ b/python_modules/dagster/dagster/_loggers/__init__.py
@@ -7,7 +7,7 @@ from dagster import _seven
 from dagster._config import Field
 from dagster._core.definitions.logger_definition import LoggerDefinition, logger
 from dagster._core.utils import coerce_valid_log_level
-from dagster._utils.log import default_date_format_string, default_format_string
+from dagster._utils.log import create_console_logger
 
 if TYPE_CHECKING:
     from dagster._core.execution.context.logger import InitLoggerContext
@@ -38,20 +38,10 @@ def colored_console_logger(init_context: "InitLoggerContext") -> logging.Logger:
     """This logger provides support for sending Dagster logs to stdout in a colored format. It is
     included by default on jobs which do not otherwise specify loggers.
     """
-    level = coerce_valid_log_level(init_context.logger_config["log_level"])
-    name = init_context.logger_config["name"]
-
-    klass = logging.getLoggerClass()
-    logger_ = klass(name, level=level)
-    coloredlogs.install(
-        logger=logger_,
-        level=level,
-        fmt=default_format_string(),
-        datefmt=default_date_format_string(),
-        field_styles={"levelname": {"color": "blue"}, "asctime": {"color": "green"}},
-        level_styles={"debug": {}, "error": {"color": "red"}},
+    return create_console_logger(
+        name=init_context.logger_config["name"],
+        level=coerce_valid_log_level(init_context.logger_config["log_level"]),
     )
-    return logger_
 
 
 @logger(

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -74,6 +74,9 @@ class _ScheduleLaunchContext:
     def add_run_info(self, run_id=None, run_key=None):
         self._tick = self._tick.with_run_info(run_id, run_key)
 
+    def add_log_key(self, log_key):
+        self._tick = self._tick.with_log_key(log_key)
+
     def _write(self):
         self._instance.update_tick(self._tick)
 
@@ -566,6 +569,9 @@ def _schedule_runs_at_time(
         scheduled_execution_time=schedule_time,
     )
     yield None
+
+    if schedule_execution_data.captured_log_key:
+        tick_context.add_log_key(schedule_execution_data.captured_log_key)
 
     if not schedule_execution_data.run_requests:
         if schedule_execution_data.skip_message:

--- a/python_modules/dagster/dagster/_utils/log.py
+++ b/python_modules/dagster/dagster/_utils/log.py
@@ -279,3 +279,17 @@ def configure_loggers(handler="default", log_level="INFO"):
     if handler == "default":
         for name in ["dagster", "dagit"]:
             logging.getLogger(name).handlers[0].formatter.formatTime = _mockable_formatTime
+
+
+def create_console_logger(name, level):
+    klass = logging.getLoggerClass()
+    handler = klass(name, level=level)
+    coloredlogs.install(
+        logger=handler,
+        level=level,
+        fmt=default_format_string(),
+        datefmt=default_date_format_string(),
+        field_styles={"levelname": {"color": "blue"}, "asctime": {"color": "green"}},
+        level_styles={"debug": {}, "error": {"color": "red"}},
+    )
+    return handler


### PR DESCRIPTION
### Summary & Motivation
We want to enable sensor/schedule logging without stuffing more data into the DB.  This creates a new instigation logger that provides a logger object on the sensor/schedule context for users to log messages, which will explicitly write json objects to log files managed by the compute log manager.  The log key for these files are scoped (and laid out on the filesystem) based on the structure: 

`repo_name > sensor_name > timestamp_string`

This is in contrast with the run compute logs, which are laid out based on the structure (these should probably not change, to maintain backwards compatibility):

`run_id > "compute_logs" > step_key (or pid)`

Once these logs are written out by the compute log manager, the `log_key` of the captured logs are stored on the sensor/schedule tick.  These are then used by dagit to load the logs, pull out the record json, and return some set of message events.

https://user-images.githubusercontent.com/1040172/196079448-5f7bc90e-e4e2-4b33-9751-668ba63087b7.mov


### How I Tested These Changes
Manually tested by adding `context.log.info` calls in a test sensor, and seeing them propagated to the frontend.

