### PR TITLE
[dagster-dbt] Fix dbt asset op name

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -303,6 +303,7 @@ def _dbt_nodes_to_assets(
     select: str,
     exclude: str,
     selected_unique_ids: AbstractSet[str],
+    project_id: str,
     runtime_metadata_fn: Optional[
         Callable[[SolidExecutionContext, Mapping[str, Any]], Mapping[str, RawMetadataValue]]
     ] = None,
@@ -321,8 +322,6 @@ def _dbt_nodes_to_assets(
 
     group_names_by_key: Dict[AssetKey, str] = {}
     fqns_by_output_name: Dict[str, str] = {}
-
-    package_name: str = ""
 
     if use_build_command:
         deps = _get_deps(
@@ -354,8 +353,6 @@ def _dbt_nodes_to_assets(
             ),
         )
 
-        package_name = node_info.get("package_name", package_name)
-
         group_name = node_info_to_group_fn(node_info)
         if group_name is not None:
             group_names_by_key[asset_key] = group_name
@@ -372,7 +369,7 @@ def _dbt_nodes_to_assets(
                 asset_ins[parent_asset_key] = (input_name, In(Nothing))
 
     # prevent op name collisions between multiple dbt multi-assets
-    op_name = f"run_dbt_{package_name}"
+    op_name = f"run_dbt_{project_id}"
     if select != "*" or exclude:
         op_name += "_" + hashlib.md5(select.encode() + exclude.encode()).hexdigest()[-5:]
 
@@ -581,6 +578,7 @@ def load_assets_from_dbt_manifest(
         select=select,
         exclude=exclude,
         selected_unique_ids=selected_unique_ids,
+        project_id=manifest_json["metadata"]["project_id"][:5],
         node_info_to_asset_key=node_info_to_asset_key,
         use_build_command=use_build_command,
         partitions_def=partitions_def,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -192,7 +192,7 @@ def test_basic(
             test_project_dir, dbt_config_dir, use_build_command=use_build
         )
 
-    assert dbt_assets[0].op.name == "run_dbt_dagster_dbt_test_project"
+    assert dbt_assets[0].op.name == "run_dbt_5ad73"
 
     result = build_assets_job(
         "test_job",
@@ -336,7 +336,7 @@ def test_select_from_project(
         for suffix in (["sort_by_calories"], ["subdir_schema", "least_caloric"])
     }
 
-    assert dbt_assets[0].op.name == "run_dbt_dagster_dbt_test_project_e4753"
+    assert dbt_assets[0].op.name == "run_dbt_5ad73_e4753"
 
     result = build_assets_job(
         "test_job",


### PR DESCRIPTION
### Summary & Motivation

Previously, we used the package_name attribute from the node_info to infer the name of the overall project. This is not a good way of doing this because if you import external dbt packages (e.g. dbt deps), then there will be multiple present package names (and so it's non-deterministic which package name will be used for the op name, which will cause errors).

Now, we use the project_id (which is guaranteed to be unique). There is no top-level human-readable project identifier, so we use the hashy thing instead, so this is a small regression in user experience in some cases, unfortunately.

### How I Tested These Changes
