### PR TITLE
[dagster-dbt] fix dbt test metadata

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -149,7 +149,7 @@ def result_to_events(
                 metadata={
                     "Test ID": result["unique_id"],
                     "Test Status": status,
-                    "Test Message": result.get("message", ""),
+                    "Test Message": result.get("message") or "",
                 },
             )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -144,7 +144,14 @@ def result_to_events(
             if node_info is None:
                 continue
             upstream_asset_key = node_info_to_asset_key(node_info)
-            yield AssetObservation(asset_key=upstream_asset_key, metadata=metadata)
+            yield AssetObservation(
+                asset_key=upstream_asset_key,
+                metadata={
+                    "Test ID": result["unique_id"],
+                    "Test Status": status,
+                    "Test Message": result.get("message", ""),
+                },
+            )
 
 
 def generate_events(


### PR DESCRIPTION
### Summary & Motivation

Fixes: https://github.com/dagster-io/dagster/issues/9952

Metadata fields on AssetObservations are intended to represent properties of the asset itself, rather than properties of tests about the asset.

### How I Tested These Changes
