### PR TITLE
[dagit] Add daemon alerts to Overview schedules/sensors pages

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceSchedules.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceSchedules.tsx
@@ -69,9 +69,10 @@ const AllSchedules: React.FC<{data: InstanceSchedulesQuery}> = ({data}) => {
 
   const loadedSchedulesSection = withSchedules.length ? (
     <>
-      <Box padding={{vertical: 16, horizontal: 24}}>
-        <SchedulerInfo daemonHealth={instance.daemonHealth} />
-      </Box>
+      <SchedulerInfo
+        daemonHealth={instance.daemonHealth}
+        padding={{vertical: 16, horizontal: 24}}
+      />
       {withSchedules.map((repository) => (
         <React.Fragment key={repository.name}>
           <Box

--- a/js_modules/dagit/packages/core/src/instance/InstanceSensors.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceSensors.tsx
@@ -66,9 +66,7 @@ const AllSensors: React.FC<{data: InstanceSensorsQuery}> = ({data}) => {
 
   const sensorDefinitionsSection = withSensors.length ? (
     <>
-      <Box padding={{horizontal: 24, vertical: 16}}>
-        <SensorInfo daemonHealth={instance.daemonHealth} />
-      </Box>
+      <SensorInfo daemonHealth={instance.daemonHealth} padding={{horizontal: 24, vertical: 16}} />
       {withSensors.map((repository) =>
         repository.sensors.length ? (
           <React.Fragment key={repository.name}>

--- a/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
@@ -17,9 +17,11 @@ import * as React from 'react';
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
+import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
 import {RepoFilterButton} from '../instance/RepoFilterButton';
 import {INSTIGATION_STATE_FRAGMENT} from '../instigation/InstigationUtils';
 import {UnloadableSchedules} from '../instigation/Unloadable';
+import {SchedulerInfo} from '../schedules/SchedulerInfo';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
@@ -131,6 +133,12 @@ export const OverviewSchedulesRoot = () => {
               count={data.unloadableInstigationStatesOrError.results.length}
             />
           ) : null}
+          <Box
+            padding={{vertical: 16, horizontal: 24}}
+            border={{side: 'top', width: 1, color: Colors.KeylineGray}}
+          >
+            <SchedulerInfo daemonHealth={data?.instance.daemonHealth} />
+          </Box>
           {content()}
         </>
       )}
@@ -279,9 +287,13 @@ const OVERVIEW_SCHEDULES_QUERY = gql`
         }
       }
     }
+    instance {
+      ...InstanceHealthFragment
+    }
   }
 
   ${PYTHON_ERROR_FRAGMENT}
+  ${INSTANCE_HEALTH_FRAGMENT}
 `;
 
 const UNLOADABLE_SCHEDULES_QUERY = gql`

--- a/js_modules/dagit/packages/core/src/overview/OverviewSensorsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSensorsRoot.tsx
@@ -17,9 +17,11 @@ import * as React from 'react';
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
+import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
 import {RepoFilterButton} from '../instance/RepoFilterButton';
 import {INSTIGATION_STATE_FRAGMENT} from '../instigation/InstigationUtils';
 import {UnloadableSensors} from '../instigation/Unloadable';
+import {SensorInfo} from '../sensors/SensorInfo';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
@@ -27,7 +29,7 @@ import {RepoAddress} from '../workspace/types';
 import {OverviewSensorTable} from './OverviewSensorsTable';
 import {OverviewTabs} from './OverviewTabs';
 import {OverviewSensorsQuery} from './types/OverviewSensorsQuery';
-import {UnloadableSchedulesQuery} from './types/UnloadableSchedulesQuery';
+import {UnloadableSensorsQuery} from './types/UnloadableSensorsQuery';
 
 export const OverviewSensorsRoot = () => {
   useTrackPageView();
@@ -131,6 +133,11 @@ export const OverviewSensorsRoot = () => {
               count={data.unloadableInstigationStatesOrError.results.length}
             />
           ) : null}
+          <SensorInfo
+            daemonHealth={data?.instance.daemonHealth}
+            padding={{vertical: 16, horizontal: 24}}
+            border={{side: 'top', width: 1, color: Colors.KeylineGray}}
+          />
           {content()}
         </>
       )}
@@ -191,7 +198,7 @@ const UnloadableSensorsAlert: React.FC<{
 };
 
 const UnloadableSensorDialog: React.FC = () => {
-  const {data} = useQuery<UnloadableSchedulesQuery>(UNLOADABLE_SENSORS_QUERY);
+  const {data} = useQuery<UnloadableSensorsQuery>(UNLOADABLE_SENSORS_QUERY);
   if (!data) {
     return <Spinner purpose="section" />;
   }
@@ -279,9 +286,13 @@ const OVERVIEW_SENSORS_QUERY = gql`
         }
       }
     }
+    instance {
+      ...InstanceHealthFragment
+    }
   }
 
   ${PYTHON_ERROR_FRAGMENT}
+  ${INSTANCE_HEALTH_FRAGMENT}
 `;
 
 const UNLOADABLE_SENSORS_QUERY = gql`

--- a/js_modules/dagit/packages/core/src/overview/types/OverviewSchedulesQuery.ts
+++ b/js_modules/dagit/packages/core/src/overview/types/OverviewSchedulesQuery.ts
@@ -85,7 +85,43 @@ export interface OverviewSchedulesQuery_unloadableInstigationStatesOrError_Insti
 
 export type OverviewSchedulesQuery_unloadableInstigationStatesOrError = OverviewSchedulesQuery_unloadableInstigationStatesOrError_PythonError | OverviewSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates;
 
+export interface OverviewSchedulesQuery_instance_daemonHealth_allDaemonStatuses_lastHeartbeatErrors_causes {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface OverviewSchedulesQuery_instance_daemonHealth_allDaemonStatuses_lastHeartbeatErrors {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  causes: OverviewSchedulesQuery_instance_daemonHealth_allDaemonStatuses_lastHeartbeatErrors_causes[];
+}
+
+export interface OverviewSchedulesQuery_instance_daemonHealth_allDaemonStatuses {
+  __typename: "DaemonStatus";
+  id: string;
+  daemonType: string;
+  required: boolean;
+  healthy: boolean | null;
+  lastHeartbeatErrors: OverviewSchedulesQuery_instance_daemonHealth_allDaemonStatuses_lastHeartbeatErrors[];
+  lastHeartbeatTime: number | null;
+}
+
+export interface OverviewSchedulesQuery_instance_daemonHealth {
+  __typename: "DaemonHealth";
+  id: string;
+  allDaemonStatuses: OverviewSchedulesQuery_instance_daemonHealth_allDaemonStatuses[];
+}
+
+export interface OverviewSchedulesQuery_instance {
+  __typename: "Instance";
+  daemonHealth: OverviewSchedulesQuery_instance_daemonHealth;
+  hasInfo: boolean;
+}
+
 export interface OverviewSchedulesQuery {
   workspaceOrError: OverviewSchedulesQuery_workspaceOrError;
   unloadableInstigationStatesOrError: OverviewSchedulesQuery_unloadableInstigationStatesOrError;
+  instance: OverviewSchedulesQuery_instance;
 }

--- a/js_modules/dagit/packages/core/src/overview/types/OverviewSensorsQuery.ts
+++ b/js_modules/dagit/packages/core/src/overview/types/OverviewSensorsQuery.ts
@@ -85,7 +85,43 @@ export interface OverviewSensorsQuery_unloadableInstigationStatesOrError_Instiga
 
 export type OverviewSensorsQuery_unloadableInstigationStatesOrError = OverviewSensorsQuery_unloadableInstigationStatesOrError_PythonError | OverviewSensorsQuery_unloadableInstigationStatesOrError_InstigationStates;
 
+export interface OverviewSensorsQuery_instance_daemonHealth_allDaemonStatuses_lastHeartbeatErrors_causes {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface OverviewSensorsQuery_instance_daemonHealth_allDaemonStatuses_lastHeartbeatErrors {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  causes: OverviewSensorsQuery_instance_daemonHealth_allDaemonStatuses_lastHeartbeatErrors_causes[];
+}
+
+export interface OverviewSensorsQuery_instance_daemonHealth_allDaemonStatuses {
+  __typename: "DaemonStatus";
+  id: string;
+  daemonType: string;
+  required: boolean;
+  healthy: boolean | null;
+  lastHeartbeatErrors: OverviewSensorsQuery_instance_daemonHealth_allDaemonStatuses_lastHeartbeatErrors[];
+  lastHeartbeatTime: number | null;
+}
+
+export interface OverviewSensorsQuery_instance_daemonHealth {
+  __typename: "DaemonHealth";
+  id: string;
+  allDaemonStatuses: OverviewSensorsQuery_instance_daemonHealth_allDaemonStatuses[];
+}
+
+export interface OverviewSensorsQuery_instance {
+  __typename: "Instance";
+  daemonHealth: OverviewSensorsQuery_instance_daemonHealth;
+  hasInfo: boolean;
+}
+
 export interface OverviewSensorsQuery {
   workspaceOrError: OverviewSensorsQuery_workspaceOrError;
   unloadableInstigationStatesOrError: OverviewSensorsQuery_unloadableInstigationStatesOrError;
+  instance: OverviewSensorsQuery_instance;
 }

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleRoot.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Box, Tabs, Tab, Page, NonIdealState} from '@dagster-io/ui';
+import {Tabs, Tab, Page, NonIdealState} from '@dagster-io/ui';
 import * as React from 'react';
 import {useParams} from 'react-router-dom';
 
@@ -82,9 +82,10 @@ export const ScheduleRoot: React.FC<Props> = (props) => {
               refreshState={refreshState}
             />
             {showDaemonWarning ? (
-              <Box padding={{vertical: 16, horizontal: 24}}>
-                <SchedulerInfo daemonHealth={instance.daemonHealth} />
-              </Box>
+              <SchedulerInfo
+                daemonHealth={instance.daemonHealth}
+                padding={{vertical: 16, horizontal: 24}}
+              />
             ) : null}
             {selectedTab === 'ticks' ? (
               <TicksTable tabs={tabs} repoAddress={repoAddress} name={scheduleOrError.name} />

--- a/js_modules/dagit/packages/core/src/schedules/SchedulerInfo.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulerInfo.tsx
@@ -1,12 +1,14 @@
-import {Alert} from '@dagster-io/ui';
+import {Alert, Box} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {DaemonHealthFragment} from '../instance/types/DaemonHealthFragment';
 
-export const SchedulerInfo: React.FC<{
+type Props = React.ComponentPropsWithRef<typeof Box> & {
   daemonHealth: DaemonHealthFragment | undefined;
-}> = ({daemonHealth}) => {
-  let healthy = false;
+};
+
+export const SchedulerInfo: React.FC<Props> = ({daemonHealth, ...boxProps}) => {
+  let healthy = undefined;
 
   if (daemonHealth) {
     const schedulerHealths = daemonHealth.allDaemonStatuses.filter(
@@ -18,21 +20,23 @@ export const SchedulerInfo: React.FC<{
     }
   }
 
-  if (!healthy) {
+  if (healthy === false) {
     return (
-      <Alert
-        intent="warning"
-        title="The scheduler daemon is not running."
-        description={
-          <div>
-            See the{' '}
-            <a href="https://docs.dagster.io/deployment/dagster-daemon">
-              dagster-daemon documentation
-            </a>{' '}
-            for more information on how to deploy the dagster-daemon process.
-          </div>
-        }
-      />
+      <Box {...boxProps}>
+        <Alert
+          intent="warning"
+          title="The scheduler daemon is not running."
+          description={
+            <div>
+              See the{' '}
+              <a href="https://docs.dagster.io/deployment/dagster-daemon">
+                dagster-daemon documentation
+              </a>{' '}
+              for more information on how to deploy the dagster-daemon process.
+            </div>
+          }
+        />
+      </Box>
     );
   }
 

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesRoot.tsx
@@ -88,9 +88,10 @@ export const SchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
 
         return (
           <>
-            <Box padding={{horizontal: 24, vertical: 16}}>
-              <SchedulerInfo daemonHealth={instance.daemonHealth} />
-            </Box>
+            <SchedulerInfo
+              daemonHealth={instance.daemonHealth}
+              padding={{horizontal: 24, vertical: 16}}
+            />
             {schedulesSection}
             {unloadableInstigationStatesOrError.__typename === 'PythonError' ? (
               <PythonErrorInfo error={unloadableInstigationStatesOrError} />

--- a/js_modules/dagit/packages/core/src/sensors/SensorInfo.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorInfo.tsx
@@ -1,12 +1,14 @@
-import {Alert} from '@dagster-io/ui';
+import {Alert, Box} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {DaemonHealthFragment} from '../instance/types/DaemonHealthFragment';
 
-export const SensorInfo: React.FC<{
+type Props = React.ComponentPropsWithRef<typeof Box> & {
   daemonHealth: DaemonHealthFragment | undefined;
-}> = ({daemonHealth}) => {
-  let healthy = false;
+};
+
+export const SensorInfo: React.FC<Props> = ({daemonHealth, ...boxProps}) => {
+  let healthy = undefined;
 
   if (daemonHealth) {
     const sensorHealths = daemonHealth.allDaemonStatuses.filter(
@@ -18,27 +20,29 @@ export const SensorInfo: React.FC<{
     }
   }
 
-  if (healthy) {
-    return null;
+  if (healthy === false) {
+    return (
+      <Box {...boxProps}>
+        <Alert
+          intent="warning"
+          title="The sensor daemon is not running."
+          description={
+            <div>
+              See the{' '}
+              <a
+                href="https://docs.dagster.io/deployment/dagster-daemon"
+                target="_blank"
+                rel="noreferrer"
+              >
+                dagster-daemon documentation
+              </a>{' '}
+              for more information on how to deploy the dagster-daemon process.
+            </div>
+          }
+        />
+      </Box>
+    );
   }
 
-  return (
-    <Alert
-      intent="warning"
-      title="The sensor daemon is not running."
-      description={
-        <div>
-          See the{' '}
-          <a
-            href="https://docs.dagster.io/deployment/dagster-daemon"
-            target="_blank"
-            rel="noreferrer"
-          >
-            dagster-daemon documentation
-          </a>{' '}
-          for more information on how to deploy the dagster-daemon process.
-        </div>
-      }
-    />
-  );
+  return null;
 };

--- a/js_modules/dagit/packages/core/src/sensors/SensorRoot.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorRoot.tsx
@@ -74,9 +74,10 @@ export const SensorRoot: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) 
               refreshState={refreshState}
             />
             {showDaemonWarning ? (
-              <Box padding={{vertical: 16, horizontal: 24}}>
-                <SensorInfo daemonHealth={instance.daemonHealth} />
-              </Box>
+              <SensorInfo
+                daemonHealth={instance.daemonHealth}
+                padding={{vertical: 16, horizontal: 24}}
+              />
             ) : null}
             <TickHistoryTimeline repoAddress={repoAddress} name={sensorOrError.name} />
             {selectedTab === 'ticks' ? (

--- a/js_modules/dagit/packages/core/src/sensors/SensorsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorsRoot.tsx
@@ -87,9 +87,10 @@ export const SensorsRoot = (props: Props) => {
             return (
               <>
                 {sensorsOrError.results.length > 0 && (
-                  <Box padding={{horizontal: 24, vertical: 16}}>
-                    <SensorInfo daemonHealth={instance.daemonHealth} />
-                  </Box>
+                  <SensorInfo
+                    daemonHealth={instance.daemonHealth}
+                    padding={{horizontal: 24, vertical: 16}}
+                  />
                 )}
                 <SensorsTable repoAddress={repoAddress} sensors={sensorsOrError.results} />
                 <UnloadableSensors sensorStates={unloadableInstigationStatesOrError.results} />


### PR DESCRIPTION
### Summary & Motivation

Add daemon alerts to Overview schedules and sensors pages.

I have added Box prop support to these Alert components so that we can apply the necessary padding and border that we might want at any callsite. (This varies slightly in different places.)

<img width="1391" alt="Screen Shot 2022-10-11 at 2 59 52 PM" src="https://user-images.githubusercontent.com/2823852/195193126-ae56ac62-0d55-4901-8897-f18acc85c435.png">


### How I Tested These Changes

Run Dagit without turning on daemons, verify that Alerts appear correctly in `/overview` pages. Verify that padding and border are correct. Turn on daemons, verify that the alerts disappear as expected.
