### PR TITLE
Add hook for launch pad root execution button

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadHooksContext.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadHooksContext.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import {LaunchRootExecutionButton} from './LaunchRootExecutionButton';
+
+type LaunchpadHooksContextValue = {
+  LaunchRootExecutionButton?: typeof LaunchRootExecutionButton;
+};
+
+export const LaunchpadHooksContext = React.createContext<LaunchpadHooksContextValue>({
+  LaunchRootExecutionButton: undefined,
+});
+
+export function useLaunchPadHooks(): {
+  LaunchRootExecutionButton: typeof LaunchRootExecutionButton;
+} {
+  const {LaunchRootExecutionButton: overrideLaunchRootExecutionButton} = React.useContext(
+    LaunchpadHooksContext,
+  );
+
+  return {
+    LaunchRootExecutionButton: overrideLaunchRootExecutionButton ?? LaunchRootExecutionButton,
+  };
+}

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -44,7 +44,7 @@ import {
   CONFIG_PARTITION_SELECTION_QUERY,
 } from './ConfigEditorConfigPicker';
 import {ConfigEditorModePicker} from './ConfigEditorModePicker';
-import {LaunchRootExecutionButton} from './LaunchRootExecutionButton';
+import {useLaunchPadHooks} from './LaunchpadHooksContext';
 import {LaunchpadType} from './LaunchpadRoot';
 import {LoadingOverlay} from './LoadingOverlay';
 import {OpSelector} from './OpSelector';
@@ -551,6 +551,8 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
       'This job is partitioned. Are you sure you want to launch' +
       ' a run without a partition specified?';
   }
+
+  const {LaunchRootExecutionButton} = useLaunchPadHooks();
 
   return (
     <>


### PR DESCRIPTION
### Summary & Motivation

Adds a context that can be provided by cloud to override the default launch pad root execution button. 

### How I Tested These Changes

Used this in cloud.
![Screen Shot 2022-10-11 at 5 01 56 PM](https://user-images.githubusercontent.com/2286579/195199282-c35dc0bf-d1cb-4c6a-8b51-12d056f3fe1c.png)
![Screen Shot 2022-10-11 at 5 02 01 PM](https://user-images.githubusercontent.com/2286579/195199294-15055a63-6af3-4599-b4bf-0c923a70a87b.png)


