### PR TITLE
Fix materialization count by partition

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1248,6 +1248,8 @@ class SqlEventLogStorage(EventLogStorage):
                         ),
                     ),
                     SqlEventLogStorageTable.c.partition != None,
+                    SqlEventLogStorageTable.c.dagster_event_type
+                    == DagsterEventType.ASSET_MATERIALIZATION.value,
                 )
             )
             .group_by(SqlEventLogStorageTable.c.asset_key, SqlEventLogStorageTable.c.partition)
@@ -1258,8 +1260,6 @@ class SqlEventLogStorage(EventLogStorage):
 
         with self.index_connection() as conn:
             results = conn.execute(query).fetchall()
-
-        # asdkljasldkj
 
         materialization_count_by_partition: Dict[AssetKey, Dict[str, int]] = {
             asset_key: {} for asset_key in asset_keys

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1259,6 +1259,8 @@ class SqlEventLogStorage(EventLogStorage):
         with self.index_connection() as conn:
             results = conn.execute(query).fetchall()
 
+        # asdkljasldkj
+
         materialization_count_by_partition: Dict[AssetKey, Dict[str, int]] = {
             asset_key: {} for asset_key in asset_keys
         }

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -1843,6 +1843,7 @@ class TestEventLogStorage:
         def materialize():
             yield AssetMaterialization(b)
             yield AssetMaterialization(c, partition="a")
+            yield AssetObservation(a, partition="a")
             yield Output(None)
 
         @op


### PR DESCRIPTION
Previously, the SQL event log storage `get_materialization_count_by_partition` method did not filter out asset observations. This PR amends this behavior to only search for asset materializations.

Internal PR: https://github.com/dagster-io/internal/pull/3754