### PR TITLE
Fix incorrect secrets_tags docs

### DIFF
--- a/docs/content/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference.mdx
@@ -56,8 +56,10 @@ locations:
   </ReferenceTableItem>
   <ReferenceTableItem propertyName="container_context.ecs.secrets_tags">
     A list of tag names. Each secret tagged with any of those tag names in AWS
-    Secrets Manager will be included in the launched tasks. These secrets must
-    be key-value dictionaries.
+    Secrets Manager will be included in the launched tasks as environment
+    variables. The name of the environment variable will be the name of the
+    secret, and the value of the environment variable will be the value of the
+    secret.
   </ReferenceTableItem>
 </ReferenceTable>
 

--- a/docs/content/deployment/guides/aws.mdx
+++ b/docs/content/deployment/guides/aws.mdx
@@ -114,7 +114,7 @@ run_launcher:
     secrets_tag: "my-tag-name"
 ```
 
-Any secret tagged with `my-tag-name` will be included in the environment.
+Any secret tagged with `my-tag-name` will be included as an environment variable with the name and value as that secret.
 
 Additionally, you can pass specific secrets using the [same structure as the ECS API](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Secret.html):
 


### PR DESCRIPTION
Summary:
I incorrectly assumed that secrets_tag secrets were kv pairs. Update the agent docs and add a clarification in the OSS docs.

### Summary & Motivation

### How I Tested These Changes
