### PR TITLE
[dagit] "Remove all" tab button to clear Launchpad tabs

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadTabs.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadTabs.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Icon, IconWrapper} from '@dagster-io/ui';
+import {Box, ButtonLink, Colors, Icon, IconWrapper} from '@dagster-io/ui';
 import * as React from 'react';
 import styled, {css} from 'styled-components/macro';
 
@@ -79,6 +79,8 @@ const LaunchpadTab = (props: ExecutationTabProps) => {
   );
 };
 
+const REMOVE_ALL_THRESHOLD = 3;
+
 interface LaunchpadTabsProps {
   data: IStorageData;
   onCreate: () => void;
@@ -100,7 +102,7 @@ export const LaunchpadTabs = (props: LaunchpadTabsProps) => {
   const onRemove = async (keyToRemove: string) => {
     if (sessionCount > 1) {
       await confirm({
-        title: 'Discard tab?',
+        title: 'Remove tab?',
         description: `The configuration for ${
           keyToRemove ? `"${sessions[keyToRemove].name}"` : 'this tab'
         } will be discarded.`,
@@ -109,11 +111,22 @@ export const LaunchpadTabs = (props: LaunchpadTabsProps) => {
     }
   };
 
+  const onRemoveAll = async () => {
+    await confirm({
+      title: 'Remove all tabs?',
+      description: 'All configuration tabs will be discarded.',
+    });
+
+    let updatedData = data;
+    sessionKeys.forEach((keyToRemove) => {
+      updatedData = applyRemoveSession(updatedData, keyToRemove);
+    });
+
+    onSave(updatedData);
+  };
+
   return (
-    <Box
-      border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-      padding={{horizontal: 12, top: 12}}
-    >
+    <Box border={{side: 'bottom', width: 1, color: Colors.KeylineGray}} padding={{top: 12}}>
       <LaunchpadTabsContainer>
         {sessionKeys.map((key) => (
           <LaunchpadTab
@@ -127,6 +140,17 @@ export const LaunchpadTabs = (props: LaunchpadTabsProps) => {
           />
         ))}
         <LaunchpadTab title="+ Add..." onClick={onCreate} />
+        {sessionKeys.length > REMOVE_ALL_THRESHOLD ? (
+          <ButtonLink color={Colors.Red500} onClick={onRemoveAll}>
+            <Box
+              flex={{direction: 'row', gap: 4, alignItems: 'center'}}
+              style={{whiteSpace: 'nowrap'}}
+            >
+              <Icon name="delete" color={Colors.Red500} />
+              <div>Remove all</div>
+            </Box>
+          </ButtonLink>
+        ) : null}
       </LaunchpadTabsContainer>
     </Box>
   );
@@ -139,6 +163,8 @@ const LaunchpadTabsContainer = styled.div`
   gap: 8px;
   z-index: 1;
   flex-direction: row;
+  padding-left: 12px;
+  overflow-x: auto;
 `;
 
 const TabContainer = styled.div<{$active: boolean}>`
@@ -150,6 +176,7 @@ const TabContainer = styled.div<{$active: boolean}>`
   gap: 4px;
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
+  white-space: nowrap;
 
   ${({$active}) =>
     $active


### PR DESCRIPTION
### Summary & Motivation

Add a "Remove all" button-link to the launchpad tabs that allows removing all tabs at once, with a confirmation dialog.

Users can accrue a ton of tabs when opening the launchpad from specific runs, and it's tedious to clean them all up.

The button appears once there are five or more tabs.

I also made the tab container hscrollable.

<img width="883" alt="Screen Shot 2022-10-12 at 9 29 50 AM" src="https://user-images.githubusercontent.com/2823852/195371523-8b5d3162-1372-40fb-8108-1bfaedc4724d.png">
<img width="546" alt="Screen Shot 2022-10-12 at 9 29 55 AM" src="https://user-images.githubusercontent.com/2823852/195371528-af656690-dc5d-42ea-b3c0-e1a98c7321ad.png">


### How I Tested These Changes

View launchpad, open a bunch of tabs. Verify that the "Remove all" button appears after a threshold. Click it, verify dialog, confirm, verify that all tabs are removed. Reload the page, verify that they're all gone.

Also create enough tabs to force hscrolling, verify that it works properly in the tab container.
