### PR TITLE
[docs] Update deployment settings reference with SSO default role

### DIFF
--- a/docs/content/dagster-cloud/account/managing-users.mdx
+++ b/docs/content/dagster-cloud/account/managing-users.mdx
@@ -30,7 +30,7 @@ Before you start, note that:
 
 - **If using Google for SSO**, users must be added in Dagster Cloud before they can log in.
 
-- **If using a SAML-based solution like Okta**, users must be assigned to the Dagster app in the SSO portal to log in. These users will be granted Viewer permissions by default.
+- **If using a SAML-based solution like Okta**, users must be assigned to the Dagster app in the SSO portal to log in. By default, users will be granted Viewer permissions on each deployment. The default role can be adjusted by modifying the [`sso_default_role` deployment setting](/dagster-cloud/developing-testing/deployment-settings-reference#sso-default-role).
 
 To add a new user to a deployment:
 

--- a/docs/content/dagster-cloud/developing-testing/deployment-settings-reference.mdx
+++ b/docs/content/dagster-cloud/developing-testing/deployment-settings-reference.mdx
@@ -30,6 +30,8 @@ run_monitoring:
 
 run_retries:
   max_retries: 0
+
+sso_default_role: EDITOR
 ```
 
 ---
@@ -41,6 +43,7 @@ For each deployment, you can configure settings for:
 - [Run queue](#run-queue-run_queue)
 - [Run monitoring](#run-monitoring-run_monitoring)
 - [Run retries](#run-retries-run_retries)
+- [SSO default role](#sso-default-role)
 
 ### Run queue (run_queue)
 
@@ -148,6 +151,27 @@ run_retries:
     <ul>
       <li>
         <strong>Default</strong> - <code>0</code>
+      </li>
+    </ul>
+  </ReferenceTableItem>
+</ReferenceTable>
+
+### SSO default role
+
+The `sso_default_role` setting lets you configure the default role on the deployment which is granted to new users which log in via SSO. For more information on available roles, see the [Dagster Cloud permissions reference](/dagster-cloud/account/managing-users#understanding-user-permissions).
+
+```yaml
+sso_default_role: EDITOR
+```
+
+<ReferenceTable>
+  <ReferenceTableItem propertyName="sso_default_role">
+    If SAML SSO is enabled, this is the default role that will be assigned to
+    Dagster Cloud users for this deployment. If SAML SSO is not enabled, this
+    setting is ignored.
+    <ul>
+      <li>
+        <strong>Default</strong> - <code>VIEWER</code>
       </li>
     </ul>
   </ReferenceTableItem>


### PR DESCRIPTION
## Summary

Adds a brief docs section describing the new `sso_default_role` Deployment setting in Cloud.
