### PR TITLE
do nothing on snapshot add conflict

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
@@ -6,7 +6,7 @@ import pendulum
 import pytest
 
 from dagster import _seven, job, op
-from dagster._core.definitions import PipelineDefinition
+from dagster._core.definitions import JobDefinition, PipelineDefinition
 from dagster._core.errors import (
     DagsterRunAlreadyExists,
     DagsterRunNotFoundError,
@@ -1299,6 +1299,14 @@ class TestRunStorage:
         storage.add_snapshot(ep_snapshot, snapshot_id=new_ep_snapshot_id)
         assert not storage.has_snapshot(ep_snapshot_id)
         assert storage.has_snapshot(new_ep_snapshot_id)
+
+    def test_snapshot_conflict(self, storage):
+        job_def = JobDefinition(name="some_job", op_defs=[])
+
+        snapshot = job_def.get_pipeline_snapshot()
+        storage.add_snapshot(snapshot)
+        # multiple calls dont throw
+        storage.add_snapshot(snapshot)
 
     def test_run_record_stats(self, storage):
         assert storage


### PR DESCRIPTION
In a condition where snapshot adds race - simply do nothing since they should be attempting to store the same data twice instead of raising.

### How I Tested These Changes

added test
