### PR TITLE
[dagit] Turn on timeline run bucketing for everyone

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Flags.tsx
+++ b/js_modules/dagit/packages/core/src/app/Flags.tsx
@@ -9,7 +9,6 @@ export enum FeatureFlag {
   flagDebugConsoleLogging = 'flagDebugConsoleLogging',
   flagDisableWebsockets = 'flagDisableWebsockets',
   flagNewWorkspace = 'flagNewWorkspace',
-  flagRunBucketing = 'flagRunBucketing',
   flagAssetGraphExperimentalZoom = 'flagAssetGraphExperimentalZoom',
 }
 

--- a/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
@@ -127,16 +127,6 @@ const UserSettingsRoot: React.FC<SettingsRootProps> = ({tabs}) => {
               ),
             },
             {
-              key: 'Bucket run timeline and jobs page by repo',
-              value: (
-                <Checkbox
-                  format="switch"
-                  checked={flags.includes(FeatureFlag.flagRunBucketing)}
-                  onChange={() => toggleFlag(FeatureFlag.flagRunBucketing)}
-                />
-              ),
-            },
-            {
               key: 'Experimental "groups-only" asset graph zoom level',
               value: (
                 <Checkbox

--- a/js_modules/dagit/packages/core/src/runs/QueryfulRunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/QueryfulRunTimeline.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import {useFeatureFlags} from '../app/Flags';
 import {RunsFilter} from '../types/globalTypes';
 
 import {RunTimeline} from './RunTimeline';
@@ -14,7 +13,6 @@ interface Props {
 
 export const QueryfulRunTimeline = (props: Props) => {
   const {range, visibleJobKeys, runsFilter = {}} = props;
-  const {flagRunBucketing} = useFeatureFlags();
   const {jobs, loading} = useRunsForTimeline(range, runsFilter);
 
   const visibleJobs = React.useMemo(() => jobs.filter(({key}) => visibleJobKeys.has(key)), [
@@ -22,12 +20,5 @@ export const QueryfulRunTimeline = (props: Props) => {
     visibleJobKeys,
   ]);
 
-  return (
-    <RunTimeline
-      loading={loading}
-      range={range}
-      jobs={visibleJobs}
-      bucketByRepo={flagRunBucketing}
-    />
-  );
+  return <RunTimeline loading={loading} range={range} jobs={visibleJobs} />;
 };

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.stories.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.stories.tsx
@@ -1,4 +1,3 @@
-import {Checkbox, Group} from '@dagster-io/ui';
 import {Meta} from '@storybook/react/types-6-0';
 import faker from 'faker';
 import * as React from 'react';
@@ -172,48 +171,6 @@ export const VeryLongRunning = () => {
   }, [twoDaysAgo, sixHoursAgo]);
 
   return <RunTimeline jobs={jobs} range={[fourHoursAgo, future]} />;
-};
-
-export const BucketByRepo = () => {
-  const [bucketByRepo, setBucketByRepo] = React.useState(true);
-  const sixHoursAgo = React.useMemo(() => Date.now() - 6 * 60 * 60 * 1000, []);
-  const now = React.useMemo(() => Date.now(), []);
-
-  const jobs = React.useMemo(() => {
-    return [...new Array(4)]
-      .fill(null)
-      .map(
-        (_) => {
-          const repoAddress = makeRepoAddress();
-          return [...new Array(4)].reduce((accum) => {
-            const jobKey = faker.random.words(3).split(' ').join('-').toLowerCase();
-            return [
-              ...accum,
-              {
-                key: jobKey,
-                jobName: jobKey,
-                path: `/${jobKey}`,
-                repoAddress,
-                runs: generateRunMocks(6, [sixHoursAgo, now]),
-              },
-            ];
-          }, []);
-        },
-        [sixHoursAgo, now],
-      )
-      .flat();
-  }, [now, sixHoursAgo]);
-
-  return (
-    <Group direction="column" spacing={12}>
-      <Checkbox
-        checked={bucketByRepo}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setBucketByRepo(e.target.checked)}
-        label="Bucket by repo?"
-      />
-      <RunTimeline bucketByRepo={bucketByRepo} jobs={jobs} range={[sixHoursAgo, now]} />
-    </Group>
-  );
 };
 
 export const MultipleStatusesBatched = () => {

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -60,7 +60,6 @@ export type TimelineJob = {
 
 interface Props {
   loading?: boolean;
-  bucketByRepo?: boolean;
   jobs: TimelineJob[];
   range: [number, number];
 }
@@ -68,7 +67,7 @@ interface Props {
 const EXPANSION_STATE_STORAGE_KEY = 'timeline-expansion-state';
 
 export const RunTimeline = (props: Props) => {
-  const {loading = false, bucketByRepo = false, jobs, range} = props;
+  const {loading = false, jobs, range} = props;
   const [width, setWidth] = React.useState<number | null>(null);
   const {expandedKeys, onToggle} = useRepoExpansionState(EXPANSION_STATE_STORAGE_KEY);
 
@@ -97,40 +96,6 @@ export const RunTimeline = (props: Props) => {
   const now = Date.now();
   const [_, end] = range;
   const includesTicks = now <= end;
-
-  if (!bucketByRepo) {
-    const anyJobs = jobs.length > 0;
-    const height = ROW_HEIGHT * jobs.length;
-    const timelineHeight = DATE_TIME_HEIGHT + (anyJobs ? height : EMPTY_STATE_HEIGHT);
-    return (
-      <Timeline $height={timelineHeight} ref={containerRef}>
-        <Box
-          padding={{left: 24}}
-          flex={{direction: 'column', justifyContent: 'center'}}
-          style={{fontSize: '16px', height: DATE_TIME_HEIGHT}}
-          border={{side: 'top', width: 1, color: Colors.KeylineGray}}
-        >
-          Jobs
-        </Box>
-        <TimeDividers interval={ONE_HOUR_MSEC} range={range} height={anyJobs ? height : 0} />
-        <div>
-          {jobs.length ? (
-            jobs.map((job, ii) => (
-              <RunTimelineRow
-                key={job.key}
-                job={job}
-                top={ii * ROW_HEIGHT + DATE_TIME_HEIGHT}
-                range={range}
-                width={width}
-              />
-            ))
-          ) : (
-            <RunsEmptyOrLoading loading={loading} includesTicks={includesTicks} />
-          )}
-        </div>
-      </Timeline>
-    );
-  }
 
   const buckets = jobs.reduce((accum, job) => {
     const {repoAddress} = job;
@@ -664,6 +629,7 @@ const JobName = styled.div`
   padding: 0 12px 0 24px;
   text-overflow: ellipsis;
   white-space: nowrap;
+  width: ${LEFT_SIDE_SPACE_ALLOTTED}px;
 `;
 
 const RunChunks = styled.div`


### PR DESCRIPTION
### Summary & Motivation

Enable per-repo timeline run bucketing for everyone, remove the feature flag.

I also fixed a bug where run chunks were being rendered slightly too far to the right, due to the job name width occupying slightly more space than before. The width on the job name is now capped, which should make the positioning calculations correct.

### How I Tested These Changes

View Dagit, verify that repo bucketing is working as expected on the run timeline.

Verify also that run chunks are positioned correctly, most notably with respect to the "Now" line.
