### PR TITLE
[dagit] Add polling to Overview pages

### DIFF
--- a/js_modules/dagit/packages/core/src/overview/OverviewJobsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewJobsRoot.tsx
@@ -3,6 +3,7 @@ import {Box, Colors, Heading, NonIdealState, PageHeader, Spinner, TextInput} fro
 import * as React from 'react';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {RepoFilterButton} from '../instance/RepoFilterButton';
@@ -27,6 +28,8 @@ export const OverviewJobsRoot = () => {
     notifyOnNetworkStatusChange: true,
   });
   const {data, loading} = queryResultOverview;
+
+  const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
   // Batch up the data and bucket by repo.
   const repoBuckets = useRepoBuckets(data);
@@ -102,7 +105,10 @@ export const OverviewJobsRoot = () => {
 
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
-      <PageHeader title={<Heading>Overview</Heading>} tabs={<OverviewTabs tab="jobs" />} />
+      <PageHeader
+        title={<Heading>Overview</Heading>}
+        tabs={<OverviewTabs tab="jobs" refreshState={refreshState} />}
+      />
       <Box
         padding={{horizontal: 24, vertical: 16}}
         flex={{direction: 'row', alignItems: 'center', gap: 12, grow: 0}}

--- a/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
@@ -15,6 +15,7 @@ import {
 import * as React from 'react';
 
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {RepoFilterButton} from '../instance/RepoFilterButton';
 import {INSTIGATION_STATE_FRAGMENT} from '../instigation/InstigationUtils';
@@ -40,6 +41,8 @@ export const OverviewSchedulesRoot = () => {
     notifyOnNetworkStatusChange: true,
   });
   const {data, loading} = queryResultOverview;
+
+  const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
   const repoBuckets = useRepoBuckets(data);
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
@@ -100,7 +103,10 @@ export const OverviewSchedulesRoot = () => {
 
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
-      <PageHeader title={<Heading>Overview</Heading>} tabs={<OverviewTabs tab="schedules" />} />
+      <PageHeader
+        title={<Heading>Overview</Heading>}
+        tabs={<OverviewTabs tab="schedules" refreshState={refreshState} />}
+      />
       <Box
         padding={{horizontal: 24, vertical: 16}}
         flex={{direction: 'row', alignItems: 'center', gap: 12, grow: 0}}

--- a/js_modules/dagit/packages/core/src/overview/OverviewSensorsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSensorsRoot.tsx
@@ -15,6 +15,7 @@ import {
 import * as React from 'react';
 
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {RepoFilterButton} from '../instance/RepoFilterButton';
 import {INSTIGATION_STATE_FRAGMENT} from '../instigation/InstigationUtils';
@@ -40,6 +41,8 @@ export const OverviewSensorsRoot = () => {
     notifyOnNetworkStatusChange: true,
   });
   const {data, loading} = queryResultOverview;
+
+  const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
   const repoBuckets = useRepoBuckets(data);
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
@@ -100,7 +103,10 @@ export const OverviewSensorsRoot = () => {
 
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
-      <PageHeader title={<Heading>Overview</Heading>} tabs={<OverviewTabs tab="sensors" />} />
+      <PageHeader
+        title={<Heading>Overview</Heading>}
+        tabs={<OverviewTabs tab="sensors" refreshState={refreshState} />}
+      />
       <Box
         padding={{horizontal: 24, vertical: 16}}
         flex={{direction: 'row', alignItems: 'center', gap: 12, grow: 0}}

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedJobRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedJobRow.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
+import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {JobMenu} from '../instance/JobMenu';
 import {LastRunSummary} from '../instance/LastRunSummary';
 import {ScheduleOrSensorTag} from '../nav/ScheduleOrSensorTag';
@@ -41,6 +42,8 @@ export const VirtualizedJobRow = (props: JobRowProps) => {
   );
 
   useDelayedRowQuery(queryJob);
+  useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
+
   const {data} = queryResult;
 
   const {schedules, sensors} = React.useMemo(() => {

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleRow.tsx
@@ -14,6 +14,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
+import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {LastRunSummary} from '../instance/LastRunSummary';
 import {TickTag, TICK_TAG_FRAGMENT} from '../instigation/InstigationTick';
 import {PipelineReference} from '../pipelines/PipelineReference';
@@ -56,9 +57,12 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
         scheduleName: name,
       },
     },
+    notifyOnNetworkStatusChange: true,
   });
 
   useDelayedRowQuery(querySchedule);
+  useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
+
   const {data} = queryResult;
 
   const scheduleData = React.useMemo(() => {

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorRow.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
+import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {AssetLink} from '../assets/AssetLink';
 import {LastRunSummary} from '../instance/LastRunSummary';
 import {TickTag, TICK_TAG_FRAGMENT} from '../instigation/InstigationTick';
@@ -47,6 +48,8 @@ export const VirtualizedSensorRow = (props: SensorRowProps) => {
   );
 
   useDelayedRowQuery(querySensor);
+  useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
+
   const {data} = queryResult;
 
   const sensorData = React.useMemo(() => {


### PR DESCRIPTION
### Summary & Motivation

Add page-level and row-level polling to the Overview jobs, schedules, and sensors pages.

In this way, these pages will remain fresh and up to date, just as the current Instance Overview page is.

### How I Tested These Changes

View each page, verify polling behavior in network tab. Kick off some runs, verify that the run status columns on the Jobs table update accordingly.

Scroll down virtualized table, verify that only visible rows (plus threshold rows) are polled, and that any rows beyond that no longer poll.
