### PR TITLE
add a link to discuss.dagster.io on README

### DIFF
--- a/python_modules/dagster/README.md
+++ b/python_modules/dagster/README.md
@@ -99,6 +99,7 @@ Join our community here:
 - 📺 [Subscribe to our YouTube channel](https://www.youtube.com/channel/UCfLnv9X8jyHTe6gJ4hVBo9Q)
 - 📚 [Read our blog posts](https://dagster.io/blog)
 - 👋 [Join us on Slack](https://dagster.io/slack)
+- 🗃 [Browse Slack archives](https://discuss.dagster.io)
 - ✏️ [Start a Github Discussion](https://github.com/dagster-io/dagster/discussions)
 
 ## Contributing


### PR DESCRIPTION
### Summary & Motivation
add a link to discuss.dagster.io on README. mainly for SEO, i.e. making slack contents indexed by google and publicly searchable

### How I Tested These Changes
link works: https://github.com/dagster-io/dagster/tree/yuhan/add-discuss-to-readme#community