### PR TITLE
Type annotations in dagster-graphql

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql/cli.py
@@ -2,9 +2,9 @@ from typing import Mapping, Optional, cast
 from urllib.parse import urljoin, urlparse
 
 import click
-from graphql.execution import ExecutionResult
 import requests
 from graphql import graphql
+from graphql.execution import ExecutionResult
 
 import dagster._check as check
 import dagster._seven as seven
@@ -43,12 +43,15 @@ def execute_query(
 
     context = workspace_process_context.create_request_context()
 
-    result = cast(ExecutionResult, graphql(
-        request_string=query,
-        schema=create_schema(),
-        context_value=context,
-        variable_values=variables,
-    ))
+    result = cast(
+        ExecutionResult,
+        graphql(
+            request_string=query,
+            schema=create_schema(),
+            context_value=context,
+            variable_values=variables,
+        ),
+    )
 
     result_dict = result.to_dict()
 
@@ -62,7 +65,7 @@ def execute_query(
     if "errors" in result_dict:
         result_dict_errors = check.list_elem(result_dict, "errors", of_type=Exception)
         result_errors = check.is_list(result.errors, of_type=Exception)
-        check.invariant(len(result_dict_errors) == len(result_errors))  # 
+        check.invariant(len(result_dict_errors) == len(result_errors))  #
         for python_error, error_dict in zip(result_errors, result_dict_errors):
             if hasattr(python_error, "original_error") and python_error.original_error:
                 error_dict["stack_trace"] = get_stack_trace_array(python_error.original_error)

--- a/python_modules/dagster-graphql/dagster_graphql/cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql/cli.py
@@ -1,3 +1,4 @@
+from typing import Mapping, Optional
 from urllib.parse import urljoin, urlparse
 
 import click
@@ -26,7 +27,11 @@ def create_dagster_graphql_cli():
     return ui
 
 
-def execute_query(workspace_process_context, query, variables=None):
+def execute_query(
+    workspace_process_context: WorkspaceProcessContext,
+    query: str,
+    variables: Optional[Mapping[str, object]] = None,
+):
     check.inst_param(
         workspace_process_context, "workspace_process_context", WorkspaceProcessContext
     )

--- a/python_modules/dagster-graphql/dagster_graphql/cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql/cli.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional, Union, cast
+from typing import Mapping, Optional, cast
 from urllib.parse import urljoin, urlparse
 
 import click

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -20,7 +20,6 @@ from dagster import (
     TextMetadataValue,
     UrlMetadataValue,
 )
-from dagster._core.event_api import EventLogRecord
 from dagster._core.events import DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.plan.objects import StepFailureData

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -225,7 +225,7 @@ def from_dagster_event_record(event_record: EventLogEntry, pipeline_name: str) -
     elif dagster_event.event_type == DagsterEventType.STEP_SUCCESS:
         return GrapheneExecutionStepSuccessEvent(**basic_params)
     elif dagster_event.event_type == DagsterEventType.STEP_INPUT:
-        input_data = dagster_event.event_specific_data
+        input_data = check.not_none(dagster_event.event_specific_data)
         return GrapheneExecutionStepInputEvent(
             input_name=input_data.input_name,
             type_check=input_data.type_check_data,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -1,17 +1,29 @@
 import sys
+from typing import Mapping, Optional, Sequence, Union
 
+from dagster_graphql.schema.errors import GrapheneRepositoryNotFoundError
+from dagster_graphql.schema.external import (
+    GrapheneRepository,
+    GrapheneRepositoryConnection,
+    GrapheneWorkspace,
+)
+from dagster_graphql.schema.util import HasContext
 from graphene import ResolveInfo
 
 import dagster._check as check
 from dagster._config import validate_config_from_snap
+from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.host_representation import ExternalPipeline, PipelineSelector, RepositorySelector
-from dagster._core.workspace.context import BaseWorkspaceRequestContext
+from dagster._core.host_representation.external import ExternalExecutionPlan
+from dagster._core.workspace.context import BaseWorkspaceRequestContext, WorkspaceRequestContext
 from dagster._utils.error import serializable_error_info_from_exc_info
 
 from .utils import UserFacingGraphQLError, capture_error
 
 
-def get_full_external_job_or_raise(graphene_info, selector):
+def get_full_external_job_or_raise(
+    graphene_info: HasContext, selector: PipelineSelector
+) -> ExternalPipeline:
     from ..schema.errors import GraphenePipelineNotFoundError
 
     check.inst_param(graphene_info, "graphene_info", ResolveInfo)
@@ -23,10 +35,11 @@ def get_full_external_job_or_raise(graphene_info, selector):
     return graphene_info.context.get_full_external_job(selector)
 
 
-def get_external_pipeline_or_raise(graphene_info, selector):
+def get_external_pipeline_or_raise(
+    graphene_info: HasContext, selector: PipelineSelector
+) -> ExternalPipeline:
     check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(selector, "selector", PipelineSelector)
-
     full_pipeline = get_full_external_job_or_raise(graphene_info, selector)
 
     if selector.solid_selection is None and selector.asset_selection is None:
@@ -35,7 +48,9 @@ def get_external_pipeline_or_raise(graphene_info, selector):
     return get_subset_external_pipeline(graphene_info.context, selector)
 
 
-def get_subset_external_pipeline(context, selector):
+def get_subset_external_pipeline(
+    context: WorkspaceRequestContext, selector: PipelineSelector
+) -> ExternalPipeline:
     from ..schema.errors import GrapheneInvalidSubsetError
     from ..schema.pipelines.pipeline import GraphenePipeline
 
@@ -62,7 +77,9 @@ def get_subset_external_pipeline(context, selector):
     return external_pipeline
 
 
-def ensure_valid_config(external_pipeline, mode, run_config):
+def ensure_valid_config(
+    external_pipeline: ExternalPipeline, mode: Optional[str], run_config: object
+) -> object:
     from ..schema.pipelines.config import GrapheneRunConfigValidationInvalid
 
     check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
@@ -71,7 +88,7 @@ def ensure_valid_config(external_pipeline, mode, run_config):
 
     validated_config = validate_config_from_snap(
         config_schema_snapshot=external_pipeline.config_schema_snapshot,
-        config_type_key=external_pipeline.root_config_key_for_mode(mode),
+        config_type_key=check.not_none(external_pipeline.root_config_key_for_mode(mode)),
         config_value=run_config,
     )
 
@@ -87,25 +104,25 @@ def ensure_valid_config(external_pipeline, mode, run_config):
 
 
 def get_external_execution_plan_or_raise(
-    graphene_info,
-    external_pipeline,
-    mode,
-    run_config,
-    step_keys_to_execute,
-    known_state,
-):
+    graphene_info: HasContext,
+    external_pipeline: ExternalPipeline,
+    mode: Optional[str],
+    run_config: Mapping[str, object],
+    step_keys_to_execute: Sequence[str],
+    known_state: KnownExecutionState,
+) -> ExternalExecutionPlan:
 
     return graphene_info.context.get_external_execution_plan(
         external_pipeline=external_pipeline,
         run_config=run_config,
-        mode=mode,
+        mode=check.not_none(mode),
         step_keys_to_execute=step_keys_to_execute,
         known_state=known_state,
     )
 
 
 @capture_error
-def fetch_repositories(graphene_info):
+def fetch_repositories(graphene_info: HasContext) -> GrapheneRepositoryConnection:
     from ..schema.external import GrapheneRepository, GrapheneRepositoryConnection
 
     check.inst_param(graphene_info, "graphene_info", ResolveInfo)
@@ -123,7 +140,9 @@ def fetch_repositories(graphene_info):
 
 
 @capture_error
-def fetch_repository(graphene_info, repository_selector):
+def fetch_repository(
+    graphene_info: HasContext, repository_selector: RepositorySelector
+) -> Union[GrapheneRepository, GrapheneRepositoryNotFoundError]:
     from ..schema.errors import GrapheneRepositoryNotFoundError
     from ..schema.external import GrapheneRepository
 
@@ -145,7 +164,7 @@ def fetch_repository(graphene_info, repository_selector):
 
 
 @capture_error
-def fetch_workspace(workspace_request_context):
+def fetch_workspace(workspace_request_context: WorkspaceRequestContext) -> GrapheneWorkspace:
     from ..schema.external import GrapheneWorkspace, GrapheneWorkspaceLocationEntry
 
     check.inst_param(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 from typing import TYPE_CHECKING, Mapping, Optional, Sequence, Union
 
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
         GrapheneWorkspace,
     )
     from dagster_graphql.schema.util import HasContext
+
 
 def get_full_external_job_or_raise(
     graphene_info: HasContext, selector: PipelineSelector

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -1,13 +1,7 @@
+from __future__ import annotations
 import sys
-from typing import Mapping, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Mapping, Optional, Sequence, Union
 
-from dagster_graphql.schema.errors import GrapheneRepositoryNotFoundError
-from dagster_graphql.schema.external import (
-    GrapheneRepository,
-    GrapheneRepositoryConnection,
-    GrapheneWorkspace,
-)
-from dagster_graphql.schema.util import HasContext
 from graphene import ResolveInfo
 
 import dagster._check as check
@@ -20,6 +14,14 @@ from dagster._utils.error import serializable_error_info_from_exc_info
 
 from .utils import UserFacingGraphQLError, capture_error
 
+if TYPE_CHECKING:
+    from dagster_graphql.schema.errors import GrapheneRepositoryNotFoundError
+    from dagster_graphql.schema.external import (
+        GrapheneRepository,
+        GrapheneRepositoryConnection,
+        GrapheneWorkspace,
+    )
+    from dagster_graphql.schema.util import HasContext
 
 def get_full_external_job_or_raise(
     graphene_info: HasContext, selector: PipelineSelector

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -1,7 +1,9 @@
 from collections import defaultdict
 from enum import Enum
 from functools import lru_cache
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
+
+from typing_extensions import TypeAlias, TypedDict
 
 from dagster import DagsterInstance
 from dagster import _check as check
@@ -51,7 +53,7 @@ class RepositoryScopedBatchLoader:
         self._data: Dict[RepositoryDataType, Dict[str, List[Any]]] = {}
         self._limits: Dict[RepositoryDataType, int] = {}
 
-    def _get(self, data_type, key, limit):
+    def _get(self, data_type: RepositoryDataType, key: str, limit: int) -> Sequence[Any]:
         check.inst_param(data_type, "data_type", RepositoryDataType)
         check.str_param(key, "key")
         check.int_param(limit, "limit")
@@ -59,11 +61,11 @@ class RepositoryScopedBatchLoader:
             self._fetch(data_type, limit)
         return self._data[data_type].get(key, [])[:limit]
 
-    def _fetch(self, data_type, limit):
+    def _fetch(self, data_type: RepositoryDataType, limit: int) -> None:
         check.inst_param(data_type, "data_type", RepositoryDataType)
         check.int_param(limit, "limit")
 
-        fetched = defaultdict(list)
+        fetched: Dict[str, List[Any]] = defaultdict(list)
 
         if data_type == RepositoryDataType.JOB_RUNS:
             job_names = [x.name for x in self._repository.get_all_external_jobs()]
@@ -129,7 +131,8 @@ class RepositoryScopedBatchLoader:
                         )
                     )
             for record in records:
-                fetched[record.pipeline_run.tags.get(SCHEDULE_NAME_TAG)].append(record)
+                tag = check.not_none(record.pipeline_run.tags.get(SCHEDULE_NAME_TAG))
+                fetched[tag].append(record)
 
         elif data_type == RepositoryDataType.SENSOR_RUNS:
             sensor_names = [sensor.name for sensor in self._repository.get_external_sensors()]
@@ -163,7 +166,8 @@ class RepositoryScopedBatchLoader:
                         )
                     )
             for record in records:
-                fetched[record.pipeline_run.tags.get(SENSOR_NAME_TAG)].append(record)
+                tag = check.not_none(record.pipeline_run.tags.get(SENSOR_NAME_TAG))
+                fetched[tag].append(record)
 
         elif data_type == RepositoryDataType.SCHEDULE_STATES:
             schedule_states = self._instance.all_instigator_state(
@@ -190,14 +194,14 @@ class RepositoryScopedBatchLoader:
                 ]
                 ticks_by_selector = self._instance.get_batch_ticks(selector_ids, limit=limit)
                 for schedule in self._repository.get_external_schedules():
-                    fetched[schedule.get_external_origin_id()] = ticks_by_selector.get(
-                        schedule.selector_id, []
+                    fetched[schedule.get_external_origin_id()] = list(
+                        ticks_by_selector.get(schedule.selector_id, [])
                     )
             else:
                 for schedule in self._repository.get_external_schedules():
                     origin_id = schedule.get_external_origin_id()
-                    fetched[origin_id] = self._instance.get_ticks(
-                        origin_id, schedule.selector_id, limit=limit
+                    fetched[origin_id] = list(
+                        self._instance.get_ticks(origin_id, schedule.selector_id, limit=limit)
                     )
 
         elif data_type == RepositoryDataType.SENSOR_TICKS:
@@ -207,14 +211,14 @@ class RepositoryScopedBatchLoader:
                 ]
                 ticks_by_selector = self._instance.get_batch_ticks(selector_ids, limit=limit)
                 for sensor in self._repository.get_external_sensors():
-                    fetched[sensor.get_external_origin_id()] = ticks_by_selector.get(
-                        sensor.selector_id, []
+                    fetched[sensor.get_external_origin_id()] = list(
+                        ticks_by_selector.get(sensor.selector_id, [])
                     )
             else:
                 for sensor in self._repository.get_external_sensors():
                     origin_id = sensor.get_external_origin_id()
-                    fetched[origin_id] = self._instance.get_ticks(
-                        origin_id, sensor.selector_id, limit=limit
+                    fetched[origin_id] = list(
+                        self._instance.get_ticks(origin_id, sensor.selector_id, limit=limit)
                     )
 
         else:
@@ -223,26 +227,26 @@ class RepositoryScopedBatchLoader:
         self._data[data_type] = fetched
         self._limits[data_type] = limit
 
-    def get_run_records_for_job(self, job_name, limit):
+    def get_run_records_for_job(self, job_name: str, limit: int) -> Sequence[Any]:
         check.invariant(
             job_name in [pipeline.name for pipeline in self._repository.get_all_external_jobs()]
         )
         return self._get(RepositoryDataType.JOB_RUNS, job_name, limit)
 
-    def get_run_records_for_schedule(self, schedule_name, limit):
+    def get_run_records_for_schedule(self, schedule_name: str, limit: int) -> Sequence[Any]:
         check.invariant(
             schedule_name
             in [schedule.name for schedule in self._repository.get_external_schedules()]
         )
         return self._get(RepositoryDataType.SCHEDULE_RUNS, schedule_name, limit)
 
-    def get_run_records_for_sensor(self, sensor_name, limit):
+    def get_run_records_for_sensor(self, sensor_name: str, limit: int) -> Sequence[Any]:
         check.invariant(
             sensor_name in [sensor.name for sensor in self._repository.get_external_sensors()]
         )
         return self._get(RepositoryDataType.SENSOR_RUNS, sensor_name, limit)
 
-    def get_schedule_state(self, schedule_name):
+    def get_schedule_state(self, schedule_name: str) -> Optional[Sequence[Any]]:
         check.invariant(
             schedule_name
             in [schedule.name for schedule in self._repository.get_external_schedules()]
@@ -250,21 +254,21 @@ class RepositoryScopedBatchLoader:
         states = self._get(RepositoryDataType.SCHEDULE_STATES, schedule_name, 1)
         return states[0] if states else None
 
-    def get_sensor_state(self, sensor_state):
+    def get_sensor_state(self, sensor_name: str) -> Optional[Sequence[Any]]:
         check.invariant(
-            sensor_state in [sensor.name for sensor in self._repository.get_external_sensors()]
+            sensor_name in [sensor.name for sensor in self._repository.get_external_sensors()]
         )
-        states = self._get(RepositoryDataType.SENSOR_STATES, sensor_state, 1)
+        states = self._get(RepositoryDataType.SENSOR_STATES, sensor_name, 1)
         return states[0] if states else None
 
-    def get_sensor_ticks(self, origin_id, selector_id, limit):
+    def get_sensor_ticks(self, origin_id: str, selector_id: str, limit: int) -> Sequence[Any]:
         check.invariant(
             selector_id
             in [sensor.selector_id for sensor in self._repository.get_external_sensors()]
         )
         return self._get(RepositoryDataType.SENSOR_TICKS, origin_id, limit)
 
-    def get_schedule_ticks(self, origin_id, selector_id, limit):
+    def get_schedule_ticks(self, origin_id: str, selector_id: str, limit: int) -> Sequence[Any]:
         check.invariant(
             selector_id
             in [schedule.selector_id for schedule in self._repository.get_external_schedules()]
@@ -293,7 +297,7 @@ class BatchRunLoader:
             self._fetch()
         return self._records.get(run_id)
 
-    def _fetch(self):
+    def _fetch(self) -> None:
         records = self._instance.get_run_records(RunsFilter(run_ids=list(self._run_ids)))
         for record in records:
             self._records[record.pipeline_run.run_id] = record
@@ -323,7 +327,7 @@ class BatchMaterializationLoader:
             self._fetch()
         return self._materializations.get(asset_key)
 
-    def _fetch(self):
+    def _fetch(self) -> None:
         self._fetched = True
         self._materializations = {
             record.asset_entry.asset_key: record.asset_entry.last_materialization

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -3,8 +3,6 @@ from enum import Enum
 from functools import lru_cache
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
 
-from typing_extensions import TypeAlias, TypedDict
-
 from dagster import DagsterInstance
 from dagster import _check as check
 from dagster._core.definitions.events import AssetKey

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -131,7 +131,7 @@ class RepositoryScopedBatchLoader:
                         )
                     )
             for record in records:
-                tag = check.not_none(record.pipeline_run.tags.get(SCHEDULE_NAME_TAG))
+                tag: str = check.not_none(record.pipeline_run.tags.get(SCHEDULE_NAME_TAG))
                 fetched[tag].append(record)
 
         elif data_type == RepositoryDataType.SENSOR_RUNS:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
 import sys
 from contextlib import contextmanager
 from contextvars import ContextVar
 from types import TracebackType
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -18,7 +20,6 @@ from typing import (
     cast,
 )
 
-from dagster_graphql.schema.errors import GraphenePythonError
 from graphene import ResolveInfo
 from typing_extensions import ParamSpec, TypeAlias
 
@@ -27,6 +28,9 @@ from dagster._core.definitions.events import AssetKey
 from dagster._core.host_representation import GraphSelector, PipelineSelector
 from dagster._core.workspace.context import BaseWorkspaceRequestContext
 from dagster._utils.error import serializable_error_info_from_exc_info
+
+if TYPE_CHECKING:
+    from dagster_graphql.schema.errors import GraphenePythonError
 
 P = ParamSpec("P")
 T = TypeVar("T")

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -118,8 +118,10 @@ class UserFacingGraphQLError(Exception):
 
 
 def pipeline_selector_from_graphql(data: Mapping[str, Any]) -> PipelineSelector:
+    asset_selection = data.get("assetSelection")
     asset_selection = cast(
-        List[Dict[str, List[str]]], check.list_elem(data, "assetSelection", of_type=dict)
+        Optional[List[Dict[str, List[str]]]],
+        check.opt_nullable_list_param(asset_selection, "assetSelection", of_type=dict),
     )
     return PipelineSelector(
         location_name=data["repositoryLocationName"],

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -9,6 +9,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     Iterator,
     List,
     Mapping,
@@ -118,11 +119,7 @@ class UserFacingGraphQLError(Exception):
 
 
 def pipeline_selector_from_graphql(data: Mapping[str, Any]) -> PipelineSelector:
-    asset_selection = data.get("assetSelection")
-    asset_selection = cast(
-        Optional[List[Dict[str, List[str]]]],
-        check.opt_nullable_list_param(asset_selection, "assetSelection", of_type=dict),
-    )
+    asset_selection = cast(Optional[Iterable[Dict[str, List[str]]]], data.get("assetSelection"))
     return PipelineSelector(
         location_name=data["repositoryLocationName"],
         repository_name=data["repositoryName"],

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 P = ParamSpec("P")
 T = TypeVar("T")
 
-GrapheneResolverFn: TypeAlias = Callable[P, T]
+GrapheneResolverFn: TypeAlias = Callable[..., object]
 T_Callable = TypeVar("T_Callable", bound=Callable)
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 from contextlib import contextmanager
 from contextvars import ContextVar

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -123,7 +123,7 @@ def pipeline_selector_from_graphql(data: Mapping[str, Any]) -> PipelineSelector:
     return PipelineSelector(
         location_name=data["repositoryLocationName"],
         repository_name=data["repositoryName"],
-        pipeline_name=check.not_none(data.get("pipelineName") or data.get("jobName")),
+        pipeline_name=data.get("pipelineName") or data.get("jobName"),  # type: ignore
         solid_selection=data.get("solidSelection"),
         asset_selection=[
             check.not_none(AssetKey.from_graphql_input(asset_key)) for asset_key in asset_selection

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -277,7 +277,7 @@ class GrapheneRun(graphene.ObjectType):
         interfaces = (GraphenePipelineRun,)
         name = "Run"
 
-    def __init__(self, record):
+    def __init__(self, record: RunRecord):
         check.inst_param(record, "record", RunRecord)
         pipeline_run = record.pipeline_run
         super().__init__(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/util.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/util.py
@@ -1,4 +1,14 @@
 import graphene
+from typing_extensions import Protocol
+
+from dagster._core.workspace.context import WorkspaceRequestContext
+
+
+# Assign this type to `graphene_info` in a resolver to apply typing to `graphene_info.context`.
+class HasContext(Protocol):
+    @property
+    def context(self) -> WorkspaceRequestContext:
+        ...
 
 
 def non_null_list(of_type):

--- a/python_modules/dagster/dagster/_api/snapshot_execution_plan.py
+++ b/python_modules/dagster/dagster/_api/snapshot_execution_plan.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, FrozenSet, List, Mapping, Optional
+from typing import TYPE_CHECKING, Any, FrozenSet, Mapping, Optional, Sequence
 
 import dagster._check as check
 from dagster._core.definitions.events import AssetKey
@@ -24,8 +24,8 @@ def sync_get_external_execution_plan_grpc(
     mode: str,
     pipeline_snapshot_id: str,
     asset_selection: Optional[FrozenSet[AssetKey]] = None,
-    solid_selection: Optional[List[str]] = None,
-    step_keys_to_execute: Optional[List[str]] = None,
+    solid_selection: Optional[Sequence[str]] = None,
+    step_keys_to_execute: Optional[Sequence[str]] = None,
     known_state: Optional[KnownExecutionState] = None,
     instance: Optional[DagsterInstance] = None,
 ) -> ExecutionPlanSnapshot:
@@ -33,11 +33,11 @@ def sync_get_external_execution_plan_grpc(
 
     check.inst_param(api_client, "api_client", DagsterGrpcClient)
     check.inst_param(pipeline_origin, "pipeline_origin", ExternalPipelineOrigin)
-    solid_selection = check.opt_list_param(solid_selection, "solid_selection", of_type=str)
+    solid_selection = check.opt_sequence_param(solid_selection, "solid_selection", of_type=str)
     check.opt_set_param(asset_selection, "asset_selection", of_type=AssetKey)
     run_config = check.dict_param(run_config, "run_config", key_type=str)
     check.str_param(mode, "mode")
-    check.opt_nullable_list_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
+    check.opt_nullable_sequence_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
     check.str_param(pipeline_snapshot_id, "pipeline_snapshot_id")
     check.opt_inst_param(known_state, "known_state", KnownExecutionState)
     check.opt_inst_param(instance, "instance", DagsterInstance)

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -2,7 +2,7 @@ import os
 import re
 import sys
 import textwrap
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, cast
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, cast
 
 import click
 import pendulum
@@ -563,10 +563,10 @@ def _check_execute_external_pipeline_args(
     mode: Optional[str],
     preset: Optional[str],
     tags: Optional[Mapping[str, object]],
-    solid_selection: Optional[List[str]],
-) -> Tuple[Dict[str, object], str, Mapping[str, object], Optional[List[str]]]:
+    solid_selection: Optional[Sequence[str]],
+) -> Tuple[Mapping[str, object], str, Mapping[str, object], Optional[Sequence[str]]]:
     check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
-    run_config = check.opt_dict_param(run_config, "run_config")
+    run_config = check.opt_mapping_param(run_config, "run_config")
     check.opt_str_param(mode, "mode")
     check.opt_str_param(preset, "preset")
     check.invariant(
@@ -577,7 +577,7 @@ def _check_execute_external_pipeline_args(
     )
 
     tags = check.opt_dict_param(tags, "tags", key_type=str)
-    check.opt_list_param(solid_selection, "solid_selection", of_type=str)
+    check.opt_sequence_param(solid_selection, "solid_selection", of_type=str)
 
     if preset is not None:
         pipeline_preset = external_pipeline.get_preset(preset)

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -2,7 +2,7 @@ import inspect
 import os
 import sys
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Dict, FrozenSet, List, NamedTuple, Optional, Union, overload
+from typing import TYPE_CHECKING, AbstractSet, Any, Dict, FrozenSet, List, NamedTuple, Optional, Union, overload
 
 import dagster._check as check
 import dagster._seven as seven
@@ -206,9 +206,9 @@ class ReconstructablePipeline(
 
     def _subset_for_execution(
         self,
-        solids_to_execute: Optional[Optional[FrozenSet[str]]],
+        solids_to_execute: Optional[AbstractSet[str]],
         solid_selection: Optional[List[str]],
-        asset_selection: Optional[FrozenSet[AssetKey]],
+        asset_selection: Optional[AbstractSet[AssetKey]],
     ) -> "ReconstructablePipeline":
         # no selection
         if solid_selection is None and solids_to_execute is None and asset_selection is None:
@@ -273,8 +273,8 @@ class ReconstructablePipeline(
 
     def subset_for_execution_from_existing_pipeline(
         self,
-        solids_to_execute: Optional[FrozenSet[str]] = None,
-        asset_selection: Optional[FrozenSet[AssetKey]] = None,
+        solids_to_execute: Optional[AbstractSet[str]] = None,
+        asset_selection: Optional[AbstractSet[AssetKey]] = None,
     ) -> "ReconstructablePipeline":
         # take a frozenset of resolved solid names from an existing pipeline
         # so there's no need to parse the selection

--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -1025,7 +1025,7 @@ def create_execution_plan(
     pipeline: Union[IPipeline, PipelineDefinition],
     run_config: Optional[Mapping[str, object]] = None,
     mode: Optional[str] = None,
-    step_keys_to_execute: Optional[List[str]] = None,
+    step_keys_to_execute: Optional[Sequence[str]] = None,
     known_state: Optional[KnownExecutionState] = None,
     instance_ref: Optional[InstanceRef] = None,
     tags: Optional[Dict[str, str]] = None,
@@ -1042,7 +1042,7 @@ def create_execution_plan(
     check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
     run_config = check.opt_mapping_param(run_config, "run_config", key_type=str)
     mode = check.opt_str_param(mode, "mode", default=pipeline_def.get_default_mode_name())
-    check.opt_nullable_list_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
+    check.opt_nullable_sequence_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
     check.opt_inst_param(instance_ref, "instance_ref", InstanceRef)
     tags = check.opt_dict_param(tags, "tags", key_type=str, value_type=str)
     known_state = check.opt_inst_param(

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -290,7 +290,7 @@ def create_backfill_run(
     external_execution_plan = repo_location.get_external_execution_plan(
         external_pipeline,
         partition_data.run_config,
-        external_partition_set.mode,
+        check.not_none(external_partition_set.mode),
         step_keys_to_execute=step_keys_to_execute,
         known_state=known_state,
         instance=instance,

--- a/python_modules/dagster/dagster/_core/execution/plan/outputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/outputs.py
@@ -104,7 +104,7 @@ class StepOutputData(
             ("step_output_handle", "StepOutputHandle"),
             ("type_check_data", Optional[TypeCheckData]),
             ("version", Optional[str]),
-            ("metadata_entries", Optional[List[MetadataEntry]]),
+            ("metadata_entries", List[MetadataEntry]),
         ],
     )
 ):

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -104,7 +104,7 @@ class _PlanBuilder:
         self,
         pipeline: IPipeline,
         resolved_run_config: ResolvedRunConfig,
-        step_keys_to_execute: Optional[List[str]],
+        step_keys_to_execute: Optional[Sequence[str]],
         known_state: KnownExecutionState,
         instance_ref: Optional[InstanceRef],
         tags: Dict[str, str],
@@ -121,7 +121,7 @@ class _PlanBuilder:
         self.resolved_run_config = check.inst_param(
             resolved_run_config, "resolved_run_config", ResolvedRunConfig
         )
-        check.opt_nullable_list_param(step_keys_to_execute, "step_keys_to_execute", str)
+        check.opt_nullable_sequence_param(step_keys_to_execute, "step_keys_to_execute", str)
         self.step_keys_to_execute = step_keys_to_execute
         self.mode_definition = (
             pipeline.get_definition().get_mode_definition(resolved_run_config.mode)
@@ -780,12 +780,12 @@ class ExecutionPlan(
 
     def build_subset_plan(
         self,
-        step_keys_to_execute: List[str],
+        step_keys_to_execute: Sequence[str],
         pipeline_def: PipelineDefinition,
         resolved_run_config: ResolvedRunConfig,
         step_output_versions=None,
     ) -> "ExecutionPlan":
-        check.list_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
+        check.sequence_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
         step_output_versions = check.opt_dict_param(
             step_output_versions, "step_output_versions", key_type=StepOutputHandle, value_type=str
         )
@@ -876,7 +876,7 @@ class ExecutionPlan(
         pipeline_def: PipelineDefinition,
         resolved_run_config: ResolvedRunConfig,
         instance: DagsterInstance,
-        selected_step_keys: Optional[List[str]],
+        selected_step_keys: Optional[Sequence[str]],
     ) -> "ExecutionPlan":
         """
         Returns:
@@ -1005,7 +1005,7 @@ class ExecutionPlan(
     def build(
         pipeline: IPipeline,
         resolved_run_config: ResolvedRunConfig,
-        step_keys_to_execute: Optional[List[str]] = None,
+        step_keys_to_execute: Optional[Sequence[str]] = None,
         known_state: Optional[KnownExecutionState] = None,
         instance_ref: Optional[InstanceRef] = None,
         tags: Optional[Dict[str, str]] = None,
@@ -1021,7 +1021,7 @@ class ExecutionPlan(
         """
         check.inst_param(pipeline, "pipeline", IPipeline)
         check.inst_param(resolved_run_config, "resolved_run_config", ResolvedRunConfig)
-        check.opt_nullable_list_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
+        check.opt_nullable_sequence_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
         known_state = check.opt_inst_param(
             known_state,
             "known_state",

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -1,8 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime
 from threading import RLock
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence, Union
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Union,
+)
 
 import dagster._check as check
 from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.metadata import MetadataEntry, PartitionMetadataEntry
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.schedule_definition import DefaultScheduleStatus
 from dagster._core.definitions.sensor_definition import (
@@ -10,8 +25,15 @@ from dagster._core.definitions.sensor_definition import (
     DefaultSensorStatus,
 )
 from dagster._core.execution.plan.handle import ResolvedFromDynamicStepHandle, StepHandle
-from dagster._core.origin import PipelinePythonOrigin
+from dagster._core.host_representation.origin import (
+    ExternalInstigatorOrigin,
+    ExternalPartitionSetOrigin,
+    ExternalPipelineOrigin,
+    ExternalRepositoryOrigin,
+)
+from dagster._core.origin import PipelinePythonOrigin, RepositoryPythonOrigin
 from dagster._core.snap import ExecutionPlanSnapshot
+from dagster._core.snap.execution_plan_snapshot import ExecutionStepSnap
 from dagster._core.utils import toposort
 from dagster._serdes import create_snapshot_id
 from dagster._utils.schedules import schedule_execution_time_iterator
@@ -21,9 +43,12 @@ from .external_data import (
     ExternalJobRef,
     ExternalPartitionSetData,
     ExternalPipelineData,
+    ExternalPresetData,
     ExternalRepositoryData,
     ExternalScheduleData,
     ExternalSensorData,
+    ExternalSensorMetadata,
+    ExternalTargetData,
 )
 from .handle import InstigatorHandle, PartitionSetHandle, PipelineHandle, RepositoryHandle
 from .pipeline_index import PipelineIndex
@@ -55,11 +80,11 @@ class ExternalRepository:
             self._job_map: Dict[str, Union[ExternalPipelineData, ExternalJobRef]] = {
                 d.name: d for d in external_repository_data.external_pipeline_datas
             }
-            self._deferred_snapshots = False
+            self._deferred_snapshots: bool = False
             self._ref_to_data_fn = None
         elif external_repository_data.external_job_refs is not None:
             self._job_map = {r.name: r for r in external_repository_data.external_job_refs}
-            self._deferred_snapshots = True
+            self._deferred_snapshots: bool = True
             if ref_to_data_fn is None:
                 check.failed(
                     "ref_to_data_fn is required when ExternalRepositoryData is loaded with deferred snapshots"
@@ -76,10 +101,10 @@ class ExternalRepository:
             *external_repository_data.external_schedule_datas,  # type: ignore
             *external_repository_data.external_sensor_datas,  # type: ignore
         ]
-        self._instigation_map = {
+        self._instigation_map: Mapping[str, Union[ExternalScheduleData, ExternalSensorData]] = {
             instigation_data.name: instigation_data for instigation_data in instigation_list
         }
-        self._partition_set_map = {
+        self._partition_set_map: Mapping[str, ExternalPartitionSetData] = {
             external_partition_set_data.name: external_partition_set_data
             for external_partition_set_data in external_repository_data.external_partition_set_datas
         }
@@ -93,60 +118,60 @@ class ExternalRepository:
                     self._asset_jobs[job_name].append(asset_node)
 
         # memoize job instances to share instances
-        self._memo_lock = RLock()
+        self._memo_lock: RLock = RLock()
         self._cached_jobs: Dict[str, ExternalPipeline] = {}
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.external_repository_data.name
 
-    def has_external_schedule(self, schedule_name):
+    def has_external_schedule(self, schedule_name: str) -> bool:
         return isinstance(self._instigation_map.get(schedule_name), ExternalScheduleData)
 
-    def get_external_schedule(self, schedule_name):
+    def get_external_schedule(self, schedule_name: str) -> ExternalSchedule:
         return ExternalSchedule(
             self.external_repository_data.get_external_schedule_data(schedule_name), self._handle
         )
 
-    def get_external_schedules(self):
+    def get_external_schedules(self) -> Sequence[ExternalSchedule]:
         return [
             ExternalSchedule(external_schedule_data, self._handle)
             for external_schedule_data in self.external_repository_data.external_schedule_datas
         ]
 
-    def has_external_sensor(self, sensor_name):
+    def has_external_sensor(self, sensor_name) -> bool:
         return isinstance(self._instigation_map.get(sensor_name), ExternalSensorData)
 
-    def get_external_sensor(self, sensor_name):
+    def get_external_sensor(self, sensor_name) -> ExternalSensor:
         return ExternalSensor(
             self.external_repository_data.get_external_sensor_data(sensor_name), self._handle
         )
 
-    def get_external_sensors(self):
+    def get_external_sensors(self) -> Sequence[ExternalSensor]:
         return [
             ExternalSensor(external_sensor_data, self._handle)
             for external_sensor_data in self.external_repository_data.external_sensor_datas
         ]
 
-    def has_external_partition_set(self, partition_set_name):
+    def has_external_partition_set(self, partition_set_name: str) -> bool:
         return partition_set_name in self._partition_set_map
 
-    def get_external_partition_set(self, partition_set_name):
+    def get_external_partition_set(self, partition_set_name: str) -> ExternalPartitionSet:
         return ExternalPartitionSet(
             self.external_repository_data.get_external_partition_set_data(partition_set_name),
             self._handle,
         )
 
-    def get_external_partition_sets(self):
+    def get_external_partition_sets(self) -> Sequence[ExternalPartitionSet]:
         return [
             ExternalPartitionSet(external_partition_set_data, self._handle)
             for external_partition_set_data in self.external_repository_data.external_partition_set_datas
         ]
 
-    def has_external_job(self, job_name):
+    def has_external_job(self, job_name: str) -> bool:
         return job_name in self._job_map
 
-    def get_full_external_job(self, job_name: str) -> "ExternalPipeline":
+    def get_full_external_job(self, job_name: str) -> ExternalPipeline:
         check.str_param(job_name, "job_name")
         check.invariant(
             self.has_external_job(job_name), f'No external job named "{job_name}" found'
@@ -174,26 +199,26 @@ class ExternalRepository:
 
             return self._cached_jobs[job_name]
 
-    def get_all_external_jobs(self):
+    def get_all_external_jobs(self) -> Sequence[ExternalPipeline]:
         return [self.get_full_external_job(pn) for pn in self._job_map]
 
     @property
-    def handle(self):
+    def handle(self) -> RepositoryHandle:
         return self._handle
 
     @property
-    def selector_id(self):
+    def selector_id(self) -> str:
         return create_snapshot_id(
             RepositorySelector(self._handle.location_name, self._handle.repository_name)
         )
 
-    def get_external_origin(self):
+    def get_external_origin(self) -> ExternalRepositoryOrigin:
         return self.handle.get_external_origin()
 
-    def get_python_origin(self):
+    def get_python_origin(self) -> RepositoryPythonOrigin:
         return self.handle.get_python_origin()
 
-    def get_external_origin_id(self):
+    def get_external_origin_id(self) -> str:
         """
         A means of identifying the repository this ExternalRepository represents based on
         where it came from.
@@ -215,7 +240,7 @@ class ExternalRepository:
         ]
         return matching[0] if matching else None
 
-    def get_display_metadata(self):
+    def get_display_metadata(self) -> Mapping[str, str]:
         return self.handle.display_metadata
 
 
@@ -264,7 +289,7 @@ class ExternalPipeline(RepresentedPipeline):
         self._handle = PipelineHandle(self._name, repository_handle)
 
     @property
-    def _pipeline_index(self):
+    def _pipeline_index(self) -> PipelineIndex:
         with self._memo_lock:
             if self._index is None:
                 self._index = PipelineIndex(
@@ -274,7 +299,7 @@ class ExternalPipeline(RepresentedPipeline):
             return self._index
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @property
@@ -296,11 +321,11 @@ class ExternalPipeline(RepresentedPipeline):
             return self._data
 
     @property
-    def repository_handle(self):
+    def repository_handle(self) -> RepositoryHandle:
         return self._repository_handle
 
     @property
-    def solid_selection(self):
+    def solid_selection(self) -> Optional[Sequence[str]]:
         return (
             self._pipeline_index.pipeline_snapshot.lineage_snapshot.solid_selection
             if self._pipeline_index.pipeline_snapshot.lineage_snapshot
@@ -308,7 +333,7 @@ class ExternalPipeline(RepresentedPipeline):
         )
 
     @property
-    def solids_to_execute(self):
+    def solids_to_execute(self) -> Optional[AbstractSet[str]]:
         return (
             self._pipeline_index.pipeline_snapshot.lineage_snapshot.solids_to_execute
             if self._pipeline_index.pipeline_snapshot.lineage_snapshot
@@ -316,7 +341,7 @@ class ExternalPipeline(RepresentedPipeline):
         )
 
     @property
-    def asset_selection(self):
+    def asset_selection(self) -> Optional[AbstractSet[AssetKey]]:
         return (
             self._pipeline_index.pipeline_snapshot.lineage_snapshot.asset_selection
             if self._pipeline_index.pipeline_snapshot.lineage_snapshot
@@ -324,34 +349,34 @@ class ExternalPipeline(RepresentedPipeline):
         )
 
     @property
-    def active_presets(self):
+    def active_presets(self) -> Sequence[ExternalPresetData]:
         return list(self._active_preset_dict.values())
 
     @property
-    def solid_names(self):
+    def solid_names(self) -> List[str]:
         return self._pipeline_index.pipeline_snapshot.solid_names
 
-    def has_solid_invocation(self, solid_name):
+    def has_solid_invocation(self, solid_name: str):
         check.str_param(solid_name, "solid_name")
         return self._pipeline_index.has_solid_invocation(solid_name)
 
-    def has_preset(self, preset_name):
+    def has_preset(self, preset_name: str) -> bool:
         check.str_param(preset_name, "preset_name")
         return preset_name in self._active_preset_dict
 
-    def get_preset(self, preset_name):
+    def get_preset(self, preset_name: str) -> ExternalPresetData:
         check.str_param(preset_name, "preset_name")
         return self._active_preset_dict[preset_name]
 
     @property
-    def available_modes(self):
+    def available_modes(self) -> Sequence[str]:
         return self._pipeline_index.available_modes
 
-    def has_mode(self, mode_name):
+    def has_mode(self, mode_name: str) -> bool:
         check.str_param(mode_name, "mode_name")
         return self._pipeline_index.has_mode_def(mode_name)
 
-    def root_config_key_for_mode(self, mode_name):
+    def root_config_key_for_mode(self, mode_name: Optional[str]) -> Optional[str]:
         check.opt_str_param(mode_name, "mode_name")
         return self.get_mode_def_snap(
             mode_name if mode_name else self.get_default_mode_name()
@@ -361,37 +386,37 @@ class ExternalPipeline(RepresentedPipeline):
         return self._pipeline_index.get_default_mode_name()
 
     @property
-    def tags(self):
+    def tags(self) -> Mapping[str, object]:
         return self._pipeline_index.pipeline_snapshot.tags
 
     @property
-    def metadata(self):
+    def metadata(self) -> Sequence[Union[MetadataEntry, PartitionMetadataEntry]]:
         return self._pipeline_index.pipeline_snapshot.metadata
 
     @property
-    def computed_pipeline_snapshot_id(self):
+    def computed_pipeline_snapshot_id(self) -> str:
         return self._snapshot_id
 
     @property
-    def identifying_pipeline_snapshot_id(self):
+    def identifying_pipeline_snapshot_id(self) -> str:
         return self._snapshot_id
 
     @property
-    def handle(self):
+    def handle(self) -> PipelineHandle:
         return self._handle
 
-    def get_python_origin(self):
+    def get_python_origin(self) -> PipelinePythonOrigin:
         repository_python_origin = self.repository_handle.get_python_origin()
         return PipelinePythonOrigin(self.name, repository_python_origin)
 
-    def get_external_origin(self):
+    def get_external_origin(self) -> ExternalPipelineOrigin:
         return self.handle.get_external_origin()
 
-    def get_external_origin_id(self):
+    def get_external_origin_id(self) -> str:
         return self.get_external_origin().get_id()
 
     @property
-    def is_job(self):
+    def is_job(self) -> bool:
         return self._is_job
 
 
@@ -401,14 +426,16 @@ class ExternalExecutionPlan:
     was compiled in another process or persisted in an instance.
     """
 
-    def __init__(self, execution_plan_snapshot):
+    def __init__(self, execution_plan_snapshot: ExecutionPlanSnapshot):
         self.execution_plan_snapshot = check.inst_param(
             execution_plan_snapshot, "execution_plan_snapshot", ExecutionPlanSnapshot
         )
 
-        self._step_index = {step.key: step for step in self.execution_plan_snapshot.steps}
+        self._step_index: Mapping[str, ExecutionStepSnap] = {
+            step.key: step for step in self.execution_plan_snapshot.steps
+        }
 
-        self._step_keys_in_plan = (
+        self._step_keys_in_plan: AbstractSet[str] = (
             set(execution_plan_snapshot.step_keys_to_execute)
             if execution_plan_snapshot.step_keys_to_execute
             else set(self._step_index.keys())
@@ -419,24 +446,24 @@ class ExternalExecutionPlan:
         self._topological_step_levels = None
 
     @property
-    def step_keys_in_plan(self):
+    def step_keys_in_plan(self) -> Sequence[str]:
         return list(self._step_keys_in_plan)
 
-    def has_step(self, key):
+    def has_step(self, key: str) -> bool:
         check.str_param(key, "key")
         handle = StepHandle.parse_from_key(key)
         if isinstance(handle, ResolvedFromDynamicStepHandle):
             return handle.unresolved_form.to_key() in self._step_index
         return key in self._step_index
 
-    def get_step_by_key(self, key):
+    def get_step_by_key(self, key: str):
         check.str_param(key, "key")
         return self._step_index[key]
 
     def get_steps_in_plan(self):
         return [self._step_index[sk] for sk in self._step_keys_in_plan]
 
-    def key_in_plan(self, key):
+    def key_in_plan(self, key: str):
         return key in self._step_keys_in_plan
 
     # Everything below this line is a near-copy of the equivalent methods on
@@ -482,7 +509,7 @@ class ExternalExecutionPlan:
 
 
 class ExternalSchedule:
-    def __init__(self, external_schedule_data, handle):
+    def __init__(self, external_schedule_data: ExternalScheduleData, handle: RepositoryHandle):
         self._external_schedule_data = check.inst_param(
             external_schedule_data, "external_schedule_data", ExternalScheduleData
         )
@@ -491,53 +518,53 @@ class ExternalSchedule:
         )
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._external_schedule_data.name
 
     @property
-    def cron_schedule(self):
+    def cron_schedule(self) -> Union[str, Sequence[str]]:
         return self._external_schedule_data.cron_schedule
 
     @property
-    def execution_timezone(self):
+    def execution_timezone(self) -> Optional[str]:
         return self._external_schedule_data.execution_timezone
 
     @property
-    def solid_selection(self):
+    def solid_selection(self) -> Optional[Sequence[str]]:
         return self._external_schedule_data.solid_selection
 
     @property
-    def pipeline_name(self):
+    def pipeline_name(self) -> str:
         return self._external_schedule_data.pipeline_name
 
     @property
-    def mode(self):
+    def mode(self) -> Optional[str]:
         return self._external_schedule_data.mode
 
     @property
-    def description(self):
+    def description(self) -> Optional[str]:
         return self._external_schedule_data.description
 
     @property
-    def partition_set_name(self):
+    def partition_set_name(self) -> Optional[str]:
         return self._external_schedule_data.partition_set_name
 
     @property
-    def environment_vars(self):
+    def environment_vars(self) -> Optional[Mapping[str, str]]:
         return self._external_schedule_data.environment_vars
 
     @property
-    def handle(self):
+    def handle(self) -> InstigatorHandle:
         return self._handle
 
-    def get_external_origin(self):
+    def get_external_origin(self) -> ExternalInstigatorOrigin:
         return self.handle.get_external_origin()
 
-    def get_external_origin_id(self):
+    def get_external_origin_id(self) -> str:
         return self.get_external_origin().get_id()
 
     @property
-    def selector_id(self):
+    def selector_id(self) -> str:
         return create_snapshot_id(
             InstigatorSelector(
                 self.handle.location_name,
@@ -554,7 +581,9 @@ class ExternalSchedule:
             else DefaultScheduleStatus.STOPPED
         )
 
-    def get_current_instigator_state(self, stored_state: Optional["InstigatorState"]):
+    def get_current_instigator_state(
+        self, stored_state: Optional["InstigatorState"]
+    ) -> InstigatorState:
         from dagster._core.scheduler.instigation import (
             InstigatorState,
             InstigatorStatus,
@@ -586,14 +615,14 @@ class ExternalSchedule:
                 ScheduleInstigatorData(self.cron_schedule, start_timestamp=None),
             )
 
-    def execution_time_iterator(self, start_timestamp):
+    def execution_time_iterator(self, start_timestamp: float) -> Iterator[datetime]:
         return schedule_execution_time_iterator(
             start_timestamp, self.cron_schedule, self.execution_timezone
         )
 
 
 class ExternalSensor:
-    def __init__(self, external_sensor_data, handle):
+    def __init__(self, external_sensor_data: ExternalSensorData, handle: RepositoryHandle):
         self._external_sensor_data = check.inst_param(
             external_sensor_data, "external_sensor_data", ExternalSensorData
         )
@@ -602,49 +631,49 @@ class ExternalSensor:
         )
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._external_sensor_data.name
 
     @property
-    def handle(self):
+    def handle(self) -> InstigatorHandle:
         return self._handle
 
     @property
-    def pipeline_name(self):
+    def pipeline_name(self) -> Optional[str]:
         target = self._get_single_target()
         return target.pipeline_name if target else None
 
     @property
-    def mode(self):
+    def mode(self) -> Optional[str]:
         target = self._get_single_target()
         return target.mode if target else None
 
     @property
-    def solid_selection(self):
+    def solid_selection(self) -> Optional[Sequence[str]]:
         target = self._get_single_target()
         return target.solid_selection if target else None
 
-    def _get_single_target(self):
+    def _get_single_target(self) -> Optional[ExternalTargetData]:
         if self._external_sensor_data.target_dict:
             return list(self._external_sensor_data.target_dict.values())[0]
         else:
             return None
 
-    def get_target_data(self, pipeline_name: Optional[str] = None):
+    def get_target_data(self, pipeline_name: Optional[str] = None) -> Optional[ExternalTargetData]:
         if pipeline_name:
             return self._external_sensor_data.target_dict[pipeline_name]
         else:
             return self._get_single_target()
 
-    def get_external_targets(self):
-        return self._external_sensor_data.target_dict.values()
+    def get_external_targets(self) -> Sequence[ExternalTargetData]:
+        return list(self._external_sensor_data.target_dict.values())
 
     @property
-    def description(self):
+    def description(self) -> Optional[str]:
         return self._external_sensor_data.description
 
     @property
-    def min_interval_seconds(self):
+    def min_interval_seconds(self) -> int:
         if (
             isinstance(self._external_sensor_data, ExternalSensorData)
             and self._external_sensor_data.min_interval
@@ -652,14 +681,14 @@ class ExternalSensor:
             return self._external_sensor_data.min_interval
         return DEFAULT_SENSOR_DAEMON_INTERVAL
 
-    def get_external_origin(self):
+    def get_external_origin(self) -> ExternalInstigatorOrigin:
         return self._handle.get_external_origin()
 
-    def get_external_origin_id(self):
+    def get_external_origin_id(self) -> str:
         return self.get_external_origin().get_id()
 
     @property
-    def selector_id(self):
+    def selector_id(self) -> str:
         return create_snapshot_id(
             InstigatorSelector(
                 self.handle.location_name,
@@ -668,7 +697,9 @@ class ExternalSensor:
             )
         )
 
-    def get_current_instigator_state(self, stored_state: Optional["InstigatorState"]):
+    def get_current_instigator_state(
+        self, stored_state: Optional["InstigatorState"]
+    ) -> InstigatorState:
         from dagster._core.scheduler.instigation import (
             InstigatorState,
             InstigatorStatus,
@@ -701,11 +732,11 @@ class ExternalSensor:
             )
 
     @property
-    def metadata(self):
+    def metadata(self) -> Optional[ExternalSensorMetadata]:
         return self._external_sensor_data.metadata
 
     @property
-    def default_status(self) -> DefaultSensorStatus:
+    def default_status(self) -> Optional[DefaultSensorStatus]:
         return (
             self._external_sensor_data.default_status
             if self._external_sensor_data
@@ -714,7 +745,9 @@ class ExternalSensor:
 
 
 class ExternalPartitionSet:
-    def __init__(self, external_partition_set_data, handle):
+    def __init__(
+        self, external_partition_set_data: ExternalPartitionSetData, handle: RepositoryHandle
+    ):
         self._external_partition_set_data = check.inst_param(
             external_partition_set_data, "external_partition_set_data", ExternalPartitionSetData
         )
@@ -723,40 +756,40 @@ class ExternalPartitionSet:
         )
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._external_partition_set_data.name
 
     @property
-    def solid_selection(self):
+    def solid_selection(self) -> Optional[Sequence[str]]:
         return self._external_partition_set_data.solid_selection
 
     @property
-    def mode(self):
+    def mode(self) -> Optional[str]:
         return self._external_partition_set_data.mode
 
     @property
-    def pipeline_name(self):
+    def pipeline_name(self) -> str:
         return self._external_partition_set_data.pipeline_name
 
     @property
-    def repository_handle(self):
+    def repository_handle(self) -> RepositoryHandle:
         return self._handle.repository_handle
 
-    def get_external_origin(self):
+    def get_external_origin(self) -> ExternalPartitionSetOrigin:
         return self._handle.get_external_origin()
 
-    def get_external_origin_id(self):
+    def get_external_origin_id(self) -> str:
         return self.get_external_origin().get_id()
 
-    def has_partition_name_data(self):
+    def has_partition_name_data(self) -> bool:
         # Partition sets from older versions of Dagster as well as partition sets using
         # a DynamicPartitionsDefinition require calling out to user code to compute the partition
         # names
         return self._external_partition_set_data.external_partitions_data != None
 
-    def get_partition_names(self):
+    def get_partition_names(self) -> Sequence[str]:
         check.invariant(self.has_partition_name_data())
         partitions = (
-            self._external_partition_set_data.external_partitions_data.get_partitions_definition()
+            self._external_partition_set_data.external_partitions_data.get_partitions_definition()  # type: ignore
         )
         return partitions.get_partition_keys()

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -84,7 +84,7 @@ class ExternalRepository:
             self._ref_to_data_fn = None
         elif external_repository_data.external_job_refs is not None:
             self._job_map = {r.name: r for r in external_repository_data.external_job_refs}
-            self._deferred_snapshots: bool = True
+            self._deferred_snapshots = True
             if ref_to_data_fn is None:
                 check.failed(
                     "ref_to_data_fn is required when ExternalRepositoryData is loaded with deferred snapshots"
@@ -264,7 +264,7 @@ class ExternalPipeline(RepresentedPipeline):
         self._repository_handle = repository_handle
 
         self._memo_lock = RLock()
-        self._index = None
+        self._index: Optional[PipelineIndex] = None
 
         self._data = external_pipeline_data
         self._ref = external_job_ref
@@ -296,7 +296,7 @@ class ExternalPipeline(RepresentedPipeline):
                     self.external_pipeline_data.pipeline_snapshot,
                     self.external_pipeline_data.parent_pipeline_snapshot,
                 )
-            return self._index
+            return self._index  # type: ignore
 
     @property
     def name(self) -> str:

--- a/python_modules/dagster/dagster/_core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/repository_location.py
@@ -368,14 +368,16 @@ class InProcessRepositoryLocation(RepositoryLocation):
         external_pipeline: ExternalPipeline,
         run_config: Mapping[str, object],
         mode: str,
-        step_keys_to_execute: Optional[List[str]],
+        step_keys_to_execute: Optional[Sequence[str]],
         known_state: Optional[KnownExecutionState],
         instance: Optional[DagsterInstance] = None,
     ) -> ExternalExecutionPlan:
         check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
         check.dict_param(run_config, "run_config")
         check.str_param(mode, "mode")
-        check.opt_nullable_list_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
+        step_keys_to_execute = check.opt_nullable_sequence_param(
+            step_keys_to_execute, "step_keys_to_execute", of_type=str
+        )
         check.opt_inst_param(known_state, "known_state", KnownExecutionState)
         check.opt_inst_param(instance, "instance", DagsterInstance)
 
@@ -383,7 +385,8 @@ class InProcessRepositoryLocation(RepositoryLocation):
             pipeline=self.get_reconstructable_pipeline(
                 external_pipeline.repository_handle.repository_name, external_pipeline.name
             ).subset_for_execution_from_existing_pipeline(
-                external_pipeline.solids_to_execute, external_pipeline.asset_selection
+                frozenset(check.not_none(external_pipeline.solids_to_execute)),
+                frozenset(check.not_none(external_pipeline.asset_selection)),
             ),
             run_config=run_config,
             mode=mode,
@@ -437,7 +440,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
             )
 
         return get_partition_names(
-            self._get_repo_def(external_partition_set.repository_handle),
+            self._get_repo_def(external_partition_set.repository_handle.repository_name),
             partition_set_name=external_partition_set.name,
         )
 
@@ -690,14 +693,14 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
         external_pipeline: ExternalPipeline,
         run_config: Mapping[str, Any],
         mode: str,
-        step_keys_to_execute: Optional[List[str]],
+        step_keys_to_execute: Optional[Sequence[str]],
         known_state: Optional[KnownExecutionState],
         instance: Optional[DagsterInstance] = None,
     ) -> ExternalExecutionPlan:
         check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
         run_config = check.dict_param(run_config, "run_config")
         check.str_param(mode, "mode")
-        check.opt_nullable_list_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
+        check.opt_nullable_sequence_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
         check.opt_inst_param(known_state, "known_state", KnownExecutionState)
         check.opt_inst_param(instance, "instance", DagsterInstance)
 
@@ -707,7 +710,9 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
             run_config=run_config,
             mode=mode,
             pipeline_snapshot_id=external_pipeline.identifying_pipeline_snapshot_id,
-            asset_selection=external_pipeline.asset_selection,
+            asset_selection=frozenset(
+                check.opt_set_param(external_pipeline.asset_selection, "asset_selection")
+            ),
             solid_selection=external_pipeline.solid_selection,
             step_keys_to_execute=step_keys_to_execute,
             known_state=known_state,

--- a/python_modules/dagster/dagster/_core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/repository_location.py
@@ -704,15 +704,19 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
         check.opt_inst_param(known_state, "known_state", KnownExecutionState)
         check.opt_inst_param(instance, "instance", DagsterInstance)
 
+        asset_selection = (
+            frozenset(check.opt_set_param(external_pipeline.asset_selection, "asset_selection"))
+            if external_pipeline.asset_selection is not None
+            else None
+        )
+
         execution_plan_snapshot_or_error = sync_get_external_execution_plan_grpc(
             api_client=self.client,
             pipeline_origin=external_pipeline.get_external_origin(),
             run_config=run_config,
             mode=mode,
             pipeline_snapshot_id=external_pipeline.identifying_pipeline_snapshot_id,
-            asset_selection=frozenset(
-                check.opt_set_param(external_pipeline.asset_selection, "asset_selection")
-            ),
+            asset_selection=asset_selection,
             solid_selection=external_pipeline.solid_selection,
             step_keys_to_execute=step_keys_to_execute,
             known_state=known_state,

--- a/python_modules/dagster/dagster/_core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/repository_location.py
@@ -385,8 +385,8 @@ class InProcessRepositoryLocation(RepositoryLocation):
             pipeline=self.get_reconstructable_pipeline(
                 external_pipeline.repository_handle.repository_name, external_pipeline.name
             ).subset_for_execution_from_existing_pipeline(
-                frozenset(check.not_none(external_pipeline.solids_to_execute)),
-                frozenset(check.not_none(external_pipeline.asset_selection)),
+                external_pipeline.solids_to_execute,
+                external_pipeline.asset_selection,
             ),
             run_config=run_config,
             mode=mode,

--- a/python_modules/dagster/dagster/_core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/repository_location.py
@@ -120,7 +120,7 @@ class RepositoryLocation(AbstractContextManager):
         external_pipeline: ExternalPipeline,
         run_config: Mapping[str, object],
         mode: str,
-        step_keys_to_execute: Optional[List[str]],
+        step_keys_to_execute: Optional[Sequence[str]],
         known_state: Optional[KnownExecutionState],
         instance: Optional[DagsterInstance] = None,
     ) -> ExternalExecutionPlan:

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -4,7 +4,7 @@ import time
 import warnings
 from abc import ABC, abstractmethod
 from contextlib import ExitStack
-from typing import TYPE_CHECKING, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Sequence, Union, cast
 
 import dagster._check as check
 from dagster._core.errors import (
@@ -195,9 +195,9 @@ class BaseWorkspaceRequestContext(IWorkspace):
     def get_external_execution_plan(
         self,
         external_pipeline: ExternalPipeline,
-        run_config: dict,
+        run_config: Mapping[str, object],
         mode: str,
-        step_keys_to_execute: List[str],
+        step_keys_to_execute: Sequence[str],
         known_state: KnownExecutionState,
     ) -> ExternalExecutionPlan:
         return self.get_repository_location(

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -612,7 +612,9 @@ def _evaluate_sensor(
     )
 
     for run_request in sensor_runtime_data.run_requests:
-        target_data: ExternalTargetData = external_sensor.get_target_data(run_request.job_name)
+        target_data: ExternalTargetData = check.not_none(
+            external_sensor.get_target_data(run_request.job_name)
+        )
 
         pipeline_selector = PipelineSelector(
             location_name=repo_location.name,

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -23,10 +23,10 @@ class ExecutionPlanSnapshotArgs(
         "_ExecutionPlanSnapshotArgs",
         [
             ("pipeline_origin", ExternalPipelineOrigin),
-            ("solid_selection", List[str]),
+            ("solid_selection", Sequence[str]),
             ("run_config", Mapping[str, object]),
             ("mode", str),
-            ("step_keys_to_execute", Optional[List[str]]),
+            ("step_keys_to_execute", Optional[Sequence[str]]),
             ("pipeline_snapshot_id", str),
             ("known_state", Optional[KnownExecutionState]),
             ("instance_ref", Optional[InstanceRef]),
@@ -37,10 +37,10 @@ class ExecutionPlanSnapshotArgs(
     def __new__(
         cls,
         pipeline_origin: ExternalPipelineOrigin,
-        solid_selection: List[str],
+        solid_selection: Sequence[str],
         run_config: Mapping[str, object],
         mode: str,
-        step_keys_to_execute: Optional[List[str]],
+        step_keys_to_execute: Optional[Sequence[str]],
         pipeline_snapshot_id: str,
         known_state: Optional[KnownExecutionState] = None,
         instance_ref: Optional[InstanceRef] = None,
@@ -51,10 +51,12 @@ class ExecutionPlanSnapshotArgs(
             pipeline_origin=check.inst_param(
                 pipeline_origin, "pipeline_origin", ExternalPipelineOrigin
             ),
-            solid_selection=check.opt_list_param(solid_selection, "solid_selection", of_type=str),
+            solid_selection=check.opt_sequence_param(
+                solid_selection, "solid_selection", of_type=str
+            ),
             run_config=check.dict_param(run_config, "run_config", key_type=str),
             mode=check.str_param(mode, "mode"),
-            step_keys_to_execute=check.opt_nullable_list_param(
+            step_keys_to_execute=check.opt_nullable_sequence_param(
                 step_keys_to_execute, "step_keys_to_execute", of_type=str
             ),
             pipeline_snapshot_id=check.str_param(pipeline_snapshot_id, "pipeline_snapshot_id"),

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -421,6 +421,8 @@ def launch_scheduled_runs_for_schedule_iterator(
     else:
         start_timestamp_utc = instigator_data.start_timestamp
 
+    start_timestamp_utc = check.not_none(start_timestamp_utc)
+
     schedule_name = external_schedule.name
 
     timezone_str = external_schedule.execution_timezone
@@ -690,7 +692,7 @@ def _create_scheduler_run(
     external_execution_plan = repo_location.get_external_execution_plan(
         external_pipeline,
         run_config,
-        external_schedule.mode,
+        check.not_none(external_schedule.mode),
         step_keys_to_execute=None,
         known_state=None,
     )

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_graphql.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_graphql.py
@@ -45,6 +45,7 @@ def test_execute_hammer_through_dagit():
             if start_pipeline_result.errors:
                 raise Exception("{}".format(start_pipeline_result.errors))
 
+            print(start_pipeline_result.data['launchPipelineExecution'])
             run_id = start_pipeline_result.data["launchPipelineExecution"]["run"]["runId"]
 
             context.instance.run_launcher.join(timeout=60)

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_graphql.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_graphql.py
@@ -45,7 +45,6 @@ def test_execute_hammer_through_dagit():
             if start_pipeline_result.errors:
                 raise Exception("{}".format(start_pipeline_result.errors))
 
-            print(start_pipeline_result.data['launchPipelineExecution'])
             run_id = start_pipeline_result.data["launchPipelineExecution"]["run"]["runId"]
 
             context.instance.run_launcher.join(timeout=60)


### PR DESCRIPTION
### Summary & Motivation

Adds type annotations for dagster-graphql implementation code. Most of it is trivial, but I also added a `WithContext` protocol that can be used to type the `graphql_info` first arg to resolvers. `WithContext` types the `context` property, which gives us type-checking for implementation logic (`graphql_info.context` is the entry point to interaction with the DB/instance).

### How I Tested These Changes

mypy/pyright
