### PR TITLE
Skip Python checks if no Python files change

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
@@ -133,5 +133,10 @@ class CommandStepBuilder:
             self._step["depends_on"] = step_keys
         return self
 
+    def with_skip(self, skip_reason: Optional[str]) -> "CommandStepBuilder":
+        if skip_reason:
+            self._step["skip"] = skip_reason
+        return self
+
     def build(self) -> CommandStep:
         return self._step

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -5,7 +5,7 @@ from typing import List
 from ..defines import GIT_REPO_ROOT
 from ..python_version import AvailablePythonVersion
 from ..step_builder import CommandStepBuilder
-from ..utils import BuildkiteStep, CommandStep, safe_getenv
+from ..utils import BuildkiteStep, CommandStep, safe_getenv, skip_if_no_python_changes
 from .helm import build_helm_steps
 from .packages import build_library_packages_steps
 from .test_project import build_test_project_steps
@@ -46,6 +46,7 @@ def build_repo_wide_black_steps() -> List[CommandStep]:
     return [
         CommandStepBuilder(":python-black: black")
         .run("pip install -e python_modules/dagster[black]", "make check_black")
+        .with_skip(skip_if_no_python_changes())
         .on_test_image(AvailablePythonVersion.get_default())
         .build(),
     ]
@@ -56,6 +57,7 @@ def build_repo_wide_isort_steps() -> List[CommandStep]:
         CommandStepBuilder(":isort: isort")
         .run("pip install -e python_modules/dagster[isort]", "make check_isort")
         .on_test_image(AvailablePythonVersion.get_default())
+        .with_skip(skip_if_no_python_changes())
         .build(),
     ]
 
@@ -80,6 +82,7 @@ def build_repo_wide_check_manifest_steps() -> List[CommandStep]:
         CommandStepBuilder(":white_check_mark: check-manifest")
         .on_test_image(AvailablePythonVersion.get_default())
         .run(*commands)
+        .with_skip(skip_if_no_python_changes())
         .build()
     ]
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -186,7 +186,7 @@ def get_commit(rev):
 
 
 def get_changed_files():
-    subprocess.check(["git", "fetch", "origin", "master"])
+    subprocess.call(["git", "fetch", "origin", "master"])
     origin = get_commit("origin/master")
     head = get_commit("HEAD")
     logging.info(f"Changed files between origin/master ({origin}) and HEAD ({head}):")

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -187,6 +187,9 @@ def get_changed_files():
         .strip()
         .split("\n")
     )
+    print("Changed files:")
+    for path in paths:
+        print(path)
     return [Path(path) for path in paths]
 
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -187,9 +187,9 @@ def get_changed_files():
         .strip()
         .split("\n")
     )
-    print("Changed files:")
+    logging.info("Changed files:")
     for path in paths:
-        print(path)
+        logging.info(path)
     return [Path(path) for path in paths]
 
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -186,6 +186,7 @@ def get_commit(rev):
 
 
 def get_changed_files():
+    subprocess.check(["git", "fetch", "origin", "master"])
     origin = get_commit("origin/master")
     head = get_commit("HEAD")
     logging.info(f"Changed files between origin/master ({origin}) and HEAD ({head}):")

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -182,7 +182,7 @@ def parse_package_version(version_str: str) -> packaging.version.Version:
 
 
 def get_commit(rev):
-    return subprocess.checkoutput(["git", "rev-parse", "--short", rev]).strip()
+    return subprocess.check_output(["git", "rev-parse", "--short", rev]).strip()
 
 
 def get_changed_files():

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -190,7 +190,7 @@ def get_changed_files():
 
 
 def skip_if_no_python_changes():
-    if not is_feature_branch():
+    if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
         return None
 
     if any(path.endswith(".py") for path in get_changed_files()):

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -186,7 +186,7 @@ def get_commit(rev):
     return subprocess.check_output(["git", "rev-parse", "--short", rev]).decode("utf-8").strip()
 
 
-@functools.lru_cache
+@functools.lru_cache(maxsize=None)
 def get_changed_files():
     subprocess.call(["git", "fetch", "origin", "master"])
     origin = get_commit("origin/master")

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -33,6 +33,7 @@ class CommandStep(TypedDict, total=False):
     plugins: List[Dict[str, object]]
     retry: Dict[str, object]
     timeout_in_minutes: int
+    skip: str
 
 
 class GroupStep(TypedDict):

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -181,14 +181,20 @@ def parse_package_version(version_str: str) -> packaging.version.Version:
     return parsed_version
 
 
+def get_commit(rev):
+    return subprocess.checkoutput(["git", "rev-parse", "--short", rev]).strip()
+
+
 def get_changed_files():
+    origin = get_commit("origin/master")
+    head = get_commit("HEAD")
+    logging.info(f"Changed files between origin/master ({origin}) and HEAD ({head}):")
     paths = (
         subprocess.check_output(["git", "diff", "origin/master...HEAD", "--name-only"])
         .decode("utf-8")
         .strip()
         .split("\n")
     )
-    logging.info("Changed files:")
     for path in paths:
         logging.info(path)
     return [Path(path) for path in paths]

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -182,7 +182,7 @@ def parse_package_version(version_str: str) -> packaging.version.Version:
 
 
 def get_commit(rev):
-    return subprocess.check_output(["git", "rev-parse", "--short", rev]).strip()
+    return subprocess.check_output(["git", "rev-parse", "--short", rev]).decode("utf-8").strip()
 
 
 def get_changed_files():

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import subprocess
 from pathlib import Path

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -187,3 +187,13 @@ def get_changed_files():
         .split("\n")
     )
     return [Path(path) for path in paths]
+
+
+def skip_if_no_python_changes():
+    if not is_feature_branch():
+        return None
+
+    if any(path.endswith(".py") for path in get_changed_files()):
+        return "No python changes"
+
+    return None

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -193,7 +193,7 @@ def skip_if_no_python_changes():
     if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
         return None
 
-    if any(path.endswith(".py") for path in get_changed_files()):
+    if any(path.suffix == ".py" for path in get_changed_files()):
         return "No python changes"
 
     return None

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -186,7 +186,7 @@ def get_commit(rev):
     return subprocess.check_output(["git", "rev-parse", "--short", rev]).decode("utf-8").strip()
 
 
-@functools.cache
+@functools.lru_cache
 def get_changed_files():
     subprocess.call(["git", "fetch", "origin", "master"])
     origin = get_commit("origin/master")

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import os
 import subprocess
@@ -185,6 +186,7 @@ def get_commit(rev):
     return subprocess.check_output(["git", "rev-parse", "--short", rev]).decode("utf-8").strip()
 
 
+@functools.cache
 def get_changed_files():
     subprocess.call(["git", "fetch", "origin", "master"])
     origin = get_commit("origin/master")

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -193,7 +193,7 @@ def skip_if_no_python_changes():
     if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
         return None
 
-    if any(path.suffix == ".py" for path in get_changed_files()):
+    if not any(path.suffix == ".py" for path in get_changed_files()):
         return "No python changes"
 
     return None


### PR DESCRIPTION
Incrementally skip more and more of our build when it isn't relevant.

This skips our three repo-wide Python checks (black, isort, and check-manifests) when there's no change to any python files.

I plan to continue to apply this pattern to more and more of margins of the build (various linters, one-off steps, etc.)