### PR TITLE
Fixup setup paths

### DIFF
--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_airflow/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_airflow/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-dask/setup.py
+++ b/python_modules/libraries/dagster-dask/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_dask/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_dask/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_dbt/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_dbt/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-duckdb-pandas/setup.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_duckdb_pandas/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_duckdb_pandas/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-duckdb-pyspark/setup.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_duckdb_pyspark/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_duckdb_pyspark/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-duckdb/setup.py
+++ b/python_modules/libraries/dagster-duckdb/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_duckdb/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_duckdb/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]

--- a/python_modules/libraries/dagster-gcp/setup.py
+++ b/python_modules/libraries/dagster-gcp/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -5,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version() -> str:
     version: Dict[str, str] = {}
-    with open("dagster_gcp/version.py", encoding="utf8") as fp:
+    with open(Path(__file__).parent / "dagster_gcp/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)  # pylint: disable=W0122
 
     return version["__version__"]


### PR DESCRIPTION
I think a bad rebase on https://github.com/dagster-io/dagster/pull/9889 broke a lot of these. We want to use the path relative to the file and not just a relative path.