### PR TITLE
[windows tests] fix start time == end time issue

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_default_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_default_io_manager.py
@@ -13,7 +13,7 @@ from dagster._core.storage.fs_io_manager import PickledObjectFilesystemIOManager
 from dagster._core.test_utils import environ, instance_for_test
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def instance():
     with instance_for_test() as instance:
         yield instance

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_local_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_local_instance.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import time
 import types
 
 import pytest
@@ -170,6 +171,7 @@ def test_run_step_stats():
     def simple():
         @solid
         def should_succeed(context):
+            time.sleep(0.001)
             context.log.info("succeed")
             return "yay"
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -270,6 +270,7 @@ def _event_types(out_events):
 
 @solid
 def should_succeed(context):
+    time.sleep(0.001)
     context.log.info("succeed")
     return "yay"
 
@@ -1106,7 +1107,8 @@ class TestEventLogStorage:
             input_defs=[InputDefinition("_input", str)],
             output_defs=[OutputDefinition(str)],
         )
-        def should_retry(context, _input):
+        def should_retry(_, _input):
+            time.sleep(0.001)
             raise RetryRequested(max_retries=3)
 
         def _one():
@@ -1175,7 +1177,7 @@ class TestEventLogStorage:
     def test_run_step_stats_with_resource_markers(self, storage, test_run_id):
         @solid(required_resource_keys={"foo"})
         def foo_solid():
-            pass
+            time.sleep(0.001)
 
         def _pipeline():
             foo_solid()


### PR DESCRIPTION
some sleeps to ensure the start and end times dont collide and fixture change to prevent leaking, fixes:
```
FAILED dagster_tests\core_tests\storage_tests\test_event_log.py::TestInMemoryEventLogStorage::test_run_step_stats
FAILED dagster_tests\core_tests\storage_tests\test_event_log.py::TestInMemoryEventLogStorage::test_run_step_stats_with_resource_markers
FAILED dagster_tests\core_tests\storage_tests\test_event_log.py::TestSqliteEventLogStorage::test_run_step_stats_with_resource_markers
FAILED dagster_tests\core_tests\storage_tests\test_event_log.py::TestConsolidatedSqliteEventLogStorage::test_run_step_stats
FAILED dagster_tests\core_tests\storage_tests\test_event_log.py::TestConsolidatedSqliteEventLogStorage::test_run_step_stats_with_resource_markers
ERROR dagster_tests\core_tests\workspace_tests\test_request_context.py::test_get_repository_location
```

### How I Tested These Changes

azure run