### PR TITLE
Don't raise an exception when changing the EcsRunLauncher's container name to a new name

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -456,6 +456,14 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
             # task definition does not exist, do not reuse
             return False
 
+        if not any(
+            [
+                container["name"] == self.container_name
+                for container in existing_task_definition["containerDefinitions"]
+            ]
+        ):
+            return False
+
         existing_task_definition_config = DagsterEcsTaskDefinitionConfig.from_task_definition_dict(
             existing_task_definition, self.container_name
         )

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -339,6 +339,17 @@ def test_reuse_task_definition(instance, ecs):
         )
     )
 
+    # Fails if the existing task definition has a different container name
+    task_definition = copy.deepcopy(original_task_definition)
+    task_definition["containerDefinitions"][0]["name"] = "foobar"
+    ecs.register_task_definition(**task_definition)
+
+    assert not instance.run_launcher._reuse_task_definition(
+        DagsterEcsTaskDefinitionConfig.from_task_definition_dict(
+            original_task_definition, instance.run_launcher.container_name
+        )
+    )
+
 
 def test_launching_custom_task_definition(
     ecs, instance_cm, run, workspace, pipeline, external_pipeline


### PR DESCRIPTION
Summary:
This fixes an issue when you change the EcsRunLauncher from expecting a container with one name to expecting a container with a different name - the reuse task definition function raises an Exception when detecting if the old task definition (with the old container name) should be re-used. Instead, it should just choose to not use the old container definition.

Test Plan: Adding a BK test now

### Summary & Motivation

### How I Tested These Changes
