### PR TITLE
[dagit] Subscribe to in progress asset runs, refresh on relevant events

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -7,12 +7,7 @@ import styled from 'styled-components/macro';
 
 import {useFeatureFlags} from '../app/Flags';
 import {GraphQueryItem} from '../app/GraphQueryImpl';
-import {
-  FIFTEEN_SECONDS,
-  QueryRefreshCountdown,
-  QueryRefreshState,
-  useQueryRefreshAtInterval,
-} from '../app/QueryRefresh';
+import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
 import {AssetKey} from '../assets/types';
 import {SVGViewport} from '../graph/SVGViewport';
@@ -32,7 +27,6 @@ import {
   LoadingNotice,
 } from '../pipelines/GraphNotices';
 import {ExplorerPath} from '../pipelines/PipelinePathUtils';
-import {useDidLaunchEvent} from '../runs/RunUtils';
 import {GraphQueryInput} from '../ui/GraphQueryInput';
 import {Loading} from '../ui/Loading';
 
@@ -83,10 +77,9 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
     applyingEmptyDefault,
   } = useAssetGraphData(props.explorerPath.opsQuery, props.fetchOptions);
 
-  const {liveResult, liveDataByNode} = useLiveDataForAssetKeys(graphAssetKeys);
-  const liveDataRefreshState = useQueryRefreshAtInterval(liveResult, FIFTEEN_SECONDS);
-
-  useDidLaunchEvent(liveResult.refetch);
+  const {liveDataByNode, liveDataRefreshState, runWatchers} = useLiveDataForAssetKeys(
+    graphAssetKeys,
+  );
 
   return (
     <Loading allowStaleData queryResult={fetchResult}>
@@ -107,16 +100,19 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
           );
         }
         return (
-          <AssetGraphExplorerWithData
-            key={props.explorerPath.pipelineName}
-            assetGraphData={assetGraphData}
-            allAssetKeys={allAssetKeys}
-            graphQueryItems={graphQueryItems}
-            applyingEmptyDefault={applyingEmptyDefault}
-            liveDataRefreshState={liveDataRefreshState}
-            liveDataByNode={liveDataByNode}
-            {...props}
-          />
+          <>
+            <AssetGraphExplorerWithData
+              key={props.explorerPath.pipelineName}
+              assetGraphData={assetGraphData}
+              allAssetKeys={allAssetKeys}
+              graphQueryItems={graphQueryItems}
+              applyingEmptyDefault={applyingEmptyDefault}
+              liveDataRefreshState={liveDataRefreshState}
+              liveDataByNode={liveDataByNode}
+              {...props}
+            />
+            {runWatchers}
+          </>
         );
       }}
     </Loading>

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetLiveRunLogsSubscription.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetLiveRunLogsSubscription.ts
@@ -1,0 +1,73 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL subscription operation: AssetLiveRunLogsSubscription
+// ====================================================
+
+export interface AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionFailure {
+  __typename: "PipelineRunLogsSubscriptionFailure";
+}
+
+export interface AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepInputEvent {
+  __typename: "ExecutionStepInputEvent" | "ExecutionStepOutputEvent" | "ExecutionStepSkippedEvent" | "ExecutionStepSuccessEvent" | "ExecutionStepUpForRetryEvent" | "ExecutionStepRestartEvent" | "LogMessageEvent" | "ResourceInitFailureEvent" | "ResourceInitStartedEvent" | "ResourceInitSuccessEvent" | "RunFailureEvent" | "RunStartEvent" | "RunEnqueuedEvent" | "RunDequeuedEvent" | "RunStartingEvent" | "RunCancelingEvent" | "RunCanceledEvent" | "RunSuccessEvent" | "StepWorkerStartedEvent" | "StepWorkerStartingEvent" | "HandledOutputEvent" | "LoadedInputEvent" | "LogsCapturedEvent" | "ObjectStoreOperationEvent" | "StepExpectationResultEvent" | "EngineEvent" | "HookCompletedEvent" | "HookSkippedEvent" | "HookErroredEvent" | "AlertStartEvent" | "AlertSuccessEvent" | "AlertFailureEvent";
+}
+
+export interface AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_AssetMaterializationPlannedEvent_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_AssetMaterializationPlannedEvent {
+  __typename: "AssetMaterializationPlannedEvent";
+  assetKey: AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_AssetMaterializationPlannedEvent_assetKey | null;
+}
+
+export interface AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent {
+  __typename: "MaterializationEvent";
+  assetKey: AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent_assetKey | null;
+}
+
+export interface AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent {
+  __typename: "ObservationEvent";
+  assetKey: AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent_assetKey | null;
+}
+
+export interface AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepStartEvent {
+  __typename: "ExecutionStepStartEvent";
+  stepKey: string | null;
+}
+
+export interface AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepFailureEvent {
+  __typename: "ExecutionStepFailureEvent";
+  stepKey: string | null;
+}
+
+export type AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages = AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepInputEvent | AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_AssetMaterializationPlannedEvent | AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_MaterializationEvent | AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ObservationEvent | AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepStartEvent | AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages_ExecutionStepFailureEvent;
+
+export interface AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess {
+  __typename: "PipelineRunLogsSubscriptionSuccess";
+  messages: AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages[];
+}
+
+export type AssetLiveRunLogsSubscription_pipelineRunLogs = AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionFailure | AssetLiveRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess;
+
+export interface AssetLiveRunLogsSubscription {
+  pipelineRunLogs: AssetLiveRunLogsSubscription_pipelineRunLogs;
+}
+
+export interface AssetLiveRunLogsSubscriptionVariables {
+  runId: string;
+}

--- a/js_modules/dagit/packages/core/src/asset-graph/useLiveDataForAssetKeys.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useLiveDataForAssetKeys.tsx
@@ -1,11 +1,18 @@
-import {gql, useQuery} from '@apollo/client';
+import {gql, NetworkStatus, useQuery, useSubscription} from '@apollo/client';
+import uniq from 'lodash/uniq';
 import React from 'react';
 
+import {useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {useDidLaunchEvent} from '../runs/RunUtils';
 import {AssetKeyInput} from '../types/globalTypes';
 
 import {ASSET_NODE_LIVE_FRAGMENT} from './AssetNode';
-import {buildLiveData} from './Utils';
+import {buildLiveData, tokenForAssetKey} from './Utils';
 import {AssetGraphLiveQuery, AssetGraphLiveQueryVariables} from './types/AssetGraphLiveQuery';
+import {AssetLiveRunLogsSubscription} from './types/AssetLiveRunLogsSubscription';
+
+const SUBSCRIPTION_IDLE_POLL_RATE = 30 * 1000;
+const SUBSCRIPTION_MAX_POLL_RATE = 2 * 1000;
 
 /** Fetches the last materialization, "upstream changed", and other live state
  * for the assets in the given pipeline or in the given set of asset keys (or both).
@@ -27,12 +34,127 @@ export function useLiveDataForAssetKeys(assetKeys: AssetKeyInput[]) {
     return liveResult.data ? buildLiveData(liveResult.data) : {};
   }, [liveResult.data]);
 
+  // Track whether the data is being refetched so incoming asset events don't trigger
+  // duplicate requests for live data.
+  const fetching = React.useRef(false);
+  fetching.current = [NetworkStatus.refetch, NetworkStatus.loading].includes(
+    liveResult.networkStatus,
+  );
+
+  const timerRef = React.useRef<NodeJS.Timeout | null>(null);
+
+  const onRefreshDebounced = React.useCallback(() => {
+    // This is a basic `throttle`, except that if it fires and finds the live
+    // query is already refreshing it debounces again.
+    const refetch = liveResult.refetch;
+    const fire = () => {
+      if (fetching.current) {
+        timerRef.current = setTimeout(fire, SUBSCRIPTION_MAX_POLL_RATE);
+      } else {
+        timerRef.current = null;
+        refetch();
+      }
+    };
+    if (!timerRef.current) {
+      timerRef.current = setTimeout(fire, SUBSCRIPTION_MAX_POLL_RATE);
+    }
+  }, [timerRef, liveResult.refetch]);
+
+  React.useEffect(() => {
+    return () => {
+      timerRef.current && clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  // If the event log storage does not support streaming us asset events, fall back to
+  // a polling approach and trigger a single refresh when a run is launched for immediate feedback
+  const liveDataRefreshState = useQueryRefreshAtInterval(liveResult, SUBSCRIPTION_IDLE_POLL_RATE);
+
+  useDidLaunchEvent(liveResult.refetch, SUBSCRIPTION_MAX_POLL_RATE);
+
+  const assetKeyTokens = React.useMemo(() => new Set(assetKeys.map(tokenForAssetKey)), [assetKeys]);
+  const assetStepKeys = React.useMemo(
+    () => new Set(...(liveResult.data?.assetNodes.flatMap((n) => n.opNames) || [])),
+    [liveResult],
+  );
+
+  const runInProgressId = uniq(
+    Object.values(liveDataByNode).flatMap((p) => [...p.unstartedRunIds, ...p.inProgressRunIds]),
+  )
+    .sort()
+    .slice(0, 3);
+
+  const runWatchers = (
+    <>
+      {runInProgressId.map((runId) => (
+        <RunLogObserver
+          runId={runId}
+          key={runId}
+          assetKeyTokens={assetKeyTokens}
+          assetStepKeys={assetStepKeys}
+          callback={onRefreshDebounced}
+        />
+      ))}
+    </>
+  );
+
   return {
-    liveResult,
     liveDataByNode,
+    liveDataRefreshState,
+    runWatchers,
     assetKeys,
   };
 }
+
+const RunLogObserver: React.FC<{
+  runId: string;
+  assetKeyTokens: Set<string>;
+  assetStepKeys: Set<string>;
+  callback: () => void;
+}> = React.memo(({runId, assetKeyTokens, assetStepKeys, callback}) => {
+  // Useful for testing this component:
+  const counter = React.useRef(0);
+  React.useEffect(() => {
+    console.log(`Subscribed to ${runId}`);
+    return () => console.log(`Unsubscribed from ${runId} after ${counter.current} messages`);
+  }, [runId]);
+
+  useSubscription<AssetLiveRunLogsSubscription>(ASSET_LIVE_RUN_LOGS_SUBSCRIPTION, {
+    fetchPolicy: 'no-cache',
+    variables: {runId},
+    onSubscriptionData: (data) => {
+      const logs = data.subscriptionData.data?.pipelineRunLogs;
+      if (logs?.__typename !== 'PipelineRunLogsSubscriptionSuccess') {
+        return;
+      }
+
+      counter.current += logs.messages.length;
+
+      if (
+        logs.messages.some((m) => {
+          if (
+            m.__typename === 'AssetMaterializationPlannedEvent' ||
+            m.__typename === 'MaterializationEvent' ||
+            m.__typename === 'ObservationEvent'
+          ) {
+            return m.assetKey && assetKeyTokens.has(tokenForAssetKey(m.assetKey));
+          }
+          if (
+            m.__typename === 'ExecutionStepFailureEvent' ||
+            m.__typename === 'ExecutionStepStartEvent'
+          ) {
+            return m.stepKey && assetStepKeys.has(m.stepKey);
+          }
+          return false;
+        })
+      ) {
+        callback();
+      }
+    },
+  });
+
+  return <span />;
+});
 
 export const ASSET_LATEST_INFO_FRAGMENT = gql`
   fragment AssetLatestInfoFragment on AssetLatestInfo {
@@ -62,4 +184,38 @@ const ASSETS_GRAPH_LIVE_QUERY = gql`
 
   ${ASSET_NODE_LIVE_FRAGMENT}
   ${ASSET_LATEST_INFO_FRAGMENT}
+`;
+
+const ASSET_LIVE_RUN_LOGS_SUBSCRIPTION = gql`
+  subscription AssetLiveRunLogsSubscription($runId: ID!) {
+    pipelineRunLogs(runId: $runId, cursor: "HEAD") {
+      __typename
+      ... on PipelineRunLogsSubscriptionSuccess {
+        messages {
+          __typename
+          ... on AssetMaterializationPlannedEvent {
+            assetKey {
+              path
+            }
+          }
+          ... on MaterializationEvent {
+            assetKey {
+              path
+            }
+          }
+          ... on ObservationEvent {
+            assetKey {
+              path
+            }
+          }
+          ... on ExecutionStepStartEvent {
+            stepKey
+          }
+          ... on ExecutionStepFailureEvent {
+            stepKey
+          }
+        }
+      }
+    }
+  }
 `;

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -92,16 +92,17 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
   );
 
   const {upstream, downstream} = useNeighborsFromGraph(assetGraphData, assetKey);
-  const {liveResult, liveDataByNode} = useLiveDataForAssetKeys(graphAssetKeys);
+  const {liveDataRefreshState, liveDataByNode, runWatchers} = useLiveDataForAssetKeys(
+    graphAssetKeys,
+  );
 
   const refreshState = useMergedRefresh(
     useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS),
-    useQueryRefreshAtInterval(liveResult, FIFTEEN_SECONDS),
+    liveDataRefreshState,
   );
 
   // Refresh immediately when a run is launched from this page
   useDidLaunchEvent(queryResult.refetch);
-  useDidLaunchEvent(liveResult.refetch);
 
   // Avoid thrashing the materializations UI (which chooses a different default query based on whether
   // data is partitioned) by waiting for the definition to be loaded. (null OR a valid definition)
@@ -111,6 +112,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
 
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', width: '100%', overflowY: 'auto'}}>
+      {runWatchers}
       <AssetPageHeader
         assetKey={assetKey}
         tags={

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
@@ -127,11 +127,13 @@ export const AssetsCatalogTable: React.FC<AssetCatalogTableProps> = ({
     () => displayed.map<AssetKey>((a) => ({path: a.key.path})),
     [displayed],
   );
-  const {liveDataByNode, liveResult} = useLiveDataForAssetKeys(displayedKeys);
+  const {liveDataByNode, liveDataRefreshState, runWatchers} = useLiveDataForAssetKeys(
+    displayedKeys,
+  );
 
   const refreshState = useMergedRefresh(
     useQueryRefreshAtInterval(query, FIFTEEN_SECONDS),
-    useQueryRefreshAtInterval(liveResult, FIFTEEN_SECONDS),
+    liveDataRefreshState,
   );
 
   React.useEffect(() => {
@@ -166,6 +168,7 @@ export const AssetsCatalogTable: React.FC<AssetCatalogTableProps> = ({
 
   return (
     <Wrapper>
+      {runWatchers}
       {/* 48px allows for the toolbar to be sticky as well */}
       <StickyTableContainer $top={48}>
         <AssetTable

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2742,7 +2742,14 @@ type DagitSubscription {
   """
   Retrieve real-time event logs after applying a filter on run id and cursor.
   """
-  pipelineRunLogs(runId: ID!, cursor: String): PipelineRunLogsSubscriptionPayload!
+  pipelineRunLogs(
+    runId: ID!
+
+    """
+    A cursor retrieved from the API. Pass 'HEAD' to stream from the current event onward.
+    """
+    cursor: String
+  ): PipelineRunLogsSubscriptionPayload!
 
   """
   Retrieve real-time compute logs after applying a filter on run id, step name, log type, and cursor.

--- a/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
@@ -405,7 +405,7 @@ class GrapheneAssetMaterializationPlannedEvent(graphene.ObjectType):
         super().__init__(**construct_basic_params(event))
 
     def resolve_assetKey(self, _graphene_info):
-        return self._event.dagster_event.asset_materialization_planned_data
+        return self._event.dagster_event.asset_materialization_planned_data.asset_key
 
     def resolve_runOrError(self, graphene_info):
         return get_run_by_id(graphene_info, self._event.run_id)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/subscription.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/subscription.py
@@ -18,7 +18,10 @@ class GrapheneDagitSubscription(graphene.ObjectType):
     pipelineRunLogs = graphene.Field(
         graphene.NonNull(GraphenePipelineRunLogsSubscriptionPayload),
         runId=graphene.Argument(graphene.NonNull(graphene.ID)),
-        cursor=graphene.Argument(graphene.String),
+        cursor=graphene.Argument(
+            graphene.String,
+            description="A cursor retrieved from the API. Pass 'HEAD' to stream from the current event onward.",
+        ),
         description="Retrieve real-time event logs after applying a filter on run id and cursor.",
     )
 


### PR DESCRIPTION
### Summary & Motivation

Video: https://www.loom.com/share/7278ffd529e04c5bb734de71a068a816
This PR is my second attempt to make the asset graph, asset details page, and asset catalog feel more "real-time" when runs are launched.

My original approach (https://github.com/dagster-io/dagster/pull/9888) added a new GraphQL subscription for asset events, but it required a bunch of new code and the structure of event storage means it was possible to see asset materializations + observations, but not step failures, which could mean some updates not reaching the UI.

This solution is much simpler and strictly client-side:

1) Dagit polls `assetsLatestInfo` every 30 seconds

2) When a run is launched, it refreshes `assetsLatestInfo` immediately and discovers the new run.

3) Whenever `assetsLatestInfo` data contains `inProgressRunIds`  for the visible assets, it subscribes to the stream of run logs (up to 3 runs at a time). When asset or step start / failure events are seen and match the visible assets, it triggers an `assetsLatestInfo` refresh, up to every two seconds.

There's one major loophole in this approach, which is that if you start a run in one tab and switch open browser tabs to an asset graph view, it takes up to 30s for it to realize the run is happening and subscribe to it. I think this is not worth fixing now, and might be easier once we have more subscriptions capability.

There are two performance considerations here:

- This work causes Dagit to subscribe to run logs on more pages. It does not stream much of the data (just the asset keys + step keys), and does not backfill historical logs, but I think it'll cause a noticeable increase in run log queries. I think this is probably OK because we already fetch run logs to calculate stats, etc and it's super well optimized.

- This work causes `assetsLatestInfo` to be called less often when the instance is idle, and much more often when runs are in flight. We can still control the maximum refresh rate (and the UI ensures the requests never stack), so I think we can adjust these constants to keep things sane.
