### PR TITLE
Skip docs changes

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_main.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_main.py
@@ -15,7 +15,6 @@ from dagster_buildkite.steps.wait import build_wait_step
 from dagster_buildkite.utils import BuildkiteStep, is_feature_branch, is_release_branch, safe_getenv
 
 _DAGIT_PATHS = ("js_modules/dagit",)
-_DOCS_PATHS = ("examples", "docs")
 
 logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(message)s",
@@ -32,7 +31,6 @@ def build_dagster_oss_main_steps() -> List[BuildkiteStep]:
     oss_contribution = os.getenv("OSS_CONTRIBUTION")
     do_coverage = DO_COVERAGE
     dagit_ui_only_diff = _is_path_only_diff(paths=_DAGIT_PATHS)
-    docs_only_diff = _is_path_only_diff(paths=_DOCS_PATHS)
 
     steps: List[BuildkiteStep] = []
 
@@ -74,13 +72,9 @@ def build_dagster_oss_main_steps() -> List[BuildkiteStep]:
     steps += build_repo_wide_steps()
 
     # Skip non-dagit-ui steps if we are on a feature branch with only dagit-ui (web app) changes.
-    logging.info(f"dagit_ui_only: {dagit_ui_only_diff}, docs_only: {docs_only_diff}")
+    logging.info(f"dagit_ui_only: {dagit_ui_only_diff}")
     if is_feature_branch(branch_name) and dagit_ui_only_diff:
         steps += build_dagit_ui_steps()
-
-    # Skip non-docs steps if we are on a feature branch with only docs changes.
-    elif is_feature_branch(branch_name) and docs_only_diff:
-        steps += build_docs_steps()
 
     # Full pipeline.
     else:

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
@@ -21,7 +21,7 @@ def build_docs_steps() -> List[BuildkiteStep]:
         # Be sure to check the diff to make sure the literalincludes are as you expect them."
         CommandStepBuilder("docs code snippets")
         .run("cd docs", "make next-dev-install", "make mdx-format", "git diff --exit-code")
-        .skip(skip_if_no_docs_changes())
+        .with_skip(skip_if_no_docs_changes())
         .on_test_image(AvailablePythonVersion.V3_7)
         .build(),
         # Make sure the docs site can build end-to-end.
@@ -45,7 +45,7 @@ def build_docs_steps() -> List[BuildkiteStep]:
             # "git diff --ignore-all-space --stat",
             # "git diff --exit-code --ignore-all-space --no-patch",
         )
-        .skip(skip_if_no_docs_changes())
+        .with_skip(skip_if_no_docs_changes())
         .on_test_image(AvailablePythonVersion.V3_9)
         .build(),
         # Verify screenshot integrity.

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -300,10 +300,12 @@ def skip_if_no_docs_changes():
 
     # If anything changes in the docs directory
     if any(Path("docs") in path.parents for path in get_changed_files()):
+        logging.info("Run docs steps because files in the docs directory changed")
         return None
 
     # If anything changes that uses the literalinclude docstring
     if any("literalinclude" in path.read_text() for path in get_changed_files()):
+        logging.info("Run docs steps because files with the literalinclude docstring changed")
         return None
 
     return "No docs changes"

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -204,6 +204,7 @@ def get_changed_files():
     return [Path(path) for path in paths]
 
 
+@functools.lru_cache(maxsize=None)
 def skip_if_no_python_changes():
     if not is_feature_branch():
         return None

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -292,3 +292,18 @@ def changed_python_package_names():
 
 def message_contains(substring: str) -> bool:
     return substring in os.getenv("BUILDKITE_MESSAGE", "")
+
+
+def skip_if_no_docs_changes():
+    if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
+        return None
+
+    # If anything changes in the docs directory
+    if any(Path("docs") in path.parents for path in get_changed_files()):
+        return None
+
+    # If anything changes that uses the literalinclude docstring
+    if any("literalinclude" in path.read_text() for path in get_changed_files()):
+        return None
+
+    return "No docs changes"

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -305,6 +305,11 @@ def skip_if_no_docs_changes():
         logging.info("Run docs steps because files in the docs directory changed")
         return None
 
+    # If anything changes in the docs directory
+    if any(Path("examples/docs_snippets") in path.parents for path in get_changed_files()):
+        logging.info("Run docs steps because files in the examples/docs_snippets directory changed")
+        return None
+
     # If anything changes that uses the literalinclude docstring
     if any("literalinclude" in path.read_text() for path in get_changed_files()):
         logging.info("Run docs steps because files with the literalinclude docstring changed")

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -305,14 +305,9 @@ def skip_if_no_docs_changes():
         logging.info("Run docs steps because files in the docs directory changed")
         return None
 
-    # If anything changes in the docs directory
+    # If anything changes in the examples directory. This is where our docs snippets live.
     if any(Path("examples") in path.parents for path in get_changed_files()):
         logging.info("Run docs steps because files in the examples directory changed")
-        return None
-
-    # If anything changes that uses the literalinclude docstring
-    if any("literalinclude" in path.read_text() for path in get_changed_files()):
-        logging.info("Run docs steps because files with the literalinclude docstring changed")
         return None
 
     return "No docs changes"

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -209,10 +209,11 @@ def skip_if_no_python_changes():
     if not is_feature_branch():
         return None
 
-    if not any(path.suffix == ".py" for path in get_changed_files()):
-        return "No python changes"
+    if any(path.suffix == ".py" for path in get_changed_files()):
+        logging.info("Run docs steps because .py files changed")
+        return None
 
-    return None
+    return "No python changes"
 
 
 @functools.lru_cache(maxsize=None)

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -306,8 +306,8 @@ def skip_if_no_docs_changes():
         return None
 
     # If anything changes in the docs directory
-    if any(Path("examples/docs_snippets") in path.parents for path in get_changed_files()):
-        logging.info("Run docs steps because files in the examples/docs_snippets directory changed")
+    if any(Path("examples") in path.parents for path in get_changed_files()):
+        logging.info("Run docs steps because files in the examples directory changed")
         return None
 
     # If anything changes that uses the literalinclude docstring


### PR DESCRIPTION
There are two kinds of changes where we want to run our docs steps:

1. Changes to anything in the docs directory
2. ~Changes to python files that use the literalinclude docstring/~

The reason for the former is obvious. ~The latter is because it's used to generate our docs snippets.~

### How I Tested These Changes

I'm going to add a few commits and revert them to see if it correctly skips/unskips the docs steps.