### PR TITLE
[dagit] Jest cleanup for missing canvas context

### DIFF
--- a/js_modules/dagit/packages/core/package.json
+++ b/js_modules/dagit/packages/core/package.json
@@ -126,6 +126,7 @@
     "graphql.macro": "^1.4.2",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.6.3",
+    "jest-canvas-mock": "^2.4.0",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "prettier": "2.2.1",
     "react": "^17.0.2",

--- a/js_modules/dagit/packages/core/src/setupTests.ts
+++ b/js_modules/dagit/packages/core/src/setupTests.ts
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom';
+import 'jest-canvas-mock';

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -5623,6 +5623,7 @@ __metadata:
     graphql.macro: ^1.4.2
     identity-obj-proxy: ^3.0.0
     jest: ^26.6.3
+    jest-canvas-mock: ^2.4.0
     jest-environment-jsdom-sixteen: ^1.0.3
     lodash: ^4.17.15
     lru-cache: ^6.0.0
@@ -14804,6 +14805,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cssfontparser@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "cssfontparser@npm:1.2.1"
+  checksum: 952d487cddab591fb944f2a4c326a7736bc963784a6d92b6ad4051f3bf5ee49a732eff62e29a52ff085197cb07f5bd66525a2245ded7fd356113ac81be9238b9
+  languageName: node
+  linkType: hard
+
 "cssnano-preset-default@npm:^5.1.10":
   version: 5.1.10
   resolution: "cssnano-preset-default@npm:5.1.10"
@@ -19955,6 +19963,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-canvas-mock@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "jest-canvas-mock@npm:2.4.0"
+  dependencies:
+    cssfontparser: ^1.2.1
+    moo-color: ^1.0.2
+  checksum: feda3c9a3301dc8f1ce3eee3d6cd944d3e2f50d713f1a3f159bdd85b88b275871c400dc0a4a50d14b36eef347dde2d7223e50d1109501b80668d87253712675e
+  languageName: node
+  linkType: hard
+
 "jest-changed-files@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-changed-files@npm:26.6.2"
@@ -23069,6 +23087,15 @@ __metadata:
   version: 2.29.1
   resolution: "moment@npm:2.29.1"
   checksum: 1e14d5f422a2687996be11dd2d50c8de3bd577c4a4ca79ba5d02c397242a933e5b941655de6c8cb90ac18f01cc4127e55b4a12ae3c527a6c0a274e455979345e
+  languageName: node
+  linkType: hard
+
+"moo-color@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "moo-color@npm:1.0.3"
+  dependencies:
+    color-name: ^1.1.4
+  checksum: 02bf59b6bbd5e86641bc062e2dc0843e6e579e18ef67e1c8e93bfc01945df578f20e66ce16aa9632db2aa0e16806e0914a26eb345a804f45fff1ae12a8906a29
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary & Motivation

A handful of tests are complaining about `HTMLCanvasElement` missing a `getContext()` function in Jest. The tests still pass, but noisily. (https://buildkite.com/dagster/dagster/builds/36738#0183d7de-6442-4faf-b955-76816d02b893/278-957)

Resolve this by using a library that mocks canvas.

### How I Tested These Changes

Run Jest locally, verify that these tests no longer produce logspew.
