### PR TITLE
Remove references to services in docker-compose down command test fixture

### DIFF
--- a/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
@@ -85,12 +85,22 @@ def docker_compose_down(docker_compose_yml, context, service):
     else:
         compose_command = ["docker-compose"]
 
-    compose_command += ["--file", str(docker_compose_yml), "down", "--volumes", "--remove-orphans"]
-
     if service:
+        compose_command += ["--file", str(docker_compose_yml), "rm", "--volumes"]
+
         compose_command.append(service)
 
-    subprocess.check_call(compose_command)
+        subprocess.check_call(compose_command)
+    else:
+        compose_command += [
+            "--file",
+            str(docker_compose_yml),
+            "down",
+            "--volumes",
+            "--remove-orphans",
+        ]
+
+        subprocess.check_call(compose_command)
 
 
 def list_containers():


### PR DESCRIPTION
### Summary & Motivation
A recent change to docker-compose down errors on additional arguments that were previously ignored (https://github.com/docker/compose/pull/9158). We had our docker-compose down setup to exactly mirror docker-compose up, which is incorrect in the exact way that it seems like this PR seeks to avoid confusion, so this PR gets rid of that parity in the command.

### How I Tested These Changes
Previously got errors on local spindown when using docker-compose, this fixes.
