### PR TITLE
fix credential helper links and volume path

### DIFF
--- a/docs/content/dagster-cloud/deployment/agents/docker.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/docker.mdx
@@ -106,8 +106,8 @@ height={320}
 
 If your images are stored in a private registry, configuring a [Docker credentials helper](https://docs.docker.com/engine/reference/commandline/login/#credential-helpers) allows the agent to log in to your registry. The agent image comes with several popular credentials helpers preinstalled:
 
-- `[docker-credential-ecr-login](https://github.com/awslabs/amazon-ecr-credential-helper)`
-- `[docker-credential-gcr](https://github.com/GoogleCloudPlatform/docker-credential-gcr)`
+- [docker-credential-ecr-login](https://github.com/awslabs/amazon-ecr-credential-helper)
+- [docker-credential-gcr](https://github.com/GoogleCloudPlatform/docker-credential-gcr)
 
 These credential helpers generally are configured in `~/.docker.config.json`. To use one, make sure you mount that file as a volume when you start your agent:
 
@@ -116,7 +116,7 @@ These credential helpers generally are configured in `~/.docker.config.json`. To
     --network=dagster_cloud_agent \
     --volume $PWD/dagster.yaml:/opt/dagster/app/dagster.yaml:ro \
     --volume /var/run/docker.sock:/var/run/docker.sock \
-    --volume ~/.docker/config.json:/root/.docker:ro \
+    --volume ~/.docker/config.json:/root/.docker/config.json:ro \
     --restart on-failure \
     -it docker.io/dagster/dagster-cloud-agent:latest \
     dagster-cloud agent run /opt/dagster/app


### PR DESCRIPTION
Summary:
Putting these in a code symbol breaks the markdown (and the volume path was missing a folder).

Test Plan: View page, now render as links
Follow tutorial steps with an ECR repo

### Summary & Motivation

### How I Tested These Changes
