### PR TITLE
[dagit] Shift-clicking Materialize should show asset launchpad even if assets are partitioned

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetLoaderResourceQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetLoaderResourceQuery.ts
@@ -3,14 +3,46 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { PipelineSelector } from "./../../types/globalTypes";
-
 // ====================================================
 // GraphQL query operation: LaunchAssetLoaderResourceQuery
 // ====================================================
 
+export interface LaunchAssetLoaderResourceQuery_partitionSetsOrError_PythonError {
+  __typename: "PythonError";
+  message: string;
+}
+
+export interface LaunchAssetLoaderResourceQuery_partitionSetsOrError_PipelineNotFoundError {
+  __typename: "PipelineNotFoundError";
+  message: string;
+}
+
+export interface LaunchAssetLoaderResourceQuery_partitionSetsOrError_PartitionSets_results {
+  __typename: "PartitionSet";
+  id: string;
+  name: string;
+}
+
+export interface LaunchAssetLoaderResourceQuery_partitionSetsOrError_PartitionSets {
+  __typename: "PartitionSets";
+  results: LaunchAssetLoaderResourceQuery_partitionSetsOrError_PartitionSets_results[];
+}
+
+export type LaunchAssetLoaderResourceQuery_partitionSetsOrError = LaunchAssetLoaderResourceQuery_partitionSetsOrError_PythonError | LaunchAssetLoaderResourceQuery_partitionSetsOrError_PipelineNotFoundError | LaunchAssetLoaderResourceQuery_partitionSetsOrError_PartitionSets;
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_PythonError {
+  __typename: "PythonError";
+  message: string;
+}
+
+export interface LaunchAssetLoaderResourceQuery_pipelineOrError_InvalidSubsetError {
+  __typename: "InvalidSubsetError";
+  message: string;
+}
+
 export interface LaunchAssetLoaderResourceQuery_pipelineOrError_PipelineNotFoundError {
-  __typename: "PipelineNotFoundError" | "InvalidSubsetError" | "PythonError";
+  __typename: "PipelineNotFoundError";
+  message: string;
 }
 
 export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {
@@ -549,12 +581,15 @@ export interface LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline {
   modes: LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline_modes[];
 }
 
-export type LaunchAssetLoaderResourceQuery_pipelineOrError = LaunchAssetLoaderResourceQuery_pipelineOrError_PipelineNotFoundError | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline;
+export type LaunchAssetLoaderResourceQuery_pipelineOrError = LaunchAssetLoaderResourceQuery_pipelineOrError_PythonError | LaunchAssetLoaderResourceQuery_pipelineOrError_InvalidSubsetError | LaunchAssetLoaderResourceQuery_pipelineOrError_PipelineNotFoundError | LaunchAssetLoaderResourceQuery_pipelineOrError_Pipeline;
 
 export interface LaunchAssetLoaderResourceQuery {
+  partitionSetsOrError: LaunchAssetLoaderResourceQuery_partitionSetsOrError;
   pipelineOrError: LaunchAssetLoaderResourceQuery_pipelineOrError;
 }
 
 export interface LaunchAssetLoaderResourceQueryVariables {
-  pipelineSelector: PipelineSelector;
+  pipelineName: string;
+  repositoryLocationName: string;
+  repositoryName: string;
 }

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Dialog, DialogHeader} from '@dagster-io/ui';
+import {CodeMirrorInDialogStyle, Dialog, DialogHeader} from '@dagster-io/ui';
 import * as React from 'react';
 import {Redirect, useParams} from 'react-router-dom';
 
@@ -49,6 +49,7 @@ export const AssetLaunchpad: React.FC<{
       onClose={() => setOpen(false)}
     >
       <DialogHeader icon="layers" label={title} />
+      <CodeMirrorInDialogStyle />
       <LaunchpadAllowedRoot
         launchpadType="asset"
         pipelinePath={assetJobName}

--- a/js_modules/dagit/packages/ui/src/components/ConfigEditorWithSchema.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ConfigEditorWithSchema.tsx
@@ -18,8 +18,9 @@ interface Props {
 }
 
 // Force code editor hints to appear above the dialog modal
-const CodeMirrorShimStyle = createGlobalStyle`
-  .CodeMirror-hints {
+export const CodeMirrorInDialogStyle = createGlobalStyle`
+  .CodeMirror-hints,
+  .CodeMirror-hints.dagit {
     z-index: 100;
   }
 `;
@@ -39,7 +40,7 @@ export const ConfigEditorWithSchema: React.FC<Props> = ({
 
   return (
     <>
-      <CodeMirrorShimStyle />
+      <CodeMirrorInDialogStyle />
       <SplitPanelContainer
         ref={editorSplitPanelContainer}
         axis="horizontal"


### PR DESCRIPTION
### Summary & Motivation

This PR makes a few small changes:

- The order of operations in the "Materialize" button has been flipped so that assets with both partitions and optional config get the launchpad rather than the "choose partitions" UI if you are holding the shift key.

- The launchpad `base` is specified so the default config of the partition set is shown and the partition picker is present.

- A few places show the real errors from the GraphQL response rather than saying "pipeline not found."

- A small CSS import ensures that the CodeMirror autocompletion dropdown is visible in the asset launchpad. It was previously under the dialog. 😬 
 
### Questions (cc @sryza):

- I'm not sure whether it's possible for a partitioned asset to have required resource config or asset config. In that case, this new code would result in the launchpad being shown all the time, even when you do not shift click. I think that may be preferable (since the config is required), but it would prevent the user from triggering a partition backfill via the Materialize button. We could also make that case still show the partitions UI.

- If you specify default config on a partitioned asset job, runs triggered from the config+partitions launchpad result in an error. This may be unrelated to this work but was tripping me up initially. Maybe this scenario is not valid at all?

```
from dagster import asset, Field, DailyPartitionsDefinition, define_asset_job, repository


@asset(
    config_schema={"a": Field(int, default_value=5)},
    partitions_def=DailyPartitionsDefinition(start_date="2020-01-01"),
)
def asset1(context):
    context.log.info(context.op_config["a"])


@repository
def repo():
    return [asset1, define_asset_job("all_job", config={"ops": {"asset1": {"config": {"a": 10}}}})]
```

```dagster._check.CheckError: Invariant failed. Description: Can't supply a ConfigMapping for 'config' when 'partitions_def' is supplied.```
