### PR TITLE
Skip dagit builds unless necessary

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_main.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_main.py
@@ -1,8 +1,6 @@
-import logging
 import os
 import re
-import subprocess
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from dagster_buildkite.defines import DO_COVERAGE
 from dagster_buildkite.steps.coverage import build_coverage_step

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagit_ui.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagit_ui.py
@@ -2,7 +2,7 @@ from typing import List
 
 from ..python_version import AvailablePythonVersion
 from ..step_builder import CommandStepBuilder
-from ..utils import CommandStep, skip_if_no_js_changes
+from ..utils import CommandStep, skip_if_no_dagit_changes
 
 
 def build_dagit_ui_steps() -> List[CommandStep]:
@@ -20,6 +20,6 @@ def build_dagit_ui_steps() -> List[CommandStep]:
             "buildkite-agent artifact upload lcov.dagit.$BUILDKITE_BUILD_ID.info",
         )
         .on_test_image(AvailablePythonVersion.get_default())
-        .with_skip(skip_if_no_js_changes())
+        .with_skip(skip_if_no_dagit_changes())
         .build(),
     ]

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagit_ui.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagit_ui.py
@@ -2,7 +2,7 @@ from typing import List
 
 from ..python_version import AvailablePythonVersion
 from ..step_builder import CommandStepBuilder
-from ..utils import CommandStep
+from ..utils import CommandStep, skip_if_no_js_changes
 
 
 def build_dagit_ui_steps() -> List[CommandStep]:
@@ -20,5 +20,6 @@ def build_dagit_ui_steps() -> List[CommandStep]:
             "buildkite-agent artifact upload lcov.dagit.$BUILDKITE_BUILD_ID.info",
         )
         .on_test_image(AvailablePythonVersion.get_default())
+        .with_skip(skip_if_no_js_changes())
         .build(),
     ]

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -292,7 +292,6 @@ def skip_if_no_docs_changes():
     return "No docs changes"
 
 
-@functools.lru_cache(maxsize=None)
 def skip_if_no_js_changes():
     if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
         return None

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -298,7 +298,7 @@ def skip_if_no_js_changes():
         return None
 
     # If anything changes in the js_modules directory
-    if any(Path("js_exaples") in path.parents for path in get_changed_files()):
+    if any(Path("js_modules") in path.parents for path in get_changed_files()):
         return None
 
     return "No JS changes"

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -292,12 +292,19 @@ def skip_if_no_docs_changes():
     return "No docs changes"
 
 
-def skip_if_no_js_changes():
+def skip_if_no_dagit_changes():
     if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
         return None
 
     # If anything changes in the js_modules directory
     if any(Path("js_modules") in path.parents for path in get_changed_files()):
+        return None
+
+    # If anything changes in python packages that our front end depend on
+    # dagster and dagster-graphql might indicate changes to our graphql schema
+    # (once we can walk a dependency tree, we can  reduce this to just dagster-graphql)
+    # dagit might indicate changes to other non-graphql endpoints
+    if ["dagster", "dagit", "dagster-graphql"] in changed_python_package_names():
         return None
 
     return "No JS changes"

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -290,3 +290,15 @@ def skip_if_no_docs_changes():
         return None
 
     return "No docs changes"
+
+
+@functools.lru_cache(maxsize=None)
+def skip_if_no_js_changes():
+    if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
+        return None
+
+    # If anything changes in the js_modules directory
+    if any(Path("js_exaples") in path.parents for path in get_changed_files()):
+        return None
+
+    return "No JS changes"

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -307,4 +307,4 @@ def skip_if_no_dagit_changes():
     if ["dagster", "dagit", "dagster-graphql"] in changed_python_package_names():
         return None
 
-    return "No JS changes"
+    return "No changes that affect the JS webapp"


### PR DESCRIPTION
This brings the dagit skipping logic inline with our new skipping logic. Traditionally, we've always run dagit and we've attempted to skip most of the rest of the build if we detect dagit-only changes. Now, we'll follow the same principle as the other steps where every step is always added to the pipeline, but each is conditionally marked as skipped depending on whether it needs to run or not.

The logic for running the dagit JS tests is:

1. On every merge to main or the release branch, execute JS tests
2. On every change to any file in the js_modules directory, execute JS tests

Otherwise, mark the JS tests as skipped. The git diffing loging introduced in #9897 more reliably identifies changed files. One small departure from the original dagit skipping logic is that we always diff against `main` instead of diffing against the base branch for reasons described in:

https://github.com/dagster-io/dagster/pull/9897/commits/55333bd413f078657acca03976534febff0009dc

Although we could potentially bring that diffing behavior back in a future PR.
