### PR TITLE
Skip integration tests

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -315,7 +315,7 @@ class PackageSpec(
                 # Our change is in this package's directory
                 (change in Path(self.directory).rglob("*"))
                 # The file can alter behavior - exclude things like README changes
-                and (change.suffix in [".py", ".cfg", ".toml"])
+                and (change.suffix in [".py", ".cfg", ".toml"] or change.name == "requirements.txt")
             ):
                 return None
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -3,7 +3,6 @@ import glob
 import logging
 import os
 import subprocess
-from collections import namedtuple
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
@@ -249,8 +248,7 @@ def python_package_directories():
 
 @functools.lru_cache(maxsize=None)
 def changed_python_package_names():
-    with_implementation_changes = []
-    with_test_changes = []
+    changes = []
 
     for directory in python_package_directories():
         for change in get_changed_files():
@@ -264,11 +262,7 @@ def changed_python_package_names():
                 # The file is part of a test suite. We treat these two cases
                 # differently because we don't need to run tests in dependent packages
                 # if only a test in an upstream package changed.
-                if any(part.endswith("tests") for part in change.parts):
-                    with_test_changes.append(directory.name)
-                else:
-                    with_implementation_changes.append(directory.name)
+                if not any(part.endswith("tests") for part in change.parts):
+                    changes.append(directory.name)
 
-    return namedtuple("ChangedPackages", ["with_implementation_changes", "with_test_changes"])(
-        with_implementation_changes, with_test_changes
-    )
+    return changes

--- a/integration_tests/test_suites/backcompat-test-suite/requirements.txt
+++ b/integration_tests/test_suites/backcompat-test-suite/requirements.txt
@@ -1,0 +1,4 @@
+  dagster
+  dagster-graphql
+  dagster-test
+  dagster-postgres

--- a/integration_tests/test_suites/backcompat-test-suite/requirements.txt
+++ b/integration_tests/test_suites/backcompat-test-suite/requirements.txt
@@ -1,4 +1,6 @@
-  dagster
-  dagster-graphql
-  dagster-test
-  dagster-postgres
+# This file is used to declare dependencies so we can
+# conditionally skip unaffected parts of the CI build
+dagster
+dagster-graphql
+dagster-test
+dagster-postgres

--- a/integration_tests/test_suites/celery-k8s-test-suite/requirements.txt
+++ b/integration_tests/test_suites/celery-k8s-test-suite/requirements.txt
@@ -1,0 +1,14 @@
+  dagster
+  dagster-graphql
+  dagster-test
+  dagster-pandas
+  dagster-k8s
+  dagster-celery
+  dagster-celery-k8s
+  dagster-celery-docker
+  dagster-postgres
+  dagster-airflow
+  dagster-docker
+  dagster-aws
+  dagster-gcp
+  dagster-k8s-test-infra

--- a/integration_tests/test_suites/celery-k8s-test-suite/requirements.txt
+++ b/integration_tests/test_suites/celery-k8s-test-suite/requirements.txt
@@ -1,14 +1,16 @@
-  dagster
-  dagster-graphql
-  dagster-test
-  dagster-pandas
-  dagster-k8s
-  dagster-celery
-  dagster-celery-k8s
-  dagster-celery-docker
-  dagster-postgres
-  dagster-airflow
-  dagster-docker
-  dagster-aws
-  dagster-gcp
-  dagster-k8s-test-infra
+# This file is used to declare dependencies so we can
+# conditionally skip unaffected parts of the CI build
+dagster
+dagster-graphql
+dagster-test
+dagster-pandas
+dagster-k8s
+dagster-celery
+dagster-celery-k8s
+dagster-celery-docker
+dagster-postgres
+dagster-airflow
+dagster-docker
+dagster-aws
+dagster-gcp
+dagster-k8s-test-infra

--- a/integration_tests/test_suites/daemon-test-suite/requirements.txt
+++ b/integration_tests/test_suites/daemon-test-suite/requirements.txt
@@ -1,0 +1,12 @@
+  dagster
+  dagster-graphql
+  dagster-test
+  dagster-aws
+  dagster-pandas
+  dagster-gcp
+  dagster-celery
+  dagster-celery-docker
+  dagster-k8s
+  dagster-celery-k8s
+  dagster-postgres
+  dagster-docker

--- a/integration_tests/test_suites/daemon-test-suite/requirements.txt
+++ b/integration_tests/test_suites/daemon-test-suite/requirements.txt
@@ -1,12 +1,14 @@
-  dagster
-  dagster-graphql
-  dagster-test
-  dagster-aws
-  dagster-pandas
-  dagster-gcp
-  dagster-celery
-  dagster-celery-docker
-  dagster-k8s
-  dagster-celery-k8s
-  dagster-postgres
-  dagster-docker
+# This file is used to declare dependencies so we can
+# conditionally skip unaffected parts of the CI build
+dagster
+dagster-graphql
+dagster-test
+dagster-aws
+dagster-pandas
+dagster-gcp
+dagster-celery
+dagster-celery-docker
+dagster-k8s
+dagster-celery-k8s
+dagster-postgres
+dagster-docker

--- a/integration_tests/test_suites/k8s-test-suite/requirements.txt
+++ b/integration_tests/test_suites/k8s-test-suite/requirements.txt
@@ -1,3 +1,5 @@
+# This file is used to declare dependencies so we can
+# conditionally skip unaffected parts of the CI build
 dagster
 dagster-graphql
 dagster-test

--- a/integration_tests/test_suites/k8s-test-suite/requirements.txt
+++ b/integration_tests/test_suites/k8s-test-suite/requirements.txt
@@ -1,0 +1,13 @@
+dagster
+dagster-graphql
+dagster-test
+dagster-pandas
+dagster-k8s
+dagster-celery
+dagster-celery-k8s
+dagster-celery-docker
+dagster-postgres
+dagster-airflow
+dagster-docker
+dagster-aws
+dagster-gcp


### PR DESCRIPTION
Previously, we relied on the existence of a setup.py to infer skips.

Now, we can also provide a requirements.txt. This is for things like our
integration test suites that never actually build a Python distribution.
Today, their dependencies are only defined in a tox.ini. We'll
instead/in addition explicitly define dependencies in a requirements.txt
as well.

This also introduces a simplifying change to the skipping logic.
Previously, we drew a distinction between packages that had their
implementation changed and packages that had their test changed. This
has been generalized so that now a package runs its steps if:

1. Any file that can drive behavior within its directory changes. This
   covers the existing case of "my tests changed" and "my implementation
   changed"
2. Any implementation file changes in an upstream package