### PR TITLE
[dagster-io/ui] Calculate available width for MiddleTruncate

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/RepositoryLink.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepositoryLink.tsx
@@ -56,7 +56,6 @@ export const RepositoryLink: React.FC<{
 
 const RepositoryName = styled(Link)`
   max-width: 280px;
-  min-width: 150px;
 `;
 
 const ReloadTooltip = styled(Tooltip)`

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedJobRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedJobRow.tsx
@@ -68,11 +68,12 @@ export const VirtualizedJobRow = (props: JobRowProps) => {
     <Row $height={height} $start={start}>
       <RowGrid border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
         <RowCell>
-          <div style={{whiteSpace: 'nowrap', fontWeight: 500}}>
-            <Link to={workspacePathFromAddress(repoAddress, `/jobs/${name}`)}>
-              <MiddleTruncate text={name} />
-            </Link>
-          </div>
+          <Link
+            to={workspacePathFromAddress(repoAddress, `/jobs/${name}`)}
+            style={{maxWidth: '100%', fontWeight: 500}}
+          >
+            <MiddleTruncate text={name} />
+          </Link>
           <div
             style={{
               maxWidth: '100%',

--- a/js_modules/dagit/packages/ui/src/components/MiddleTruncate.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/MiddleTruncate.stories.tsx
@@ -2,6 +2,9 @@ import {Meta} from '@storybook/react/types-6-0';
 import faker from 'faker';
 import * as React from 'react';
 
+import {Box} from './Box';
+import {Colors} from './Colors';
+import {Icon} from './Icon';
 import {MiddleTruncate} from './MiddleTruncate';
 import {Slider} from './Slider';
 
@@ -13,19 +16,11 @@ export default {
 
 export const Simple = () => {
   const sizer = React.useRef<HTMLDivElement>(null);
-  const [width, setWidth] = React.useState<number | null>(null);
   const [controlledWidth, setControlledWidth] = React.useState(400);
 
   const sentences = React.useMemo(() => {
     return new Array(30).fill(null).map(() => faker.random.words(20));
   }, []);
-
-  React.useEffect(() => {
-    const width = sizer.current?.getBoundingClientRect().width;
-    if (width) {
-      setWidth(width);
-    }
-  }, [controlledWidth]);
 
   return (
     <>
@@ -38,14 +33,121 @@ export const Simple = () => {
         onChange={(value) => setControlledWidth(value)}
       />
       <div ref={sizer} style={{width: controlledWidth}}>
-        {width
-          ? sentences.map((sentence) => (
-              <div key={sentence}>
-                <MiddleTruncate text={sentence} />
+        {sentences.map((sentence) => (
+          <div key={sentence}>
+            <MiddleTruncate text={sentence} />
+          </div>
+        ))}
+        <MiddleTruncate text="Hello world" />
+      </div>
+    </>
+  );
+};
+
+export const Containers = () => {
+  const sizer = React.useRef<HTMLDivElement>(null);
+  const [controlledWidth, setControlledWidth] = React.useState(400);
+
+  const LONG_TEXT =
+    'Four score and seven years ago our fathers brought forth on this continent, a new nation, conceived in Liberty, and dedicated to the proposition that all men are created equal.';
+  const SHORT_TEXT = 'Hello world';
+  return (
+    <>
+      <Slider
+        min={200}
+        max={600}
+        stepSize={10}
+        value={controlledWidth}
+        labelRenderer={false}
+        onChange={(value) => setControlledWidth(value)}
+      />
+      <div ref={sizer} style={{width: controlledWidth}}>
+        <Box flex={{direction: 'row', gap: 24, alignItems: 'center'}} margin={{vertical: 12}}>
+          <Box
+            flex={{direction: 'column', gap: 8, alignItems: 'flex-start'}}
+            background={Colors.Gray100}
+            padding={12}
+            style={{overflow: 'hidden'}}
+          >
+            <div style={{width: '100%'}}>
+              <MiddleTruncate text={LONG_TEXT} />
+            </div>
+            <Box
+              flex={{direction: 'row', gap: 4}}
+              background={Colors.Blue100}
+              padding={4}
+              style={{maxWidth: '100px'}}
+            >
+              <Icon name="account_circle" />
+              <MiddleTruncate text={LONG_TEXT} />
+            </Box>
+            <Box
+              flex={{direction: 'row', gap: 4}}
+              background={Colors.Blue100}
+              padding={4}
+              style={{maxWidth: '300px'}}
+            >
+              <Icon name="account_circle" />
+              <MiddleTruncate text={LONG_TEXT} />
+            </Box>
+            <Box
+              flex={{direction: 'row', gap: 4}}
+              background={Colors.Blue100}
+              padding={4}
+              style={{width: '100%'}}
+            >
+              <Icon name="account_circle" />
+              <div style={{flex: 1, overflow: 'hidden'}}>
+                <MiddleTruncate text={LONG_TEXT} />
               </div>
-            ))
-          : null}
-        {width ? <MiddleTruncate text="Hello world" /> : null}
+            </Box>
+            <Box flex={{direction: 'row', gap: 4}} background={Colors.Blue100} padding={4}>
+              <Icon name="account_circle" />
+              <MiddleTruncate text={LONG_TEXT} />
+            </Box>
+          </Box>
+        </Box>
+        <Box margin={{bottom: 12}}>
+          <Box
+            flex={{direction: 'column', gap: 8, alignItems: 'flex-start'}}
+            background={Colors.Gray100}
+            padding={12}
+            style={{overflow: 'hidden'}}
+          >
+            <MiddleTruncate text={SHORT_TEXT} />
+            <Box
+              flex={{direction: 'row', gap: 4}}
+              background={Colors.Blue100}
+              padding={4}
+              style={{maxWidth: '100px'}}
+            >
+              <Icon name="account_circle" />
+              <MiddleTruncate text={SHORT_TEXT} />
+            </Box>
+            <Box
+              flex={{direction: 'row', gap: 4}}
+              background={Colors.Blue100}
+              padding={4}
+              style={{maxWidth: '60px'}}
+            >
+              <Icon name="account_circle" />
+              <MiddleTruncate text={SHORT_TEXT} />
+            </Box>
+            <Box
+              flex={{direction: 'row', gap: 4}}
+              background={Colors.Blue100}
+              padding={4}
+              style={{maxWidth: '100%'}}
+            >
+              <Icon name="account_circle" />
+              <MiddleTruncate text={SHORT_TEXT} />
+            </Box>
+            <Box flex={{direction: 'row', gap: 4}} background={Colors.Blue100} padding={4}>
+              <Icon name="account_circle" />
+              <MiddleTruncate text={SHORT_TEXT} />
+            </Box>
+          </Box>
+        </Box>
       </div>
     </>
   );


### PR DESCRIPTION
### Summary & Motivation

The `MiddleTruncate` component is currently a bit fussy when rendered in a flex item, and also has some issues with the resize observer firing its callback when resizes have occurred due to the truncated text being rendered.

In order to alleviate these issues, I have modified `MiddleTruncate` to do the following:

1. Render a "fill" string into the container, and measure the container's width. Set the computed font style and available width in state.
2. Use the canvas 2D context as before, using the font style and available width to calculate the longest possible middle-truncated string that can fit within the container.
3. When the middle truncated string is available, render it into the container. Set a flag to denote that we have just determined the width and rendered the middle-truncated string, so the resize observer handler should be skipped.
4. After a brief delay, clear the flag. The delay is in place to ensure that we don't end up in an observe->measure->render loop.
5. When an element resize occurs, start at step 1 again.

### How I Tested These Changes

Added a handful of Storybook examples to test flex item rendering.

Tested RepositoryLink components within Dagit to ensure that middle truncation looks appropriate, and that strings that are short enough to fit in the max-width of `RepositoryLink` are correctly *not* truncated.

Resize window when viewing virtualized jobs table in Overview, verify that job names are correctly middle truncated.

Tested in Chrome, FF, Safari.
