### PR TITLE
Skip grapqhl and mysql checks

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -5,7 +5,14 @@ from typing import List
 from ..defines import GIT_REPO_ROOT
 from ..python_version import AvailablePythonVersion
 from ..step_builder import CommandStepBuilder
-from ..utils import BuildkiteStep, CommandStep, safe_getenv, skip_if_no_python_changes
+from ..utils import (
+    BuildkiteStep,
+    CommandStep,
+    safe_getenv,
+    skip_graphql,
+    skip_if_no_python_changes,
+    skip_mysql,
+)
 from .helm import build_helm_steps
 from .packages import build_library_packages_steps
 from .test_project import build_test_project_steps
@@ -92,6 +99,7 @@ def build_sql_schema_check_steps() -> List[CommandStep]:
         CommandStepBuilder(":mysql: mysql-schema")
         .on_test_image(AvailablePythonVersion.get_default())
         .run("pip install -e python_modules/dagster", "python scripts/check_schemas.py")
+        .with_skip(skip_mysql())
         .build()
     ]
 
@@ -104,5 +112,6 @@ def build_graphql_python_client_backcompat_steps() -> List[CommandStep]:
             "pip install -e python_modules/dagster[test] -e python_modules/dagster-graphql -e python_modules/automation",
             "dagster-graphql-client query check",
         )
+        with_skip(skip_graphql())
         .build()
     ]

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -9,9 +9,9 @@ from ..utils import (
     BuildkiteStep,
     CommandStep,
     safe_getenv,
-    skip_graphql,
+    skip_graphql_if_no_changes_to_dependencies,
     skip_if_no_python_changes,
-    skip_mysql,
+    skip_mysql_if_no_changes_to_dependencies,
 )
 from .helm import build_helm_steps
 from .packages import build_library_packages_steps
@@ -99,7 +99,7 @@ def build_sql_schema_check_steps() -> List[CommandStep]:
         CommandStepBuilder(":mysql: mysql-schema")
         .on_test_image(AvailablePythonVersion.get_default())
         .run("pip install -e python_modules/dagster", "python scripts/check_schemas.py")
-        .with_skip(skip_mysql())
+        .with_skip(skip_mysql_if_no_changes_to_dependencies(["dagster"]))
         .build()
     ]
 
@@ -112,6 +112,8 @@ def build_graphql_python_client_backcompat_steps() -> List[CommandStep]:
             "pip install -e python_modules/dagster[test] -e python_modules/dagster-graphql -e python_modules/automation",
             "dagster-graphql-client query check",
         )
-        .with_skip(skip_graphql())
+        .with_skip(
+            skip_graphql_if_no_changes_to_dependencies(["dagster", "dagster-graphql", "automation"])
+        )
         .build()
     ]

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -112,6 +112,6 @@ def build_graphql_python_client_backcompat_steps() -> List[CommandStep]:
             "pip install -e python_modules/dagster[test] -e python_modules/dagster-graphql -e python_modules/automation",
             "dagster-graphql-client query check",
         )
-        with_skip(skip_graphql())
+        .with_skip(skip_graphql())
         .build()
     ]

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -145,7 +145,7 @@ def connect_sibling_docker_container(
     ]
 
 
-def is_feature_branch(branch_name: str) -> bool:
+def is_feature_branch(branch_name: str = safe_getenv("BUILDKITE_BRANCH")) -> bool:
     return not (branch_name == "master" or branch_name.startswith("release"))
 
 
@@ -205,7 +205,7 @@ def get_changed_files():
 
 
 def skip_if_no_python_changes():
-    if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
+    if not is_feature_branch():
         return None
 
     if not any(path.suffix == ".py" for path in get_changed_files()):
@@ -216,7 +216,7 @@ def skip_if_no_python_changes():
 
 @functools.lru_cache(maxsize=None)
 def skip_if_no_helm_changes():
-    if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
+    if not is_feature_branch():
         return None
 
     if any(Path("helm") in path.parents for path in get_changed_files()):
@@ -228,14 +228,14 @@ def skip_if_no_helm_changes():
 
 @functools.lru_cache(maxsize=None)
 def skip_coverage_if_feature_branch():
-    if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
+    if not is_feature_branch():
         return None
 
     return "Skip coverage uploads until we're finished with our Buildkite refactor"
 
 
 def skip_mysql_if_no_changes_to_dependencies(dependencies: List[str]):
-    if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
+    if not is_feature_branch():
         return None
 
     for dependency in dependencies:
@@ -246,7 +246,7 @@ def skip_mysql_if_no_changes_to_dependencies(dependencies: List[str]):
 
 
 def skip_graphql_if_no_changes_to_dependencies(dependencies: List[str]):
-    if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
+    if not is_feature_branch():
         return None
 
     for dependency in dependencies:

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -234,21 +234,22 @@ def skip_coverage_if_feature_branch():
     return "Skip coverage uploads until we're finished with our Buildkite refactor"
 
 
-def skip_mysql():
+def skip_mysql_checks_if_no_changes_to_dependencies(dependencies: List[str]):
     if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
         return None
 
-    if "dagster" in changed_python_package_names():
-        return None
+    for dependency in dependencies:
+        if dependency in changed_python_package_names():
+            return None
 
     return "Skip unless mysql schemas might have changed"
 
 
-def skip_graphql():
+def skip_graphql_checks_if_no_changes_to_dependencies(dependencies: List[str]):
     if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
         return None
 
-    for dependency in ["dagster", "dagster-graphql", "automation"]:
+    for dependency in dependencies:
         if dependency in changed_python_package_names():
             return None
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -235,6 +235,29 @@ def skip_coverage_if_feature_branch():
 
 
 @functools.lru_cache(maxsize=None)
+def skip_mysql():
+    if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
+        return None
+
+    if "dagster" in changed_python_package_names():
+        return None
+
+    return "Skip unless mysql schemas might have changed"
+
+
+@functools.lru_cache(maxsize=None)
+def skip_graphql():
+    if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
+        return None
+
+    for dependency in ["dagster", "dagster-graphql", "automation"]:
+        if dependency in changed_python_package_names():
+            return None
+
+    return "Skip unless GraphQL schemas might have changed"
+
+
+@functools.lru_cache(maxsize=None)
 def python_package_directories():
     # Consider any directory with a setup.py file to be a package
     packages = [Path(setup).parent for setup in glob.glob("**/setup.py", recursive=True)]

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -234,7 +234,6 @@ def skip_coverage_if_feature_branch():
     return "Skip coverage uploads until we're finished with our Buildkite refactor"
 
 
-@functools.lru_cache(maxsize=None)
 def skip_mysql():
     if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
         return None
@@ -245,7 +244,6 @@ def skip_mysql():
     return "Skip unless mysql schemas might have changed"
 
 
-@functools.lru_cache(maxsize=None)
 def skip_graphql():
     if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
         return None

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -234,7 +234,7 @@ def skip_coverage_if_feature_branch():
     return "Skip coverage uploads until we're finished with our Buildkite refactor"
 
 
-def skip_mysql_checks_if_no_changes_to_dependencies(dependencies: List[str]):
+def skip_mysql_if_no_changes_to_dependencies(dependencies: List[str]):
     if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
         return None
 
@@ -245,7 +245,7 @@ def skip_mysql_checks_if_no_changes_to_dependencies(dependencies: List[str]):
     return "Skip unless mysql schemas might have changed"
 
 
-def skip_graphql_checks_if_no_changes_to_dependencies(dependencies: List[str]):
+def skip_graphql_if_no_changes_to_dependencies(dependencies: List[str]):
     if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
         return None
 


### PR DESCRIPTION
We don't really capture these steps' dependencies anywhere other than in Buildkite so for now, just hardcode which packages they depend on.