### PR TITLE
fix Dagit execution of partitioned asset jobs with hardcoded config

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
@@ -425,6 +425,11 @@ def test_job_config_with_asset_partitions():
     ).resolve([asset1], [])
 
     assert the_job.execute_in_process(partition_key="2020-01-01").success
+    assert (
+        the_job.get_job_def_for_subset_selection(asset_selection={AssetKey("asset1")})
+        .execute_in_process(partition_key="2020-01-01")
+        .success
+    )
 
 
 def test_job_partitioned_config_with_asset_partitions():


### PR DESCRIPTION
### Summary & Motivation

Fixes #10041

Prior to this change, if you tried to "Materialize All" on this job in Dagit:

```
from dagster import asset, Field, DailyPartitionsDefinition, define_asset_job, repository


@asset(
    config_schema={"a": Field(int, default_value=5)},
    partitions_def=DailyPartitionsDefinition(start_date="2020-01-01"),
)
def asset1(context):
    context.log.info(context.op_config["a"])


@repository
def repo():
    return [
        asset1,
        define_asset_job(
            "all_job",
            config={"ops": {"asset1": {"config": {"a": 10}}}},
            partitions_def=DailyPartitionsDefinition(start_date="2020-01-01"),
        ),
    ]
```

You would hit this error:

```
   dagster._check.CheckError: Invariant failed. Description: Can't supply a ConfigMapping for 'config' when 'partitions_def' is supplied.
```

### How I Tested These Changes
