### PR TITLE
Fix runs yielded error for multi asset sensor

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -1781,7 +1781,8 @@ class MultiAssetSensorDefinition(SensorDefinition):
                 runs_yielded = False
                 if inspect.isgenerator(result) or isinstance(result, list):
                     for item in result:
-                        runs_yielded = True
+                        if isinstance(item, RunRequest):
+                            runs_yielded = True
                         yield item
                 elif isinstance(result, RunRequest):
                     runs_yielded = True

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
@@ -21,6 +21,7 @@ from dagster import (
     PartitionsDefinition,
     RunRequest,
     SensorEvaluationContext,
+    SkipReason,
     StaticPartitionsDefinition,
     asset,
     build_multi_asset_sensor_context,
@@ -1227,3 +1228,17 @@ def test_error_exec_in_process_to_build_multi_asset_sensor_context():
                 cursor_from_latest_materializations=True,
                 cursor="alskdjalsjk",
             )
+
+
+def test_error_not_thrown_for_skip_reason():
+    @multi_asset_sensor(asset_keys=[july_asset.key])
+    def test_unconsumed_events_sensor(context):
+        return SkipReason("I am skipping")
+
+    with instance_for_test() as instance:
+        ctx = build_multi_asset_sensor_context(
+            asset_keys=[july_asset.key],
+            repository_def=my_repo,
+            instance=instance,
+        )
+        list(test_unconsumed_events_sensor(ctx))

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
@@ -1232,7 +1232,7 @@ def test_error_exec_in_process_to_build_multi_asset_sensor_context():
 
 def test_error_not_thrown_for_skip_reason():
     @multi_asset_sensor(asset_keys=[july_asset.key])
-    def test_unconsumed_events_sensor(context):
+    def test_unconsumed_events_sensor(_):
         return SkipReason("I am skipping")
 
     with instance_for_test() as instance:


### PR DESCRIPTION
Currently, when any skip reasons are returned from the multi asset sensor, a `Asset materializations have been handled in this sensor, but the cursor was not updated` error was raised. This PR fixes the error. This occurs because all decorated multi asset sensor functions are wrapped with generator functions.

[Reported by a user](https://dagster.slack.com/archives/C01U954MEER/p1666036752225909)