### PR TITLE
[dagster-duckdb] support loading pyspark dfs

### DIFF
--- a/python_modules/libraries/dagster-duckdb-pyspark/setup.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/setup.py
@@ -40,6 +40,7 @@ if __name__ == "__main__":
             # Pyspark 2.x is incompatible with Python 3.8+
             'pyspark>=3.0.0; python_version >= "3.8"',
             'pyspark>=2.0.2; python_version < "3.8"',
+            "pandas"
         ],
         zip_safe=False,
     )

--- a/python_modules/libraries/dagster-duckdb-pyspark/setup.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/setup.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
             # Pyspark 2.x is incompatible with Python 3.8+
             'pyspark>=3.0.0; python_version >= "3.8"',
             'pyspark>=2.0.2; python_version < "3.8"',
-            "pandas"
+            "pandas",
         ],
         zip_safe=False,
     )

--- a/python_modules/libraries/dagster-duckdb/setup.py
+++ b/python_modules/libraries/dagster-duckdb/setup.py
@@ -38,13 +38,5 @@ if __name__ == "__main__":
             "duckdb",
             f"dagster{pin}",
         ],
-        extras_require={
-            "pandas": ["pandas"],
-            # Pyspark 2.x is incompatible with Python 3.8+
-            "pyspark": [
-                'pyspark>=3.0.0; python_version >= "3.8"',
-                'pyspark>=2.0.2; python_version < "3.8"',
-            ],
-        },
         zip_safe=False,
     )


### PR DESCRIPTION
### Summary & Motivation
adds support for loading inputs as pyspark dataframes

### How I Tested These Changes
new unit test