### PR TITLE
[dagit] Add "Materialize" action item to asset action menu

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetActionMenu.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetActionMenu.tsx
@@ -1,4 +1,4 @@
-import {Button, Icon, Menu, MenuItem, Popover} from '@dagster-io/ui';
+import {Button, Icon, Menu, MenuItem, Popover, Spinner, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {usePermissions} from '../app/Permissions';
@@ -6,6 +6,7 @@ import {MenuLink} from '../ui/MenuLink';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
+import {useMaterializationAction} from './LaunchAssetExecutionButton';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {AssetTableFragment} from './types/AssetTableFragment';
 
@@ -17,56 +18,69 @@ interface Props {
 
 export const AssetActionMenu: React.FC<Props> = (props) => {
   const {repoAddress, asset, onWipe} = props;
-  const {canWipeAssets} = usePermissions();
+  const {canWipeAssets, canLaunchPipelineExecution} = usePermissions();
   const {path} = asset.key;
 
+  const {onClick, loading, launchpadElement} = useMaterializationAction([asset.key]);
+
   return (
-    <Popover
-      position="bottom-right"
-      content={
-        <Menu>
-          <MenuLink
-            text="Show in group"
-            to={
-              repoAddress && asset.definition?.groupName
-                ? workspacePathFromAddress(
-                    repoAddress,
-                    `/asset-groups/${asset.definition.groupName}`,
-                  )
-                : ''
-            }
-            disabled={!asset?.definition}
-            icon="asset_group"
-          />
-          <MenuLink
-            text="View neighbors"
-            to={assetDetailsPathForKey({path}, {view: 'lineage', lineageScope: 'neighbors'})}
-            disabled={!asset?.definition}
-            icon="graph_neighbors"
-          />
-          <MenuLink
-            text="View upstream assets"
-            to={assetDetailsPathForKey({path}, {view: 'lineage', lineageScope: 'upstream'})}
-            disabled={!asset?.definition}
-            icon="graph_upstream"
-          />
-          <MenuLink
-            text="View downstream assets"
-            to={assetDetailsPathForKey({path}, {view: 'lineage', lineageScope: 'downstream'})}
-            disabled={!asset?.definition}
-            icon="graph_downstream"
-          />
-          <MenuItem
-            text="Wipe materializations"
-            icon="delete"
-            disabled={!onWipe || !canWipeAssets.enabled}
-            intent="danger"
-            onClick={() => canWipeAssets.enabled && onWipe && onWipe([asset])}
-          />
-        </Menu>
-      }
-    >
-      <Button icon={<Icon name="expand_more" />} />
-    </Popover>
+    <>
+      <Popover
+        position="bottom-right"
+        content={
+          <Menu>
+            <Tooltip content="Shift+click to add configuration" placement="left" display="block">
+              <MenuItem
+                text="Materialize"
+                icon={loading ? <Spinner purpose="body-text" /> : 'materialization'}
+                disabled={!canLaunchPipelineExecution || loading}
+                onClick={onClick}
+              />
+            </Tooltip>
+            <MenuLink
+              text="Show in group"
+              to={
+                repoAddress && asset.definition?.groupName
+                  ? workspacePathFromAddress(
+                      repoAddress,
+                      `/asset-groups/${asset.definition.groupName}`,
+                    )
+                  : ''
+              }
+              disabled={!asset?.definition}
+              icon="asset_group"
+            />
+            <MenuLink
+              text="View neighbors"
+              to={assetDetailsPathForKey({path}, {view: 'lineage', lineageScope: 'neighbors'})}
+              disabled={!asset?.definition}
+              icon="graph_neighbors"
+            />
+            <MenuLink
+              text="View upstream assets"
+              to={assetDetailsPathForKey({path}, {view: 'lineage', lineageScope: 'upstream'})}
+              disabled={!asset?.definition}
+              icon="graph_upstream"
+            />
+            <MenuLink
+              text="View downstream assets"
+              to={assetDetailsPathForKey({path}, {view: 'lineage', lineageScope: 'downstream'})}
+              disabled={!asset?.definition}
+              icon="graph_downstream"
+            />
+            <MenuItem
+              text="Wipe materializations"
+              icon="delete"
+              disabled={!onWipe || !canWipeAssets.enabled}
+              intent="danger"
+              onClick={() => canWipeAssets.enabled && onWipe && onWipe([asset])}
+            />
+          </Menu>
+        }
+      >
+        <Button icon={<Icon name="expand_more" />} />
+      </Popover>
+      {launchpadElement}
+    </>
   );
 };


### PR DESCRIPTION
### Summary & Motivation

Resolves #9970.

Add a "Materialize" action item to the Asset actions menu on asset list views. I factored the launchpad state management code into a hook that can be used by the main "Materialize" button and the menu item.

### How I Tested These Changes

Use the action menu to materialize assets, with and without the "Shift+Click" behavior. Use the button to do the same. Verify that the materialize behavior works correctly in both scenarios.
