### PR TITLE
Raise if we can't infer distribution

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -1,3 +1,4 @@
+import functools
 import os
 from distutils import core as distutils_core  # pylint: disable=deprecated-module
 from importlib import reload
@@ -279,6 +280,7 @@ class PackageSpec(
         ]
 
     @property
+    @functools.lru_cache(maxsize=None)
     def distribution(self):
         # run_setup stores state in a global variable. Reload the module
         # each time we use it - otherwise we'll get the previous invocation's
@@ -290,6 +292,7 @@ class PackageSpec(
             return distutils_core.run_setup(setup)
 
     @property
+    @functools.lru_cache(maxsize=None)
     def requirements(self):
         # First try to infer requirements from the distribution
         if self.distribution:
@@ -312,6 +315,7 @@ class PackageSpec(
         return []
 
     @property
+    @functools.lru_cache(maxsize=None)
     def skip_reason(self) -> Optional[str]:
         if not is_feature_branch(os.getenv("BUILDKITE_BRANCH", "")):
             return None

--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -1,5 +1,6 @@
 import os
-from distutils.core import run_setup  # pylint: disable=deprecated-module
+from distutils import core as distutils_core
+from importlib import reload
 from pathlib import Path
 from typing import Callable, List, Mapping, NamedTuple, Optional, Union
 
@@ -279,9 +280,14 @@ class PackageSpec(
 
     @property
     def distribution(self):
+        # run_setup stores state in a global variable. Reload the module
+        # each time we use it - otherwise we'll get the previous invocation's
+        # distribution if our setup.py doesn't implement setup() correctly
+        reload(distutils_core)
+
         setup = Path(self.directory) / "setup.py"
         if setup.exists():
-            return run_setup(Path(self.directory) / "setup.py")
+            return distutils_core.run_setup(setup)
 
     @property
     def requirements(self):

--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -1,5 +1,5 @@
 import os
-from distutils import core as distutils_core
+from distutils import core as distutils_core  # pylint: disable=deprecated-module
 from importlib import reload
 from pathlib import Path
 from typing import Callable, List, Mapping, NamedTuple, Optional, Union

--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -1,4 +1,3 @@
-import functools
 import os
 from distutils import core as distutils_core  # pylint: disable=deprecated-module
 from importlib import reload
@@ -280,7 +279,6 @@ class PackageSpec(
         ]
 
     @property
-    @functools.lru_cache(maxsize=None)
     def distribution(self):
         # run_setup stores state in a global variable. Reload the module
         # each time we use it - otherwise we'll get the previous invocation's
@@ -292,7 +290,6 @@ class PackageSpec(
             return distutils_core.run_setup(setup)
 
     @property
-    @functools.lru_cache(maxsize=None)
     def requirements(self):
         # First try to infer requirements from the distribution
         if self.distribution:
@@ -315,7 +312,6 @@ class PackageSpec(
         return []
 
     @property
-    @functools.lru_cache(maxsize=None)
     def skip_reason(self) -> Optional[str]:
         if not is_feature_branch(os.getenv("BUILDKITE_BRANCH", "")):
             return None


### PR DESCRIPTION
This fixes a kind of strange issue that bit us in #10063.

If `run_setup()` doesn't actually find a `setup()` function to execute, it's supposed to raise:

https://github.com/pypa/distutils/blob/45295fc5dc2b85a4a0d19b92429d4779db87ba79/distutils/core.py#L277-L283

However, each time it runs, it stores state in a global module variable:

https://github.com/pypa/distutils/blob/45295fc5dc2b85a4a0d19b92429d4779db87ba79/distutils/core.py#L254

This means if we call `run_setup()` on a script without a `setup()` function (or with a `setup()` function that's guarded by `if __name__ == "__main__":`) and we've already successfully run `run_setup()`, we get the _previous_ distribution instead of raising an error.

Now, we reload the module each time to clear out the global.