### PR TITLE
[dagit] Update Backfill table styles

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
@@ -10,6 +10,7 @@ import {
   Popover,
   Table,
   Tag,
+  Mono,
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {useHistory, Link} from 'react-router-dom';
@@ -105,7 +106,7 @@ export const BackfillTable = ({
 
   return (
     <>
-      <Table>
+      <Table $monospaceFont={false}>
         <thead>
           <tr>
             <th style={{width: 120}}>Backfill ID</th>
@@ -181,7 +182,9 @@ const BackfillRow = ({
 
   return (
     <tr>
-      <td style={{width: 120}}>{backfill.backfillId}</td>
+      <td style={{width: 120}}>
+        <Mono style={{fontSize: '16px', lineHeight: '18px'}}>{backfill.backfillId}</Mono>
+      </td>
       <td style={{width: 240}}>
         {backfill.timestamp ? <TimestampDisplay timestamp={backfill.timestamp} /> : '-'}
       </td>
@@ -372,14 +375,14 @@ const BackfillTarget: React.FC<{
   const repo = useRepository(repoAddress);
 
   if (!partitionSet || !repoAddress) {
-    return <span>{partitionSetName}</span>;
+    return <span style={{fontWeight: 500}}>{partitionSetName}</span>;
   }
 
   const isJob = !!(repo && isThisThingAJob(repo, partitionSet.pipelineName));
   const isHiddenAssetJob = isHiddenAssetGroupJob(partitionSet.pipelineName);
 
   const repoLink = (
-    <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+    <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}} style={{fontSize: '12px'}}>
       <Icon name="repo" color={Colors.Gray400} />
       <Link to={workspacePathFromAddress(repoAddress)}>{repoAddressAsString(repoAddress)}</Link>
     </Box>
@@ -389,7 +392,7 @@ const BackfillTarget: React.FC<{
     return (
       <Box flex={{direction: 'column', gap: 8}}>
         {repoLink}
-        <AssetKeyTagCollection assetKeys={assetSelection} modalTitle="Assets in Backfill" />
+        <AssetKeyTagCollection assetKeys={assetSelection} modalTitle="Assets in backfill" />
       </Box>
     );
   }
@@ -404,20 +407,23 @@ const BackfillTarget: React.FC<{
           isJob,
           path: `/partitions?partitionSet=${encodeURIComponent(partitionSet.name)}`,
         })}
+        style={{fontWeight: 500}}
       >
         {partitionSet.name}
       </Link>
-      {repoLink}
-      <PipelineReference
-        showIcon
-        size="small"
-        pipelineName={partitionSet.pipelineName}
-        pipelineHrefContext={{
-          name: partitionSet.repositoryOrigin.repositoryName,
-          location: partitionSet.repositoryOrigin.repositoryLocationName,
-        }}
-        isJob={isJob}
-      />
+      <Box flex={{direction: 'column', gap: 4}} style={{fontSize: '12px'}}>
+        {repoLink}
+        <PipelineReference
+          showIcon
+          size="small"
+          pipelineName={partitionSet.pipelineName}
+          pipelineHrefContext={{
+            name: partitionSet.repositoryOrigin.repositoryName,
+            location: partitionSet.repositoryOrigin.repositoryLocationName,
+          }}
+          isJob={isJob}
+        />
+      </Box>
     </Box>
   );
 };

--- a/js_modules/dagit/packages/ui/src/components/Table.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Table.tsx
@@ -1,13 +1,14 @@
 // eslint-disable-next-line no-restricted-imports
-import {HTMLTable, IHTMLTableProps} from '@blueprintjs/core';
-import styled from 'styled-components/macro';
+import {HTMLTable, HTMLTableProps} from '@blueprintjs/core';
+import styled, {css} from 'styled-components/macro';
 
 import {StyledTag} from './BaseTag';
 import {Colors} from './Colors';
 import {FontFamily} from './styles';
 
-export interface TableProps extends IHTMLTableProps {
+export interface TableProps extends HTMLTableProps {
   $compact?: boolean;
+  $monospaceFont?: boolean;
 }
 
 export const Table = styled(HTMLTable)<TableProps>`
@@ -36,8 +37,16 @@ export const Table = styled(HTMLTable)<TableProps>`
 
   & tr td {
     color: ${Colors.Gray900};
-    font-family: ${FontFamily.monospace};
-    font-size: 16px;
+    ${({$monospaceFont}) =>
+      $monospaceFont === false
+        ? css`
+            font-family: ${FontFamily.default};
+            font-size: 14px;
+          `
+        : css`
+            font-family: ${FontFamily.monospace};
+            font-size: 16px;
+          `}
     padding: ${({$compact}) => ($compact ? '8px' : '12px')};
   }
 


### PR DESCRIPTION
### Summary & Motivation

Modify the Backfill table to use default font, and tweak some font sizing/spacing/weights.

This adds a `$monospaceFont` prop to `Table`, the first step toward making all `Table`s use Inter instead of Inconsolata by default.

<img width="1164" alt="Screen Shot 2022-10-18 at 2 49 54 PM" src="https://user-images.githubusercontent.com/2823852/196530345-d94be863-b4fc-4490-abec-b9a78b1c5c97.png">


### How I Tested These Changes

View Backfills table, verify desired changes.

View Runs table, verify that the default Table style still uses Inconsolata.
