### PR TITLE
RepositoryDefinition.materialize

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -1,7 +1,7 @@
 import operator
 from abc import ABC
 from functools import reduce
-from typing import AbstractSet, FrozenSet, Optional, Sequence, Union
+from typing import AbstractSet, FrozenSet, Iterable, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._annotations import public
@@ -209,7 +209,7 @@ class UpstreamAssetSelection(AssetSelection):
 
 
 class Resolver:
-    def __init__(self, all_assets: Sequence[Union[AssetsDefinition, SourceAsset]]):
+    def __init__(self, all_assets: Iterable[Union[AssetsDefinition, SourceAsset]]):
         assets_defs = []
         source_assets = []
         for asset in all_assets:

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -30,7 +30,7 @@ from .utils import DEFAULT_IO_MANAGER_KEY
 ASSET_BASE_JOB_PREFIX = "__ASSET_JOB"
 
 
-def is_base_asset_job_name(name) -> bool:
+def is_base_asset_job_name(name: str) -> bool:
     return name.startswith(ASSET_BASE_JOB_PREFIX)
 
 


### PR DESCRIPTION
### Summary & Motivation

This allows someone to kick off a materialization of an asset, using the resources and upstream asset definitions that they've included on their repository.

I'm imagining one of the main uses would be to call it from a Jupyter notebook.

It depends on the repository being defined at module scope.

### How I Tested These Changes
