### PR TITLE
[dagit] Add Shift+click to expand/collapse all repos in run timeline and tables

### DIFF
--- a/js_modules/dagit/packages/core/src/overview/OverviewJobsTable.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewJobsTable.tsx
@@ -30,7 +30,14 @@ const JOBS_EXPANSION_STATE_STORAGE_KEY = 'jobs-virtualized-expansion-state';
 
 export const OverviewJobsTable: React.FC<Props> = ({repos}) => {
   const parentRef = React.useRef<HTMLDivElement | null>(null);
-  const {expandedKeys, onToggle} = useRepoExpansionState(JOBS_EXPANSION_STATE_STORAGE_KEY);
+  const allKeys = React.useMemo(
+    () => repos.map(({repoAddress}) => repoAddressAsString(repoAddress)),
+    [repos],
+  );
+  const {expandedKeys, onToggle, onToggleAll} = useRepoExpansionState(
+    JOBS_EXPANSION_STATE_STORAGE_KEY,
+    allKeys,
+  );
 
   const flattened: RowType[] = React.useMemo(() => {
     const flat: RowType[] = [];
@@ -92,6 +99,8 @@ export const OverviewJobsTable: React.FC<Props> = ({repos}) => {
                   height={size}
                   start={start}
                   onToggle={onToggle}
+                  onToggleAll={onToggleAll}
+                  expanded={expandedKeys.includes(repoAddressAsString(row.repoAddress))}
                   showLocation={duplicateRepoNames.has(row.repoAddress.name)}
                   rightElement={
                     <Tooltip

--- a/js_modules/dagit/packages/core/src/overview/OverviewSchedulesTable.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSchedulesTable.tsx
@@ -27,7 +27,14 @@ const SCHEDULES_EXPANSION_STATE_STORAGE_KEY = 'schedules-virtualized-expansion-s
 
 export const OverviewScheduleTable: React.FC<Props> = ({repos}) => {
   const parentRef = React.useRef<HTMLDivElement | null>(null);
-  const {expandedKeys, onToggle} = useRepoExpansionState(SCHEDULES_EXPANSION_STATE_STORAGE_KEY);
+  const allKeys = React.useMemo(
+    () => repos.map(({repoAddress}) => repoAddressAsString(repoAddress)),
+    [repos],
+  );
+  const {expandedKeys, onToggle, onToggleAll} = useRepoExpansionState(
+    SCHEDULES_EXPANSION_STATE_STORAGE_KEY,
+    allKeys,
+  );
 
   const flattened: RowType[] = React.useMemo(() => {
     const flat: RowType[] = [];
@@ -90,6 +97,8 @@ export const OverviewScheduleTable: React.FC<Props> = ({repos}) => {
                   height={size}
                   start={start}
                   onToggle={onToggle}
+                  onToggleAll={onToggleAll}
+                  expanded={expandedKeys.includes(repoAddressAsString(row.repoAddress))}
                   showLocation={duplicateRepoNames.has(row.repoAddress.name)}
                   rightElement={
                     <Tooltip

--- a/js_modules/dagit/packages/core/src/overview/OverviewSensorsTable.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSensorsTable.tsx
@@ -27,7 +27,14 @@ const SENSORS_EXPANSION_STATE_STORAGE_KEY = 'sensors-virtualized-expansion-state
 
 export const OverviewSensorTable: React.FC<Props> = ({repos}) => {
   const parentRef = React.useRef<HTMLDivElement | null>(null);
-  const {expandedKeys, onToggle} = useRepoExpansionState(SENSORS_EXPANSION_STATE_STORAGE_KEY);
+  const allKeys = React.useMemo(
+    () => repos.map(({repoAddress}) => repoAddressAsString(repoAddress)),
+    [repos],
+  );
+  const {expandedKeys, onToggle, onToggleAll} = useRepoExpansionState(
+    SENSORS_EXPANSION_STATE_STORAGE_KEY,
+    allKeys,
+  );
 
   const flattened: RowType[] = React.useMemo(() => {
     const flat: RowType[] = [];
@@ -89,6 +96,8 @@ export const OverviewSensorTable: React.FC<Props> = ({repos}) => {
                   height={size}
                   start={start}
                   onToggle={onToggle}
+                  onToggleAll={onToggleAll}
+                  expanded={expandedKeys.includes(repoAddressAsString(row.repoAddress))}
                   showLocation={duplicateRepoNames.has(row.repoAddress.name)}
                   rightElement={
                     <Tooltip

--- a/js_modules/dagit/packages/core/src/runs/RepoSectionHeader.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RepoSectionHeader.tsx
@@ -6,7 +6,7 @@ export const SECTION_HEADER_HEIGHT = 32;
 
 interface Props {
   expanded: boolean;
-  onClick: () => void;
+  onClick: (e: React.MouseEvent) => void;
   repoName: string;
   repoLocation: string;
   showLocation: boolean;

--- a/js_modules/dagit/packages/core/src/ui/useRepoExpansionState.tsx
+++ b/js_modules/dagit/packages/core/src/ui/useRepoExpansionState.tsx
@@ -11,7 +11,7 @@ const validateExpandedKeys = (parsed: unknown) => (Array.isArray(parsed) ? parse
  * Use localStorage to persist the expanded/collapsed visual state of repository containers,
  * e.g. for the left nav or run timeline.
  */
-export const useRepoExpansionState = (storageKey: string) => {
+export const useRepoExpansionState = (storageKey: string, allKeys: string[]) => {
   const {basePath} = React.useContext(AppContext);
   const [expandedKeys, setExpandedKeys] = useStateWithStorage<string[]>(
     `${basePath}:dagit.${storageKey}`,
@@ -34,11 +34,19 @@ export const useRepoExpansionState = (storageKey: string) => {
     [setExpandedKeys],
   );
 
+  const onToggleAll = React.useCallback(
+    (expand: boolean) => {
+      setExpandedKeys(expand ? allKeys : []);
+    },
+    [allKeys, setExpandedKeys],
+  );
+
   return React.useMemo(
     () => ({
       expandedKeys,
       onToggle,
+      onToggleAll,
     }),
-    [expandedKeys, onToggle],
+    [expandedKeys, onToggle, onToggleAll],
   );
 };

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedWorkspaceTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedWorkspaceTable.tsx
@@ -13,15 +13,28 @@ export const RepoRow: React.FC<{
   start: number;
   showLocation: boolean;
   rightElement: React.ReactNode;
+  expanded: boolean;
   onToggle: (repoAddress: RepoAddress) => void;
-}> = ({repoAddress, height, start, onToggle, showLocation, rightElement}) => {
+  onToggleAll: (expanded: boolean) => void;
+}> = ({
+  repoAddress,
+  height,
+  start,
+  expanded,
+  onToggle,
+  onToggleAll,
+  showLocation,
+  rightElement,
+}) => {
   return (
     <Row $height={height} $start={start}>
       <RepoSectionHeader
         repoName={repoAddress.name}
         repoLocation={repoAddress.location}
         expanded
-        onClick={() => onToggle(repoAddress)}
+        onClick={(e: React.MouseEvent) =>
+          e.getModifierState('Shift') ? onToggleAll(!expanded) : onToggle(repoAddress)
+        }
         showLocation={showLocation}
         rightElement={rightElement}
       />


### PR DESCRIPTION
### Summary & Motivation

Add a little bonus feature on the run timeline and virtualized repo-bucketed tables: shift+click will expand or collapse all repo sections. If the clicked repo header is expanded, collapse all. If it's collapsed, expand all.

### How I Tested These Changes

View run timeline and virtualized tables. Verify shift+click behavior as described above.
