### PR TITLE
[dagit] Fix repo row expanded icon

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedWorkspaceTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedWorkspaceTable.tsx
@@ -31,7 +31,7 @@ export const RepoRow: React.FC<{
       <RepoSectionHeader
         repoName={repoAddress.name}
         repoLocation={repoAddress.location}
-        expanded
+        expanded={expanded}
         onClick={(e: React.MouseEvent) =>
           e.getModifierState('Shift') ? onToggleAll(!expanded) : onToggle(repoAddress)
         }


### PR DESCRIPTION
### Summary & Motivation

I hadn't passed the "expanded" value along on `RepoSectionHeader`, so the arrow icon wasn't rotating properly. Fix this.

### How I Tested These Changes

View run timeline and virtualized tables, verify that the icon rotates correctly when the repo is expanded/collapsed.
