### PR TITLE
[dagit] Use gray tags in repo headers

### DIFF
--- a/js_modules/dagit/packages/core/src/overview/OverviewJobsTable.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewJobsTable.tsx
@@ -107,7 +107,7 @@ export const OverviewJobsTable: React.FC<Props> = ({repos}) => {
                       content={row.jobCount === 1 ? '1 job' : `${row.jobCount} jobs`}
                       placement="top"
                     >
-                      <Tag intent="primary">{row.jobCount}</Tag>
+                      <Tag>{row.jobCount}</Tag>
                     </Tooltip>
                   }
                 />

--- a/js_modules/dagit/packages/core/src/overview/OverviewSchedulesTable.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSchedulesTable.tsx
@@ -107,7 +107,7 @@ export const OverviewScheduleTable: React.FC<Props> = ({repos}) => {
                       }
                       placement="top"
                     >
-                      <Tag intent="primary">{row.scheduleCount}</Tag>
+                      <Tag>{row.scheduleCount}</Tag>
                     </Tooltip>
                   }
                 />

--- a/js_modules/dagit/packages/core/src/overview/OverviewSensorsTable.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSensorsTable.tsx
@@ -104,7 +104,7 @@ export const OverviewSensorTable: React.FC<Props> = ({repos}) => {
                       content={row.sensorCount === 1 ? '1 sensor' : `${row.sensorCount} sensors`}
                       placement="top"
                     >
-                      <Tag intent="primary">{row.sensorCount}</Tag>
+                      <Tag>{row.sensorCount}</Tag>
                     </Tooltip>
                   }
                 />


### PR DESCRIPTION
### Summary & Motivation

Use gray tags instead of blue in the object count on the repo header in virtualized tables.

### How I Tested These Changes

View tables in Dagit.
