### PR TITLE
[docs] - improve partitioned asset examples on partitions concepts page

### DIFF
--- a/docs/content/concepts/assets/software-defined-assets.mdx
+++ b/docs/content/concepts/assets/software-defined-assets.mdx
@@ -196,12 +196,12 @@ from dagster import asset
 
 
 @asset
-def upstream_asset():
+def upstream_asset() -> None:
     execute_query("CREATE TABLE sugary_cereals AS SELECT * FROM cereals")
 
 
 @asset(non_argument_deps={"upstream_asset"})
-def downstream_asset():
+def downstream_asset() -> None:
     execute_query("CREATE TABLE shopping_list AS SELECT * FROM sugary_cereals")
 ```
 

--- a/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
@@ -34,22 +34,51 @@ Having defined a partitioned job or asset, you can:
 | <PyObject object="MonthlyPartitionsDefinition" /> | A partitions definition with a partition for each month.                          |
 | <PyObject object="StaticPartitionsDefinition" />  | A partitions definition with a fixed set of partitions.                           |
 
-A software-defined asset can be assigned a <PyObject object="PartitionsDefinition" />, which determines the set of partitions that compose it. Once an asset has a set of partitions, you can launch materializations of individual partitions and view the materialization history by partition in Dagit.
+A software-defined asset can be assigned a <PyObject object="PartitionsDefinition" />, which determines the set of partitions that compose it. If the asset is stored in a filesystem or an object store, then each partition will typically correspond to a file or object. If the asset is stored in a database, then each partition will typically correspond to a range of values in a table that fall within a particular window.
 
-For example, below is an asset with a partition for each day since the first day of 2022:
+Once an asset has a set of partitions, you can launch materializations of individual partitions and view the materialization history by partition in Dagit.
+
+### Defining partitioned assets
+
+For example, below is a software-defined asset with a partition for each day since the first day of 2022. Materializing partition `2022-07-23` of this asset would result in fetching data from the URL `coolweatherwebsite.com/weather_obs\&date=2022-07-23` and storing it at the path `weather_observations/2022-07-23.csv`.
 
 ```python file=/concepts/partitions_schedules_sensors/partitioned_asset.py
+import urllib.request
+
 from dagster import DailyPartitionsDefinition, asset
 
 
 @asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
-def my_daily_partitioned_asset(context):
-    context.log.info(
-        f"Processing asset partition '{context.asset_partition_key_for_output()}'"
-    )
+def my_daily_partitioned_asset(context) -> None:
+    partition_date_str = context.asset_partition_key_for_output()
+
+    url = f"coolweatherwebsite.com/weather_obs&date={partition_date_str}"
+    target_location = f"weather_observations/{partition_date_str}.csv"
+
+    urllib.request.urlretrieve(url, target_location)
 ```
 
-When an asset is unpartitioned, the default IO manager stores it in a file whose location is based on the asset's key. When an asset is partitioned, the default IO manager stores each partition in a separate file, all underneath a directory whose location is based on the asset's key.
+#### Partitioned assets with partitioned I/O managers
+
+In the above code snippet, the body of the decorated function writes out data to a file, but it's common to delegate this I/O to an [I/O manager](/concepts/io-management/io-managers). Dagster's [built-in I/O managers](/concepts/io-management/io-managers#built-in-io-managers) know how to handle partitioned assets. You can also handle them when writing your own I/O manager, following the instructions [here](/concepts/io-management/io-managers#handling-partitioned-assets).
+
+Here's a software-defined asset that relies on an I/O manager to store its output:
+
+```python file=/concepts/partitions_schedules_sensors/partitioned_asset_uses_io_manager.py
+import pandas as pd
+
+from dagster import DailyPartitionsDefinition, asset
+
+
+@asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
+def my_daily_partitioned_asset(context) -> pd.DataFrame:
+    partition_date_str = context.asset_partition_key_for_output()
+    return pd.read_csv(f"coolweatherwebsite.com/weather_obs&date={partition_date_str}")
+```
+
+If you're using the default I/O manager, materializing partition `2022-07-23` of this asset would store the output `DataFrame` in a pickle file at a path like `my_daily_partitioned_asset/2022-07-23`.
+
+### Viewing asset partition status
 
 To view all partitions for an asset, open the **Definition** tab of the asset's details page. The bar in the **Partitions** section represents all of the partitions for the asset.
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/non_argument_deps.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/non_argument_deps.py
@@ -8,12 +8,12 @@ from dagster import asset
 
 
 @asset
-def upstream_asset():
+def upstream_asset() -> None:
     execute_query("CREATE TABLE sugary_cereals AS SELECT * FROM cereals")
 
 
 @asset(non_argument_deps={"upstream_asset"})
-def downstream_asset():
+def downstream_asset() -> None:
     execute_query("CREATE TABLE shopping_list AS SELECT * FROM sugary_cereals")
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_asset.py
@@ -1,8 +1,13 @@
+import urllib.request
+
 from dagster import DailyPartitionsDefinition, asset
 
 
 @asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
-def my_daily_partitioned_asset(context):
-    context.log.info(
-        f"Processing asset partition '{context.asset_partition_key_for_output()}'"
-    )
+def my_daily_partitioned_asset(context) -> None:
+    partition_date_str = context.asset_partition_key_for_output()
+
+    url = f"coolweatherwebsite.com/weather_obs&date={partition_date_str}"
+    target_location = f"weather_observations/{partition_date_str}.csv"
+
+    urllib.request.urlretrieve(url, target_location)

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_asset_uses_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_asset_uses_io_manager.py
@@ -1,0 +1,9 @@
+import pandas as pd
+
+from dagster import DailyPartitionsDefinition, asset
+
+
+@asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
+def my_daily_partitioned_asset(context) -> pd.DataFrame:
+    partition_date_str = context.asset_partition_key_for_output()
+    return pd.read_csv(f"coolweatherwebsite.com/weather_obs&date={partition_date_str}")

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_partitioned_asset.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_partitioned_asset.py
@@ -1,9 +1,17 @@
-from dagster import define_asset_job
+from unittest.mock import patch
+
+from dagster import materialize_to_memory
 from docs_snippets.concepts.partitions_schedules_sensors.partitioned_asset import (
     my_daily_partitioned_asset,
 )
 
 
-def test_partitioned_asset():
-    my_job = define_asset_job("a").resolve([my_daily_partitioned_asset], [])
-    assert my_job.execute_in_process(partition_key="2022-01-01").success
+@patch("urllib.request.urlretrieve")
+def test_partitioned_asset(mock_urlretrieve):
+    assert materialize_to_memory(
+        [my_daily_partitioned_asset], partition_key="2022-01-01"
+    ).success
+    assert mock_urlretrieve.call_args[0] == (
+        "coolweatherwebsite.com/weather_obs&date=2022-01-01",
+        "weather_observations/2022-01-01.csv",
+    )

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_partitioned_asset_uses_io_manager.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_partitioned_asset_uses_io_manager.py
@@ -1,0 +1,18 @@
+from unittest.mock import MagicMock, patch
+
+from pandas import DataFrame
+
+from dagster import materialize_to_memory
+from docs_snippets.concepts.partitions_schedules_sensors.partitioned_asset_uses_io_manager import (
+    my_daily_partitioned_asset,
+)
+
+
+@patch(
+    "docs_snippets.concepts.partitions_schedules_sensors.partitioned_asset_uses_io_manager.pd.read_csv"
+)
+def test_partitioned_asset(mock_read_csv):
+    mock_read_csv.return_value = MagicMock(spec=DataFrame)
+    assert materialize_to_memory(
+        [my_daily_partitioned_asset], partition_key="2022-01-01"
+    ).success


### PR DESCRIPTION
### Summary & Motivation

Motivated by @slopp 's feedback:
> It took me a TON of time to map these vague ideas into how dagster asset partitions work. I wasn’t able to find many examples, and the documentation for partitions left a lot to the imagination (the examples usually just logged partition keys).

### How I Tested These Changes

Manual inspection
