### PR TITLE
Fix assets with dashes in their path and `io_manager_def`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -250,8 +250,7 @@ class _Asset:
                 io_manager_def = check.inst_param(
                     self.io_manager, "io_manager", IOManagerDefinition
                 )
-                out_asset_resource_key = "__".join(out_asset_key.path)
-                io_manager_key = f"{out_asset_resource_key}__io_manager"
+                io_manager_key = out_asset_key.to_python_identifier("io_manager")
                 self.resource_defs[io_manager_key] = cast(ResourceDefinition, io_manager_def)
             else:
                 io_manager_key = DEFAULT_IO_MANAGER_KEY
@@ -265,7 +264,7 @@ class _Asset:
             )
 
             op = _Op(
-                name="__".join(out_asset_key.path).replace("-", "_"),
+                name=out_asset_key.to_python_identifier(),
                 description=self.description,
                 ins=dict(asset_ins.values()),
                 out=out,

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -121,6 +121,17 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[List[str]])])):
         """
         return ASSET_KEY_DELIMITER.join(self.path)
 
+    def to_python_identifier(self, suffix: Optional[str] = None) -> str:
+        """Build a valid Python identifier based on the asset key that can be used for
+        operation names or I/O manager keys.
+        """
+        path = list(self.path)
+
+        if suffix is not None:
+            path.append(suffix)
+
+        return "__".join(path).replace("-", "_")
+
     @staticmethod
     def from_user_string(asset_key_string: str) -> "AssetKey":
         return AssetKey(asset_key_string.split(ASSET_KEY_DELIMITER))

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -87,8 +87,7 @@ class SourceAsset(
         io_manager_def = check.opt_inst_param(io_manager_def, "io_manager_def", IOManagerDefinition)
         if io_manager_def:
             if not io_manager_key:
-                source_asset_path = "__".join(key.path)
-                io_manager_key = f"{source_asset_path}__io_manager"
+                io_manager_key = key.to_python_identifier("io_manager")
 
             if io_manager_key in resource_defs and resource_defs[io_manager_key] != io_manager_def:
                 raise DagsterInvalidDefinitionError(


### PR DESCRIPTION
### Summary & Motivation

Dagster accepts dashes (`-`) in asset key path components. When automatically creating an operation for assets, dashes are replaced by underscores (`_`).

However, when defining an asset with either `@asset(..., io_manager_def=...)` or `SourceAsset(..., io_manager_def=...)`, it fails if the asset key contains a dash:

```
dagster._check.CheckError: Failure condition: Resource key 'my-repo_test1__io_manager' must be a valid Python identifier.
```

The reason is that the sanitization done for creating an operation is not done when creating an I/O manager resource. This PR adds a method to `AssetKey` to produce a sanitized name that can be used for the operation name as well as in `@asset` and `SourceAsset` for `io_manager_def`. This fixes the issue, and avoids hardcoding this rule in three places.

### How I Tested These Changes

This does not produce an error anymore:

```py
test_asset = SourceAsset(
   ["some-prefix", "test-asset"],
   io_manager_def=custom_io_manager
)
```
