### PR TITLE
[dagster-postgres] Use SQLAlchemy engine in pynotify instead of psycopg2 directly

### DIFF
--- a/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
@@ -18,6 +18,7 @@ class DagsterPostgresException(Exception):
 
 
 def get_conn(conn_string):
+    """Get a connection directly without SQLAlchemy for tests."""
     conn = psycopg2.connect(conn_string)
     conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
     return conn
@@ -125,6 +126,7 @@ def retry_pg_connection_fn(fn, retry_limit=5, retry_wait=0.2):
 
 
 def wait_for_connection(conn_string, retry_limit=5, retry_wait=0.2):
+    """Get a connection with retries directly without SQLAlchemy for tests."""
     retry_pg_connection_fn(
         lambda: psycopg2.connect(conn_string), retry_limit=retry_limit, retry_wait=retry_wait
     )


### PR DESCRIPTION
### Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/9661.

`dagster_postgres/pynotif.py` was using `psycopg2` to connect to the database and listen for notifications, unlike the rest of the code which uses a SQLAlchemy engine. When SQLAlchemy-specific options were provided in the connection string, the event watcher would just fail to create a connection, and Dagit would not be able to stream run events.

This PR fixes that by using a SQLAlchemy engine as well in `pynotify.py`.

### How I Tested These Changes

- Ran `python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_pynotify.py` successfully.
- Ran the following against a remote database for a while and validated that run events were being streamed:

```py
from dagster_postgres.pynotify import await_pg_notifications

for event in await_pg_notifications("...", channels=["run_events"]):
  print(event)

# Notify(7121, 'run_events', '81eaf309-8983-4aa9-a3f7-0879fae3aa35_2199032')
# Notify(7125, 'run_events', '81eaf309-8983-4aa9-a3f7-0879fae3aa35_2199033')
# Notify(7128, 'run_events', '81eaf309-8983-4aa9-a3f7-0879fae3aa35_2199034')
# Notify(7132, 'run_events', '81eaf309-8983-4aa9-a3f7-0879fae3aa35_2199035')
# Notify(7135, 'run_events', '81eaf309-8983-4aa9-a3f7-0879fae3aa35_2199036')
# ...
```