### PR TITLE
[dagit] Fix repo bucket sorting in virtualized tables

### DIFF
--- a/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
@@ -28,6 +28,7 @@ import {RepoAddress} from '../workspace/types';
 
 import {OverviewScheduleTable} from './OverviewSchedulesTable';
 import {OverviewTabs} from './OverviewTabs';
+import {sortRepoBuckets} from './sortRepoBuckets';
 import {OverviewSchedulesQuery} from './types/OverviewSchedulesQuery';
 import {UnloadableSchedulesQuery} from './types/UnloadableSchedulesQuery';
 
@@ -46,7 +47,7 @@ export const OverviewSchedulesRoot = () => {
 
   const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
-  const repoBuckets = useRepoBuckets(data);
+  const repoBuckets = React.useMemo(() => buildBuckets(data), [data]);
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
   const anySearch = sanitizedSearch.length > 0;
 
@@ -221,37 +222,35 @@ type RepoBucket = {
   schedules: string[];
 };
 
-const useRepoBuckets = (data?: OverviewSchedulesQuery): RepoBucket[] => {
-  return React.useMemo(() => {
-    if (data?.workspaceOrError.__typename !== 'Workspace') {
-      return [];
+const buildBuckets = (data?: OverviewSchedulesQuery): RepoBucket[] => {
+  if (data?.workspaceOrError.__typename !== 'Workspace') {
+    return [];
+  }
+
+  const entries = data.workspaceOrError.locationEntries.map((entry) => entry.locationOrLoadError);
+
+  const buckets = [];
+
+  for (const entry of entries) {
+    if (entry?.__typename !== 'RepositoryLocation') {
+      continue;
     }
 
-    const entries = data.workspaceOrError.locationEntries.map((entry) => entry.locationOrLoadError);
+    for (const repo of entry.repositories) {
+      const {name, schedules} = repo;
+      const repoAddress = buildRepoAddress(name, entry.name);
+      const scheduleNames = schedules.map(({name}) => name);
 
-    const buckets = [];
-
-    for (const entry of entries) {
-      if (entry?.__typename !== 'RepositoryLocation') {
-        continue;
-      }
-
-      for (const repo of entry.repositories) {
-        const {name, schedules} = repo;
-        const repoAddress = buildRepoAddress(name, entry.name);
-        const scheduleNames = schedules.map(({name}) => name);
-
-        if (scheduleNames.length > 0) {
-          buckets.push({
-            repoAddress,
-            schedules: scheduleNames,
-          });
-        }
+      if (scheduleNames.length > 0) {
+        buckets.push({
+          repoAddress,
+          schedules: scheduleNames,
+        });
       }
     }
+  }
 
-    return buckets;
-  }, [data]);
+  return sortRepoBuckets(buckets);
 };
 
 const OVERVIEW_SCHEDULES_QUERY = gql`

--- a/js_modules/dagit/packages/core/src/overview/sortRepoBuckets.test.tsx
+++ b/js_modules/dagit/packages/core/src/overview/sortRepoBuckets.test.tsx
@@ -1,0 +1,59 @@
+import {buildRepoAddress} from '../workspace/buildRepoAddress';
+import {repoAddressAsString} from '../workspace/repoAddressAsString';
+
+import {sortRepoBuckets} from './sortRepoBuckets';
+
+describe('sortRepoBuckets', () => {
+  it('does basic sorting properly', () => {
+    const lorem = {repoAddress: buildRepoAddress('lorem', 'ipsum')};
+    const dolorsit = {repoAddress: buildRepoAddress('dolorsit', 'amet')};
+    const consectetur = {repoAddress: buildRepoAddress('consectetur', 'adipiscing')};
+    const list = [lorem, dolorsit, consectetur];
+
+    const sorted = sortRepoBuckets(list);
+
+    // The input object is not mutated.
+    expect(sorted).not.toBe(list);
+
+    // Same repo bucket objects, sorted.
+    expect(sorted).toEqual([consectetur, dolorsit, lorem]);
+  });
+
+  it('sorts by repo location when repo names are the same', () => {
+    const newyork = {repoAddress: buildRepoAddress('lorem', 'newyork')};
+    const chicago = {repoAddress: buildRepoAddress('lorem', 'chicago')};
+    const boston = {repoAddress: buildRepoAddress('lorem', 'boston')};
+    const list = [newyork, chicago, boston];
+
+    const sorted = sortRepoBuckets(list);
+
+    // Same repo bucket objects, sorted by repo location because repo names are all the same.
+    expect(sorted).toEqual([boston, chicago, newyork]);
+  });
+
+  it('sorts correctly with regard to capitalization and diacritics', () => {
+    // Would be sorted after "lorem" because of `ä`, in spite of `a` being after `o`.
+    const umlaut = {repoAddress: buildRepoAddress('lärem', 'ipsum')};
+
+    // Would be sorted before "lorem" because of capital `L`, in spite of `u` being after `o`.
+    const capitalizedWithU = {repoAddress: buildRepoAddress('Lurem', 'ipsum')};
+
+    // Would be sorted before "lorem" because of capital `L`, in spite of `upsum` being after `ipsum`.
+    const capitalizedWithO = {repoAddress: buildRepoAddress('Lorem', 'upsum')};
+
+    const normal = {repoAddress: buildRepoAddress('lorem', 'ipsum')};
+    const list = [umlaut, capitalizedWithU, capitalizedWithO, normal];
+
+    // Sanity check default sorting, which does not give us the ideal result.
+    expect(list.map(({repoAddress}) => repoAddressAsString(repoAddress)).sort()).toEqual([
+      'Lorem@upsum',
+      'Lurem@ipsum',
+      'lorem@ipsum',
+      'lärem@ipsum',
+    ]);
+    const sorted = sortRepoBuckets(list);
+
+    // Desired sort order:
+    expect(sorted).toEqual([umlaut, normal, capitalizedWithO, capitalizedWithU]);
+  });
+});

--- a/js_modules/dagit/packages/core/src/overview/sortRepoBuckets.tsx
+++ b/js_modules/dagit/packages/core/src/overview/sortRepoBuckets.tsx
@@ -1,0 +1,14 @@
+import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {RepoAddress} from '../workspace/types';
+
+interface Bucket {
+  repoAddress: RepoAddress;
+}
+
+export const sortRepoBuckets = <B extends Bucket>(buckets: B[]) => {
+  return [...buckets].sort((a, b) => {
+    const aString = repoAddressAsString(a.repoAddress);
+    const bString = repoAddressAsString(b.repoAddress);
+    return aString.localeCompare(bString);
+  });
+};

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -111,9 +111,7 @@ export const RunTimeline = (props: Props) => {
     );
   }
 
-  const repoOrder = Object.keys(buckets).sort((a, b) =>
-    a.toLocaleLowerCase().localeCompare(b.toLocaleLowerCase()),
-  );
+  const repoOrder = Object.keys(buckets).sort((a, b) => a.localeCompare(b));
 
   let nextTop = DATE_TIME_HEIGHT;
   const expandedRepos = repoOrder.filter((repoKey) => expandedKeys.includes(repoKey));


### PR DESCRIPTION
### Summary & Motivation

Use consistent sort order for repo buckets in new Overview pages.

### How I Tested These Changes

`sortRepoBuckets.test`, view Dagit pages and verify that sort order looks appropriate.
