### PR TITLE
docs(slack-alert-policies): add slack bot name to setup instructions

### DIFF
--- a/docs/content/dagster-cloud/account/setting-up-alerts.mdx
+++ b/docs/content/dagster-cloud/account/setting-up-alerts.mdx
@@ -52,7 +52,7 @@ Currently, Slack and email notifications are supported.
    - **Events** - Select whether the alert should trigger on job success, failure, or both
    - **Notification service** - Select the service for the alert policy:
 
-     - **Slack** - If you haven't connected Slack, click **Connect** to add the Dagster Cloud Slack app to your workspace. After the installation completes, invite the bot user to the desired channel.
+     - **Slack** - If you haven't connected Slack, click **Connect** to add the Dagster Cloud Slack app to your workspace. After the installation completes, invite the `@Dagster Cloud` bot user to the desired channel.
 
        You can then configure the alert policy to message this channel. **Note**: Only messaging one channel per alert policy is currently supported:
 


### PR DESCRIPTION
### Summary & Motivation
Clarifies the name of the bot user to add to a Slack channel.

### How I Tested These Changes
eyes
