### PR TITLE
[dagit] Some typographic and spacing tweaks on virtualized tables

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -6,6 +6,7 @@ import {
   NonIdealState,
   PageHeader,
   Heading,
+  Page,
 } from '@dagster-io/ui';
 import * as React from 'react';
 
@@ -57,7 +58,7 @@ export const InstanceBackfills = () => {
   useDocumentTitle('Backfills');
 
   return (
-    <>
+    <Page>
       <PageHeader
         title={<Heading>{flagNewWorkspace ? 'Overview' : pageTitle}</Heading>}
         tabs={
@@ -127,7 +128,7 @@ export const InstanceBackfills = () => {
           );
         }}
       </Loading>
-    </>
+    </Page>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/instance/LastRunSummary.tsx
+++ b/js_modules/dagit/packages/core/src/instance/LastRunSummary.tsx
@@ -16,10 +16,11 @@ interface Props {
   run: RunTimeFragment;
   showHover?: boolean;
   showButton?: boolean;
+  showSummary?: boolean;
 }
 
 export const LastRunSummary: React.FC<Props> = React.memo(
-  ({name, run, showHover = false, showButton = true}) => {
+  ({name, run, showHover = false, showButton = true, showSummary = true}) => {
     const {status} = run;
 
     const intent = React.useMemo(() => {
@@ -77,9 +78,9 @@ export const LastRunSummary: React.FC<Props> = React.memo(
         <Box flex={{direction: 'column', alignItems: 'flex-start', gap: 4}}>
           <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
             {tag()}
-            <RunStateSummary run={run} />
+            {showSummary ? <RunStateSummary run={run} /> : null}
           </Box>
-          {failedStatuses.has(run.status) || inProgressStatuses.has(run.status) ? (
+          {showSummary && (failedStatuses.has(run.status) || inProgressStatuses.has(run.status)) ? (
             <StepSummaryForRun runId={run.id} />
           ) : undefined}
         </Box>

--- a/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
@@ -110,8 +110,8 @@ export const TickTag: React.FC<{
                 Failure
               </Tag>
             </LinkButton>
-            <ButtonLink onClick={showError} style={{marginLeft: 8, fontSize: 14}}>
-              View error
+            <ButtonLink onClick={showError} style={{marginLeft: 8, fontSize: 12}}>
+              View
             </ButtonLink>
           </>
         );

--- a/js_modules/dagit/packages/core/src/nav/JobMetadata.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/JobMetadata.test.tsx
@@ -114,7 +114,6 @@ describe('JobMetadata', () => {
         renderWithMocks(mocks);
 
         await waitFor(() => {
-          expect(screen.getByText(/schedule:/i)).toBeVisible();
           expect(screen.getByRole('link', {name: /every 5 minutes/i})).toBeVisible();
         });
       });
@@ -130,7 +129,7 @@ describe('JobMetadata', () => {
 
         renderWithMocks(mocks);
         await waitFor(() => {
-          expect(screen.getByRole('button', {name: /view 2 schedules/i})).toBeVisible();
+          expect(screen.getByRole('button', {name: /2 schedules/i})).toBeVisible();
         });
       });
 
@@ -145,7 +144,6 @@ describe('JobMetadata', () => {
 
         renderWithMocks(mocks);
         await waitFor(() => {
-          expect(screen.getByText(/sensor:/i)).toBeVisible();
           expect(screen.getByRole('link', {name: /cool_sensor/i})).toBeVisible();
         });
       });
@@ -161,7 +159,7 @@ describe('JobMetadata', () => {
 
         renderWithMocks(mocks);
         await waitFor(() => {
-          expect(screen.getByRole('button', {name: /view 2 sensors/i})).toBeVisible();
+          expect(screen.getByRole('button', {name: /2 sensors/i})).toBeVisible();
         });
       });
 
@@ -176,7 +174,7 @@ describe('JobMetadata', () => {
 
         renderWithMocks(mocks);
         await waitFor(() => {
-          expect(screen.getByRole('button', {name: /view 4 schedules\/sensors/i})).toBeVisible();
+          expect(screen.getByRole('button', {name: /4 schedules\/sensors/i})).toBeVisible();
         });
       });
     });
@@ -223,7 +221,6 @@ describe('JobMetadata', () => {
 
         renderWithMocks(mocks);
         await waitFor(() => {
-          expect(screen.queryByText(/schedule:/i)).toBeNull();
           expect(screen.queryByRole('link', {name: /every 5 minutes/i})).toBeNull();
         });
       });
@@ -239,7 +236,6 @@ describe('JobMetadata', () => {
 
         renderWithMocks(mocks);
         await waitFor(() => {
-          expect(screen.getByText(/schedule:/i)).toBeVisible();
           expect(screen.getByRole('link', {name: /every 5 minutes/i})).toBeVisible();
         });
       });
@@ -255,7 +251,7 @@ describe('JobMetadata', () => {
 
         renderWithMocks(mocks);
         await waitFor(() => {
-          expect(screen.getByRole('button', {name: /view 2 schedules/i})).toBeVisible();
+          expect(screen.getByRole('button', {name: /2 schedules/i})).toBeVisible();
         });
       });
 
@@ -270,7 +266,6 @@ describe('JobMetadata', () => {
 
         renderWithMocks(mocks);
         await waitFor(() => {
-          expect(screen.getByText(/sensor:/i)).toBeVisible();
           expect(screen.getByRole('link', {name: /cool_sensor/i})).toBeVisible();
         });
       });
@@ -286,7 +281,7 @@ describe('JobMetadata', () => {
 
         renderWithMocks(mocks);
         await waitFor(() => {
-          expect(screen.getByRole('button', {name: /view 2 sensors/i})).toBeVisible();
+          expect(screen.getByRole('button', {name: /2 sensors/i})).toBeVisible();
         });
       });
 
@@ -301,7 +296,7 @@ describe('JobMetadata', () => {
 
         renderWithMocks(mocks);
         await waitFor(() => {
-          expect(screen.getByRole('button', {name: /view 4 schedules\/sensors/i})).toBeVisible();
+          expect(screen.getByRole('button', {name: /4 schedules\/sensors/i})).toBeVisible();
         });
       });
     });

--- a/js_modules/dagit/packages/core/src/nav/ScheduleOrSensorTag.tsx
+++ b/js_modules/dagit/packages/core/src/nav/ScheduleOrSensorTag.tsx
@@ -1,4 +1,4 @@
-import {Box, ButtonLink, Colors, Tag, Tooltip, FontFamily} from '@dagster-io/ui';
+import {Box, ButtonLink, Colors, Tag, Tooltip, FontFamily, MiddleTruncate} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
@@ -26,10 +26,10 @@ export const ScheduleOrSensorTag: React.FC<{
   if (scheduleCount > 1 || sensorCount > 1 || (scheduleCount && sensorCount)) {
     const buttonText =
       scheduleCount && sensorCount
-        ? `View ${scheduleCount + sensorCount} schedules/sensors`
+        ? `${scheduleCount + sensorCount} schedules/sensors`
         : scheduleCount
-        ? `View ${scheduleCount} schedules`
-        : `View ${sensorCount} sensors`;
+        ? `${scheduleCount} schedules`
+        : `${sensorCount} sensors`;
 
     const icon = scheduleCount > 1 ? 'schedule' : 'sensors';
 
@@ -75,8 +75,10 @@ const MatchingSchedule: React.FC<{
   const tag = (
     <Tag intent={running ? 'primary' : 'none'} icon="schedule">
       <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-        Schedule:
-        <Link to={workspacePathFromAddress(repoAddress, `/schedules/${schedule.name}`)}>
+        <Link
+          to={workspacePathFromAddress(repoAddress, `/schedules/${schedule.name}`)}
+          style={{overflow: 'hidden', textOverflow: 'ellipsis'}}
+        >
           {humanCronString(cronSchedule, executionTimezone || 'UTC')}
         </Link>
         {showSwitch ? (
@@ -88,7 +90,7 @@ const MatchingSchedule: React.FC<{
 
   return schedule.cronSchedule ? (
     <Tooltip
-      placement="bottom"
+      placement="top-start"
       content={
         <Box flex={{direction: 'column', gap: 4}}>
           <div>
@@ -122,9 +124,11 @@ const MatchingSensor: React.FC<{
   return (
     <Tag intent={running ? 'primary' : 'none'} icon="sensors">
       <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-        Sensor:
-        <Link to={workspacePathFromAddress(repoAddress, `/sensors/${sensor.name}`)}>
-          {sensor.name}
+        <Link
+          to={workspacePathFromAddress(repoAddress, `/sensors/${sensor.name}`)}
+          style={{maxWidth: 200, overflow: 'hidden'}}
+        >
+          <MiddleTruncate text={sensor.name} />
         </Link>
         {showSwitch ? (
           <SensorSwitch size="small" repoAddress={repoAddress} sensor={sensor} />

--- a/js_modules/dagit/packages/core/src/overview/OverviewJobsTable.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewJobsTable.tsx
@@ -1,11 +1,11 @@
-import {Box, Colors, Tag, Tooltip} from '@dagster-io/ui';
+import {Tag, Tooltip} from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 
-import {Container, HeaderCell, Inner} from '../ui/VirtualizedTable';
+import {Container, Inner} from '../ui/VirtualizedTable';
 import {findDuplicateRepoNames} from '../ui/findDuplicateRepoNames';
 import {useRepoExpansionState} from '../ui/useRepoExpansionState';
-import {VirtualizedJobRow} from '../workspace/VirtualizedJobRow';
+import {VirtualizedJobHeader, VirtualizedJobRow} from '../workspace/VirtualizedJobRow';
 import {RepoRow} from '../workspace/VirtualizedWorkspaceTable';
 import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
@@ -70,22 +70,7 @@ export const OverviewJobsTable: React.FC<Props> = ({repos}) => {
 
   return (
     <>
-      <Box
-        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '34% 30% 20% 8% 8%',
-          height: '32px',
-          fontSize: '12px',
-          color: Colors.Gray600,
-        }}
-      >
-        <HeaderCell>Job name</HeaderCell>
-        <HeaderCell>Schedules/sensors</HeaderCell>
-        <HeaderCell>Latest run</HeaderCell>
-        <HeaderCell>Run history</HeaderCell>
-        <HeaderCell>Actions</HeaderCell>
-      </Box>
+      <VirtualizedJobHeader />
       <div style={{overflow: 'hidden'}}>
         <Container ref={parentRef}>
           <Inner $totalHeight={totalHeight}>

--- a/js_modules/dagit/packages/core/src/overview/OverviewSchedulesTable.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSchedulesTable.tsx
@@ -1,11 +1,14 @@
-import {Box, Colors, Tag, Tooltip} from '@dagster-io/ui';
+import {Tag, Tooltip} from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 
-import {Container, HeaderCell, Inner} from '../ui/VirtualizedTable';
+import {Container, Inner} from '../ui/VirtualizedTable';
 import {findDuplicateRepoNames} from '../ui/findDuplicateRepoNames';
 import {useRepoExpansionState} from '../ui/useRepoExpansionState';
-import {VirtualizedScheduleRow} from '../workspace/VirtualizedScheduleRow';
+import {
+  VirtualizedScheduleHeader,
+  VirtualizedScheduleRow,
+} from '../workspace/VirtualizedScheduleRow';
 import {RepoRow} from '../workspace/VirtualizedWorkspaceTable';
 import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
@@ -67,23 +70,7 @@ export const OverviewScheduleTable: React.FC<Props> = ({repos}) => {
 
   return (
     <>
-      <Box
-        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '76px 28% 30% 10% 20% 10%',
-          height: '32px',
-          fontSize: '12px',
-          color: Colors.Gray600,
-        }}
-      >
-        <HeaderCell />
-        <HeaderCell>Schedule name</HeaderCell>
-        <HeaderCell>Schedule</HeaderCell>
-        <HeaderCell>Last tick</HeaderCell>
-        <HeaderCell>Last run</HeaderCell>
-        <HeaderCell>Actions</HeaderCell>
-      </Box>
+      <VirtualizedScheduleHeader />
       <div style={{overflow: 'hidden'}}>
         <Container ref={parentRef}>
           <Inner $totalHeight={totalHeight}>

--- a/js_modules/dagit/packages/core/src/overview/OverviewSensorsTable.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSensorsTable.tsx
@@ -1,11 +1,11 @@
-import {Box, Colors, Tag, Tooltip} from '@dagster-io/ui';
+import {Tag, Tooltip} from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 
-import {Container, HeaderCell, Inner} from '../ui/VirtualizedTable';
+import {Container, Inner} from '../ui/VirtualizedTable';
 import {findDuplicateRepoNames} from '../ui/findDuplicateRepoNames';
 import {useRepoExpansionState} from '../ui/useRepoExpansionState';
-import {VirtualizedSensorRow} from '../workspace/VirtualizedSensorRow';
+import {VirtualizedSensorHeader, VirtualizedSensorRow} from '../workspace/VirtualizedSensorRow';
 import {RepoRow} from '../workspace/VirtualizedWorkspaceTable';
 import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
@@ -67,22 +67,7 @@ export const OverviewSensorTable: React.FC<Props> = ({repos}) => {
 
   return (
     <>
-      <Box
-        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '76px 38% 30% 10% 20%',
-          height: '32px',
-          fontSize: '12px',
-          color: Colors.Gray600,
-        }}
-      >
-        <HeaderCell />
-        <HeaderCell>Sensor name</HeaderCell>
-        <HeaderCell>Frequency</HeaderCell>
-        <HeaderCell>Last tick</HeaderCell>
-        <HeaderCell>Last run</HeaderCell>
-      </Box>
+      <VirtualizedSensorHeader />
       <div style={{overflow: 'hidden'}}>
         <Container ref={parentRef}>
           <Inner $totalHeight={totalHeight}>

--- a/js_modules/dagit/packages/core/src/runs/RunStatusPez.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStatusPez.tsx
@@ -3,10 +3,11 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import {SectionHeader} from '../pipelines/SidebarComponents';
+import {StepSummaryForRun} from '../instance/StepSummaryForRun';
 import {RunStatus} from '../types/globalTypes';
 
 import {RunStatusIndicator} from './RunStatusDots';
+import {failedStatuses, inProgressStatuses} from './RunStatuses';
 import {RunStateSummary, RunTime, titleForRun} from './RunUtils';
 import {RunTimeFragment} from './types/RunTimeFragment';
 
@@ -86,16 +87,22 @@ export const RunStatusOverlay = ({name, run}: OverlayProps) => {
     <OverlayContainer>
       <OverlayTitle>{name}</OverlayTitle>
       <RunRow>
-        <RunStatusIndicator status={run.status} />
-        <Link to={`/instance/runs/${run.runId}`}>
-          <Mono>{titleForRun(run)}</Mono>
-        </Link>
-        <HorizontalSpace />
-        <Box flex={{direction: 'column'}}>
+        <Box flex={{alignItems: 'center', direction: 'row', gap: 8}}>
+          <RunStatusIndicator status={run.status} />
+          <Link to={`/instance/runs/${run.runId}`}>
+            <Mono style={{fontSize: '14px'}}>{titleForRun(run)}</Mono>
+          </Link>
+        </Box>
+        <Box flex={{direction: 'column', gap: 4}} padding={{top: 2}}>
           <RunTime run={run} />
           <RunStateSummary run={run} />
         </Box>
       </RunRow>
+      {failedStatuses.has(run.status) || inProgressStatuses.has(run.status) ? (
+        <SummaryContainer>
+          <StepSummaryForRun runId={run.id} />
+        </SummaryContainer>
+      ) : null}
     </OverlayContainer>
   );
 };
@@ -103,16 +110,16 @@ export const RunStatusOverlay = ({name, run}: OverlayProps) => {
 const OverlayContainer = styled.div`
   padding: 4px;
   font-size: 12px;
-  width: 280px;
+  width: 220px;
 `;
 
-const HorizontalSpace = styled.div`
-  flex: 1;
-`;
-
-const OverlayTitle = styled(SectionHeader)`
+const OverlayTitle = styled.div`
   padding: 8px;
   box-shadow: inset 0 -1px ${Colors.KeylineGray};
+  font-family: ${FontFamily.default};
+  font-size: 14px;
+  font-weight: 500;
+  color: ${Colors.Dark};
   max-width: 100%;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -120,13 +127,22 @@ const OverlayTitle = styled(SectionHeader)`
 `;
 
 const RunRow = styled.div`
-  align-items: baseline;
   padding: 8px;
-  font-family: ${FontFamily.monospace};
-  font-size: 14px;
-  line-height: 20px;
+  font-size: 12px;
   display: flex;
-  gap: 8px;
+  align-items: flex-start;
+  justify-content: space-between;
+`;
+
+const SummaryContainer = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 4px 8px 8px;
+
+  :empty {
+    display: none;
+  }
 `;
 
 const Pez = styled.div<{$color: string; $opacity: number}>`

--- a/js_modules/dagit/packages/core/src/schedules/TimestampDisplay.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/TimestampDisplay.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Icon, Tooltip} from '@dagster-io/ui';
+import {Colors, Icon, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
@@ -17,18 +17,17 @@ export const TimestampDisplay = (props: Props) => {
   const {timestamp, timezone, timeFormat, tooltipTimeFormat} = props;
   const [userTimezone] = React.useContext(TimezoneContext);
   const locale = navigator.language;
+  const mainString = timestampToString({
+    timestamp: {unix: timestamp},
+    locale,
+    timezone: timezone || userTimezone,
+    timeFormat,
+  });
 
   return (
-    <Box
-      flex={{display: 'inline-flex', direction: 'row', alignItems: 'center', wrap: 'wrap', gap: 8}}
-    >
-      <TabularNums>
-        {timestampToString({
-          timestamp: {unix: timestamp},
-          locale,
-          timezone: timezone || userTimezone,
-          timeFormat,
-        })}
+    <span>
+      <TabularNums style={{minWidth: 0}} title={mainString}>
+        {mainString}
       </TabularNums>
       {timezone && timezone !== userTimezone ? (
         <TimestampTooltip
@@ -44,10 +43,10 @@ export const TimestampDisplay = (props: Props) => {
             </TabularNums>
           }
         >
-          <Icon name="schedule" color={Colors.Gray400} />
+          <Icon name="schedule" color={Colors.Gray400} size={12} />
         </TimestampTooltip>
       ) : null}
-    </Box>
+    </span>
   );
 };
 
@@ -56,14 +55,13 @@ TimestampDisplay.defaultProps = {
   tooltipTimeFormat: {showSeconds: false, showTimezone: true},
 };
 
-const TabularNums = styled.div`
+const TabularNums = styled.span`
   font-variant-numeric: tabular-nums;
 `;
 
 const TimestampTooltip = styled(Tooltip)`
   cursor: pointer;
-
-  &.bp3-popover2-target {
-    display: block;
-  }
+  position: relative;
+  top: 2px;
+  margin-left: 4px;
 `;

--- a/js_modules/dagit/packages/core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorDetails.tsx
@@ -30,21 +30,21 @@ export const humanizeSensorInterval = (minIntervalSeconds?: number) => {
   }
   minIntervalSeconds = Math.max(30, minIntervalSeconds);
   if (minIntervalSeconds < 60 || minIntervalSeconds % 60) {
-    return `~ ${minIntervalSeconds} sec`;
+    return `~${minIntervalSeconds} sec`;
   }
   if (minIntervalSeconds === 3600) {
-    return `~ 1 hour`;
+    return `~1 hour`;
   }
   if (minIntervalSeconds < 3600 || minIntervalSeconds % 3600) {
-    return `~ ${minIntervalSeconds / 60} min`;
+    return `~${minIntervalSeconds / 60} min`;
   }
   if (minIntervalSeconds === 86400) {
-    return `~ 1 day`;
+    return `~1 day`;
   }
   if (minIntervalSeconds < 86400 || minIntervalSeconds % 86400) {
-    return `~ ${minIntervalSeconds / 3600} hours`;
+    return `~${minIntervalSeconds / 3600} hours`;
   }
-  return `~ ${minIntervalSeconds / 86400} days`;
+  return `~${minIntervalSeconds / 86400} days`;
 };
 
 export const SensorDetails: React.FC<{

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedJobRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedJobRow.tsx
@@ -1,5 +1,5 @@
 import {gql, useLazyQuery} from '@apollo/client';
-import {Box, Caption, Colors, MiddleTruncate} from '@dagster-io/ui';
+import {Box, Colors, MiddleTruncate} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -12,13 +12,15 @@ import {RunStatusPezList} from '../runs/RunStatusPez';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
 import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
-import {Row, RowCell} from '../ui/VirtualizedTable';
+import {HeaderCell, Row, RowCell} from '../ui/VirtualizedTable';
 
-import {LoadingOrNone, useDelayedRowQuery} from './VirtualizedWorkspaceTable';
+import {CaptionText, LoadingOrNone, useDelayedRowQuery} from './VirtualizedWorkspaceTable';
 import {buildPipelineSelector} from './WorkspaceContext';
 import {RepoAddress} from './types';
 import {SingleJobQuery, SingleJobQueryVariables} from './types/SingleJobQuery';
 import {workspacePathFromAddress} from './workspacePath';
+
+const TEMPLATE_COLUMNS = '1.5fr 1fr 180px 96px 80px';
 
 interface JobRowProps {
   name: string;
@@ -68,39 +70,27 @@ export const VirtualizedJobRow = (props: JobRowProps) => {
     <Row $height={height} $start={start}>
       <RowGrid border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
         <RowCell>
-          <Link
-            to={workspacePathFromAddress(repoAddress, `/jobs/${name}`)}
-            style={{maxWidth: '100%', fontWeight: 500}}
-          >
-            <MiddleTruncate text={name} />
-          </Link>
-          <div
-            style={{
-              maxWidth: '100%',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            }}
-          >
-            <Caption
-              style={{
-                color: Colors.Gray500,
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {data?.pipelineOrError.__typename === 'Pipeline'
-                ? data.pipelineOrError.description
-                : ''}
-            </Caption>
+          <div style={{maxWidth: '100%', whiteSpace: 'nowrap', fontWeight: 500}}>
+            <Link to={workspacePathFromAddress(repoAddress, `/jobs/${name}`)}>
+              <MiddleTruncate text={name} />
+            </Link>
           </div>
+          <CaptionText>
+            {data?.pipelineOrError.__typename === 'Pipeline'
+              ? data.pipelineOrError.description
+              : ''}
+          </CaptionText>
         </RowCell>
         <RowCell>
           {schedules.length || sensors.length ? (
             <Box flex={{direction: 'column', alignItems: 'flex-start', gap: 8}}>
-              <ScheduleOrSensorTag
-                schedules={schedules}
-                sensors={sensors}
-                repoAddress={repoAddress}
-              />
+              <ScheduleSensorTagContainer>
+                <ScheduleOrSensorTag
+                  schedules={schedules}
+                  sensors={sensors}
+                  repoAddress={repoAddress}
+                />
+              </ScheduleSensorTagContainer>
               {/* {schedules.length ? <NextTick schedules={schedules} /> : null} */}
             </Box>
           ) : (
@@ -109,32 +99,69 @@ export const VirtualizedJobRow = (props: JobRowProps) => {
         </RowCell>
         <RowCell>
           {latestRuns.length ? (
-            <LastRunSummary run={latestRuns[0]} showButton={false} showHover name={name} />
+            <LastRunSummary
+              run={latestRuns[0]}
+              showButton={false}
+              showHover
+              showSummary={false}
+              name={name}
+            />
           ) : (
             <LoadingOrNone queryResult={queryResult} />
           )}
         </RowCell>
         <RowCell>
           {latestRuns.length ? (
-            <RunStatusPezList jobName={name} runs={[...latestRuns].reverse()} fade />
+            <Box padding={{top: 4}}>
+              <RunStatusPezList jobName={name} runs={[...latestRuns].reverse()} fade />
+            </Box>
           ) : (
             <LoadingOrNone queryResult={queryResult} />
           )}
         </RowCell>
         <RowCell>
-          <div>
+          <Box flex={{justifyContent: 'flex-end'}} style={{marginTop: '-2px'}}>
             <JobMenu job={{isJob, name, runs: latestRuns}} repoAddress={repoAddress} />
-          </div>
+          </Box>
         </RowCell>
       </RowGrid>
     </Row>
   );
 };
 
+export const VirtualizedJobHeader = () => {
+  return (
+    <Box
+      border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: TEMPLATE_COLUMNS,
+        height: '32px',
+        fontSize: '12px',
+        color: Colors.Gray600,
+      }}
+    >
+      <HeaderCell>Name</HeaderCell>
+      <HeaderCell>Schedules/sensors</HeaderCell>
+      <HeaderCell>Latest run</HeaderCell>
+      <HeaderCell>Run history</HeaderCell>
+      <HeaderCell></HeaderCell>
+    </Box>
+  );
+};
+
 const RowGrid = styled(Box)`
   display: grid;
-  grid-template-columns: 34% 30% 20% 8% 8%;
+  grid-template-columns: ${TEMPLATE_COLUMNS};
   height: 100%;
+`;
+
+const ScheduleSensorTagContainer = styled.div`
+  width: 100%;
+
+  > .bp3-popover2-target {
+    width: 100%;
+  }
 `;
 
 const SINGLE_JOB_QUERY = gql`

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedJobTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedJobTable.tsx
@@ -1,10 +1,9 @@
-import {Box, Colors} from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 
-import {Container, HeaderCell, Inner} from '../ui/VirtualizedTable';
+import {Container, Inner} from '../ui/VirtualizedTable';
 
-import {VirtualizedJobRow} from './VirtualizedJobRow';
+import {VirtualizedJobHeader, VirtualizedJobRow} from './VirtualizedJobRow';
 import {RepoAddress} from './types';
 
 type Job = {isJob: boolean; name: string};
@@ -29,22 +28,7 @@ export const VirtualizedJobTable: React.FC<Props> = ({repoAddress, jobs}) => {
 
   return (
     <>
-      <Box
-        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '34% 30% 20% 8% 8%',
-          height: '32px',
-          fontSize: '12px',
-          color: Colors.Gray600,
-        }}
-      >
-        <HeaderCell>Job name</HeaderCell>
-        <HeaderCell>Schedules/sensors</HeaderCell>
-        <HeaderCell>Latest run</HeaderCell>
-        <HeaderCell>Run history</HeaderCell>
-        <HeaderCell>Actions</HeaderCell>
-      </Box>
+      <VirtualizedJobHeader />
       <div style={{overflow: 'hidden'}}>
         <Container ref={parentRef}>
           <Inner $totalHeight={totalHeight}>

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleTable.tsx
@@ -1,10 +1,9 @@
-import {Box, Colors} from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 
-import {Container, HeaderCell, Inner} from '../ui/VirtualizedTable';
+import {Container, Inner} from '../ui/VirtualizedTable';
 
-import {VirtualizedScheduleRow} from './VirtualizedScheduleRow';
+import {VirtualizedScheduleHeader, VirtualizedScheduleRow} from './VirtualizedScheduleRow';
 import {RepoAddress} from './types';
 
 type Schedule = {name: string};
@@ -29,23 +28,7 @@ export const VirtualizedScheduleTable: React.FC<Props> = ({repoAddress, schedule
 
   return (
     <>
-      <Box
-        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '76px 28% 30% 10% 20% 10%',
-          height: '32px',
-          fontSize: '12px',
-          color: Colors.Gray600,
-        }}
-      >
-        <HeaderCell />
-        <HeaderCell>Schedule name</HeaderCell>
-        <HeaderCell>Schedule</HeaderCell>
-        <HeaderCell>Last tick</HeaderCell>
-        <HeaderCell>Last run</HeaderCell>
-        <HeaderCell>Actions</HeaderCell>
-      </Box>
+      <VirtualizedScheduleHeader />
       <div style={{overflow: 'hidden'}}>
         <Container ref={parentRef}>
           <Inner $totalHeight={totalHeight}>

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorTable.tsx
@@ -1,10 +1,9 @@
-import {Box, Colors} from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 
-import {Container, HeaderCell, Inner} from '../ui/VirtualizedTable';
+import {Container, Inner} from '../ui/VirtualizedTable';
 
-import {VirtualizedSensorRow} from './VirtualizedSensorRow';
+import {VirtualizedSensorHeader, VirtualizedSensorRow} from './VirtualizedSensorRow';
 import {RepoAddress} from './types';
 type Sensor = {name: string};
 
@@ -28,22 +27,7 @@ export const VirtualizedSensorTable: React.FC<Props> = ({repoAddress, sensors}) 
 
   return (
     <>
-      <Box
-        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '76px 38% 30% 10% 20%',
-          height: '32px',
-          fontSize: '12px',
-          color: Colors.Gray600,
-        }}
-      >
-        <HeaderCell />
-        <HeaderCell>Sensor name</HeaderCell>
-        <HeaderCell>Frequency</HeaderCell>
-        <HeaderCell>Last tick</HeaderCell>
-        <HeaderCell>Last run</HeaderCell>
-      </Box>
+      <VirtualizedSensorHeader />
       <div style={{overflow: 'hidden'}}>
         <Container ref={parentRef}>
           <Inner $totalHeight={totalHeight}>

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedWorkspaceTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedWorkspaceTable.tsx
@@ -1,6 +1,7 @@
 import {LazyQueryExecFunction, QueryResult} from '@apollo/client';
-import {Colors} from '@dagster-io/ui';
+import {Caption, Colors} from '@dagster-io/ui';
 import * as React from 'react';
+import styled from 'styled-components/macro';
 
 import {RepoSectionHeader} from '../runs/RepoSectionHeader';
 import {Row} from '../ui/VirtualizedTable';
@@ -48,6 +49,25 @@ export const LoadingOrNone: React.FC<{queryResult: QueryResult<any, any>}> = ({q
     <div style={{color: Colors.Gray500}}>{!called || (loading && !data) ? 'Loading' : 'None'}</div>
   );
 };
+
+export const CaptionText: React.FC = ({children}) => {
+  return (
+    <CaptionTextContainer>
+      <Caption>{children}</Caption>
+    </CaptionTextContainer>
+  );
+};
+
+const CaptionTextContainer = styled.div`
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  ${Caption} {
+    color: ${Colors.Gray500};
+    white-space: nowrap;
+  }
+`;
 
 const JOB_QUERY_DELAY = 100;
 

--- a/js_modules/dagit/packages/core/src/workspace/types/SingleSensorQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/SingleSensorQuery.ts
@@ -81,11 +81,11 @@ export interface SingleSensorQuery_sensorOrError_Sensor_sensorState {
 export interface SingleSensorQuery_sensorOrError_Sensor {
   __typename: "Sensor";
   id: string;
+  description: string | null;
   name: string;
   targets: SingleSensorQuery_sensorOrError_Sensor_targets[] | null;
   metadata: SingleSensorQuery_sensorOrError_Sensor_metadata;
   minIntervalSeconds: number;
-  description: string | null;
   sensorState: SingleSensorQuery_sensorOrError_Sensor_sensorState;
   jobOriginId: string;
 }

--- a/js_modules/dagit/packages/ui/src/components/Icon.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Icon.tsx
@@ -281,7 +281,7 @@ export const IconNames = Object.keys(Icons) as IconName[];
 interface Props {
   color?: string;
   name: IconName;
-  size?: 16 | 20 | 24 | 48;
+  size?: 12 | 16 | 20 | 24 | 48;
   style?: React.CSSProperties;
 }
 


### PR DESCRIPTION
### Summary & Motivation

Make some changes to the virtualized tables to improve consistency, spacing, alignment, truncation, typography. The main objective is to prevent cell contents from invisibly overflowing, except through middle/end truncation.

- Consolidate template-columns configuration for each of our virtualized Overview tables, to make it simpler to tweak column sizes as needed.
- Don't show the run summary (timing etc) next to the latest run tag. Instead, show it within its popover. Also make some changes to the popover to consolidate space and clean up the typography a bit.
- Repair alignment of latest run tag, run pez, and action menu button.
- In schedule/sensor tag, Use middle-truncation on sensor name and end-truncation on schedule human-readable cron strings. This way, when the column shrinks down, we can continue to fit content as needed.
- End-truncate human readable schedule strings on the Schedules table.
- End-truncate and tidy up the timestamp string on Schedules table.
- Use a separate column to show job/asset name on Sensors table. This will need some further fixing to middle-truncate the object names, but these components are a little too complex to do this easily here.


<img width="268" alt="Screen Shot 2022-10-20 at 3 39 51 PM" src="https://user-images.githubusercontent.com/2823852/197054614-398194e0-cf9f-42aa-ae9f-93b0e30f7914.png">
<img width="247" alt="Screen Shot 2022-10-20 at 3 40 23 PM" src="https://user-images.githubusercontent.com/2823852/197054618-7181fd47-8ab3-43b5-b8d7-cf55550c653d.png">

### How I Tested These Changes

View Dagit in dev, verify that tables and their contents render nicely, with appropriate truncation when the viewport shrinks.

View Dagit with a heavy workspace with lots of jobs/schedules/sensors, verify same.
