### PR TITLE
Don't gate on elementl emails

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_main.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_main.py
@@ -28,47 +28,39 @@ def build_dagster_oss_main_steps() -> List[BuildkiteStep]:
 
     branch_name = safe_getenv("BUILDKITE_BRANCH")
     commit_hash = safe_getenv("BUILDKITE_COMMIT")
-    build_creator_email = os.getenv("BUILDKITE_BUILD_CREATOR_EMAIL")
-    oss_contribution = os.getenv("OSS_CONTRIBUTION")
     do_coverage = DO_COVERAGE
     dagit_ui_only_diff = _is_path_only_diff(paths=_DAGIT_PATHS)
     docs_only_diff = _is_path_only_diff(paths=_DOCS_PATHS)
 
     steps: List[BuildkiteStep] = []
 
-    # Trigger a build on the internal pipeline for Elementl dev PRs. Feature branches use the
+    # Trigger a build on the internal pipeline for dagster PRs. Feature branches use the
     # `oss-internal-compatibility` pipeline, master/release branches use the full `internal`
     # pipeline. Feature branches use internal' `master` branch by default, but this can be
     # overridden by setting the `INTERNAL_BRANCH` environment variable or passing
     # `[INTERNAL_BRANCH=<branch>]` in the commit message. Master/release branches
     # always run on the matching internal branch.
-    if (
-        build_creator_email
-        and build_creator_email.endswith("@elementl.com")
-        and build_creator_email != "devtools@elementl.com"
-        and not oss_contribution
-    ):
-        if branch_name == "master" or is_release_branch(branch_name):
-            pipeline_name = "internal"
-            trigger_branch = branch_name  # build on matching internal release branch
-            async_step = True
-        else:  # feature branch
-            pipeline_name = "oss-internal-compatibility"
-            trigger_branch = _get_internal_branch_specifier() or "master"
-            async_step = False
+    if branch_name == "master" or is_release_branch(branch_name):
+        pipeline_name = "internal"
+        trigger_branch = branch_name  # build on matching internal release branch
+        async_step = True
+    else:  # feature branch
+        pipeline_name = "oss-internal-compatibility"
+        trigger_branch = _get_internal_branch_specifier() or "master"
+        async_step = False
 
-        steps.append(
-            build_trigger_step(
-                pipeline=pipeline_name,
-                trigger_branch=trigger_branch,
-                async_step=async_step,
-                env={
-                    "DAGSTER_BRANCH": branch_name,
-                    "DAGSTER_COMMIT_HASH": commit_hash,
-                    "DAGIT_ONLY_OSS_CHANGE": "1" if dagit_ui_only_diff else "",
-                },
-            ),
-        )
+    steps.append(
+        build_trigger_step(
+            pipeline=pipeline_name,
+            trigger_branch=trigger_branch,
+            async_step=async_step,
+            env={
+                "DAGSTER_BRANCH": branch_name,
+                "DAGSTER_COMMIT_HASH": commit_hash,
+                "DAGIT_ONLY_OSS_CHANGE": "1" if dagit_ui_only_diff else "",
+            },
+        ),
+    )
 
     # Always include repo wide steps
     steps += build_repo_wide_steps()


### PR DESCRIPTION
This was originally added to prevent anybody from being able to kick off a build of our internal pipelines with a PR against Dagster. But we should relax this logic for two reasons:

1. We still want to know that a Dagster change is compatible with our Internal code even if we aren't the one making the change.
2. Only members of the Dagster organization in GitHub can kick off builds automatically - builds are off by default for pull requests from forked repositories.

This will unblock the ability for us to commit using our GitHub no-reply email address like https://buildkite.com/dagster/dagster/builds/37140#0183f725-5646-43ba-ac88-247f93e9f1d0
