### PR TITLE
Allow singular inputs to with_resources utility

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/with_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/with_resources.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abc import Iterable as IterableABC
 from typing import Any, Iterable, List, Mapping, Optional, Sequence, TypeVar, Union, cast
 
 from dagster import _check as check
@@ -97,7 +97,7 @@ def with_resources(
                 )
             resource_defs[key] = resource_defs[key].configured(resource_config["config"])
 
-    if not isinstance(definitions, collections.Iterable):
+    if not isinstance(definitions, IterableABC):
         definitions = [definitions]
 
     transformed_defs: List[T] = []

--- a/python_modules/dagster/dagster/_core/execution/with_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/with_resources.py
@@ -1,4 +1,5 @@
-from typing import Any, Iterable, List, Mapping, Optional, Sequence, TypeVar, cast
+import collections
+from typing import Any, Iterable, List, Mapping, Optional, Sequence, TypeVar, Union, cast
 
 from dagster import _check as check
 from dagster._utils import merge_dicts
@@ -13,7 +14,7 @@ T = TypeVar("T", bound=ResourceAddable)
 
 
 def with_resources(
-    definitions: Iterable[T],
+    definitions: Union[Iterable[T], T],
     resource_defs: Mapping[str, ResourceDefinition],
     resource_config_by_key: Optional[Mapping[str, Any]] = None,
 ) -> Sequence[T]:
@@ -95,6 +96,9 @@ def with_resources(
                     resource_config,
                 )
             resource_defs[key] = resource_defs[key].configured(resource_config["config"])
+
+    if not isinstance(definitions, collections.Iterable):
+        definitions = [definitions]
 
     transformed_defs: List[T] = []
     for definition in definitions:

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_materialize.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_materialize.py
@@ -114,6 +114,18 @@ def test_materialize_resources_not_satisfied():
         ).success
 
 
+def test_with_resources_non_iterable():
+    @asset(required_resource_keys={"foo"})
+    def the_asset(context):
+        assert context.resources.foo == "blah"
+
+    with instance_for_test() as instance:
+        assert materialize(
+            with_resources(the_asset, {"foo": ResourceDefinition.hardcoded_resource("blah")}),
+            instance=instance,
+        ).success
+
+
 def test_materialize_conflicting_resources():
     @asset(resource_defs={"foo": ResourceDefinition.hardcoded_resource("1")})
     def first():


### PR DESCRIPTION
## Summary

`CacheableAssetsDefinition` objects are singular, but might end up generating multiple assets. To make working with `CacheableAssetsDefinition`s feel natural & akin to the assets they represent, this PR allows `with_resources` to apply to singular objects as well as iterables, so users can write e.g.

```python
my_cached_assets = MyCacheableAssetsDefinition()

with_resources(
  my_cached_assets,
  {"foo": bar}
)
```

with the ergonomics identical to if they were working with the assets that will end up being produced

```python
my_assets = [ foo_asset, bar_asset ]

with_resources(
  my_assets,
  {"foo": bar}
)
```

## Test Plan

Unit test.