### PR TITLE
Fix schema_type of TypedDictTypeLoader

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_input_type_loading.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_input_type_loading.py
@@ -1,0 +1,87 @@
+from typing import Any, Dict
+
+import pytest
+
+from dagster import DagsterInvalidConfigError, job, op
+
+
+def test_dict_input():
+    @op
+    def the_op(x: Dict[str, str]):
+        assert x == {"foo": "bar"}
+
+    @job
+    def the_job():
+        the_op()
+
+    assert the_job.execute_in_process(
+        run_config={
+            "ops": {
+                "the_op": {
+                    "inputs": {
+                        "x": {
+                            "foo": "bar",
+                        },
+                    }
+                }
+            }
+        }
+    ).success
+
+    @job
+    def the_job_top_lvl_input(x):
+        the_op(x)
+
+    assert the_job_top_lvl_input.execute_in_process(
+        run_config={"inputs": {"x": {"foo": "bar"}}}
+    ).success
+
+
+def test_any_dict_input():
+    @op
+    def the_op(x: Dict[str, Any]):
+        assert x == {"foo": "bar"}
+
+    @job
+    def the_job():
+        the_op()
+
+    assert the_job.execute_in_process(
+        run_config={
+            "ops": {
+                "the_op": {
+                    "inputs": {
+                        "x": {
+                            "foo": {"value": "bar"},
+                        },
+                    }
+                }
+            }
+        }
+    ).success
+
+    @job
+    def the_job_top_lvl_input(x):
+        the_op(x)
+
+    assert the_job_top_lvl_input.execute_in_process(
+        run_config={"inputs": {"x": {"foo": {"value": "bar"}}}}
+    ).success
+
+
+def test_malformed_input_schema_dict():
+    @op
+    def the_op(_x: Dict[str, Any]):
+        pass
+
+    @job
+    def the_job(x):
+        the_op(x)
+
+    # Case: I specify a dict input, and I try to pass a string to the Any parameter.
+    with pytest.raises(DagsterInvalidConfigError):
+        the_job.execute_in_process(run_config={"inputs": {"x": {"foo": "bar"}}})
+
+    # Case: I specify a dict input, and I try to pass a dictionary to the Any parameter (but not an input schema dictionary)
+    with pytest.raises(DagsterInvalidConfigError):
+        the_job.execute_in_process(run_config={"inputs": {"x": {"foo": {"foo": "bar"}}}})

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_dict.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_dict.py
@@ -3,6 +3,7 @@ import typing
 import pytest
 
 from dagster import (
+    DagsterInvalidConfigError,
     DagsterInvalidDefinitionError,
     DagsterTypeCheckDidNotPass,
     Dict,
@@ -215,9 +216,7 @@ def test_dict_type_loader_inner_type_mismatch():
     def emit_dict(dict_input):
         return dict_input
 
-    # TODO: change this depending on the resolution of
-    # https://github.com/dagster-io/dagster/issues/3180
-    with pytest.raises(DagsterTypeCheckDidNotPass):
+    with pytest.raises(DagsterInvalidConfigError):
         execute_solid(
             emit_dict,
             run_config={"ops": {"emit_dict": {"inputs": {"dict_input": test_input}}}},


### PR DESCRIPTION
Changes dictionary config type loader to use Map config type. This allows us to catch errors resulting from mismatches in the inner type at config validation time.