### PR TITLE
Cache docstring check

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/inference.py
+++ b/python_modules/dagster/dagster/_core/definitions/inference.py
@@ -7,6 +7,7 @@ from .utils import NoValueSentinel
 
 IS_DOCSTRING_PARSER_AVAILABLE = is_module_available("docstring_parser")
 
+
 class InferredInputProps(NamedTuple):
     """The information about an input that can be inferred from the function signature"""
 

--- a/python_modules/dagster/dagster/_core/definitions/inference.py
+++ b/python_modules/dagster/dagster/_core/definitions/inference.py
@@ -5,6 +5,7 @@ from dagster._seven import funcsigs, is_module_available
 
 from .utils import NoValueSentinel
 
+IS_DOCSTRING_PARSER_AVAILABLE = is_module_available("docstring_parser")
 
 class InferredInputProps(NamedTuple):
     """The information about an input that can be inferred from the function signature"""
@@ -24,7 +25,7 @@ class InferredOutputProps(NamedTuple):
 
 def _infer_input_description_from_docstring(fn: Callable) -> Dict[str, Optional[str]]:
     doc_str = fn.__doc__
-    if not is_module_available("docstring_parser") or doc_str is None:
+    if not IS_DOCSTRING_PARSER_AVAILABLE or doc_str is None:
         return {}
 
     from docstring_parser import parse
@@ -38,7 +39,7 @@ def _infer_input_description_from_docstring(fn: Callable) -> Dict[str, Optional[
 
 def _infer_output_description_from_docstring(fn: Callable) -> Optional[str]:
     doc_str = fn.__doc__
-    if not is_module_available("docstring_parser") or doc_str is None:
+    if not IS_DOCSTRING_PARSER_AVAILABLE or doc_str is None:
         return None
     from docstring_parser import parse
 


### PR DESCRIPTION
### Summary & Motivation

To refamiliarize myself with the codebase I'm doing some profiling on different scenarios which allows for some quick wins and to see how everything is working end-to-end.

In case I saw that for larger graphs we were making huge numbers of expensive calls to `is_module_available("docstring_parser")` which can be easily cached. This diff assigns the results of that into a global constant.

On a test of constructing 10,000 assets this reduces execution time by 35%.

### How I Tested These Changes

Ran this script:

```
assets = []

for i in range(0, 10000):
    @asset(name=f"asset_{i}")
    def foo():
        pass

    assets.append(foo)

@repository
def large_repo():
    return assets
```

Under a profiler.

Before:
    
![Screen Shot 2022-10-21 at 10 56 08 AM](https://user-images.githubusercontent.com/28738937/197225935-2bd62ffb-c1e2-42b4-9ff9-255a427b3d24.png)

![Screen Shot 2022-10-21 at 10 56 14 AM](https://user-images.githubusercontent.com/28738937/197225959-6e5bbc02-8b10-4524-af4c-39e1068ab861.png)

After

![Screen Shot 2022-10-21 at 10 57 35 AM](https://user-images.githubusercontent.com/28738937/197226214-64000f88-6953-4dbc-8e8e-c5a5fc290cf4.png)

![Screen Shot 2022-10-21 at 10 57 42 AM](https://user-images.githubusercontent.com/28738937/197226232-e6d3c234-08d3-4caa-823f-2cda8263e1ef.png)

