### PR TITLE
[dagit] Add some right padding to clearable text input

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/TextInput.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TextInput.tsx
@@ -32,6 +32,7 @@ export const TextInput = React.forwardRef(
           disabled={disabled}
           ref={ref}
           $hasIcon={!!icon}
+          $hasRightElement={!!rightElement}
           type={type}
         />
         {rightElement ? <RightContainer>{rightElement}</RightContainer> : null}
@@ -112,10 +113,20 @@ export const TextInputStyles = css`
 interface StyledInputProps {
   $hasIcon: boolean;
   $strokeColor: string;
+  $hasRightElement: boolean;
 }
 
 const StyledInput = styled.input<StyledInputProps>`
   ${TextInputStyles}
+
+  ${({$hasRightElement}) =>
+    $hasRightElement
+      ? css`
+          & {
+            padding-right: 28px;
+          }
+        `
+      : null}
 
   box-shadow: ${({$strokeColor}) => $strokeColor} inset 0px 0px 0px 1px,
     ${Colors.KeylineGray} inset 2px 2px 1.5px;


### PR DESCRIPTION
### Summary & Motivation

In the log filter input, the "clear" button sits on top of the text. Repair this by adding some right-padding to the input in cases where a `rightElement` is present. This won't be perfect since it's a hardcoded padding value, but since this is the only callsite for this prop, it should be fine for now.

<img width="331" alt="Screen Shot 2022-10-21 at 10 15 22 AM" src="https://user-images.githubusercontent.com/2823852/197230620-3d9c1b44-23be-46f6-9769-7bada123d1a9.png">


### How I Tested These Changes

Type a long string into the input, verify that the clear button no longer sits on top of the text.
