### PR TITLE
[dagster-airbyte] Docs fix using with_resources with cacheable asset

### DIFF
--- a/docs/content/integrations/airbyte.mdx
+++ b/docs/content/integrations/airbyte.mdx
@@ -66,7 +66,7 @@ from dagster_airbyte import airbyte_resource, load_assets_from_airbyte_project
 from dagster import with_resources
 
 airbyte_assets = with_resources(
-    load_assets_from_airbyte_project(project_dir="path/to/airbyte/project"),
+    [load_assets_from_airbyte_project(project_dir="path/to/airbyte/project")],
     {
         "airbyte": airbyte_resource.configured(
             {

--- a/examples/docs_snippets/docs_snippets/integrations/airbyte/airbyte.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airbyte/airbyte.py
@@ -42,7 +42,7 @@ def scope_airbyte_project_config():
     from dagster import with_resources
 
     airbyte_assets = with_resources(
-        load_assets_from_airbyte_project(project_dir="path/to/airbyte/project"),
+        [load_assets_from_airbyte_project(project_dir="path/to/airbyte/project")],
         {
             "airbyte": airbyte_resource.configured(
                 {


### PR DESCRIPTION
### Summary & Motivation

The changes to loading Airbyte assets from YAML introduced in #9998 had the unfortunate side-effect of invalidating this docs example. (I'm a little confused as to why our snippet mypy tests didn't catch)

Since the `with_resources` utility only takes an iterable, and the load function now returns a singular `CacheableAssetsDefinition`, we need to wrap it in a list.

#10121 should make it possible to revert this docs change, once landed.
