### PR TITLE
[docs formatter] Drop mypy ignore lines in docs

### DIFF
--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -428,7 +428,7 @@ class BetterPandasIOManager(IOManager):
             obj.to_csv(file_path, index=False)
 
     def load_input(self, context) -> pd.DataFrame:
-        return pd.read_csv(self._get_path(context.upstream_output))  # type: ignore
+        return pd.read_csv(self._get_path(context.upstream_output))
 
 
 # write a subclass that uses _get_path for your custom loading logic

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -393,9 +393,7 @@ you create a run failure sensor that will message a given Slack channel:
 ```python file=/concepts/partitions_schedules_sensors/sensors/sensor_alert.py startafter=start_slack_marker endbefore=end_slack_marker
 from dagster_slack import make_slack_on_run_failure_sensor
 
-slack_on_run_failure = make_slack_on_run_failure_sensor(
-    "#my_channel", os.getenv("MY_SLACK_TOKEN")
-)
+slack_on_run_failure = make_slack_on_run_failure_sensor("#my_channel", os.getenv("MY_SLACK_TOKEN"))
 ```
 
 <PyObject object="make_email_on_run_failure_sensor" /> helps you create a run failure
@@ -430,6 +428,7 @@ Sometimes, you may want to monitor jobs in a repository other than the one where
 def team_a_repo_sensor():
     # when any job in team_a_repository succeeds, this sensor will trigger
     send_slack_alert()
+
 
 
 @run_failure_sensor(

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -430,7 +430,6 @@ def team_a_repo_sensor():
     send_slack_alert()
 
 
-
 @run_failure_sensor(
     monitored_jobs=[
         JobSelector(

--- a/docs/next/util/limit.ts
+++ b/docs/next/util/limit.ts
@@ -1,6 +1,6 @@
 const SPLIT_PATTERN = /\r?\n/;
 const JOIN_PATTERN = '\n';
-
+const MYPY_IGNORE = '# type: ignore';
 /**
  * Use this method to apply a limit for file snippets generated
  * using the ::literalinclude directive
@@ -50,7 +50,9 @@ export const limitSnippetLines = (content, fromTo, dedent, startAfter, endBefore
   }
 
   const dedentedElements = elements.map((x) => x.substring(dedentLevel));
-  const filteredElements = dedentedElements.filter((x) => !x.trim().startsWith('# type: ignore'));
+  const filteredElements = dedentedElements.map((x) =>
+    x.includes(MYPY_IGNORE) ? x.substring(0, x.indexOf(MYPY_IGNORE)).trimEnd() : x,
+  );
 
   let result = filteredElements;
   if (fromTo) {

--- a/docs/next/util/limit.ts
+++ b/docs/next/util/limit.ts
@@ -50,8 +50,9 @@ export const limitSnippetLines = (content, fromTo, dedent, startAfter, endBefore
   }
 
   const dedentedElements = elements.map((x) => x.substring(dedentLevel));
+  const filteredElements = dedentedElements.filter((x) => !x.trim().startsWith('# type: ignore'));
 
-  let result = dedentedElements;
+  let result = filteredElements;
   if (fromTo) {
     const desiredLineNumbers = parseLineNumbersToSet(fromTo, dedentedElements.length);
     result = result.filter((_, i) => desiredLineNumbers.has(i));

--- a/docs/next/util/limit.ts
+++ b/docs/next/util/limit.ts
@@ -50,11 +50,11 @@ export const limitSnippetLines = (content, fromTo, dedent, startAfter, endBefore
   }
 
   const dedentedElements = elements.map((x) => x.substring(dedentLevel));
-  const filteredElements = dedentedElements.map((x) =>
+  const mypyStrippedElements = dedentedElements.map((x) =>
     x.includes(MYPY_IGNORE) ? x.substring(0, x.indexOf(MYPY_IGNORE)).trimEnd() : x,
   );
 
-  let result = filteredElements;
+  let result = mypyStrippedElements;
   if (fromTo) {
     const desiredLineNumbers = parseLineNumbersToSet(fromTo, dedentedElements.length);
     result = result.filter((_, i) => desiredLineNumbers.has(i));

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
@@ -83,6 +83,7 @@ my_email_failure_sensor(run_failure_sensor_context)
 # start_slack_marker
 from dagster_slack import make_slack_on_run_failure_sensor
 
+# type: ignore
 slack_on_run_failure = make_slack_on_run_failure_sensor(
     "#my_channel", os.getenv("MY_SLACK_TOKEN")
 )
@@ -97,6 +98,7 @@ from dagster import make_email_on_run_failure_sensor
 
 email_on_run_failure = make_email_on_run_failure_sensor(
     email_from="no-reply@example.com",
+    # type: ignore
     email_password=os.getenv("ALERT_EMAIL_PASSWORD"),
     email_to=["xxx@example.com", "xyz@example.com"],
 )
@@ -170,7 +172,10 @@ my_email_sensor(run_status_sensor_context)
 
 # end_run_status_sensor_testing_marker
 
-my_jobs = []
+from dagster._core.definitions.sensor_definition import SensorDefinition
+from typing import List
+
+my_jobs: List[SensorDefinition] = []
 
 # start_repo_marker
 from dagster import repository

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
@@ -83,10 +83,7 @@ my_email_failure_sensor(run_failure_sensor_context)
 # start_slack_marker
 from dagster_slack import make_slack_on_run_failure_sensor
 
-# type: ignore
-slack_on_run_failure = make_slack_on_run_failure_sensor(
-    "#my_channel", os.getenv("MY_SLACK_TOKEN")
-)
+slack_on_run_failure = make_slack_on_run_failure_sensor("#my_channel", os.getenv("MY_SLACK_TOKEN"))  # type: ignore[arg-type]
 
 
 # end_slack_marker
@@ -98,8 +95,7 @@ from dagster import make_email_on_run_failure_sensor
 
 email_on_run_failure = make_email_on_run_failure_sensor(
     email_from="no-reply@example.com",
-    # type: ignore
-    email_password=os.getenv("ALERT_EMAIL_PASSWORD"),
+    email_password=os.getenv("ALERT_EMAIL_PASSWORD"),  # type: ignore[arg-type]
     email_to=["xxx@example.com", "xyz@example.com"],
 )
 


### PR DESCRIPTION
## Summary

Docs snippets aren't always totally mypy compliant, but we don't want to dillute them with `casts` everywhere. This lets us mark specific lines of docs snippets to be ignored by mypy & have the linter filter them out when populating the actual docs page, so users don't see them.

#10136 turns mypy bk tests back on.

Changes one file as a demo.

## Test Plan

Tested locally.
