### PR TITLE
Make AssetKey.__eq__ more efficient

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -103,7 +103,12 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[List[str]])])):
     def __eq__(self, other):
         if not isinstance(other, AssetKey):
             return False
-        return self.to_string() == other.to_string()
+        if len(self.path) != len(other.path):
+            return False
+        for i in range(0, len(self.path)):
+            if self.path[i] != other.path[i]:
+                return False
+        return True
 
     def to_string(self, legacy: Optional[bool] = False) -> Optional[str]:
         """


### PR DESCRIPTION
### Summary & Motivation

Noticed another wasteful codepath in asset construction path. In this case the equality operator for AssetKey did an expensive equality step that invoked serialization without caching. When building dictionaries and similar activities this was very wasteful.

### How I Tested These Changes

Similar to previous change, did this on constructing 10000 asset.

```
from dagster import asset, repository


assets = []

for i in range(0, 10000):
    @asset(name=f"asset_{i}")
    def foo():
        pass

    assets.append(foo)

@repository
def large_repo():
    return assets
```

Before:

![Screen Shot 2022-10-21 at 2.58.21 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/53a5e381-4bf0-4817-a659-63f132949226/Screen%20Shot%202022-10-21%20at%202.58.21%20PM.png)

After:

![Screen Shot 2022-10-21 at 2 58 24 PM](https://user-images.githubusercontent.com/28738937/197270340-b483a222-0532-481c-ad7a-effee5ca7550.png)
