### PR TITLE
Clicking on top-level concept sections takes you to a page

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -79,6 +79,7 @@
     "children": [
       {
         "title": "Assets",
+        "path": "/concepts/assets/software-defined-assets",
         "children": [
           {
             "title": "Software-Defined Assets",
@@ -104,6 +105,7 @@
       },
       {
         "title": "Ops",
+        "path": "/concepts/ops-jobs-graphs/ops",
         "children": [
           {
             "title": "Ops",
@@ -125,6 +127,7 @@
       },
       {
         "title": "Graphs",
+        "path": "/concepts/ops-jobs-graphs/graphs",
         "children": [
           {
             "title": "Graphs",
@@ -142,6 +145,7 @@
       },
       {
         "title": "Jobs",
+        "path": "/concepts/ops-jobs-graphs/jobs",
         "children": [
           {
             "title": "Jobs",
@@ -184,6 +188,7 @@
       },
       {
         "title": "IO Management",
+        "path": "/concepts/io-management/io-managers",
         "children": [
           {
             "title": "IO Managers",
@@ -197,6 +202,7 @@
       },
       {
         "title": "Configuration",
+        "path": "/concepts/configuration/config-schema",
         "children": [
           {
             "title": "Run Configuration",
@@ -210,15 +216,11 @@
       },
       {
         "title": "Resources",
-        "children": [
-          {
-            "title": "Resources",
-            "path": "/concepts/resources"
-          }
-        ]
+        "path": "/concepts/resources"
       },
       {
         "title": "Code locations",
+        "path": "/concepts/code-locations",
         "children": [
           {
             "title": "Code locations",
@@ -249,12 +251,7 @@
       },
       {
         "title": "Dagster Types",
-        "children": [
-          {
-            "title": "Dagster Types",
-            "path": "/concepts/types"
-          }
-        ]
+        "path": "/concepts/types"
       },
       {
         "title": "Logging",
@@ -271,12 +268,7 @@
       },
       {
         "title": "Testing",
-        "children": [
-          {
-            "title": "Testing",
-            "path": "/concepts/testing"
-          }
-        ]
+        "path": "/concepts/testing"
       }
     ]
   },


### PR DESCRIPTION
### Summary & Motivation

This also removes a level of hierarchy for top-level concept sections that only have one subpage, like resources and dagster types

### How I Tested These Changes
