### PR TITLE
graph_asset and graph_multi_asset decorators

### DIFF
--- a/docs/content/concepts/assets/graph-backed-assets.mdx
+++ b/docs/content/concepts/assets/graph-backed-assets.mdx
@@ -5,29 +5,29 @@ description: Defining a software-defined asset with multiple discrete computatio
 
 # Graph-Backed Assets
 
-[Basic software-defined assets](/concepts/assets/software-defined-assets#a-basic-software-defined-asset) are computed using a single op. If generating an asset involves multiple discrete computations, you can use graph-backed assets by separating each computation into an op and building a graph to combine your computations. This allows you to launch re-executions of runs at the op boundaries but doesn't require you to link each intermediate value to an asset in persistent storage.
-
-Graph-backed assets are useful if you have an existing graph that produces and consumes assets. Wrapping your graph inside a software-defined asset gives you all the benefits of software-defined assets — like cross-job lineage — without requiring you to change the code inside your graph.
-
-Additionally, graph-backed assets allow you to reuse an existing op across other graph-backed assets and jobs, or within the same graph.
+[Basic software-defined assets](/concepts/assets/software-defined-assets#a-basic-software-defined-asset) are computed using a single op. If generating an asset involves multiple discrete computations, you can use graph-backed assets by separating each computation into an op and building a graph to combine your computations. This allows you to launch re-executions of runs at the op boundaries, but doesn't require you to link each intermediate value to an asset in persistent storage.
 
 ---
 
 ## Relevant APIs
 
-| Name                                                       | Description                                   |
-| ---------------------------------------------------------- | --------------------------------------------- |
-| <PyObject object="AssetsDefinition" method="from_graph" /> | Constructs an asset given a graph definition. |
+| Name                                                       | Description                                                                                                                                                              |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| <PyObject object="graph_asset" decorator />                | Decorator for defining an asset that's computed using a graph of ops. The dependencies between the ops are specified inside the body of the decorated function.          |
+| <PyObject object="graph_multi_asset" decorator />          | Decorator for defining a set of assets that are computed using a graph of ops. The dependencies between the ops are specified inside the body of the decorated function. |
+| <PyObject object="AssetsDefinition" method="from_graph" /> | Constructs an asset, given a graph definition. Useful if you have a single graph that you want to use to power multiple different assets.                                |
 
 ---
 
 ## Defining graph-backed assets
 
-To define a graph-backed asset, use the `from_graph` attribute on the <PyObject object="AssetsDefinition" /> object. The value returned from the graph that becomes the graph-backed asset will be stored in persistent storage as the asset:
+To define a graph-backed asset, use the <PyObject object="graph_asset" decorator /> decorator. The decorated function defines the dependencies between a set of ops, which are combined to compute the asset.
+
+In this case, when you tell Dagster to materialize the `slack_files_table` asset, Dagster will invoke `fetch_files_from_slack` and then invoke `store_files` after `fetch_files_from_slack` has completed.
 
 ```python file=/concepts/assets/graph_backed_asset.py startafter=start example endbefore=end example
 import pandas as pd
-from dagster import AssetsDefinition, graph, op
+from dagster import graph_asset, op
 
 
 @op(required_resource_keys={"slack"})
@@ -51,22 +51,19 @@ def store_files(files):
     return files.to_sql(name="slack_files", con=create_db_connection())
 
 
-@graph
-def store_slack_files_in_sql():
+@graph_asset
+def slack_files_table():
     return store_files(fetch_files_from_slack())
-
-
-graph_asset = AssetsDefinition.from_graph(store_slack_files_in_sql)
 ```
 
 ### Defining basic dependencies for graph-backed assets
 
-The `from_graph` attribute on the `AssetsDefinition` object infers upstream and downstream asset dependencies from the graph definition provided. In the most simple case when the graph returns a singular output, Dagster infers the name of the graph to be the outputted asset key.
+Similar to with basic software-defined assets, Dagster infers the upstream assets from the names of the arguments to the decorated function.
 
-In the example below, Dagster creates an asset with key `middle_asset` from the `middle_asset` graph. Just like assets defined via <PyObject object="asset" decorator />, each argument to the decorated graph function is an upstream asset name. `middle_asset` depends on `upstream_asset`, and `downstream_asset` depends on `middle_asset`:
+The example below includes an asset named `middle_asset`. `middle_asset` depends on `upstream_asset`, and `downstream_asset` depends on `middle_asset`:
 
 ```python file=/concepts/assets/graph_backed_asset.py startafter=start_basic_dependencies endbefore=end_basic_dependencies
-from dagster import AssetsDefinition, asset, graph
+from dagster import asset, graph_asset, op
 
 
 @asset
@@ -74,56 +71,40 @@ def upstream_asset():
     return 1
 
 
-@graph
+@op
+def add_one(input_num):
+    return input_num + 1
+
+
+@op
+def multiply_by_two(input_num):
+    return input_num * 2
+
+
+@graph_asset
 def middle_asset(upstream_asset):
-    return add_one(upstream_asset)
-
-
-middle_asset = AssetsDefinition.from_graph(middle_asset)
+    return multiply_by_two(add_one(upstream_asset))
 
 
 @asset
 def downstream_asset(middle_asset):
-    return middle_asset + 1
+    return middle_asset + 7
 ```
 
-When your graph returns multiple outputs, Dagster infers each output name to be the outputted asset key. In the below example, `two_assets_graph` accepts `upstream_asset` and outputs two assets, `first_asset` and `second_asset`:
+### Graph-backed multi-assets
+
+Using the <PyObject object="graph_multi_asset" decorator />, you can create a combined definition of multiple assets that are computed using the same graph of ops and same upstream assets.
+
+In the below example, `two_assets` accepts `upstream_asset` and outputs two assets, `first_asset` and `second_asset`:
 
 ```python file=/concepts/assets/graph_backed_asset.py startafter=start_basic_dependencies_2 endbefore=end_basic_dependencies_2
-from dagster import AssetsDefinition, GraphOut, graph
+from dagster import AssetOut, graph_multi_asset
 
 
-@graph(out={"first_asset": GraphOut(), "second_asset": GraphOut()})
-def two_assets_graph(upstream_asset):
+@graph_multi_asset(outs={"first_asset": AssetOut(), "second_asset": AssetOut()})
+def two_assets(upstream_asset):
     one, two = two_outputs(upstream_asset)
     return {"first_asset": one, "second_asset": two}
-
-
-two_assets = AssetsDefinition.from_graph(two_assets_graph)
-```
-
-### Defining explicit dependencies for graph-backed assets
-
-You can also define dependencies for graph-backed assets explicitly via the `asset_keys_by_input_name` and `asset_keys_by_output_name` arguments to `from_graph`:
-
-```python file=/concepts/assets/graph_backed_asset.py startafter=start_explicit_dependencies endbefore=end_explicit_dependencies
-from dagster import AssetsDefinition, GraphOut, graph
-
-
-@graph(out={"one": GraphOut(), "two": GraphOut()})
-def return_one_and_two(zero):
-    one, two = two_outputs(zero)
-    return {"one": one, "two": two}
-
-
-explicit_deps_asset = AssetsDefinition.from_graph(
-    return_one_and_two,
-    keys_by_input_name={"zero": AssetKey("upstream_asset")},
-    keys_by_output_name={
-        "one": AssetKey("asset_one"),
-        "two": AssetKey("asset_two"),
-    },
-)
 ```
 
 ### Advanced: Subsetting graph-backed assets
@@ -176,17 +157,16 @@ def baz(foo_2, bar_2):
     return foo_2 + bar_2
 
 
-@graph(out={"foo_asset": GraphOut(), "baz_asset": GraphOut()})
-def my_graph():
+@graph_multi_asset(
+    outs={"foo_asset": AssetOut(), "baz_asset": AssetOut()}, can_subset=True
+)
+def my_graph_assets():
     bar_1, bar_2 = bar()
     foo_1, foo_2 = foo(bar_1)
     return {"foo_asset": foo_1, "baz_asset": baz(foo_2, bar_2)}
 
 
-defs = Definitions(
-    assets=[AssetsDefinition.from_graph(my_graph, can_subset=True)],
-    jobs=[define_asset_job("graph_asset")],
-)
+defs = Definitions(assets=[my_graph_assets], jobs=[define_asset_job("graph_asset")])
 ```
 
 Depending on how outputs are returned from the ops within a graph-backed asset, there could be unexpected materializations. For example, the following `foo` implementation would unexpectedly materialize `foo_asset` if `baz_asset` was the only asset selected for execution.
@@ -198,7 +178,7 @@ def foo():
 
 
 # Will unexpectedly materialize foo_asset
-defs.get_job_def("graph_asset").execute_in_process(
+defs.get_job_def("my_graph_assets").execute_in_process(
     asset_selection=[AssetKey("baz_asset")]
 )
 ```

--- a/examples/docs_snippets/docs_snippets/concepts/assets/graph_backed_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/graph_backed_asset.py
@@ -17,7 +17,7 @@ def create_db_connection():
 
 # start example
 import pandas as pd
-from dagster import AssetsDefinition, graph, op
+from dagster import graph_asset, op
 
 
 @op(required_resource_keys={"slack"})
@@ -41,29 +41,22 @@ def store_files(files):
     return files.to_sql(name="slack_files", con=create_db_connection())
 
 
-@graph
-def store_slack_files_in_sql():
+@graph_asset
+def slack_files_table():
     return store_files(fetch_files_from_slack())
 
-
-graph_asset = AssetsDefinition.from_graph(store_slack_files_in_sql)
 
 # end example
 
 slack_mock = MagicMock()
 
 store_slack_files = define_asset_job(
-    "store_slack_files", selection=AssetSelection.assets(graph_asset)
+    "store_slack_files", selection=AssetSelection.assets(slack_files_table)
 )
 
 
-@op
-def add_one(input_num):
-    return input_num + 1
-
-
 # start_basic_dependencies
-from dagster import AssetsDefinition, asset, graph
+from dagster import asset, graph_asset, op
 
 
 @asset
@@ -71,24 +64,31 @@ def upstream_asset():
     return 1
 
 
-@graph
+@op
+def add_one(input_num):
+    return input_num + 1
+
+
+@op
+def multiply_by_two(input_num):
+    return input_num * 2
+
+
+@graph_asset
 def middle_asset(upstream_asset):
-    return add_one(upstream_asset)
-
-
-middle_asset = AssetsDefinition.from_graph(middle_asset)  # type: ignore
+    return multiply_by_two(add_one(upstream_asset))
 
 
 @asset
 def downstream_asset(middle_asset):
-    return middle_asset + 1
+    return middle_asset + 7
 
 
 # end_basic_dependencies
 
 basic_deps_job = define_asset_job(
     "basic_deps_job",
-    AssetSelection.assets(upstream_asset, middle_asset, downstream_asset),  # type: ignore
+    AssetSelection.assets(upstream_asset, middle_asset, downstream_asset),
 )
 
 
@@ -99,16 +99,14 @@ def two_outputs(upstream):
 
 
 # start_basic_dependencies_2
-from dagster import AssetsDefinition, GraphOut, graph
+from dagster import AssetOut, graph_multi_asset
 
 
-@graph(out={"first_asset": GraphOut(), "second_asset": GraphOut()})
-def two_assets_graph(upstream_asset):
+@graph_multi_asset(outs={"first_asset": AssetOut(), "second_asset": AssetOut()})
+def two_assets(upstream_asset):
     one, two = two_outputs(upstream_asset)
     return {"first_asset": one, "second_asset": two}
 
-
-two_assets = AssetsDefinition.from_graph(two_assets_graph)
 
 # end_basic_dependencies_2
 
@@ -117,28 +115,19 @@ second_basic_deps_job = define_asset_job(
 )
 
 # start_explicit_dependencies
-from dagster import AssetsDefinition, GraphOut, graph
+from dagster import AssetOut, graph_multi_asset
 
 
-@graph(out={"one": GraphOut(), "two": GraphOut()})
-def return_one_and_two(zero):
-    one, two = two_outputs(zero)
-    return {"one": one, "two": two}
+@graph_multi_asset(outs={"asset_one": AssetOut(), "asset_two": AssetOut()})
+def one_and_two(upstream_asset):
+    one, two = two_outputs(upstream_asset)
+    return {"asset_one": one, "asset_two": two}
 
-
-explicit_deps_asset = AssetsDefinition.from_graph(
-    return_one_and_two,
-    keys_by_input_name={"zero": AssetKey("upstream_asset")},
-    keys_by_output_name={
-        "one": AssetKey("asset_one"),
-        "two": AssetKey("asset_two"),
-    },
-)
 
 # end_explicit_dependencies
 
 explicit_deps_job = define_asset_job(
-    "explicit_deps_job", AssetSelection.assets(upstream_asset, explicit_deps_asset)
+    "explicit_deps_job", AssetSelection.assets(upstream_asset, one_and_two)
 )
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/subset_graph_backed_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/subset_graph_backed_asset.py
@@ -1,11 +1,10 @@
 from dagster import (
-    AssetsDefinition,
+    AssetOut,
     Definitions,
-    GraphOut,
     Out,
     Output,
     define_asset_job,
-    graph,
+    graph_multi_asset,
     op,
 )
 
@@ -35,16 +34,15 @@ def baz(foo_2, bar_2):
     return foo_2 + bar_2
 
 
-@graph(out={"foo_asset": GraphOut(), "baz_asset": GraphOut()})
-def my_graph():
+@graph_multi_asset(
+    outs={"foo_asset": AssetOut(), "baz_asset": AssetOut()}, can_subset=True
+)
+def my_graph_assets():
     bar_1, bar_2 = bar()
     foo_1, foo_2 = foo(bar_1)
     return {"foo_asset": foo_1, "baz_asset": baz(foo_2, bar_2)}
 
 
-defs = Definitions(
-    assets=[AssetsDefinition.from_graph(my_graph, can_subset=True)],
-    jobs=[define_asset_job("graph_asset")],
-)
+defs = Definitions(assets=[my_graph_assets], jobs=[define_asset_job("graph_asset")])
 
 # end_graph_backed_asset_example

--- a/examples/docs_snippets/docs_snippets/concepts/assets/subset_graph_backed_asset_unexpected_materializations.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/subset_graph_backed_asset_unexpected_materializations.py
@@ -10,7 +10,7 @@ def foo():
 
 
 # Will unexpectedly materialize foo_asset
-defs.get_job_def("graph_asset").execute_in_process(
+defs.get_job_def("my_graph_assets").execute_in_process(
     asset_selection=[AssetKey("baz_asset")]
 )
 # end_unexpected_materialization_foo

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -111,6 +111,7 @@ from dagster._core.definitions.config import ConfigMapping as ConfigMapping
 from dagster._core.definitions.configurable import configured as configured
 from dagster._core.definitions.decorators.asset_decorator import (
     asset as asset,
+    graph_asset as graph_asset,
     multi_asset as multi_asset,
 )
 from dagster._core.definitions.decorators.config_mapping_decorator import (

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -112,6 +112,7 @@ from dagster._core.definitions.configurable import configured as configured
 from dagster._core.definitions.decorators.asset_decorator import (
     asset as asset,
     graph_asset as graph_asset,
+    graph_multi_asset as graph_multi_asset,
     multi_asset as multi_asset,
 )
 from dagster._core.definitions.decorators.config_mapping_decorator import (

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -32,6 +32,7 @@ from dagster._utils.backcompat import (
 from ..asset_in import AssetIn
 from ..asset_out import AssetOut
 from ..assets import AssetsDefinition
+from ..decorators.graph_decorator import graph
 from ..decorators.op_decorator import _Op
 from ..events import AssetKey, CoercibleToAssetKeyPrefix
 from ..input import In
@@ -615,6 +616,133 @@ def build_asset_ins(
         ins_by_asset_key[asset_key] = (stringified_asset_key, In(cast(type, Nothing)))
 
     return ins_by_asset_key
+
+
+@overload
+def graph_asset(compose_fn: Callable) -> AssetsDefinition:
+    ...
+
+
+@overload
+def graph_asset(
+    *,
+    name: Optional[str] = None,
+    key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
+    ins: Optional[Mapping[str, AssetIn]] = None,
+    description: Optional[str] = None,
+    partitions_def: Optional[PartitionsDefinition] = None,
+    group_name: Optional[str] = None,
+) -> Callable[[Callable[..., Any]], AssetsDefinition]:
+    ...
+
+
+def graph_asset(
+    compose_fn: Optional[Callable] = None,
+    *,
+    name: Optional[str] = None,
+    key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
+    ins: Optional[Mapping[str, AssetIn]] = None,
+    description: Optional[str] = None,
+    partitions_def: Optional[PartitionsDefinition] = None,
+    group_name: Optional[str] = None,
+) -> Union[AssetsDefinition, Callable[[Callable[..., Any]], AssetsDefinition]]:
+    """
+    Creates a software-defined asset that's computed using a graph of ops.
+
+    This decorator is meant to decorate a function that composes a set of ops or graphs to define
+    the dependencies between them.
+
+    Args:
+        name (Optional[str]): The name of the asset.  If not provided, defaults to the name of the
+            decorated function. The asset's name must be a valid name in dagster (ie only contains
+            letters, numbers, and _) and may not contain python reserved keywords.
+        key_prefix (Optional[Union[str, Sequence[str]]]): If provided, the asset's key is the
+            concatenation of the key_prefix and the asset's name, which defaults to the name of
+            the decorated function. Each item in key_prefix must be a valid name in dagster (ie only
+            contains letters, numbers, and _) and may not contain python reserved keywords.
+        ins (Optional[Mapping[str, AssetIn]]): A dictionary that maps input names to information
+            about the input.
+        partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
+            compose the asset.
+        group_name (Optional[str]): A string name used to organize multiple assets into groups. If
+            not provided, the name "default" is used.
+
+    Examples:
+        .. code-block:: python
+
+            @op
+            def fetch_files_from_slack(context) -> pd.DataFrame:
+                ...
+
+            @op
+            def store_files_in_table(files) -> None:
+                files.to_sql(name="slack_files", con=create_db_connection())
+
+            @graph_asset
+            def slack_files_table():
+                return store_files(fetch_files_from_slack())
+    """
+    if compose_fn is not None:
+        return _GraphBackedAsset()(compose_fn)
+
+    def inner(fn: Callable[..., Any]) -> AssetsDefinition:
+        return _GraphBackedAsset(
+            name=cast(Optional[str], name),  # (mypy bug that it can't infer name is Optional[str])
+            key_prefix=key_prefix,
+            ins=ins,
+            description=description,
+            partitions_def=partitions_def,
+            group_name=group_name,
+        )(fn)
+
+    return inner
+
+
+class _GraphBackedAsset:
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
+        ins: Optional[Mapping[str, AssetIn]] = None,
+        description: Optional[str] = None,
+        partitions_def: Optional[PartitionsDefinition] = None,
+        group_name: Optional[str] = None,
+    ):
+        self.name = name
+
+        if isinstance(key_prefix, str):
+            key_prefix = [key_prefix]
+        self.key_prefix = key_prefix
+        self.ins = ins or {}
+        self.description = description
+        self.partitions_def = partitions_def
+        self.group_name = group_name
+
+    def __call__(self, fn: Callable) -> AssetsDefinition:
+        asset_name = self.name or fn.__name__
+        asset_ins = build_asset_ins(fn, self.ins or {}, set())
+        out_asset_key = AssetKey(list(filter(None, [*(self.key_prefix or []), asset_name])))
+
+        keys_by_input_name = {
+            input_name: asset_key for asset_key, (input_name, _) in asset_ins.items()
+        }
+        partition_mappings = {
+            input_name: asset_in.partition_mapping
+            for input_name, asset_in in self.ins.items()
+            if asset_in.partition_mapping
+        }
+
+        op_graph = graph(
+            name="__".join(out_asset_key.path).replace("-", "_"), description=self.description
+        )(fn)
+        return AssetsDefinition.from_graph(
+            op_graph,
+            keys_by_input_name=keys_by_input_name,
+            keys_by_output_name={"result": out_asset_key},
+            partitions_def=self.partitions_def,
+            partition_mappings=partition_mappings if partition_mappings else None,
+            group_name=self.group_name,
+        )
 
 
 def build_asset_outs(asset_outs: Mapping[str, AssetOut]) -> Mapping[AssetKey, Tuple[str, Out]]:


### PR DESCRIPTION
### Summary & Motivation

I was inspired to write this when I came across this example: https://docs.dagster.io/concepts/assets/graph-backed-assets#defining-basic-dependencies-for-graph-backed-assets.

I think `AssetsDefinition.from_graph` is useful in situations where someone has a general / reusable graph that they want to build assets from, but the decorators in this PR will be a lot more ergonomic in situations where someone has specific assets in mind when they define their graph.

This PR also updates the docs to focus primarily on the new decorators: [preview](https://dagster-git-graph-backed-asset-decorator-elementl.vercel.app/concepts/assets/graph-backed-assets).

### How I Tested These Changes

Added tests
