### PR TITLE
improve api doc examples for cloud object store IO managers

### DIFF
--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
@@ -110,23 +110,55 @@ def gcs_pickle_io_manager(init_context):
     `AssetKey(["one", "two", "three"])` would be stored in a file called "three" in a directory
     with path "/my/base/path/one/two/".
 
-    Attach this resource definition to your job to make it available to your ops.
+    Example usage:
+
+    1. Attach this IO manager to a set of assets.
 
     .. code-block:: python
 
-        @job(resource_defs={'io_manager': gcs_pickle_io_manager, 'gcs': gcs_resource, ...})
+        from dagster import asset, repository, with_resources
+        from dagster_gcp.gcs import gcs_pickle_io_manager, gcs_resource
+
+        @asset
+        def asset1():
+            # create df ...
+            return df
+
+        @asset
+        def asset2(asset1):
+            return df[:5]
+
+        @repository
+        def repo():
+            return with_resources(
+                [asset1, asset2],
+                resource_defs={
+                    "io_manager": gcs_pickle_io_manager.configured(
+                        {"gcs_bucket": "my-cool-bucket", "gcs_prefix": "my-cool-prefix"}
+                    ),
+                    "gcs": gcs_resource,
+                },
+            )
+        )
+
+
+    2. Attach this IO manager to your job to make it available to your ops.
+
+    .. code-block:: python
+
+        from dagster import job
+        from dagster_gcp.gcs import gcs_pickle_io_manager, gcs_resource
+
+        @job(
+            resource_defs={
+                "io_manager": gcs_pickle_io_manager.configured(
+                    {"gcs_bucket": "my-cool-bucket", "gcs_prefix": "my-cool-prefix"}
+                ),
+                "gcs": gcs_resource,
+            },
+        )
         def my_job():
-            my_op()
-
-    You may configure this storage as follows:
-
-    .. code-block:: YAML
-
-        resources:
-            io_manager:
-                config:
-                    gcs_bucket: my-cool-bucket
-                    gcs_prefix: good/prefix-for-files-
+            ...
     """
     client = init_context.resources.gcs
     pickled_io_manager = PickledObjectGCSIOManager(


### PR DESCRIPTION
### Summary & Motivation

- Demonstrate config via `configured` instead of a yaml blob
- Add imports
- Software-defined assets

### How I Tested These Changes
