### PR TITLE
docs: add h1 header to Dagster readme

### DIFF
--- a/python_modules/dagster/README.md
+++ b/python_modules/dagster/README.md
@@ -25,6 +25,8 @@
   <img src="https://img.shields.io/pypi/pyversions/dagster?labelColor=4F43DD&color=163B36">
 </p>
 
+# Dagster
+
 Dagster is an orchestrator that's designed for developing and maintaining data assets, such as tables, data sets, machine learning models, and reports.
 
 You declare functions that you want to run and the data assets that those functions produce or update. Dagster then helps you run your functions at the right time and keep your assets up-to-date.


### PR DESCRIPTION
### Summary & Motivation
Our search result on Google displays `dagster.io - GitHub`, rather than `Dagster - GitHub`.

![image](https://user-images.githubusercontent.com/16431325/197354911-d5a2ef13-1d37-4deb-b688-c5ee6d6d9438.png)

This is because we do not have an H1 header. Fix that.

### How I Tested These Changes
https://github.com/dagster-io/dagster/tree/rl/h1-dagster-readme/python_modules/dagster#readme
