### PR TITLE
Fix AssetsDefinition.with_prefix_or_group to update partition mappings

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -593,7 +593,10 @@ class AssetsDefinition(ResourceAddable):
             },
             node_def=self.node_def,
             partitions_def=self.partitions_def,
-            partition_mappings=self._partition_mappings,
+            partition_mappings={
+                input_asset_key_replacements.get(key, key): partition_mapping
+                for key, partition_mapping in self._partition_mappings.items()
+            },
             asset_deps={
                 # replace both the keys and the values in this mapping
                 output_asset_key_replacements.get(key, key): {


### PR DESCRIPTION
### Summary & Motivation

`AssetsDefinition.with_prefix_or_group` can be used to add a prefix or group to either the inputs or outputs of an assets definition.

Currently, partition mappings are not being updated when the inputs are renamed. Hence, after renaming an input from `A` to `B`, the partition mapping for A is lost.

This PR modifies `with_prefix_or_group` to rename the keys in `AssetsDefinition._partition_mappings`.


Notes:

- Should we also subset the partition mappings in [`AssetsDefinition.subset_for`](https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/_core/definitions/assets.py#L717) a bit further below? I haven't used this particular API myself, but it looks like it might unnecessarily include partition mappings for inputs that have not been selected. cc @clairelin135 

### How I Tested These Changes

- Added a unit test

cc @sryza 