### PR TITLE
Allow default io_manager load_input to support partitions of differing frequencies

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -145,7 +145,7 @@ class PickledObjectFilesystemIOManager(MemoizableIOManager):
 
         return os.path.join(self.base_dir, *path)
 
-    def _get_path_partition(self, asset_key: AssetKey, partition_key: str) -> str:
+    def _get_path_for_partition(self, asset_key: AssetKey, partition_key: str) -> str:
         """Construct filepath for a particular partition_key"""
         return os.path.join(self.base_dir, *asset_key.path, partition_key)
 
@@ -216,7 +216,7 @@ class PickledObjectFilesystemIOManager(MemoizableIOManager):
             # Multiple partition load
             partition_keys = context.asset_partition_keys
             paths = [
-                self._get_path_partition(context.asset_key, partition_key)
+                self._get_path_for_partition(context.asset_key, partition_key)
                 for partition_key in partition_keys
             ]
             return {key: self._load_pickle(path) for (key, path) in zip(partition_keys, paths)}

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -199,6 +199,24 @@ class PickledObjectFilesystemIOManager(MemoizableIOManager):
 
     def load_input(self, context):
         """Unpickle the file and Load it to a data object."""
+        if context.has_asset_partitions:
+            return [
+                self._load_pickle(self._partition_path(context.asset_key, partition_key))
+                for partition_key in context.asset_partition_keys
+            ]
+        else:
+            return self._load_input(context)
+
+    def _partition_path(self, asset_key, partition_key):
+        return os.path.join(self.base_dir, *asset_key.path, partition_key)
+
+    def _load_pickle(self, filepath):
+        with open(filepath, self.read_mode) as read_obj:
+            return pickle.load(read_obj)
+
+    def _load_input(self, context):
+        """Unpickle the file and Load it to a data object."""
+
         check.inst_param(context, "context", InputContext)
 
         if context.dagster_type.typing_type == type(None):

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -145,6 +145,10 @@ class PickledObjectFilesystemIOManager(MemoizableIOManager):
 
         return os.path.join(self.base_dir, *path)
 
+    def _get_path_partition(self, asset_key: AssetKey, partition_key: str) -> str:
+        """Construct filepath for a particular partition_key"""
+        return os.path.join(self.base_dir, *asset_key.path, partition_key)
+
     def has_output(self, context):
         filepath = self._get_path(context)
 
@@ -212,7 +216,7 @@ class PickledObjectFilesystemIOManager(MemoizableIOManager):
             # Multiple partition load
             partition_keys = context.asset_partition_keys
             paths = [
-                self._partition_path(context.asset_key, partition_key)
+                self._get_path_partition(context.asset_key, partition_key)
                 for partition_key in partition_keys
             ]
             return {key: self._load_pickle(path) for (key, path) in zip(partition_keys, paths)}
@@ -221,9 +225,6 @@ class PickledObjectFilesystemIOManager(MemoizableIOManager):
             filepath = self._get_path(context)
             context.add_input_metadata({"path": MetadataValue.path(os.path.abspath(filepath))})
             return self._load_pickle(filepath)
-
-    def _partition_path(self, asset_key: AssetKey, partition_key: str) -> str:
-        return os.path.join(self.base_dir, *asset_key.path, partition_key)
 
     def _load_pickle(self, filepath: str):
         """Unpickle the file and Load it to a data object."""

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -212,7 +212,11 @@ class PickledObjectFilesystemIOManager(MemoizableIOManager):
             key_range = context.asset_partition_key_range
             return key_range.start != key_range.end
 
-        if context.has_asset_partitions and has_multiple_partitions(context):
+        if (
+            context.has_input_name
+            and context.has_asset_partitions
+            and has_multiple_partitions(context)
+        ):
             # Multiple partition load
             partition_keys = context.asset_partition_keys
             paths = [

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -199,7 +199,6 @@ class PickledObjectFilesystemIOManager(MemoizableIOManager):
 
     def load_input(self, context):
         """Unpickle the file and Load it to a data object."""
-
         check.inst_param(context, "context", InputContext)
 
         if context.dagster_type.typing_type == type(None):

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partitioned_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partitioned_io_manager.py
@@ -1,0 +1,50 @@
+from dagster import (
+    asset,
+    AssetKey,
+    build_input_context,
+    build_output_context,
+    materialize,
+    DailyPartitionsDefinition,
+    HourlyPartitionsDefinition,
+)
+from pytest import fixture
+import datetime
+
+
+@fixture
+def start():
+    return datetime.datetime(2022, 1, 1)
+
+
+@fixture
+def hourly(start):
+    return HourlyPartitionsDefinition(start_date=f"{start:%Y-%m-%d-%H:%M}")
+
+
+@fixture
+def daily(start):
+    return DailyPartitionsDefinition(start_date=f"{start:%Y-%m-%d}")
+
+
+def test_partitioned_io_manager(hourly, daily):
+    @asset(partitions_def=hourly)
+    def hourly_asset():
+        return 42
+
+    @asset(partitions_def=daily)
+    def daily_asset(hourly_asset):
+        return hourly_asset
+
+    # Build hourly materializations
+    for hour in range(0, 24):
+        materialize(
+            [hourly_asset],
+            partition_key=f"2022-01-01-{hour:02d}:00",
+        )
+
+    # Materialize daily asset that depends on hourlies
+    result = materialize(
+        [*hourly_asset.to_source_assets(), daily_asset],
+        partition_key="2022-01-01",
+    )
+    assert result.output_for_node("daily_asset") == 24 * [42]

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partitioned_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partitioned_io_manager.py
@@ -3,13 +3,9 @@ import datetime
 from pytest import fixture
 
 from dagster import (
-    AssetKey,
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
     asset,
-    build_input_context,
-    build_op_context,
-    build_output_context,
     materialize,
 )
 

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partitioned_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partitioned_io_manager.py
@@ -2,12 +2,7 @@ import datetime
 
 from pytest import fixture
 
-from dagster import (
-    DailyPartitionsDefinition,
-    HourlyPartitionsDefinition,
-    asset,
-    materialize,
-)
+from dagster import DailyPartitionsDefinition, HourlyPartitionsDefinition, asset, materialize
 
 
 @fixture

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partitioned_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partitioned_io_manager.py
@@ -1,15 +1,17 @@
+import datetime
+
+from pytest import fixture
+
 from dagster import (
-    asset,
     AssetKey,
-    build_op_context,
-    build_input_context,
-    build_output_context,
-    materialize,
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    asset,
+    build_input_context,
+    build_op_context,
+    build_output_context,
+    materialize,
 )
-from pytest import fixture
-import datetime
 
 
 @fixture


### PR DESCRIPTION
### Summary & Motivation

The default `io_manager` raises an exception when a partitioned asset depends on a higher frequency partitioned asset, if the resulting `partition_key_range start !== end`. In the use case considered here a daily asset that depends on hourly assets would like to have access to all 24 hourly partitions. For example, to generate an asset that summarises the hourly values in some way, perhaps reports or statistics generation. 

Minor refactorings were carried out on the existing default IOManager to support partitioned assets explicitly, an improvement may be to continue the refactoring to abstract the path details away from the load/save logic.

Fixes #10120 

### How I Tested These Changes

I wrote a unit test that simulates the above use case. It recreated the error reported in the slack channel and simulated the situation using real materialisations. The "unit" test itself is probably more in the category of integration test and should be optimised to run faster (since it takes 6 seconds on my macbook).
