### PR TITLE
Make PythonPackages.get() more flexible to _/-

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/python_packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/python_packages.py
@@ -70,7 +70,11 @@ class PythonPackages:
         # We're inconsistent about whether we use dashes or undrescores and we
         # get away with it because pip converts all underscores to dashes. So
         # mimic that behavior.
-        return cls.all.get(name) or cls.all.get(name.replace("_", "-"))
+        return (
+            cls.all.get(name)
+            or cls.all.get(name.replace("_", "-"))
+            or cls.all.get(name.replace("-", "_"))
+        )
 
     @classmethod
     def walk_dependencies(cls, requirement: Requirement) -> Set[PythonPackage]:


### PR DESCRIPTION
Basically the same thing we already do, but in reverse. Since we remain very inconsistent about when we refer to a package with its dashes and when we refer to it with its underscores because pip generally treats the two as synonyms.