### PR TITLE
[dagster-dbt] allow missing run_results.json

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -455,6 +455,7 @@ class DbtCloudResourceV2:
             run_results = self.get_run_results(run_id)
         # if you fail to get run_results for this job, just leave it empty
         except Failure as _:
+            self._log.info("run_results.json not available for this run")
             run_results = {}
         output = DbtCloudOutput(run_details=final_run_details, result=run_results)
         if output.docs_url:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -451,7 +451,12 @@ class DbtCloudResourceV2:
         final_run_details = self.poll_run(
             run_id, poll_interval=poll_interval, poll_timeout=poll_timeout, href=href
         )
-        output = DbtCloudOutput(run_details=final_run_details, result=self.get_run_results(run_id))
+        try:
+            run_results = self.get_run_results(run_id)
+        # if you fail to get run_results for this job, just leave it empty
+        except Failure as _:
+            run_results = {}
+        output = DbtCloudOutput(run_details=final_run_details, result=run_results)
         if output.docs_url:
             self._log.info(f"Docs for this run can be viewed here: {output.docs_url}")
         return output

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -455,7 +455,9 @@ class DbtCloudResourceV2:
             run_results = self.get_run_results(run_id)
         # if you fail to get run_results for this job, just leave it empty
         except Failure as _:
-            self._log.info("run_results.json not available for this run")
+            self._log.info(
+                "run_results.json not available for this run. Defaulting to empty value."
+            )
             run_results = {}
         output = DbtCloudOutput(run_details=final_run_details, result=run_results)
         if output.docs_url:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/types.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/types.py
@@ -18,9 +18,9 @@ class DbtCloudOutput(DbtOutput):
     Attributes:
         run_details (Dict[str, Any]): The raw dictionary data representing the run details returned
             by the dbt Cloud API. For more info, see: https://docs.getdbt.com/dbt-cloud/api-v2#operation/getRunById
-        result (Optional[Dict[str, Any]]): Dictionary containing dbt-reported result information
+        result (Dict[str, Any]): Dictionary containing dbt-reported result information
             contained in run_results.json. Some dbt commands do not produce results, and will
-            therefore have result = None.
+            therefore have result = {}.
         job_id (int): The integer ID of the dbt Cloud job
         job_name (Optional[str]): The name of the dbt Cloud job (if present in the run details)
         run_id (int): The integer ID of the run that was initiated


### PR DESCRIPTION
### Summary & Motivation

Some dbt cloud jobs (ones which do not run "dbt run" or "dbt build" etc.) will not produce a run_results.json artifact. This will cause the step to fail.

This PR will allow run_results.json artifacts to be missing without failing the step.

### How I Tested These Changes
