### PR TITLE
UPathIOManager - filesystem-agnostic IOManager base

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from abc import abstractmethod
-from typing import Any, List, Union
+from typing import Any, List, Union, Dict
 
 from upath import UPath
 
@@ -13,6 +13,7 @@ from dagster import (
     MetadataValue,
     OutputContext,
     TimeWindowPartitionsDefinition,
+    AssetKey,
 )
 from dagster import _check as check
 
@@ -23,23 +24,13 @@ class UPathIOManagerBase(MemoizableIOManager):
     What it handles for the use:
      - working with any filesystem supported by `fsspec`
      - handling loading multiple upstream asset partitions via PartitionMapping
+     (returns a dictionary with mappings from partition_keys to loaded objects)
      - the `get_metadata` method can be customized to add additional metadata to the outputs
      - the `allow_missing_partitions: bool` metadata value can control
      either raising an error or skipping on missing partitions
     """
 
     extension: str = ""  # override in child class
-
-    def __init__(
-        self,
-        base_path: UPath,
-    ):
-        assert self.extension == "" or "." in self.extension
-
-        self._base_path = base_path
-
-    def has_output(self, context: OutputContext) -> bool:
-        return self.get_path(context).exists()
 
     @abstractmethod
     def dump_to_path(self, context: OutputContext, obj: Any, path: UPath):
@@ -71,7 +62,7 @@ class UPathIOManagerBase(MemoizableIOManager):
         ...
 
     @staticmethod
-    def get_metadata(context: OutputContext, obj: Any) -> dict[str, MetadataValue]:
+    def get_metadata(context: OutputContext, obj: Any) -> Dict[str, MetadataValue]:
         """
         Child classes should override this method to add custom metadata to the outputs.
 
@@ -84,26 +75,35 @@ class UPathIOManagerBase(MemoizableIOManager):
         """
         return {}
 
-    def get_path(self, context: InputContext | OutputContext) -> UPath:
+    def __init__(
+        self,
+        base_path: UPath,
+    ):
+        assert self.extension == "" or "." in self.extension
+
+        self._base_path = base_path
+
+    def has_output(self, context: OutputContext) -> bool:
+        return self._get_path(context).exists()
+
+    def _get_path(self, context: Union[InputContext, OutputContext]) -> UPath:
         if context.has_asset_key:
             # we are dealing with an asset
-            # filesystem-friendly string that is scoped to the start/end times of the data slice
             context_path = ["assets"] + list(context.asset_key.path)
 
             if context.has_asset_partitions:
                 # add partition
-                context_path = context_path + [context.asset_partition_key_range.start]
-
+                context_path += [context.partition_key]
         else:
-            # we are dealing with op output
+            # we are dealing with an op output
             context_path = ["runs"] + list(context.get_identifier())
 
         return self._base_path.joinpath(*context_path).with_suffix(self.extension)
 
-    def load_input(self, context: InputContext) -> Union[Any, List[Any]]:
+    def load_input(self, context: InputContext) -> Union[Any, Dict[str, Any]]:
         # In this load_input function, we vary the behavior based on the type of the downstream input
         # if the type is a List, we load a list of mapped partitions.
-        path = self.get_path(context)
+        path = self._get_path(context)
         assert context.metadata is not None
         allow_missing_partitions = context.metadata.get("allow_missing_partitions", False)
 
@@ -120,11 +120,11 @@ class UPathIOManagerBase(MemoizableIOManager):
             )
             return obj
 
-        # FIXME: use a custom PartitionsList type instead of List
+        # FIXME: use a custom PartitionsDict type instead of Dict
         elif (
             hasattr(context.dagster_type.typing_type, "__origin__")
-            and context.dagster_type.typing_type.__origin__ in (List, list)
-            and context.dagster_type.typing_type.__args__[0] == expected_type
+            and context.dagster_type.typing_type.__origin__ in (Dict, dict)
+            and context.dagster_type.typing_type.__args__[1] == expected_type
         ):
             # load multiple partitions
             if not context.has_asset_partitions:
@@ -135,26 +135,20 @@ class UPathIOManagerBase(MemoizableIOManager):
 
             base_dir: UPath = path.parent
 
-            # access the mapped partitions of the upstream asset
-            # this should be simplified in the future
-            partitions_def = context.asset_partitions_def
-            assert partitions_def is not None
-            assert isinstance(partitions_def, TimeWindowPartitionsDefinition)
-            partitions = partitions_def.get_partition_keys_in_range(
-                context.asset_partition_key_range
-            )
+            partition_keys = context.asset_partition_keys
 
-            context.log.debug(f"Loading {len(partitions)} partitions...")
+            context.log.debug(f"Loading {len(partition_keys)} partitions...")
 
-            objs: list[Any] = []
-            for partition in partitions:
-                path_with_partition = base_dir / f"{partition}{self.extension}"
+            objs: Dict[str, Any] = {}
+
+            for partition_key in partition_keys:
+                path_with_partition = base_dir / f"{partition_key}{self.extension}"
                 context.log.debug(
                     f"Loading partition from {path_with_partition} using {self.__class__.__name__}"
                 )
                 try:
                     obj = self.load_from_path(context=context, path=path_with_partition)
-                    objs.append(obj)
+                    objs[partition_key] = obj
                 except FileNotFoundError as e:
                     if not allow_missing_partitions:
                         raise e
@@ -166,11 +160,11 @@ class UPathIOManagerBase(MemoizableIOManager):
             return check.failed(
                 f"Inputs of type {context.dagster_type} are not supported. Expected {expected_type}. "
                 f"Please specify the correct type for this input either in the op signature, "
-                f"corresponding In or in the IOManager annotations."
+                f"corresponding In or in the {self.__class__.__name__}.dump_to_path type annotation."
             )
 
     def handle_output(self, context: OutputContext, obj: Any):
-        path = self.get_path(context)
+        path = self._get_path(context)
         path.parent.mkdir(parents=True, exist_ok=True)
         context.log.debug(f"Saving to {path} using {self.__class__.__name__}")
         self.dump_to_path(context=context, obj=obj, path=path)

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -8,8 +8,10 @@ from upath import UPath
 
 from dagster import InputContext, MemoizableIOManager, MetadataValue, OutputContext
 from dagster import _check as check
+from dagster._annotations import experimental
 
 
+@experimental
 class UPathIOManagerBase(MemoizableIOManager):
     """
     Abstract IOManager base class compatible with local and cloud storage via `fsspec` (using `universal-pathlib`).

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import inspect
+from abc import abstractmethod
+from typing import Any, List
+
+from upath import UPath
+
+from dagster import (
+    IOManager,
+    InputContext,
+    MemoizableIOManager,
+    MetadataValue,
+    OutputContext,
+    TimeWindowPartitionsDefinition,
+)
+from dagster import _check as check
+
+
+class UPathIOManager(MemoizableIOManager):
+    """
+    Abstract IOManager base class compatible with local and cloud storage via `fsspec` (using `iniversal-pathlib`).
+    """
+
+    extension: str = ""  # override in child class
+
+    def __init__(
+        self,
+        base_path: UPath,
+    ):
+        assert self.extension == "" or "." in self.extension
+
+        self._base_path = base_path
+
+    def has_output(self, context: OutputContext) -> bool:
+        return self.get_path(context).exists()
+
+    @abstractmethod
+    def serialize(self, obj: Any, path: UPath, context: OutputContext):
+        """
+        Child classes should override this method.
+        :param obj:
+        :param path:
+        :return:
+        """
+        ...
+
+    @abstractmethod
+    def deserialize(self, path: UPath, context: InputContext) -> Any:
+        """
+        Child classes should override this method.
+        The `context` argument can be used to control the IOManager behavior (via `context.metadata`).
+        :param path:
+        :param context:
+        :return:
+        """
+        ...
+
+    @staticmethod
+    def get_metadata(obj: Any, context: OutputContext) -> dict[str, MetadataValue]:
+        """
+        Child classes should override this method to add custom metadata to the outputs.
+        :param obj:
+        :param context:
+        :return:
+        """
+        return {}
+
+    def get_path(self, context: InputContext | OutputContext) -> UPath:
+        if context.has_asset_key:
+            # we are dealing with an asset
+            # filesystem-friendly string that is scoped to the start/end times of the data slice
+            context_path = ["assets"] + list(context.asset_key.path)
+
+            if context.has_asset_partitions:
+                # add partition
+                context_path = context_path + [context.asset_partition_key_range.start]
+
+        else:
+            # we are dealing with op output
+            context_path = ["runs"] + list(context.get_identifier())
+
+        return self._base_path.joinpath(*context_path).with_suffix(self.extension)
+
+    def load_input(self, context: InputContext) -> Any | list[Any]:
+        # In this load_input function, we vary the behavior based on the type of the downstream input
+        # if the type is a List, we load a list of mapped partitions.
+        path = self.get_path(context)
+        assert context.metadata is not None
+        allow_missing_partitions = context.metadata.get("allow_missing_partitions", False)
+
+        # unfortunately, this doesn't work for Python 3.7
+        # expected_type = inspect.get_annotations(self.serialize)["obj"]
+        expected_type = inspect.signature(self.serialize).parameters["obj"].annotation
+
+        if context.dagster_type.typing_type == expected_type:
+            context.log.debug(f"Loading from {path} using {self.__class__.__name__}")
+            obj = self.deserialize(path, context)
+            context.add_input_metadata(
+                {
+                    "path": MetadataValue.path(path),
+                }
+            )
+            return obj
+        elif context.dagster_type.typing_type == List[expected_type]:  # type: ignore
+            # load multiple partitions
+            if not context.has_asset_partitions:
+                raise TypeError(
+                    f"Detected {context.dagster_type.typing_type} input type "
+                    f"but the asset is not partitioned"
+                )
+
+            base_dir: UPath = path.parent
+
+            # access the mapped partitions of the upstream asset
+            # this should be simplified in the future
+            partitions_def = context.asset_partitions_def
+            assert partitions_def is not None
+            assert isinstance(partitions_def, TimeWindowPartitionsDefinition)
+            partitions = partitions_def.get_partition_keys_in_range(
+                context.asset_partition_key_range
+            )
+
+            context.log.debug(f"Loading {len(partitions)} partitions...")
+
+            objs: list[Any] = []
+            for partition in partitions:
+                path_with_partition = base_dir / f"{partition}{self.extension}"
+                context.log.debug(
+                    f"Loading partition from {path_with_partition} using {self.__class__.__name__}"
+                )
+                try:
+                    obj = self.deserialize(path_with_partition, context)
+                    objs.append(obj)
+                except FileNotFoundError as e:
+                    if not allow_missing_partitions:
+                        raise e
+                    context.log.debug(
+                        f"Couldn't load partition {path_with_partition} and skipped it"
+                    )
+            return objs
+        else:
+            return check.failed(
+                f"Inputs of type {context.dagster_type} not supported. Please specify "
+                "for this input either in the op signature, corresponding In or in the IOManager annotations."
+            )
+
+    def handle_output(self, context: OutputContext, obj: Any):
+        path = self.get_path(context)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        context.log.debug(f"Saving to {path} using {self.__class__.__name__}")
+        self.serialize(obj, path, context)
+
+        context.add_output_metadata(
+            {"path": MetadataValue.path(path), **self.get_metadata(obj, context)}
+        )

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -2,18 +2,18 @@ from __future__ import annotations
 
 import inspect
 from abc import abstractmethod
-from typing import Any, List, Union, Dict
+from typing import Any, Dict, List, Union
 
 from upath import UPath
 
 from dagster import (
+    AssetKey,
     IOManager,
     InputContext,
     MemoizableIOManager,
     MetadataValue,
     OutputContext,
     TimeWindowPartitionsDefinition,
-    AssetKey,
 )
 from dagster import _check as check
 

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -61,8 +61,7 @@ class UPathIOManagerBase(MemoizableIOManager):
         """
         ...
 
-    @staticmethod
-    def get_metadata(context: OutputContext, obj: Any) -> Dict[str, MetadataValue]:
+    def get_metadata(self, context: OutputContext, obj: Any) -> Dict[str, MetadataValue]:
         """
         Child classes should override this method to add custom metadata to the outputs.
 

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -40,7 +40,7 @@ class UPathIOManagerBase(MemoizableIOManager):
         Returns:
 
         """
-        ...
+        pass
 
     @abstractmethod
     def load_from_path(self, context: InputContext, path: UPath) -> Any:
@@ -54,9 +54,11 @@ class UPathIOManagerBase(MemoizableIOManager):
         Returns:
 
         """
-        ...
+        pass
 
-    def get_metadata(self, context: OutputContext, obj: Any) -> Dict[str, MetadataValue]:
+    def get_metadata(
+        self, context: OutputContext, obj: Any  # pylint: disable=unused-argument
+    ) -> Dict[str, MetadataValue]:
         """
         Child classes should override this method to add custom metadata to the outputs.
 

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -40,7 +40,7 @@ class UPathIOManagerBase(MemoizableIOManager):
         Returns:
 
         """
-        pass
+        pass  # pylint: disable=W0107
 
     @abstractmethod
     def load_from_path(self, context: InputContext, path: UPath) -> Any:
@@ -54,7 +54,7 @@ class UPathIOManagerBase(MemoizableIOManager):
         Returns:
 
         """
-        pass
+        pass  # pylint: disable=W0107
 
     def get_metadata(
         self, context: OutputContext, obj: Any  # pylint: disable=unused-argument

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -19,7 +19,7 @@ from dagster import _check as check
 
 class UPathIOManagerBase(MemoizableIOManager):
     """
-    Abstract IOManager base class compatible with local and cloud storage via `fsspec` (using `iniversal-pathlib`).
+    Abstract IOManager base class compatible with local and cloud storage via `fsspec` (using `universal-pathlib`).
     """
 
     extension: str = ""  # override in child class

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -12,7 +12,7 @@ from dagster._annotations import experimental
 
 
 @experimental
-class UPathIOManagerBase(MemoizableIOManager):
+class UPathIOManager(MemoizableIOManager):
     """
     Abstract IOManager base class compatible with local and cloud storage via `fsspec` (using `universal-pathlib`).
 
@@ -40,7 +40,6 @@ class UPathIOManagerBase(MemoizableIOManager):
         Returns:
 
         """
-        pass  # pylint: disable=W0107
 
     @abstractmethod
     def load_from_path(self, context: InputContext, path: UPath) -> Any:
@@ -54,7 +53,6 @@ class UPathIOManagerBase(MemoizableIOManager):
         Returns:
 
         """
-        pass  # pylint: disable=W0107
 
     def get_metadata(
         self, context: OutputContext, obj: Any  # pylint: disable=unused-argument

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -119,7 +119,8 @@ class UPathIOManagerBase(MemoizableIOManager):
             context
         ):
             return check.failed(
-                f"Received `{context.dagster_type.typing_type.__name__}` op/asset type annotation, "
+                f"Received `{context.dagster_type.typing_type.__name__}` type "
+                f"in input DagsterType {context.dagster_type}, "
                 f"but the input has multiple partitions. "
                 f"`Dict[str, {context.dagster_type.typing_type.__name__}]` should be used in this case."
             )
@@ -175,7 +176,8 @@ class UPathIOManagerBase(MemoizableIOManager):
             return objs
         else:
             return check.failed(
-                f"Received {context.dagster_type.typing_type} op/asset type annotation, "
+                f"Received `{context.dagster_type.typing_type.__name__}` type "
+                f"in input DagsterType {context.dagster_type}, "
                 f"but `{self.dump_to_path}` has {expected_type} type annotation. "
                 f"They should match."
             )

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -13,7 +13,8 @@ from dagster import _check as check
 class UPathIOManagerBase(MemoizableIOManager):
     """
     Abstract IOManager base class compatible with local and cloud storage via `fsspec` (using `universal-pathlib`).
-    What it handles for the use:
+
+    Features:
      - working with any filesystem supported by `fsspec`
      - handling loading multiple upstream asset partitions via PartitionMapping
      (returns a dictionary with mappings from partition_keys to loaded objects)

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -2,19 +2,11 @@ from __future__ import annotations
 
 import inspect
 from abc import abstractmethod
-from typing import Any, Dict, List, Union, Mapping
+from typing import Any, Dict, Mapping, Union
 
 from upath import UPath
 
-from dagster import (
-    AssetKey,
-    IOManager,
-    InputContext,
-    MemoizableIOManager,
-    MetadataValue,
-    OutputContext,
-    TimeWindowPartitionsDefinition,
-)
+from dagster import InputContext, MemoizableIOManager, MetadataValue, OutputContext
 from dagster import _check as check
 
 

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -89,10 +89,12 @@ class UPathIOManagerBase(MemoizableIOManager):
     def _get_path_without_extension(self, context: Union[InputContext, OutputContext]) -> UPath:
         if context.has_asset_key:
             # we are dealing with an asset
-            context_path = ["assets"] + list(context.asset_key.path)
+
+            # we are not using context.get_asset_identifier() because it already includes the partition_key
+            context_path = list(context.asset_key.path)
         else:
             # we are dealing with an op output
-            context_path = ["runs"] + list(context.get_identifier())
+            context_path = list(context.get_identifier())
 
         return self._base_path.joinpath(*context_path)
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
@@ -146,9 +146,7 @@ def test_upath_io_manager_multiple_static_partitions(dummy_io_manager: DummyIOMa
         return context.partition_key
 
     @asset(ins={"upstream_asset": AssetIn(partition_mapping=AllPartitionMapping())})
-    def downstream_asset(
-        upstream_asset: Dict[str, str]
-    ) -> Dict[str, str]:
+    def downstream_asset(upstream_asset: Dict[str, str]) -> Dict[str, str]:
         return upstream_asset
 
     my_job = build_assets_job(

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
@@ -1,7 +1,7 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
 import pytest
 from upath import UPath
@@ -100,8 +100,8 @@ def test_upath_io_manager_with_json(tmp_path: Path, json_data: Any):
     )
     manager.handle_output(context, json_data)
 
-    with manager._get_path(context).open("rb") as file:
-        assert json.loads(file.read()) == json_data
+    with manager._get_path(context).open("r") as file:  # pylint: disable=W0212
+        assert json.load(file) == json_data
 
     context = build_input_context(
         name="abc",
@@ -152,7 +152,7 @@ def test_upath_io_manager_multiple_static_partitions(dummy_io_manager: DummyIOMa
 
     @asset(ins={"upstream_asset": AssetIn(partition_mapping=AllPartitionMapping())})
     def downstream_asset(
-        context: OpExecutionContext, upstream_asset: Dict[str, str]
+        upstream_asset: Dict[str, str]
     ) -> Dict[str, str]:
         return upstream_asset
 
@@ -198,7 +198,7 @@ def test_user_forgot_dict_type_annotation_for_multiple_partitions(
     @asset(
         partitions_def=daily,
     )
-    def downstream_asset(context: OpExecutionContext, upstream_asset: str) -> str:
+    def downstream_asset(upstream_asset: str) -> str:
         return upstream_asset
 
     with pytest.raises(

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Dict
 
 import pandas
 import pendulum
@@ -66,7 +66,7 @@ def test_upath_io_manager_with_json(tmp_path: Path, json_data: Any):
     )
     manager.handle_output(context, json_data)
 
-    with manager.get_path(context).open("rb") as file:
+    with manager._get_path(context).open("rb") as file:
         assert json.loads(file.read()) == json_data
 
     context = build_input_context(
@@ -103,7 +103,9 @@ def test_upath_io_manager_multiple_partitions(tmp_path: Path):
     @asset(
         partitions_def=downstream_partitions_def,
     )
-    def downstream_asset(context: OpExecutionContext, upstream_asset: List[str]) -> List[str]:
+    def downstream_asset(
+        context: OpExecutionContext, upstream_asset: Dict[str, str]
+    ) -> Dict[str, str]:
         return upstream_asset
 
     # period = pendulum.period(pendulum.DateTime(2022, 1, 1), pendulum.DateTime(2022, 1, 2))

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
@@ -133,9 +133,7 @@ def test_upath_io_manager_multiple_time_partitions(
     @asset(
         partitions_def=daily,
     )
-    def downstream_asset(
-        context: OpExecutionContext, upstream_asset: Dict[str, str]
-    ) -> Dict[str, str]:
+    def downstream_asset(upstream_asset: Dict[str, str]) -> Dict[str, str]:
         return upstream_asset
 
     result = materialize(

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
@@ -77,12 +77,13 @@ def test_upath_io_manager_with_json(tmp_path: Path, json_data: Any):
         extension: str = ".json"
 
         def dump_to_path(self, context: OutputContext, obj: Any, path: UPath):
-            with path.open("wb") as file:
-                file.write(json.dumps(obj).encode())
+            with path.open("w") as file:
+                json.dump(obj, file)
+                # file.write(json.dumps(obj).encode())
 
         def load_from_path(self, context: InputContext, path: UPath) -> Any:
-            with path.open("rb") as file:
-                return json.loads(file.read())
+            with path.open("r") as file:
+                return json.load(file)
 
     @io_manager(config_schema={"base_path": Field(str, is_required=False)})
     def json_io_manager(init_context: InitResourceContext):

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, List, Optional, Dict
+from typing import Any, Dict, List, Optional
 
 import pandas
 import pendulum
@@ -36,6 +36,28 @@ from dagster import (
 )
 from dagster._core.definitions import AssetGroup, build_assets_job
 from dagster._core.storage.upath_io_manager import UPathIOManagerBase
+
+
+class DummyIOManager(UPathIOManagerBase):
+    def dump_to_path(self, obj: str, path: UPath, context: OutputContext):
+        return str(path)
+
+    def load_from_path(self, path: UPath, context: InputContext) -> str:
+        return str(path)
+
+
+@pytest.fixture
+def dummy_io_manager(tmp_path: Path) -> DummyIOManager:
+    @io_manager(config_schema={"base_path": Field(str, is_required=False)})
+    def dummy_io_manager(init_context: InitResourceContext):
+        base_path = UPath(
+            init_context.resource_config.get("base_path", init_context.instance.storage_directory())
+        )
+        return DummyIOManager(base_path=base_path)
+
+    io_manager_def = dummy_io_manager.configured({"base_path": str(tmp_path)})
+
+    return io_manager_def
 
 
 @pytest.mark.parametrize("json_data", [0, 0.0, [0, 1, 2], {"a": 0}, [{"a": 0}, {"b": 1}, {"c": 2}]])
@@ -77,22 +99,7 @@ def test_upath_io_manager_with_json(tmp_path: Path, json_data: Any):
     assert manager.load_input(context) == json_data
 
 
-def test_upath_io_manager_multiple_partitions(tmp_path: Path):
-    class DummyIOManager(UPathIOManagerBase):
-        def dump_to_path(self, obj: str, path: UPath, context: OutputContext):
-            return str(path)
-
-        def load_from_path(self, path: UPath, context: InputContext) -> str:
-            return str(path)
-
-    @io_manager(config_schema={"base_path": Field(str, is_required=False)})
-    def dummy_io_manager(init_context: InitResourceContext):
-        base_path = UPath(
-            init_context.resource_config.get("base_path", init_context.instance.storage_directory())
-        )
-        return DummyIOManager(base_path=base_path)
-
-    io_manager_def = dummy_io_manager.configured({"base_path": str(tmp_path)})
+def test_upath_io_manager_multiple_time_partitions(dummy_io_manager: DummyIOManager):
     upstream_partitions_def = HourlyPartitionsDefinition(start_date="2020-01-01-00:00")
     downstream_partitions_def = DailyPartitionsDefinition(start_date="2020-01-01")
 
@@ -120,8 +127,38 @@ def test_upath_io_manager_multiple_partitions(tmp_path: Path):
     result = materialize(
         [*upstream_asset.to_source_assets(), downstream_asset],
         partition_key="2022-01-01",
-        resources={"io_manager": io_manager_def},
+        resources={"io_manager": dummy_io_manager},
     )
     downstream_asset_data = result._get_output_for_handle("downstream_asset", "result")
     assert len(downstream_asset_data) == 24, "downstream day should map to upstream 24 hours"
     # assert downstream_asset_data == upstream_asset_datas
+
+
+def test_upath_io_manager_multiple_static_partitions(dummy_io_manager: DummyIOManager):
+    @io_manager(config_schema={"base_path": Field(str, is_required=False)})
+    def dummy_io_manager(init_context: InitResourceContext):
+        base_path = UPath(
+            init_context.resource_config.get("base_path", init_context.instance.storage_directory())
+        )
+        return DummyIOManager(base_path=base_path)
+
+    upstream_partitions_def = StaticPartitionsDefinition(["A", "B"])
+
+    @asset(partitions_def=upstream_partitions_def)
+    def upstream_asset(context: OpExecutionContext) -> str:
+        return context.partition_key
+
+    @asset(ins={"upstream_asset": AssetIn(partition_mapping=AllPartitionMapping())})
+    def downstream_asset(
+        context: OpExecutionContext, upstream_asset: Dict[str, str]
+    ) -> Dict[str, str]:
+        return upstream_asset
+
+    my_job = build_assets_job(
+        "my_job",
+        assets=[upstream_asset, downstream_asset],
+        resource_defs={"io_manager": dummy_io_manager},
+    )
+    result = my_job.execute_in_process(partition_key="A")
+    downstream_asset_data = result._get_output_for_handle("downstream_asset", "result")
+    assert list(downstream_asset_data.keys()) == ["A", "B"]

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
@@ -1,29 +1,46 @@
 import json
+from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, List, Optional
 
+import pandas
+import pendulum
 import pytest
 from upath import UPath
 
 from dagster import (
+    AllPartitionMapping,
+    AssetIn,
+    AssetKey,
+    AssetMaterialization,
     DagsterType,
+    DailyPartitionsDefinition,
     Field,
+    HourlyPartitionsDefinition,
     IOManager,
     InitResourceContext,
     InputContext,
+    OpExecutionContext,
     OutputContext,
+    PartitionKeyRange,
+    PartitionMapping,
+    PartitionsDefinition,
     PythonObjectDagsterType,
+    StaticPartitionsDefinition,
+    asset,
     build_init_resource_context,
     build_input_context,
     build_output_context,
     io_manager,
+    materialize,
 )
-from dagster._core.storage.upath_io_manager import UPathIOManager
+from dagster._core.definitions import AssetGroup, build_assets_job
+from dagster._core.storage.upath_io_manager import UPathIOManagerBase
 
 
 @pytest.mark.parametrize("json_data", [0, 0.0, [0, 1, 2], {"a": 0}, [{"a": 0}, {"b": 1}, {"c": 2}]])
 def test_upath_io_manager_with_json(tmp_path: Path, json_data: Any):
-    class JSONIOManager(UPathIOManager):
+    class JSONIOManager(UPathIOManagerBase):
         extension: str = ".json"
 
         def serialize(self, obj: Any, path: UPath, context: OutputContext):
@@ -58,3 +75,51 @@ def test_upath_io_manager_with_json(tmp_path: Path, json_data: Any):
         dagster_type=DagsterType(type_check_fn=lambda _, value: True, name="any", typing_type=Any),
     )
     assert manager.load_input(context) == json_data
+
+
+def test_upath_io_manager_multiple_partitions(tmp_path: Path):
+    class DummyIOManager(UPathIOManagerBase):
+        def serialize(self, obj: str, path: UPath, context: OutputContext):
+            return str(path)
+
+        def deserialize(self, path: UPath, context: InputContext) -> str:
+            return str(path)
+
+    @io_manager(config_schema={"base_path": Field(str, is_required=False)})
+    def dummy_io_manager(init_context: InitResourceContext):
+        base_path = UPath(
+            init_context.resource_config.get("base_path", init_context.instance.storage_directory())
+        )
+        return DummyIOManager(base_path=base_path)
+
+    io_manager_def = dummy_io_manager.configured({"base_path": str(tmp_path)})
+    upstream_partitions_def = HourlyPartitionsDefinition(start_date="2020-01-01-00:00")
+    downstream_partitions_def = DailyPartitionsDefinition(start_date="2020-01-01")
+
+    @asset(partitions_def=upstream_partitions_def)
+    def upstream_asset(context: OpExecutionContext) -> str:
+        return context.partition_key
+
+    @asset(
+        partitions_def=downstream_partitions_def,
+    )
+    def downstream_asset(context: OpExecutionContext, upstream_asset: List[str]) -> List[str]:
+        return upstream_asset
+
+    # period = pendulum.period(pendulum.DateTime(2022, 1, 1), pendulum.DateTime(2022, 1, 2))
+    #
+    # upstream_asset_datas = []
+    # for dt in period.range("hours", amount=24):
+    #     result = materialize([upstream_asset], partition_key=dt.strftime(upstream_partitions_def.fmt), resources={
+    #         "io_manager": io_manager_def
+    #     })
+    #     upstream_asset_datas.append(result._get_output_for_handle("upstream_asset", "result"))
+
+    result = materialize(
+        [*upstream_asset.to_source_assets(), downstream_asset],
+        partition_key="2022-01-01",
+        resources={"io_manager": io_manager_def},
+    )
+    downstream_asset_data = result._get_output_for_handle("downstream_asset", "result")
+    assert len(downstream_asset_data) == 24, "downstream day should map to upstream 24 hours"
+    # assert downstream_asset_data == upstream_asset_datas

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
@@ -35,10 +35,10 @@ class DummyIOManager(UPathIOManagerBase):
     This IOManager simply outputs the object path without loading or writing anything
     """
 
-    def dump_to_path(self, obj: str, path: UPath, context: OutputContext):
+    def dump_to_path(self, context: OutputContext, obj: str, path: UPath):
         pass
 
-    def load_from_path(self, path: UPath, context: InputContext) -> str:
+    def load_from_path(self, context: InputContext, path: UPath) -> str:
         return str(path)
 
 
@@ -76,11 +76,11 @@ def test_upath_io_manager_with_json(tmp_path: Path, json_data: Any):
     class JSONIOManager(UPathIOManagerBase):
         extension: str = ".json"
 
-        def dump_to_path(self, obj: Any, path: UPath, context: OutputContext):
+        def dump_to_path(self, context: OutputContext, obj: Any, path: UPath):
             with path.open("wb") as file:
                 file.write(json.dumps(obj).encode())
 
-        def load_from_path(self, path: UPath, context: InputContext) -> Any:
+        def load_from_path(self, context: InputContext, path: UPath) -> Any:
             with path.open("rb") as file:
                 return json.loads(file.read())
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
@@ -39,45 +39,6 @@ from dagster._core.storage.upath_io_manager import UPathIOManagerBase
 
 
 @pytest.mark.parametrize("json_data", [0, 0.0, [0, 1, 2], {"a": 0}, [{"a": 0}, {"b": 1}, {"c": 2}]])
-def test_upath_io_manager_raises_type_error(tmp_path: Path, json_data: Any):
-    class JSONIOManager(UPathIOManagerBase):
-        extension: str = ".json"
-
-        def dump_to_path(self, obj: Any, path: UPath, context: OutputContext):
-            with path.open("wb") as file:
-                file.write(json.dumps(obj).encode())
-
-        def load_from_path(self, path: UPath, context: InputContext) -> Any:
-            with path.open("rb") as file:
-                return json.loads(file.read())
-
-    @io_manager(config_schema={"base_path": Field(str, is_required=False)})
-    def json_io_manager(init_context: InitResourceContext):
-        base_path = UPath(
-            init_context.resource_config.get("base_path", init_context.instance.storage_directory())
-        )
-        return JSONIOManager(base_path=base_path)
-
-    manager = json_io_manager(build_init_resource_context(config={"base_path": str(tmp_path)}))
-    context = build_output_context(
-        name="abc",
-        step_key="123",
-        dagster_type=DagsterType(type_check_fn=lambda _, value: True, name="any", typing_type=Any),
-    )
-    manager.handle_output(context, json_data)
-
-    with manager.get_path(context).open("rb") as file:
-        assert json.loads(file.read()) == json_data
-
-    context = build_input_context(
-        name="abc",
-        upstream_output=context,
-        dagster_type=DagsterType(type_check_fn=lambda _, value: True, name="any", typing_type=Any),
-    )
-    assert manager.load_input(context) == json_data
-
-
-@pytest.mark.parametrize("json_data", [0, 0.0, [0, 1, 2], {"a": 0}, [{"a": 0}, {"b": 1}, {"c": 2}]])
 def test_upath_io_manager_with_json(tmp_path: Path, json_data: Any):
     class JSONIOManager(UPathIOManagerBase):
         extension: str = ".json"

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
@@ -39,15 +39,54 @@ from dagster._core.storage.upath_io_manager import UPathIOManagerBase
 
 
 @pytest.mark.parametrize("json_data", [0, 0.0, [0, 1, 2], {"a": 0}, [{"a": 0}, {"b": 1}, {"c": 2}]])
+def test_upath_io_manager_raises_type_error(tmp_path: Path, json_data: Any):
+    class JSONIOManager(UPathIOManagerBase):
+        extension: str = ".json"
+
+        def dump_to_path(self, obj: Any, path: UPath, context: OutputContext):
+            with path.open("wb") as file:
+                file.write(json.dumps(obj).encode())
+
+        def load_from_path(self, path: UPath, context: InputContext) -> Any:
+            with path.open("rb") as file:
+                return json.loads(file.read())
+
+    @io_manager(config_schema={"base_path": Field(str, is_required=False)})
+    def json_io_manager(init_context: InitResourceContext):
+        base_path = UPath(
+            init_context.resource_config.get("base_path", init_context.instance.storage_directory())
+        )
+        return JSONIOManager(base_path=base_path)
+
+    manager = json_io_manager(build_init_resource_context(config={"base_path": str(tmp_path)}))
+    context = build_output_context(
+        name="abc",
+        step_key="123",
+        dagster_type=DagsterType(type_check_fn=lambda _, value: True, name="any", typing_type=Any),
+    )
+    manager.handle_output(context, json_data)
+
+    with manager.get_path(context).open("rb") as file:
+        assert json.loads(file.read()) == json_data
+
+    context = build_input_context(
+        name="abc",
+        upstream_output=context,
+        dagster_type=DagsterType(type_check_fn=lambda _, value: True, name="any", typing_type=Any),
+    )
+    assert manager.load_input(context) == json_data
+
+
+@pytest.mark.parametrize("json_data", [0, 0.0, [0, 1, 2], {"a": 0}, [{"a": 0}, {"b": 1}, {"c": 2}]])
 def test_upath_io_manager_with_json(tmp_path: Path, json_data: Any):
     class JSONIOManager(UPathIOManagerBase):
         extension: str = ".json"
 
-        def serialize(self, obj: Any, path: UPath, context: OutputContext):
+        def dump_to_path(self, obj: Any, path: UPath, context: OutputContext):
             with path.open("wb") as file:
                 file.write(json.dumps(obj).encode())
 
-        def deserialize(self, path: UPath, context: InputContext) -> Any:
+        def load_from_path(self, path: UPath, context: InputContext) -> Any:
             with path.open("rb") as file:
                 return json.loads(file.read())
 
@@ -79,10 +118,10 @@ def test_upath_io_manager_with_json(tmp_path: Path, json_data: Any):
 
 def test_upath_io_manager_multiple_partitions(tmp_path: Path):
     class DummyIOManager(UPathIOManagerBase):
-        def serialize(self, obj: str, path: UPath, context: OutputContext):
+        def dump_to_path(self, obj: str, path: UPath, context: OutputContext):
             return str(path)
 
-        def deserialize(self, path: UPath, context: InputContext) -> str:
+        def load_from_path(self, path: UPath, context: InputContext) -> str:
             return str(path)
 
     @io_manager(config_schema={"base_path": Field(str, is_required=False)})

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
@@ -3,30 +3,20 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import pandas
-import pendulum
 import pytest
 from upath import UPath
 
-from dagster._check import CheckError
 from dagster import (
     AllPartitionMapping,
     AssetIn,
-    AssetKey,
-    AssetMaterialization,
     DagsterType,
     DailyPartitionsDefinition,
     Field,
     HourlyPartitionsDefinition,
-    IOManager,
     InitResourceContext,
     InputContext,
     OpExecutionContext,
     OutputContext,
-    PartitionKeyRange,
-    PartitionMapping,
-    PartitionsDefinition,
-    PythonObjectDagsterType,
     StaticPartitionsDefinition,
     asset,
     build_init_resource_context,
@@ -34,9 +24,9 @@ from dagster import (
     build_output_context,
     io_manager,
     materialize,
-    DagsterInvariantViolationError,
 )
-from dagster._core.definitions import AssetGroup, build_assets_job
+from dagster._check import CheckError
+from dagster._core.definitions import build_assets_job
 from dagster._core.storage.upath_io_manager import UPathIOManagerBase
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
@@ -214,7 +214,7 @@ def test_user_forgot_dict_type_annotation_for_multiple_partitions(
 
     with pytest.raises(
         CheckError,
-        match=r"Failure condition: Received .* op/asset type annotation, "
+        match=r"Failure condition: Received .*"
         "but the input has multiple partitions. .* should be used in this case.",
     ):
         materialize(

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from upath import UPath
+
+from dagster import (
+    DagsterType,
+    Field,
+    IOManager,
+    InitResourceContext,
+    InputContext,
+    OutputContext,
+    PythonObjectDagsterType,
+    build_init_resource_context,
+    build_input_context,
+    build_output_context,
+    io_manager,
+)
+from dagster._core.storage.upath_io_manager import UPathIOManager
+
+
+@pytest.mark.parametrize("json_data", [0, 0.0, [0, 1, 2], {"a": 0}, [{"a": 0}, {"b": 1}, {"c": 2}]])
+def test_upath_io_manager_with_json(tmp_path: Path, json_data: Any):
+    class JSONIOManager(UPathIOManager):
+        extension: str = ".json"
+
+        def serialize(self, obj: Any, path: UPath, context: OutputContext):
+            with path.open("wb") as file:
+                file.write(json.dumps(obj).encode())
+
+        def deserialize(self, path: UPath, context: InputContext) -> Any:
+            with path.open("rb") as file:
+                return json.loads(file.read())
+
+    @io_manager(config_schema={"base_path": Field(str, is_required=False)})
+    def json_io_manager(init_context: InitResourceContext):
+        base_path = UPath(
+            init_context.resource_config.get("base_path", init_context.instance.storage_directory())
+        )
+        return JSONIOManager(base_path=base_path)
+
+    manager = json_io_manager(build_init_resource_context(config={"base_path": str(tmp_path)}))
+    context = build_output_context(
+        name="abc",
+        step_key="123",
+        dagster_type=DagsterType(type_check_fn=lambda _, value: True, name="any", typing_type=Any),
+    )
+    manager.handle_output(context, json_data)
+
+    with manager.get_path(context).open("rb") as file:
+        assert json.loads(file.read()) == json_data
+
+    context = build_input_context(
+        name="abc",
+        upstream_output=context,
+        dagster_type=DagsterType(type_check_fn=lambda _, value: True, name="any", typing_type=Any),
+    )
+    assert manager.load_input(context) == json_data

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -79,6 +79,7 @@ setup(
         # https://github.com/mhammond/pywin32/issues/1439
         'pywin32 != 226; platform_system=="Windows"',
         "docstring-parser",
+        "universal_pathlib",
     ],
     extras_require={
         "docker": ["docker"],


### PR DESCRIPTION
### Summary & Motivation
Currently Dagster's fs_io_manager isn't compatible with filesystems other than local. This is an attempt to add a new IOManager base, that would be compatible with cloud storages via `universal_pathlib` (and internally `fsspec`). 

The new `UPathIOManager` class also handles other stuff like loading multiple asset partitions via partition mapping.
It already specifies the `load_input` and `handle_output` for the user, but requires to specify a specific implementation for `dump_to_path` and `load_from_path`. These implementations, however, will be fs-agnostic, which is a big improvement!

### How I Tested These Changes
Added tests for:
 - JSONIOManager
 - loading multiple partitions for static and time-based partitions
 - preserving single partition dependency
  
Probably will need integration tests for S3, GCS, etc. 