### PR TITLE
add cpu and memory to DagsterEcsTaskDefinitionConfig

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
@@ -23,6 +23,8 @@ class DagsterEcsTaskDefinitionConfig(
             ("task_role_arn", Optional[str]),
             ("sidecars", List[Dict[str, Any]]),
             ("requires_compatibilities", List[str]),
+            ("cpu", str),
+            ("memory", str),
         ],
     )
 ):
@@ -42,6 +44,8 @@ class DagsterEcsTaskDefinitionConfig(
         task_role_arn: Optional[str],
         sidecars: Optional[List[Dict[str, Any]]],
         requires_compatibilities: Optional[List[str]],
+        cpu: Optional[str] = None,
+        memory: Optional[str] = None,
     ):
         return super(DagsterEcsTaskDefinitionConfig, cls).__new__(
             cls,
@@ -56,6 +60,8 @@ class DagsterEcsTaskDefinitionConfig(
             check.opt_str_param(task_role_arn, "task_role_arn"),
             check.opt_list_param(sidecars, "sidecars"),
             check.opt_list_param(requires_compatibilities, "requires_compatibilities"),
+            check.opt_str_param(cpu, "cpu", default="256"),
+            check.opt_str_param(memory, "memory", default="512"),
         )
 
     def task_definition_dict(self):
@@ -80,9 +86,8 @@ class DagsterEcsTaskDefinitionConfig(
                 ),
                 *self.sidecars,
             ],
-            # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
-            cpu="256",
-            memory="512",
+            cpu=self.cpu,
+            memory=self.memory,
         )
 
         if self.execution_role_arn:
@@ -125,6 +130,8 @@ class DagsterEcsTaskDefinitionConfig(
             task_role_arn=task_definition_dict.get("taskRoleArn"),
             sidecars=sidecars,
             requires_compatibilities=task_definition_dict.get("requiresCompatibilities"),
+            cpu=task_definition_dict.get("cpu"),
+            memory=task_definition_dict.get("memory"),
         )
 
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_tasks.py
@@ -74,3 +74,8 @@ def test_create_dagster_task_definition_dict():
         "memory": "512",
         "taskRoleArn": "fake-task-role",
     }
+
+    new_cpu_mem = task_config._replace(cpu="512", memory="1024")
+
+    assert new_cpu_mem.task_definition_dict()["cpu"] == "512"
+    assert new_cpu_mem.task_definition_dict()["memory"] == "1024"


### PR DESCRIPTION
Summary:
This opens the door to being able to configure ecs task memory/cpu for services using DagsterEcsTaskDefinitionConfig.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
