### PR TITLE
Override default io manager in more places

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_group.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_group.py
@@ -25,13 +25,12 @@ from dagster._core.errors import (
     DagsterUnmetExecutorRequirementsError,
 )
 from dagster._core.selector.subset_selector import AssetSelectionData
-from dagster._core.storage.fs_io_manager import fs_io_manager
 from dagster._utils import merge_dicts
 
 from .asset_layer import build_asset_selection_job
 from .assets import AssetsDefinition
 from .assets_job import check_resources_satisfy_requirements
-from .job_definition import JobDefinition
+from .job_definition import JobDefinition, default_job_io_manager_with_fs_io_manager_schema
 from .load_assets_from_modules import (
     assets_and_source_assets_from_modules,
     assets_and_source_assets_from_package_module,
@@ -114,7 +113,10 @@ class AssetGroup:
         resource_defs = check.opt_mapping_param(
             resource_defs, "resource_defs", key_type=str, value_type=ResourceDefinition
         )
-        resource_defs = merge_dicts({DEFAULT_IO_MANAGER_KEY: fs_io_manager}, resource_defs)
+        resource_defs = merge_dicts(
+            {DEFAULT_IO_MANAGER_KEY: default_job_io_manager_with_fs_io_manager_schema},
+            resource_defs,
+        )
         executor_def = check.opt_inst_param(executor_def, "executor_def", ExecutorDefinition)
 
         check_resources_satisfy_requirements(assets, source_assets, resource_defs)

--- a/python_modules/dagster/dagster/_core/definitions/materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/materialize.py
@@ -7,11 +7,11 @@ from dagster._utils.backcompat import ExperimentalWarning
 
 from ..errors import DagsterInvariantViolationError
 from ..instance import DagsterInstance
-from ..storage.fs_io_manager import fs_io_manager
 from ..storage.io_manager import IOManagerDefinition
 from ..storage.mem_io_manager import mem_io_manager
 from .assets import AssetsDefinition
 from .assets_job import build_assets_job
+from .job_definition import default_job_io_manager_with_fs_io_manager_schema
 from .source_asset import SourceAsset
 from .utils import DEFAULT_IO_MANAGER_KEY
 
@@ -55,7 +55,9 @@ def materialize(
     partition_key = check.opt_str_param(partition_key, "partition_key")
     resources = check.opt_mapping_param(resources, "resources", key_type=str)
     resource_defs = wrap_resources_for_execution(resources)
-    resource_defs = merge_dicts({DEFAULT_IO_MANAGER_KEY: fs_io_manager}, resource_defs)
+    resource_defs = merge_dicts(
+        {DEFAULT_IO_MANAGER_KEY: default_job_io_manager_with_fs_io_manager_schema}, resource_defs
+    )
 
     with warnings.catch_warnings():
         warnings.filterwarnings(

--- a/python_modules/dagster/dagster/_core/execution/with_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/with_resources.py
@@ -67,14 +67,18 @@ def with_resources(
 
     """
     from dagster._config import validate_config
-    from dagster._core.storage.fs_io_manager import fs_io_manager
+    from dagster._core.definitions.job_definition import (
+        default_job_io_manager_with_fs_io_manager_schema,
+    )
 
     check.mapping_param(resource_defs, "resource_defs")
     resource_config_by_key = check.opt_mapping_param(
         resource_config_by_key, "resource_config_by_key"
     )
 
-    resource_defs = merge_dicts({DEFAULT_IO_MANAGER_KEY: fs_io_manager}, resource_defs)
+    resource_defs = merge_dicts(
+        {DEFAULT_IO_MANAGER_KEY: default_job_io_manager_with_fs_io_manager_schema}, resource_defs
+    )
 
     for key, resource_def in resource_defs.items():
         if key in resource_config_by_key:

--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -4,6 +4,9 @@ from typing import Dict, Mapping, Optional, Type, cast
 from dagster._annotations import public
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
+from dagster._core.definitions.job_definition import (
+    default_job_io_manager_with_fs_io_manager_schema,
+)
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster._core.execution.build_resources import build_resources, get_mapped_resource_config
@@ -13,7 +16,6 @@ from dagster._core.instance import DagsterInstance, is_dagster_home_set
 from dagster._core.types.dagster_type import resolve_dagster_type
 from dagster._utils import merge_dicts
 
-from .fs_io_manager import fs_io_manager
 from .io_manager import IOManager
 
 
@@ -80,7 +82,8 @@ class AssetValueLoader:
 
         assets_def = self._assets_defs_by_key[asset_key]
         resource_defs = merge_dicts(
-            {DEFAULT_IO_MANAGER_KEY: fs_io_manager}, assets_def.resource_defs
+            {DEFAULT_IO_MANAGER_KEY: default_job_io_manager_with_fs_io_manager_schema},
+            assets_def.resource_defs,
         )
         io_manager_key = assets_def.get_io_manager_key_for_asset_key(asset_key)
         io_manager_def = resource_defs[io_manager_key]

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_default_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_default_io_manager.py
@@ -36,12 +36,13 @@ def test_default_io_manager(instance):
 
 
 class FooIoManager(PickledObjectFilesystemIOManager):
-    def __init__(self):
+    def __init__(self, ctx):
         super().__init__(base_dir="/tmp/dagster/foo-io-manager")
+        assert ctx.instance
 
 
 foo_io_manager_def = IOManagerDefinition(
-    resource_fn=lambda _: FooIoManager(),
+    resource_fn=lambda ctx: FooIoManager(ctx),
     config_schema={},
 )
 


### PR DESCRIPTION
https://github.com/dagster-io/dagster/commit/064a376cde2017448e3e11f2352c0c510c3c9284

Doesn't seem to be applying to asset jobs. It was tested with `define_asset_job` but I guess these use different pathways?