### PR TITLE
Mark celery-k8s-test-suite as flaky

### DIFF
--- a/integration_tests/test_suites/celery-k8s-test-suite/tests/test_daemon_scheduler.py
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tests/test_daemon_scheduler.py
@@ -1,5 +1,6 @@
 import time
 
+import pytest
 from dagster_test.test_project import (
     ReOriginatedExternalScheduleForTest,
     get_test_project_external_schedule,
@@ -11,6 +12,7 @@ from dagster._core.test_utils import poll_for_finished_run
 
 
 @mark_daemon
+@pytest.mark.flaky(reruns=2)
 def test_execute_schedule_on_celery_k8s(  # pylint: disable=redefined-outer-name, disable=unused-argument
     dagster_instance_for_daemon, helm_namespace_for_daemon
 ):

--- a/integration_tests/test_suites/celery-k8s-test-suite/tests/test_queued_run_coordinator.py
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tests/test_queued_run_coordinator.py
@@ -1,5 +1,6 @@
 import os
 
+import pytest
 from dagster_k8s.test import wait_for_job_and_get_raw_logs
 from dagster_k8s_test_infra.integration_utils import image_pull_policy, launch_run_over_graphql
 from dagster_test.test_project import get_test_project_environments_path
@@ -32,6 +33,7 @@ def assert_events_in_order(logs, expected_events):
 
 
 @mark_daemon
+@pytest.mark.flaky(reruns=2)
 def test_execute_queued_run_on_celery_k8s(  # pylint: disable=redefined-outer-name
     dagster_docker_image,
     dagster_instance_for_daemon,


### PR DESCRIPTION
We already install https://github.com/pytest-dev/pytest-rerunfailures but we don't use it. I'm curious if rerunning a single test via PyTest (instead of rerunning the entire test suite via Buildkite) will make this fail builds less frequently until we manage to make it less flaky.