### PR TITLE
Extend default timeout

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
@@ -6,7 +6,7 @@ from .images.versions import BUILDKITE_TEST_IMAGE_VERSION
 from .python_version import AvailablePythonVersion
 from .utils import CommandStep, message_contains, safe_getenv
 
-DEFAULT_TIMEOUT_IN_MIN = 20
+DEFAULT_TIMEOUT_IN_MIN = 25
 
 DOCKER_PLUGIN = "docker#v3.7.0"
 ECR_PLUGIN = "ecr#v2.2.0"


### PR DESCRIPTION
A lot of our builds run long because test suites hit their 20 minute timeout and re-run from the beginning.

This timeout is for the buildkite step - not the actual tests. So all of the Docker pulling, tox setup, etc. counts againt our total.

I'd like to extend this global timeout while I investigate:

  - shortening the amount of pre-work that needs to happen in each step
  - speeding up/breaking apart our longest running test suites

Anecodtally, many timeouts happen when we're > 90% done with the tests so I think a few more minutes mightly drastically reduce the number of Buildkite retries (and consequently, the length of most builds).
