### PR TITLE
Run core tests in parallel

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -296,12 +296,8 @@ class PackageSpec(
             return None
 
         for change in ChangedFiles.all:
-            if (
-                # Our change is in this package's directory
-                (Path(self.directory) in change.parents)
-                # The file can alter behavior - exclude things like README changes
-                and (change.suffix in [".py", ".cfg", ".toml"] or change.name == "requirements.txt")
-            ):
+            # Our change is in this package's directory
+            if Path(self.directory) in change.parents:
                 logging.info(f"Building {self.name} because it has changed")
                 return None
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/python_packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/python_packages.py
@@ -135,7 +135,7 @@ class PythonPackages:
                     # Our change is in this package's directory
                     (change in package.directory.rglob("*"))
                     # The file can alter behavior - exclude things like README changes
-                    and (change.suffix in [".py", ".cfg", ".toml"])
+                    and (change.suffix in [".py", ".cfg", ".toml", ".ini"])
                     # The file is not part of a test suite. We treat this differently
                     # because we don't want to run tests in dependent packages
                 ):

--- a/.buildkite/dagster-buildkite/dagster_buildkite/python_packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/python_packages.py
@@ -135,7 +135,7 @@ class PythonPackages:
                     # Our change is in this package's directory
                     (change in package.directory.rglob("*"))
                     # The file can alter behavior - exclude things like README changes
-                    and (change.suffix in [".py", ".cfg", ".toml", ".ini"])
+                    and (change.suffix in [".py", ".cfg", ".toml"])
                     # The file is not part of a test suite. We treat this differently
                     # because we don't want to run tests in dependent packages
                 ):

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -23,7 +23,7 @@ commands =
 
   api_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/api_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
   cli_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/cli_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
-  core_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
+  core_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests -n auto --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
   definitions_tests_old_pendulum: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests/definitions_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
   core_tests_old_sqlalchemy: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}
   daemon_sensor_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/daemon_sensor_tests --junitxml=test_results.xml {env:COVERAGE_ARGS} --durations 10 {posargs}


### PR DESCRIPTION
We frequently time out when running our core tests. I have low hopes of this working, but I'm curious if pytest-xdist can successfully parallelize the test suite without any additional work from us.