### PR TITLE
Parse HEAD commit in addition to BUILDKITE_MESSAGE

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/git.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/git.py
@@ -10,6 +10,14 @@ def get_commit(rev):
     return subprocess.check_output(["git", "rev-parse", "--short", rev]).decode("utf-8").strip()
 
 
+def get_commit_message(rev):
+    return (
+        subprocess.check_output(["git", "rev-list", "--format=%B", "--max-count=1", rev])
+        .decode("utf-8")
+        .strip()
+    )
+
+
 @dataclass
 class GitInfo:
     directory: Path

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -218,7 +218,10 @@ def skip_coverage_if_feature_branch():
 
 
 def message_contains(substring: str) -> bool:
-    return any(substring in [os.getenv("BUILDKITE_MESSAGE", ""), get_commit_message("HEAD")])
+    return any(
+        substring in message
+        for message in [os.getenv("BUILDKITE_MESSAGE", ""), get_commit_message("HEAD")]
+    )
 
 
 def skip_if_no_docs_changes():

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Union
 
 import packaging.version
 import yaml
-from dagster_buildkite.git import ChangedFiles
+from dagster_buildkite.git import ChangedFiles, get_commit_message
 from typing_extensions import Literal, TypeAlias, TypedDict
 
 BUILD_CREATOR_EMAIL_TO_SLACK_CHANNEL_MAP = {
@@ -218,7 +218,7 @@ def skip_coverage_if_feature_branch():
 
 
 def message_contains(substring: str) -> bool:
-    return substring in os.getenv("BUILDKITE_MESSAGE", "")
+    return any(substring in [os.getenv("BUILDKITE_MESSAGE", ""), get_commit_message("HEAD")])
 
 
 def skip_if_no_docs_changes():


### PR DESCRIPTION
It looks like when you trigger a build by opening a PR, BUILDKITE_MESSAGE is the PR title and not the body of the latest commit.

Subsequent commits set BUILDKITE_MESSAGE to the commit message.

This means if you want to use any of our substring tooling to configure buildkite (NO_SKIP=true, etc.), you need to either include it in your title of your PR or you need to add a second commit.

Now, we'll parse both BUILDKITE_MESSAGE and check the HEAD commit message.
