### PR TITLE
Install the correct dagster-buildkite CLI

### DIFF
--- a/python_modules/automation/setup.py
+++ b/python_modules/automation/setup.py
@@ -31,7 +31,6 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "dagster-buildkite = automation.buildkite.cli:main",
             "dagster-image = automation.docker.cli:main",
             "dagster-scaffold = automation.scaffold.cli:main",
             "dagster-graphql-client = automation.graphql.python_client.cli:main",

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -80,6 +80,7 @@ def main(quiet: bool, extra_packages: List[str]) -> None:
         "-e python_modules/libraries/dagster-duckdb-pandas",
         "-e python_modules/libraries/dagster-duckdb-pyspark",
         "-e helm/dagster/schema[test]",
+        "-e .buildkite/dagster-buildkite",
     ]
 
     if sys.version_info > (3, 7):


### PR DESCRIPTION
This gets installed via make_dev_install but the module it points to no longer exists.

Instead, we should be installing the CLI located at .buildkite/dagster-buildkite.