### PR TITLE
adds dagster-aws install to dockerfile in docker deployment guide

### DIFF
--- a/docs/content/deployment/guides/docker.mdx
+++ b/docs/content/deployment/guides/docker.mdx
@@ -14,7 +14,7 @@ FROM python:3.7-slim
 
 RUN mkdir -p /opt/dagster/dagster_home /opt/dagster/app
 
-RUN pip install dagit dagster-postgres
+RUN pip install dagit dagster-postgres dagster-aws
 
 # Copy your code and workspace to /opt/dagster/app
 COPY repo.py workspace.yaml /opt/dagster/app/

--- a/examples/docs_snippets/docs_snippets/deploying/docker/Dockerfile
+++ b/examples/docs_snippets/docs_snippets/deploying/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7-slim
 
 RUN mkdir -p /opt/dagster/dagster_home /opt/dagster/app
 
-RUN pip install dagit dagster-postgres
+RUN pip install dagit dagster-postgres dagster-aws
 
 # Copy your code and workspace to /opt/dagster/app
 COPY repo.py workspace.yaml /opt/dagster/app/


### PR DESCRIPTION
### Summary & Motivation
dockerfile doesn't install dagster-aws but needs if for log storage

### How I Tested These Changes
