### PR TITLE
add materialization property on dagster event

### DIFF
--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -707,6 +707,14 @@ class DagsterEvent(
         return cast(StepExpectationResultData, self.event_specific_data)
 
     @property
+    def materialization(self) -> AssetMaterialization:
+        _assert_type(
+            "step_materialization_data", DagsterEventType.ASSET_MATERIALIZATION, self.event_type
+        )
+        return cast(StepMaterializationData, self.event_specific_data).materialization
+
+
+    @property
     def pipeline_failure_data(self) -> "PipelineFailureData":
         _assert_type("pipeline_failure_data", DagsterEventType.RUN_FAILURE, self.event_type)
         return cast(PipelineFailureData, self.event_specific_data)

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
@@ -1112,7 +1112,7 @@ def test_build_multi_asset_sensor_context_set_to_latest_materializations():
             # Test that materialization exists
             assert context.latest_materialization_records_by_key()[
                 my_asset.key
-            ].event_log_entry.dagster_event.step_materialization_data.materialization.metadata_entries[
+            ].event_log_entry.dagster_event.materialization.metadata_entries[
                 0
             ].entry_data == BoolMetadataValue(
                 value=True

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_assets.py
@@ -95,7 +95,7 @@ def test_backcompat_asset_materializations():
         assert isinstance(event, EventLogEntry)
         assert event.dagster_event
         assert event.dagster_event.is_step_materialization
-        assert event.dagster_event.step_materialization_data.materialization.asset_key == asset_key
+        assert event.dagster_event.materialization.asset_key == asset_key
 
     a = AssetKey("a")
     b = AssetKey("b")
@@ -151,7 +151,7 @@ def test_backcompat_get_asset_records():
         assert isinstance(event, EventLogEntry)
         assert event.dagster_event
         assert event.dagster_event.is_step_materialization
-        assert event.dagster_event.step_materialization_data.materialization.asset_key == asset_key
+        assert event.dagster_event.materialization.asset_key == asset_key
 
     b = AssetKey("b")
 


### PR DESCRIPTION
### Summary & Motivation
Add a convenience property to access materialization data off of the event.

Helps with https://github.com/dagster-io/dagster/issues/7384, such that you can now just do:
```event.dagster_event.materialization.metadata```

### How I Tested These Changes
BK