### PR TITLE
Allow for longer messages in Teams HeroCard

### DIFF
--- a/python_modules/libraries/dagster-msteams/dagster_msteams/card.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/card.py
@@ -18,7 +18,7 @@ class Card:
     def _create_attachment(self, text_message: str) -> Dict:
         content = {
             "title": "Dagster Pipeline Alert",
-            "subtitle": text_message,
+            "text": text_message,
         }
         content_type = "application/vnd.microsoft.card.hero"
         return {"contentType": content_type, "content": content}

--- a/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_card.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_card.py
@@ -7,5 +7,5 @@ def test_add_attachment_to_card():
     card.add_attachment("Pipeline success !!!")
     assert len(card.attachments) == 2
     assert card.attachments[0]["contentType"] == "application/vnd.microsoft.card.hero"
-    assert card.attachments[0]["content"]["subtitle"] == "Pipeline failure !!!"
+    assert card.attachments[0]["content"]["text"] == "Pipeline failure !!!"
     assert card.type == "message"


### PR DESCRIPTION
### Summary & Motivation

Resolves #10232.

dagster-msteams uses HeroCard to send content to Teams. In the current implementation, the `subtitle` field is used for the message content.  This results in long messages being truncated. This resolves the issue by instead using the `text` field of the card.

### How I Tested These Changes

Sent a test message to a teams channel. See below.
<img width="810" alt="image" src="https://user-images.githubusercontent.com/31579448/198398909-f87974ff-71b3-4a09-bd4a-43b753e6603c.png">

