### PR TITLE
re-use AssetSelectionResolver when constructing multiple jobs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -137,7 +137,7 @@ class AssetSelection(ABC):
         self, all_assets: Sequence[Union[AssetsDefinition, SourceAsset]]
     ) -> FrozenSet[AssetKey]:
         check.sequence_param(all_assets, "all_assets", (AssetsDefinition, SourceAsset))
-        return Resolver(all_assets).resolve(self)
+        return AssetSelectionResolver(all_assets).resolve(self)
 
 
 class AllAssetSelection(AssetSelection):
@@ -208,7 +208,7 @@ class UpstreamAssetSelection(AssetSelection):
 # ########################
 
 
-class Resolver:
+class AssetSelectionResolver:
     def __init__(self, all_assets: Sequence[Union[AssetsDefinition, SourceAsset]]):
         assets_defs = []
         source_assets = []

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -713,7 +713,6 @@ class DagsterEvent(
         )
         return cast(StepMaterializationData, self.event_specific_data).materialization
 
-
     @property
     def pipeline_failure_data(self) -> "PipelineFailureData":
         _assert_type("pipeline_failure_data", DagsterEventType.RUN_FAILURE, self.event_type)


### PR DESCRIPTION
### Summary & Motivation

The following repository takes ~36 seconds to load on my laptop:

```
    @repository
    def experiment():
        elements = []
        for i in range(1, 1000):

            @asset(name=f"a{i}")
            def myAsset():
                return 42

            asset_job = define_asset_job(
                name=f"a{i}_materialize", selection=AssetSelection.keys(myAsset.key)
            )
            elements += [myAsset, asset_job]
        return elements
```

Taking this to py-spy, we get the following flame graph:

![profile](https://user-images.githubusercontent.com/22457492/198402275-62a1a79d-11eb-4d99-8a79-2c3069a9c4fe.svg)


There are two culprits that are slowing down this repo, the main one being discussed here: https://github.com/dagster-io/dagster/issues/10236, but this change was easier so I did this (it has a much smaller impact). Basically, we stop re-generating the asset dependency graph for every single asset selection

### How I Tested These Changes
