### PR TITLE
Highlight config entry when being hovered in yaml editor

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/ConfigTypeSchema.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ConfigTypeSchema.tsx
@@ -223,6 +223,8 @@ const HoveredDictEntryContextProvider = React.memo(({children}: {children: React
       const self = React.useMemo(() => ({setHovered}), []);
       return {
         hovered,
+
+        // Unset the previous hovered target and set the current one
         onMouseEnter: React.useCallback(() => {
           const lastHovered = currentHoveredStack[currentHoveredStack.length - 1];
           if (lastHovered) {
@@ -233,24 +235,30 @@ const HoveredDictEntryContextProvider = React.memo(({children}: {children: React
           currentHoveredStack.push(self);
           setHovered(true);
         }, [self]),
+
+        // Unset the current hovered target and use its parent as the next hovered target if it has one
         onMouseLeave: React.useCallback(() => {
           const lastHovered = currentHoveredStack[currentHoveredStack.length - 1];
           if (!lastHovered) {
-            // This should never happen but if it does we're fine.
+            // This should never happen since we can't MouseLeave something we never MouseEnter'd
             return;
           }
           // We should be the last hovered element, if not lets proceed anyways because
           // we'll hover the correct element later.
           lastHovered.setHovered(false);
+
+          // Find the index of this element and remove it.
+          // There shouldn't be anything after it since MouseLeave events should bubble upwards
           const currentIndex = currentHoveredStack.indexOf(self);
           if (currentIndex !== -1) {
             // This should only remove 1 entry, the last hovered entry
             currentHoveredStack = currentHoveredStack.slice(0, currentIndex);
           }
+
+          // If something is still on the stack after this dict entry is no longer hovered then
+          // its a parent dict entry and should be hovered
           const nextLastHovered = currentHoveredStack[currentHoveredStack.length - 1];
           if (nextLastHovered) {
-            // If something is still on the stack after this dict entry is no longer hovered then
-            // its a parent dict entry and should be hovered
             nextLastHovered.setHovered(true);
           }
         }, [self]),

--- a/js_modules/dagit/packages/ui/src/components/ConfigTypeSchema.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ConfigTypeSchema.tsx
@@ -195,8 +195,12 @@ export const ConfigTypeSchema = React.memo((props: ConfigTypeSchemaProps) => {
   );
 });
 
-const HoveredDictEntryContext = React.createContext<{setHovered: (unhover: () => void) => void}>({
-  setHovered: (_) => {},
+const HoveredDictEntryContext = React.createContext<{
+  useDictEntryHover: () => {hovered: boolean; onMouseEnter: () => void; onMouseLeave: () => void};
+}>({
+  useDictEntryHover() {
+    return {hovered: false, onMouseEnter: () => {}, onMouseLeave: () => {}};
+  },
 });
 
 /**
@@ -207,15 +211,52 @@ const HoveredDictEntryContext = React.createContext<{setHovered: (unhover: () =>
  */
 const HoveredDictEntryContextProvider = React.memo(({children}: {children: React.ReactNode}) => {
   const value = React.useMemo(() => {
-    let currentUnhover: null | (() => void) = null;
-    return {
-      setHovered(unhover: typeof currentUnhover) {
-        if (currentUnhover) {
-          currentUnhover();
-        }
-        currentUnhover = unhover;
-      },
-    };
+    // We need to keep a stack of the entries that are hovered because they are nested.
+    // The `MouseEnter` handler only fires when we first hover the entry, but it does not
+    // fire when exiting a nested dict entry because technically we never left.
+    // To handle that case whenever we `MouseLeave` fires we restore the last element in the
+    // stack before the leaving element as hovered
+
+    let currentHoveredStack: Array<{setHovered: (hovered: boolean) => void}> = [];
+    function useDictEntryHover() {
+      const [hovered, setHovered] = React.useState(false);
+      const self = React.useMemo(() => ({setHovered}), []);
+      return {
+        hovered,
+        onMouseEnter: React.useCallback(() => {
+          const lastHovered = currentHoveredStack[currentHoveredStack.length - 1];
+          if (lastHovered) {
+            // If there is already a hovered element, unhover it.
+            lastHovered.setHovered(false);
+          }
+          // Record that we're now the last entry to be hovered
+          currentHoveredStack.push(self);
+          setHovered(true);
+        }, [self]),
+        onMouseLeave: React.useCallback(() => {
+          const lastHovered = currentHoveredStack[currentHoveredStack.length - 1];
+          if (!lastHovered) {
+            // This should never happen but if it does we're fine.
+            return;
+          }
+          // We should be the last hovered element, if not lets proceed anyways because
+          // we'll hover the correct element later.
+          lastHovered.setHovered(false);
+          const currentIndex = currentHoveredStack.indexOf(self);
+          if (currentIndex !== -1) {
+            // This should only remove 1 entry, the last hovered entry
+            currentHoveredStack = currentHoveredStack.slice(0, currentIndex);
+          }
+          const nextLastHovered = currentHoveredStack[currentHoveredStack.length - 1];
+          if (nextLastHovered) {
+            // If something is still on the stack after this dict entry is no longer hovered then
+            // its a parent dict entry and should be hovered
+            nextLastHovered.setHovered(true);
+          }
+        }, [self]),
+      };
+    }
+    return {useDictEntryHover};
   }, []);
   return (
     <HoveredDictEntryContext.Provider value={value}>{children}</HoveredDictEntryContext.Provider>
@@ -227,22 +268,16 @@ const DictEntry = React.forwardRef(
     props: React.ComponentProps<typeof DictEntryDiv>,
     ref: React.ForwardedRef<HTMLButtonElement>,
   ) => {
-    const [hovered, setHovered] = React.useState(false);
-    const {setHovered: setHoveredGlobally} = React.useContext(HoveredDictEntryContext);
+    const {hovered, onMouseEnter, onMouseLeave} = React.useContext(
+      HoveredDictEntryContext,
+    ).useDictEntryHover();
 
     return (
       <DictEntryDiv
         {...props}
         $hovered={hovered}
-        onMouseEnter={() => {
-          setHovered(true);
-          setHoveredGlobally(() => {
-            setHovered(false);
-          });
-        }}
-        onMouseLeave={() => {
-          setHovered(false);
-        }}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         ref={ref}
       />
     );

--- a/js_modules/dagit/packages/ui/src/components/ConfigTypeSchema.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ConfigTypeSchema.tsx
@@ -273,23 +273,31 @@ const DictEntry = React.forwardRef(
     ).useDictEntryHover();
 
     return (
-      <DictEntryDiv
-        {...props}
-        $hovered={hovered}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        ref={ref}
-      />
+      <DictEntryDiv2>
+        <DictEntryDiv
+          {...props}
+          $hovered={hovered}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+          ref={ref}
+        />
+      </DictEntryDiv2>
     );
   },
 );
+
+const DictEntryDiv2 = styled.div``;
 const DictEntryDiv = styled.div<{$hovered: boolean}>`
+  border: 1px solid transparent;
+
   ${({$hovered}) =>
     $hovered
       ? `
-      box-shadow: inset 0 0 0 1px ${Colors.Gray200};
+      border: 1px solid ${Colors.Gray200};
       background-color: ${Colors.Gray100};
-      font-weight: 400;
+      >${DictEntryDiv2} {
+        background-color: ${Colors.Gray50};
+      }
     `
       : ``}
   }

--- a/js_modules/dagit/packages/ui/src/components/ConfigTypeSchema.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ConfigTypeSchema.tsx
@@ -216,8 +216,8 @@ const HoveredDictEntryContextProvider = React.memo(({children}: {children: React
     // fire when exiting a nested dict entry because technically we never left.
     // To handle that case whenever we `MouseLeave` fires we restore the last element in the
     // stack before the leaving element as hovered
-
     let currentHoveredStack: Array<{setHovered: (hovered: boolean) => void}> = [];
+
     function useDictEntryHover() {
       const [hovered, setHovered] = React.useState(false);
       const self = React.useMemo(() => ({setHovered}), []);
@@ -241,10 +241,10 @@ const HoveredDictEntryContextProvider = React.memo(({children}: {children: React
           const lastHovered = currentHoveredStack[currentHoveredStack.length - 1];
           if (!lastHovered) {
             // This should never happen since we can't MouseLeave something we never MouseEnter'd
+            // We should be the last hovered element since events bubble up
             return;
           }
-          // We should be the last hovered element, if not lets proceed anyways because
-          // we'll hover the correct element later.
+          // Unhover the current element
           lastHovered.setHovered(false);
 
           // Find the index of this element and remove it.


### PR DESCRIPTION
### Summary & Motivation

This improves the affordance given to types in the config schema helper. This is to clearly delineate which comments belong to which field since they can be either above/below and the ambiguity leads to misinterpretation.

### How I Tested These Changes
<img width="508" alt="Screen Shot 2022-10-27 at 7 26 15 PM" src="https://user-images.githubusercontent.com/2286579/198416196-9104aba7-f5ad-4cf7-9a3a-2aefec845e88.png">
<img width="571" alt="Screen Shot 2022-10-27 at 7 26 12 PM" src="https://user-images.githubusercontent.com/2286579/198416199-78c3f71c-afb1-4bbf-8348-eb9111db9fbf.png">
<img width="559" alt="Screen Shot 2022-10-27 at 7 26 09 PM" src="https://user-images.githubusercontent.com/2286579/198416200-0b8c55ae-4e74-485e-8ee7-e92ed15b3d7b.png">
<img width="639" alt="Screen Shot 2022-10-27 at 7 26 06 PM" src="https://user-images.githubusercontent.com/2286579/198416201-9420837b-8d83-4144-9b35-0589a6f4f4a2.png">
<img width="522" alt="Screen Shot 2022-10-27 at 7 26 01 PM" src="https://user-images.githubusercontent.com/2286579/198416203-4fc8f706-7cb4-4496-9266-f044f9a3cb52.png">



https://www.loom.com/share/e170355e63be4b639331425d6d23b823
