### PR TITLE
Fetch asset materialization planned event from index shard in Sqlite

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -262,10 +262,11 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         is_asset_query = event_records_filter and (
             event_records_filter.event_type == DagsterEventType.ASSET_MATERIALIZATION
             or event_records_filter.event_type == DagsterEventType.ASSET_OBSERVATION
+            or event_records_filter.event_type == DagsterEventType.ASSET_MATERIALIZATION_PLANNED
         )
         if is_asset_query:
-            # asset materializations and observations get mirrored into the index shard, so no
-            # custom run shard-aware cursor logic needed
+            # asset materializations, observations and materialization planned events
+            # get mirrored into the index shard, so no custom run shard-aware cursor logic needed
             return super(SqliteEventLogStorage, self).get_event_records(
                 event_records_filter=event_records_filter, limit=limit, ascending=ascending
             )


### PR DESCRIPTION
We're currently mirroring asset materialization planned events into the index shard of Sqlite event log storage.

However, `get_event_records` doesn't search for asset materialization planned events in the index shard--this PR amends this behavior. The query in the test failed before this PR and now succeeds.