### PR TITLE
[dagit] Updated Asset DAG styling

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -35,7 +35,7 @@ import {AssetEdges} from './AssetEdges';
 import {AssetGraphJobSidebar} from './AssetGraphJobSidebar';
 import {AssetGroupNode} from './AssetGroupNode';
 import {AssetNode, AssetNodeMinimal} from './AssetNode';
-import {SourceAssetNode} from './ForeignNode';
+import {AssetNodeLink} from './ForeignNode';
 import {SidebarAssetInfo} from './SidebarAssetInfo';
 import {
   GraphData,
@@ -366,14 +366,12 @@ export const AssetGraphExplorerWithData: React.FC<
                         }}
                         style={{overflow: 'visible'}}
                       >
-                        {false && (!graphNode || !graphNode.definition.opNames.length) ? (
-                          <SourceAssetNode
-                            assetKey={{path}}
-                            selected={selectedAssetValues.includes(path)}
-                          />
+                        {!graphNode ? (
+                          <AssetNodeLink assetKey={{path}} />
                         ) : scale < MINIMAL_SCALE ? (
                           <AssetNodeMinimal
                             definition={graphNode.definition}
+                            liveData={liveDataByNode[graphNode.id]}
                             selected={selectedGraphNodes.includes(graphNode)}
                           />
                         ) : (

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGroupNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGroupNode.tsx
@@ -21,12 +21,7 @@ export const AssetGroupNode: React.FC<{group: GroupLayout; scale: number}> = ({g
   return (
     <div style={{position: 'relative', width: '100%', height: '100%'}}>
       {scale > EXPERIMENTAL_SCALE && (
-        <Box
-          flex={{alignItems: 'flex-end'}}
-          style={{
-            height: 70,
-          }}
-        >
+        <Box flex={{alignItems: 'flex-end'}} style={{height: 70}}>
           <Mono
             style={{
               fontWeight: 600,
@@ -36,10 +31,14 @@ export const AssetGroupNode: React.FC<{group: GroupLayout; scale: number}> = ({g
               gap: 6,
             }}
           >
-            <Icon name="asset_group" size={scale > MINIMAL_SCALE ? 20 : 48} />
+            <Icon
+              name="asset_group"
+              color={Colors.Gray400}
+              size={scale > MINIMAL_SCALE ? 20 : 48}
+            />
             <Box flex={{direction: 'column'}}>
               <Link
-                style={{color: Colors.Gray900}}
+                style={{color: Colors.Gray400}}
                 onClick={(e) => e.stopPropagation()}
                 to={workspacePath(
                   repositoryName,
@@ -66,11 +65,8 @@ export const AssetGroupNode: React.FC<{group: GroupLayout; scale: number}> = ({g
           inset: 0,
           top: 75,
           position: 'absolute',
-          border: `${Math.max(2, 2 / scale)}px dashed ${Colors.Gray300}`,
           background:
-            scale < EXPERIMENTAL_SCALE
-              ? `rgba(243, 243, 243, 1)`
-              : `rgba(223, 223, 223, ${0.4 - Math.max(0, scale - MINIMAL_SCALE) * 0.3})`,
+            scale < EXPERIMENTAL_SCALE ? `rgba(234, 234, 234, 1)` : `rgba(217, 217, 217, 0.25)`,
         }}
       />
 

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -151,20 +151,6 @@ export const AssetNodeStatusRow: React.FC<{
         background={Colors.Red50}
       >
         <Caption color={Colors.Red700}>Failed</Caption>
-        {lastMaterialization && (
-          <AssetNodeShowOnHover>
-            <AssetRunLink
-              color={Colors.Red700}
-              runId={lastMaterialization.runId}
-              event={{stepKey, timestamp: lastMaterialization.timestamp}}
-            >
-              <TimestampDisplay
-                timestamp={Number(lastMaterialization.timestamp) / 1000}
-                timeFormat={{showSeconds: false, showTimezone: false}}
-              />
-            </AssetRunLink>
-          </AssetNodeShowOnHover>
-        )}
       </Box>
     );
   }

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetRunLinking.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetRunLinking.tsx
@@ -1,0 +1,119 @@
+import {Colors, Icon, Tooltip, Box, Spinner, Tag, Caption} from '@dagster-io/ui';
+import React from 'react';
+import {Link} from 'react-router-dom';
+
+import {CurrentMinutesLateTag} from '../assets/CurrentMinutesLateTag';
+import {titleForRun, linkToRunEvent} from '../runs/RunUtils';
+
+import {LiveDataForNode, MISSING_LIVE_DATA} from './Utils';
+
+export const AssetLatestRunSpinner: React.FC<{
+  liveData?: LiveDataForNode;
+  purpose?: 'caption-text' | 'body-text';
+}> = ({liveData, purpose = 'body-text'}) => {
+  if (liveData?.inProgressRunIds?.length) {
+    return (
+      <Tooltip content="A run is currently rematerializing this asset.">
+        <Spinner purpose={purpose} />
+      </Tooltip>
+    );
+  }
+  if (liveData?.unstartedRunIds?.length) {
+    return (
+      <Tooltip content="A run has started that will rematerialize this asset soon.">
+        <Spinner purpose={purpose} stopped />
+      </Tooltip>
+    );
+  }
+  return null;
+};
+
+export const AssetLatestRunWithNotices: React.FC<{
+  liveData?: LiveDataForNode;
+  includeFreshness: boolean;
+  includeRunStatus: boolean;
+}> = ({liveData, includeFreshness, includeRunStatus}) => {
+  const {
+    lastMaterialization,
+    unstartedRunIds,
+    inProgressRunIds,
+    runWhichFailedToMaterialize,
+    stepKey,
+  } = liveData || MISSING_LIVE_DATA;
+
+  const buildRunTagContent = () => {
+    if (inProgressRunIds?.length > 0) {
+      return (
+        <Box flex={{gap: 4, alignItems: 'center'}}>
+          {includeRunStatus && <AssetLatestRunSpinner liveData={liveData} />}
+          <AssetRunLink runId={inProgressRunIds[0]} />
+        </Box>
+      );
+    }
+    if (unstartedRunIds?.length > 0) {
+      return (
+        <Box flex={{gap: 4, alignItems: 'center'}}>
+          {includeRunStatus && <AssetLatestRunSpinner liveData={liveData} />}
+          <AssetRunLink runId={unstartedRunIds[0]} />
+        </Box>
+      );
+    }
+    if (runWhichFailedToMaterialize?.__typename === 'Run') {
+      return (
+        <Box flex={{gap: 4, alignItems: 'center'}}>
+          {includeRunStatus && (
+            <Tooltip
+              content={`Run ${titleForRun({
+                runId: runWhichFailedToMaterialize.id,
+              })} failed to materialize this asset`}
+            >
+              <Icon name="warning" color={Colors.Red500} />
+            </Tooltip>
+          )}
+          <AssetRunLink runId={runWhichFailedToMaterialize.id} />
+        </Box>
+      );
+    }
+    if (lastMaterialization) {
+      return (
+        <Box flex={{gap: 6, alignItems: 'center'}}>
+          <AssetRunLink
+            runId={lastMaterialization.runId}
+            event={{stepKey, timestamp: lastMaterialization.timestamp}}
+          />
+        </Box>
+      );
+    }
+    return undefined;
+  };
+
+  const runTagContent = buildRunTagContent();
+
+  if (!includeFreshness) {
+    return runTagContent || <span>–</span>;
+  }
+
+  return (
+    <Box flex={{direction: 'row', gap: 4}}>
+      {runTagContent ? <Tag>{runTagContent}</Tag> : <span>–</span>}
+      {liveData && <CurrentMinutesLateTag liveData={liveData} policyOnHover />}
+    </Box>
+  );
+};
+
+export const AssetRunLink: React.FC<{
+  runId: string;
+  event?: Parameters<typeof linkToRunEvent>[1];
+  color?: string;
+}> = ({runId, children, event, color}) => (
+  <Caption>
+    <Link
+      to={event ? linkToRunEvent({runId}, event) : `/instance/runs/${runId}`}
+      style={{color}}
+      target="_blank"
+      rel="noreferrer"
+    >
+      {children || titleForRun({runId})}
+    </Link>
+  </Caption>
+);

--- a/js_modules/dagit/packages/core/src/asset-graph/ForeignNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/ForeignNode.tsx
@@ -2,36 +2,23 @@ import {Colors, Icon, FontFamily} from '@dagster-io/ui';
 import React from 'react';
 import styled from 'styled-components/macro';
 
-import {AssetNodeBox, AssetNodeContainer, VersionedBadge} from './AssetNode';
 import {displayNameForAssetKey} from './Utils';
 
-export const SourceAssetNode: React.FC<{
+export const AssetNodeLink: React.FC<{
   assetKey: {path: string[]};
-  backgroundColor?: string;
-  selected: boolean;
-  observable?: boolean;
-}> = React.memo(({assetKey, backgroundColor, selected, observable}) => (
-  <AssetNodeContainer $selected={selected}>
-    <AssetNodeBox $selected={selected}>
-      <SourceAssetNodeLink style={{backgroundColor}}>
-        <span className="label">{displayNameForAssetKey(assetKey)}</span>
-        {observable ? (
-          <VersionedBadge $isSource={true} $isStale={false}>
-            V
-          </VersionedBadge>
-        ) : null}
-        <Icon name="open_in_new" color={Colors.Gray500} />
-      </SourceAssetNodeLink>
-    </AssetNodeBox>
-  </AssetNodeContainer>
+}> = React.memo(({assetKey}) => (
+  <AssetNodeLinkContainer>
+    <Icon name="open_in_new" color={Colors.Link} />
+    <span className="label">{displayNameForAssetKey(assetKey)}</span>
+  </AssetNodeLinkContainer>
 ));
 
-const SourceAssetNodeLink = styled.div`
+const AssetNodeLinkContainer = styled.div`
   display: flex;
   padding: 4px 8px 6px;
   line-height: 30px;
   font-family: ${FontFamily.monospace};
-  color: ${Colors.Gray500};
+  color: ${Colors.Link};
   align-items: center;
   font-weight: 600;
   gap: 4px;

--- a/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
@@ -128,6 +128,22 @@ export interface LiveDataForNode {
   projectedLogicalVersion: string | null;
   computeStatus: AssetComputeStatus;
 }
+
+export const MISSING_LIVE_DATA: LiveDataForNode = {
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  runWhichFailedToMaterialize: null,
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  lastMaterialization: null,
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  currentLogicalVersion: null,
+  projectedLogicalVersion: null,
+  computeStatus: AssetComputeStatus.NONE,
+  stepKey: '',
+};
+
 export interface LiveData {
   [assetId: GraphId]: LiveDataForNode;
 }

--- a/js_modules/dagit/packages/core/src/assets/AssetEventList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventList.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import styled from 'styled-components/macro';
 
 import {Timestamp} from '../app/time/Timestamp';
-import {AssetRunLink} from '../asset-graph/AssetNode';
+import {AssetRunLink} from '../asset-graph/AssetRunLinking';
 import {RunStatusWithStats} from '../runs/RunStatusDots';
 import {titleForRun} from '../runs/RunUtils';
 import {Container, Inner, Row} from '../ui/VirtualizedTable';

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -1,18 +1,13 @@
 import {gql} from '@apollo/client';
-import {Box, Colors, Icon, Caption, Subheading, Mono, ConfigTypeSchema, Body} from '@dagster-io/ui';
+import {Body, Box, Caption, Colors, ConfigTypeSchema, Icon, Mono, Subheading} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
-import {
-  ASSET_NODE_FRAGMENT,
-  CurrentMinutesLateTag,
-  freshnessPolicyDescription,
-} from '../asset-graph/AssetNode';
+import {ASSET_NODE_FRAGMENT} from '../asset-graph/AssetNode';
 import {
   displayNameForAssetKey,
-  LiveData,
   isHiddenAssetGroupJob,
-  __ASSET_JOB_PREFIX,
+  LiveData,
   toGraphId,
 } from '../asset-graph/Utils';
 import {AssetGraphQuery_assetNodes} from '../asset-graph/types/AssetGraphQuery';
@@ -31,6 +26,7 @@ import {
   metadataForAssetNode,
 } from './AssetMetadata';
 import {AssetNodeList} from './AssetNodeList';
+import {CurrentMinutesLateTag, freshnessPolicyDescription} from './CurrentMinutesLateTag';
 import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinitionFragment';
 
 export const AssetNodeDefinition: React.FC<{

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineageGraph.tsx
@@ -7,7 +7,7 @@ import {AssetEdges} from '../asset-graph/AssetEdges';
 import {MINIMAL_SCALE} from '../asset-graph/AssetGraphExplorer';
 import {AssetGroupNode} from '../asset-graph/AssetGroupNode';
 import {AssetNodeMinimal, AssetNode} from '../asset-graph/AssetNode';
-import {SourceAssetNode} from '../asset-graph/ForeignNode';
+import {AssetNodeLink} from '../asset-graph/ForeignNode';
 import {GraphData, LiveData, toGraphId} from '../asset-graph/Utils';
 import {SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
@@ -99,12 +99,8 @@ export const AssetNodeLineageGraph: React.FC<{
                   e.stopPropagation();
                 }}
               >
-                {!graphNode || !graphNode.definition.opNames.length ? (
-                  <SourceAssetNode
-                    assetKey={{path}}
-                    observable={graphNode.definition.isObservable || false}
-                    selected={graphNode.id === assetGraphId}
-                  />
+                {!graphNode ? (
+                  <AssetNodeLink assetKey={{path}} />
                 ) : scale < MINIMAL_SCALE ? (
                   <AssetNodeMinimal
                     definition={graphNode.definition}

--- a/js_modules/dagit/packages/core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetSidebarActivitySummary.tsx
@@ -1,11 +1,11 @@
 import {Body, Box, Colors, Spinner} from '@dagster-io/ui';
 import * as React from 'react';
 
-import {CurrentMinutesLateTag, freshnessPolicyDescription} from '../asset-graph/AssetNode';
 import {LiveDataForNode} from '../asset-graph/Utils';
 import {SidebarSection} from '../pipelines/SidebarComponents';
 
 import {AssetMaterializationGraphs} from './AssetMaterializationGraphs';
+import {CurrentMinutesLateTag, freshnessPolicyDescription} from './CurrentMinutesLateTag';
 import {CurrentRunsBanner} from './CurrentRunsBanner';
 import {FailedRunsSinceMaterializationBanner} from './FailedRunsSinceMaterializationBanner';
 import {LatestMaterializationMetadata} from './LastMaterializationMetadata';

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -18,12 +18,9 @@ import styled from 'styled-components/macro';
 
 import {usePermissions} from '../app/Permissions';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
-import {
-  AssetLatestRunWithNotices,
-  AssetRunLink,
-  ComputeStatusNotice,
-} from '../asset-graph/AssetNode';
+import {AssetLatestRunWithNotices, AssetRunLink} from '../asset-graph/AssetRunLinking';
 import {LiveData, toGraphId} from '../asset-graph/Utils';
+import {StaleTag} from '../assets/StaleTag';
 import {useSelectionReducer} from '../hooks/useSelectionReducer';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
@@ -277,11 +274,15 @@ const AssetEntryRow: React.FC<{
               ) : (
                 <span>–</span>
               )}
-              <ComputeStatusNotice computeStatus={liveData?.computeStatus} />
+              <StaleTag liveData={liveData} />
             </Box>
           ) : undefined}
         </td>
-        <td>{liveData && <AssetLatestRunWithNotices liveData={liveData} includeFreshness />}</td>
+        <td>
+          {liveData && (
+            <AssetLatestRunWithNotices liveData={liveData} includeFreshness includeRunStatus />
+          )}
+        </td>
         <td>
           {asset ? (
             <Box flex={{gap: 8, alignItems: 'center'}}>

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -1,7 +1,6 @@
 import {gql, useQuery} from '@apollo/client';
 import {
   Alert,
-  BaseTag,
   Box,
   ButtonLink,
   Colors,
@@ -21,13 +20,12 @@ import {
   useQueryRefreshAtInterval,
 } from '../app/QueryRefresh';
 import {Timestamp} from '../app/time/Timestamp';
-import {CurrentMinutesLateTag} from '../asset-graph/AssetNode';
 import {GraphData, LiveDataForNode, toGraphId, tokenForAssetKey} from '../asset-graph/Utils';
 import {useAssetGraphData} from '../asset-graph/useAssetGraphData';
 import {useLiveDataForAssetKeys} from '../asset-graph/useLiveDataForAssetKeys';
+import {StaleTag} from '../assets/StaleTag';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {RepositoryLink} from '../nav/RepositoryLink';
-import {AssetComputeStatus} from '../types/globalTypes';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
@@ -39,6 +37,7 @@ import {AssetLineageScope} from './AssetNodeLineageGraph';
 import {AssetPageHeader} from './AssetPageHeader';
 import {AssetPartitions} from './AssetPartitions';
 import {AssetPlots} from './AssetPlots';
+import {CurrentMinutesLateTag} from './CurrentMinutesLateTag';
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
 import {AssetKey} from './types';
 import {
@@ -411,7 +410,6 @@ const AssetViewPageHeaderTags: React.FC<{
   liveData?: LiveDataForNode;
   onShowUpstream: () => void;
 }> = ({definition, liveData, onShowUpstream}) => {
-  const isUpstreamChanged = liveData?.computeStatus === AssetComputeStatus.OUT_OF_DATE;
   const repoAddress = definition
     ? buildRepoAddress(definition.repository.name, definition.repository.location.name)
     : null;
@@ -436,16 +434,7 @@ const AssetViewPageHeaderTags: React.FC<{
         </Tag>
       )}
       {liveData?.freshnessPolicy && <CurrentMinutesLateTag liveData={liveData} policyOnHover />}
-      {isUpstreamChanged ? (
-        <Box onClick={onShowUpstream}>
-          <BaseTag
-            fillColor={Colors.Yellow50}
-            textColor={Colors.Yellow700}
-            label="Upstream changed"
-            interactive
-          />
-        </Box>
-      ) : undefined}
+      <StaleTag liveData={liveData} onClick={onShowUpstream} />
     </>
   );
 };

--- a/js_modules/dagit/packages/core/src/assets/CurrentMinutesLateTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/CurrentMinutesLateTag.tsx
@@ -1,0 +1,75 @@
+import {Tooltip, Tag} from '@dagster-io/ui';
+import moment from 'moment';
+import React from 'react';
+
+import {LiveDataForNode} from '../asset-graph/Utils';
+import {AssetGraphLiveQuery_assetNodes_freshnessPolicy} from '../asset-graph/types/AssetGraphLiveQuery';
+import {humanCronString} from '../schedules/humanCronString';
+
+const STALE_OVERDUE_MSG = `A materialization incorporating more recent upstream data is overdue.`;
+const STALE_UNMATERIALIZED_MSG = `This asset has never been materialized.`;
+
+export const CurrentMinutesLateTag: React.FC<{
+  liveData: LiveDataForNode;
+  policyOnHover?: boolean;
+}> = ({liveData, policyOnHover}) => {
+  const {freshnessInfo, freshnessPolicy} = liveData;
+  const description = policyOnHover ? freshnessPolicyDescription(freshnessPolicy) : '';
+
+  if (!freshnessInfo) {
+    return <span />;
+  }
+
+  if (freshnessInfo.currentMinutesLate === null) {
+    return (
+      <Tooltip
+        content={<div style={{maxWidth: 400}}>{`${STALE_UNMATERIALIZED_MSG} ${description}`}</div>}
+      >
+        <Tag intent="danger">Late</Tag>
+      </Tooltip>
+    );
+  }
+
+  if (freshnessInfo.currentMinutesLate === 0) {
+    return description ? (
+      <Tooltip content={freshnessPolicyDescription(freshnessPolicy)}>
+        <Tag intent="success">Fresh</Tag>
+      </Tooltip>
+    ) : (
+      <Tag intent="success">Fresh</Tag>
+    );
+  }
+
+  return (
+    <Tooltip content={<div style={{maxWidth: 400}}>{`${STALE_OVERDUE_MSG} ${description}`}</div>}>
+      <Tag intent="danger">
+        {moment
+          .duration(freshnessInfo.currentMinutesLate, 'minute')
+          .humanize(false, {m: 120, h: 48})}
+        {' late'}
+      </Tag>
+    </Tooltip>
+  );
+};
+
+export const freshnessPolicyDescription = (
+  freshnessPolicy: AssetGraphLiveQuery_assetNodes_freshnessPolicy | null,
+) => {
+  if (!freshnessPolicy) {
+    return '';
+  }
+
+  const {cronSchedule, maximumLagMinutes} = freshnessPolicy;
+
+  const cronDesc = cronSchedule ? humanCronString(cronSchedule, 'UTC').replace(/^At /, '') : '';
+  const lagDesc =
+    maximumLagMinutes % 30 === 0
+      ? `${maximumLagMinutes / 60} hour${maximumLagMinutes / 60 !== 1 ? 's' : ''}`
+      : `${maximumLagMinutes} min`;
+
+  if (cronDesc) {
+    return `By ${cronDesc}, this asset should incorporate all data up to ${lagDesc} before that time.`;
+  } else {
+    return `At any point in time, this asset should incorporate all data up to ${lagDesc} before that time.`;
+  }
+};

--- a/js_modules/dagit/packages/core/src/assets/CurrentMinutesLateTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/CurrentMinutesLateTag.tsx
@@ -25,7 +25,9 @@ export const CurrentMinutesLateTag: React.FC<{
       <Tooltip
         content={<div style={{maxWidth: 400}}>{`${STALE_UNMATERIALIZED_MSG} ${description}`}</div>}
       >
-        <Tag intent="danger">Late</Tag>
+        <Tag intent="danger" icon="warning">
+          Late
+        </Tag>
       </Tooltip>
     );
   }
@@ -33,16 +35,20 @@ export const CurrentMinutesLateTag: React.FC<{
   if (freshnessInfo.currentMinutesLate === 0) {
     return description ? (
       <Tooltip content={freshnessPolicyDescription(freshnessPolicy)}>
-        <Tag intent="success">Fresh</Tag>
+        <Tag intent="success" icon="check_circle">
+          On time
+        </Tag>
       </Tooltip>
     ) : (
-      <Tag intent="success">Fresh</Tag>
+      <Tag intent="success" icon="check_circle">
+        On time
+      </Tag>
     );
   }
 
   return (
     <Tooltip content={<div style={{maxWidth: 400}}>{`${STALE_OVERDUE_MSG} ${description}`}</div>}>
-      <Tag intent="danger">
+      <Tag intent="danger" icon="warning">
         {moment
           .duration(freshnessInfo.currentMinutesLate, 'minute')
           .humanize(false, {m: 120, h: 48})}

--- a/js_modules/dagit/packages/core/src/assets/StaleTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/StaleTag.tsx
@@ -1,0 +1,19 @@
+import {Colors, Box, BaseTag} from '@dagster-io/ui';
+import React from 'react';
+
+import {LiveDataForNode} from '../asset-graph/Utils';
+
+export const StaleTag: React.FC<{liveData?: LiveDataForNode; onClick?: () => void}> = ({
+  liveData,
+  onClick,
+}) =>
+  liveData?.currentLogicalVersion !== liveData?.projectedLogicalVersion ? (
+    <Box onClick={onClick}>
+      <BaseTag
+        fillColor={Colors.Yellow50}
+        textColor={Colors.Yellow700}
+        label="Stale"
+        interactive={!!onClick}
+      />
+    </Box>
+  ) : null;

--- a/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
@@ -500,7 +500,7 @@ export class SVGViewport extends React.Component<SVGViewportProps, SVGViewportSt
   render() {
     const {children, onClick, interactor} = this.props;
     const {x, y, scale} = this.state;
-    const dotsize = Math.max(14, 30 * scale);
+    const dotsize = Math.max(7, 30 * scale);
 
     return (
       <div

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
@@ -6,17 +6,14 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {AppContext} from '../app/AppContext';
-import {
-  AssetLatestRunWithNotices,
-  AssetRunLink,
-  ASSET_NODE_LIVE_FRAGMENT,
-  ComputeStatusNotice,
-} from '../asset-graph/AssetNode';
+import {ASSET_NODE_LIVE_FRAGMENT} from '../asset-graph/AssetNode';
+import {AssetLatestRunWithNotices, AssetRunLink} from '../asset-graph/AssetRunLinking';
 import {buildLiveDataForNode} from '../asset-graph/Utils';
 import {ASSET_LATEST_INFO_FRAGMENT} from '../asset-graph/useLiveDataForAssetKeys';
 import {AssetActionMenu} from '../assets/AssetActionMenu';
 import {AssetLink} from '../assets/AssetLink';
 import {ASSET_TABLE_FRAGMENT} from '../assets/AssetTable';
+import {StaleTag} from '../assets/StaleTag';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
@@ -224,7 +221,7 @@ const AssetRow = (props: JobRowProps) => {
                   />
                 </AssetRunLink>
               </>
-              <ComputeStatusNotice computeStatus={liveData?.computeStatus} />
+              <StaleTag liveData={liveData} />
             </Box>
           ) : (
             <LoadingOrNone queryResult={queryResult} />
@@ -232,7 +229,7 @@ const AssetRow = (props: JobRowProps) => {
         </RowCell>
         <RowCell>
           {liveData ? (
-            <AssetLatestRunWithNotices liveData={liveData} includeFreshness />
+            <AssetLatestRunWithNotices liveData={liveData} includeFreshness includeRunStatus />
           ) : (
             <LoadingOrNone queryResult={queryResult} />
           )}


### PR DESCRIPTION
### Summary & Motivation

Loom video: https://www.loom.com/share/d4b422d4f60147cd8399a80fe4ab5cf2

This PR is based on Sean's excellent asset versioning work and updates the Asset DAG UI to reflect Josh's latest designs here: https://www.figma.com/file/vpKJztqdb5uOLsF2ipzjiK/Asset-Graph?node-id=372%3A1249

Screenshots:

![image](https://user-images.githubusercontent.com/1037212/202240053-4c66bda1-66a6-4a4a-bdef-30a2d33318c7.png)
![image](https://user-images.githubusercontent.com/1037212/202240069-ac24a995-bd74-4e69-98e5-94f7fcd84699.png)
![image](https://user-images.githubusercontent.com/1037212/202240089-aac9f408-062d-42db-a5ca-8fcb84880ca1.png)

### How I Tested These Changes
