### PR TITLE
[dagit] Fix issues with embedding fonts in downloaded DAG SVGs

### DIFF
--- a/js_modules/dagit/packages/core/src/graph/makeSVGPortable.tsx
+++ b/js_modules/dagit/packages/core/src/graph/makeSVGPortable.tsx
@@ -111,11 +111,19 @@ export async function makeSVGPortable(svg: SVGElement) {
     }
   }
 
-  // Find all the stylesheets on the page and embed the font-face declarations into
-  // the SVG document.
-  const fontFaces = Array.from(document.querySelectorAll('style'))
-    .flatMap((style) => (style.textContent || '').match(/@font-face ?{[^\}]*}/gim))
-    .filter(Boolean);
+  // Find all the stylesheets on the page and embed the font-face declarations
+  // into the SVG document.
+  const cssSources = Array.from<HTMLStyleElement | HTMLLinkElement>(
+    document.querySelectorAll('style,link[rel=stylesheet]'),
+  );
+  const fontFaces = cssSources.flatMap((el) =>
+    el.sheet
+      ? Array.from(el.sheet.cssRules)
+          .filter((r) => r instanceof CSSFontFaceRule)
+          .map((r) => r.cssText)
+      : [],
+  );
+
   const styleEl = document.createElement('style');
   styleEl.textContent = fontFaces.join('\n\n');
   svg.appendChild(styleEl);


### PR DESCRIPTION
### Summary & Motivation
Discussion / bug report: https://elementl-workspace.slack.com/archives/C03CCE471E0/p1666730195801019

If you use Dagit's "Export DAG to SVG" feature in Cloud, the exported SVG is missing our official monospace font. This causes it to render poorly and truncate op + asset names.

This PR switches to a cleaner method of retrieving the fonts present on the web page and embedding them in the SVG. I had no idea this API existed, and it's actually fully supported! (https://caniuse.com/?search=CSSFontFaceRule, https://caniuse.com/?search=CssStyleSheet)

I also verified that this code works in both OSS and Cloud.

### How I Tested These Changes
