### PR TITLE
[dagit] Move the refresh indicator on asset details pages to avoid flicker

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -157,42 +157,50 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
           </>
         }
         tabs={
-          <Tabs size="large" selectedTabId={params.view || defaultTab}>
-            {flagNewAssetDetails ? (
+          <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
+            <Tabs size="large" selectedTabId={params.view || defaultTab}>
+              {flagNewAssetDetails ? (
+                <Tab
+                  id="overview"
+                  title="Overview"
+                  onClick={() => setParams({...params, view: 'overview'})}
+                />
+              ) : (
+                <Tab
+                  id="activity"
+                  title="Activity"
+                  onClick={() => setParams({...params, view: 'activity'})}
+                />
+              )}
               <Tab
-                id="overview"
-                title="Overview"
-                onClick={() => setParams({...params, view: 'overview'})}
+                id="definition"
+                title="Definition"
+                onClick={() => setParams({...params, view: 'definition'})}
+                disabled={!definition}
               />
-            ) : (
               <Tab
-                id="activity"
-                title="Activity"
-                onClick={() => setParams({...params, view: 'activity'})}
+                id="lineage"
+                title="Lineage"
+                onClick={() => setParams({...params, view: 'lineage'})}
+                disabled={!definition}
               />
+              {flagNewAssetDetails && (
+                <Tab
+                  id="plots"
+                  title="Plots"
+                  onClick={() => setParams({...params, view: 'plots'})}
+                />
+              )}
+            </Tabs>
+            {refreshState && (
+              <Box padding={{bottom: 8}}>
+                <QueryRefreshCountdown refreshState={refreshState} />
+              </Box>
             )}
-            <Tab
-              id="definition"
-              title="Definition"
-              onClick={() => setParams({...params, view: 'definition'})}
-              disabled={!definition}
-            />
-            <Tab
-              id="lineage"
-              title="Lineage"
-              onClick={() => setParams({...params, view: 'lineage'})}
-              disabled={!definition}
-            />
-            {flagNewAssetDetails && (
-              <Tab id="plots" title="Plots" onClick={() => setParams({...params, view: 'plots'})} />
-            )}
-          </Tabs>
+          </Box>
         }
         right={
-          <Box style={{margin: '-4px 0'}} flex={{gap: 12, alignItems: 'baseline'}}>
-            <Box margin={{top: 4}}>
-              <QueryRefreshCountdown refreshState={refreshState} />
-            </Box>
+          <Box style={{margin: '-4px 0'}}>
             {definition && definition.jobNames.length > 0 && repoAddress && upstream && (
               <LaunchAssetExecutionButton assetKeys={[definition.assetKey]} />
             )}


### PR DESCRIPTION
### Summary & Motivation

This PR moves the reload countdown on asset detail pages so that it does not reflow the tags when it switches to "Refreshing..." text. This placement is also more consistent with other areas of Dagit that have tabs.

Fixes https://github.com/dagster-io/dagster/issues/9983

Before:
![image](https://user-images.githubusercontent.com/1037212/198736735-acc13e8f-7c63-47e6-82e5-02982fd431dd.png)

After:
![image](https://user-images.githubusercontent.com/1037212/198736694-c5937658-6712-4488-a97a-5fd4118b0d9f.png)

### How I Tested These Changes
