### PR TITLE
[jog] resource_tests

### DIFF
--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -587,6 +587,10 @@ class DagsterEvent(
     def is_pipeline_failure(self) -> bool:
         return self.event_type == DagsterEventType.RUN_FAILURE
 
+    @property
+    def is_run_failure(self) -> bool:
+        return self.event_type == DagsterEventType.RUN_FAILURE
+
     @public  # type: ignore
     @property
     def is_failure(self) -> bool:


### PR DESCRIPTION
One weird thing here; it seems that when using the job API as opposed to the pipeline API, resource teardown failures are not considered run failures. Future bugfix should be incoming for this.
