### PR TITLE
disentangle asset reconciliation sensor from MultiAssetSensorDefinition

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_asset_sensors.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_asset_sensors.py
@@ -45,7 +45,7 @@ def test_asset_sensors():
         instance=instance,
         repository_def=my_repo,
     )
-    assert isinstance(list(asset_a_and_b_sensor(ctx))[0], RunRequest)
+    assert isinstance(asset_a_and_b_sensor(ctx), RunRequest)
 
     for _ in range(5):
         materialize([asset_c], instance=instance)
@@ -55,7 +55,7 @@ def test_asset_sensors():
         instance=instance,
         repository_def=my_repo,
     )
-    assert list(asset_a_and_b_sensor_with_skip_reason(ctx))[0].run_config == {}
+    assert asset_a_and_b_sensor_with_skip_reason(ctx).run_config == {}
 
 
 @repository

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -15,9 +15,8 @@ from dagster._utils import utc_datetime_from_timestamp
 
 from .asset_selection import AssetSelection
 from .events import AssetKey
-from .multi_asset_sensor_definition import MultiAssetSensorDefinition
 from .run_request import RunRequest
-from .sensor_definition import DefaultSensorStatus
+from .sensor_definition import DefaultSensorStatus, SensorDefinition
 from .utils import check_valid_name
 
 if TYPE_CHECKING:
@@ -213,7 +212,7 @@ def _make_sensor(
     description: Optional[str],
     default_status: DefaultSensorStatus,
     run_tags: Optional[Mapping[str, str]],
-) -> MultiAssetSensorDefinition:
+) -> SensorDefinition:
     """Creates the sensor that will monitor the parents of all provided assets and determine
     which assets should be materialized (ie their parents have been updated).
 
@@ -297,10 +296,8 @@ def _make_sensor(
                 run_key=f"{context.cursor}", asset_selection=list(should_materialize), tags=run_tags
             )
 
-    return MultiAssetSensorDefinition(
-        asset_selection=selection,
-        asset_keys=None,
-        asset_materialization_fn=sensor_fn,
+    return SensorDefinition(
+        evaluation_fn=sensor_fn,
         name=name,
         job_name="__ASSET_JOB",
         minimum_interval_seconds=minimum_interval_seconds,
@@ -319,7 +316,7 @@ def build_asset_reconciliation_sensor(
     description: Optional[str] = None,
     default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
     run_tags: Optional[Mapping[str, str]] = None,
-) -> MultiAssetSensorDefinition:
+) -> SensorDefinition:
     """Constructs a sensor that will monitor the parents of the provided assets and materialize an asset
     based on the materialization of its parents. This will keep the monitored assets up to date with the
     latest data available to them. The sensor defaults to materializing an asset when all of
@@ -344,7 +341,7 @@ def build_asset_reconciliation_sensor(
         run_tags (Optional[Mapping[str, str]): Dictionary of tags to pass to the RunRequests launched by this sensor
 
     Returns:
-        A MultiAssetSensorDefinition that will monitor the parents of the provided assets to determine when
+        A SensorDefinition that will monitor the parents of the provided assets to determine when
         the provided assets should be materialized
 
     Example:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -240,35 +240,19 @@ def multi_asset_sensor(
         check.callable_param(fn, "fn")
         sensor_name = name or fn.__name__
 
-        def _wrapped_fn(context):
-            result = fn(context)
-
-            if inspect.isgenerator(result) or isinstance(result, list):
-                for item in result:
-                    yield item
-            elif isinstance(result, (RunRequest, SkipReason)):
-                yield result
-
-            elif result is not None:
-                raise DagsterInvariantViolationError(
-                    (
-                        "Error in sensor {sensor_name}: Sensor unexpectedly returned output "
-                        "{result} of type {type_}.  Should only return SkipReason or "
-                        "RunRequest objects."
-                    ).format(sensor_name=sensor_name, result=result, type_=type(result))
-                )
-
-        return MultiAssetSensorDefinition(
+        sensor_def = MultiAssetSensorDefinition(
             name=sensor_name,
             asset_keys=asset_keys,
             asset_selection=asset_selection,
             job_name=job_name,
-            asset_materialization_fn=_wrapped_fn,
+            asset_materialization_fn=fn,
             minimum_interval_seconds=minimum_interval_seconds,
             description=description,
             job=job,
             jobs=jobs,
             default_status=default_status,
         )
+        update_wrapper(sensor_def, wrapped=fn)
+        return sensor_def
 
     return inner

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
@@ -313,7 +313,7 @@ def test_multi_asset_sensor():
             instance=instance,
             repository_def=my_repo,
         )
-        assert list(a_and_b_sensor(ctx))[0].run_config == {}
+        assert a_and_b_sensor(ctx).run_config == {}
 
 
 def test_multi_asset_sensor_selection():
@@ -362,7 +362,7 @@ def test_multi_asset_sensor_has_assets():
             instance=instance,
             repository_def=my_repo,
         )
-        list(passing_sensor(ctx))
+        passing_sensor(ctx)
 
 
 def test_multi_asset_sensor_invalid_partitions():
@@ -443,7 +443,7 @@ def test_partitions_multi_asset_sensor_context():
             instance=instance,
             repository_def=my_repo,
         )
-        assert list(two_asset_sensor(ctx))[0].tags["dagster/partition"] == "2022-08-01"
+        assert two_asset_sensor(ctx).tags["dagster/partition"] == "2022-08-01"
         assert ctx.get_cursor_partition(AssetKey("daily_partitions_asset")) == "2022-08-01"
 
 
@@ -491,7 +491,7 @@ def test_invalid_partition_mapping():
             asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
         )
         with pytest.warns(UserWarning):
-            list(asset_sensor(ctx))
+            asset_sensor(ctx)
 
 
 def test_multi_asset_sensor_after_cursor_partition_flag():
@@ -533,9 +533,9 @@ def test_multi_asset_sensor_after_cursor_partition_flag():
         ctx = build_multi_asset_sensor_context(
             asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
         )
-        list(after_cursor_partitions_asset_sensor(ctx))
+        after_cursor_partitions_asset_sensor(ctx)
         materialize([july_asset], partition_key="2022-07-05", instance=instance)
-        list(after_cursor_partitions_asset_sensor(ctx))
+        after_cursor_partitions_asset_sensor(ctx)
 
 
 def test_multi_asset_sensor_all_partitions_materialized():
@@ -561,7 +561,7 @@ def test_multi_asset_sensor_all_partitions_materialized():
         ctx = build_multi_asset_sensor_context(
             asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
         )
-        list(asset_sensor(ctx))
+        asset_sensor(ctx)
 
 
 def test_multi_asset_sensor_custom_partition_mapping():
@@ -627,7 +627,7 @@ def test_multi_asset_sensor_custom_partition_mapping():
         ctx = build_multi_asset_sensor_context(
             asset_keys=[july_daily_partitions.key], instance=instance, repository_def=my_repo
         )
-        list(asset_sensor(ctx))
+        asset_sensor(ctx)
 
 
 def test_multi_asset_sensor_retains_ordering_and_fetches_latest_per_partition():
@@ -652,7 +652,7 @@ def test_multi_asset_sensor_retains_ordering_and_fetches_latest_per_partition():
         ctx = build_multi_asset_sensor_context(
             asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
         )
-        list(asset_sensor(ctx))
+        asset_sensor(ctx)
 
 
 def test_multi_asset_sensor_update_cursor_no_overwrite():
@@ -686,9 +686,9 @@ def test_multi_asset_sensor_update_cursor_no_overwrite():
         ctx = build_multi_asset_sensor_context(
             asset_keys=[july_asset.key, august_asset.key], instance=instance, repository_def=my_repo
         )
-        list(after_cursor_partitions_asset_sensor(ctx))
+        after_cursor_partitions_asset_sensor(ctx)
         materialize([august_asset], partition_key="2022-08-05", instance=instance)
-        list(after_cursor_partitions_asset_sensor(ctx))
+        after_cursor_partitions_asset_sensor(ctx)
 
 
 def test_multi_asset_sensor_latest_materialization_records_by_partition_and_asset():
@@ -711,7 +711,7 @@ def test_multi_asset_sensor_latest_materialization_records_by_partition_and_asse
         ctx = build_multi_asset_sensor_context(
             asset_keys=[july_asset.key, july_asset_2.key], instance=instance, repository_def=my_repo
         )
-        list(my_sensor(ctx))
+        my_sensor(ctx)
 
 
 def test_asset_keys_or_selection_mandatory():
@@ -737,7 +737,7 @@ def test_build_multi_asset_sensor_context_asset_selection():
         asset_selection=AssetSelection.groups("ladies").upstream(depth=1, include_self=False)
     )
     def asset_selection_sensor(context):
-        assert context.asset_keys == [candace.key, danny.key, alice.key]
+        assert context.asset_keys == [danny.key]
 
     @repository
     def my_repo():
@@ -808,7 +808,7 @@ def test_multi_asset_sensor_unconsumed_events():
         ctx = build_multi_asset_sensor_context(
             asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
         )
-        list(test_unconsumed_events_sensor(ctx))
+        test_unconsumed_events_sensor(ctx)
         july_asset_cursor = ctx._get_cursor(july_asset.key)  # pylint: disable=protected-access
         assert first_2022_07_10_mat < july_asset_cursor.latest_consumed_event_id
         assert july_asset_cursor.latest_consumed_event_partition == "2022-07-10"
@@ -821,7 +821,7 @@ def test_multi_asset_sensor_unconsumed_events():
         # Confirm that the unconsumed event is fetched. After, the unconsumed event should
         # no longer show up in the cursor. The storage ID of the cursor should stay the same.
         invocation_num += 1
-        list(test_unconsumed_events_sensor(ctx))
+        test_unconsumed_events_sensor(ctx)
         second_july_cursor = ctx._get_cursor(july_asset.key)  # pylint: disable=protected-access
         assert second_july_cursor.latest_consumed_event_partition == "2022-07-10"
         assert (
@@ -865,7 +865,7 @@ def test_advance_all_cursors_clears_unconsumed_events():
         ctx = build_multi_asset_sensor_context(
             asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
         )
-        list(test_unconsumed_events_sensor(ctx))
+        test_unconsumed_events_sensor(ctx)
         july_asset_cursor = ctx._get_cursor(july_asset.key)  # pylint: disable=protected-access
         first_storage_id = july_asset_cursor.latest_consumed_event_id
         assert first_storage_id
@@ -881,7 +881,7 @@ def test_advance_all_cursors_clears_unconsumed_events():
             partition_key="2022-07-06",
             instance=instance,
         )
-        list(test_unconsumed_events_sensor(ctx))
+        test_unconsumed_events_sensor(ctx)
         july_asset_cursor = ctx._get_cursor(july_asset.key)  # pylint: disable=protected-access
         assert july_asset_cursor.latest_consumed_event_partition == "2022-07-06"
         assert july_asset_cursor.trailing_unconsumed_partitioned_event_ids == {}
@@ -908,7 +908,7 @@ def test_error_when_max_num_unconsumed_events():
         ctx = build_multi_asset_sensor_context(
             asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
         )
-        list(test_unconsumed_events_sensor(ctx))
+        test_unconsumed_events_sensor(ctx)
         july_asset_cursor = ctx._get_cursor(july_asset.key)  # pylint: disable=protected-access
         assert july_asset_cursor.latest_consumed_event_id
         assert july_asset_cursor.latest_consumed_event_partition == "2022-07-25"
@@ -924,7 +924,7 @@ def test_error_when_max_num_unconsumed_events():
             DagsterInvariantViolationError,
             match="maximum number of trailing unconsumed events",
         ):
-            list(test_unconsumed_events_sensor(ctx))
+            test_unconsumed_events_sensor(ctx)
 
 
 def test_latest_materialization_records_by_partition_fetches_unconsumed_events():
@@ -967,7 +967,7 @@ def test_latest_materialization_records_by_partition_fetches_unconsumed_events()
         ctx = build_multi_asset_sensor_context(
             asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
         )
-        list(test_unconsumed_events_sensor(ctx))
+        test_unconsumed_events_sensor(ctx)
         first_july_cursor = ctx._get_cursor(july_asset.key)  # pylint: disable=protected-access
         assert first_july_cursor.latest_consumed_event_id
         assert first_july_cursor.latest_consumed_event_partition == "2022-07-03"
@@ -980,7 +980,7 @@ def test_latest_materialization_records_by_partition_fetches_unconsumed_events()
                 partition_key=f"2022-07-{date}",
                 instance=instance,
             )
-        list(test_unconsumed_events_sensor(ctx))
+        test_unconsumed_events_sensor(ctx)
         second_july_cursor = ctx._get_cursor(july_asset.key)  # pylint: disable=protected-access
         assert second_july_cursor.latest_consumed_event_partition == "2022-07-02"
         assert (
@@ -1017,7 +1017,7 @@ def test_unfetched_partitioned_events_are_unconsumed():
         ctx = build_multi_asset_sensor_context(
             asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
         )
-        list(test_unconsumed_events_sensor(ctx))
+        test_unconsumed_events_sensor(ctx)
         first_july_cursor = ctx._get_cursor(july_asset.key)  # pylint: disable=protected-access
         assert first_july_cursor.latest_consumed_event_id
         assert first_july_cursor.latest_consumed_event_partition == "2022-07-05"
@@ -1049,7 +1049,7 @@ def test_unfetched_partitioned_events_are_unconsumed():
         ctx = build_multi_asset_sensor_context(
             asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
         )
-        list(test_unconsumed_events_sensor(ctx))
+        test_unconsumed_events_sensor(ctx)
         second_july_cursor = ctx._get_cursor(july_asset.key)  # pylint: disable=protected-access
         assert (
             second_july_cursor.latest_consumed_event_id > first_july_cursor.latest_consumed_event_id
@@ -1094,7 +1094,7 @@ def test_build_multi_asset_sensor_context_asset_selection_set_to_latest_material
             ).latest_consumed_event_id
             == records.storage_id
         )
-        list(my_sensor(ctx))
+        my_sensor(ctx)
 
 
 def test_build_multi_asset_sensor_context_set_to_latest_materializations():
@@ -1141,11 +1141,11 @@ def test_build_multi_asset_sensor_context_set_to_latest_materializations():
             ).latest_consumed_event_id
             == records.storage_id
         )
-        list(my_sensor(ctx))
+        my_sensor(ctx)
         evaluated = True
 
         materialize([my_asset], instance=instance)
-        list(my_sensor(ctx))
+        my_sensor(ctx)
 
 
 def test_build_multi_asset_context_set_after_multiple_materializations():
@@ -1241,4 +1241,4 @@ def test_error_not_thrown_for_skip_reason():
             repository_def=my_repo,
             instance=instance,
         )
-        list(test_unconsumed_events_sensor(ctx))
+        test_unconsumed_events_sensor(ctx)


### PR DESCRIPTION
### Summary & Motivation

Asset reconciliation sensors are multi-asset sensors, but they don't seem to use multi-asset sensor features.

When working on improvements to asset reconciliation sensors, I found that this was causing a bug where the multi-asset sensor code would do post-processing on the cursor object produced by the reconciliation sensor, even though it didn't match the shape expected by the multi-asset sensor code.

This makes it so that asset reconciliation sensors are no longer multi-asset sensors. I think it will make sense to make them multi-asset sensors in the future if we harmonize the way they view their cursors.

An effect of this PR is that now all sensors get the repository definition on them.

### How I Tested These Changes
