### PR TITLE
[freshness-policy] Add utility method for calculating upstream data time

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -1,5 +1,6 @@
 import warnings
-from typing import AbstractSet, Iterator, Optional, Sequence, Union
+from collections import deque
+from typing import AbstractSet, Iterator, Optional, Sequence, Set, Union
 
 import toposort
 
@@ -62,16 +63,21 @@ class AssetGraph:
 
     def get_roots(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
         """Returns all root assets that the given asset depends on"""
-        parents = self.get_parents(asset_key)
-        if not parents:
+        if not self.get_parents(asset_key):
             return {asset_key}
-        return set().union(*(self.get_roots(parent_key) for parent_key in parents))
+        return {key for key in self.upstream_key_iterator(asset_key) if not self.get_parents(key)}
 
     def upstream_key_iterator(self, asset_key: AssetKey) -> Iterator[AssetKey]:
         """Iterates through all asset keys which are upstream of the given key."""
-        for parent_key in self.get_parents(asset_key):
-            yield parent_key
-            yield from self.upstream_key_iterator(parent_key)
+        visited: Set[AssetKey] = set()
+        queue = deque([asset_key])
+        while queue:
+            current_key = queue.popleft()
+            for parent_key in self.get_parents(current_key):
+                if parent_key not in visited:
+                    yield parent_key
+                    queue.append(parent_key)
+                    visited.add(parent_key)
 
     def get_children_partitions(
         self, asset_key: AssetKey, partition_key: Optional[str] = None

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1301,6 +1301,22 @@ class DagsterInstance:
         return self._run_storage.add_run_tags(run_id, new_tags)
 
     @traced
+    def add_asset_event_tags(self, asset_event_id: int, new_tags: Dict[str, str]):
+        import json
+
+        cur_tags = self.get_asset_event_tags(asset_event_id)
+
+        self._run_storage.kvs_set({str(asset_event_id): json.dumps({**cur_tags, **new_tags})})
+
+    @traced
+    def get_asset_event_tags(self, asset_event_id: int) -> Dict[str, str]:
+        import json
+
+        return json.loads(
+            self._run_storage.kvs_get({str(asset_event_id)}).get(str(asset_event_id), "{}")
+        )
+
+    @traced
     def has_run(self, run_id: str) -> bool:
         return self._run_storage.has_run(run_id)
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1301,22 +1301,6 @@ class DagsterInstance:
         return self._run_storage.add_run_tags(run_id, new_tags)
 
     @traced
-    def add_asset_event_tags(self, asset_event_id: int, new_tags: Dict[str, str]):
-        import json
-
-        cur_tags = self.get_asset_event_tags(asset_event_id)
-
-        self._run_storage.kvs_set({str(asset_event_id): json.dumps({**cur_tags, **new_tags})})
-
-    @traced
-    def get_asset_event_tags(self, asset_event_id: int) -> Dict[str, str]:
-        import json
-
-        return json.loads(
-            self._run_storage.kvs_get({str(asset_event_id)}).get(str(asset_event_id), "{}")
-        )
-
-    @traced
     def has_run(self, run_id: str) -> bool:
         return self._run_storage.has_run(run_id)
 

--- a/python_modules/dagster/dagster/_utils/calculate_data_time.py
+++ b/python_modules/dagster/dagster/_utils/calculate_data_time.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import AbstractSet, Mapping, Optional
+from typing import AbstractSet, Mapping, Optional, cast
 
 from dagster import AssetKey, DagsterEventType, DagsterInstance, EventLogRecord, EventRecordsFilter
 
@@ -21,19 +21,19 @@ def get_upstream_materialization_times_for_record(
     given materialization event.
     """
 
-    def _upstream_key_str_iterator(asset_key_str):
+    def _upstream_key_str_iterator(asset_key_str: str):
         for key_str in upstream_asset_key_mapping[asset_key_str]:
             yield key_str
             yield from _upstream_key_str_iterator(key_str)
 
-    def _get_upstream_times_and_ids(record, required_keys):
+    def _get_upstream_times_and_ids(record: EventLogRecord, required_keys: AbstractSet[AssetKey]):
         # no record available, so the data time for all keys upstream of here is None
         if record is None:
             return {k: (None, None) for k in required_keys}
 
         cur_tags = instance.get_asset_event_tags(record.storage_id)
 
-        cur_key = record.event_log_entry.dagster_event.event_specific_data.materialization.asset_key
+        cur_key = cast(AssetKey, record.asset_key)
         cur_key_str = cur_key.to_user_string()
 
         # grab the existing upstream data times already calculated for this record (if any)
@@ -44,55 +44,59 @@ def get_upstream_materialization_times_for_record(
 
         # this is a required key to track, so grab its record
         if cur_key in required_keys:
-            known_times[cur_key.to_user_string()] = (
+            known_times[cur_key_str] = (
                 record.storage_id,
                 record.event_log_entry.timestamp,
             )
 
-        # at this point, we already have all required keys, so can just return the known times
-        if set(known_times.keys()) > required_keys:
-            return known_times
+        # not all required data times are present in the tags
+        if required_keys - set(known_times.keys()):
 
-        # find all the required keys that are upstream of this key
-        required_upstream_keys = set()
-        for upstream_key_str in _upstream_key_str_iterator(cur_key_str):
-            upstream_key = AssetKey.from_user_string(upstream_key_str)
-            if upstream_key in required_keys:
-                required_upstream_keys.add(upstream_key)
+            # find all the required keys that are upstream of this key
+            required_upstream_keys = set()
+            for upstream_key_str in _upstream_key_str_iterator(cur_key_str):
+                upstream_key = AssetKey.from_user_string(upstream_key_str)
+                if upstream_key in required_keys:
+                    required_upstream_keys.add(upstream_key)
 
-        # find the upstream times of each of the parents of this asset
-        for parent_key_str in upstream_asset_key_mapping[cur_key_str]:
-            parent_key = AssetKey.from_user_string(parent_key_str)
+            # find the upstream times of each of the parents of this asset
+            for parent_key_str in upstream_asset_key_mapping[cur_key_str]:
+                parent_key = AssetKey.from_user_string(parent_key_str)
 
-            # get the most recent asset materialization for this parent which happened before
-            # the current record
-            parent_records = instance.get_event_records(
-                EventRecordsFilter(
-                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                    asset_key=parent_key,
-                    before_cursor=record.storage_id,
-                ),
-                ascending=False,
-                limit=1,
-            )
-            latest_parent_record = parent_records[0] if parent_records else None
+                # get the most recent asset materialization for this parent which happened before
+                # the current record
+                parent_records = instance.get_event_records(
+                    EventRecordsFilter(
+                        event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                        asset_key=parent_key,
+                        before_cursor=record.storage_id,
+                    ),
+                    ascending=False,
+                    limit=1,
+                )
+                latest_parent_record = parent_records[0] if parent_records else None
 
-            # recurse to find the data times of this parent
-            for key, tup in _get_upstream_times_and_ids(
-                latest_parent_record, required_upstream_keys
-            ).items():
-                tup = tuple(tup)
-                # if root data is missing, override other values
-                if tup == (None, None) or known_times.get(key) == (None, None):
-                    known_times[key] = (None, None)
-                else:
-                    known_times[key] = min(tuple(known_times.get(key, tup)), tup)
+                # recurse to find the data times of this parent
+                for key, tup in _get_upstream_times_and_ids(
+                    latest_parent_record, required_upstream_keys
+                ).items():
+                    tup = tuple(tup)
+                    # if root data is missing, override other values
+                    if tup == (None, None) or known_times.get(key) == (None, None):
+                        known_times[key] = (None, None)
+                    else:
+                        known_times[key] = min(tuple(known_times.get(key, tup)), tup)
 
         # cache asset event in the database
         instance.add_asset_event_tags(
             record.storage_id, {UPSTREAM_MATERIALIZATION_TIMES_TAG: known_times}
         )
-        return known_times
+        return {
+            k: v
+            for k, v in known_times.items()
+            # filter out unnecessary info
+            if AssetKey.from_user_string(k) in required_keys
+        }
 
     return {
         # convert to nicer output format
@@ -100,6 +104,4 @@ def get_upstream_materialization_times_for_record(
         if timestamp is not None
         else None
         for k, (_, timestamp) in _get_upstream_times_and_ids(record, relevant_upstream_keys).items()
-        # filter out irrelevant upstream asset keys
-        if AssetKey.from_user_string(k) in relevant_upstream_keys
     }

--- a/python_modules/dagster/dagster/_utils/calculate_data_time.py
+++ b/python_modules/dagster/dagster/_utils/calculate_data_time.py
@@ -1,126 +1,167 @@
 import datetime
 import json
-from typing import AbstractSet, Dict, Iterator, Mapping, Optional, Tuple, cast
+from typing import AbstractSet, Dict, Mapping, Optional, Tuple
 
-from dagster import AssetKey, DagsterEventType, DagsterInstance, EventLogRecord, EventRecordsFilter
+from dagster import (
+    AssetKey,
+    DagsterEventType,
+    DagsterInstance,
+    DagsterInvariantViolationError,
+    EventLogRecord,
+    EventRecordsFilter,
+)
 from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._utils.cached_method import cached_method
+from dagster._utils.merger import merge_dicts
 
 
-def get_used_upstream_materialization_times_for_record(
-    record: EventLogRecord,
-    instance: DagsterInstance,
-    asset_graph: AssetGraph,
-    upstream_keys: AbstractSet[AssetKey],
-) -> Mapping[AssetKey, Optional[datetime.datetime]]:
-    """Method to enable calculating the timestamps of materializations of upstream assets
-    which were relevant to a given AssetMaterialization. These timestamps can be calculated relative
-    to any upstream asset keys.
+class DataTimeInstanceQueryer:
+    """Allows caching queries to the instance while evaluating"""
 
-    The heart of this functionality is a recursive method which takes a given asset materialization
-    and finds the most recent materialization of each of its parents which happened *before* that
-    given materialization event.
-    """
+    def __init__(self, instance: DagsterInstance, asset_graph: AssetGraph):
+        self._instance = instance
+        self._asset_graph = asset_graph
 
-    def _storage_key(storage_id: int) -> str:
-        return f".dagster-used_upstream_times-{storage_id}"
+    @property
+    def instance(self) -> DagsterInstance:
+        return self._instance
 
-    _local_cache: Dict[int, Dict[AssetKey, Tuple[Optional[int], Optional[float]]]] = {}
+    @property
+    def asset_graph(self) -> AssetGraph:
+        return self._asset_graph
 
-    def _get_known_times(
-        storage_id: int,
+    def _kvs_key_for_record_id(self, record_id: int) -> str:
+        return f".dagster/used_data/{record_id}"
+
+    def set_known_used_data(
+        self,
+        record_id: int,
+        new_known_data: Dict[AssetKey, Tuple[Optional[int], Optional[float]]],
+    ):
+        if self.instance.run_storage.supports_kvs():
+            current_known_data = self.get_known_used_data(record_id)
+            known_data = merge_dicts(current_known_data, new_known_data)
+            serialized_times = json.dumps(
+                {key.to_user_string(): value for key, value in known_data.items()}
+            )
+            self.instance.run_storage.kvs_set(
+                {self._kvs_key_for_record_id(record_id): serialized_times}
+            )
+
+    def get_known_used_data(
+        self, record_id: int
     ) -> Dict[AssetKey, Tuple[Optional[int], Optional[float]]]:
-        if storage_id in _local_cache:
-            # fetch from local cache if possible
-            return _local_cache[storage_id]
-        elif instance.run_storage.supports_kvs():
+        """Returns the known upstream ids and timestamps stored on the instance"""
+        if self.instance.run_storage.supports_kvs():
             # otherwise, attempt to fetch from the instance key-value store
-            storage_key = _storage_key(storage_id)
-            serialized_times = instance.run_storage.kvs_get({storage_key}).get(storage_key, "{}")
+            kvs_key = self._kvs_key_for_record_id(record_id)
+            serialized_times = self.instance.run_storage.kvs_get({kvs_key}).get(kvs_key, "{}")
             return {
                 AssetKey.from_user_string(key): tuple(value)  # type:ignore
                 for key, value in json.loads(serialized_times).items()
             }
         return {}
 
-    def _set_known_times(
-        storage_id: int, known_times: Dict[AssetKey, Tuple[Optional[int], Optional[float]]]
-    ):
-        if known_times != _local_cache.get(storage_id):
-            _local_cache[storage_id] = known_times
-            if instance.run_storage.supports_kvs():
-                # store this info in the instance key-value store for future calls
-                storage_key = _storage_key(storage_id)
-                serialized_times = json.dumps(
-                    {key.to_user_string(): value for key, value in known_times.items()}
-                )
-                instance.run_storage.kvs_set({storage_key: serialized_times})
+    @cached_method
+    def get_most_recent_materialization_record(
+        self, asset_key: AssetKey, before_cursor: Optional[int] = None
+    ) -> Optional[EventLogRecord]:
+        records = self.instance.get_event_records(
+            EventRecordsFilter(
+                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                asset_key=asset_key,
+                before_cursor=before_cursor,
+            ),
+            ascending=False,
+            limit=1,
+        )
+        return records[0] if records else None
 
-    def _upstream_key_iterator(key: AssetKey) -> Iterator[AssetKey]:
-        yield key
-        for parent_key in asset_graph.get_parents(key):
-            yield from _upstream_key_iterator(parent_key)
-
-    def _get_upstream_ids_and_times(
-        record: Optional[EventLogRecord], required_keys: AbstractSet[AssetKey]
+    @cached_method
+    def calculate_used_data(
+        self,
+        asset_key: AssetKey,
+        record_id: Optional[int],
+        record_timestamp: Optional[float],
+        required_keys: AbstractSet[AssetKey],
     ) -> Dict[AssetKey, Tuple[Optional[int], Optional[float]]]:
 
-        if record is None:
+        if record_id is None:
             return {key: (None, None) for key in required_keys}
 
-        key = cast(AssetKey, record.asset_key)
-
         # grab the existing upstream data times already calculated for this record (if any)
-        known_times = _get_known_times(record.storage_id)
-        if key in required_keys:
-            known_times[key] = (
-                record.storage_id,
-                record.event_log_entry.timestamp,
-            )
+        known_data = self.get_known_used_data(record_id)
+        if asset_key in required_keys:
+            known_data[asset_key] = (record_id, record_timestamp)
 
         # not all required keys have known values
-        unknown_required_keys = required_keys - set(known_times.keys())
+        unknown_required_keys = required_keys - set(known_data.keys())
         if unknown_required_keys:
 
             # find the upstream times of each of the parents of this asset
-            for parent_key in asset_graph.get_parents(key):
-                # the set of required keys which are upstream of this key
+            for parent_key in self.asset_graph.get_parents(asset_key):
+                # the set of required keys which are upstream of this parent
                 upstream_required_keys = set()
-                for upstream_key in _upstream_key_iterator(parent_key):
+                if parent_key in unknown_required_keys:
+                    upstream_required_keys.add(parent_key)
+                for upstream_key in self.asset_graph.upstream_key_iterator(parent_key):
                     if upstream_key in unknown_required_keys:
                         upstream_required_keys.add(upstream_key)
 
                 # get the most recent asset materialization for this parent which happened before
                 # the current record
-                parent_records = instance.get_event_records(
-                    EventRecordsFilter(
-                        event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                        asset_key=parent_key,
-                        before_cursor=record.storage_id,
-                    ),
-                    ascending=False,
-                    limit=1,
+                latest_parent_record = self.get_most_recent_materialization_record(
+                    asset_key=parent_key, before_cursor=record_id
                 )
-                latest_parent_record = parent_records[0] if parent_records else None
 
                 # recurse to find the data times of this parent
-                for key, tup in _get_upstream_ids_and_times(
-                    latest_parent_record, upstream_required_keys
+                for key, tup in self.calculate_used_data(
+                    asset_key=parent_key,
+                    record_id=latest_parent_record.storage_id if latest_parent_record else None,
+                    record_timestamp=latest_parent_record.event_log_entry.timestamp
+                    if latest_parent_record
+                    else None,
+                    required_keys=frozenset(upstream_required_keys),
                 ).items():
                     # if root data is missing, this overrides other values
-                    if tup == (None, None) or known_times.get(key) == (None, None):
-                        known_times[key] = (None, None)
+                    if tup == (None, None) or known_data.get(key) == (None, None):
+                        known_data[key] = (None, None)
                     else:
-                        known_times[key] = min(known_times.get(key, tup), tup)
+                        known_data[key] = min(known_data.get(key, tup), tup)
 
-        # cache these calculated values
-        _set_known_times(record.storage_id, known_times)
+        return {k: v for k, v in known_data.items() if k in required_keys}
 
-        return {k: v for k, v in known_times.items() if k in required_keys}
+    def get_used_data_times_for_record(
+        self,
+        record: EventLogRecord,
+        upstream_keys: Optional[AbstractSet[AssetKey]] = None,
+    ) -> Mapping[AssetKey, Optional[datetime.datetime]]:
+        """Method to enable calculating the timestamps of materializations of upstream assets
+        which were relevant to a given AssetMaterialization. These timestamps can be calculated relative
+        to any upstream asset keys.
 
-    return {
-        # convert to nicer output format
-        k: datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
-        if timestamp is not None
-        else None
-        for k, (_, timestamp) in _get_upstream_ids_and_times(record, upstream_keys).items()
-    }
+        The heart of this functionality is a recursive method which takes a given asset materialization
+        and finds the most recent materialization of each of its parents which happened *before* that
+        given materialization event.
+        """
+        if record.asset_key is None:
+            raise DagsterInvariantViolationError(
+                "Can only calculate data times for records with an `asset_key`."
+            )
+        if upstream_keys is None:
+            upstream_keys = self.asset_graph.get_roots(record.asset_key)
+
+        data = self.calculate_used_data(
+            asset_key=record.asset_key,
+            record_id=record.storage_id,
+            record_timestamp=record.event_log_entry.timestamp,
+            required_keys=frozenset(upstream_keys),
+        )
+        self.set_known_used_data(record.storage_id, new_known_data=data)
+
+        return {
+            key: datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
+            if timestamp is not None
+            else None
+            for key, (_, timestamp) in data.items()
+        }

--- a/python_modules/dagster/dagster/_utils/calculate_data_time.py
+++ b/python_modules/dagster/dagster/_utils/calculate_data_time.py
@@ -1,10 +1,7 @@
 from datetime import datetime
-from typing import AbstractSet, Mapping, Optional, Tuple
+from typing import AbstractSet, Mapping, Optional
 
-from dagster import EventLogRecord
-
-from ..definitions.events import AssetKey
-from ..instance import DagsterInstance
+from dagster import AssetKey, DagsterEventType, DagsterInstance, EventLogRecord, EventRecordsFilter
 
 UPSTREAM_MATERIALIZATION_TIMES_TAG = ".dagster/upstream_times"
 
@@ -15,71 +12,94 @@ def get_upstream_materialization_times_for_record(
     relevant_upstream_keys: AbstractSet[AssetKey],
     record: EventLogRecord,
 ) -> Mapping[AssetKey, Optional[datetime]]:
-    from dagster._core.events import DagsterEventType
-    from dagster._core.storage.event_log.base import EventRecordsFilter
+    """Helper method to enable calculating the timestamps of materializations of upstream assets
+    which were relevant to a given AssetMaterialization. These timestamps can be calculated relative
+    to any upstream asset keys.
 
-    def _upstream_key_iterator(asset_key_str):
+    The heart of this functionality is a recursive method which takes a given asset materialization
+    and finds the most recent materialization of each of its parents which happened *before* that
+    given materialization event.
+    """
+
+    def _upstream_key_str_iterator(asset_key_str):
         for key_str in upstream_asset_key_mapping[asset_key_str]:
             yield key_str
-            yield from _upstream_key_iterator(key_str)
+            yield from _upstream_key_str_iterator(key_str)
 
     def _get_upstream_times_and_ids(record, required_keys):
+        # no record available, so the data time for all keys upstream of here is None
+        if record is None:
+            return {k: (None, None) for k in required_keys}
+
         cur_tags = instance.get_asset_event_tags(record.storage_id)
+
+        cur_key = record.event_log_entry.dagster_event.event_specific_data.materialization.asset_key
+        cur_key_str = cur_key.to_user_string()
+
+        # grab the existing upstream data times already calculated for this record (if any)
         if UPSTREAM_MATERIALIZATION_TIMES_TAG in cur_tags:
             known_times = cur_tags[UPSTREAM_MATERIALIZATION_TIMES_TAG]
-            # already have calculated all the required times
-            if not (required_keys - set(known_times.keys())):
-                return known_times
         else:
             known_times = {}
 
-        cur_key = record.event_log_entry.dagster_event.event_specific_data.materialization.asset_key
-        upstream_key_strs = upstream_asset_key_mapping[cur_key.to_user_string()]
-
+        # this is a required key to track, so grab its record
         if cur_key in required_keys:
             known_times[cur_key.to_user_string()] = (
                 record.storage_id,
                 record.event_log_entry.timestamp,
             )
-        else:
-            for upstream_key_str in upstream_key_strs:
-                upstream_key = AssetKey.from_user_string(upstream_key_str)
-                upstream_records = instance.get_event_records(
-                    EventRecordsFilter(
-                        event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                        asset_key=upstream_key,
-                        before_cursor=record.storage_id,
-                    ),
-                    ascending=False,
-                    limit=1,
-                )
-                if not upstream_records:
-                    # find all the required keys upstream of this one and set their values to None
-                    for k in _upstream_key_iterator(upstream_key_str):
-                        if AssetKey.from_user_string(k) in required_keys:
-                            known_times[k] = (None, None)
-                else:
-                    # recurse to find the data times of this parent
-                    for key, tup in _get_upstream_times_and_ids(
-                        upstream_records[0], required_keys
-                    ).items():
-                        tup = tuple(tup)
-                        # if root data is missing, override other values
-                        if tup == (None, None) or known_times.get(key) == (None, None):
-                            known_times[key] = (None, None)
-                        else:
-                            known_times[key] = max(known_times.get(key, tup), tup)
 
+        # at this point, we already have all required keys, so can just return the known times
+        if set(known_times.keys()) > required_keys:
+            return known_times
+
+        # find all the required keys that are upstream of this key
+        required_upstream_keys = set()
+        for upstream_key_str in _upstream_key_str_iterator(cur_key_str):
+            upstream_key = AssetKey.from_user_string(upstream_key_str)
+            if upstream_key in required_keys:
+                required_upstream_keys.add(upstream_key)
+
+        # find the upstream times of each of the parents of this asset
+        for parent_key_str in upstream_asset_key_mapping[cur_key_str]:
+            parent_key = AssetKey.from_user_string(parent_key_str)
+
+            # get the most recent asset materialization for this parent which happened before
+            # the current record
+            parent_records = instance.get_event_records(
+                EventRecordsFilter(
+                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                    asset_key=parent_key,
+                    before_cursor=record.storage_id,
+                ),
+                ascending=False,
+                limit=1,
+            )
+            latest_parent_record = parent_records[0] if parent_records else None
+
+            # recurse to find the data times of this parent
+            for key, tup in _get_upstream_times_and_ids(
+                latest_parent_record, required_upstream_keys
+            ).items():
+                tup = tuple(tup)
+                # if root data is missing, override other values
+                if tup == (None, None) or known_times.get(key) == (None, None):
+                    known_times[key] = (None, None)
+                else:
+                    known_times[key] = min(tuple(known_times.get(key, tup)), tup)
+
+        # cache asset event in the database
         instance.add_asset_event_tags(
             record.storage_id, {UPSTREAM_MATERIALIZATION_TIMES_TAG: known_times}
         )
         return known_times
 
     return {
+        # convert to nicer output format
         AssetKey.from_user_string(k): datetime.fromtimestamp(timestamp)
         if timestamp is not None
         else None
-        for k, (_, timestamp) in _get_upstream_times_and_ids(
-            materialization_record, upstream_keys
-        ).items()
+        for k, (_, timestamp) in _get_upstream_times_and_ids(record, relevant_upstream_keys).items()
+        # filter out irrelevant upstream asset keys
+        if AssetKey.from_user_string(k) in relevant_upstream_keys
     }

--- a/python_modules/dagster/dagster/_utils/calculate_data_time.py
+++ b/python_modules/dagster/dagster/_utils/calculate_data_time.py
@@ -1,0 +1,85 @@
+from datetime import datetime
+from typing import AbstractSet, Mapping, Optional, Tuple
+
+from dagster import EventLogRecord
+
+from ..definitions.events import AssetKey
+from ..instance import DagsterInstance
+
+UPSTREAM_MATERIALIZATION_TIMES_TAG = ".dagster/upstream_times"
+
+
+def get_upstream_materialization_times_for_record(
+    instance: DagsterInstance,
+    upstream_asset_key_mapping: Mapping[str, AbstractSet[str]],
+    relevant_upstream_keys: AbstractSet[AssetKey],
+    record: EventLogRecord,
+) -> Mapping[AssetKey, Optional[datetime]]:
+    from dagster._core.events import DagsterEventType
+    from dagster._core.storage.event_log.base import EventRecordsFilter
+
+    def _upstream_key_iterator(asset_key_str):
+        for key_str in upstream_asset_key_mapping[asset_key_str]:
+            yield key_str
+            yield from _upstream_key_iterator(key_str)
+
+    def _get_upstream_times_and_ids(record, required_keys):
+        cur_tags = instance.get_asset_event_tags(record.storage_id)
+        if UPSTREAM_MATERIALIZATION_TIMES_TAG in cur_tags:
+            known_times = cur_tags[UPSTREAM_MATERIALIZATION_TIMES_TAG]
+            # already have calculated all the required times
+            if not (required_keys - set(known_times.keys())):
+                return known_times
+        else:
+            known_times = {}
+
+        cur_key = record.event_log_entry.dagster_event.event_specific_data.materialization.asset_key
+        upstream_key_strs = upstream_asset_key_mapping[cur_key.to_user_string()]
+
+        if cur_key in required_keys:
+            known_times[cur_key.to_user_string()] = (
+                record.storage_id,
+                record.event_log_entry.timestamp,
+            )
+        else:
+            for upstream_key_str in upstream_key_strs:
+                upstream_key = AssetKey.from_user_string(upstream_key_str)
+                upstream_records = instance.get_event_records(
+                    EventRecordsFilter(
+                        event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                        asset_key=upstream_key,
+                        before_cursor=record.storage_id,
+                    ),
+                    ascending=False,
+                    limit=1,
+                )
+                if not upstream_records:
+                    # find all the required keys upstream of this one and set their values to None
+                    for k in _upstream_key_iterator(upstream_key_str):
+                        if AssetKey.from_user_string(k) in required_keys:
+                            known_times[k] = (None, None)
+                else:
+                    # recurse to find the data times of this parent
+                    for key, tup in _get_upstream_times_and_ids(
+                        upstream_records[0], required_keys
+                    ).items():
+                        tup = tuple(tup)
+                        # if root data is missing, override other values
+                        if tup == (None, None) or known_times.get(key) == (None, None):
+                            known_times[key] = (None, None)
+                        else:
+                            known_times[key] = max(known_times.get(key, tup), tup)
+
+        instance.add_asset_event_tags(
+            record.storage_id, {UPSTREAM_MATERIALIZATION_TIMES_TAG: known_times}
+        )
+        return known_times
+
+    return {
+        AssetKey.from_user_string(k): datetime.fromtimestamp(timestamp)
+        if timestamp is not None
+        else None
+        for k, (_, timestamp) in _get_upstream_times_and_ids(
+            materialization_record, upstream_keys
+        ).items()
+    }

--- a/python_modules/dagster/dagster_tests/utils_tests/test_calculate_materialization_times.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_calculate_materialization_times.py
@@ -1,96 +1,82 @@
+from collections import defaultdict
+from datetime import datetime
+
+import pytest
+
+from dagster import (
+    AssetKey,
+    AssetOut,
+    AssetSelection,
+    DagsterEventType,
+    EventRecordsFilter,
+    Output,
+    asset,
+    multi_asset,
+    repository,
+)
+from dagster._core.definitions.asset_layer import build_asset_selection_job
+from dagster._core.selector.subset_selector import generate_asset_dep_graph
+from dagster._core.test_utils import instance_for_test
 from dagster._utils.calculate_data_time import get_upstream_materialization_times_for_record
 
 
 @pytest.mark.parametrize(
-    ["asset_keys", "materialization_effects"],
+    ["relative_to", "runs_to_expected_data_times_index"],
     [
         (
-            "e",
+            "ROOTS",
             [
-                ("e", {"e": False}),
-                ("abd", {"e": False}),
-                ("ac", {"e": False}),
-                ("e", {"e": True}),
+                ("ace", {"ace": {"a": 0}}),
+                ("abd", {"ab": {"a": 1}, "cde": {"a": 0}}),
+                ("ac", {"ac": {"a": 2}, "b": {"a": 1}, "ed": {"a": 0}}),
+                ("e", {"ace": {"a": 2}, "b": {"a": 1}, "d": {"a": 0}}),
             ],
         ),
         (
-            "e",
+            "ROOTS",
             [
-                ("abce", {"e": True}),
+                ("abcf", {"abc": {"a": 0}}),
+                ("bd", {"abd": {"a": 0}}),
+                ("a", {"a": {"a": 2}, "bcd": {"a": 0}}),
+                ("f", {"a": {"a": 2}, "bcdf": {"a": 0}}),
+                ("bdf", {"ab": {"a": 2}, "cdf": {"a": 0}}),
+                ("c", {"abc": {"a": 2}, "df": {"a": 0}}),
+                ("df", {"abcdf": {"a": 2}}),
             ],
         ),
         (
-            "e",
+            "SELF",
             [
-                ("ae", {"e": False}),
-                ("b", {"e": False}),
-                ("c", {"e": False}),
-                ("e", {"e": True}),
+                ("abcdef", {a: {a: 0} for a in "abcdef"}),
+                ("abc", {a: {a: 1 if a in "abc" else 0} for a in "abcdef"}),
+                ("def", {a: {a: 2 if a in "def" else 1} for a in "abcdef"}),
+                ("abcdef", {a: {a: 3} for a in "abcdef"}),
+                ("acd", {a: {a: 4 if a in "acd" else 3} for a in "abcdef"}),
+                ("bef", {a: {a: 5 if a in "bef" else 4} for a in "abcdef"}),
             ],
         ),
         (
-            "e",
+            "bc",
             [
-                ("a", {"e": False}),
-                ("c", {"e": False}),
-                ("e", {"e": True}),
+                ("abcd", {"d": {"b": 0, "c": 0}}),
+                ("acd", {"d": {"b": 0, "c": 1}}),
+                ("abd", {"d": {"b": 2, "c": 1}}),
+                ("f", {"df": {"b": 2, "c": 1}}),
             ],
         ),
         (
-            "e",
+            "ac",
             [
-                ("ce", {"e": False}),
-                ("ac", {"e": False}),
-                ("e", {"e": True}),
-            ],
-        ),
-        (
-            "f",
-            [
-                ("acd", {"f": False}),
-                ("bf", {"f": False}),
-                ("bdf", {"f": True}),
-            ],
-        ),
-        (
-            "f",
-            [
-                ("bdf", {"f": False}),
-                ("a", {"f": False}),
-                ("bdf", {"f": False}),
-                ("c", {"f": False}),
-                ("bdf", {"f": True}),
-            ],
-        ),
-        (
-            "ef",
-            [
-                ("a", {"f": False, "e": False}),
-                ("bc", {"f": False, "e": False}),
-                ("de", {"f": False, "e": True}),
-                ("f", {"f": True, "e": True}),
-            ],
-        ),
-        (
-            "ef",
-            [
-                ("cdef", {"f": False, "e": False}),
-                ("ab", {"f": False, "e": False}),
-                ("cdef", {"f": True, "e": True}),
-            ],
-        ),
-        (
-            "ef",
-            [
-                ("acdef", {"f": False, "e": True}),
-                ("ab", {"f": False, "e": True}),
-                ("bd", {"f": False, "e": True}),
-                ("f", {"f": True, "e": True}),
+                ("abcd", {"d": {"a": 0, "c": 0}}),
+                ("ce", {"d": {"a": 0, "c": 0}, "e": {"a": 0, "c": 1}}),
+                ("df", {"de": {"a": 0, "c": 1}}),
+                ("abc", {"de": {"a": 0, "c": 1}}),
+                ("d", {"d": {"a": 3, "c": 3}, "e": {"a": 0, "c": 1}}),
             ],
         ),
     ],
 )
-def test_calculate_data_time(asset_keys, materialization_effects):
+def test_calculate_data_time(relative_to, runs_to_expected_data_times_index):
     """
     A = B = D = F
      \\  //
@@ -128,18 +114,32 @@ def test_calculate_data_time(asset_keys, materialization_effects):
     def f():
         return 1
 
-    asset_keys = [AssetKey(c) for c in asset_keys]
     all_assets = [a, bcd, e, f]
+
+    upstream_mapping = generate_asset_dep_graph(all_assets, [])["upstream"]
 
     @repository
     def my_repo():
         return [all_assets]
 
+    def _get_root_keys(key_str):
+        upstream_key_strs = upstream_mapping[key_str]
+        if not upstream_key_strs:
+            return {AssetKey.from_user_string(key_str)}
+        return set().union(
+            *(_get_root_keys(upstream_key_str) for upstream_key_str in upstream_key_strs)
+        )
+
     with instance_for_test() as instance:
 
-        for to_materialize, expected_results in materialization_effects:
+        # mapping from asset key to a mapping of materialization timestamp to run index
+        materialization_times_index = defaultdict(dict)
+
+        for idx, (to_materialize, expected_index_mapping) in enumerate(
+            runs_to_expected_data_times_index
+        ):
             # materialize selected assets
-            build_asset_selection_job(
+            result = build_asset_selection_job(
                 "materialize_job",
                 assets=all_assets,
                 source_assets=[],
@@ -148,17 +148,40 @@ def test_calculate_data_time(asset_keys, materialization_effects):
                 ),
             ).execute_in_process(instance=instance)
 
-        # 1.5 hours later, everything should be stale
-        with pendulum.test(pendulum.now().add(hours=1.5)):
-            ctx = build_freshness_policy_sensor_context(
-                asset_keys=asset_keys,
-                repository_def=my_repo,
-                cursor=ctx.cursor,
-                instance=instance,
-            )
-            ret = list(my_sla_sensor(ctx))
-            assert len(ret) == len(asset_keys)
-            for ak in asset_keys:
-                assert (
-                    RunRequest(run_key=None, tags={"status": "False"}, asset_selection=[ak]) in ret
+            assert result.success
+
+            # build mapping of expected timestamps
+            for entry in instance.all_logs(
+                result.run_id, of_type=DagsterEventType.ASSET_MATERIALIZATION
+            ):
+                asset_key = entry.dagster_event.event_specific_data.materialization.asset_key
+                materialization_times_index[asset_key][idx] = datetime.fromtimestamp(
+                    entry.timestamp
                 )
+
+            for asset_keys, expected_data_times in expected_index_mapping.items():
+                for ak in asset_keys:
+                    latest_asset_record = instance.get_event_records(
+                        EventRecordsFilter(
+                            event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                            asset_key=AssetKey(ak),
+                        ),
+                        ascending=False,
+                        limit=1,
+                    )[0]
+                    if relative_to == "ROOTS":
+                        relevant_upstream_keys = _get_root_keys(ak)
+                    elif relative_to == "SELF":
+                        relevant_upstream_keys = {AssetKey(ak)}
+                    else:
+                        relevant_upstream_keys = {AssetKey(u) for u in relative_to}
+                    upstream_data_times = get_upstream_materialization_times_for_record(
+                        instance=instance,
+                        upstream_asset_key_mapping=upstream_mapping,
+                        relevant_upstream_keys=relevant_upstream_keys,
+                        record=latest_asset_record,
+                    )
+                    assert upstream_data_times == {
+                        AssetKey(k): materialization_times_index[AssetKey(k)][v]
+                        for k, v in expected_data_times.items()
+                    }

--- a/python_modules/dagster/dagster_tests/utils_tests/test_calculate_materialization_times.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_calculate_materialization_times.py
@@ -1,0 +1,164 @@
+from dagster._utils.calculate_data_time import get_upstream_materialization_times_for_record
+
+
+@pytest.mark.parametrize(
+    ["asset_keys", "materialization_effects"],
+    [
+        (
+            "e",
+            [
+                ("e", {"e": False}),
+                ("abd", {"e": False}),
+                ("ac", {"e": False}),
+                ("e", {"e": True}),
+            ],
+        ),
+        (
+            "e",
+            [
+                ("abce", {"e": True}),
+            ],
+        ),
+        (
+            "e",
+            [
+                ("ae", {"e": False}),
+                ("b", {"e": False}),
+                ("c", {"e": False}),
+                ("e", {"e": True}),
+            ],
+        ),
+        (
+            "e",
+            [
+                ("a", {"e": False}),
+                ("c", {"e": False}),
+                ("e", {"e": True}),
+            ],
+        ),
+        (
+            "e",
+            [
+                ("ce", {"e": False}),
+                ("ac", {"e": False}),
+                ("e", {"e": True}),
+            ],
+        ),
+        (
+            "f",
+            [
+                ("acd", {"f": False}),
+                ("bf", {"f": False}),
+                ("bdf", {"f": True}),
+            ],
+        ),
+        (
+            "f",
+            [
+                ("bdf", {"f": False}),
+                ("a", {"f": False}),
+                ("bdf", {"f": False}),
+                ("c", {"f": False}),
+                ("bdf", {"f": True}),
+            ],
+        ),
+        (
+            "ef",
+            [
+                ("a", {"f": False, "e": False}),
+                ("bc", {"f": False, "e": False}),
+                ("de", {"f": False, "e": True}),
+                ("f", {"f": True, "e": True}),
+            ],
+        ),
+        (
+            "ef",
+            [
+                ("cdef", {"f": False, "e": False}),
+                ("ab", {"f": False, "e": False}),
+                ("cdef", {"f": True, "e": True}),
+            ],
+        ),
+        (
+            "ef",
+            [
+                ("acdef", {"f": False, "e": True}),
+                ("ab", {"f": False, "e": True}),
+                ("bd", {"f": False, "e": True}),
+                ("f", {"f": True, "e": True}),
+            ],
+        ),
+    ],
+)
+def test_calculate_data_time(asset_keys, materialization_effects):
+    """
+    A = B = D = F
+     \\  //
+       C = E
+    B,C,D share an op
+    """
+
+    @asset
+    def a():
+        return 1
+
+    @multi_asset(
+        non_argument_deps={AssetKey("a")},
+        outs={
+            "b": AssetOut(is_required=False),
+            "c": AssetOut(is_required=False),
+            "d": AssetOut(is_required=False),
+        },
+        can_subset=True,
+        internal_asset_deps={
+            "b": {AssetKey("a")},
+            "c": {AssetKey("a")},
+            "d": {AssetKey("b"), AssetKey("c")},
+        },
+    )
+    def bcd(context):
+        for output_name in sorted(context.selected_output_names):
+            yield Output(output_name, output_name)
+
+    @asset(non_argument_deps={AssetKey("c")})
+    def e():
+        return 1
+
+    @asset(non_argument_deps={AssetKey("d")})
+    def f():
+        return 1
+
+    asset_keys = [AssetKey(c) for c in asset_keys]
+    all_assets = [a, bcd, e, f]
+
+    @repository
+    def my_repo():
+        return [all_assets]
+
+    with instance_for_test() as instance:
+
+        for to_materialize, expected_results in materialization_effects:
+            # materialize selected assets
+            build_asset_selection_job(
+                "materialize_job",
+                assets=all_assets,
+                source_assets=[],
+                asset_selection=AssetSelection.keys(*(AssetKey(c) for c in to_materialize)).resolve(
+                    all_assets
+                ),
+            ).execute_in_process(instance=instance)
+
+        # 1.5 hours later, everything should be stale
+        with pendulum.test(pendulum.now().add(hours=1.5)):
+            ctx = build_freshness_policy_sensor_context(
+                asset_keys=asset_keys,
+                repository_def=my_repo,
+                cursor=ctx.cursor,
+                instance=instance,
+            )
+            ret = list(my_sla_sensor(ctx))
+            assert len(ret) == len(asset_keys)
+            for ak in asset_keys:
+                assert (
+                    RunRequest(run_key=None, tags={"status": "False"}, asset_selection=[ak]) in ret
+                )


### PR DESCRIPTION
### Summary & Motivation

This separates out (and reworks) some functionality from a different PR, just to keep things a little cleaner (and multiple future PRs depend on this function, so I wanted to make my life a little easier).

Adds a utility function to recursively calculate the data times for a given asset materialization record. This is done by recursively examining the latest materialization times for each parent asset, filtering for materializations which happened before the given materialization record.

### How I Tested These Changes

The format I used to express the expected results is pretty gnarly, but I think it makes a fair amount of sense once you wrap your mind around it. Basically, we can't check for explicit timestamps that will be returned by this function, because the time that each pipeline is run changes every time you run the test, and even if you did some time freeze stuff in pytest, you don't know how long each step will take once you start the run, so the materialization timestamps are pretty much unknowable beforehand.

Instead, I keep track of a mapping from AssetKey to an index of what time it was materialized in each run. This way, I can express things like "I expect AssetKey(b)'s root materialization times to be {AssetKey("a"): <timestamp of A from the first of these runs>}". This leads to a pretty terse (if a bit opaque) format, that is independent of the actual timestamps.
