### PR TITLE
specify schema in pandas to_sql

### DIFF
--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -84,8 +84,9 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
                 _convert_timestamp_to_string, axis="index"
             )
             with_uppercase_cols.to_sql(
-                table_slice.table,
+                name=table_slice.table,
                 con=con.engine,
+                schema=table_slice.schema,
                 if_exists="append",
                 index=False,
                 method=pd_writer,


### PR DESCRIPTION
### Summary & Motivation
This explicitly specifies the schema in the `to_sql` call 

### How I Tested These Changes
