### PR TITLE
[dagit] Fix very tall configs in run config dialog

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
@@ -202,15 +202,15 @@ export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({r
         }}
         title="Run configuration"
       >
-        <Box flex={{direction: 'column'}} style={{flex: 1}}>
-          <Box flex={{direction: 'column', gap: 20}} style={{flex: 1}}>
+        <Box flex={{direction: 'column'}} style={{flex: 1, overflow: 'hidden'}}>
+          <Box flex={{direction: 'column', gap: 20}} style={{flex: 1, overflow: 'hidden'}}>
             <Box flex={{direction: 'column', gap: 12}} padding={{top: 16, horizontal: 24}}>
               <Subheading>Tags</Subheading>
               <div>
                 <RunTags tags={run.tags} mode={isJob ? null : run.mode} />
               </div>
             </Box>
-            <Box flex={{direction: 'column'}} style={{flex: 1}}>
+            <Box flex={{direction: 'column'}} style={{flex: 1, overflow: 'hidden'}}>
               <Box
                 border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
                 padding={{left: 24, bottom: 16}}
@@ -275,6 +275,7 @@ export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({r
 
 const CodeMirrorContainer = styled.div`
   flex: 1;
+  overflow: hidden;
 
   .react-codemirror2,
   .CodeMirror {


### PR DESCRIPTION
### Summary & Motivation

Resolves #10291.

Restrict the CodeMirror container in the Run details config dialog so that the CodeMirror scrolls and the footer is visible on the bottom of the dialog. Looks like this broke for tall configs.

### How I Tested These Changes

View a run with a very long config, verify that the dialog renders correctly, with a visible footer and a scrollable CodeMirror.
