### PR TITLE
Don't repeat skip logs

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -113,7 +113,7 @@ class PackageSpec:
     pytest_tox_factors: Optional[List[str]] = None
     env_vars: Optional[List[str]] = None
     tox_file: Optional[str] = None
-    retries: Optional[str] = None
+    retries: Optional[int] = None
     upload_coverage: Optional[bool] = None
     timeout_in_minutes: Optional[int] = None
     queue: Optional[BuildkiteQueue] = None
@@ -235,7 +235,7 @@ class PackageSpec:
                 )
             )
 
-        emoji = _PACKAGE_TYPE_TO_EMOJI_MAP[self.package_type]
+        emoji = _PACKAGE_TYPE_TO_EMOJI_MAP[self.package_type]  # type: ignore[index]
         return [
             GroupStep(
                 group=f"{emoji} {base_name}",

--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -1,7 +1,8 @@
 import logging
 import os
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, List, Mapping, NamedTuple, Optional, Union
+from typing import Callable, List, Mapping, Optional, Union
 
 import pkg_resources
 from dagster_buildkite.git import ChangedFiles
@@ -55,29 +56,8 @@ PytestExtraCommandsFunction = Callable[[AvailablePythonVersion, Optional[str]], 
 PytestDependenciesFunction = Callable[[AvailablePythonVersion, Optional[str]], List[str]]
 
 
-class PackageSpec(
-    NamedTuple(
-        "_PackageSpec",
-        [
-            ("directory", str),
-            ("name", str),
-            ("package_type", str),
-            ("unsupported_python_versions", List[AvailablePythonVersion]),
-            ("pytest_extra_cmds", Optional[Union[List[str], PytestExtraCommandsFunction]]),
-            ("pytest_step_dependencies", Optional[Union[List[str], PytestDependenciesFunction]]),
-            ("pytest_tox_factors", Optional[List[str]]),
-            ("env_vars", List[str]),
-            ("tox_file", Optional[str]),
-            ("retries", Optional[int]),
-            ("upload_coverage", bool),
-            ("timeout_in_minutes", Optional[int]),
-            ("queue", Optional[BuildkiteQueue]),
-            ("run_pytest", bool),
-            ("run_mypy", bool),
-            ("run_pylint", bool),
-        ],
-    )
-):
+@dataclass
+class PackageSpec:
     """Main spec for testing Dagster Python packages using tox.
 
     Args:
@@ -124,45 +104,36 @@ class PackageSpec(
             Python version. Enabled by default.
     """
 
-    def __new__(
-        cls,
-        directory: str,
-        name: Optional[str] = None,
-        package_type: Optional[str] = None,
-        unsupported_python_versions: Optional[List[AvailablePythonVersion]] = None,
-        pytest_extra_cmds: Optional[Union[List[str], PytestExtraCommandsFunction]] = None,
-        pytest_step_dependencies: Optional[Union[List[str], PytestDependenciesFunction]] = None,
-        pytest_tox_factors: Optional[List[str]] = None,
-        env_vars: Optional[List[str]] = None,
-        tox_file: Optional[str] = None,
-        retries: Optional[int] = None,
-        upload_coverage: Optional[bool] = None,
-        timeout_in_minutes: Optional[int] = None,
-        queue: Optional[BuildkiteQueue] = None,
-        run_pytest: bool = True,
-        run_mypy: bool = True,
-        run_pylint: bool = True,
-    ):
-        package_type = package_type or _infer_package_type(directory)
-        return super(PackageSpec, cls).__new__(
-            cls,
-            directory,
-            name or os.path.basename(directory),
-            package_type,
-            unsupported_python_versions or [],
-            pytest_extra_cmds,
-            pytest_step_dependencies,
-            pytest_tox_factors,
-            env_vars or [],
-            tox_file,
-            retries,
-            upload_coverage if upload_coverage is not None else package_type in ("core", "library"),
-            timeout_in_minutes,
-            queue,
-            run_pytest,
-            run_mypy,
-            run_pylint,
-        )
+    directory: str
+    name: Optional[str] = None
+    package_type: Optional[str] = None
+    unsupported_python_versions: List[AvailablePythonVersion] = field(default_factory=lambda: [])
+    pytest_extra_cmds: Optional[Union[List[str], PytestExtraCommandsFunction]] = None
+    pytest_step_dependencies: Optional[Union[List[str], PytestDependenciesFunction]] = None
+    pytest_tox_factors: Optional[List[str]] = None
+    env_vars: Optional[List[str]] = None
+    tox_file: Optional[str] = None
+    retries: Optional[str] = None
+    upload_coverage: Optional[bool] = None
+    timeout_in_minutes: Optional[int] = None
+    queue: Optional[BuildkiteQueue] = None
+    run_pytest: bool = True
+    run_mypy: bool = True
+    run_pylint: bool = True
+
+    def __post_init__(self):
+        if not self.name:
+            self.name = os.path.basename(self.directory)
+
+        if not self.package_type:
+            self.package_type = _infer_package_type(self.directory)
+
+        if not self.upload_coverage:
+            if self.package_type in ("core", "library"):
+                self.upload_coverage = True
+
+        self._should_skip = None
+        self._skip_reason = None
 
     def build_steps(self) -> List[GroupStep]:
         base_name = self.name or os.path.basename(self.directory)
@@ -292,7 +263,16 @@ class PackageSpec(
 
     @property
     def skip_reason(self) -> Optional[str]:
+        # Memoize so we don't log twice
+        if self._should_skip == False:
+            return None
+
+        if self._skip_reason:
+            return self._skip_reason
+
         if not is_feature_branch(os.getenv("BUILDKITE_BRANCH", "")):
+            logging.info(f"Building {self.name} we're not on a feature branch")
+            self._should_skip = False
             return None
 
         for change in ChangedFiles.all:
@@ -306,6 +286,7 @@ class PackageSpec(
                 )
             ):
                 logging.info(f"Building {self.name} because it has changed")
+                self._should_skip = False
                 return None
 
         # Consider anything required by install or an extra to be in scope.
@@ -315,8 +296,10 @@ class PackageSpec(
                 PythonPackages.walk_dependencies(requirement)
             )
             if in_scope_changes:
-
                 logging.info(f"Building {self.name} because of changes to {in_scope_changes}")
+                self._should_skip = False
                 return None
 
-        return "Package unaffected by these changes"
+        self._skip_reason = "Package unaffected by these changes"
+        self._should_skip = True
+        return self._skip_reason

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -59,7 +59,7 @@ def _build_steps_from_package_specs(package_specs: List[PackageSpec]) -> List[Bu
     steps: List[BuildkiteStep] = []
     all_packages = sorted(
         package_specs,
-        key=lambda p: f"{_PACKAGE_TYPE_ORDER.index(p.package_type)} {p.name}",
+        key=lambda p: f"{_PACKAGE_TYPE_ORDER.index(p.package_type)} {p.name}",  # type: ignore[arg-type]
     )
 
     for pkg in all_packages:


### PR DESCRIPTION
This changes from using a NamedTuple to using a dataclass so we can more easily have a few "private" instance variables to control memoization of our skip reason property. Decorating it with an lrucache wasn't worth the effort because our clash isn't hashable.

Instead, use two variables to decide whether or not we already have a skip reason:

self._should_skip which initializes as empty but gets set to False any time we have no skip reason. This is because Buildkite's API expects either a string or nothing so self._skip_reason being None is a valid condition.

self._skip_reason which initializes as empty but is assigned a string if we actually do skip.

The end result is cleaner logs because we don't repeat lines every time we check the skip reason.