### PR TITLE
Packages with test changes only shouldn't run deps

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/python_packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/python_packages.py
@@ -142,6 +142,7 @@ class PythonPackages:
                     and (change.suffix in [".py", ".cfg", ".toml"])
                     # The file is not part of a test suite. We treat this differently
                     # because we don't want to run tests in dependent packages
+                    and "_tests/" not in str(change)
                 ):
                     packages_with_changes.add(package)
 


### PR DESCRIPTION
The comment is still accurate but the logic got lost at some point. Downstream dependencies don't need to run if only a test changed.