### PR TITLE
Remove special casing for graphql tests

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/python_packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/python_packages.py
@@ -122,7 +122,7 @@ class PythonPackages:
             [
                 PythonPackage(Path(setup))
                 for setup in git_info.directory.rglob("setup.py")
-                if "_tests" not in str(setup) and not git_ignore_spec.match_file(str(setup))
+                if not git_ignore_spec.match_file(str(setup))
             ]
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/empty_repo.yaml
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/empty_repo.yaml
@@ -1,4 +1,4 @@
 load_from:
   - python_file:
-      relative_path: setup.py
+      relative_path: repo.py
       attribute: empty_repo

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
@@ -37,7 +37,7 @@ from dagster._utils.test.postgres_instance import TestPostgresInstance
 def get_main_loadable_target_origin():
     return LoadableTargetOrigin(
         executable_path=sys.executable,
-        python_file=file_relative_path(__file__, "setup.py"),
+        python_file=file_relative_path(__file__, "repo.py"),
         attribute="test_repo",
     )
 
@@ -408,7 +408,7 @@ class EnvironmentManagers:
             with WorkspaceProcessContext(
                 instance,
                 PythonFileTarget(
-                    python_file=file_relative_path(__file__, "setup.py"),
+                    python_file=file_relative_path(__file__, "repo.py"),
                     attribute="test_dict_repo",
                     working_directory=None,
                     location_name="test",

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/multi_location.yaml
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/multi_location.yaml
@@ -1,9 +1,9 @@
 load_from:
   - python_file:
-      relative_path: setup.py
+      relative_path: repo.py
       attribute: empty_repo
       location_name: empty_repo
   - python_file:
-      relative_path: setup.py
+      relative_path: repo.py
       attribute: test_repo
       location_name: test

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -152,7 +152,7 @@ def get_main_workspace(instance):
     with WorkspaceProcessContext(
         instance,
         PythonFileTarget(
-            python_file=file_relative_path(__file__, "setup.py"),
+            python_file=file_relative_path(__file__, "repo.py"),
             attribute=main_repo_name(),
             working_directory=None,
             location_name=main_repo_location_name(),

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_dagster_environment.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_dagster_environment.py
@@ -12,7 +12,7 @@ def test_dagster_out_of_process_location():
             location_name="test_location",
             loadable_target_origin=LoadableTargetOrigin(
                 executable_path=sys.executable,
-                python_file=file_relative_path(__file__, "setup.py"),
+                python_file=file_relative_path(__file__, "repo.py"),
                 attribute="test_repo",
             ),
         ).create_single_location(instance) as env:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_cancellation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_cancellation.py
@@ -303,7 +303,7 @@ class TestRunVariantTermination(RunTerminationTestSuite):
         instance = graphql_context.instance
 
         pipeline = ReconstructableRepository.for_file(
-            file_relative_path(__file__, "setup.py"),
+            file_relative_path(__file__, "repo.py"),
             "test_repo",
         ).get_reconstructable_pipeline("noop_pipeline")
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/workspace.yaml
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/workspace.yaml
@@ -1,4 +1,4 @@
 load_from:
   - python_file:
-      relative_path: graphql/setup.py
+      relative_path: graphql/repo.py
       attribute: test_repo


### PR DESCRIPTION
We had a file in here called setup.py that doesn't actually behave like a typical Python setup.py - it's just defining a repo to be used in other tests.

We had special casing in our PythonPackages to ignore anything with `_tests` in the filepath but that's overly restrictive. Instead, let's rename the poorly named module.
