### PR TITLE
chore: add project urls to dagster pypi

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -34,7 +34,16 @@ setup(
     description="The data orchestration platform built for productivity.",
     long_description=get_description(),
     long_description_content_type="text/markdown",
-    url="https://github.com/dagster-io/dagster",
+    project_urls={
+        "Homepage": "https://dagster.io",
+        "GitHub": "https://github.com/dagster-io/dagster",
+        "Changelog": "https://github.com/dagster-io/dagster/releases",
+        "Issue Tracker": "https://github.com/dagster-io/dagster/issues",
+        "Twitter": "https://twitter.com/dagster",
+        "YouTube": "https://www.youtube.com/channel/UCfLnv9X8jyHTe6gJ4hVBo9Q"
+        "Slack": "https://dagster.io/slack",
+        "Blog": "https://dagster.io/blog",
+    },
     classifiers=[
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
### Summary & Motivation
While looking into https://dagster.slack.com/archives/C01U954MEER/p1667481048576219, saw that you can set these. Might as well have more key references back to our main channels of communication. 

The list of options are here: https://github.com/pypi/warehouse/blob/main/warehouse/templates/packaging/detail.html

### How I Tested These Changes
N/A
