### PR TITLE
Enable action logging in dagit

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2213,7 +2213,6 @@ type Instance {
   executablePath: String!
   daemonHealth: DaemonHealth!
   hasInfo: Boolean!
-  dagitTelemetryEnabled: Boolean!
   hasCapturedLogManager: Boolean!
 }
 

--- a/python_modules/dagit/dagit/webserver.py
+++ b/python_modules/dagit/dagit/webserver.py
@@ -192,11 +192,13 @@ class DagitWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
         filebase = "__".join(log_key)
         return FileResponse(location, filename=f"{filebase}.{file_extension}")
 
-    def index_html_endpoint(self, _request: Request):
+    def index_html_endpoint(self, request: Request):
         """
         Serves root html
         """
         index_path = self.relative_path("webapp/build/index.html")
+
+        context = self.make_request_context(request)
 
         try:
             with open(index_path, encoding="utf8") as f:
@@ -210,6 +212,7 @@ class DagitWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
                     rendered_template.replace('href="/', f'href="{self._app_path_prefix}/')
                     .replace('src="/', f'src="{self._app_path_prefix}/')
                     .replace("__PATH_PREFIX__", self._app_path_prefix)
+                    .replace("__TELEMETRY_ENABLED__", str(context.instance.telemetry_enabled))
                     .replace("NONCE-PLACEHOLDER", nonce),
                     headers=headers,
                 )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
@@ -3,7 +3,7 @@ import sys
 import graphene
 
 import dagster._check as check
-from dagster._core.instance import DagsterInstance, is_dagit_telemetry_enabled
+from dagster._core.instance import DagsterInstance
 from dagster._core.launcher.base import RunLauncher
 from dagster._core.storage.captured_log_manager import CapturedLogManager
 from dagster._daemon.types import DaemonStatus
@@ -95,7 +95,6 @@ class GrapheneInstance(graphene.ObjectType):
     executablePath = graphene.NonNull(graphene.String)
     daemonHealth = graphene.NonNull(GrapheneDaemonHealth)
     hasInfo = graphene.NonNull(graphene.Boolean)
-    dagitTelemetryEnabled = graphene.NonNull(graphene.Boolean)
     hasCapturedLogManager = graphene.NonNull(graphene.Boolean)
 
     class Meta:
@@ -128,9 +127,6 @@ class GrapheneInstance(graphene.ObjectType):
 
     def resolve_daemonHealth(self, _graphene_info):
         return GrapheneDaemonHealth(instance=self._instance)
-
-    def resolve_dagitTelemetryEnabled(self, _graphene_info):
-        return is_dagit_telemetry_enabled(self._instance)
 
     def resolve_hasCapturedLogManager(self, _graphene_info):
         return isinstance(self._instance.compute_log_manager, CapturedLogManager)

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -646,8 +646,6 @@ class DagsterInstance:
 
         if "enabled" in telemetry_settings:
             return telemetry_settings["enabled"]
-        elif "experimental_dagit" in telemetry_settings:
-            return telemetry_settings["experimental_dagit"]
         else:
             return dagster_telemetry_enabled_default
 
@@ -2113,14 +2111,3 @@ class DagsterInstance:
         )
         default_tick_settings = get_default_tick_retention_settings(instigator_type)
         return get_tick_retention_settings(tick_settings, default_tick_settings)
-
-
-def is_dagit_telemetry_enabled(instance):
-    telemetry_settings = instance.get_settings("telemetry")
-    if not telemetry_settings:
-        return False
-
-    if "experimental_dagit" in telemetry_settings:
-        return telemetry_settings["experimental_dagit"]
-    else:
-        return False

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -247,10 +247,7 @@ def dagster_instance_config_schema():
         "run_coordinator": config_field_for_configurable_class(),
         "run_launcher": config_field_for_configurable_class(),
         "telemetry": Field(
-            {
-                "enabled": Field(Bool, is_required=False),
-                "experimental_dagit": Field(Bool, is_required=False, default_value=False),
-            },
+            {"enabled": Field(Bool, is_required=False)},
         ),
         "instance_class": config_field_for_configurable_class(),
         "python_logs": python_logs_config_schema(),


### PR DESCRIPTION
Enables action logging in dagit for folks who already have telemetry enabled. Also gets rid of a bit of unused graphql schema.
