### PR TITLE
Mock tqdm in tests to avoid segfaults

### DIFF
--- a/python_modules/dagster/dagster_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/conftest.py
@@ -143,3 +143,13 @@ def docker_grpc_client(
     ) if not IS_BUILDKITE else nullcontext():
         wait_for_connection(grpc_host, grpc_port)
         yield DagsterGrpcClient(port=grpc_port, host=grpc_host)
+
+
+@pytest.fixture(autouse=True)
+def mock_tqdm(monkeypatch):
+    def noop_tqdm(iterable):
+        return iterable
+
+    monkeypatch.setattr("tqdm.tqdm", noop_tqdm)
+
+    yield

--- a/python_modules/dagster/dagster_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/conftest.py
@@ -145,6 +145,7 @@ def docker_grpc_client(
         yield DagsterGrpcClient(port=grpc_port, host=grpc_host)
 
 
+# https://github.com/dagster-io/dagster/pull/10343
 @pytest.fixture(autouse=True)
 def mock_tqdm(monkeypatch):
     def noop_tqdm(iterable):


### PR DESCRIPTION
We've been plagued by segfaults in some of our core test suites for a long time and we've never quite been able to nail down why.

Often the segfault's stack track includes reference to `tqdm` - which we barely use. We print some progress bars during a few migrations and in a few CLI tools.

My hunch is that the monitoring thread for `tqdm` stays alive long after it's needed and when we start playing around with multi-threading of our own - in the grpc test suite - some interaction between all these extra threads occassionally causes a segfault.

I've been able to confirm my hunch by patching `tqdm` to log on each iteration of its monitoring loop and observing that it continues to log beyond the tests that use it (mostly backcompat tests).

Some (weak) supporting evidence for this theory is that a couple of other similarly hard to diagnose segfaults also make reference to tqdm:

https://github.com/davisking/dlib/issues/1104
https://github.com/scikit-hep/pyhf/issues/1501

I can't reproduce the segfaults at all locally (both MacOS native and in a container using the Buildkite test image). Nor can I deterministically reproduce the segfaults on Buildkite. But we do see a handful a day.

We don't rely on the progress bar behavior for any of our test assertions - my hope is by globally patching `tqdm` in tests to do nothing, we might see these segfaults go away. If that happens, we can either investigate removing `tqdm` entirely, finding a real fix, or just leaving it patched.

Some example failures:

- https://buildkite.com/dagster/dagster/builds/38158#01843e2c-1694-4909-9a20-c9fab38f928f
- https://buildkite.com/dagster/dagster/builds/38134#01843b03-52a2-4380-99fe-7cef870c4383