### PR TITLE
JB - Docs Typography Follow-ups

### DIFF
--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -234,11 +234,11 @@ const ADMONITION_STYLES = {
       borderIcon: 'primary-500',
       text: 'gray-900',
     },
-    icon: Icons.InfoCircle,
+    icon: Icons.About,
   },
   warning: {
     colors: {bg: 'yellow-50', borderIcon: 'yellow-400', text: 'yellow-700'},
-    icon: Icons.Warning,
+    icon: Icons.About,
   },
 };
 
@@ -255,7 +255,7 @@ const Admonition = ({style, children}) => {
             fill="currentColor"
             aria-hidden="true"
           >
-            {icon}
+            {icon && icon}
           </svg>
         </div>
         <div className="ml-3">

--- a/docs/next/styles/globals.css
+++ b/docs/next/styles/globals.css
@@ -270,7 +270,7 @@ dt > a.reference.internal {
 
 .DocSearch-Hit-source {
   line-height: 1.5rem;
-  font-weight: bold;
+  font-weight: 400;
   color: theme("colors.gable-green");
   margin-top: 1.5rem;
   margin-bottom: 1rem;
@@ -321,7 +321,7 @@ dt > a.reference.internal {
 .DocSearch-Hit-title {
   color: black;
   line-height: 1.5rem;
-  font-weight: 600;
+  font-weight: 500;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
### Summary & Motivation
This PR fixes two small typography/icon issues I introduced in my last update to the docs site.
1. It removes the extra bold text in the search results
2. It fixes the icons inside the <note> and <warning> components

### How I Tested These Changes
