### PR TITLE
[dagit] Fix materialization log padding when no metadata is present

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/LogsRowStructuredContent.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRowStructuredContent.tsx
@@ -440,6 +440,7 @@ const AssetMetadataContent: React.FC<{
     <DefaultContent message={message} eventType={eventType}>
       <>
         <LogRowStructuredContentTable
+          styles={metadataEntries?.length ? {paddingBottom: 0} : {}}
           rows={[
             {
               label: 'asset_key',
@@ -451,7 +452,6 @@ const AssetMetadataContent: React.FC<{
               ),
             },
           ]}
-          styles={{paddingBottom: 0}}
         />
         <MetadataEntries entries={metadataEntries} />
       </>


### PR DESCRIPTION
### Summary & Motivation
Looks like this has been a bug for almost two years and has slipped by because our default setup serializes the asset and adds a "path" metadata entry 100% of the time.

### How I Tested These Changes
