### PR TITLE
RFC: add mdx file for continuous integration

### DIFF
--- a/docs/content/dagster-cloud/developing-testing/continuous-integration.mdx
+++ b/docs/content/dagster-cloud/developing-testing/continuous-integration.mdx
@@ -1,0 +1,74 @@
+---
+title: Continuously Deploying to Dagster Cloud
+---
+
+# Dagster Cloud GitHub Action
+
+The [Dagster Cloud GitHub Action](https://github.com/dagster-io/dagster-cloud-action) lets you automatically update Dagster Cloud code locations when job code is updated. The action builds a Docker image, pushes it to a Docker repository, and uses the Dagster Cloud API to tell your agent to add the built image to your workspace.
+
+## Quickstart Template Repo
+
+We provide quickstart repos for [Serverless](https://github.com/dagster-io/dagster-cloud-serverless-quickstart) and [Hybrid](https://github.com/dagster-io/dagster-cloud-hybrid-quickstart) deployments, which you can use to get CI/CD for your Cloud instance up and running quickly.
+
+These quickstart repos set up separate GitHub actions to update your prod deployment from your `main` GitHub branch and update branch deployments for any opened pull requests.
+
+## Usage
+
+To use the Dagster Cloud GitHub Action, you will first need to [create a new GitHub Actions Workflow](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions#create-an-example-workflow). The job must first clone your Git repository using the [`actions/checkout`](https://github.com/actions/checkout) action, and then enable access build and deploy images to your code location. The Workflow included in the quickstart template already has this workflow set up for you.
+
+Next, you must set up a `dagster_cloud.yaml` file which describes each of the Dagster Cloud repo locations to be built and updated. If this `dagster_cloud.yaml` file is not located at the repo root, it must be specified with the `dagster_cloud_file` input.
+
+###
+
+### Mapping source directories to code locations: `dagster_cloud.yaml`
+
+This `dagster_cloud.yaml` file maps your Github repositories source directories to the Dagster Cloud repo locations you wish to deploy. In this example, the `dagster_cloud.yaml` file indicates that two locations, `foo` and `bar`, should be built.
+
+```yaml
+# Example dagster_cloud.yaml, for a Serverless deployment
+locations:
+  # Location name
+  foo:
+    # Path to build directory, which must a setup.py or requirements.txt file
+    build: ./foo_src
+    # Python file containing the job repo
+    # Can alternatively supply package_name, as below
+    python_file: repo.py
+  bar:
+    build: ./bar_src
+    registry: dagster-io/bar
+    package_name: bar
+```
+
+For Hybrid deployments, your `dagster_cloud.yaml` file should include registry information for where the images should be uploaded to and your build directories must include a `Dockerfile`. In this example, there are two specified locations that have Dockerfiles located at `/foo_src/Dockerfile` and `/bar_src/Dockerfile`, and are pushed to the `dagster-io/foo` and `dagster-io/bar` registries, respectively.
+
+```yaml
+# Example dagster_cloud.yaml, for a Hybrid deployment
+locations:
+  # Location name
+  foo:
+    # Path to build directory, which must contain a Dockerfile
+    build: ./foo_src
+    # Docker registry to push the built Docker image to
+    registry: dagster-io/foo
+    # Python file containing the job repo
+    # Can alternatively supply package_name, as below
+    python_file: repo.py
+  bar:
+    build: ./bar_src
+    registry: dagster-io/bar
+    package_name: bar
+```
+
+Note: Your GitHub action script must be configured to enable access to the specified registries (e.g. authenticating to AWS for an ECR registry).
+
+### `dagster_cloud.yaml` Properties
+
+Each location specified in the `dagster_cloud.yaml` can have the following properties:
+
+| Name           | Description                                                                                                                                                          |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `build`        | **(Required)** Path to the build directory relative to the `dagster_cloud.yaml`'s folder. Build directory must contain a `Dockerfile` for Hybrid deployments.        |
+| `registry`     | **(Required for Hybrid)** Docker registry to push the built Docker image to.                                                                                         |
+| `package_name` | Python module containing the [Dagster Repository](https://docs.dagster.io/concepts/repositories-workspaces/repositories). Can alternatively use `python_file` below. |
+| `python_file`  | Python file containing the [Dagster Repository](https://docs.dagster.io/concepts/repositories-workspaces/repositories). Can alternatively use `package_name` above.  |

--- a/docs/content/dagster-cloud/developing-testing/continuous-integration.mdx
+++ b/docs/content/dagster-cloud/developing-testing/continuous-integration.mdx
@@ -24,20 +24,27 @@ Next, you must set up a `dagster_cloud.yaml` file which describes each of the Da
 
 This `dagster_cloud.yaml` file maps your Github repositories source directories to the Dagster Cloud repo locations you wish to deploy. In this example, the `dagster_cloud.yaml` file indicates that two locations, `foo` and `bar`, should be built.
 
+The optional `build` property of the location is used to map a source directory to build into an image, which defaults to the current directory.
+
+The `code_source` property points to the location of the Dagster definitions to be loaded into your workspace. It should contain either a `package_name` or `python_file` property.
+
 ```yaml
 # Example dagster_cloud.yaml, for a Serverless deployment
 locations:
   # Location name
   foo:
-    # Path to build directory, which must a setup.py or requirements.txt file
-    build: ./foo_src
-    # Python file containing the job repo
-    # Can alternatively supply package_name, as below
-    python_file: repo.py
+    build:
+      # Path to build directory, which must contain a setup.py or requirements.txt file.  Defaults to the current directory
+      directory: ./foo_src
+    code_source:
+      # Python file containing the job repo
+      # Can alternatively supply package_name, as below
+      python_file: repo.py
   bar:
-    build: ./bar_src
-    registry: dagster-io/bar
-    package_name: bar
+    build:
+      directory: ./bar_src
+    code_source:
+      package_name: bar
 ```
 
 For Hybrid deployments, your `dagster_cloud.yaml` file should include registry information for where the images should be uploaded to and your build directories must include a `Dockerfile`. In this example, there are two specified locations that have Dockerfiles located at `/foo_src/Dockerfile` and `/bar_src/Dockerfile`, and are pushed to the `dagster-io/foo` and `dagster-io/bar` registries, respectively.
@@ -47,17 +54,21 @@ For Hybrid deployments, your `dagster_cloud.yaml` file should include registry i
 locations:
   # Location name
   foo:
-    # Path to build directory, which must contain a Dockerfile
-    build: ./foo_src
-    # Docker registry to push the built Docker image to
-    registry: dagster-io/foo
-    # Python file containing the job repo
-    # Can alternatively supply package_name, as below
-    python_file: repo.py
+    build:
+      # Path to build directory, which must contain a Dockerfile
+      directory: ./foo_src
+      # Docker registry to push the built Docker image to
+      registry: dagster-io/foo
+    code_source:
+      # Python file containing the job repo
+      # Can alternatively supply package_name, as below
+      python_file: repo.py
   bar:
-    build: ./bar_src
-    registry: dagster-io/bar
-    package_name: bar
+    build:
+      directory: ./bar_src
+      registry: dagster-io/bar
+    code_source:
+      package_name: bar
 ```
 
 Note: Your GitHub action script must be configured to enable access to the specified registries (e.g. authenticating to AWS for an ECR registry).
@@ -66,9 +77,11 @@ Note: Your GitHub action script must be configured to enable access to the speci
 
 Each location specified in the `dagster_cloud.yaml` can have the following properties:
 
-| Name           | Description                                                                                                                                                          |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `build`        | **(Required)** Path to the build directory relative to the `dagster_cloud.yaml`'s folder. Build directory must contain a `Dockerfile` for Hybrid deployments.        |
-| `registry`     | **(Required for Hybrid)** Docker registry to push the built Docker image to.                                                                                         |
-| `package_name` | Python module containing the [Dagster Repository](https://docs.dagster.io/concepts/repositories-workspaces/repositories). Can alternatively use `python_file` below. |
-| `python_file`  | Python file containing the [Dagster Repository](https://docs.dagster.io/concepts/repositories-workspaces/repositories). Can alternatively use `package_name` above.  |
+| Name                       | Description                                                                                                                                                                      |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `build`                    | **(Required for Hybrid)** Configuration which maps source directories to images that are uploaded to the specified registries.                                                   |
+| `build.directory`          | Path to the build directory relative to the `dagster_cloud.yaml`'s folder. Build directory must contain a `Dockerfile` for Hybrid deployments. Defaults to the current directory |
+| `build.registry`           | **(Required for Hybrid)** Docker registry to push the built Docker image to.                                                                                                     |
+| `code_source`              | Configuration which specifies how to load the [Dagster Repository](https://docs.dagster.io/concepts/repositories-workspaces/repositories) in the code location.                  |
+| `code_source.package_name` | Python module containing the [Dagster Repository](https://docs.dagster.io/concepts/repositories-workspaces/repositories). Can alternatively use `python_file` below.             |
+| `code_source.python_file`  | Python file containing the [Dagster Repository](https://docs.dagster.io/concepts/repositories-workspaces/repositories). Can alternatively use `package_name` above.              |


### PR DESCRIPTION
### Summary & Motivation
Context: when users try to hook up their GitHub repository to Dagster Cloud but don't have a `dagster_cloud.yaml` file, it'd be nice to link them to a docs page where they can read about what it is, what it's used for.

One thing that's missing in our cloud docs is a description of the `dagster_cloud.yaml` file and how it's used in our GitHub CI/CD workflow.  This PR resurrects the old continuous integration page on the old docs site and updates it to reflect how things work now for Hybrid/Serverless.

A lot of the existing docs / guides that talk about our GitHub integration are siloed in the branch deployment feature, but our GitHub action is used for both branch deployments and for regular deployments.

I think the general content in this MDX file is important and useful, but I'm generally unsure of where to put it.  The other articles in the dev/test section are pretty closely named so it's not clear the best way to lay this out.  I would describe this mostly as a concept page, tied to CICD.  The other articles look like step-by-step guides - here are a few examples:

* Adding and managing Dagster code
* Using Dagster Cloud environment variables
* Using Branch Deployments for Continous Integration (CI)
* Setting up Branch Deployments with GitHub Actions

### How I Tested These Changes
BK