### PR TITLE
Build integration steps before test project steps

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_main.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_main.py
@@ -8,7 +8,6 @@ from dagster_buildkite.steps.coverage import build_coverage_step
 from dagster_buildkite.steps.dagit_ui import build_dagit_ui_steps, skip_if_no_dagit_changes
 from dagster_buildkite.steps.dagster import build_dagster_steps, build_repo_wide_steps
 from dagster_buildkite.steps.docs import build_docs_steps
-from dagster_buildkite.steps.integration import build_integration_steps
 from dagster_buildkite.steps.trigger import build_trigger_step
 from dagster_buildkite.steps.wait import build_wait_step
 from dagster_buildkite.utils import BuildkiteStep, is_release_branch, safe_getenv
@@ -55,7 +54,6 @@ def build_dagster_oss_main_steps() -> List[BuildkiteStep]:
     steps += build_docs_steps()
     steps += build_dagit_ui_steps()
     steps += build_dagster_steps()
-    steps += build_integration_steps()
 
     if do_coverage:
         steps.append(build_wait_step())

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -15,6 +15,7 @@ from ..utils import (
     skip_if_no_python_changes,
 )
 from .helm import build_helm_steps
+from .integration import build_integration_steps
 from .packages import build_library_packages_steps
 from .test_project import build_test_project_steps
 
@@ -39,14 +40,15 @@ def build_dagster_steps() -> List[BuildkiteStep]:
     # toxfile that defines the tests for that package.
     steps += build_library_packages_steps()
 
+    steps += build_helm_steps()
+    steps += build_sql_schema_check_steps()
+    steps += build_graphql_python_client_backcompat_steps()
+    steps += build_integration_steps()
+
     # Build images containing the dagster-test sample project. This is a dependency of certain
     # dagster core and extension lib tests. Run this after we build our library package steps
     # because need to know whether it's a dependency of any of them.
     steps += build_test_project_steps()
-
-    steps += build_helm_steps()
-    steps += build_sql_schema_check_steps()
-    steps += build_graphql_python_client_backcompat_steps()
 
     return steps
 

--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -1,3 +1,4 @@
+# Trigger builds
 from pathlib import Path
 from typing import Dict
 

--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -1,4 +1,3 @@
-# Trigger builds
 from pathlib import Path
 from typing import Dict
 


### PR DESCRIPTION
Since we use the existence of depends_on to trigger skipping/running the test project steps

This should get the tests properly running on changes like https://buildkite.com/dagster/dagster/builds/38272

### How I Tested These Changes

- [x] Initial commit skips image builds
- [x] Modify dagster-aws, trigger integration builds and image builds