### PR TITLE
fix duckdb configs

### DIFF
--- a/docs/content/integrations/dbt/using-dbt-with-dagster/part-three.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/part-three.mdx
@@ -131,7 +131,7 @@ def tutorial_dbt_dagster():
                 },
             ),
             "io_manager": duckdb_io_manager.configured(
-                {"duckdb_path": os.path.join(DBT_PROJECT_PATH, "tutorial.duckdb")}
+                {"database": os.path.join(DBT_PROJECT_PATH, "tutorial.duckdb")}
             ),
         },
     )

--- a/examples/assets_dbt_python/assets_dbt_python/repository.py
+++ b/examples/assets_dbt_python/assets_dbt_python/repository.py
@@ -54,7 +54,7 @@ def assets_dbt_python():
         resource_defs={
             # this io_manager allows us to load dbt models as pandas dataframes
             "io_manager": duckdb_io_manager.configured(
-                {"duckdb_path": os.path.join(DBT_PROJECT_DIR, "example.duckdb")}
+                {"database": os.path.join(DBT_PROJECT_DIR, "example.duckdb")}
             ),
             # this io_manager is responsible for storing/loading our pickled machine learning model
             "model_io_manager": fs_io_manager,

--- a/examples/tutorial_dbt_dagster/tutorial_finished/tutorial_dbt_dagster/repository.py
+++ b/examples/tutorial_dbt_dagster/tutorial_finished/tutorial_dbt_dagster/repository.py
@@ -23,7 +23,7 @@ def tutorial_dbt_dagster():
                 },
             ),
             "io_manager": duckdb_io_manager.configured(
-                {"duckdb_path": os.path.join(DBT_PROJECT_PATH, "tutorial.duckdb")}
+                {"database": os.path.join(DBT_PROJECT_PATH, "tutorial.duckdb")}
             ),
         },
     )


### PR DESCRIPTION
### Summary & Motivation
making the duckdb io manager inherit from db_io_manager forced a config change from `duckdb_path` to `database`. I missed updating a couple of our examples to reflect that 

### How I Tested These Changes
