### PR TITLE
[dagit] Use a batch loader to load the partition health of several assets at once

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/useLiveDataForAssetKeys.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useLiveDataForAssetKeys.tsx
@@ -173,7 +173,7 @@ export const ASSET_LATEST_INFO_FRAGMENT = gql`
 
 const ASSETS_GRAPH_LIVE_QUERY = gql`
   query AssetGraphLiveQuery($assetKeys: [AssetKeyInput!]!) {
-    assetNodes(assetKeys: $assetKeys, loadMaterializations: true) {
+    assetNodes(assetKeys: $assetKeys) {
       id
       ...AssetNodeLiveFragment
     }

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -534,7 +534,7 @@ const LAUNCH_ASSET_LOADER_RESOURCE_QUERY = gql`
 
 const LAUNCH_ASSET_CHECK_UPSTREAM_QUERY = gql`
   query LaunchAssetCheckUpstreamQuery($assetKeys: [AssetKeyInput!]!) {
-    assetNodes(assetKeys: $assetKeys, loadMaterializations: true) {
+    assetNodes(assetKeys: $assetKeys) {
       id
       assetKey {
         path

--- a/js_modules/dagit/packages/core/src/assets/types/PartitionHealthQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/PartitionHealthQuery.ts
@@ -9,28 +9,28 @@ import { AssetKeyInput } from "./../../types/globalTypes";
 // GraphQL query operation: PartitionHealthQuery
 // ====================================================
 
-export interface PartitionHealthQuery_assetNodeOrError_AssetNotFoundError {
-  __typename: "AssetNotFoundError";
+export interface PartitionHealthQuery_assetNodes_assetKey {
+  __typename: "AssetKey";
+  path: string[];
 }
 
-export interface PartitionHealthQuery_assetNodeOrError_AssetNode_materializationCountByPartition {
+export interface PartitionHealthQuery_assetNodes_materializationCountByPartition {
   __typename: "MaterializationCountByPartition";
   partition: string;
   materializationCount: number;
 }
 
-export interface PartitionHealthQuery_assetNodeOrError_AssetNode {
+export interface PartitionHealthQuery_assetNodes {
   __typename: "AssetNode";
   id: string;
-  materializationCountByPartition: PartitionHealthQuery_assetNodeOrError_AssetNode_materializationCountByPartition[];
+  assetKey: PartitionHealthQuery_assetNodes_assetKey;
+  materializationCountByPartition: PartitionHealthQuery_assetNodes_materializationCountByPartition[];
 }
 
-export type PartitionHealthQuery_assetNodeOrError = PartitionHealthQuery_assetNodeOrError_AssetNotFoundError | PartitionHealthQuery_assetNodeOrError_AssetNode;
-
 export interface PartitionHealthQuery {
-  assetNodeOrError: PartitionHealthQuery_assetNodeOrError;
+  assetNodes: PartitionHealthQuery_assetNodes[];
 }
 
 export interface PartitionHealthQueryVariables {
-  assetKey: AssetKeyInput;
+  assetKeys: AssetKeyInput[];
 }

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -177,7 +177,6 @@ type DagitQuery {
     group: AssetGroupSelector
     pipeline: PipelineSelector
     assetKeys: [AssetKeyInput!]
-    loadMaterializations: Boolean = false
   ): [AssetNode!]!
 
   """

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -350,7 +350,7 @@ class CountByPartitionLoader:
             self._fetch()
 
         counts = self._counts_by_partition.get(asset_key)
-        if not counts:
+        if counts is None:
             check.failed(
                 f"Asset key {asset_key} not recognized for this loader.  Expected one of: {self._asset_keys}"
             )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -335,7 +335,7 @@ class BatchMaterializationLoader:
 
 class CountByPartitionLoader:
     """
-    A batch loader that fetches materialization count by partition for asset keys. 
+    A batch loader that fetches materialization count by partition for asset keys.
     This loader is expected to be instantiated with a set of asset keys.
     """
 
@@ -345,21 +345,23 @@ class CountByPartitionLoader:
         self._counts_by_partition: Mapping["AssetKey", Mapping[str, int]] = {}
         self._fetched = False
 
-    def get_results(
-        self, asset_key: AssetKey
-    ) -> Mapping[str, int]:
-        if asset_key not in self._asset_keys:
+    def get_results(self, asset_key: AssetKey) -> Mapping[str, int]:
+        if not self._fetched:
+            self._fetch()
+
+        counts = self._counts_by_partition.get(asset_key)
+        if not counts:
             check.failed(
                 f"Asset key {asset_key} not recognized for this loader.  Expected one of: {self._asset_keys}"
             )
 
-        if not self._fetched:
-            self._fetch()
-        return self._counts_by_partition.get(asset_key)
+        return counts
 
     def _fetch(self) -> None:
         self._fetched = True
-        self._counts_by_partition = self._.instance.get_materialization_count_by_partition(self._asset_keys)
+        self._counts_by_partition = self._instance.get_materialization_count_by_partition(
+            self._asset_keys
+        )
 
 
 class CrossRepoAssetDependedByLoader:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -22,7 +22,11 @@ from dagster._core.host_representation.external_data import (
 from dagster._core.snap.solid import CompositeSolidDefSnap, SolidDefSnap
 
 from ..implementation.fetch_runs import AssetComputeStatus
-from ..implementation.loader import BatchMaterializationLoader, CountByPartitionLoader, CrossRepoAssetDependedByLoader
+from ..implementation.loader import (
+    BatchMaterializationLoader,
+    CountByPartitionLoader,
+    CrossRepoAssetDependedByLoader,
+)
 from . import external
 from .asset_key import GrapheneAssetKey
 from .dagster_types import GrapheneDagsterType, to_dagster_type
@@ -468,7 +472,11 @@ class GrapheneAssetNode(graphene.ObjectType):
         if self._count_by_partition_loader:
             count_by_partition = self._count_by_partition_loader.get_results(asset_key)
         else:
-            count_by_partition = graphene_info.context.instance.get_materialization_count_by_partition([asset_key])[asset_key]
+            count_by_partition = (
+                graphene_info.context.instance.get_materialization_count_by_partition([asset_key])[
+                    asset_key
+                ]
+            )
 
         return [
             GrapheneMaterializationCount(partition_key, count_by_partition.get(partition_key, 0))

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -50,7 +50,11 @@ from ...implementation.fetch_schedules import (
 )
 from ...implementation.fetch_sensors import get_sensor_or_error, get_sensors_or_error
 from ...implementation.fetch_solids import get_graph_or_error
-from ...implementation.loader import BatchMaterializationLoader, CountByPartitionLoader, CrossRepoAssetDependedByLoader
+from ...implementation.loader import (
+    BatchMaterializationLoader,
+    CountByPartitionLoader,
+    CrossRepoAssetDependedByLoader,
+)
 from ...implementation.run_config_schema import resolve_run_config_schema_or_error
 from ...implementation.utils import graph_selector_from_graphql, pipeline_selector_from_graphql
 from ..asset_graph import (
@@ -581,7 +585,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
         materialization_loader = BatchMaterializationLoader(
             instance=graphene_info.context.instance, asset_keys=[node.assetKey for node in results]
         )
-        
+
         count_by_partition_loader = CountByPartitionLoader(
             instance=graphene_info.context.instance, asset_keys=[node.assetKey for node in results]
         )
@@ -594,7 +598,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
                 node.external_asset_node,
                 materialization_loader=materialization_loader,
                 depended_by_loader=depended_by_loader,
-                count_by_partition_loader=count_by_partition_loader
+                count_by_partition_loader=count_by_partition_loader,
             )
             for node in results
         ]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -326,7 +326,7 @@ GET_ASSET_TYPE = """
 
 BATCH_LOAD_ASSETS = """
     query BatchLoadQuery($assetKeys: [AssetKeyInput!]) {
-        assetNodes(assetKeys: $assetKeys, loadMaterializations: true) {
+        assetNodes(assetKeys: $assetKeys) {
             assetMaterializations(limit: 1) {
                 timestamp
                 runId


### PR DESCRIPTION
### Summary & Motivation

This PR adds a new batch loader to our GraphQL layer that makes it efficient to ask for:

```
assetNodes($assetKeys: [AssetKey!]!) {
   id
   materializationCountByPartition {
        partition
        materializationCount
   }
}
```

Previously, the UI would make a separate GraphQL query for each asset node in your selection one by one. After seeing that these fall through to a `GROUP BY asset_key, partition` in run storage and the underlying API supports asking for multiple asset keys at once, I think this is likely faster?

The UI will now ask for up to 50 at once, and we can configure that count via a constant in the code.

I also removed an unused `loadMaterializations: true` optional param, since the batch loaders are now lazy.

### How I Tested These Changes
