### PR TITLE
[dagit] Refactor per-step partition matrix to work for asset jobs

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
@@ -9,7 +9,7 @@ import {assembleIntoSpans} from '../partitions/PartitionRangeInput';
 import {AssetKey} from './types';
 import {PartitionHealthQuery, PartitionHealthQueryVariables} from './types/PartitionHealthQuery';
 
-interface PartitionHealthData {
+export interface PartitionHealthData {
   assetKey: AssetKey;
   keys: string[];
   spans: {startIdx: number; endIdx: number; status: boolean}[];

--- a/js_modules/dagit/packages/core/src/instance/BackfillStepStatusDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillStepStatusDialog.tsx
@@ -1,7 +1,7 @@
 import {Button, DialogFooter, Dialog} from '@dagster-io/ui';
 import * as React from 'react';
 
-import {PartitionStepStatus} from '../partitions/PartitionStepStatus';
+import {PartitionPerOpStatus} from '../partitions/PartitionStepStatus';
 import {usePartitionStepQuery} from '../partitions/usePartitionStepQuery';
 import {RunFilterToken} from '../runs/RunsFilterInput';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
@@ -83,7 +83,7 @@ export const BackfillStepStatusDialogContent = ({
   );
 
   return (
-    <PartitionStepStatus
+    <PartitionPerOpStatus
       partitionNames={backfill.partitionNames}
       partitions={partitions}
       pipelineName={partitionSet?.pipelineName}

--- a/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
@@ -11,7 +11,8 @@ import {RepoAddress} from '../workspace/types';
 import {JobBackfillsTable} from './JobBackfillsTable';
 import {CountBox} from './OpJobPartitionsView';
 import {PartitionState, PartitionStatus} from './PartitionStatus';
-import {PartitionPerAssetStatus} from './PartitionStepStatus';
+import {getVisibleItemCount, PartitionPerAssetStatus} from './PartitionStepStatus';
+import {GRID_FLOATING_CONTAINER_WIDTH} from './RunMatrixUtils';
 
 export const AssetJobPartitionsView: React.FC<{
   pipelineName: string;
@@ -55,8 +56,8 @@ export const AssetJobPartitionsView: React.FC<{
       // magical numbers to approximate the size of the window, which is calculated in the step
       // status component.  This approximation is to make sure that the window does not jump as
       // the pageSize gets recalculated
-      const _approximatePageSize = Math.ceil((viewport.width - 330) / 32) - 3;
-      setPageSize(_approximatePageSize);
+      const approxPageSize = getVisibleItemCount(viewport.width - GRID_FLOATING_CONTAINER_WIDTH);
+      setPageSize(approxPageSize);
     }
   }, [viewport.width, showSteps, setPageSize]);
 

--- a/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
@@ -11,6 +11,7 @@ import {RepoAddress} from '../workspace/types';
 import {JobBackfillsTable} from './JobBackfillsTable';
 import {CountBox} from './OpJobPartitionsView';
 import {PartitionState, PartitionStatus} from './PartitionStatus';
+import {PartitionPerAssetStatus} from './PartitionStepStatus';
 
 export const AssetJobPartitionsView: React.FC<{
   pipelineName: string;
@@ -118,7 +119,19 @@ export const AssetJobPartitionsView: React.FC<{
             tooltipMessage="Click to view per-step status"
           />
         </div>
-        {showSteps && <Box margin={{top: 16}} />}
+        {showSteps && (
+          <Box margin={{top: 16}}>
+            <PartitionPerAssetStatus
+              partitionNames={partitionNames}
+              assetHealth={assetHealth}
+              assetQueryItems={assetGraph.graphQueryItems}
+              pipelineName={pipelineName}
+              setPageSize={setPageSize}
+              offset={offset}
+              setOffset={setOffset}
+            />
+          </Box>
+        )}
       </Box>
       <Box
         padding={{horizontal: 24, vertical: 16}}

--- a/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
@@ -136,6 +136,7 @@ export const AssetJobPartitionsView: React.FC<{
       <Box
         padding={{horizontal: 24, vertical: 16}}
         border={{side: 'horizontal', color: Colors.KeylineGray, width: 1}}
+        style={{marginBottom: -1}}
       >
         <Subheading>Backfill history</Subheading>
       </Box>

--- a/js_modules/dagit/packages/core/src/partitions/OpJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/OpJobPartitionsView.tsx
@@ -268,6 +268,7 @@ const OpJobPartitionsViewContent: React.FC<{
       <Box
         padding={{horizontal: 24, vertical: 16}}
         border={{side: 'horizontal', color: Colors.KeylineGray, width: 1}}
+        style={{marginBottom: -1}}
       >
         <Subheading>Backfill history</Subheading>
       </Box>

--- a/js_modules/dagit/packages/core/src/partitions/OpJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/OpJobPartitionsView.tsx
@@ -13,7 +13,7 @@ import {BackfillPartitionSelector} from './BackfillSelector';
 import {JobBackfillsTable} from './JobBackfillsTable';
 import {PartitionGraph} from './PartitionGraph';
 import {PartitionState, PartitionStatus, runStatusToPartitionState} from './PartitionStatus';
-import {PartitionStepStatus} from './PartitionStepStatus';
+import {PartitionPerOpStatus} from './PartitionStepStatus';
 import {
   PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionStatusesOrError_PartitionStatuses_results,
   PartitionsStatusQuery_partitionSetOrError_PartitionSet,
@@ -222,7 +222,7 @@ const OpJobPartitionsViewContent: React.FC<{
         </div>
         {showSteps ? (
           <Box margin={{top: 16}}>
-            <PartitionStepStatus
+            <PartitionPerOpStatus
               partitionNames={partitionNames}
               partitions={partitions}
               pipelineName={partitionSet.pipelineName}

--- a/js_modules/dagit/packages/core/src/partitions/OpJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/OpJobPartitionsView.tsx
@@ -13,7 +13,8 @@ import {BackfillPartitionSelector} from './BackfillSelector';
 import {JobBackfillsTable} from './JobBackfillsTable';
 import {PartitionGraph} from './PartitionGraph';
 import {PartitionState, PartitionStatus, runStatusToPartitionState} from './PartitionStatus';
-import {PartitionPerOpStatus} from './PartitionStepStatus';
+import {getVisibleItemCount, PartitionPerOpStatus} from './PartitionStepStatus';
+import {GRID_FLOATING_CONTAINER_WIDTH} from './RunMatrixUtils';
 import {
   PartitionsStatusQuery_partitionSetOrError_PartitionSet_partitionStatusesOrError_PartitionStatuses_results,
   PartitionsStatusQuery_partitionSetOrError_PartitionSet,
@@ -89,8 +90,8 @@ const OpJobPartitionsViewContent: React.FC<{
       // magical numbers to approximate the size of the window, which is calculated in the step
       // status component.  This approximation is to make sure that the window does not jump as
       // the pageSize gets recalculated
-      const _approximatePageSize = Math.ceil((viewport.width - 330) / 32) - 3;
-      setPageSize(_approximatePageSize);
+      const approxPageSize = getVisibleItemCount(viewport.width - GRID_FLOATING_CONTAINER_WIDTH);
+      setPageSize(approxPageSize);
     }
   }, [viewport.width, showSteps, setPageSize]);
 

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
@@ -10,9 +10,15 @@ import {
   Menu,
   Popover,
 } from '@dagster-io/ui';
+import keyBy from 'lodash/keyBy';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
+import {GraphQueryItem} from '../app/GraphQueryImpl';
+import {tokenForAssetKey} from '../asset-graph/Utils';
+import {PartitionHealthData} from '../assets/PartitionHealthSummary';
+import {GanttChartMode} from '../gantt/Constants';
+import {buildLayout} from '../gantt/GanttChartLayout';
 import {useViewport} from '../gantt/useViewport';
 import {linkToRunEvent} from '../runs/RunUtils';
 import {RunFilterToken} from '../runs/RunsFilterInput';
@@ -41,6 +47,7 @@ import {
   PartitionRuns,
   StatusSquareFinalColor,
   useMatrixData,
+  MatrixData,
 } from './useMatrixData';
 
 interface PartitionRunSelection {
@@ -48,16 +55,15 @@ interface PartitionRunSelection {
   stepName?: string;
 }
 
-interface PartitionStepStatusProps {
-  pipelineName: string;
-  partitionNames: string[];
-  partitions: PartitionRuns[];
-  repoAddress: RepoAddress;
-  runFilters?: RunFilterToken[];
-  setRunFilters?: (val: RunFilterToken[]) => void;
+interface PartitionStepStatusBaseProps {
   offset: number;
   setOffset: (val: number) => void;
   setPageSize: (val: number) => void;
+  pipelineName: string;
+  partitionNames: string[];
+
+  runFilters?: RunFilterToken[];
+  setRunFilters?: (val: RunFilterToken[]) => void;
 }
 
 const timeboundsOfPartitions = (partitionColumns: {steps: {unix: number}[]}[]) => {
@@ -73,22 +79,59 @@ const timeboundsOfPartitions = (partitionColumns: {steps: {unix: number}[]}[]) =
   return [minUnix, maxUnix] as const;
 };
 
-export const PartitionStepStatus: React.FC<PartitionStepStatusProps> = (props) => {
-  const {viewport, containerProps} = useViewport();
-  const [hovered, setHovered] = React.useState<PartitionRunSelection | null>(null);
-  const [focused, setFocused] = React.useState<PartitionRunSelection | null>(null);
-  const {setPageSize} = props;
+export const PartitionPerAssetStatus: React.FC<
+  PartitionStepStatusBaseProps & {
+    assetHealth: PartitionHealthData[];
+    assetQueryItems: GraphQueryItem[];
+  }
+> = ({assetHealth, partitionNames, assetQueryItems, ...rest}) => {
+  const healthByAssetKey = keyBy(assetHealth, (a) => tokenForAssetKey(a.assetKey));
 
-  React.useEffect(() => {
-    if (viewport.width) {
-      const pageSize = Math.ceil(viewport.width / BOX_SIZE) - BUFFER;
-      setPageSize(pageSize);
-    }
-  }, [viewport.width, setPageSize]);
+  const layout = buildLayout({nodes: assetQueryItems, mode: GanttChartMode.FLAT});
+  const layoutBoxesWithPartitions = layout.boxes.filter(
+    (b) => healthByAssetKey[b.node.name].keys.length,
+  );
 
+  const data: MatrixData = {
+    stepRows: layoutBoxesWithPartitions.map((box) => ({
+      x: box.x,
+      name: box.node.name,
+      totalFailurePercent: 0,
+      finalFailurePercent: 0,
+    })),
+    partitions: [],
+    partitionColumns: partitionNames.map((p, idx) => ({
+      steps: layoutBoxesWithPartitions.map((a) => ({
+        name: a.node.name,
+        color: healthByAssetKey[a.node.name].statusByPartition[p] ? 'SUCCESS' : 'MISSING',
+        unix: 0,
+      })),
+      idx,
+      name: p,
+      runsLoaded: true,
+      runs: [],
+    })),
+  };
+
+  return (
+    <PartitionStepStatus
+      {...rest}
+      partitionNames={partitionNames}
+      data={data}
+      showLatestRun={false}
+    />
+  );
+};
+
+export const PartitionPerOpStatus: React.FC<
+  PartitionStepStatusBaseProps & {
+    repoAddress: RepoAddress;
+    partitions: PartitionRuns[];
+  }
+> = ({repoAddress, pipelineName, partitions, partitionNames, ...rest}) => {
   // Retrieve the pipeline's structure
-  const repositorySelector = repoAddressToSelector(props.repoAddress);
-  const pipelineSelector = {...repositorySelector, pipelineName: props.pipelineName};
+  const repositorySelector = repoAddressToSelector(repoAddress);
+  const pipelineSelector = {...repositorySelector, pipelineName};
   const pipeline = useQuery<
     PartitionStepStatusPipelineQuery,
     PartitionStepStatusPipelineQueryVariables
@@ -101,15 +144,43 @@ export const PartitionStepStatus: React.FC<PartitionStepStatusProps> = (props) =
     pipeline.data.pipelineSnapshotOrError.solidHandles;
 
   const data = useMatrixData({
-    partitionNames: props.partitionNames,
-    partitions: props.partitions,
+    partitionNames,
+    partitions,
     stepQuery: '',
     solidHandles,
   });
 
-  if (!data || !solidHandles) {
+  if (!data) {
     return <span />;
   }
+  return (
+    <PartitionStepStatus
+      {...rest}
+      showLatestRun={true}
+      pipelineName={pipelineName}
+      partitionNames={partitionNames}
+      data={data}
+    />
+  );
+};
+
+const PartitionStepStatus: React.FC<
+  PartitionStepStatusBaseProps & {
+    data: MatrixData;
+    showLatestRun: boolean;
+  }
+> = (props) => {
+  const {viewport, containerProps} = useViewport();
+  const [hovered, setHovered] = React.useState<PartitionRunSelection | null>(null);
+  const [focused, setFocused] = React.useState<PartitionRunSelection | null>(null);
+  const {setPageSize, data} = props;
+
+  React.useEffect(() => {
+    if (viewport.width) {
+      const pageSize = Math.ceil(viewport.width / BOX_SIZE) - BUFFER;
+      setPageSize(pageSize);
+    }
+  }, [viewport.width, setPageSize]);
 
   const {stepRows, partitionColumns} = data;
 
@@ -158,7 +229,7 @@ export const PartitionStepStatus: React.FC<PartitionStepStatusProps> = (props) =
         <GridFloatingContainer floating={props.offset + visibleCount < props.partitionNames.length}>
           <GridColumn disabled style={{flex: 1, flexShrink: 1, overflow: 'hidden'}}>
             <TopLabel style={{height: topLabelHeight}} />
-            <LeftLabel style={{paddingLeft: 24}}>Last run</LeftLabel>
+            {props.showLatestRun && <LeftLabel style={{paddingLeft: 24}}>Last Run</LeftLabel>}
             <Divider />
             {stepRows.map((step) => (
               <LeftLabel
@@ -212,19 +283,21 @@ export const PartitionStepStatus: React.FC<PartitionStepStatusProps> = (props) =
                 }}
               >
                 <TopLabelTilted $height={topLabelHeight} label={p.name} />
-                <LeftLabel style={{textAlign: 'center'}}>
-                  <PartitionSquare
-                    key={`${p.name}:__full_status`}
-                    runs={p.runs}
-                    runsLoaded={p.runsLoaded}
-                    minUnix={minUnix}
-                    maxUnix={maxUnix}
-                    hovered={hovered}
-                    setHovered={setHovered}
-                    setFocused={setFocused}
-                    partitionName={p.name}
-                  />
-                </LeftLabel>
+                {props.showLatestRun && (
+                  <LeftLabel style={{textAlign: 'center'}}>
+                    <PartitionSquare
+                      key={`${p.name}:__full_status`}
+                      runs={p.runs}
+                      runsLoaded={p.runsLoaded}
+                      minUnix={minUnix}
+                      maxUnix={maxUnix}
+                      hovered={hovered}
+                      setHovered={setHovered}
+                      setFocused={setFocused}
+                      partitionName={p.name}
+                    />
+                  </LeftLabel>
+                )}
                 <Divider />
                 {sortPartitionSteps(p.steps).map((s) => (
                   <PartitionSquare
@@ -345,10 +418,10 @@ const PartitionSquare: React.FC<{
 
   if (!runsLoaded) {
     squareStatus = 'loading';
-  } else if (runs.length === 0) {
-    squareStatus = 'empty';
   } else if (step) {
     squareStatus = (StatusSquareFinalColor[step.color] || step.color).toLowerCase();
+  } else if (runs.length === 0) {
+    squareStatus = 'empty';
   } else {
     squareStatus = runs[runs.length - 1].status.toLowerCase();
   }

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
@@ -50,6 +50,11 @@ import {
   MatrixData,
 } from './useMatrixData';
 
+const BUFFER = 3;
+
+export const getVisibleItemCount = (viewportWidth: number) =>
+  Math.ceil(viewportWidth / BOX_SIZE) - BUFFER;
+
 interface PartitionRunSelection {
   partitionName: string;
   stepName?: string;
@@ -177,8 +182,7 @@ const PartitionStepStatus: React.FC<
 
   React.useEffect(() => {
     if (viewport.width) {
-      const pageSize = Math.ceil(viewport.width / BOX_SIZE) - BUFFER;
-      setPageSize(pageSize);
+      setPageSize(getVisibleItemCount(viewport.width));
     }
   }, [viewport.width, setPageSize]);
 
@@ -190,8 +194,7 @@ const PartitionStepStatus: React.FC<
     return stepRows.map((stepRow) => stepsByName[stepRow.name]);
   };
 
-  const BUFFER = 3;
-  const visibleCount = Math.ceil(viewport.width / BOX_SIZE) - BUFFER;
+  const visibleCount = getVisibleItemCount(viewport.width);
   const visibleStart = Math.max(0, partitionColumns.length - props.offset - visibleCount);
   const visibleEnd = Math.max(visibleCount, partitionColumns.length - props.offset);
   const visibleColumns = partitionColumns.slice(visibleStart, visibleEnd);

--- a/js_modules/dagit/packages/core/src/partitions/RunMatrixUtils.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/RunMatrixUtils.tsx
@@ -260,11 +260,13 @@ const TopLabelTiltedInner = styled.div`
   }
 `;
 
+export const GRID_FLOATING_CONTAINER_WIDTH = 330;
+
 export const GridFloatingContainer = styled.div<{floating: boolean}>`
   display: flex;
   border-right: 1px solid ${Colors.Gray200};
   padding-bottom: 16px;
-  width: 330px;
+  width: ${GRID_FLOATING_CONTAINER_WIDTH}px;
   z-index: 1;
   ${({floating}) => (floating ? 'box-shadow: 1px 0 4px rgba(0, 0, 0, 0.15)' : '')};
 `;

--- a/js_modules/dagit/packages/core/src/partitions/useMatrixData.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/useMatrixData.tsx
@@ -169,6 +169,8 @@ interface MatrixDataInputs {
   options?: DisplayOptions;
 }
 
+export type MatrixData = ReturnType<typeof buildMatrixData>;
+
 /**
  * This hook uses the inputs provided to filter the data displayed and calls through to buildMatrixData.
  * It uses a React ref to cache the result and avoids re-computing when all inputs are shallow-equal.
@@ -182,7 +184,7 @@ interface MatrixDataInputs {
  */
 export const useMatrixData = (inputs: MatrixDataInputs) => {
   const cachedMatrixData = React.useRef<{
-    result: ReturnType<typeof buildMatrixData>;
+    result: MatrixData;
     inputs: MatrixDataInputs;
   }>();
   if (!inputs.solidHandles) {


### PR DESCRIPTION
### Summary & Motivation

This PR refactors the "Per-step Partition Matrix" shown on the Job Partitions page a bit so that it can display a matrix of assets instead of steps for asset jobs.

Rather than fully refactor all of the code to have a more abstract concept of "green / red / yellow", I essentially coerced asset data into the right shape for the existing component. I think this is probably ok for now, but we'll probably want to rebuild this entire component in the near future when we layer in asset versioning, etc.

