### PR TITLE
[dagster-airbyte] When loading managed connections, ignore those which are not managed

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
@@ -667,6 +667,7 @@ class AirbyteManagedElementCacheableAssetsDefinition(AirbyteInstanceCacheableAss
         connections: Iterable[AirbyteConnection],
         connection_to_io_manager_key_fn: Optional[Callable[[str], Optional[str]]],
     ):
+        defined_conn_names = {conn.name for conn in connections}
         super().__init__(
             airbyte_resource_def=airbyte_resource_def,
             workspace_id=None,
@@ -674,7 +675,7 @@ class AirbyteManagedElementCacheableAssetsDefinition(AirbyteInstanceCacheableAss
             create_assets_for_normalization_tables=create_assets_for_normalization_tables,
             connection_to_group_fn=connection_to_group_fn,
             connection_to_io_manager_key_fn=connection_to_io_manager_key_fn,
-            connection_filter=None,
+            connection_filter=lambda conn: conn.name in defined_conn_names,
         )
         self._connections: List[AirbyteConnection] = list(connections)
 


### PR DESCRIPTION
## Summary

With the `delete_unmentioned_resources` flag enabled, it's possible to have Airbyte connections which are not specified int he list of connections provided to the managed element reconciler, but which do not cause a diff.

This change adds a filter to `load_assets_from_connections` to ensure it only loads assets corresponding to the Airbyte connections passed in.


