### PR TITLE
Add support for loading cacheable assets from module

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_group.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_group.py
@@ -30,11 +30,7 @@ from .asset_layer import build_asset_selection_job
 from .assets import AssetsDefinition
 from .assets_job import check_resources_satisfy_requirements
 from .job_definition import JobDefinition, default_job_io_manager_with_fs_io_manager_schema
-from .load_assets_from_modules import (
-    assets_and_source_assets_from_modules,
-    assets_and_source_assets_from_package_module,
-    prefix_assets,
-)
+from .load_assets_from_modules import assets_from_modules, assets_from_package_module, prefix_assets
 from .resource_definition import ResourceDefinition
 from .source_asset import SourceAsset
 
@@ -256,9 +252,7 @@ class AssetGroup:
         Returns:
             AssetGroup: An asset group with all the assets in the package.
         """
-        assets, source_assets = assets_and_source_assets_from_package_module(
-            package_module, extra_source_assets
-        )
+        assets, source_assets, _ = assets_from_package_module(package_module, extra_source_assets)
         return AssetGroup(
             assets=assets,
             source_assets=source_assets,
@@ -320,7 +314,7 @@ class AssetGroup:
         Returns:
             AssetGroup: An asset group with all the assets defined in the given modules.
         """
-        assets, source_assets = assets_and_source_assets_from_modules(modules, extra_source_assets)
+        assets, source_assets, _ = assets_from_modules(modules, extra_source_assets)
 
         return AssetGroup(
             assets=assets,

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -111,6 +111,10 @@ def load_assets_from_modules(
     group_name = check.opt_str_param(group_name, "group_name")
     key_prefix = check.opt_inst_param(key_prefix, "key_prefix", (str, list))
 
+    # There is a tricky edge case here where if a non-cacheable asset depends on a cacheable asset,
+    # and the assets are prefixed, the non-cacheable asset's dependency will not be prefixed since
+    # at prefix-time it is not known that its dependency is one of the cacheable assets.
+    # https://github.com/dagster-io/dagster/pull/10389#pullrequestreview-1170913271
     (
         assets,
         source_assets,
@@ -218,6 +222,10 @@ def load_assets_from_package_module(
     group_name = check.opt_str_param(group_name, "group_name")
     key_prefix = check.opt_inst_param(key_prefix, "key_prefix", (str, list))
 
+    # There is a tricky edge case here where if a non-cacheable asset depends on a cacheable asset,
+    # and the assets are prefixed, the non-cacheable asset's dependency will not be prefixed since
+    # at prefix-time it is not known that its dependency is one of the cacheable assets.
+    # https://github.com/dagster-io/dagster/pull/10389#pullrequestreview-1170913271
     (
         assets,
         source_assets,

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -44,7 +44,7 @@ def assets_from_modules(
             group in addition to the source assets found in the modules.
 
     Returns:
-        Tuple[List[AssetsDefinition], List[SourceAsset], List[CacheableAssetsDefinition]]]:
+        Tuple[Sequence[AssetsDefinition], Sequence[SourceAsset], Sequence[CacheableAssetsDefinition]]]:
             A tuple containing a list of assets, a list of source assets, and a list of
             cacheable assets defined in the given modules.
     """
@@ -100,12 +100,12 @@ def load_assets_from_modules(
         group_name (Optional[str]):
             Group name to apply to the loaded assets. The returned assets will be copies of the
             loaded objects, with the group name added.
-        key_prefix (Optional[Union[str, List[str]]]):
+        key_prefix (Optional[Union[str, Sequence[str]]]):
             Prefix to prepend to the keys of the loaded assets. The returned assets will be copies
             of the loaded objects, with the prefix prepended.
 
     Returns:
-        List[Union[AssetsDefinition, SourceAsset]]:
+        Sequence[Union[AssetsDefinition, SourceAsset]]:
             A list containing assets and source assets defined in the given modules.
     """
     group_name = check.opt_str_param(group_name, "group_name")
@@ -152,12 +152,12 @@ def load_assets_from_current_module(
         group_name (Optional[str]):
             Group name to apply to the loaded assets. The returned assets will be copies of the
             loaded objects, with the group name added.
-        key_prefix (Optional[Union[str, List[str]]]):
+        key_prefix (Optional[Union[str, Sequence[str]]]):
             Prefix to prepend to the keys of the loaded assets. The returned assets will be copies
             of the loaded objects, with the prefix prepended.
 
     Returns:
-        List[Union[AssetsDefinition, SourceAsset, CachableAssetsDefinition]]:
+        Sequence[Union[AssetsDefinition, SourceAsset, CachableAssetsDefinition]]:
             A list containing assets, source assets, and cacheable assets defined in the module.
     """
     caller = inspect.stack()[1]
@@ -175,7 +175,7 @@ def load_assets_from_current_module(
 def assets_from_package_module(
     package_module: ModuleType,
     extra_source_assets: Optional[Sequence[SourceAsset]] = None,
-) -> Union[Sequence[AssetsDefinition], Sequence[SourceAsset], Sequence[CacheableAssetsDefinition]]:
+) -> Tuple[Sequence[AssetsDefinition], Sequence[SourceAsset], Sequence[CacheableAssetsDefinition]]:
     """
     Constructs three lists, a list of assets, a list of source assets, and a list of cacheable assets
     from the given package module.
@@ -186,7 +186,7 @@ def assets_from_package_module(
             group in addition to the source assets found in the modules.
 
     Returns:
-        Tuple[List[AssetsDefinition], List[SourceAsset], List[CacheableAssetsDefinition]]:
+        Tuple[Sequence[AssetsDefinition], Sequence[SourceAsset], Sequence[CacheableAssetsDefinition]]:
             A tuple containing a list of assets, a list of source assets, and a list of cacheable assets
             defined in the given modules.
     """
@@ -211,12 +211,12 @@ def load_assets_from_package_module(
         group_name (Optional[str]):
             Group name to apply to the loaded assets. The returned assets will be copies of the
             loaded objects, with the group name added.
-        key_prefix (Optional[Union[str, List[str]]]):
+        key_prefix (Optional[Union[str, Sequence[str]]]):
             Prefix to prepend to the keys of the loaded assets. The returned assets will be copies
             of the loaded objects, with the prefix prepended.
 
     Returns:
-        List[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
+        Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
             A list containing assets, source assets, and cacheable assets defined in the module.
     """
     group_name = check.opt_str_param(group_name, "group_name")
@@ -260,12 +260,12 @@ def load_assets_from_package_name(
         group_name (Optional[str]):
             Group name to apply to the loaded assets. The returned assets will be copies of the
             loaded objects, with the group name added.
-        key_prefix (Optional[Union[str, List[str]]]):
+        key_prefix (Optional[Union[str, Sequence[str]]]):
             Prefix to prepend to the keys of the loaded assets. The returned assets will be copies
             of the loaded objects, with the prefix prepended.
 
     Returns:
-        List[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
+        Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
             A list containing assets, source assets, and cacheable assets defined in the module.
     """
     package_module = import_module(package_name)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_package_with_cacheable/__init__.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_package_with_cacheable/__init__.py
@@ -1,0 +1,41 @@
+from dagster import AssetKey, op
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.cacheable_assets import (
+    AssetsDefinitionCacheableData,
+    CacheableAssetsDefinition,
+)
+
+
+class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
+    def compute_cacheable_data(self):
+        return [
+            AssetsDefinitionCacheableData(
+                keys_by_input_name={}, keys_by_output_name={"result": AssetKey(self.unique_id)}
+            )
+        ]
+
+    def build_definitions(self, data):
+        @op
+        def my_op():
+            return 1
+
+        return [
+            AssetsDefinition.from_op(
+                my_op,
+                keys_by_input_name=cd.keys_by_input_name,
+                keys_by_output_name=cd.keys_by_output_name,
+            )
+            for cd in data
+        ]
+
+
+x = MyCacheableAssetsDefinition("foo")
+
+
+def make_list_of_cacheable_assets():
+    return [MyCacheableAssetsDefinition("abc"), MyCacheableAssetsDefinition("def")]
+
+
+list_of_assets_and_source_assets = [
+    *make_list_of_cacheable_assets(),
+]

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
@@ -1,4 +1,6 @@
 import re
+from types import ModuleType
+from typing import Callable, List, Union, cast
 
 import pytest
 
@@ -13,10 +15,32 @@ from dagster import (
     load_assets_from_package_module,
     load_assets_from_package_name,
 )
+from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 
 get_unique_asset_identifier = (
     lambda asset: asset.op.name if isinstance(asset, AssetsDefinition) else asset.key
 )
+
+
+def check_asset_group(assets):
+    for asset in assets:
+        if isinstance(asset, AssetsDefinition):
+            asset_keys = asset.keys
+            for asset_key in asset_keys:
+                assert asset.group_names_by_key.get(asset_key) == "my_cool_group"
+        elif isinstance(asset, SourceAsset):
+            assert asset.group_name == "my_cool_group"
+
+
+def check_asset_prefix(prefix, assets):
+    for asset in assets:
+        if isinstance(asset, AssetsDefinition):
+            asset_keys = asset.keys
+            for asset_key in asset_keys:
+                observed_prefix = asset_key.path[:-1]
+                if len(observed_prefix) == 1:
+                    observed_prefix = observed_prefix[0]
+                assert observed_prefix == prefix
 
 
 def test_load_assets_from_package_name():
@@ -101,15 +125,6 @@ def test_load_assets_from_modules_with_group_name():
     from . import asset_package
     from .asset_package import module_with_assets
 
-    def check_asset_group(assets):
-        for asset in assets:
-            if isinstance(asset, AssetsDefinition):
-                asset_keys = asset.keys
-                for asset_key in asset_keys:
-                    assert asset.group_names_by_key.get(asset_key) == "my_cool_group"
-            elif isinstance(asset, SourceAsset):
-                assert asset.group_name == "my_cool_group"
-
     assets = load_assets_from_modules(
         [asset_package, module_with_assets], group_name="my_cool_group"
     )
@@ -139,18 +154,55 @@ def test_prefix(prefix):
     from . import asset_package
     from .asset_package import module_with_assets
 
-    def check_asset_prefix(assets):
-        for asset in assets:
-            if isinstance(asset, AssetsDefinition):
-                asset_keys = asset.keys
-                for asset_key in asset_keys:
-                    observed_prefix = asset_key.path[:-1]
-                    if len(observed_prefix) == 1:
-                        observed_prefix = observed_prefix[0]
-                    assert observed_prefix == prefix
-
     assets = load_assets_from_modules([asset_package, module_with_assets], key_prefix=prefix)
-    check_asset_prefix(assets)
+    check_asset_prefix(prefix, assets)
 
     assets = load_assets_from_package_module(asset_package, key_prefix=prefix)
-    check_asset_prefix(assets)
+    check_asset_prefix(prefix, assets)
+
+
+@pytest.mark.parametrize(
+    "load_fn",
+    [
+        load_assets_from_package_module,
+        lambda x, **kwargs: load_assets_from_package_name(x.__name__, **kwargs),
+    ],
+)
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "my_cool_prefix",
+        ["foo", "my_cool_prefix"],
+        ["foo", "bar", "baz", "my_cool_prefix"],
+    ],
+)
+def test_load_assets_cacheable(load_fn, prefix):
+    """
+    Tests the load-from-module and load-from-package-name functinos with cacheable assets
+    """
+    from . import asset_package_with_cacheable
+
+    assets_defs = load_fn(asset_package_with_cacheable)
+    assert len(assets_defs) == 3
+
+    assets_defs = load_fn(asset_package_with_cacheable, group_name="my_cool_group")
+    assert len(assets_defs) == 3
+
+    for assets_def in assets_defs:
+        cacheable_def = cast(CacheableAssetsDefinition, assets_def)
+        resolved_asset_defs = cacheable_def.build_definitions(
+            cacheable_def.compute_cacheable_data()
+        )
+
+        check_asset_group(resolved_asset_defs)
+
+    assets_defs = load_fn(asset_package_with_cacheable, key_prefix=prefix)
+    assert len(assets_defs) == 3
+
+    for assets_def in assets_defs:
+        cacheable_def = cast(CacheableAssetsDefinition, assets_def)
+        resolved_asset_defs = cacheable_def.build_definitions(
+            cacheable_def.compute_cacheable_data()
+        )
+
+        check_asset_prefix(prefix, resolved_asset_defs)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
@@ -1,6 +1,5 @@
 import re
-from types import ModuleType
-from typing import Callable, List, Union, cast
+from typing import cast
 
 import pytest
 


### PR DESCRIPTION
## Summary

The various 'load assets from module' functions currently ignore cacheable assets.

This PR allows them to be imported just like any other asset or source asset. It also adds some utility functions to mass-apply groups and prefixes to a cacheable asset definition's generated assets. Right now, doing so is tricky because these functions require an explicit mapping of asset key to group, but asset keys aren't known at initialization time for cacheable assets.

## Test Plan

New unit test.