### PR TITLE
[easy][dagster-airbyte] Treat SSH key as secret for managed stack

### DIFF
--- a/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/types.py
+++ b/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/types.py
@@ -11,7 +11,7 @@ class ManagedElementError(enum.Enum):
     CANNOT_CONNECT = "cannot_connect"
 
 
-SANITIZE_KEY_KEYWORDS = ["password", "token", "secret"]
+SANITIZE_KEY_KEYWORDS = ["password", "token", "secret", "ssh_key"]
 
 SECRET_MASK_VALUE = "**********"
 


### PR DESCRIPTION
## Summary

Airbyte treats `ssh_key` as a secret, so we should too.

