### PR TITLE
cached_method decorator

### DIFF
--- a/python_modules/dagster/dagster/_utils/cached_method.py
+++ b/python_modules/dagster/dagster/_utils/cached_method.py
@@ -1,0 +1,108 @@
+from functools import wraps
+
+from dagster import _check as check
+
+NO_VALUE_IN_CACHE_SENTINEL = object()
+
+
+def cached_method(method):
+    """
+    Caches the results of a method call.
+
+    Usage:
+
+        .. code-block:: python
+
+            class MyClass:
+                @cached_method
+                def fetch_value_from_database(self, key):
+                    ...
+
+    The main difference between this decorator and `functools.lru_cache(max_size=None)` is that each
+    instance of the class whose method is decorated gets its own cache. This means that the cache
+    can be garbage-collected when the object is garbage-collected.
+
+    A more subtle difference between this decorator and `functools.lru_cache` is that this one
+    prioritizes preventing mistakes over ease-of-use and performance. With `functools.lru_cache`,
+    these three invocations would all result in separate cache entries:
+
+        .. code-block:: python
+
+            class MyClass:
+                @cached_method
+                def a_method(self, arg1, arg2):
+                    ...
+
+            obj = MyClass()
+            obj.a_method(arg1="a", arg2=5)
+            obj.a_method(arg2=5, arg1="a")
+            obj.a_method("a", 5)
+
+    With this decorator, the first two would point to the same cache entry, and non-kwarg arguments
+    are not allowed.
+    """
+
+    @wraps(method)
+    def helper(self, *args, **kwargs):
+        cache_attr_name = method.__name__ + "_cache"
+        if not hasattr(self, cache_attr_name):
+            cache = {}
+            setattr(self, cache_attr_name, cache)
+        else:
+            cache = getattr(self, cache_attr_name)
+
+        key = _make_key(args, kwargs)
+        cached_result = cache.get(key, NO_VALUE_IN_CACHE_SENTINEL)
+        if cached_result is not NO_VALUE_IN_CACHE_SENTINEL:
+            return cached_result
+        else:
+            result = method(self, *args, **kwargs)
+            cache[key] = result
+            return result
+
+    return helper
+
+
+class _HashedSeq(list):
+    """
+    Adapted from https://github.com/python/cpython/blob/f9433fff476aa13af9cb314fcc6962055faa4085/Lib/functools.py#L432
+
+    This class guarantees that hash() will be called no more than once
+    per element.  This is important because the lru_cache() will hash
+    the key multiple times on a cache miss.
+    """
+
+    __slots__ = "hashvalue"
+
+    def __init__(self, tup):  # pylint: disable=super-init-not-called
+        self[:] = tup
+        self.hashvalue = hash(tup)
+
+    def __hash__(self):
+        return self.hashvalue
+
+
+def _make_key(args, kwds, fasttypes={int, str}):  # pylint: disable=dangerous-default-value
+    """
+    Adapted from https://github.com/python/cpython/blob/f9433fff476aa13af9cb314fcc6962055faa4085/Lib/functools.py#L448
+
+    Make a cache key from optionally typed positional and keyword arguments
+    The key is constructed in a way that is flat as possible rather than
+    as a nested structure that would take more memory.
+    If there is only a single argument and its data type is known to cache
+    its hash value, then that argument is returned without a wrapper.  This
+    saves space and improves lookup speed.
+    """
+    check.invariant(
+        not args,
+        "@cached_method does not support non-keyword arguments, because doing so would enable "
+        "functionally identical sets of arguments to correpond to different cache keys.",
+    )
+    key = tuple()
+    if kwds:
+        key = tuple(sorted(kwds.items()))
+    else:
+        key = tuple()
+    if len(key) == 1 and type(key[0]) in fasttypes:
+        return key[0]
+    return _HashedSeq(key)

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_cached_method.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_cached_method.py
@@ -1,0 +1,80 @@
+import gc
+from typing import NamedTuple
+
+import objgraph
+import pytest
+
+from dagster._check import CheckError
+from dagster._utils.cached_method import cached_method
+
+
+def test_cached_method():
+    class MyClass:
+        def __init__(self, attr1):
+            self._attr1 = attr1
+            self.calls = []
+
+        @cached_method
+        def my_method(self, arg1):
+            self.calls.append(arg1)
+            return (arg1, self._attr1)
+
+    obj1 = MyClass(4)
+    assert obj1.my_method(arg1="a") == ("a", 4)
+    assert obj1.my_method(arg1="a") == ("a", 4)
+    assert obj1.my_method(arg1="b") == ("b", 4)
+    assert obj1.my_method(arg1="a") == ("a", 4)
+    assert obj1.calls == ["a", "b"]
+
+    obj2 = MyClass(5)
+    assert obj2.my_method(arg1="a") == ("a", 5)
+    assert obj2.my_method(arg1="b") == ("b", 5)
+    assert obj2.calls == ["a", "b"]
+
+
+def test_kwargs_order_irrelevant_and_no_kwargs():
+    class MyClass:
+        def __init__(self):
+            self.calls = []
+
+        @cached_method
+        def my_method(self, arg1, arg2):
+            self.calls.append(arg1)
+            return arg1, arg2
+
+    obj1 = MyClass()
+    assert obj1.my_method(arg1="a", arg2=5) == ("a", 5)
+    assert obj1.my_method(arg2=5, arg1="a") == ("a", 5)
+    assert len(obj1.calls) == 1
+
+    with pytest.raises(CheckError, match="does not support non-keyword arguments"):
+        obj1.my_method("a", 5)
+
+
+def test_does_not_leak():
+    class KeyClass(NamedTuple):
+        attr: str
+
+    class ValueClass(NamedTuple):
+        attr: str
+
+    class MyClass:
+        @cached_method
+        def my_method(self, _arg1: KeyClass) -> ValueClass:
+            return ValueClass("abc")
+
+    obj = MyClass()
+    assert objgraph.count("MyClass") == 1
+    assert objgraph.count("KeyClass") == 0
+    assert objgraph.count("ValueClass") == 0
+
+    obj.my_method(_arg1=KeyClass("1234"))
+    assert objgraph.count("MyClass") == 1
+    assert objgraph.count("KeyClass") == 1
+    assert objgraph.count("ValueClass") == 1
+
+    del obj
+    gc.collect()
+    assert objgraph.count("MyClass") == 0
+    assert objgraph.count("KeyClass") == 0
+    assert objgraph.count("ValueClass") == 0


### PR DESCRIPTION
### Motivation

I found myself wanting this a few times while working on partitioned asset reconciliation.

### Docstring

Caches the results of a method call.

Usage:

    .. code-block:: python

        class MyClass:
            @cached_method
            def fetch_value_from_database(self, key):
                ...

The main difference between this decorator and `functools.lru_cache(max_size=None)` is that each instance of the class whose method is decorated gets its own cache. This means that the cache can be garbage-collected when the object is garbage-collected.

A more subtle difference between this decorator and `functools.lru_cache` is that this one prioritizes preventing mistakes over ease-of-use and performance. With `functools.lru_cache`, these three invocations would all result in separate cache entries:

    .. code-block:: python

        class MyClass:
            @cached_method
            def a_method(self, arg1, arg2):
                ...

        obj = MyClass()
        obj.a_method(arg1="a", arg2=5)
        obj.a_method(arg2=5, arg1="a")
        obj.a_method("a", 5)

With this decorator, the first two would point to the same cache entry, and non-kwarg arguments are not allowed.