### PR TITLE
Resolver -> AssetGraph

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,22 @@
+{
+  "include": [
+    ".",
+  ],
+  "exclude": [
+    "**/alembic",
+    "**/__pycache__",
+    "**/node_modules",
+    "**/.git",
+    "**/.tox",
+    "**/.venv*",
+    "../internal/**/alembic",
+    "../internal/**/__pycache__",
+    "../internal/**/node_modules",
+    "../internal/**/.git",
+    "../internal/**/.tox",
+    "../internal/**/.venv*"
+  ],
+  "venvPath": "/Users/sryza/.pyenv/versions/3.9.11/envs/",
+  "venv": "dagster-3.9.11",
+  "reportImplicitStringConcatenation": false
+}

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -1,0 +1,30 @@
+from typing import Sequence, Union
+
+import dagster._check as check
+from dagster._core.selector.subset_selector import (
+    generate_asset_dep_graph,
+    generate_asset_name_to_definition_map,
+)
+
+from .assets import AssetsDefinition
+from .source_asset import SourceAsset
+
+
+class AssetGraph:
+    def __init__(self, all_assets: Sequence[Union[AssetsDefinition, SourceAsset]]):
+        assets_defs = []
+        source_assets = []
+        for asset in all_assets:
+            if isinstance(asset, SourceAsset):
+                source_assets.append(asset)
+            elif isinstance(asset, AssetsDefinition):
+                assets_defs.append(asset)
+            else:
+                check.failed(f"Expected SourceAsset or AssetsDefinition, got {type(asset)}")
+
+        self.assets_defs = assets_defs
+        self.asset_dep_graph = generate_asset_dep_graph(assets_defs, source_assets)
+        self.all_assets_by_key_str = generate_asset_name_to_definition_map(assets_defs)
+        self.source_asset_key_strs = {
+            source_asset.key.to_user_string() for source_asset in source_assets
+        }

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition.py
@@ -28,6 +28,7 @@ from dagster._core.selector import parse_solid_selection
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils import make_readonly_value, merge_dicts
 
+from .asset_selection import AssetGraph
 from .assets_job import get_base_asset_jobs, is_base_asset_job_name
 from .cacheable_assets import AssetsDefinitionCacheableData
 from .events import AssetKey, CoercibleToAssetKey
@@ -1421,6 +1422,10 @@ class RepositoryDefinition:
         from dagster._core.storage.asset_value_loader import AssetValueLoader
 
         return AssetValueLoader(self._assets_defs_by_key, instance=instance)
+
+    @property
+    def asset_graph(self) -> AssetGraph:
+        return AssetGraph([*self._assets_defs_by_key.values(), *self.source_assets_by_key.values()])
 
     # If definition comes from the @repository decorator, then the __call__ method will be
     # overwritten. Therefore, we want to maintain the call-ability of repository definitions.

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -247,6 +247,19 @@ def fetch_sinks(graph: DependencyGraph, within_selection: AbstractSet[str]) -> F
     return frozenset(sinks)
 
 
+def fetch_sources(graph: DependencyGraph, within_selection: AbstractSet[str]) -> FrozenSet[str]:
+    """
+    A source is a node that has no upstream dependencies within the provided selection.
+    It can have other dependencies outside of the selection.
+    """
+    traverser = Traverser(graph)
+    sources = set()
+    for item in within_selection:
+        if len(traverser.fetch_upstream(item, depth=MAX_NUM) & within_selection) == 0:
+            sources.add(item)
+    return frozenset(sources)
+
+
 # Maps string names of individual assets (used in the dependency graphs) to `AssetsDefinition`
 # objects
 def generate_asset_name_to_definition_map(


### PR DESCRIPTION
### Summary & Motivation

This renames AssetGraph to Resolver, factors it out into its own module, and moves the resolution logic onto the subclasses of AssetSelection.

The idea is that we can then use AssetGraph in a bunch of other places that aren't centered on AssetSelection (e.g. partitioned reconciliation sensors).

This shouldn't change any user-facing behavior.

### How I Tested These Changes
