### PR TITLE
operate on keys instead of strings in AssetSelection and AssetGraph

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -1,10 +1,7 @@
 from typing import Sequence, Union
 
 import dagster._check as check
-from dagster._core.selector.subset_selector import (
-    generate_asset_dep_graph,
-    generate_asset_name_to_definition_map,
-)
+from dagster._core.selector.subset_selector import generate_asset_dep_graph
 
 from .assets import AssetsDefinition
 from .source_asset import SourceAsset
@@ -23,8 +20,10 @@ class AssetGraph:
                 check.failed(f"Expected SourceAsset or AssetsDefinition, got {type(asset)}")
 
         self.assets_defs = assets_defs
-        self.asset_dep_graph = generate_asset_dep_graph(assets_defs, source_assets)
-        self.all_assets_by_key_str = generate_asset_name_to_definition_map(assets_defs)
-        self.source_asset_key_strs = {
-            source_asset.key.to_user_string() for source_asset in source_assets
+        self.all_asset_keys = {
+            asset_key
+            for assets_def in assets_defs
+            for asset_key, group in assets_def.group_names_by_key.items()
         }
+        self.asset_dep_graph = generate_asset_dep_graph(assets_defs, source_assets)
+        self.source_asset_keys = {source_asset.key for source_asset in source_assets}

--- a/python_modules/dagster/dagster/_core/definitions/asset_group.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_group.py
@@ -3,6 +3,7 @@ from importlib import import_module
 from types import ModuleType
 from typing import (
     TYPE_CHECKING,
+    AbstractSet,
     Any,
     Dict,
     FrozenSet,
@@ -193,7 +194,7 @@ class AssetGroup:
         check.str_param(name, "name")
         check.opt_inst_param(_asset_selection_data, "_asset_selection_data", AssetSelectionData)
 
-        selected_asset_keys: FrozenSet[AssetKey] = frozenset()
+        selected_asset_keys: AbstractSet[AssetKey] = frozenset()
         if isinstance(selection, str):
             selected_asset_keys = parse_asset_selection(
                 self.assets, self.source_assets, [selection]

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -6,7 +6,6 @@ from typing import (
     Any,
     Callable,
     Dict,
-    FrozenSet,
     Iterable,
     List,
     Mapping,
@@ -789,7 +788,7 @@ def build_asset_selection_job(
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     description: Optional[str] = None,
     tags: Optional[Mapping[str, Any]] = None,
-    asset_selection: Optional[FrozenSet[AssetKey]] = None,
+    asset_selection: Optional[AbstractSet[AssetKey]] = None,
     asset_selection_data: Optional[AssetSelectionData] = None,
 ) -> "JobDefinition":
     from dagster._core.definitions import build_assets_job

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -332,33 +332,33 @@ def _attempt_resolve_cycles(
     asset_deps = generate_asset_dep_graph(assets_defs, source_assets)
 
     # index AssetsDefinitions by their asset names
-    assets_defs_by_asset_name = {}
+    assets_defs_by_asset_key: Dict[AssetKey, AssetsDefinition] = {}
     for assets_def in assets_defs:
         for asset_key in assets_def.keys:
-            assets_defs_by_asset_name[asset_key.to_user_string()] = assets_def
+            assets_defs_by_asset_key[asset_key] = assets_def
 
     # color for each asset
     colors = {}
 
     # recursively color an asset and all of its downstream assets
-    def _dfs(name, cur_color):
-        colors[name] = cur_color
-        if name in assets_defs_by_asset_name:
-            cur_node_asset_keys = assets_defs_by_asset_name[name].keys
+    def _dfs(key, cur_color):
+        colors[key] = cur_color
+        if key in assets_defs_by_asset_key:
+            cur_node_asset_keys = assets_defs_by_asset_key[key].keys
         else:
             # in a SourceAsset, treat all downstream as if they're in the same node
-            cur_node_asset_keys = asset_deps["downstream"][name]
+            cur_node_asset_keys = asset_deps["downstream"][key]
 
-        for downstream_name in asset_deps["downstream"][name]:
+        for downstream_key in asset_deps["downstream"][key]:
             # if the downstream asset is in the current node,keep the same color
-            if AssetKey.from_user_string(downstream_name) in cur_node_asset_keys:
+            if downstream_key in cur_node_asset_keys:
                 new_color = cur_color
             else:
                 new_color = cur_color + 1
 
             # if current color of the downstream asset is less than the new color, re-do dfs
-            if colors.get(downstream_name, -1) < new_color:
-                _dfs(downstream_name, new_color)
+            if colors.get(downstream_key, -1) < new_color:
+                _dfs(downstream_key, new_color)
 
     # validate that there are no cycles in the overall asset graph
     toposorted = list(toposort(asset_deps["upstream"]))
@@ -370,14 +370,11 @@ def _attempt_resolve_cycles(
     color_mapping_by_assets_defs: Dict[AssetsDefinition, Any] = defaultdict(
         lambda: defaultdict(set)
     )
-    for name, color in colors.items():
-        asset_key = AssetKey.from_user_string(name)
+    for key, color in colors.items():
         # ignore source assets
-        if name not in assets_defs_by_asset_name:
+        if key not in assets_defs_by_asset_key:
             continue
-        color_mapping_by_assets_defs[assets_defs_by_asset_name[name]][color].add(
-            AssetKey.from_user_string(name)
-        )
+        color_mapping_by_assets_defs[assets_defs_by_asset_key[key]][color].add(key)
 
     ret = []
     for assets_def, color_mapping in color_mapping_by_assets_defs.items():

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     AbstractSet,
     Any,
+    Callable,
     Dict,
     FrozenSet,
     Iterable,
@@ -16,6 +17,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    TypeVar,
 )
 
 from typing_extensions import Literal, TypeAlias
@@ -33,7 +35,8 @@ if TYPE_CHECKING:
 
 MAX_NUM = sys.maxsize
 
-DependencyGraph: TypeAlias = Dict[str, Dict[str, FrozenSet[str]]]
+T = TypeVar("T")
+DependencyGraph: TypeAlias = Mapping[str, Mapping[T, AbstractSet[T]]]
 
 
 class OpSelectionData(
@@ -107,22 +110,20 @@ def generate_asset_dep_graph(
 
     resolved_asset_deps = ResolvedAssetDependencies(assets_defs, source_assets)
 
-    upstream: Dict[str, Set[str]] = {}
-    downstream: Dict[str, Set[str]] = {}
+    upstream: Dict[AssetKey, Set[AssetKey]] = {}
+    downstream: Dict[AssetKey, Set[AssetKey]] = {}
     for assets_def in assets_defs:
         for asset_key in assets_def.keys:
-            asset_name = asset_key.to_user_string()
-            upstream[asset_name] = set()
-            downstream[asset_name] = downstream.get(asset_name, set())
+            upstream[asset_key] = set()
+            downstream[asset_key] = downstream.get(asset_key, set())
             # for each asset upstream of this one, set that as upstream, and this downstream of it
             upstream_asset_keys = resolved_asset_deps.get_resolved_upstream_asset_keys(
                 assets_def, asset_key
             )
             for upstream_key in upstream_asset_keys:
-                upstream_name = upstream_key.to_user_string()
-                upstream[asset_name].add(upstream_name)
-                downstream[upstream_name] = downstream.get(upstream_name, set()) | {asset_name}
-    return freeze_graph({"upstream": upstream, "downstream": downstream})
+                upstream[asset_key].add(upstream_key)
+                downstream[upstream_key] = downstream.get(upstream_key, set()) | {asset_key}
+    return {"upstream": upstream, "downstream": downstream}
 
 
 def generate_dep_graph(pipeline_def: "PipelineDefinition") -> DependencyGraph:
@@ -170,16 +171,7 @@ def generate_dep_graph(pipeline_def: "PipelineDefinition") -> DependencyGraph:
             for down in downstreams:
                 graph["downstream"][item_name].add(down.solid_name)
 
-    return freeze_graph(graph)
-
-
-def freeze_graph(graph: Mapping[str, Mapping[str, MutableSet[str]]]) -> DependencyGraph:
-    frozen_graph: DependencyGraph = {}
-    for direction, asset_map in graph.items():
-        frozen_graph[direction] = {}
-        for k, name_set in asset_map.items():
-            frozen_graph[direction][k] = frozenset(name_set)
-    return frozen_graph
+    return graph
 
 
 Direction = Literal["downstream", "upstream"]
@@ -190,7 +182,7 @@ class Traverser:
         self.graph = graph
 
     # `depth=None` is infinite depth
-    def _fetch_items(self, item_name: str, depth: int, direction: Direction) -> FrozenSet[str]:
+    def _fetch_items(self, item_name: T, depth: int, direction: Direction) -> AbstractSet[T]:
         dep_graph = self.graph[direction]
         stack = deque([item_name])
         result = set()
@@ -208,24 +200,24 @@ class Traverser:
                         stack.append(item)
                         result.add(item)
             curr_depth += 1
-        return frozenset(result)
+        return result
 
-    def fetch_upstream(self, item_name: str, depth: int) -> FrozenSet[str]:
+    def fetch_upstream(self, item_name: T, depth: int) -> AbstractSet[T]:
         # return a set of ancestors of the given item, up to the given depth
         return self._fetch_items(item_name, depth, "upstream")
 
-    def fetch_downstream(self, item_name: str, depth: int) -> FrozenSet[str]:
+    def fetch_downstream(self, item_name: T, depth: int) -> AbstractSet[T]:
         # return a set of descendants of the given item, down to the given depth
         return self._fetch_items(item_name, depth, "downstream")
 
 
 def fetch_connected(
-    item: str,
+    item: T,
     graph: DependencyGraph,
     *,
     direction: Direction,
     depth: Optional[int] = None,
-) -> FrozenSet[str]:
+) -> AbstractSet[T]:
     if depth is None:
         depth = MAX_NUM
     if direction == "downstream":
@@ -234,7 +226,7 @@ def fetch_connected(
         return Traverser(graph).fetch_upstream(item, depth)
 
 
-def fetch_sinks(graph: DependencyGraph, within_selection: AbstractSet[str]) -> FrozenSet[str]:
+def fetch_sinks(graph: DependencyGraph, within_selection: AbstractSet[T]) -> AbstractSet[T]:
     """
     A sink is an asset that has no downstream dependencies within the provided selection.
     It can have other dependencies outside of the selection.
@@ -244,10 +236,10 @@ def fetch_sinks(graph: DependencyGraph, within_selection: AbstractSet[str]) -> F
     for item in within_selection:
         if len(traverser.fetch_downstream(item, depth=MAX_NUM) & within_selection) == 0:
             sinks.add(item)
-    return frozenset(sinks)
+    return sinks
 
 
-def fetch_sources(graph: DependencyGraph, within_selection: AbstractSet[str]) -> FrozenSet[str]:
+def fetch_sources(graph: DependencyGraph, within_selection: AbstractSet[T]) -> AbstractSet[T]:
     """
     A source is a node that has no upstream dependencies within the provided selection.
     It can have other dependencies outside of the selection.
@@ -257,20 +249,7 @@ def fetch_sources(graph: DependencyGraph, within_selection: AbstractSet[str]) ->
     for item in within_selection:
         if len(traverser.fetch_upstream(item, depth=MAX_NUM) & within_selection) == 0:
             sources.add(item)
-    return frozenset(sources)
-
-
-# Maps string names of individual assets (used in the dependency graphs) to `AssetsDefinition`
-# objects
-def generate_asset_name_to_definition_map(
-    assets_defs: Iterable["AssetsDefinition"],
-) -> Mapping[str, "AssetsDefinition"]:
-    asset_name_map = {}
-    for assets_def in assets_defs:
-        for asset_key in assets_def.keys:
-            asset_name = asset_key.to_user_string()
-            asset_name_map[asset_name] = assets_def
-    return asset_name_map
+    return sources
 
 
 def fetch_connected_assets_definitions(
@@ -324,19 +303,23 @@ def parse_items_from_selection(selection: List[str]) -> List[str]:
     return items
 
 
-def clause_to_subset(graph: DependencyGraph, clause: str) -> List[str]:
+def clause_to_subset(
+    graph: DependencyGraph, clause: str, item_name_to_item_fn: Callable[[str], T]
+) -> List[T]:
     """Take a selection query and return a list of the selected and qualified items.
 
     Args:
-        graph (Dict[str, Dict[str, Set[str]]]): the input and output dependency graph.
+        graph (Dict[str, Dict[T, Set[T]]]): the input and output dependency graph.
         clause (str): the subselection query in model selection syntax, e.g. "*some_solid+" will
             select all of some_solid's upstream dependencies and its direct downstream dependecies.
+        item_name_to_item_fn (Callable[[str], T]): Converts item names found in the clause to items
+            of the type held in the graph.
 
     Returns:
-        subset_list (List[str]): a list of selected and qualified solid names, empty if input is
+        subset_list (List[T]): a list of selected and qualified items, empty if input is
             invalid.
     """
-    # parse cluase
+    # parse clause
     if not isinstance(clause, str):
         return []
     parts = parse_clause(clause)
@@ -344,15 +327,16 @@ def clause_to_subset(graph: DependencyGraph, clause: str) -> List[str]:
         return []
     up_depth, item_name, down_depth = parts
     # item_name invalid
-    if item_name not in graph["upstream"]:
+    item = item_name_to_item_fn(item_name)
+    if item not in graph["upstream"]:
         return []
 
     subset_list = []
     traverser = Traverser(graph=graph)
-    subset_list.append(item_name)
+    subset_list.append(item)
     # traverse graph to get up/downsteam items
-    subset_list += traverser.fetch_upstream(item_name, up_depth)
-    subset_list += traverser.fetch_downstream(item_name, down_depth)
+    subset_list += traverser.fetch_upstream(item, up_depth)
+    subset_list += traverser.fetch_downstream(item, down_depth)
 
     return subset_list
 
@@ -439,7 +423,7 @@ def parse_solid_selection(
 
     # loop over clauses
     for clause in solid_selection:
-        subset = clause_to_subset(graph, clause)
+        subset = clause_to_subset(graph, clause, lambda x: x)
         if len(subset) == 0:
             raise DagsterInvalidSubsetError(
                 "No qualified {node_type} to execute found for {selection_type}={requested}".format(
@@ -454,7 +438,7 @@ def parse_solid_selection(
 
 
 def parse_step_selection(
-    step_deps: Dict[str, Set[str]], step_selection: List[str]
+    step_deps: Mapping[str, AbstractSet[str]], step_selection: List[str]
 ) -> FrozenSet[str]:
     """Take the dependency dictionary generated while building execution plan and a list of step key
      selection queries and return a set of the qualified step keys.
@@ -474,15 +458,13 @@ def parse_step_selection(
     check.list_param(step_selection, "step_selection", of_type=str)
     # reverse step_deps to get the downstream_deps
     # make sure we have all items as keys, including the ones without downstream dependencies
-    downstream_deps: Dict[str, MutableSet[str]] = defaultdict(
-        set, {k: set() for k in step_deps.keys()}
-    )
+    downstream_deps: Dict[str, Set[str]] = defaultdict(set, {k: set() for k in step_deps.keys()})
     for downstream_key, upstream_keys in step_deps.items():
         for step_key in upstream_keys:
             downstream_deps[step_key].add(downstream_key)
 
     # generate dep graph
-    graph = freeze_graph({"upstream": step_deps, "downstream": downstream_deps})
+    graph = {"upstream": step_deps, "downstream": downstream_deps}
     steps_set = set()
 
     step_keys = parse_items_from_selection(step_selection)
@@ -495,7 +477,7 @@ def parse_step_selection(
 
     # loop over clauses
     for clause in step_selection:
-        subset = clause_to_subset(graph, clause)
+        subset = clause_to_subset(graph, clause, lambda x: x)
         if len(subset) == 0:
             raise DagsterInvalidSubsetError(
                 "No qualified steps to execute found for step_selection={requested}".format(
@@ -511,7 +493,7 @@ def parse_asset_selection(
     assets_defs: Sequence["AssetsDefinition"],
     source_assets: Sequence["SourceAsset"],
     asset_selection: Sequence[str],
-) -> FrozenSet["AssetKey"]:
+) -> AbstractSet[AssetKey]:
     """Find assets that match the given selection query
 
     Args:
@@ -520,26 +502,25 @@ def parse_asset_selection(
             asset key) to execute.
 
     Returns:
-        FrozenSet[str]: a frozenset of qualified deduplicated asset keys, empty if no qualified
-            subset selected.
+        AbstractSet[AssetKey]: a frozenset of qualified deduplicated asset keys, empty if no
+            qualified subset selected.
     """
     check.list_param(asset_selection, "asset_selection", of_type=str)
 
     # special case: select *
     if len(asset_selection) == 1 and asset_selection[0] == "*":
-        return frozenset(set().union(*(ad.keys for ad in assets_defs)))
+        return set().union(*(ad.keys for ad in assets_defs))
 
     graph = generate_asset_dep_graph(assets_defs, source_assets)
-    assets_set: Set[str] = set()
+    assets_set: Set[AssetKey] = set()
 
     # loop over clauses
     for clause in asset_selection:
-        subset = clause_to_subset(graph, clause)
+        subset = clause_to_subset(graph, clause, AssetKey.from_user_string)
         if len(subset) == 0:
             raise DagsterInvalidSubsetError(
                 f"No qualified assets to execute found for clause='{clause}'"
             )
         assets_set.update(subset)
 
-    # at the end, turn the user selection strings into asset keys
-    return frozenset({AssetKey.from_user_string(asset_string) for asset_string in assets_set})
+    return assets_set

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -179,22 +179,22 @@ def _get_assets_defs(use_multi: bool = False, allow_subset: bool = False):
         (
             "x",
             False,
-            (DagsterInvalidSubsetError, r"AssetKey\(s\) {'x'} were selected"),
+            (DagsterInvalidSubsetError, r"were selected"),
         ),
         (
             "x",
             True,
-            (DagsterInvalidSubsetError, r"AssetKey\(s\) {'x'} were selected"),
+            (DagsterInvalidSubsetError, r"were selected"),
         ),
         (
             ["start", "x"],
             False,
-            (DagsterInvalidSubsetError, r"AssetKey\(s\) {'x'} were selected"),
+            (DagsterInvalidSubsetError, r"were selected"),
         ),
         (
             ["start", "x"],
             True,
-            (DagsterInvalidSubsetError, r"AssetKey\(s\) {'x'} were selected"),
+            (DagsterInvalidSubsetError, r"were selected"),
         ),
         (["d", "e", "f"], False, None),
         (["d", "e", "f"], True, None),

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -674,7 +674,9 @@ def test_bad_coerce():
 
 def test_bad_resolve():
 
-    with pytest.raises(DagsterInvalidSubsetError, match=r"AssetKey\(s\) {'foo'} were selected"):
+    with pytest.raises(
+        DagsterInvalidSubsetError, match=r"AssetKey\(s\) {AssetKey\(\['foo'\]\)} were selected"
+    ):
 
         @repository
         def _fails():

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
@@ -196,7 +196,7 @@ def test_clause_to_subset(clause, expected_subset):
             "e": {"f"},
         },
     }
-    assert set(clause_to_subset(graph, clause)) == set(expected_subset.split(","))
+    assert set(clause_to_subset(graph, clause, lambda x: x)) == set(expected_subset.split(","))
 
 
 def test_parse_step_selection_single():


### PR DESCRIPTION
### Summary & Motivation

This enables `AssetGraph` and the operations within asset selection resolution to operate on asset keys instead of strings.  It changes the underlying implementation inside subset_selector to support arbitrary key types, not just strings. Advantages:
- Performance: less time spent converting to/from the string representations of asset keys
- Readability: less characters converting to/from the string representations of asset keys
- Wider use: `AssetGraph` will be able to be used in parts of the codebase that deal in asset keys

It also moves the selection code from `FrozenSet` to `AbstractSet`, trusting the type system to enforce that these return values don't get mutated instead of doing lots of copies.

It shouldn't change any user-facing behavior.

### How I Tested These Changes
