### PR TITLE
Expose sqlalchemy pool recycle option for mysql/postgres

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/dagit.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/dagit.py
@@ -41,6 +41,7 @@ class Dagit(BaseModel):
     annotations: kubernetes.Annotations
     enableReadOnly: bool
     dbStatementTimeout: Optional[int]
+    dbPoolRecycle: Optional[int]
     logLevel: Optional[str]
     schedulerName: Optional[str]
     volumeMounts: Optional[List[kubernetes.VolumeMount]]

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -204,6 +204,16 @@ def test_dagit_db_statement_timeout(deployment_template: HelmTemplate):
     assert f"--db-statement-timeout {db_statement_timeout_ms}" in command
 
 
+def test_dagit_db_pool_recycle(deployment_template: HelmTemplate):
+    pool_recycle_s = 7200
+    helm_values = DagsterHelmValues.construct(dagit=Dagit.construct(dbPoolRecycle=pool_recycle_s))
+
+    dagit_deployments = deployment_template.render(helm_values)
+    command = " ".join(dagit_deployments[0].spec.template.spec.containers[0].command)
+
+    assert f"--db-pool-recycle {pool_recycle_s}" in command
+
+
 def test_dagit_log_level(deployment_template: HelmTemplate):
     log_level = "trace"
     helm_values = DagsterHelmValues.construct(dagit=Dagit.construct(logLevel=log_level))

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -44,6 +44,7 @@ If release name contains chart name it will be used as a full name.
 dagit -h 0.0.0.0 -p {{ .Values.dagit.service.port }}
 {{- if $userDeployments.enabled }} -w /dagster-workspace/workspace.yaml {{- end -}}
 {{- with .Values.dagit.dbStatementTimeout }} --db-statement-timeout {{ . }} {{- end -}}
+{{- with .Values.dagit.dbPoolRecycle }} --db-pool-recycle {{ . }} {{- end -}}
 {{- with .Values.dagit.logLevel }} --log-level {{ . }} {{- end -}}
 {{- if .dagitReadOnly }} --read-only {{- end -}}
 {{- end -}}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -415,7 +415,7 @@
                     ]
                 },
                 "dbPoolRecycle": {
-                    "title": "DbPoolRecycle",
+                    "title": "Dbpoolrecycle",
                     "anyOf": [
                         {
                             "type": "integer"

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -414,6 +414,17 @@
                         }
                     ]
                 },
+                "dbPoolRecycle": {
+                    "title": "DbPoolRecycle",
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
                 "logLevel": {
                     "title": "Loglevel",
                     "anyOf": [

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -73,6 +73,11 @@ dagit:
   # The timeout in milliseconds to set on database statements sent to the Dagster instance.
   dbStatementTimeout: ~
 
+  # The maximum age in seconds of a connection to use in the sqlalchemy connection pool.
+  # Defaults to 1 hour if not set.
+  # Set to -1 to disable.
+  dbPoolRecycle: ~
+
   # The log level of the uvicorn web server, defaults to warning if not set
   logLevel: ~
 

--- a/python_modules/dagit/dagit/cli.py
+++ b/python_modules/dagit/dagit/cli.py
@@ -30,6 +30,7 @@ DEFAULT_DAGIT_HOST = "127.0.0.1"
 DEFAULT_DAGIT_PORT = 3000
 
 DEFAULT_DB_STATEMENT_TIMEOUT = 15000  # 15 sec
+DEFAULT_POOL_RECYCLE = 3600  # 1 hr
 
 
 @click.command(
@@ -87,6 +88,13 @@ DEFAULT_DB_STATEMENT_TIMEOUT = 15000  # 15 sec
     show_default=True,
 )
 @click.option(
+    "--db-pool-recycle",
+    help="The maximum age of a connection to use from the sqlalchemy pool without connection recycling. Set to -1 to disable. Not respected in all configurations.",
+    default=DEFAULT_POOL_RECYCLE,
+    type=click.INT,
+    show_default=True,
+)
+@click.option(
     "--read-only",
     help="Start Dagit in read-only mode, where all mutations such as launching runs and "
     "turning schedules on/off are turned off.",
@@ -112,6 +120,7 @@ def dagit(
     port,
     path_prefix,
     db_statement_timeout,
+    db_pool_recycle,
     read_only,
     suppress_warnings,
     log_level,
@@ -122,7 +131,7 @@ def dagit(
 
     with get_instance_for_service("dagit") as instance:
         # Allow the instance components to change behavior in the context of a long running server process
-        instance.optimize_for_dagit(db_statement_timeout)
+        instance.optimize_for_dagit(db_statement_timeout, db_pool_recycle)
 
         with get_workspace_process_context_from_kwargs(
             instance,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -733,11 +733,17 @@ class DagsterInstance:
             self._schedule_storage.upgrade()
             self._schedule_storage.migrate(print_fn)
 
-    def optimize_for_dagit(self, statement_timeout):
+    def optimize_for_dagit(self, statement_timeout, pool_recycle):
         if self._schedule_storage:
-            self._schedule_storage.optimize_for_dagit(statement_timeout=statement_timeout)
-        self._run_storage.optimize_for_dagit(statement_timeout=statement_timeout)
-        self._event_storage.optimize_for_dagit(statement_timeout=statement_timeout)
+            self._schedule_storage.optimize_for_dagit(
+                statement_timeout=statement_timeout, pool_recycle=pool_recycle
+            )
+        self._run_storage.optimize_for_dagit(
+            statement_timeout=statement_timeout, pool_recycle=pool_recycle
+        )
+        self._event_storage.optimize_for_dagit(
+            statement_timeout=statement_timeout, pool_recycle=pool_recycle
+        )
 
     def reindex(self, print_fn=lambda _: None):
         print_fn("Checking for reindexing...")

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -222,7 +222,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
     def dispose(self):
         """Explicit lifecycle management."""
 
-    def optimize_for_dagit(self, statement_timeout: int):
+    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int):
         """Allows for optimizing database connection / use in the context of a long lived dagit process"""
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -265,8 +265,8 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     def dispose(self):
         return self._storage.run_storage.dispose()
 
-    def optimize_for_dagit(self, statement_timeout: int):
-        return self._storage.run_storage.optimize_for_dagit(statement_timeout)
+    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int):
+        return self._storage.run_storage.optimize_for_dagit(statement_timeout, pool_recycle)
 
     def add_daemon_heartbeat(self, daemon_heartbeat: "DaemonHeartbeat"):
         return self._storage.run_storage.add_daemon_heartbeat(daemon_heartbeat)
@@ -370,8 +370,8 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     def dispose(self):
         return self._storage.event_storage.dispose()
 
-    def optimize_for_dagit(self, statement_timeout: int):
-        return self._storage.event_storage.optimize_for_dagit(statement_timeout)
+    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int):
+        return self._storage.event_storage.optimize_for_dagit(statement_timeout, pool_recycle)
 
     def get_event_records(
         self,
@@ -542,5 +542,5 @@ class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):
     def optimize(self, print_fn: Optional[Callable] = None, force_rebuild_all: bool = False):
         return self._storage.schedule_storage.optimize(print_fn, force_rebuild_all)
 
-    def optimize_for_dagit(self, statement_timeout: int):
-        return self._storage.schedule_storage.optimize_for_dagit(statement_timeout)
+    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int):
+        return self._storage.schedule_storage.optimize_for_dagit(statement_timeout, pool_recycle)

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -336,7 +336,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
     def dispose(self):
         """Explicit lifecycle management."""
 
-    def optimize_for_dagit(self, statement_timeout: int):
+    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int):
         """Allows for optimizing database connection / use in the context of a long lived dagit process"""
 
     # Daemon Heartbeat Storage

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -139,7 +139,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
     def optimize(self, print_fn: Optional[Callable] = None, force_rebuild_all: bool = False):
         """Call this method to run any optional data migrations for optimized reads"""
 
-    def optimize_for_dagit(self, statement_timeout: int):
+    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int):
         """Allows for optimizing database connection / use in the context of a long lived dagit process"""
 
     def alembic_version(self):

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -19,7 +19,6 @@ from dagster._core.storage.sql import (
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 
 from ..utils import (
-    MYSQL_POOL_RECYCLE,
     create_mysql_connection,
     mysql_alembic_config,
     mysql_url_from_config,
@@ -79,14 +78,14 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 SqlEventLogStorageMetadata.create_all(conn)
                 stamp_alembic_rev(mysql_alembic_config(__file__), conn)
 
-    def optimize_for_dagit(self, statement_timeout):
+    def optimize_for_dagit(self, statement_timeout, pool_recycle):
         # When running in dagit, hold an open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
             self.mysql_url,
             isolation_level="AUTOCOMMIT",
             pool_size=1,
-            pool_recycle=MYSQL_POOL_RECYCLE,
+            pool_recycle=pool_recycle,
         )
 
     def upgrade(self):

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -22,7 +22,6 @@ from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_
 from dagster._utils import utc_datetime_from_timestamp
 
 from ..utils import (
-    MYSQL_POOL_RECYCLE,
     create_mysql_connection,
     mysql_alembic_config,
     mysql_url_from_config,
@@ -85,14 +84,14 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
                 RunStorageSqlMetadata.create_all(conn)
                 stamp_alembic_rev(mysql_alembic_config(__file__), conn)
 
-    def optimize_for_dagit(self, statement_timeout):
+    def optimize_for_dagit(self, statement_timeout, pool_recycle):
         # When running in dagit, hold 1 open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
             self.mysql_url,
             isolation_level="AUTOCOMMIT",
             pool_size=1,
-            pool_recycle=MYSQL_POOL_RECYCLE,
+            pool_recycle=pool_recycle,
         )
 
     @property

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -15,7 +15,6 @@ from dagster._core.storage.sql import (
 from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_dagster_namedtuple
 
 from ..utils import (
-    MYSQL_POOL_RECYCLE,
     create_mysql_connection,
     mysql_alembic_config,
     mysql_url_from_config,
@@ -74,14 +73,14 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         self.migrate()
         self.optimize()
 
-    def optimize_for_dagit(self, statement_timeout):
+    def optimize_for_dagit(self, statement_timeout, pool_recycle):
         # When running in dagit, hold an open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
             self.mysql_url,
             isolation_level="AUTOCOMMIT",
             pool_size=1,
-            pool_recycle=MYSQL_POOL_RECYCLE,
+            pool_recycle=pool_recycle,
         )
 
     @property

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
@@ -10,9 +10,6 @@ import sqlalchemy as db
 from dagster import _check as check
 from dagster._core.storage.sql import get_alembic_config
 
-# 1 hr - anything less than 8 hrs (MySQL's default `wait_timeout` should work)
-MYSQL_POOL_RECYCLE = 3600
-
 
 class DagsterMySQLException(Exception):
     pass

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
@@ -115,7 +115,7 @@ def test_load_instance(conn_string, hostname):
 @pytest.mark.skip("https://github.com/dagster-io/dagster/issues/3719")
 def test_statement_timeouts(hostname):
     with instance_for_test(overrides=yaml.safe_load(full_mysql_config(hostname))) as instance:
-        instance.optimize_for_dagit(statement_timeout=500)  # 500ms
+        instance.optimize_for_dagit(statement_timeout=500, pool_recycle=-1)  # 500ms
 
         # ensure migration error is not raised by being up to date
         instance.upgrade()

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_wait_timeout.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_wait_timeout.py
@@ -2,13 +2,12 @@ import time
 
 import pytest
 from dagster_mysql.run_storage import MySQLRunStorage
-from mock import patch
 from sqlalchemy import exc
 
 
-def retry_connect(conn_string: str, num_retries: int = 5):
+def retry_connect(conn_string: str, num_retries: int = 5, pool_recycle=-1):
     storage = MySQLRunStorage.create_clean_storage(conn_string)
-    storage.optimize_for_dagit(-1)
+    storage.optimize_for_dagit(-1, pool_recycle=pool_recycle)
 
     with storage.connect() as conn:
         conn.execute("SET SESSION wait_timeout = 2;")
@@ -27,6 +26,5 @@ def test_pool_recycle_greater_than_wait_timeout(conn_string):
 
 
 def test_pool_recycle_less_than_wait_timeout(conn_string):
-    with patch("dagster_mysql.run_storage.run_storage.MYSQL_POOL_RECYCLE", 1):
-        runs_lst = retry_connect(conn_string)
-        assert len(runs_lst) == 0
+    runs_lst = retry_connect(conn_string, pool_recycle=1)
+    assert len(runs_lst) == 0

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -101,13 +101,14 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 SqlEventLogStorageMetadata.create_all(conn)
                 stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
-    def optimize_for_dagit(self, statement_timeout):
+    def optimize_for_dagit(self, statement_timeout, pool_recycle):
         # When running in dagit, hold an open connection and set statement_timeout
         self._engine = create_engine(
             self.postgres_url,
             isolation_level="AUTOCOMMIT",
             pool_size=1,
             connect_args={"options": pg_statement_timeout(statement_timeout)},
+            pool_recycle=pool_recycle,
         )
 
     def upgrade(self):

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -94,13 +94,14 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
                 # This revision may be shared by any other dagster storage classes using the same DB
                 stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
-    def optimize_for_dagit(self, statement_timeout):
+    def optimize_for_dagit(self, statement_timeout, pool_recycle):
         # When running in dagit, hold 1 open connection and set statement_timeout
         self._engine = create_engine(
             self.postgres_url,
             isolation_level="AUTOCOMMIT",
             pool_size=1,
             connect_args={"options": pg_statement_timeout(statement_timeout)},
+            pool_recycle=pool_recycle,
         )
 
     @property

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -83,13 +83,14 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         self.migrate()
         self.optimize()
 
-    def optimize_for_dagit(self, statement_timeout):
+    def optimize_for_dagit(self, statement_timeout, pool_recycle):
         # When running in dagit, hold an open connection and set statement_timeout
         self._engine = create_engine(
             self.postgres_url,
             isolation_level="AUTOCOMMIT",
             pool_size=1,
             connect_args={"options": pg_statement_timeout(statement_timeout)},
+            pool_recycle=pool_recycle,
         )
 
     @property

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
@@ -189,7 +189,7 @@ def test_connection_leak(hostname, conn_string):
 
 def test_statement_timeouts(hostname):
     with instance_for_test(overrides=yaml.safe_load(full_pg_config(hostname))) as instance:
-        instance.optimize_for_dagit(statement_timeout=500)  # 500ms
+        instance.optimize_for_dagit(statement_timeout=500, pool_recycle=-1)  # 500ms
 
         # ensure migration error is not raised by being up to date
         instance.upgrade()


### PR DESCRIPTION
### Summary & Motivation
We experience intermittent dagit postgres connection issues (similar to #8462 and #8877).

This PR exposes a new parameter to the dagit invocation that is passed to sqlalchemy for mysql and postgres connections when in dagit mode for `pool_recycle`.

I put a little thought into making this just be `extra_kwargs` or something, but I couldn't think of a non-clunky way to pass that via a CLI arg (string encoded json?)

### How I Tested These Changes
Updated unit tests.