### PR TITLE
allow sensors to target asset selections instead of jobs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -37,6 +37,7 @@ def sensor(
     job: Optional[ExecutableDefinition] = None,
     jobs: Optional[Sequence[ExecutableDefinition]] = None,
     default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
+    asset_selection: Optional[AssetSelection] = None,
 ) -> Callable[[RawSensorEvaluationFunction], SensorDefinition]:
     """
     Creates a sensor where the decorated function is used as the sensor's evaluation function.  The
@@ -62,6 +63,8 @@ def sensor(
             (experimental) A list of jobs to be executed when the sensor fires.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
             status can be overridden from Dagit or via the GraphQL API.
+        asset_selection (AssetSelection): (Experimental) an asset selection to launch a run for if
+            the sensor condition is met. This can be provided instead of specifying a job.
     """
     check.opt_str_param(name, "name")
 
@@ -77,6 +80,7 @@ def sensor(
             job=job,
             jobs=jobs,
             default_status=default_status,
+            asset_selection=asset_selection,
         )
 
         update_wrapper(sensor_def, wrapped=fn)

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -92,6 +92,17 @@ class RunRequest(
             ),
         )
 
+    def with_replaced_attrs(
+        self, job_name: Optional[str] = None, asset_selection: Optional[Sequence[AssetKey]] = None
+    ) -> "RunRequest":
+        return RunRequest(
+            run_key=self.run_key,
+            run_config=self.run_config,
+            tags=self.tags,
+            job_name=job_name or self.job_name,
+            asset_selection=asset_selection or self.asset_selection,
+        )
+
 
 @whitelist_for_serdes
 class PipelineRunReaction(

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
@@ -355,7 +355,7 @@ def test_multi_asset_sensor_has_assets():
     def my_repo():
         return [two_assets, passing_sensor]
 
-    assert passing_sensor.asset_keys == [AssetKey("asset_a"), AssetKey("asset_b")]
+    assert passing_sensor.monitored_asset_keys == [AssetKey("asset_a"), AssetKey("asset_b")]
     with instance_for_test() as instance:
         ctx = build_multi_asset_sensor_context(
             asset_keys=[AssetKey("asset_a"), AssetKey("asset_b")],

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -267,6 +267,11 @@ def asset_selection_sensor(context):
     assert context.latest_materialization_records_by_key().keys() == {AssetKey("asset_b")}
 
 
+@sensor(asset_selection=AssetSelection.keys("asset_a", "asset_b"))
+def targets_asset_selection_sensor():
+    return [RunRequest(), RunRequest(asset_selection=[AssetKey("asset_b")])]
+
+
 hourly_partitions_def_2022 = HourlyPartitionsDefinition(start_date="2022-08-01-00:00")
 
 
@@ -531,6 +536,7 @@ def the_repo():
         multi_asset_sensor_hourly_to_hourly,
         partitioned_asset_selection_sensor,
         asset_selection_sensor,
+        targets_asset_selection_sensor,
     ]
 
 
@@ -1727,6 +1733,55 @@ def test_run_request_asset_selection_sensor(executor, instance, workspace_contex
             )
         }
         assert planned_asset_keys == {AssetKey("a"), AssetKey("b")}
+
+
+@pytest.mark.parametrize("executor", get_sensor_executors())
+def test_targets_asset_selection_sensor(executor, instance, workspace_context, external_repo):
+    freeze_datetime = to_timezone(
+        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
+        "US/Central",
+    )
+    with pendulum.test(freeze_datetime):
+        external_sensor = external_repo.get_external_sensor("targets_asset_selection_sensor")
+        external_origin_id = external_sensor.get_external_origin_id()
+        instance.start_sensor(external_sensor)
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        assert len(ticks) == 0
+
+        evaluate_sensors(workspace_context, executor)
+
+        assert instance.get_runs_count() == 2
+        runs = instance.get_runs()
+        assert (
+            len(
+                [
+                    run
+                    for run in runs
+                    if run.asset_selection == {AssetKey("asset_a"), AssetKey("asset_b")}
+                ]
+            )
+            == 1
+        )
+        assert len([run for run in runs if run.asset_selection == {AssetKey("asset_b")}]) == 1
+        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        assert len(ticks) == 1
+        validate_tick(
+            ticks[0],
+            external_sensor,
+            freeze_datetime,
+            TickStatus.SUCCESS,
+            [run.run_id for run in runs],
+        )
+        planned_asset_keys = [
+            record.event_log_entry.dagster_event.event_specific_data.asset_key
+            for record in instance.get_event_records(
+                EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION_PLANNED)
+            )
+        ]
+        assert len(planned_asset_keys) == 3
+        assert set(planned_asset_keys) == {AssetKey("asset_a"), AssetKey("asset_b")}
 
 
 @pytest.mark.parametrize("executor", get_sensor_executors())


### PR DESCRIPTION
### Summary & Motivation

This adds an `asset_selection` property to `@sensor` that enables defining a sensor that directly submits run requests for assets, instead of submitting run requests for a job.

`@multi_asset_sensor` currently has an `asset_selection` property, which refers to something different: the assets that the sensor listens. This PR renames that property to `monitored_asset_selection`, which is in line with name of the `monitored_jobs` parameter on `@run_status_sensor`, to avoid confusion.
