### PR TITLE
[dagster-airbyte] Allow configuring destination namespace for managed connections

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/__init__.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/__init__.py
@@ -6,6 +6,7 @@ try:
     from .managed import (
         AirbyteConnection,
         AirbyteDestination,
+        AirbyteDestinationNamespace,
         AirbyteManagedElementReconciler,
         AirbyteSource,
         AirbyteSyncMode,

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/__init__.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/__init__.py
@@ -1,2 +1,8 @@
 from .reconciliation import AirbyteManagedElementReconciler, load_assets_from_connections
-from .types import AirbyteConnection, AirbyteDestination, AirbyteSource, AirbyteSyncMode
+from .types import (
+    AirbyteConnection,
+    AirbyteDestination,
+    AirbyteDestinationNamespace,
+    AirbyteSource,
+    AirbyteSyncMode,
+)

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
@@ -589,7 +589,7 @@ def reconcile_connections_post(
             connection_base_json["namespaceDefinition"] = config_conn.destination_namespace.value
         else:
             connection_base_json["namespaceDefinition"] = "customformat"
-            connection_base_json["namespaceFormat"] = config_conn.destination_namespace
+            connection_base_json["namespaceFormat"] = cast(str, config_conn.destination_namespace)
 
         if existing_conn:
             if not dry_run:

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
@@ -8,6 +8,7 @@ from dagster_airbyte.asset_defs import (
 from dagster_airbyte.managed.types import (
     AirbyteConnection,
     AirbyteDestination,
+    AirbyteDestinationNamespace,
     AirbyteSource,
     AirbyteSyncMode,
     InitializedAirbyteConnection,
@@ -115,6 +116,9 @@ def conn_dict(conn: Optional[AirbyteConnection]) -> Mapping[str, Any]:
         "destination": conn.destination.name if conn.destination else "Unknown",
         "normalize data": conn.normalize_data,
         "streams": {k: v.name for k, v in conn.stream_config.items()},
+        "destination namespace": conn.destination_namespace.name
+        if isinstance(conn.destination_namespace, AirbyteDestinationNamespace)
+        else conn.destination_namespace,
     }
 
 
@@ -580,6 +584,12 @@ def reconcile_connections_post(
             "scheduleType": "manual",
             "status": "active",
         }
+
+        if isinstance(config_conn.destination_namespace, AirbyteDestinationNamespace):
+            connection_base_json["namespaceDefinition"] = config_conn.destination_namespace.value
+        else:
+            connection_base_json["namespaceDefinition"] = "customformat"
+            connection_base_json["namespaceFormat"] = config_conn.destination_namespace
 
         if existing_conn:
             if not dry_run:

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/example_stacks/example_airbyte_stack.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/example_stacks/example_airbyte_stack.py
@@ -3,6 +3,7 @@ import os
 from dagster_airbyte import (
     AirbyteConnection,
     AirbyteDestination,
+    AirbyteDestinationNamespace,
     AirbyteManagedElementReconciler,
     AirbyteSource,
     AirbyteSyncMode,
@@ -110,6 +111,51 @@ reconciler_different_dest = AirbyteManagedElementReconciler(
     airbyte=airbyte_instance,
     connections=[
         alt_dest_local_json_conn,
+    ],
+    delete_unmentioned_resources=True,
+)
+
+# Version with destination namespace as destination default
+
+
+dest_default_local_json_conn = AirbyteConnection(
+    name="local-json-conn",
+    source=local_json_source,
+    destination=local_json_destination,
+    stream_config={
+        "my_data_stream": AirbyteSyncMode.FULL_REFRESH_APPEND,
+    },
+    normalize_data=False,
+    destination_namespace=AirbyteDestinationNamespace.DESTINATION_DEFAULT,
+)
+
+
+reconciler_dest_default = AirbyteManagedElementReconciler(
+    airbyte=airbyte_instance,
+    connections=[
+        dest_default_local_json_conn,
+    ],
+    delete_unmentioned_resources=True,
+)
+
+# Version with destination namespace as custom
+
+custom_namespace_local_json_conn = AirbyteConnection(
+    name="local-json-conn",
+    source=local_json_source,
+    destination=local_json_destination,
+    stream_config={
+        "my_data_stream": AirbyteSyncMode.FULL_REFRESH_APPEND,
+    },
+    normalize_data=False,
+    destination_namespace="my-cool-namespace",
+)
+
+
+reconciler_custom_namespace = AirbyteManagedElementReconciler(
+    airbyte=airbyte_instance,
+    connections=[
+        custom_namespace_local_json_conn,
     ],
     delete_unmentioned_resources=True,
 )


### PR DESCRIPTION
## Summary

Allows managed elements to configure the destination namespace for a particular Airbyte connection.

There are three options here - "Same as Source" and "Destination Default", which are represented by enum values, and then a configurable user-defined string.

Example:

```python
local_json_comm = AirbyteConnection(
    name="local-json-conn",
    source=local_json_source,
    destination=local_json_destination,
    ...
    destination_namespace=AirbyteDestinationNamespace.DESTINATION_DEFAULT,
)
```

```python
local_json_comm = AirbyteConnection(
    name="local-json-conn",
    source=local_json_source,
    destination=local_json_destination,
    ...
    destination_namespace="my-custom-namespace",
)
```

## Test Plan

New integration test.
