### PR TITLE
Install project-fully-featured

### DIFF
--- a/examples/project_fully_featured/setup.py
+++ b/examples/project_fully_featured/setup.py
@@ -37,7 +37,7 @@ setup(
         "fsspec",
         "s3fs",
         "scipy",
-        "sklearn",
+        "scikit-learn",
         "sqlalchemy!=1.4.42",  # workaround for https://github.com/snowflakedb/snowflake-sqlalchemy/issues/350
         "snowflake-sqlalchemy",
     ],

--- a/examples/project_fully_featured/tox.ini
+++ b/examples/project_fully_featured/tox.ini
@@ -17,6 +17,7 @@ deps =
   -e ../../python_modules/libraries/dagster-slack/
   -e ../../python_modules/libraries/dagster-aws/
   -e ../../python_modules/libraries/dagster-postgres/
+  -e .
 allowlist_externals =
   /bin/bash
 commands =


### PR DESCRIPTION
I'm not sure how this was succeeding in the past. Maybe we were just lucky that everything we needed was installed elsewhere?

Now we're missing sklearn though:

https://buildkite.com/dagster/dagster/builds/38482#01845319-435b-44cc-83a7-d53fe6831c30