### PR TITLE
[dagster-io/ui] Add stroke color to TextArea

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/TextArea.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TextArea.stories.tsx
@@ -1,0 +1,48 @@
+import {Meta} from '@storybook/react/types-6-0';
+import * as React from 'react';
+
+import {Colors} from './Colors';
+import {TextArea} from './TextInput';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'TextArea',
+  component: TextArea,
+} as Meta;
+
+export const Default = () => {
+  const [value, setValue] = React.useState('');
+  return (
+    <TextArea
+      placeholder="Type anything…"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      $resize="none"
+    />
+  );
+};
+
+export const Resize = () => {
+  const [value, setValue] = React.useState('');
+  return (
+    <TextArea
+      placeholder="Type anything…"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      $resize="vertical"
+    />
+  );
+};
+
+export const StrokeColor = () => {
+  const [value, setValue] = React.useState('');
+  return (
+    <TextArea
+      placeholder="Type anything…"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      $resize="none"
+      $strokeColor={Colors.Red500}
+    />
+  );
+};

--- a/js_modules/dagit/packages/ui/src/components/TextInput.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TextInput.tsx
@@ -140,10 +140,19 @@ const StyledInput = styled.input<StyledInputProps>`
 
 interface TextAreaProps {
   $resize: React.CSSProperties['resize'];
+  $strokeColor?: string;
 }
 
 export const TextArea = styled.textarea<TextAreaProps>`
   ${TextInputStyles}
+
+  box-shadow: ${({$strokeColor}) => $strokeColor || Colors.Gray300} inset 0px 0px 0px 1px,
+    ${Colors.KeylineGray} inset 2px 2px 1.5px;
+
+  :focus {
+    box-shadow: ${({$strokeColor}) => $strokeColor || Colors.Gray300} inset 0px 0px 0px 1px,
+      ${Colors.KeylineGray} inset 2px 2px 1.5px, rgba(58, 151, 212, 0.6) 0 0 0 3px;
+  }
 
   ${({$resize}) => ($resize ? `resize: ${$resize};` : null)}
 `;


### PR DESCRIPTION
### Summary & Motivation

It will be useful to have the ability to set a stroke color on `TextArea`, specifically for showing an error state.

<img width="214" alt="Screenshot 2022-11-07 at 2 35 23 PM" src="https://user-images.githubusercontent.com/2823852/200410096-30da75c6-1a58-4b87-8371-5edb7e0a4176.png">

### How I Tested These Changes

Storybook examples
