### PR TITLE
Revert "Unpin grpc (#10386)"

### DIFF
--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/pins.txt
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/pins.txt
@@ -9,5 +9,5 @@ nbformat<=5.1.3
 # protobuf 4 retroactively breaks old versions of dagster
 protobuf>=3.13.0,<4
 
-# Deadlock / hang issue in some versions of grpc
-grpcio!=1.48.*,!=1.49.*
+# Deadlock / hang issue in new version of grpc
+grpcio<1.48.1

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -65,9 +65,9 @@ setup(
         # pin around issues in specific versions of alembic that broke our migrations
         "alembic>=1.2.1,!=1.6.3,!=1.7.0",
         "croniter>=0.3.34",
-        # grpcio 1.48 and 1.49 have hanging/crashing issues: https://github.com/grpc/grpc/issues/30843
+        # grpcio 1.48.1 has hanging/crashing issues: https://github.com/grpc/grpc/issues/30843
         # ensure version we require is >= that with which we generated the grpc code (set in dev-requirements)
-        "grpcio>=1.32.0,!=1.48.*,!=1.49.*",
+        "grpcio>=1.32.0,<1.48.1",
         "grpcio-health-checking>=1.32.0,<1.44.0",
         "packaging>=20.9",
         "pendulum",


### PR DESCRIPTION
This reverts commit b4ccac32a0832a2f7698c8c96b7248580e5c0375. Sadly timeouts and hangs persist even after 1.50.0, for example: https://buildkite.com/dagster/internal/builds/31850#01844519-2440-4480-8d5e-365f798c6b58

### Summary & Motivation

### How I Tested These Changes
