### PR TITLE
Fix execute_in_process io manager behavior for graphs and aliased graphs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -656,7 +656,6 @@ class PendingNodeInvocation:
             )
 
         from dagster._core.execution.build_resources import wrap_resources_for_execution
-        from dagster._core.execution.execute_in_process import core_execute_in_process
 
         from .executor_definition import execute_in_process_executor
         from .job_definition import JobDefinition
@@ -674,11 +673,9 @@ class PendingNodeInvocation:
             input_values=input_values,
         )
 
-        return core_execute_in_process(
-            ephemeral_pipeline=ephemeral_job,
-            run_config=run_config if run_config is not None else {},
+        return ephemeral_job.execute_in_process(
+            run_config=run_config,
             instance=instance,
-            output_capturing_enabled=True,
             raise_on_error=raise_on_error,
             run_id=run_id,
         )

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -664,7 +664,6 @@ class GraphDefinition(NodeDefinition):
             :py:class:`~dagster.ExecuteInProcessResult`
         """
         from dagster._core.execution.build_resources import wrap_resources_for_execution
-        from dagster._core.execution.execute_in_process import core_execute_in_process
         from dagster._core.instance import DagsterInstance
 
         from .executor_definition import execute_in_process_executor
@@ -687,11 +686,9 @@ class GraphDefinition(NodeDefinition):
         run_config = run_config if run_config is not None else {}
         op_selection = check.opt_sequence_param(op_selection, "op_selection", str)
 
-        return core_execute_in_process(
-            ephemeral_pipeline=ephemeral_job,
+        return ephemeral_job.execute_in_process(
             run_config=run_config,
             instance=instance,
-            output_capturing_enabled=True,
             raise_on_error=raise_on_error,
             run_id=run_id,
         )

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -21,6 +21,7 @@ from dagster import (
     Out,
     Output,
     build_op_context,
+    fs_io_manager,
     graph,
     job,
     mem_io_manager,
@@ -38,12 +39,12 @@ def some_fn(a):
 the_lambda = lambda a: a
 
 
-def execute_op_in_graph(an_op, instance=None):
+def execute_op_in_graph(an_op, instance=None, resources=None):
     @graph
     def my_graph():
         an_op()
 
-    result = my_graph.execute_in_process(instance=instance)
+    result = my_graph.execute_in_process(instance=instance, resources=resources)
     return result
 
 
@@ -672,7 +673,7 @@ def test_log_metadata_asset_materialization():
         context.add_output_metadata({"bar": "baz"})
         return 5
 
-    result = execute_op_in_graph(the_op)
+    result = execute_op_in_graph(the_op, resources={"io_manager": fs_io_manager})
     materialization = result.asset_materializations_for_node("the_op")[0]
     assert len(materialization.metadata_entries) == 2
     assert materialization.metadata_entries[0].label == "bar"


### PR DESCRIPTION
### Summary & Motivation
https://github.com/dagster-io/dagster/issues/10412 - behavioral regression for graphs executed using execute_in_process. Haven't found the exact code change that is the culprit, but it's only a regression for graphs and aliased graphs. This PR fixes by having all flow through the job execute_in_process codepath, which explicitly swaps the default io manager. 
### How I Tested These Changes
Added a test that ensures same default io manager behavior for all 3 cases (job, graph, and aliased graph)
