### PR TITLE
Run builds on changes to .txt files

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -280,10 +280,8 @@ class PackageSpec:
                 # Our change is in this package's directory
                 (Path(self.directory) in change.parents)
                 # The file can alter behavior - exclude things like README changes
-                and (
-                    change.suffix in [".py", ".cfg", ".toml", ".ini"]
-                    or change.name == "requirements.txt"
-                )
+                # which we tend to include in .md files
+                and change.suffix in [".py", ".cfg", ".toml", ".ini", ".txt"]
             ):
                 logging.info(f"Building {self.name} because it has changed")
                 self._should_skip = False


### PR DESCRIPTION
Originally I ignored these because I figured they were mostly docs changes. But .txt files are also commonly used for passing in requirements to pip - and we don't always follow the requirements.txt convention.

This loosens the logic so changes to .txt files also trigger builds.
