### PR TITLE
Implement abstract methods

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
@@ -1,7 +1,7 @@
 import hashlib
 import inspect
 import json
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import AbstractSet, Any, Mapping, NamedTuple, Optional, Sequence
 
 import dagster._check as check
@@ -92,7 +92,7 @@ class AssetsDefinitionCacheableData(
         )
 
 
-class CacheableAssetsDefinition(ResourceAddable):
+class CacheableAssetsDefinition(ResourceAddable, ABC):
     def __init__(self, unique_id: str):
         self._unique_id = unique_id
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/single_pending_repository.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/single_pending_repository.py
@@ -2,6 +2,14 @@ from dagster import repository
 from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 
 
+class FooCacheableAssetsDefinition(CacheableAssetsDefinition):
+    def compute_cacheable_data(self):
+        return []
+
+    def build_definitions(self, *_args, **_kwargs):
+        return []
+
+
 @repository
 def single_pending_repository():
-    return [CacheableAssetsDefinition("abc")]
+    return [FooCacheableAssetsDefinition("abc")]


### PR DESCRIPTION
Alternatively, we could revert:

https://github.com/dagster-io/dagster/pull/10424

I don't know enough about the API here - should this entire class be marked abstract (like I did here) or should we instead provide default implementations so we can initialize it directly?
