### PR TITLE
feat(dbt-cloud): generate asset dependencies from a cloud job

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -2,7 +2,13 @@ from dagster._core.utils import check_dagster_package_version
 
 from .asset_defs import load_assets_from_dbt_manifest, load_assets_from_dbt_project
 from .cli import DbtCliOutput, DbtCliResource, dbt_cli_resource
-from .cloud import DbtCloudOutput, DbtCloudResourceV2, dbt_cloud_resource, dbt_cloud_run_op
+from .cloud import (
+    DbtCloudOutput,
+    DbtCloudResourceV2,
+    dbt_cloud_resource,
+    dbt_cloud_run_op,
+    load_assets_from_dbt_cloud_job,
+)
 from .dbt_resource import DbtResource
 from .errors import (
     DagsterDbtCliFatalRuntimeError,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/__init__.py
@@ -1,3 +1,4 @@
+from .asset_defs import load_assets_from_dbt_cloud_job
 from .ops import dbt_cloud_run_op
 from .resources import DbtCloudResourceV2, dbt_cloud_resource
 from .types import DbtCloudOutput

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -1,0 +1,207 @@
+from typing import Any, Callable, Dict, FrozenSet, Mapping, Optional, Sequence, Set, Tuple, cast
+
+from dagster import AssetKey, AssetOut, AssetsDefinition, ResourceDefinition
+from dagster import _check as check
+from dagster import multi_asset, with_resources
+from dagster._annotations import experimental
+from dagster._core.definitions.cacheable_assets import (
+    AssetsDefinitionCacheableData,
+    CacheableAssetsDefinition,
+)
+from dagster._core.execution.context.init import build_init_resource_context
+
+from ..asset_defs import _get_asset_deps, _get_deps, _get_node_asset_key, _get_node_group_name
+from ..utils import ASSET_RESOURCE_TYPES
+from .resources import DbtCloudResourceV2
+
+
+class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
+    def __init__(
+        self,
+        dbt_cloud_resource_def: ResourceDefinition,
+        job_id: int,
+        node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey],
+        node_info_to_group_fn: Callable[[Dict[str, Any]], Optional[str]],
+    ):
+        self._dbt_cloud_resource_def = dbt_cloud_resource_def
+        self._dbt_cloud: DbtCloudResourceV2 = dbt_cloud_resource_def(build_init_resource_context())
+        self._job_id = job_id
+        self._node_info_to_asset_key = node_info_to_asset_key
+        self._node_info_to_group_fn = node_info_to_group_fn
+
+        super().__init__(unique_id=f"dbt-cloud-{job_id}")
+
+    def compute_cacheable_data(self) -> Sequence[AssetsDefinitionCacheableData]:
+        dbt_nodes, dbt_dependencies = self._get_dbt_nodes_and_dependencies()
+        return [self._build_dbt_cloud_assets_metadata(dbt_nodes, dbt_dependencies)]
+
+    def build_definitions(
+        self, data: Sequence[AssetsDefinitionCacheableData]
+    ) -> Sequence[AssetsDefinition]:
+        return with_resources(
+            [
+                self._build_dbt_cloud_assets_from_metadata(assets_definition_metadata)
+                for assets_definition_metadata in data
+            ],
+            {"dbt_cloud": self._dbt_cloud_resource_def},
+        )
+
+    def _get_dbt_nodes_and_dependencies(
+        self,
+    ) -> Tuple[Mapping[str, Any], Mapping[str, FrozenSet[str]]]:
+        """
+        For a given dbt Cloud job, fetch the latest run's dependency structure of executed nodes.
+        """
+
+        # Fetch the latest run for the job.
+        runs = self._dbt_cloud.get_runs(job_id=self._job_id, order_by="-id", limit=1)
+
+        # Assume that a run already exists for the job.
+        #
+        # In the future, we should be able to create a run for the job if one does not exist.
+        # This can be done by triggering the job to run and then specifying a step override to
+        # compile the dbt project.
+        check.invariant(
+            len(runs) == 1,
+            (
+                f"No runs found for the dbt Cloud job ({self._job_id}). "
+                "The job must be run at least once in order to generate its assets. "
+                "Run the job manually in dbt Cloud and try again."
+            ),
+        )
+
+        # Fetch the latest run's manifest and run results.
+        #
+        # In the future, we should target the correct execution step, rather than assuming that
+        # the last step is the one that we want.
+        last_run_id = cast(int, runs[0]["id"])
+        step = None
+
+        manifest_json = self._dbt_cloud.get_manifest(run_id=last_run_id, step=step)
+        run_results_json = self._dbt_cloud.get_run_results(run_id=last_run_id, step=step)
+
+        # Filter the manifest to only include the nodes that were executed.
+        dbt_nodes: Dict[str, Any] = {
+            **manifest_json.get("nodes", {}),
+            **manifest_json.get("sources", {}),
+            **manifest_json.get("metrics", {}),
+        }
+        executed_node_ids: Set[str] = set(
+            result["unique_id"] for result in run_results_json["results"]
+        )
+
+        dbt_dependencies = _get_deps(
+            dbt_nodes=dbt_nodes,
+            selected_unique_ids=executed_node_ids,
+            asset_resource_types=ASSET_RESOURCE_TYPES,
+        )
+
+        return dbt_nodes, dbt_dependencies
+
+    def _build_dbt_cloud_assets_metadata(
+        self, dbt_nodes: Mapping[str, Any], dbt_dependencies: Mapping[str, FrozenSet[str]]
+    ) -> AssetsDefinitionCacheableData:
+        """
+        Given all of the nodes and dependencies for a dbt Cloud job, build the cacheable
+        representation that generate the asset defintion for the job.
+        """
+
+        (asset_deps, asset_ins, asset_outs, group_names_by_key, _) = _get_asset_deps(
+            dbt_nodes=dbt_nodes,
+            deps=dbt_dependencies,
+            node_info_to_asset_key=self._node_info_to_asset_key,
+            node_info_to_group_fn=self._node_info_to_group_fn,
+            # In the future, allow the IO manager to be specified.
+            io_manager_key=None,
+            # We shouldn't display the raw sql. Instead, inspect if dbt docs were generated,
+            # and attach metadata to link to the docs.
+            display_raw_sql=False,
+        )
+
+        return AssetsDefinitionCacheableData(
+            # In the future, we should allow additional upstream assets to be specified.
+            keys_by_input_name={
+                input_name: asset_key for asset_key, (input_name, _) in asset_ins.items()
+            },
+            keys_by_output_name={
+                output_name: asset_key for asset_key, (output_name, _) in asset_outs.items()
+            },
+            internal_asset_deps={
+                asset_outs[asset_key][0]: asset_deps for asset_key, asset_deps in asset_deps.items()
+            },
+            # We don't rely on a static group name. Instead, we map over the dbt metadata to
+            # determine the group name for each asset.
+            group_name=None,
+            metadata_by_output_name=None,
+            # In the future, we should allow the key prefix to be specified.
+            key_prefix=None,
+            # In the future, we should allow these assets to be subset, but this requires ad-hoc
+            # overrides to the job's run/build step to materialize only the subset.
+            can_subset=False,
+            extra_metadata={
+                "job_id": self._job_id,
+                "group_names_by_output_name": {
+                    asset_outs[asset_key][0]: group_name
+                    for asset_key, group_name in group_names_by_key.items()
+                },
+            },
+        )
+
+    def _build_dbt_cloud_assets_from_metadata(
+        self, assets_definition_metadata: AssetsDefinitionCacheableData
+    ) -> AssetsDefinition:
+        metadata = cast(Mapping[str, Any], assets_definition_metadata.extra_metadata)
+        job_id = cast(int, metadata["job_id"])
+        group_names_by_output_name = cast(Mapping[str, str], metadata["group_names_by_output_name"])
+
+        @multi_asset(
+            name=f"dbt_cloud_job_{job_id}",
+            non_argument_deps=set((assets_definition_metadata.keys_by_input_name or {}).values()),
+            outs={
+                output_name: AssetOut(
+                    key=asset_key, group_name=group_names_by_output_name.get(output_name)
+                )
+                for output_name, asset_key in (
+                    assets_definition_metadata.keys_by_output_name or {}
+                ).items()
+            },
+            internal_asset_deps={
+                output_name: set(asset_deps)
+                for output_name, asset_deps in (
+                    assets_definition_metadata.internal_asset_deps or {}
+                ).items()
+            },
+            required_resource_keys={"dbt_cloud"},
+            compute_kind="dbt",
+        )
+        def _assets(_context):
+            # Defer implementation of the asset for now. For simplicity, we just want the
+            # dependency structure of the dbt Cloud assets to be defined.
+            pass
+
+        return _assets
+
+
+@experimental
+def load_assets_from_dbt_cloud_job(
+    dbt_cloud: ResourceDefinition,
+    job_id: int,
+) -> CacheableAssetsDefinition:
+    """
+    Loads a set of assets from a dbt Cloud job.
+
+    Args:
+        dbt_cloud (ResourceDefinition): The dbt Cloud resource to use to connect to the dbt Cloud API.
+        job_id (int): The ID of the dbt Cloud job to load assets from.
+
+    Returns:
+        CacheableAssetsDefinition: A definition for the loaded assets.
+    """
+
+    return DbtCloudCacheableAssetsDefinition(
+        dbt_cloud_resource_def=dbt_cloud,
+        job_id=job_id,
+        # In the future, allow arbitrary mappings to asset keys and groups from the dbt metadata.
+        node_info_to_asset_key=_get_node_asset_key,
+        node_info_to_group_fn=_get_node_group_name,
+    )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
@@ -1,0 +1,64 @@
+import json
+
+import responses
+from dagster_dbt import dbt_cloud_resource, load_assets_from_dbt_cloud_job
+
+from dagster import build_init_resource_context, file_relative_path
+
+from ..utils import assert_assets_match_project
+
+
+@responses.activate
+def test_load_assets_from_dbt_cloud_job():
+    account_id = 123
+    run_id = 1234
+
+    manifest_path = file_relative_path(__file__, "../sample_manifest.json")
+    with open(manifest_path, "r", encoding="utf8") as f:
+        manifest_json = json.load(f)
+
+    run_results_path = file_relative_path(__file__, "../sample_run_results.json")
+    with open(run_results_path, "r", encoding="utf8") as f:
+        run_results_json = json.load(f)
+
+    api_base_url = dbt_cloud_resource(
+        build_init_resource_context(
+            config={
+                "auth_token": "abc",
+                "account_id": account_id,
+            }
+        )
+    ).api_base_url
+
+    dbt_cloud = dbt_cloud_resource.configured(
+        {
+            "auth_token": "abc",
+            "account_id": account_id,
+        }
+    )
+
+    responses.add(
+        method=responses.GET,
+        url=f"{api_base_url}{account_id}/runs/",
+        json={"data": [{"id": run_id}]},
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url=f"{api_base_url}{account_id}/runs/{run_id}/artifacts/manifest.json",
+        json=manifest_json,
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url=f"{api_base_url}{account_id}/runs/{run_id}/artifacts/run_results.json",
+        json=run_results_json,
+        status=200,
+    )
+
+    dbt_cloud_cacheable_assets = load_assets_from_dbt_cloud_job(dbt_cloud=dbt_cloud, job_id=1)
+    dbt_cloud_assets = dbt_cloud_cacheable_assets.build_definitions(
+        dbt_cloud_cacheable_assets.compute_cacheable_data()
+    )
+
+    assert_assets_match_project(dbt_cloud_assets, has_non_argument_deps=True)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -23,6 +23,8 @@ from dagster._core.definitions import build_assets_job
 from dagster._legacy import AssetGroup
 from dagster._utils import file_relative_path
 
+from .utils import assert_assets_match_project
+
 
 @pytest.mark.parametrize(
     "prefix",
@@ -97,44 +99,6 @@ def test_runtime_metadata_fn():
         MetadataEntry("dbt_model", value=materializations[0].asset_key.path[-1]),
     ]:
         assert entry in materializations[0].metadata_entries
-
-
-def assert_assets_match_project(dbt_assets, prefix=None):
-    if prefix is None:
-        prefix = []
-    elif isinstance(prefix, str):
-        prefix = [prefix]
-
-    assert len(dbt_assets) == 1
-    assets_op = dbt_assets[0].op
-    assert assets_op.tags == {"kind": "dbt"}
-    assert len(assets_op.input_defs) == 0
-    assert set(assets_op.output_dict.keys()) == {
-        "sort_by_calories",
-        "least_caloric",
-        "sort_hot_cereals_by_calories",
-        "sort_cold_cereals_by_calories",
-    }
-    for asset_name in [
-        "subdir_schema/least_caloric",
-        "sort_hot_cereals_by_calories",
-        "cold_schema/sort_cold_cereals_by_calories",
-    ]:
-        asset_key = AssetKey(prefix + asset_name.split("/"))
-        output_name = asset_key.path[-1]
-        assert dbt_assets[0].keys_by_output_name[output_name] == asset_key
-        assert dbt_assets[0].asset_deps[asset_key] == {AssetKey(prefix + ["sort_by_calories"])}
-
-    for asset_key, group_name in dbt_assets[0].group_names_by_key.items():
-        if asset_key == AssetKey(prefix + ["subdir_schema", "least_caloric"]):
-            assert group_name == "subdir"
-        else:
-            assert group_name == "default"
-
-    assert dbt_assets[0].keys_by_output_name["sort_by_calories"] == AssetKey(
-        prefix + ["sort_by_calories"]
-    )
-    assert not dbt_assets[0].asset_deps[AssetKey(prefix + ["sort_by_calories"])]
 
 
 def test_fail_immediately(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/utils.py
@@ -1,0 +1,41 @@
+from dagster import AssetKey
+
+
+def assert_assets_match_project(dbt_assets, prefix=None, has_non_argument_deps=False):
+    if prefix is None:
+        prefix = []
+    elif isinstance(prefix, str):
+        prefix = [prefix]
+
+    assert len(dbt_assets) == 1
+    assets_op = dbt_assets[0].op
+    assert assets_op.tags == {"kind": "dbt"}
+    assert len(assets_op.input_defs) == int(has_non_argument_deps)
+    assert set(assets_op.output_dict.keys()) == {
+        "sort_by_calories",
+        "least_caloric",
+        "sort_hot_cereals_by_calories",
+        "sort_cold_cereals_by_calories",
+    }
+    for asset_name in [
+        "subdir_schema/least_caloric",
+        "sort_hot_cereals_by_calories",
+        "cold_schema/sort_cold_cereals_by_calories",
+    ]:
+        asset_key = AssetKey(prefix + asset_name.split("/"))
+        output_name = asset_key.path[-1]
+        assert dbt_assets[0].keys_by_output_name[output_name] == asset_key
+        assert dbt_assets[0].asset_deps[asset_key] == {AssetKey(prefix + ["sort_by_calories"])}
+
+    for asset_key, group_name in dbt_assets[0].group_names_by_key.items():
+        if asset_key == AssetKey(prefix + ["subdir_schema", "least_caloric"]):
+            assert group_name == "subdir"
+        else:
+            assert group_name == "default"
+
+    assert dbt_assets[0].keys_by_output_name["sort_by_calories"] == AssetKey(
+        prefix + ["sort_by_calories"]
+    )
+    assert len(dbt_assets[0].asset_deps[AssetKey(prefix + ["sort_by_calories"])]) == int(
+        has_non_argument_deps
+    )


### PR DESCRIPTION
### Summary & Motivation
Sets out an initial scaffold for supporting the automatic ingestion of software-defined assets from a dbt Cloud job. For ease of review, this initial implementation is bare-bones, and will only generate the asset dependency structure. In the following stack, we'll support more and more features to achieve some parity with the dbt cli integration experience. Some of these features include:

- arbitrary group names and asset keys generated from the dbt metadata 
- arbitrary prefixes for the generated assets
- links to the documentation generated from the dbt Cloud job
- re-execution of the dbt Cloud job
- relaxation of dbt Cloud job constraints (e.g. automatic compilation for non-executed jobs)
- etc 

### How I Tested These Changes
- pytest
- local
