### PR TITLE
feat(dbt-cloud): add URL links to dbt documentation

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -55,6 +55,18 @@ class DbtCloudResourceV2:
     def api_base_url(self) -> str:
         return urljoin(self._dbt_cloud_host, DBT_ACCOUNTS_PATH)
 
+    def build_url_for_job(self, project_id: int, job_id: int) -> str:
+        return urljoin(
+            self._dbt_cloud_host,
+            f"next/deploy/{self._account_id}/projects/{project_id}/jobs/{job_id}/",
+        )
+
+    def build_url_for_cloud_docs(self, job_id: int, resource_type: str, unique_id: str) -> str:
+        return urljoin(
+            self._dbt_cloud_host,
+            f"/accounts/{self._account_id}/jobs/{job_id}/docs/#!/{resource_type}/{unique_id}",
+        )
+
     def make_request(
         self,
         method: str,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
@@ -3,14 +3,16 @@ import json
 import responses
 from dagster_dbt import dbt_cloud_resource, load_assets_from_dbt_cloud_job
 
-from dagster import build_init_resource_context, file_relative_path
+from dagster import MetadataValue, build_init_resource_context, file_relative_path
 
 from ..utils import assert_assets_match_project
 
 
 @responses.activate
 def test_load_assets_from_dbt_cloud_job():
-    account_id = 123
+    account_id = 1
+    project_id = 12
+    job_id = 123
     run_id = 1234
 
     manifest_path = file_relative_path(__file__, "../sample_manifest.json")
@@ -21,14 +23,14 @@ def test_load_assets_from_dbt_cloud_job():
     with open(run_results_path, "r", encoding="utf8") as f:
         run_results_json = json.load(f)
 
-    api_base_url = dbt_cloud_resource(
+    dbt_cloud_service = dbt_cloud_resource(
         build_init_resource_context(
             config={
                 "auth_token": "abc",
                 "account_id": account_id,
             }
         )
-    ).api_base_url
+    )
 
     dbt_cloud = dbt_cloud_resource.configured(
         {
@@ -39,26 +41,40 @@ def test_load_assets_from_dbt_cloud_job():
 
     responses.add(
         method=responses.GET,
-        url=f"{api_base_url}{account_id}/runs/",
+        url=f"{dbt_cloud_service.api_base_url}{account_id}/jobs/{job_id}/",
+        json={"data": {"project_id": project_id, "generate_docs": True}},
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url=f"{dbt_cloud_service.api_base_url}{account_id}/runs/",
         json={"data": [{"id": run_id}]},
         status=200,
     )
     responses.add(
         method=responses.GET,
-        url=f"{api_base_url}{account_id}/runs/{run_id}/artifacts/manifest.json",
+        url=f"{dbt_cloud_service.api_base_url}{account_id}/runs/{run_id}/artifacts/manifest.json",
         json=manifest_json,
         status=200,
     )
     responses.add(
         method=responses.GET,
-        url=f"{api_base_url}{account_id}/runs/{run_id}/artifacts/run_results.json",
+        url=f"{dbt_cloud_service.api_base_url}{account_id}/runs/{run_id}/artifacts/run_results.json",
         json=run_results_json,
         status=200,
     )
 
-    dbt_cloud_cacheable_assets = load_assets_from_dbt_cloud_job(dbt_cloud=dbt_cloud, job_id=1)
+    dbt_cloud_cacheable_assets = load_assets_from_dbt_cloud_job(dbt_cloud=dbt_cloud, job_id=job_id)
+    dbt_assets_definition_cacheable_data = dbt_cloud_cacheable_assets.compute_cacheable_data()
     dbt_cloud_assets = dbt_cloud_cacheable_assets.build_definitions(
-        dbt_cloud_cacheable_assets.compute_cacheable_data()
+        dbt_assets_definition_cacheable_data
     )
 
     assert_assets_match_project(dbt_cloud_assets, has_non_argument_deps=True)
+
+    # Assert that the outputs have the correct metadata
+    for output in dbt_cloud_assets[0].op.output_dict.values():
+        assert output.metadata.keys() == {"dbt Cloud Job", "dbt Cloud Documentation"}
+        assert output.metadata["dbt Cloud Job"] == MetadataValue.url(
+            dbt_cloud_service.build_url_for_job(project_id=project_id, job_id=job_id)
+        )


### PR DESCRIPTION
### Summary & Motivation
From each dbt Cloud asset, link back to:
- the dbt Cloud job managing the asset
- the dbt Cloud documentation for the asset

### How I Tested These Changes
- local
- pytest
