### PR TITLE
enable launching a run that targets a range of asset partitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -612,11 +612,22 @@ class AssetLayer:
                 node_output_handle = NodeOutputHandle(
                     check.not_none(inner_node_handle), inner_output_def.name
                 )
-                partition_fn = lambda context: {context.partition_key}
+
+                def partitions_fn(context: "OutputContext") -> AbstractSet[str]:
+                    from dagster._core.definitions.partition import PartitionsDefinition
+
+                    if context.has_partition_key:
+                        return {context.partition_key}
+
+                    return set(
+                        cast(
+                            PartitionsDefinition, context.asset_partitions_def
+                        ).get_partition_keys_in_range(context.asset_partition_key_range)
+                    )
 
                 asset_info_by_output[node_output_handle] = AssetOutputInfo(
                     asset_key,
-                    partitions_fn=partition_fn if assets_def.partitions_def else None,
+                    partitions_fn=partitions_fn if assets_def.partitions_def else None,
                     partitions_def=assets_def.partitions_def,
                     is_required=asset_key in assets_def.keys,
                 )

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -287,6 +287,7 @@ class JobDefinition(PipelineDefinition):
         asset_selection: Optional[Sequence[AssetKey]] = None,
         run_id: Optional[str] = None,
         input_values: Optional[Mapping[str, object]] = None,
+        tags: Optional[Mapping[str, str]] = None,
     ) -> "ExecuteInProcessResult":
         """
         Execute the Job in-process, gathering results in-memory.
@@ -363,7 +364,7 @@ class JobDefinition(PipelineDefinition):
             op_selection, frozenset(asset_selection) if asset_selection else None
         )
 
-        tags = None
+        merged_tags = merge_dicts(self.tags, tags or {})
         if partition_key:
             if not self.partitioned_config:
                 check.failed(
@@ -379,7 +380,7 @@ class JobDefinition(PipelineDefinition):
             run_config = (
                 run_config if run_config else partition_set.run_config_for_partition(partition)
             )
-            tags = partition_set.tags_for_partition(partition)
+            merged_tags.update(partition_set.tags_for_partition(partition))
 
         return core_execute_in_process(
             ephemeral_pipeline=ephemeral_job,
@@ -387,7 +388,7 @@ class JobDefinition(PipelineDefinition):
             instance=instance,
             output_capturing_enabled=True,
             raise_on_error=raise_on_error,
-            run_tags=tags,
+            run_tags=merged_tags,
             run_id=run_id,
             asset_selection=frozenset(asset_selection),
         )

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -18,6 +18,7 @@ from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.mode import ModeDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import PartitionsDefinition
+from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.pipeline_definition import PipelineDefinition
 from dagster._core.definitions.solid_definition import SolidDefinition
 from dagster._core.definitions.step_launcher import StepLauncher
@@ -296,6 +297,15 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
 
     @public  # type: ignore
     @property
+    def asset_partition_key_range(self) -> PartitionKeyRange:
+        """The asset partition key for the current run.
+
+        Raises an error if the current run is not a partitioned run.
+        """
+        return self._step_execution_context.asset_partition_key_range
+
+    @public  # type: ignore
+    @property
     def partition_time_window(self) -> str:
         """The partition time window for the current run.
 
@@ -389,6 +399,16 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
         - The output asset is not partitioned with a TimeWindowPartitionsDefinition.
         """
         return self._step_execution_context.asset_partitions_time_window_for_output(output_name)
+
+    @public
+    def asset_partition_key_range_for_output(
+        self, output_name: str = "result"
+    ) -> PartitionKeyRange:
+        return self._step_execution_context.asset_partition_key_range_for_output(output_name)
+
+    @public
+    def asset_partition_key_range_for_input(self, input_name: str) -> PartitionKeyRange:
+        return self._step_execution_context.asset_partition_key_range_for_input(input_name)
 
     @public
     def asset_partition_key_for_input(self, input_name: str) -> str:

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -49,7 +49,12 @@ from dagster._core.executor.base import Executor
 from dagster._core.log_manager import DagsterLogManager
 from dagster._core.storage.io_manager import IOManager
 from dagster._core.storage.pipeline_run import PipelineRun
-from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX, PARTITION_NAME_TAG
+from dagster._core.storage.tags import (
+    ASSET_PARTITION_RANGE_END_TAG,
+    ASSET_PARTITION_RANGE_START_TAG,
+    MULTIDIMENSIONAL_PARTITION_PREFIX,
+    PARTITION_NAME_TAG,
+)
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.types.dagster_type import DagsterType
 
@@ -352,6 +357,19 @@ class PlanExecutionContext(IPlanContext):
         return MultiPartitionKey(partitions_by_dimension)
 
     @property
+    def asset_partition_key_range(self) -> PartitionKeyRange:
+        tags = self._plan_data.pipeline_run.tags
+        partition_key = tags.get(PARTITION_NAME_TAG)
+        if partition_key is not None:
+            return PartitionKeyRange(partition_key, partition_key)
+
+        partition_key_range_start = tags.get(ASSET_PARTITION_RANGE_START_TAG)
+        if partition_key_range_start is not None:
+            return PartitionKeyRange(partition_key_range_start, tags[ASSET_PARTITION_RANGE_END_TAG])
+
+        check.failed("Tried to access partition_key_range for a non-partitioned run")
+
+    @property
     def partition_time_window(self) -> str:
         from dagster._core.definitions.job_definition import JobDefinition
 
@@ -379,6 +397,10 @@ class PlanExecutionContext(IPlanContext):
                 for tag in self._plan_data.pipeline_run.tags.keys()
             ]
         )
+
+    @property
+    def has_partition_key_range(self) -> bool:
+        return ASSET_PARTITION_RANGE_START_TAG in self._plan_data.pipeline_run.tags
 
     def for_type(self, dagster_type: DagsterType) -> "TypeCheckContext":
         return TypeCheckContext(
@@ -786,9 +808,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
             if assets_def is not None and upstream_asset_partitions_def is not None:
                 partition_key_range = (
-                    PartitionKeyRange(self.partition_key, self.partition_key)
-                    if assets_def.partitions_def
-                    else None
+                    self.asset_partition_key_range if assets_def.partitions_def else None
                 )
                 return get_upstream_partitions_for_partition_range(
                     assets_def,
@@ -816,14 +836,14 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         if asset_info:
             return asset_info.partitions_def
         else:
-            return asset_info
+            return None
 
     def has_asset_partitions_for_output(self, output_name: str) -> bool:
         return self._partitions_def_for_output(output_name) is not None
 
     def asset_partition_key_range_for_output(self, output_name: str) -> PartitionKeyRange:
         if self._partitions_def_for_output(output_name) is not None:
-            return PartitionKeyRange(self.partition_key, self.partition_key)
+            return self.asset_partition_key_range
 
         check.failed("The output has no asset partitions")
 

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -162,8 +162,6 @@ class PickledObjectFilesystemIOManager(MemoizableIOManager):
         """
         check.inst_param(context, "context", OutputContext)
 
-        filepath = self._get_path(context)
-
         if context.dagster_type.typing_type == type(None):
             check.invariant(
                 obj is None,
@@ -171,6 +169,8 @@ class PickledObjectFilesystemIOManager(MemoizableIOManager):
                 f"that was not None and was of type {type(obj)}.",
             )
             return None
+
+        filepath = self._get_path(context)
 
         # Ensure path exists
         mkdir_p(os.path.dirname(filepath))

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -19,6 +19,11 @@ MULTIDIMENSIONAL_PARTITION_PREFIX = f"{PARTITION_NAME_TAG}/"
 get_multidimensional_partition_tag = (
     lambda dimension_name: f"{MULTIDIMENSIONAL_PARTITION_PREFIX}{dimension_name}"
 )
+ASSET_PARTITION_RANGE_START_TAG = "{prefix}asset_partition_range_start".format(
+    prefix=SYSTEM_TAG_PREFIX
+)
+
+ASSET_PARTITION_RANGE_END_TAG = "{prefix}asset_partition_range_end".format(prefix=SYSTEM_TAG_PREFIX)
 
 PARTITION_SET_TAG = "{prefix}partition_set".format(prefix=SYSTEM_TAG_PREFIX)
 


### PR DESCRIPTION
### Summary & Motivation

With this change, you can set these two tags on a run instead of setting an individual partition tag:
- dagster/asset_partition_range_start
- dagster/asset_partition_range_end

The run will then expose that range within ops and I/O managers and generate asset materializations for all the partitions in the range.

Motivated by this request: https://dagster.slack.com/archives/C01U954MEER/p1667922601771249.

### Future work

This gets us part of the way to closing https://github.com/dagster-io/dagster/issues/8706. There are some gaps:
- This experience isn't yet integrated with the backfill dialog. You need to use the launchpad (shift+click "Materialize") and supply the tags using the "Edit tags" button.
- The partitions bar on the relevant asset details pages will be updated, but the Partitions tab on a job page won't reflect partitions that are backfilled this way. Relevant discussion here about making the Partitions tab on job pages more asset-oriented, which should address this: https://github.com/dagster-io/dagster/issues/10159.
- The built-in I/O managers don't yet support output partition key ranges.

### How I Tested These Changes

- Added test
- Tried it out in Dagit and made sure that that the partitions show up correctly on the asset details page