### PR TITLE
feat: bind command-K to search

### DIFF
--- a/js_modules/dagit/packages/core/src/search/SearchDialog.tsx
+++ b/js_modules/dagit/packages/core/src/search/SearchDialog.tsx
@@ -141,7 +141,11 @@ export const SearchDialog: React.FC<{searchPlaceholder: string}> = ({searchPlace
         onShortcut={openSearch}
         shortcutLabel="/"
         shortcutFilter={(e) =>
-          e.key === '/' && !e.altKey && !e.metaKey && !e.shiftKey && !e.ctrlKey
+          (e.key === '/' || (e.code === 'KeyK' && e.metaKey)) &&
+          !(e.key === '/' && e.metaKey) &&
+          !e.altKey &&
+          !e.shiftKey &&
+          !e.ctrlKey
         }
       >
         <SearchTrigger onClick={openSearch}>


### PR DESCRIPTION
### Summary & Motivation
I think this is a common hotkey for this sort of utility. I find myself reaching for Command-K over / anyways.

Bind to both. 

Guard against the use case where a user is commenting code in a config editor.

### How I Tested These Changes
local
