### PR TITLE
Revert "specify schema in pandas to_sql"

### DIFF
--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -84,9 +84,8 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
                 _convert_timestamp_to_string, axis="index"
             )
             with_uppercase_cols.to_sql(
-                name=table_slice.table,
+                table_slice.table,
                 con=con.engine,
-                schema=table_slice.schema,
                 if_exists="append",
                 index=False,
                 method=pd_writer,


### PR DESCRIPTION
Reverts dagster-io/dagster#10289

adding the schema to the pandas to_sql caused  problems with case matching in snowflake (ie the schema had to match case with the snowflake schema, when previously it didn't). reverting the PR for now until we find a solution