### PR TITLE
[dagit] Clarify notebook buttons

### DIFF
--- a/js_modules/dagit/packages/core/src/plugins/ipynb.tsx
+++ b/js_modules/dagit/packages/core/src/plugins/ipynb.tsx
@@ -10,7 +10,7 @@ export const SidebarComponent: React.FC<IPluginSidebarProps> = (props) => {
   const repoLocName = props.repoAddress?.location;
 
   return (
-    <Box padding={{horizontal: 16}}>
+    <Box padding={16}>
       <NotebookButton
         path={notebookPath?.value}
         repoLocation={repoLocName || ''}

--- a/js_modules/dagit/packages/core/src/plugins/ipynb.tsx
+++ b/js_modules/dagit/packages/core/src/plugins/ipynb.tsx
@@ -10,8 +10,12 @@ export const SidebarComponent: React.FC<IPluginSidebarProps> = (props) => {
   const repoLocName = props.repoAddress?.location;
 
   return (
-    <Box>
-      <NotebookButton path={notebookPath?.value} repoLocation={repoLocName || ''} />
+    <Box padding={{horizontal: 16}}>
+      <NotebookButton
+        path={notebookPath?.value}
+        repoLocation={repoLocName || ''}
+        label="View Source Notebook"
+      />
     </Box>
   );
 };

--- a/js_modules/dagit/packages/core/src/plugins/ipynb.tsx
+++ b/js_modules/dagit/packages/core/src/plugins/ipynb.tsx
@@ -8,5 +8,10 @@ export const SidebarComponent: React.FC<IPluginSidebarProps> = (props) => {
   const notebookPath = metadata.find((m) => m.key === 'notebook_path');
   const repoLocName = props.repoAddress?.location;
 
-  return <NotebookButton path={notebookPath?.value} repoLocation={repoLocName || ''} />;
+  return (
+    <div>
+      Source Notebook:
+      <NotebookButton path={notebookPath?.value} repoLocation={repoLocName || ''} />
+    </div>
+  );
 };

--- a/js_modules/dagit/packages/core/src/plugins/ipynb.tsx
+++ b/js_modules/dagit/packages/core/src/plugins/ipynb.tsx
@@ -1,3 +1,4 @@
+import {Box} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {IPluginSidebarProps} from '../plugins';
@@ -9,9 +10,8 @@ export const SidebarComponent: React.FC<IPluginSidebarProps> = (props) => {
   const repoLocName = props.repoAddress?.location;
 
   return (
-    <div>
-      Source Notebook:
+    <Box>
       <NotebookButton path={notebookPath?.value} repoLocation={repoLocName || ''} />
-    </div>
+    </Box>
   );
 };

--- a/js_modules/dagit/packages/core/src/ui/NotebookButton.tsx
+++ b/js_modules/dagit/packages/core/src/ui/NotebookButton.tsx
@@ -6,7 +6,8 @@ import {AppContext} from '../app/AppContext';
 export const NotebookButton: React.FC<{
   path?: string;
   repoLocation: string;
-}> = ({path, repoLocation}) => {
+  label?: string;
+}> = ({path, repoLocation, label}) => {
   const {rootServerURI} = React.useContext(AppContext);
   const [open, setOpen] = React.useState(false);
 
@@ -31,17 +32,19 @@ export const NotebookButton: React.FC<{
     return <span />;
   }
 
+  const buttonLabel = label || 'View Notebook';
+
   if (url) {
     return (
       <ExternalAnchorButton href={url} icon={<Icon name="open_in_new" />}>
-        View Notebook
+        {buttonLabel}
       </ExternalAnchorButton>
     );
   }
   return (
     <div>
       <Button icon={<Icon name="content_copy" />} onClick={() => setOpen(true)}>
-        View Notebook
+        {buttonLabel}
       </Button>
       <Dialog
         icon="info"

--- a/python_modules/libraries/dagstermill/dagstermill/examples/workspace.yaml
+++ b/python_modules/libraries/dagstermill/dagstermill/examples/workspace.yaml
@@ -3,6 +3,3 @@ load_from:
       module_name: dagstermill.examples.repository
       attribute: notebook_repo
 
-  - python_module:
-      module_name: dagstermill.examples.repository
-      attribute: notebook_assets_repo

--- a/python_modules/libraries/dagstermill/dagstermill/io_managers.py
+++ b/python_modules/libraries/dagstermill/dagstermill/io_managers.py
@@ -54,7 +54,7 @@ class LocalOutputNotebookIOManager(OutputNotebookIOManager):
         mkdir_p(os.path.dirname(output_notebook_path))
         with open(output_notebook_path, self.write_mode) as dest_file_obj:
             dest_file_obj.write(obj)
-        yield MetadataEntry("notebook", value=MetadataValue.notebook(output_notebook_path))
+        yield MetadataEntry("Executed notebook", value=MetadataValue.notebook(output_notebook_path))
 
     def load_input(self, context) -> bytes:
         check.inst_param(context, "context", InputContext)


### PR DESCRIPTION
### Summary & Motivation
Changes some text to clarify the two View Notebook buttons for notebook assets

Now we can specify that one button opens the Source notebook and one opens the executed notebook



<img width="356" alt="Screen Shot 2022-11-10 at 9 52 24 AM" src="https://user-images.githubusercontent.com/19783112/201123892-e4aaf6f5-57a3-464d-8c5e-dfb786e60b2f.png">


### How I Tested These Changes
