### PR TITLE
refactor resolve_to_config_type

### DIFF
--- a/python_modules/dagster/dagster/_config/config_schema.py
+++ b/python_modules/dagster/dagster/_config/config_schema.py
@@ -33,7 +33,7 @@ class ConfigSchema:
        * ``@op(config_schema=int)``
        * ``@op(config_schema=str)``
 
-    #. A built-in python collection (:py:class:`~python:list`, or :py:class:`~python:dict`).
+    #. A built-in python collection class (:py:class:`~python:list`, or :py:class:`~python:dict`).
        :py:class:`~python:list` is exactly equivalent to :py:class:`~dagster.Array` [
        :py:class:`~dagster.Any` ] and :py:class:`~python:dict` is equivalent to
        :py:class:`~dagster.Permissive`. For example:

--- a/python_modules/dagster/dagster/_config/config_type.py
+++ b/python_modules/dagster/dagster/_config/config_type.py
@@ -202,9 +202,9 @@ class Noneable(ConfigType):
     def __init__(self, inner_type: object):
         from .field import resolve_to_config_type
 
-        self.inner_type = cast(ConfigType, resolve_to_config_type(inner_type))
+        self.inner_type = resolve_to_config_type(inner_type)
         super(Noneable, self).__init__(
-            key="Noneable.{inner_type}".format(inner_type=self.inner_type.key),
+            key=f"Noneable.{self.inner_type.key}",
             kind=ConfigTypeKind.NONEABLE,
             type_params=[self.inner_type],
         )
@@ -225,7 +225,7 @@ class Array(ConfigType):
     def __init__(self, inner_type: object):
         from .field import resolve_to_config_type
 
-        self.inner_type = cast(ConfigType, resolve_to_config_type(inner_type))
+        self.inner_type = resolve_to_config_type(inner_type)
         super(Array, self).__init__(
             key="Array.{inner_type}".format(inner_type=self.inner_type.key),
             type_params=[self.inner_type],

--- a/python_modules/dagster/dagster/_config/field_utils.py
+++ b/python_modules/dagster/dagster/_config/field_utils.py
@@ -426,11 +426,11 @@ def convert_potential_field(potential_field: object) -> "Field":
     return _convert_potential_field(potential_field, potential_field, [])
 
 
-def _convert_potential_type(original_root: object, potential_type, stack: List[str]):
+def _convert_potential_type(original_root: object, potential_type, stack: List[str]) -> ConfigType:
     from .field import resolve_to_config_type
 
     if isinstance(potential_type, Mapping):
-        # A dictionary, containing a single key which is a type (int, str, etc) and not a string is interpreted as a Map
+        # A dictionary, containing a single key which is a type (int, str, etc) is interpreted as a Map
         if len(potential_type) == 1:
             key = list(potential_type.keys())[0]
             if not isinstance(key, str) and _convert_potential_type(original_root, key, stack):

--- a/python_modules/dagster/dagster/_config/validate.py
+++ b/python_modules/dagster/dagster/_config/validate.py
@@ -56,7 +56,6 @@ def is_config_scalar_valid(config_type_snap: ConfigTypeSnap, config_value: objec
 def validate_config(config_schema: object, config_value: T) -> EvaluateValueResult[T]:
 
     config_type = resolve_to_config_type(config_schema)
-    config_type = check.inst(cast(ConfigType, config_type), ConfigType)
 
     return validate_config_from_snap(
         config_schema_snapshot=config_type.get_schema_snapshot(),
@@ -422,7 +421,6 @@ def process_config(
     config_type: object, config_dict: Mapping[str, object]
 ) -> EvaluateValueResult[Mapping]:
     config_type = resolve_to_config_type(config_type)
-    config_type = check.inst(cast(ConfigType, config_type), ConfigType)
     validate_evr = validate_config(config_type, config_dict)
     if not validate_evr.success:
         return validate_evr


### PR DESCRIPTION
### Summary & Motivation

This refactors `resolve_to_config_type` so that it always returns a `ConfigType` instead of `Union[ConfigType, bool]`. This allowed removal of some casts and checks elsewhere. I was careful to adjust all callsites that needed it.

### How I Tested These Changes

Existing test suite
