### PR TITLE
[dagit] Link to Schedules Overview from ticks empty state

### DIFF
--- a/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
@@ -17,6 +17,7 @@ import {
   Table,
   Subheading,
   StyledReadOnlyCodeMirror,
+  ExternalAnchorButton,
 } from '@dagster-io/ui';
 import qs from 'qs';
 import * as React from 'react';
@@ -61,11 +62,14 @@ export const SchedulesNextTicks: React.FC<{
 }> = React.memo(({repos}) => {
   const nextTicks: ScheduleTick[] = [];
   let anyPipelines = false;
+  let anySchedules = false;
 
   const {options} = useRepositoryOptions();
 
   repos.forEach((repo) => {
     const {schedules} = repo;
+    anySchedules = anySchedules || schedules.length > 0;
+
     const repoAddress = {
       name: repo.name,
       location: repo.location.name,
@@ -105,7 +109,29 @@ export const SchedulesNextTicks: React.FC<{
         <NonIdealState
           icon="error"
           title="No scheduled ticks"
-          description="There are no running schedules. Start a schedule to see scheduled ticks."
+          description={
+            anySchedules ? (
+              <>
+                There are no running schedules.{' '}
+                <Link to="/overview/schedules">Start a schedule</Link> to see scheduled ticks.
+              </>
+            ) : (
+              <>
+                There are no schedules in this workspace. Create a running schedule to view its
+                scheduled ticks.
+              </>
+            )
+          }
+          action={
+            anySchedules ? null : (
+              <ExternalAnchorButton
+                icon={<Icon name="open_in_new" />}
+                href="https://docs.dagster.io/concepts/partitions-schedules-sensors/schedules"
+              >
+                View documentation
+              </ExternalAnchorButton>
+            )
+          }
         />
       </Box>
     );


### PR DESCRIPTION
### Summary & Motivation

Make it a little easier to get to your schedules from the empty state on "Scheduled" tab.

<img width="539" alt="Screenshot 2022-11-10 at 10 09 50 AM" src="https://user-images.githubusercontent.com/2823852/201147750-52010144-bc83-4ef8-8f5c-fa0610004ab7.png">

<img width="533" alt="Screenshot 2022-11-10 at 10 21 37 AM" src="https://user-images.githubusercontent.com/2823852/201150885-3ad2a36f-839b-412d-a5bc-c0ad841e4102.png">


### How I Tested These Changes

Load Dagit, view "Scheduled", verify link rendering and behavior.
