### PR TITLE
[job] drop default resolve config_mapping when op subsetting

### DIFF
--- a/python_modules/dagster/dagster_tests/execution_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_job.py
@@ -196,3 +196,35 @@ def test_job_input_values_out_of_process():
     with instance_for_test() as instance:
         result = execute_pipeline(reconstructable(pass_from_job), instance=instance)
         assert result.success
+
+
+def test_subset_job_with_config():
+    @op
+    def echo(x: int):
+        return x
+
+    @job
+    def no_config():
+        echo(echo.alias("emit")())
+
+    result = no_config.execute_in_process(run_config={"ops": {"emit": {"inputs": {"x": 1}}}})
+    assert result.success
+
+    subset_no_config = no_config.get_job_def_for_subset_selection(op_selection=["echo"])
+
+    result = subset_no_config.execute_in_process(run_config={"ops": {"echo": {"inputs": {"x": 1}}}})
+    assert result.success
+
+    @job(config={"ops": {"emit": {"inputs": {"x": 1}}}})
+    def with_config():
+        echo(echo.alias("emit")())
+
+    result = with_config.execute_in_process()
+    assert result.success
+
+    subset_with_config = with_config.get_job_def_for_subset_selection(op_selection=["echo"])
+
+    result = subset_with_config.execute_in_process(
+        run_config={"ops": {"echo": {"inputs": {"x": 1}}}}
+    )
+    assert result.success


### PR DESCRIPTION
### Summary & Motivation

When an explicit config dict is passed to a job, we create a preset to show the value in dagit and config_mapping that will resolve the values as defaults if nothing is passed in.

When op subelection occurs - we currently copy over the parent `config_mapping` directly, even though the schema has changed as a function of subsetting.

This change drops the default config mapping entirely when subsetting a job with explicit config. 


### How I Tested These Changes

added test that previously failed

did subsetting in dagit - verified preset driven experience still positive