### PR TITLE
fix backfill termination dialog

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
@@ -29,7 +29,7 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
         partition.runStatus && partition.runId && cancelableStatuses.has(partition.runStatus),
     );
     return (
-      unfinishedPartitions?.reduce(
+      unfinishedPartitions.reduce(
         (accum, partition) =>
           partition && partition.runId ? {...accum, [partition.runId]: true} : accum,
         {},

--- a/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
@@ -20,7 +20,22 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
     CANCEL_BACKFILL_MUTATION,
   );
   const [isSubmitting, setIsSubmitting] = React.useState(false);
-
+  const unfinishedMap = React.useMemo(() => {
+    if (!backfill) {
+      return {};
+    }
+    const unfinishedPartitions = backfill.partitionStatuses.results.filter(
+      (partition) =>
+        partition.runStatus && partition.runId && cancelableStatuses.has(partition.runStatus),
+    );
+    return (
+      unfinishedPartitions?.reduce(
+        (accum, partition) =>
+          partition && partition.runId ? {...accum, [partition.runId]: true} : accum,
+        {},
+      ) || {}
+    );
+  }, [backfill]);
   if (!backfill) {
     return null;
   }
@@ -33,17 +48,6 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
     setIsSubmitting(false);
     onClose();
   };
-
-  const unfinishedPartitions = backfill.partitionStatuses.results.filter(
-    (partition) =>
-      partition.runStatus && partition.runId && partition.runStatus in cancelableStatuses,
-  );
-  const unfinishedMap =
-    unfinishedPartitions?.reduce(
-      (accum, partition) =>
-        partition && partition.runId ? {...accum, [partition.runId]: true} : accum,
-      {},
-    ) || {};
 
   return (
     <>
@@ -75,7 +79,7 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
         isOpen={
           !!backfill &&
           (!numUnscheduled || backfill.status !== 'REQUESTED') &&
-          !!unfinishedPartitions.length
+          !!Object.keys(unfinishedMap).length
         }
         onClose={onClose}
         onComplete={onComplete}


### PR DESCRIPTION
### Summary & Motivation
Stems from filter condition, checking for presence in a set using `in` instead of `has`.

Fixes https://github.com/dagster-io/dagster/issues/10148

https://user-images.githubusercontent.com/1040172/201246731-6e6ebcaa-f0ac-4adb-a182-0e2e4a08e337.mov

### How I Tested These Changes
Created a backfill, canceled the backfill, terminated all the runs.