### PR TITLE
incorporate run step history into step matrix

### DIFF
--- a/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
@@ -16,7 +16,9 @@ const MIN_SPAN_WIDTH = 8;
 export enum PartitionState {
   MISSING = 'missing',
   SUCCESS = 'success',
+  SUCCESS_MISSING = 'success_missing', // states where the run succeeded in the past for a given step, but is missing for the last run
   FAILURE = 'failure',
+  FAILURE_MISSING = 'failure_missing', // states where the run failed in the past for a given step, but is missing for the last run
   QUEUED = 'queued',
   STARTED = 'started',
 }

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
@@ -22,6 +22,7 @@ import {buildLayout} from '../gantt/GanttChartLayout';
 import {useViewport} from '../gantt/useViewport';
 import {linkToRunEvent} from '../runs/RunUtils';
 import {RunFilterToken} from '../runs/RunsFilterInput';
+import {RunStatus} from '../types/globalTypes';
 import {MenuLink} from '../ui/MenuLink';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
@@ -45,7 +46,6 @@ import {
   PARTITION_MATRIX_SOLID_HANDLE_FRAGMENT,
   MatrixStep,
   PartitionRuns,
-  StatusSquareFinalColor,
   useMatrixData,
   MatrixData,
 } from './useMatrixData';
@@ -422,11 +422,12 @@ const PartitionSquare: React.FC<{
   if (!runsLoaded) {
     squareStatus = 'loading';
   } else if (step) {
-    squareStatus = (StatusSquareFinalColor[step.color] || step.color).toLowerCase();
+    squareStatus = step.color.toLowerCase();
   } else if (runs.length === 0) {
     squareStatus = 'empty';
   } else {
-    squareStatus = runs[runs.length - 1].status.toLowerCase();
+    const runStatus = runs[runs.length - 1].status;
+    squareStatus = runStatus === RunStatus.CANCELED ? 'failure' : runStatus.toLowerCase();
   }
 
   const content = (

--- a/js_modules/dagit/packages/core/src/partitions/RunMatrixUtils.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/RunMatrixUtils.tsx
@@ -6,7 +6,9 @@ export const BOX_SIZE = 32;
 
 export const STEP_STATUS_COLORS = {
   SUCCESS: Colors.Green500,
+  SUCCESS_SKIPPED: Colors.Green200,
   FAILURE: Colors.Red500,
+  FAILURE_SKIPPED: Colors.Red200,
   SKIPPED: Colors.Yellow500,
   IN_PROGRESS: '#eee',
 };
@@ -125,20 +127,12 @@ export const GridColumn = styled.div<{
     }
     &.success-skipped {
       &:before {
-        background: linear-gradient(
-          135deg,
-          ${STEP_STATUS_COLORS.SUCCESS} 49%,
-          ${STEP_STATUS_COLORS.SKIPPED} 51%
-        );
+        background: ${STEP_STATUS_COLORS.SUCCESS_SKIPPED};
       }
     }
     &.success-failure {
       &:before {
-        background: linear-gradient(
-          135deg,
-          ${STEP_STATUS_COLORS.SUCCESS} 49%,
-          ${STEP_STATUS_COLORS.FAILURE} 51%
-        );
+        background: ${STEP_STATUS_COLORS.FAILURE};
       }
     }
     &.failure {
@@ -148,29 +142,17 @@ export const GridColumn = styled.div<{
     }
     &.failure-success {
       &:before {
-        background: linear-gradient(
-          135deg,
-          ${STEP_STATUS_COLORS.FAILURE} 49%,
-          ${STEP_STATUS_COLORS.SUCCESS} 51%
-        );
+        background: ${STEP_STATUS_COLORS.SUCCESS};
       }
     }
     &.failure-skipped {
       &:before {
-        background: linear-gradient(
-          135deg,
-          ${STEP_STATUS_COLORS.FAILURE} 49%,
-          ${STEP_STATUS_COLORS.SKIPPED} 51%
-        );
+        background: ${STEP_STATUS_COLORS.FAILURE_SKIPPED};
       }
     }
     &.failure-blank {
       &:before {
-        background: linear-gradient(
-          135deg,
-          ${STEP_STATUS_COLORS.FAILURE} 49%,
-          rgba(150, 150, 150, 0.3) 51%
-        );
+        background: ${STEP_STATUS_COLORS.FAILURE_SKIPPED};
       }
     }
     &.skipped {
@@ -180,20 +162,12 @@ export const GridColumn = styled.div<{
     }
     &.skipped-success {
       &:before {
-        background: linear-gradient(
-          135deg,
-          ${STEP_STATUS_COLORS.SKIPPED} 49%,
-          ${STEP_STATUS_COLORS.SUCCESS} 51%
-        );
+        background: ${STEP_STATUS_COLORS.SUCCESS};
       }
     }
     &.skipped-failure {
       &:before {
-        background: linear-gradient(
-          135deg,
-          ${STEP_STATUS_COLORS.SKIPPED} 49%,
-          ${STEP_STATUS_COLORS.FAILURE} 51%
-        );
+        background: ${STEP_STATUS_COLORS.FAILURE};
       }
     }
   }

--- a/js_modules/dagit/packages/core/src/partitions/RunMatrixUtils.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/RunMatrixUtils.tsx
@@ -125,27 +125,17 @@ export const GridColumn = styled.div<{
         background: ${STEP_STATUS_COLORS.SUCCESS};
       }
     }
-    &.success-skipped {
-      &:before {
-        background: ${STEP_STATUS_COLORS.SUCCESS_SKIPPED};
-      }
-    }
-    &.success-failure {
-      &:before {
-        background: ${STEP_STATUS_COLORS.FAILURE};
-      }
-    }
     &.failure {
       &:before {
         background: ${STEP_STATUS_COLORS.FAILURE};
       }
     }
-    &.failure-success {
+    &.success-missing {
       &:before {
-        background: ${STEP_STATUS_COLORS.SUCCESS};
+        background: ${STEP_STATUS_COLORS.SUCCESS_SKIPPED};
       }
     }
-    &.failure-skipped {
+    &.failure-missing {
       &:before {
         background: ${STEP_STATUS_COLORS.FAILURE_SKIPPED};
       }
@@ -158,16 +148,6 @@ export const GridColumn = styled.div<{
     &.skipped {
       &:before {
         background: ${STEP_STATUS_COLORS.SKIPPED};
-      }
-    }
-    &.skipped-success {
-      &:before {
-        background: ${STEP_STATUS_COLORS.SUCCESS};
-      }
-    }
-    &.skipped-failure {
-      &:before {
-        background: ${STEP_STATUS_COLORS.FAILURE};
       }
     }
   }

--- a/js_modules/dagit/packages/core/src/partitions/useMatrixData.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/useMatrixData.tsx
@@ -13,26 +13,7 @@ import {StepEventStatus} from '../types/globalTypes';
 import {PartitionMatrixSolidHandleFragment} from './types/PartitionMatrixSolidHandleFragment';
 import {PartitionMatrixStepRunFragment} from './types/PartitionMatrixStepRunFragment';
 
-type StatusSquareColor =
-  | 'SUCCESS'
-  | 'FAILURE'
-  | 'SKIPPED'
-  | 'MISSING'
-  | 'FAILURE-SUCCESS'
-  | 'FAILURE-SKIPPED'
-  | 'SUCCESS-FAILURE'
-  | 'SUCCESS-SKIPPED'
-  | 'SKIPPED-SUCCESS'
-  | 'SKIPPED-FAILURE';
-
-export const StatusSquareFinalColor: {[key: string]: StatusSquareColor} = {
-  'FAILURE-SUCCESS': 'SUCCESS',
-  'SKIPPED-SUCCESS': 'SUCCESS',
-  'SUCCESS-FAILURE': 'FAILURE',
-  'SKIPPED-FAILURE': 'FAILURE',
-  'FAILURE-SKIPPED': 'SKIPPED',
-  'SUCCESS-SKIPPED': 'SKIPPED',
-};
+type StatusSquareColor = 'SUCCESS' | 'FAILURE' | 'MISSING' | 'FAILURE-MISSING' | 'SUCCESS-MISSING';
 
 export interface PartitionRuns {
   name: string;
@@ -134,7 +115,7 @@ function buildMatrixData(
 
       const color: StatusSquareColor =
         !lastRunStepStatus || MISSING_STEP_STATUSES.has(lastRunStepStatus)
-          ? (`${previousRunStatus}-SKIPPED` as StatusSquareColor)
+          ? (`${previousRunStatus}-MISSING` as StatusSquareColor)
           : (lastRunStepStatus as StatusSquareColor);
       return {
         name: node.name,


### PR DESCRIPTION
### Summary & Motivation
We were actually fetching enough information to show the past step status for partitions, but we weren't displaying them.

Previously, when these looked like boxes, we'd have a historical view where it'd be split according to a 45 degree angle.  This instead only shows past run statuses if the most recent step has a skipped/missing status, and it distinguishes them from the last run by choosing a paler shade of green/red.

<img width="1648" alt="Screen Shot 2022-11-10 at 9 57 47 PM" src="https://user-images.githubusercontent.com/1040172/201273583-e797abbf-602b-440c-a213-483c22787f1b.png">


### How I Tested These Changes
BK, rendered partition matrix