### PR TITLE
feat(dbt-cloud): run ad hoc compile step to generate the project dependencies

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -440,6 +440,7 @@ class DbtCloudResourceV2:
         job_id: int,
         poll_interval: float = DEFAULT_POLL_INTERVAL,
         poll_timeout: Optional[float] = None,
+        **kwargs,
     ) -> DbtCloudOutput:
         """
         Runs a dbt Cloud job and polls until it completes. Will raise a `dagster.Failure` exception
@@ -459,7 +460,7 @@ class DbtCloudResourceV2:
             :py:class:`~DbtCloudOutput`: Class containing details about the specific job run and the
                 parsed run results.
         """
-        run_details = self.run_job(job_id)
+        run_details = self.run_job(job_id, **kwargs)
         run_id = run_details["id"]
         href = run_details["href"]
         final_run_details = self.poll_run(


### PR DESCRIPTION
### Summary & Motivation
We currently generate the project structure using the last run of the dbt Cloud job. This has the following issues:

- If the last run is a failure, we cannot generate the project structure
- We could use the last successful run, but it could be out of date with the existing commands on the dbt Cloud job

In general, generating the project structure requires a run. Taking a look at all the dbt Cloud endpoints, a run id is required as a parameter to access information:

- GraphQL API (for querying metadata): https://metadata.cloud.getdbt.com/graphiql
- v2 API: https://docs.getdbt.com/dbt-cloud/api-v2#tag/Runs

I am thinking: we trigger an ad hoc run of `dbt compile` anytime we want to load the assets. This is possible using the current APIs right now - you can trigger jobs with a list of steps that you want it to execute, as an override.

I am assuming that dbt compile will save us here because:
- It will not actually run the models in your data warehouse - it will just generate the compiled SQL files from jinja.
- It generates a `manifest.json` and `run_results.json` that will supposedly have the information we need.

### How I Tested These Changes
- local
- pytest
