### PR TITLE
[freshness-policy] Fix bug with latestMaterializationMinutesLate

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -1305,6 +1305,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
 
     def test_freshness_info(self, graphql_context, snapshot):
         _create_run(graphql_context, "fresh_diamond_assets")
+        _create_run(graphql_context, "fresh_diamond_assets")
         result = execute_dagster_graphql(graphql_context, GET_FRESHNESS_INFO)
 
         assert result.data


### PR DESCRIPTION
### Summary & Motivation

Fix bug w/ how we were calculating latestMaterializationMinutesLate. To see how late you were when you emitted a given materialization, you need to see what the state of the asset was at the time of that materialization, which involves looking at the most recent materialization which happened before that. 

### How I Tested These Changes
