### PR TITLE
docs: add test to verify repository loads code definitions

### DIFF
--- a/docs/content/concepts/testing.mdx
+++ b/docs/content/concepts/testing.mdx
@@ -420,3 +420,20 @@ job_result = the_job.execute_in_process(
     input_values={"x": 6}
 )  # Overrides existing input value
 ```
+
+### Testing repositories can load all code definitions
+
+You can verify that your code definitions in a <PyObject object="repository" decorator /> are well formed before they are executed.
+
+```python file=/concepts/repositories_workspaces/unit_tests.py startafter=start_repository_loads_all_definitions endbefore=end_repository_loads_all_definitions
+from .hello_world_repository import hello_world_repository
+
+
+def test_repository_loads_all_definitions():
+    """
+    Asserts that the repository can load all definitions (jobs, assets, schedules, etc)
+    without errors.
+    """
+
+    hello_world_repository.load_all_definitions()
+```

--- a/examples/docs_snippets/docs_snippets/concepts/repositories_workspaces/unit_tests.py
+++ b/examples/docs_snippets/docs_snippets/concepts/repositories_workspaces/unit_tests.py
@@ -1,0 +1,14 @@
+# start_repository_loads_all_definitions
+from .hello_world_repository import hello_world_repository
+
+
+def test_repository_loads_all_definitions():
+    """
+    Asserts that the repository can load all definitions (jobs, assets, schedules, etc)
+    without errors.
+    """
+
+    hello_world_repository.load_all_definitions()
+
+
+# end_repository_loads_all_definitions


### PR DESCRIPTION
### Summary & Motivation
This is a common pattern to verify that user defined code definitions are well formed.

Let's put it in the documentation.

### How I Tested These Changes
vercel
