### PR TITLE
feat(dbt-cloud): constrain support to jobs that only execute `dbt run` or `dbt build`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -16,6 +16,7 @@ from .errors import (
     DagsterDbtCliOutputsNotFoundError,
     DagsterDbtCliRuntimeError,
     DagsterDbtCliUnexpectedOutputError,
+    DagsterDbtCloudJobInvariantViolationError,
     DagsterDbtError,
     DagsterDbtRpcUnexpectedPollOutputError,
 )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
@@ -2,7 +2,7 @@ import warnings
 from abc import ABC
 from typing import Any, Mapping, Optional, Sequence
 
-from dagster import Failure, MetadataValue
+from dagster import DagsterInvariantViolationError, Failure, MetadataValue
 from dagster import _check as check
 
 
@@ -91,3 +91,7 @@ class DagsterDbtCliOutputsNotFoundError(DagsterDbtError):
 
     def __init__(self, path: str):
         super().__init__("Expected to find file at path {}".format(path))
+
+
+class DagsterDbtCloudJobInvariantViolationError(DagsterDbtError, DagsterInvariantViolationError):
+    """Represents an error when a dbt Cloud job is not supported by the ``dagster-dbt`` library."""

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
@@ -1,7 +1,12 @@
 import json
 
+import pytest
 import responses
-from dagster_dbt import dbt_cloud_resource, load_assets_from_dbt_cloud_job
+from dagster_dbt import (
+    DagsterDbtCloudJobInvariantViolationError,
+    dbt_cloud_resource,
+    load_assets_from_dbt_cloud_job,
+)
 
 from dagster import (
     AssetSelection,
@@ -48,7 +53,13 @@ def test_load_assets_from_dbt_cloud_job():
     responses.add(
         method=responses.GET,
         url=f"{dbt_cloud_service.api_base_url}{account_id}/jobs/{job_id}/",
-        json={"data": {"project_id": project_id, "generate_docs": True}},
+        json={
+            "data": {
+                "project_id": project_id,
+                "generate_docs": True,
+                "execute_steps": ["dbt build"],
+            }
+        },
         status=200,
     )
     responses.add(
@@ -109,3 +120,78 @@ def test_load_assets_from_dbt_cloud_job():
     ).resolve(assets=dbt_cloud_assets, source_assets=[])
 
     assert materialize_cereal_assets.execute_in_process().success
+
+
+@responses.activate
+def test_invalid_dbt_cloud_job():
+    account_id = 1
+    project_id = 12
+    job_id = 123
+
+    dbt_cloud_service = dbt_cloud_resource(
+        build_init_resource_context(
+            config={
+                "auth_token": "abc",
+                "account_id": account_id,
+            }
+        )
+    )
+    dbt_cloud = dbt_cloud_resource.configured(
+        {
+            "auth_token": "abc",
+            "account_id": account_id,
+        }
+    )
+
+    dbt_cloud_cacheable_assets = load_assets_from_dbt_cloud_job(dbt_cloud=dbt_cloud, job_id=job_id)
+
+    responses.add(
+        method=responses.GET,
+        url=f"{dbt_cloud_service.api_base_url}{account_id}/jobs/{job_id}/",
+        json={
+            "data": {
+                "project_id": project_id,
+                "generate_docs": True,
+                "execute_steps": [],
+                "name": "A dbt Cloud job",
+                "id": "1",
+            }
+        },
+        status=200,
+    )
+    with pytest.raises(DagsterDbtCloudJobInvariantViolationError):
+        dbt_cloud_cacheable_assets.compute_cacheable_data()
+
+    responses.add(
+        method=responses.GET,
+        url=f"{dbt_cloud_service.api_base_url}{account_id}/jobs/{job_id}/",
+        json={
+            "data": {
+                "project_id": project_id,
+                "generate_docs": True,
+                "execute_steps": ["dbt deps"],
+                "name": "A dbt Cloud job",
+                "id": "1",
+            }
+        },
+        status=200,
+    )
+    with pytest.raises(DagsterDbtCloudJobInvariantViolationError):
+        dbt_cloud_cacheable_assets.compute_cacheable_data()
+
+    responses.add(
+        method=responses.GET,
+        url=f"{dbt_cloud_service.api_base_url}{account_id}/jobs/{job_id}/",
+        json={
+            "data": {
+                "project_id": project_id,
+                "generate_docs": True,
+                "execute_steps": ["dbt deps", "dbt build"],
+                "name": "A dbt Cloud job",
+                "id": "1",
+            }
+        },
+        status=200,
+    )
+    with pytest.raises(DagsterDbtCloudJobInvariantViolationError):
+        dbt_cloud_cacheable_assets.compute_cacheable_data()


### PR DESCRIPTION
### Summary & Motivation
Initially, we'll constraint the kinds of dbt Cloud jobs that we support running.
A simple constraint to is that we only support jobs that run a single command,
as defined in the dbt Cloud job's execution settings.

For the moment, we'll support either `dbt run` or `dbt build`. In the future, we can
adjust this to support multiple commands.

To note `dbt deps` is automatically run before the job's configured commands. And, if the settings are enabled, `dbt docs generate` and `dbt source freshness` can automatically run after the job's configured commands. These commands will be supported, and do not count towards the single command constraint.

### How I Tested These Changes
pytest, local
