### PR TITLE
[dagit] Asset catalog list UI for asset freshness

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
@@ -1,6 +1,6 @@
 import {pathVerticalDiagonal} from '@vx/shape';
 
-import {AssetComputeStatus} from '../types/globalTypes';
+import {AssetComputeStatus, RunStatus} from '../types/globalTypes';
 
 import {
   AssetGraphLiveQuery_assetsLatestInfo_latestRun,
@@ -8,6 +8,8 @@ import {
   AssetGraphLiveQuery,
   AssetGraphLiveQuery_assetsLatestInfo,
   AssetGraphLiveQuery_assetNodes,
+  AssetGraphLiveQuery_assetNodes_freshnessPolicy,
+  AssetGraphLiveQuery_assetNodes_freshnessInfo,
 } from './types/AssetGraphLiveQuery';
 import {
   AssetGraphQuery_assetNodes,
@@ -120,6 +122,9 @@ export interface LiveDataForNode {
   inProgressRunIds: string[]; // run in progress and step in progress
   runWhichFailedToMaterialize: AssetGraphLiveQuery_assetsLatestInfo_latestRun | null;
   lastMaterialization: AssetGraphLiveQuery_assetNodes_assetMaterializations | null;
+  lastMaterializationRunStatus: RunStatus | null; // only available if runWhichFailedToMaterialize is null
+  freshnessPolicy: AssetGraphLiveQuery_assetNodes_freshnessPolicy | null;
+  freshnessInfo: AssetGraphLiveQuery_assetNodes_freshnessInfo | null;
   computeStatus: AssetComputeStatus;
 }
 export interface LiveData {
@@ -166,7 +171,13 @@ export const buildLiveDataForNode = (
 
   return {
     lastMaterialization,
+    lastMaterializationRunStatus:
+      latestRunForAsset && lastMaterialization?.runId === latestRunForAsset?.id
+        ? latestRunForAsset.status
+        : null,
     stepKey: assetNode.opNames[0],
+    freshnessInfo: assetNode.freshnessInfo,
+    freshnessPolicy: assetNode.freshnessPolicy,
     inProgressRunIds: assetLatestInfo?.inProgressRunIds || [],
     unstartedRunIds: assetLatestInfo?.unstartedRunIds || [],
     computeStatus: assetLatestInfo?.computeStatus || AssetComputeStatus.NONE,

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphLiveQuery.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphLiveQuery.ts
@@ -25,6 +25,17 @@ export interface AssetGraphLiveQuery_assetNodes_assetMaterializations {
   runId: string;
 }
 
+export interface AssetGraphLiveQuery_assetNodes_freshnessPolicy {
+  __typename: "FreshnessPolicy";
+  maximumLagMinutes: number;
+  cronSchedule: string | null;
+}
+
+export interface AssetGraphLiveQuery_assetNodes_freshnessInfo {
+  __typename: "AssetFreshnessInfo";
+  currentMinutesLate: number | null;
+}
+
 export interface AssetGraphLiveQuery_assetNodes {
   __typename: "AssetNode";
   id: string;
@@ -32,6 +43,8 @@ export interface AssetGraphLiveQuery_assetNodes {
   repository: AssetGraphLiveQuery_assetNodes_repository;
   assetKey: AssetGraphLiveQuery_assetNodes_assetKey;
   assetMaterializations: AssetGraphLiveQuery_assetNodes_assetMaterializations[];
+  freshnessPolicy: AssetGraphLiveQuery_assetNodes_freshnessPolicy | null;
+  freshnessInfo: AssetGraphLiveQuery_assetNodes_freshnessInfo | null;
 }
 
 export interface AssetGraphLiveQuery_assetsLatestInfo_assetKey {

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetNodeLiveFragment.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetNodeLiveFragment.ts
@@ -23,6 +23,17 @@ export interface AssetNodeLiveFragment_assetMaterializations {
   runId: string;
 }
 
+export interface AssetNodeLiveFragment_freshnessPolicy {
+  __typename: "FreshnessPolicy";
+  maximumLagMinutes: number;
+  cronSchedule: string | null;
+}
+
+export interface AssetNodeLiveFragment_freshnessInfo {
+  __typename: "AssetFreshnessInfo";
+  currentMinutesLate: number | null;
+}
+
 export interface AssetNodeLiveFragment {
   __typename: "AssetNode";
   id: string;
@@ -30,4 +41,6 @@ export interface AssetNodeLiveFragment {
   repository: AssetNodeLiveFragment_repository;
   assetKey: AssetNodeLiveFragment_assetKey;
   assetMaterializations: AssetNodeLiveFragment_assetMaterializations[];
+  freshnessPolicy: AssetNodeLiveFragment_freshnessPolicy | null;
+  freshnessInfo: AssetNodeLiveFragment_freshnessInfo | null;
 }

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -1,15 +1,20 @@
 import {gql} from '@apollo/client';
-import {Box, Colors, Icon, Caption, Subheading, Mono, ConfigTypeSchema} from '@dagster-io/ui';
+import {Box, Colors, Icon, Caption, Subheading, Mono, ConfigTypeSchema, Body} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
-import {ASSET_NODE_FRAGMENT} from '../asset-graph/AssetNode';
+import {
+  ASSET_NODE_FRAGMENT,
+  CurrentMinutesLateTag,
+  freshnessPolicyDescription,
+} from '../asset-graph/AssetNode';
 import {
   displayNameForAssetKey,
   isSourceAsset,
   LiveData,
   isHiddenAssetGroupJob,
   __ASSET_JOB_PREFIX,
+  toGraphId,
 } from '../asset-graph/Utils';
 import {AssetGraphQuery_assetNodes} from '../asset-graph/types/AssetGraphQuery';
 import {DagsterTypeSummary} from '../dagstertype/DagsterType';
@@ -38,6 +43,7 @@ export const AssetNodeDefinition: React.FC<{
 }> = ({assetNode, upstream, downstream, liveDataByNode}) => {
   const partitionHealthData = usePartitionHealthData([assetNode.assetKey]);
   const {assetMetadata, assetType} = metadataForAssetNode(assetNode);
+  const liveDataForNode = liveDataByNode[toGraphId(assetNode.assetKey)];
 
   const assetConfigSchema = assetNode.configField?.configType;
   const repoAddress = buildRepoAddress(
@@ -75,6 +81,20 @@ export const AssetNodeDefinition: React.FC<{
               maxHeight={260}
             />
           </Box>
+          {liveDataForNode?.freshnessPolicy && (
+            <>
+              <Box
+                padding={{vertical: 16, horizontal: 24}}
+                border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+              >
+                <Subheading>Freshness Policy</Subheading>
+              </Box>
+              <Box padding={{vertical: 16, horizontal: 24}} flex={{gap: 12, alignItems: 'center'}}>
+                <CurrentMinutesLateTag liveData={liveDataForNode} />
+                <Body>{freshnessPolicyDescription(liveDataForNode.freshnessPolicy)}</Body>
+              </Box>
+            </>
+          )}
           {assetNode.partitionDefinition && (
             <>
               <Box

--- a/js_modules/dagit/packages/core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetSidebarActivitySummary.tsx
@@ -1,6 +1,7 @@
-import {Box, Colors, Spinner} from '@dagster-io/ui';
+import {Body, Box, Colors, Spinner} from '@dagster-io/ui';
 import * as React from 'react';
 
+import {CurrentMinutesLateTag, freshnessPolicyDescription} from '../asset-graph/AssetNode';
 import {LiveDataForNode} from '../asset-graph/Utils';
 import {SidebarSection} from '../pipelines/SidebarComponents';
 
@@ -63,6 +64,16 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
         liveData={liveData}
         border={{side: 'top', width: 1, color: Colors.KeylineGray}}
       />
+
+      {liveData?.freshnessPolicy && (
+        <SidebarSection title="Freshness Policy">
+          <Box margin={{horizontal: 24, vertical: 12}} flex={{gap: 12, alignItems: 'center'}}>
+            <CurrentMinutesLateTag liveData={liveData} />
+            <Body>{freshnessPolicyDescription(liveData.freshnessPolicy)}</Body>
+          </Box>
+        </SidebarSection>
+      )}
+
       <SidebarSection title="Materialization in Last Run">
         {materializations[0] ? (
           <div style={{margin: -1, maxWidth: '100%', overflowX: 'auto'}}>

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -138,7 +138,7 @@ export const AssetTable = ({
             <th>{view === 'directory' ? 'Asset Key Prefix' : 'Asset Key'}</th>
             <th style={{width: 340}}>Defined in</th>
             <th style={{width: 265}}>Materialized</th>
-            <th style={{width: 115}}>Latest run</th>
+            <th style={{width: 215}}>Latest run</th>
             <th style={{width: 80}}>Actions</th>
           </tr>
         </thead>
@@ -281,13 +281,7 @@ const AssetEntryRow: React.FC<{
             </Box>
           ) : undefined}
         </td>
-        <td>
-          {liveData && (
-            <Mono>
-              <AssetLatestRunWithNotices liveData={liveData} />
-            </Mono>
-          )}
-        </td>
+        <td>{liveData && <AssetLatestRunWithNotices liveData={liveData} includeFreshness />}</td>
         <td>
           {asset ? (
             <Box flex={{gap: 8, alignItems: 'center'}}>

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -22,6 +22,7 @@ import {
   useQueryRefreshAtInterval,
 } from '../app/QueryRefresh';
 import {Timestamp} from '../app/time/Timestamp';
+import {CurrentMinutesLateTag} from '../asset-graph/AssetNode';
 import {GraphData, LiveDataForNode, toGraphId, tokenForAssetKey} from '../asset-graph/Utils';
 import {useAssetGraphData} from '../asset-graph/useAssetGraphData';
 import {useLiveDataForAssetKeys} from '../asset-graph/useLiveDataForAssetKeys';
@@ -437,6 +438,7 @@ const AssetViewPageHeaderTags: React.FC<{
           </Link>
         </Tag>
       )}
+      {liveData?.freshnessPolicy && <CurrentMinutesLateTag liveData={liveData} policyOnHover />}
       {isUpstreamChanged ? (
         <Box onClick={onShowUpstream}>
           <BaseTag

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
@@ -232,7 +232,7 @@ const AssetRow = (props: JobRowProps) => {
         </RowCell>
         <RowCell>
           {liveData ? (
-            <AssetLatestRunWithNotices liveData={liveData} />
+            <AssetLatestRunWithNotices liveData={liveData} includeFreshness />
           ) : (
             <LoadingOrNone queryResult={queryResult} />
           )}

--- a/js_modules/dagit/packages/core/src/workspace/types/SingleAssetQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/SingleAssetQuery.ts
@@ -53,6 +53,17 @@ export interface SingleAssetQuery_assetOrError_Asset_definition_assetMaterializa
   runId: string;
 }
 
+export interface SingleAssetQuery_assetOrError_Asset_definition_freshnessPolicy {
+  __typename: "FreshnessPolicy";
+  maximumLagMinutes: number;
+  cronSchedule: string | null;
+}
+
+export interface SingleAssetQuery_assetOrError_Asset_definition_freshnessInfo {
+  __typename: "AssetFreshnessInfo";
+  currentMinutesLate: number | null;
+}
+
 export interface SingleAssetQuery_assetOrError_Asset_definition {
   __typename: "AssetNode";
   id: string;
@@ -63,6 +74,8 @@ export interface SingleAssetQuery_assetOrError_Asset_definition {
   opNames: string[];
   assetKey: SingleAssetQuery_assetOrError_Asset_definition_assetKey;
   assetMaterializations: SingleAssetQuery_assetOrError_Asset_definition_assetMaterializations[];
+  freshnessPolicy: SingleAssetQuery_assetOrError_Asset_definition_freshnessPolicy | null;
+  freshnessInfo: SingleAssetQuery_assetOrError_Asset_definition_freshnessInfo | null;
 }
 
 export interface SingleAssetQuery_assetOrError_Asset {


### PR DESCRIPTION
### Summary & Motivation

This PR adds asset freshness UI to the asset catalog! Here's a quick visual walk through of the changes. There is more work to do, specifically showing this info on the DAG itself and adjusting the appearance in the asset catalog, but I think it'll make more sense to do a final pass after asset versioning has landed and we can look at everything together.

cc @OwenKephart this no longer uses `latestMaterializationMinutesLate` so we can remove that if we want!

This PR doesn't change the UI for non-freshness-policy assets, EXCEPT that run status dots are now shown in the DAG and asset catalog per the latest mockups.

<img width="947" alt="image" src="https://user-images.githubusercontent.com/1037212/201446124-c557362c-687c-4b05-af41-4dd9d241c652.png">
<img width="689" alt="image" src="https://user-images.githubusercontent.com/1037212/201446139-77cc76a5-eeda-446d-b954-015c660b31f3.png">
<img width="621" alt="image" src="https://user-images.githubusercontent.com/1037212/201446171-48bc9b92-0a77-43c7-b124-b389bd9449b1.png">
<img width="874" alt="image" src="https://user-images.githubusercontent.com/1037212/201446193-86fac05c-ed65-4f10-ad7a-b8f659c57991.png">
