### PR TITLE
[freshness-policy] assets_to_reconcile_for_freshness

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -8,6 +8,7 @@ import dagster._seven as seven
 from dagster import AssetKey, DagsterEventType, EventRecordsFilter
 from dagster import _check as check
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.events import ASSET_EVENTS
 from dagster._core.storage.tags import get_dimension_from_partition_tag
 from dagster._utils.calculate_data_time import DataTimeInstanceQueryer
@@ -343,6 +344,7 @@ def get_freshness_info(
     asset_key: AssetKey,
     freshness_policy: FreshnessPolicy,
     data_time_queryer: DataTimeInstanceQueryer,
+    asset_graph: AssetGraph,
 ) -> "GrapheneAssetFreshnessInfo":
     from ..schema.freshness_policy import GrapheneAssetFreshnessInfo
 
@@ -354,7 +356,9 @@ def get_freshness_info(
         tz=datetime.timezone.utc,
     )
 
-    used_data_times = data_time_queryer.get_used_data_times_for_record(record=latest_record)
+    used_data_times = data_time_queryer.get_used_data_times_for_record(
+        asset_graph=asset_graph, record=latest_record
+    )
 
     # in the future, if you have upstream source assets with versioning policies, available data
     # times will be based off of the timestamp of the most recent materializations.

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -11,7 +11,7 @@ from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.events import ASSET_EVENTS
 from dagster._core.storage.tags import get_dimension_from_partition_tag
-from dagster._utils.calculate_data_time import DataTimeInstanceQueryer
+from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from .utils import capture_error
 
@@ -343,7 +343,7 @@ def get_materialization_cts_by_partition(
 def get_freshness_info(
     asset_key: AssetKey,
     freshness_policy: FreshnessPolicy,
-    data_time_queryer: DataTimeInstanceQueryer,
+    data_time_queryer: CachingInstanceQueryer,
     asset_graph: AssetGraph,
 ) -> "GrapheneAssetFreshnessInfo":
     from ..schema.freshness_policy import GrapheneAssetFreshnessInfo

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -350,7 +350,7 @@ def get_freshness_info(
 
     current_time = datetime.datetime.now(tz=datetime.timezone.utc)
 
-    latest_record = data_time_queryer.get_most_recent_materialization_record(asset_key=asset_key)
+    latest_record = data_time_queryer.get_latest_materialization_record(asset_key)
     latest_materialization_time = datetime.datetime.fromtimestamp(
         latest_record.event_log_entry.timestamp,
         tz=datetime.timezone.utc,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -7,8 +7,8 @@ from dagster_graphql.implementation.loader import CrossRepoAssetDependedByLoader
 import dagster._seven as seven
 from dagster import AssetKey, DagsterEventType, EventRecordsFilter
 from dagster import _check as check
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.events import ASSET_EVENTS
 from dagster._core.storage.tags import get_dimension_from_partition_tag
 from dagster._utils.calculate_data_time import DataTimeInstanceQueryer
@@ -351,6 +351,11 @@ def get_freshness_info(
     current_time = datetime.datetime.now(tz=datetime.timezone.utc)
 
     latest_record = data_time_queryer.get_latest_materialization_record(asset_key)
+    if latest_record is None:
+        return GrapheneAssetFreshnessInfo(
+            currentMinutesLate=None,
+            latestMaterializationMinutesLate=None,
+        )
     latest_materialization_time = datetime.datetime.fromtimestamp(
         latest_record.event_log_entry.timestamp,
         tz=datetime.timezone.utc,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -493,11 +493,10 @@ class GrapheneAssetNode(graphene.ObjectType):
             return get_freshness_info(
                 asset_key=self._external_asset_node.asset_key,
                 freshness_policy=self._external_asset_node.freshness_policy,
+                asset_graph=asset_graph,
                 # in the future, we can share this same DataTimeInstanceQueryer across all
                 # GrapheneAssetNodes which share an external repository for improved performance
-                data_time_queryer=DataTimeInstanceQueryer(
-                    instance=graphene_info.context.instance, asset_graph=asset_graph
-                ),
+                data_time_queryer=DataTimeInstanceQueryer(instance=graphene_info.context.instance),
             )
         return None
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -26,7 +26,7 @@ from dagster._core.host_representation.external_data import (
     ExternalTimeWindowPartitionsDefinitionData,
 )
 from dagster._core.snap.solid import CompositeSolidDefSnap, SolidDefSnap
-from dagster._utils.calculate_data_time import DataTimeInstanceQueryer
+from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from ..implementation.fetch_assets import (
     get_freshness_info,
@@ -494,9 +494,9 @@ class GrapheneAssetNode(graphene.ObjectType):
                 asset_key=self._external_asset_node.asset_key,
                 freshness_policy=self._external_asset_node.freshness_policy,
                 asset_graph=asset_graph,
-                # in the future, we can share this same DataTimeInstanceQueryer across all
+                # in the future, we can share this same CachingInstanceQueryer across all
                 # GrapheneAssetNodes which share an external repository for improved performance
-                data_time_queryer=DataTimeInstanceQueryer(instance=graphene_info.context.instance),
+                data_time_queryer=CachingInstanceQueryer(instance=graphene_info.context.instance),
             )
         return None
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -25,9 +25,9 @@ import pendulum
 import dagster._check as check
 from dagster._annotations import experimental
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
-from dagster._core.definitions.freshness_policy import FreshnessConstraint, FreshnessPolicy
+from dagster._core.definitions.freshness_policy import FreshnessConstraint
 from dagster._core.storage.tags import PARTITION_NAME_TAG
-from dagster._utils.calculate_data_time import DataTimeInstanceQueryer
+from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from .asset_selection import AssetGraph, AssetSelection
 from .partition import PartitionsDefinition, PartitionsSubset
@@ -217,7 +217,7 @@ class ToposortedPriorityQueue:
 
 
 def find_stale_candidates(
-    instance_queryer: DataTimeInstanceQueryer,
+    instance_queryer: CachingInstanceQueryer,
     cursor: AssetReconciliationCursor,
     target_asset_selection: AssetSelection,
     asset_graph: AssetGraph,
@@ -261,7 +261,7 @@ def find_stale_candidates(
 
 
 def find_never_materialized_or_requested_root_asset_partitions(
-    instance_queryer: DataTimeInstanceQueryer,
+    instance_queryer: CachingInstanceQueryer,
     cursor: AssetReconciliationCursor,
     target_asset_selection: AssetSelection,
     asset_graph: AssetGraph,
@@ -308,10 +308,11 @@ def find_never_materialized_or_requested_root_asset_partitions(
 
 
 def determine_asset_partitions_to_reconcile(
-    instance_queryer: DataTimeInstanceQueryer,
+    instance_queryer: CachingInstanceQueryer,
     cursor: AssetReconciliationCursor,
     target_asset_selection: AssetSelection,
     asset_graph: AssetGraph,
+    eventual_asset_partitions_to_reconcile_for_freshness: AbstractSet[AssetKeyPartitionKey],
 ) -> Tuple[
     AbstractSet[AssetKeyPartitionKey],
     AbstractSet[AssetKey],
@@ -345,6 +346,10 @@ def determine_asset_partitions_to_reconcile(
 
     while len(candidates_queue) > 0:
         candidate = candidates_queue.dequeue()
+
+        # no need to update this now, as it will be updated later
+        if candidate in eventual_asset_partitions_to_reconcile_for_freshness:
+            continue
 
         if (
             # all of its parents reconciled first
@@ -393,33 +398,22 @@ def determine_asset_partitions_to_reconcile(
     )
 
 
-def determine_asset_partitions_to_reconcile_for_freshness(
-    instance_queryer: DataTimeInstanceQueryer,
+def get_freshness_constraints_by_key(
+    instance_queryer: CachingInstanceQueryer,
     asset_graph: AssetGraph,
-    freshness_policies_by_key: Mapping[AssetKey, FreshnessPolicy],
-) -> Tuple[Set[AssetKeyPartitionKey], Set[AssetKeyPartitionKey]]:
-    """Returns a set of AssetKeyPartitionKeys to materialize in order to abide by the given
-    FreshnessPolicies, as well as a set of AssetKeyPartitionKeys which will be materialized at
-    some point within the plan window.
-
-    Attempts to minimize the total number of asset executions.
-    """
-
-    # exit early
-    if not freshness_policies_by_key:
-        return set(), set()
-
-    # look within a 12-hour time window to combine future runs together
-    current_time = pendulum.now(tz=pendulum.UTC)
-    plan_window_start = current_time
-    plan_window_end = plan_window_start + datetime.timedelta(hours=12)
-
+    plan_window_start: datetime.datetime,
+    plan_window_end: datetime.datetime,
+) -> Mapping[AssetKey, AbstractSet[FreshnessConstraint]]:
     # a dictionary mapping each asset to a set of constraints that must be satisfied about the data
     # times of its upstream assets
     constraints_by_key: Dict[AssetKey, AbstractSet[FreshnessConstraint]] = defaultdict(set)
 
     # for each asset with a FreshnessPolicy, get all unsolved constraints for the given time window
-    for key, freshness_policy in freshness_policies_by_key.items():
+    has_freshness_policy = False
+    for key, freshness_policy in asset_graph.freshness_policies_by_key.items():
+        if freshness_policy is None:
+            continue
+        has_freshness_policy = True
         upstream_keys = asset_graph.get_roots(key)
         latest_record = instance_queryer.get_latest_materialization_record(key)
         used_data_times = (
@@ -437,124 +431,215 @@ def determine_asset_partitions_to_reconcile_for_freshness(
             available_data_times=available_data_times,
         )
 
-    toposorted_assets = asset_graph.toposort_asset_keys()
+    # no freshness policies, so don't bother with constraints
+    if not has_freshness_policy:
+        return {}
+
     # propagate constraints upwards through the graph
     #
     # we ignore whether or not the constraint we're propagating corresponds to an asset which
     # is actually upstream of the asset we're operating on, as we'll filter those invalid
     # constraints out in the next step, and it's expensive to calculate if a given asset is
     # upstream of another asset.
-    for level in reversed(toposorted_assets):
+    for level in reversed(asset_graph.toposort_asset_keys()):
         for key in level:
             for upstream_key in asset_graph.get_parents(key):
                 # pass along all of your constraints to your parents
                 constraints_by_key[upstream_key] |= constraints_by_key[key]
+    return constraints_by_key
 
-    # now we have a full set of constraints, we can find solutions for them as we move back down
+
+def get_current_data_times_for_key(
+    instance_queryer: CachingInstanceQueryer,
+    asset_graph: AssetGraph,
+    constraints: AbstractSet[FreshnessConstraint],
+    expected_data_times: Mapping[AssetKey, datetime.datetime],
+    asset_key: AssetKey,
+) -> Mapping[AssetKey, Optional[datetime.datetime]]:
+    relevant_upstream_keys = set()
+    for constraint in constraints:
+        # we take in expected data times as a trick to keep track of which constraint keys are
+        # actually relevant to this asset
+        if constraint.asset_key in expected_data_times:
+            relevant_upstream_keys.add(constraint.asset_key)
+
+    # calculate the data time for this record in relation to the upstream keys which are
+    # set to be updated this tick and are involved in some constraint
+    latest_record = instance_queryer.get_latest_materialization_record(asset_key)
+    if latest_record is None:
+        return {}
+    else:
+        return instance_queryer.get_used_data_times_for_record(
+            asset_graph=asset_graph,
+            upstream_keys=relevant_upstream_keys,
+            record=latest_record,
+        )
+
+
+def get_expected_data_times_for_key(
+    asset_graph: AssetGraph,
+    current_time: datetime.datetime,
+    expected_data_times_by_key: Mapping[AssetKey, Mapping[AssetKey, datetime.datetime]],
+    asset_key: AssetKey,
+) -> Mapping[AssetKey, datetime.datetime]:
+    """Returns the data times for the given asset key if this asset were to be executed in this
+    tick.
+    """
+    expected_data_times: Dict[AssetKey, datetime.datetime] = {asset_key: current_time}
+
+    # get the expected data time for each upstream asset key if you were to run this asset on
+    # this tick
+    for upstream_key in asset_graph.get_parents(asset_key):
+        for upstream_upstream_key, expected_data_time in expected_data_times_by_key[
+            upstream_key
+        ].items():
+            # take the minimum data time from each of your parents that uses this key
+            expected_data_times[upstream_upstream_key] = min(
+                expected_data_times.get(upstream_upstream_key, expected_data_time),
+                expected_data_time,
+            )
+
+    return expected_data_times
+
+
+def get_execution_time_window_for_constraints(
+    instance_queryer: CachingInstanceQueryer,
+    constraints: AbstractSet[FreshnessConstraint],
+    current_time: datetime.datetime,
+    current_data_times: Mapping[AssetKey, Optional[datetime.datetime]],
+    expected_data_times: Mapping[AssetKey, datetime.datetime],
+    asset_key: AssetKey,
+) -> Tuple[Optional[datetime.datetime], Optional[datetime.datetime]]:
+    """Determines a range of times for which you can kick off an execution of this asset to solve
+    the most pressing constraint, alongside a maximum number of additional constraints.
+    """
+    # check to find if this asset is currently being materialized by a run, and if so, which
+    # other assets are being materialized in that run
+    (
+        current_run_data_time,
+        currently_materializing,
+    ) = instance_queryer.get_in_progress_run_time_and_planned_materializations(asset_key)
+
+    execution_window_start = None
+    execution_window_end = None
+    for constraint in sorted(constraints, key=lambda c: c.required_by_time):
+        current_data_time = current_data_times.get(constraint.asset_key)
+
+        if not (
+            # this constraint is irrelevant, as it is satisfied by the current data time
+            (current_data_time is not None and current_data_time > constraint.required_data_time)
+            # this constraint is irrelevant, as a currently-executing run will satisfy it
+            or (
+                constraint.asset_key in currently_materializing
+                # if the run hasn't started yet, assume it'll get data from the current time
+                and (current_run_data_time or current_time) > constraint.required_data_time
+            )
+            # this constraint is irrelevant, as it does not correspond to an asset which is
+            # directly upstream of this asset, nor to an asset which is transitively
+            # upstream of this asset and will be materialized this tick
+            or constraint.asset_key not in expected_data_times
+        ):
+            if execution_window_start is None:
+                execution_window_start = constraint.required_data_time
+            if execution_window_end is None:
+                execution_window_end = constraint.required_by_time
+
+            # you can solve this constraint within the existing execution window
+            if constraint.required_data_time < execution_window_end:
+                execution_window_start = max(
+                    execution_window_start,
+                    constraint.required_data_time,
+                )
+                execution_window_end = min(
+                    execution_window_end,
+                    constraint.required_by_time,
+                )
+    return execution_window_start, execution_window_end
+
+
+def determine_asset_partitions_to_reconcile_for_freshness(
+    instance_queryer: CachingInstanceQueryer,
+    asset_graph: AssetGraph,
+    target_asset_selection: AssetSelection,
+) -> Tuple[AbstractSet[AssetKeyPartitionKey], AbstractSet[AssetKeyPartitionKey]]:
+    """Returns a set of AssetKeyPartitionKeys to materialize in order to abide by the given
+    FreshnessPolicies, as well as a set of AssetKeyPartitionKeys which will be materialized at
+    some point within the plan window.
+
+    Attempts to minimize the total number of asset executions.
+    """
+
+    # look within a 12-hour time window to combine future runs together
+    current_time = pendulum.now(tz=pendulum.UTC)
+    plan_window_start = current_time
+    plan_window_end = plan_window_start + datetime.timedelta(hours=12)
+
+    # get a set of constraints that must be satisfied for each key
+    constraints_by_key = get_freshness_constraints_by_key(
+        instance_queryer, asset_graph, plan_window_start, plan_window_end
+    )
+
+    # no constraints, so exit early
+    if not constraints_by_key:
+        return (set(), set())
+
+    # get the set of asset keys we're allowed to execute
+    target_asset_keys = target_asset_selection.resolve(asset_graph)
+
+    # now we have a full set of constraints, we can find solutions for them as we move down
     to_materialize: Set[AssetKeyPartitionKey] = set()
     eventually_materialize: Set[AssetKeyPartitionKey] = set()
-    expected_data_times_by_key: Dict[AssetKey, Dict[AssetKey, datetime.datetime]] = defaultdict(
+    expected_data_times_by_key: Dict[AssetKey, Mapping[AssetKey, datetime.datetime]] = defaultdict(
         dict
     )
-    for level in toposorted_assets:
+    for level in asset_graph.toposort_asset_keys():
         for key in level:
-            # no need to evaluate this key, as it is not involved in any constraints
+            # no need to evaluate this key, as it has no constraints
             constraints = constraints_by_key[key]
             if not constraints:
                 continue
+            # this key has constraints within the plan window, so must be updated within it
+            eventually_materialize.add(AssetKeyPartitionKey(key, None))
 
-            # check to find if this asset is currently being materialized by a run, and if so, which
-            # other assets are being materialized in that run
-            (
-                current_run_data_time,
-                currently_materializing,
-            ) = instance_queryer.get_in_progress_run_time_and_planned_materializations(key)
-
-            expected_data_times: Dict[AssetKey, datetime.datetime] = {key: current_time}
-
-            # get the expected data time for each upstream asset key if you were to run this asset on
-            # this tick
-            for upstream_key in asset_graph.get_parents(key):
-                for upstream_upstream_key, expected_data_time in expected_data_times_by_key[
-                    upstream_key
-                ].items():
-                    # take the minimum data time from each of your parents
-                    expected_data_times[upstream_upstream_key] = min(
-                        expected_data_times.get(upstream_upstream_key, expected_data_time),
-                        expected_data_time,
-                    )
-
-            relevant_upstream_keys = set()
-            for constraint in constraints:
-                if constraint.asset_key in expected_data_times:
-                    relevant_upstream_keys.add(constraint.asset_key)
-
-            # calculate the data time for this record in relation to the upstream keys which are
-            # set to be updated this tick and are involved in some constraint
-            latest_record = instance_queryer.get_latest_materialization_record(key)
-            current_data_times = (
-                instance_queryer.get_used_data_times_for_record(
-                    asset_graph=asset_graph,
-                    upstream_keys=relevant_upstream_keys,
-                    record=latest_record,
-                )
-                if latest_record is not None
-                else {}
+            # figure out the data times you'd expect for this key if you were to run it on this tick
+            expected_data_times = get_expected_data_times_for_key(
+                asset_graph, current_time, expected_data_times_by_key, key
             )
 
-            # figure out a range of times that you could kick off an execution to solve the most
-            # pressing constraint, alongside a maximum number of additional constraints
-            execution_window_start = None
-            execution_window_end = None
-            for constraint in sorted(constraints_by_key[key], key=lambda c: c.required_by_time):
-                current_data_time = current_data_times.get(constraint.asset_key)
+            # figure out the current contents of this asset with respect to its constraints
+            current_data_times = get_current_data_times_for_key(
+                instance_queryer, asset_graph, constraints, expected_data_times, key
+            )
 
-                if not (
-                    # this constraint is irrelevant, as it is satisfied by the current data time
-                    (
-                        current_data_time is not None
-                        and current_data_time > constraint.required_data_time
-                    )
-                    # this constraint is irrelevant, as a currently-executing run will satisfy it
-                    or (
-                        constraint.asset_key in currently_materializing
-                        # if the run hasn't started yet, assume it'll get data from the current time
-                        and (current_run_data_time or plan_window_start)
-                        > constraint.required_data_time
-                    )
-                    # this constraint is irrelevant, as it does not correspond to an asset which is
-                    # directly upstream of this asset, nor to an asset which is transitively
-                    # upstream of this asset and will be materialized this tick
-                    or constraint.asset_key not in expected_data_times
-                ):
-                    if execution_window_start is None:
-                        execution_window_start = constraint.required_data_time
-                    if execution_window_end is None:
-                        execution_window_end = constraint.required_by_time
+            if key not in target_asset_keys:
+                # cannot execute this asset, so if something consumes it, it should expect to
+                # recieve the current contents of the asset
+                expected_data_times_by_key[key] = {
+                    key: time for key, time in current_data_times.items() if time is not None
+                }
+                continue
 
-                    # you can solve this constraint within the existing execution window
-                    if constraint.required_data_time < execution_window_end:
-                        execution_window_start = max(
-                            execution_window_start,
-                            constraint.required_data_time,
-                        )
-                        execution_window_end = min(
-                            execution_window_end,
-                            constraint.required_by_time,
-                        )
+            # figure out a time window that you can execute this asset within to solve a maximum
+            # number of constraints
+            (
+                execution_window_start,
+                _execution_window_end,
+            ) = get_execution_time_window_for_constraints(
+                instance_queryer,
+                constraints,
+                current_time,
+                current_data_times,
+                expected_data_times,
+                key,
+            )
 
-            # now that you have an execution window that will allow you to solve a maximum number of
-            # constraints at once, kick off a run at the beginning of that time window to give it
-            # maximum time to complete
+            # this key should be updated on this tick, as we are within the allowable window
             if execution_window_start is not None and execution_window_start <= current_time:
                 to_materialize.add(AssetKeyPartitionKey(key, None))
-                # only propogate these expected data times if you plan on kicking off a run
                 expected_data_times_by_key[key] = expected_data_times
             else:
-                # this key is planned to be updated within the plan window
-                if execution_window_start is not None:
-                    eventually_materialize.add(AssetKeyPartitionKey(key, None))
-                # otherwise, the expected data time will be the current one
+                # if downstream assets consume this, they should expect data times equal to the
+                # current times for this asset, as it's not going to be updated
                 expected_data_times_by_key[key] = {
                     key: time for key, time in current_data_times.items() if time is not None
                 }
@@ -569,7 +654,7 @@ def reconcile(
     cursor: AssetReconciliationCursor,
     run_tags: Optional[Mapping[str, str]],
 ):
-    instance_queryer = DataTimeInstanceQueryer(instance=instance)
+    instance_queryer = CachingInstanceQueryer(instance=instance)
     asset_graph = repository_def.asset_graph
 
     (
@@ -578,11 +663,7 @@ def reconcile(
     ) = determine_asset_partitions_to_reconcile_for_freshness(
         instance_queryer=instance_queryer,
         asset_graph=asset_graph,
-        freshness_policies_by_key={
-            key: assets_def.freshness_policies_by_key[key]
-            for key, assets_def in repository_def._assets_defs_by_key.items()  # pylint:disable=protected-access
-            if assets_def.freshness_policies_by_key.get(key) is not None
-        },
+        target_asset_selection=asset_selection,
     )
 
     (
@@ -595,6 +676,7 @@ def reconcile(
         asset_graph=asset_graph,
         cursor=cursor,
         target_asset_selection=asset_selection,
+        eventual_asset_partitions_to_reconcile_for_freshness=eventual_asset_partitions_to_reconcile_for_freshness,
     )
 
     assets_to_reconcile_by_partitions_def_partition_key: Mapping[
@@ -604,9 +686,6 @@ def reconcile(
     for asset_partition in (
         asset_partitions_to_reconcile | asset_partitions_to_reconcile_for_freshness
     ):
-        # defer materializing the asset now if it will be materialized later
-        if asset_partition in eventual_asset_partitions_to_reconcile_for_freshness:
-            continue
         assets_to_reconcile_by_partitions_def_partition_key[
             asset_graph.get_partitions_def(asset_partition.asset_key), asset_partition.partition_key
         ].add(asset_partition.asset_key)

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -412,7 +412,7 @@ def determine_asset_partitions_to_reconcile_for_freshness(
     # look within a 12-hour time window to combine future runs together
     current_time = pendulum.now(tz=pendulum.UTC)
     plan_window_start = current_time
-    plan_window_end = plan_window_start + pendulum.duration(hours=12)
+    plan_window_end = plan_window_start + datetime.timedelta(hours=12)
 
     # a dictionary mapping each asset to a set of constraints that must be satisfied about the data
     # times of its upstream assets

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -80,7 +80,10 @@ class FreshnessPolicy(
             # this constraint must be satisfied at all points in time, so generate a series of
             # many constraints (10 per maximum lag window)
             period = pendulum.period(pendulum.instance(window_start), pendulum.instance(window_end))
-            constraint_ticks = period.range("minutes", (self.maximum_lag_minutes / 10.0) + 0.1)
+            # old versions of pendulum return a list, so ensure this is an iterator
+            constraint_ticks = iter(
+                period.range("minutes", (self.maximum_lag_minutes / 10.0) + 0.1)
+            )
 
         # iterate over each schedule tick in the provided time window
         evaluation_tick = next(constraint_ticks, None)

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Mapping, NamedTuple, Optional, AbstractSet
+from typing import AbstractSet, Mapping, NamedTuple, Optional
 
 import pendulum
 from croniter import croniter
@@ -77,7 +77,7 @@ class FreshnessPolicy(
         else:
             # this constraint must be satisfied at all points in time, so generate a series of
             # many constraints (10 per maximum lag window)
-            period = pendulum.period(window_start, window_end)
+            period = pendulum.period(pendulum.instance(window_start), pendulum.instance(window_end))
             constraint_ticks = period.range("minutes", (self.maximum_lag_minutes / 10.0) + 0.1)
 
         # iterate over each schedule tick in the provided time window

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -81,9 +81,8 @@ class FreshnessPolicy(
             constraint_ticks = period.range("minutes", (self.maximum_lag_minutes / 10.0) + 0.1)
 
         # iterate over each schedule tick in the provided time window
-        n_ticks = 0
-        evaluation_tick = next(constraint_ticks)
-        while evaluation_tick < window_end:
+        evaluation_tick = next(constraint_ticks, None)
+        while evaluation_tick is not None and evaluation_tick < window_end:
             for asset_key, available_data_time in available_data_times.items():
                 # assume updated data is always available
                 if available_data_time == window_start:
@@ -106,10 +105,9 @@ class FreshnessPolicy(
                         )
                     )
 
-            evaluation_tick = next(constraint_ticks)
+            evaluation_tick = next(constraint_ticks, None)
             # fallback if the user selects a very small maximum_lag_minutes value
-            n_ticks += 1
-            if n_ticks > 100:
+            if len(constraints) > 100:
                 break
         return constraints
 

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from dagster import DagsterInstance
 
 
-class DataTimeInstanceQueryer:
+class CachingInstanceQueryer:
     """Allows caching queries to the instance while calculating data times."""
 
     def __init__(self, instance: "DagsterInstance"):

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -22,7 +22,8 @@ if TYPE_CHECKING:
 
 
 class CachingInstanceQueryer:
-    """Allows caching queries to the instance while calculating data times."""
+    """Provides utility functions for querying for asset-materialization related data from the
+    instance which will attempt to limit redundant expensive calls."""
 
     def __init__(self, instance: "DagsterInstance"):
         self._instance = instance

--- a/python_modules/dagster/dagster/_utils/calculate_data_time.py
+++ b/python_modules/dagster/dagster/_utils/calculate_data_time.py
@@ -1,34 +1,216 @@
 import datetime
 import json
-from typing import AbstractSet, Dict, Mapping, Optional, Tuple
+from typing import AbstractSet, Dict, Mapping, Optional, Tuple, TYPE_CHECKING, Union, Iterable, cast
 
-from dagster import (
-    AssetKey,
-    DagsterEventType,
-    DagsterInstance,
-    DagsterInvariantViolationError,
-    EventLogRecord,
-    EventRecordsFilter,
-)
+from dagster._core.storage.tags import PARTITION_NAME_TAG
+from dagster._core.storage.pipeline_run import DagsterRun, RunRecord, RunsFilter
+from dagster._core.storage.event_log import EventLogRecord
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._utils.cached_method import cached_method
 from dagster._utils.merger import merge_dicts
+from dagster._core.errors import DagsterInvariantViolationError
+from dagster._core.storage.pipeline_run import IN_PROGRESS_RUN_STATUSES
+
+if TYPE_CHECKING:
+    from dagster import DagsterInstance
 
 
 class DataTimeInstanceQueryer:
-    """Allows caching queries to the instance while evaluating"""
+    """Allows caching queries to the instance while calculating data times."""
 
-    def __init__(self, instance: DagsterInstance, asset_graph: AssetGraph):
+    def __init__(self, instance: "DagsterInstance"):
         self._instance = instance
-        self._asset_graph = asset_graph
 
-    @property
-    def instance(self) -> DagsterInstance:
-        return self._instance
+        self._latest_materialization_record_cache: Dict[AssetKeyPartitionKey, EventLogRecord] = {}
+        # if we try to fetch the latest materialization record after a given cursor and don't find
+        # anything, we can keep track of that fact, so that the next time try to fetch the latest
+        # materialization record for a >= cursor, we don't need to query the instance
+        self._no_materializations_after_cursor_cache: Dict[AssetKeyPartitionKey, int] = {}
 
-    @property
-    def asset_graph(self) -> AssetGraph:
-        return self._asset_graph
+    def get_in_progress_run_time_and_planned_materializations(
+        self, asset_key: AssetKey
+    ) -> Tuple[Optional[datetime.datetime], AbstractSet[AssetKey]]:
+        # the latest asset record is updated when the run is created
+        asset_records = self._instance.get_asset_records({asset_key})
+        asset_record = next(iter(asset_records), None)
+        if asset_record is None or asset_record.asset_entry.last_run_id is None:
+            return (None, set())
+        run_id = asset_record.asset_entry.last_run_id
+
+        run_record = self._get_run_record_by_id(run_id=run_id)
+        if run_record is not None and run_record.pipeline_run.status in IN_PROGRESS_RUN_STATUSES:
+            data_time = (
+                datetime.datetime.fromtimestamp(run_record.start_time, tz=datetime.timezone.utc)
+                if run_record.start_time
+                else None
+            )
+            return (data_time, self._get_planned_materializations_for_run(run_id=run_id))
+        return (None, set())
+
+    def is_asset_partition_in_run(self, run_id: str, asset_partition: AssetKeyPartitionKey) -> bool:
+        run = self._get_run_by_id(run_id=run_id)
+        if not run:
+            check.failed("")
+
+        if run.tags.get(PARTITION_NAME_TAG) != asset_partition.partition_key:
+            return False
+
+        if run.asset_selection:
+            return asset_partition.asset_key in run.asset_selection
+        else:
+            return asset_partition.asset_key in self._get_planned_materializations_for_run(
+                run_id=run_id
+            )
+
+    def _get_run_by_id(self, run_id: str) -> Optional[DagsterRun]:
+        run_record = self._get_run_record_by_id(run_id=run_id)
+        if run_record is not None:
+            return run_record.pipeline_run
+        return None
+
+    @cached_method
+    def _get_run_record_by_id(self, run_id: str) -> Optional[RunRecord]:
+        return next(
+            iter(self._instance.get_run_records(filters=RunsFilter(run_ids=[run_id]), limit=1)),
+            None,
+        )
+
+    @cached_method
+    def _get_planned_materializations_for_run(self, run_id: str) -> AbstractSet[AssetKey]:
+        from dagster._core.events import DagsterEventType
+
+        materializations_planned = self._instance.get_records_for_run(
+            run_id=run_id,
+            of_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+        ).records
+        return set(cast(AssetKey, record.asset_key) for record in materializations_planned)
+
+    @cached_method
+    def _get_materialization_record(
+        self,
+        asset_partition: AssetKeyPartitionKey,
+        after_cursor: Optional[int] = None,
+        before_cursor: Optional[int] = None,
+    ) -> Optional[EventLogRecord]:
+        from dagster import DagsterEventType, EventRecordsFilter
+
+        records = self._instance.get_event_records(
+            EventRecordsFilter(
+                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                asset_key=asset_partition.asset_key,
+                asset_partitions=[asset_partition.partition_key]
+                if asset_partition.partition_key
+                else None,
+                after_cursor=after_cursor,
+                before_cursor=before_cursor,
+            ),
+            ascending=False,
+            limit=1,
+        )
+        return next(iter(records), None)
+
+    def get_latest_materialization_record(
+        self,
+        asset: Union[AssetKey, AssetKeyPartitionKey],
+        after_cursor: Optional[int] = None,
+        before_cursor: Optional[int] = None,
+    ) -> Optional["EventLogRecord"]:
+        from dagster._core.events import DagsterEventType
+        from dagster._core.storage.event_log.base import EventRecordsFilter
+
+        if isinstance(asset, AssetKey):
+            asset_partition = AssetKeyPartitionKey(asset_key=asset)
+        else:
+            asset_partition = asset
+
+        if asset_partition in self._latest_materialization_record_cache:
+            cached_record = self._latest_materialization_record_cache[asset_partition]
+            if (after_cursor is None or after_cursor < cached_record.storage_id) and (
+                before_cursor is None or before_cursor > cached_record.storage_id
+            ):
+                return cached_record
+            else:
+                return None
+        elif asset_partition in self._no_materializations_after_cursor_cache:
+            if (
+                after_cursor is not None
+                and after_cursor >= self._no_materializations_after_cursor_cache[asset_partition]
+            ):
+                return None
+
+        record = self._get_materialization_record(
+            asset_partition=asset_partition, after_cursor=after_cursor, before_cursor=before_cursor
+        )
+
+        if record:
+            self._latest_materialization_record_cache[asset_partition] = record
+            return record
+        else:
+            if after_cursor is not None and before_cursor is None:
+                self._no_materializations_after_cursor_cache[asset_partition] = min(
+                    after_cursor,
+                    self._no_materializations_after_cursor_cache.get(asset_partition, after_cursor),
+                )
+            return None
+
+    def get_latest_materialization_records_by_key(
+        self,
+        asset_keys: Iterable[AssetKey],
+        after_cursor: Optional[int] = None,
+        before_cursor: Optional[int] = None,
+    ) -> Mapping[AssetKey, "EventLogRecord"]:
+        """
+        Only returns entries for assets that have been materialized since the cursor.
+        """
+        result: Dict[AssetKey, "EventLogRecord"] = {}
+
+        for asset_key in asset_keys:
+            latest_record = self.get_latest_materialization_record(
+                AssetKeyPartitionKey(asset_key),
+                after_cursor=after_cursor,
+                before_cursor=before_cursor,
+            )
+            if latest_record is not None:
+                result[asset_key] = latest_record
+
+        return result
+
+    @cached_method
+    def is_reconciled(
+        self,
+        asset_partition: AssetKeyPartitionKey,
+        asset_graph: AssetGraph,
+    ) -> bool:
+        """
+        An asset (partition) is considered unreconciled if any of:
+        - It has never been materialized
+        - One of its parents has been updated more recently than it has
+        - One of its parents is unreconciled
+        """
+        latest_materialization_record = self.get_latest_materialization_record(
+            asset_partition, None
+        )
+
+        if latest_materialization_record is None:
+            return False
+
+        for parent in asset_graph.get_parents_partitions(
+            asset_partition.asset_key, asset_partition.partition_key
+        ):
+            if (
+                self.get_latest_materialization_record(
+                    parent, after_cursor=latest_materialization_record.storage_id
+                )
+                is not None
+            ):
+                return False
+
+            if not self.is_reconciled(asset_partition=parent, asset_graph=asset_graph):
+                return False
+
+        return True
 
     def _kvs_key_for_record_id(self, record_id: int) -> str:
         return f".dagster/used_data/{record_id}"
@@ -38,13 +220,13 @@ class DataTimeInstanceQueryer:
         record_id: int,
         new_known_data: Dict[AssetKey, Tuple[Optional[int], Optional[float]]],
     ):
-        if self.instance.run_storage.supports_kvs():
+        if self._instance.run_storage.supports_kvs():
             current_known_data = self.get_known_used_data(record_id)
             known_data = merge_dicts(current_known_data, new_known_data)
             serialized_times = json.dumps(
                 {key.to_user_string(): value for key, value in known_data.items()}
             )
-            self.instance.run_storage.kvs_set(
+            self._instance.run_storage.kvs_set(
                 {self._kvs_key_for_record_id(record_id): serialized_times}
             )
 
@@ -52,10 +234,10 @@ class DataTimeInstanceQueryer:
         self, record_id: int
     ) -> Dict[AssetKey, Tuple[Optional[int], Optional[float]]]:
         """Returns the known upstream ids and timestamps stored on the instance"""
-        if self.instance.run_storage.supports_kvs():
+        if self._instance.run_storage.supports_kvs():
             # otherwise, attempt to fetch from the instance key-value store
             kvs_key = self._kvs_key_for_record_id(record_id)
-            serialized_times = self.instance.run_storage.kvs_get({kvs_key}).get(kvs_key, "{}")
+            serialized_times = self._instance.run_storage.kvs_get({kvs_key}).get(kvs_key, "{}")
             return {
                 AssetKey.from_user_string(key): tuple(value)  # type:ignore
                 for key, value in json.loads(serialized_times).items()
@@ -63,25 +245,9 @@ class DataTimeInstanceQueryer:
         return {}
 
     @cached_method
-    def get_most_recent_materialization_record(
-        self, asset_key: AssetKey, before_cursor: Optional[int] = None
-    ) -> Optional[EventLogRecord]:
-        records = list(
-            self.instance.get_event_records(
-                EventRecordsFilter(
-                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                    asset_key=asset_key,
-                    before_cursor=before_cursor,
-                ),
-                ascending=False,
-                limit=1,
-            )
-        )
-        return next(iter(records), None)
-
-    @cached_method
     def calculate_used_data(
         self,
+        asset_graph: AssetGraph,
         asset_key: AssetKey,
         record_id: Optional[int],
         record_timestamp: Optional[float],
@@ -101,23 +267,24 @@ class DataTimeInstanceQueryer:
         if unknown_required_keys:
 
             # find the upstream times of each of the parents of this asset
-            for parent_key in self.asset_graph.get_parents(asset_key):
+            for parent_key in asset_graph.get_parents(asset_key):
                 # the set of required keys which are upstream of this parent
                 upstream_required_keys = set()
                 if parent_key in unknown_required_keys:
                     upstream_required_keys.add(parent_key)
-                for upstream_key in self.asset_graph.upstream_key_iterator(parent_key):
+                for upstream_key in asset_graph.upstream_key_iterator(parent_key):
                     if upstream_key in unknown_required_keys:
                         upstream_required_keys.add(upstream_key)
 
                 # get the most recent asset materialization for this parent which happened before
                 # the current record
-                latest_parent_record = self.get_most_recent_materialization_record(
-                    asset_key=parent_key, before_cursor=record_id
+                latest_parent_record = self.get_latest_materialization_record(
+                    parent_key, before_cursor=record_id
                 )
 
                 # recurse to find the data times of this parent
                 for key, tup in self.calculate_used_data(
+                    asset_graph=asset_graph,
                     asset_key=parent_key,
                     record_id=latest_parent_record.storage_id if latest_parent_record else None,
                     record_timestamp=latest_parent_record.event_log_entry.timestamp
@@ -135,6 +302,7 @@ class DataTimeInstanceQueryer:
 
     def get_used_data_times_for_record(
         self,
+        asset_graph: AssetGraph,
         record: EventLogRecord,
         upstream_keys: Optional[AbstractSet[AssetKey]] = None,
     ) -> Mapping[AssetKey, Optional[datetime.datetime]]:
@@ -151,9 +319,10 @@ class DataTimeInstanceQueryer:
                 "Can only calculate data times for records with an `asset_key`."
             )
         if upstream_keys is None:
-            upstream_keys = self.asset_graph.get_roots(record.asset_key)
+            upstream_keys = asset_graph.get_roots(record.asset_key)
 
         data = self.calculate_used_data(
+            asset_graph=asset_graph,
             asset_key=record.asset_key,
             record_id=record.storage_id,
             record_timestamp=record.event_log_entry.timestamp,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_reconciliation_sensor.py
@@ -1,7 +1,8 @@
-import itertools
 import contextlib
+import itertools
 from typing import Iterable, List, Mapping, NamedTuple, Optional, Sequence, Union
 
+import pendulum
 import pytest
 
 from dagster import (
@@ -26,7 +27,6 @@ from dagster import (
     repository,
     with_resources,
 )
-import pendulum
 from dagster._core.definitions.asset_reconciliation_sensor import (
     AssetReconciliationCursor,
     reconcile,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_reconciliation_sensor.py
@@ -1,4 +1,5 @@
 import contextlib
+import datetime
 import itertools
 from typing import Iterable, List, Mapping, NamedTuple, Optional, Sequence, Union
 
@@ -44,7 +45,7 @@ class RunSpec(NamedTuple):
 class AssetReconciliationScenario(NamedTuple):
     unevaluated_runs: Sequence[RunSpec]
     assets: Sequence[AssetsDefinition]
-    evaluation_delta: Optional[pendulum.Duration] = None
+    evaluation_delta: Optional[datetime.timedelta] = None
     cursor_from: Optional["AssetReconciliationScenario"] = None  # type: ignore
 
     expected_run_requests: Optional[Sequence[RunRequest]] = None
@@ -589,7 +590,7 @@ scenarios = {
             unevaluated_runs=[run(["asset1", "asset2", "asset3", "asset4"])],
         ),
         unevaluated_runs=[run(["asset1"])],
-        evaluation_delta=pendulum.duration(minutes=35),
+        evaluation_delta=datetime.timedelta(minutes=35),
         expected_run_requests=[run_request(asset_keys=["asset1", "asset2", "asset3", "asset4"])],
     ),
     "freshness_half_run": AssetReconciliationScenario(
@@ -600,7 +601,7 @@ scenarios = {
     "freshness_half_run_stale": AssetReconciliationScenario(
         assets=diamond_freshness,
         unevaluated_runs=[run(["asset1", "asset2"])],
-        evaluation_delta=pendulum.duration(minutes=35),
+        evaluation_delta=datetime.timedelta(minutes=35),
         expected_run_requests=[run_request(asset_keys=["asset1", "asset2", "asset3", "asset4"])],
     ),
     "freshness_overlapping_runs": AssetReconciliationScenario(
@@ -612,7 +613,7 @@ scenarios = {
         assets=overlapping_freshness,
         unevaluated_runs=[run(["asset1", "asset3", "asset5"]), run(["asset2", "asset4", "asset6"])],
         # evaluate 35 minutes later, only need to refresh the assets on the shorter freshness policy
-        evaluation_delta=pendulum.duration(minutes=35),
+        evaluation_delta=datetime.timedelta(minutes=35),
         expected_run_requests=[run_request(asset_keys=["asset1", "asset3", "asset5"])],
     ),
     "freshness_overlapping_defer_propogate": AssetReconciliationScenario(

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_reconciliation_sensor.py
@@ -578,7 +578,7 @@ scenarios = {
         expected_run_requests=[],
     ),
     "freshness_all_fresh_with_new_run": AssetReconciliationScenario(
-        # expect no runs as the freshness policy will propogate the new change w/in the plan window
+        # expect no runs as the freshness policy will propagate the new change w/in the plan window
         assets=diamond_freshness,
         cursor_from=AssetReconciliationScenario(
             assets=diamond_freshness,
@@ -620,19 +620,19 @@ scenarios = {
         evaluation_delta=datetime.timedelta(minutes=35),
         expected_run_requests=[run_request(asset_keys=["asset1", "asset3", "asset5"])],
     ),
-    "freshness_overlapping_defer_propogate": AssetReconciliationScenario(
+    "freshness_overlapping_defer_propagate": AssetReconciliationScenario(
         assets=overlapping_freshness_inf,
         cursor_from=AssetReconciliationScenario(
             assets=overlapping_freshness_inf,
             unevaluated_runs=[run(["asset1", "asset2", "asset3", "asset4", "asset5", "asset6"])],
         ),
-        # change at the top, doesn't need to be propogated to 1, 3, 5 as freshness policy will
+        # change at the top, doesn't need to be propagated to 1, 3, 5 as freshness policy will
         # handle it, but assets 2, 4, 6 will not recieve an update in the plan window. 2 can be
         # updated immediately, but 4 and 6 depend on 3, so will be defered
         unevaluated_runs=[run(["asset1"])],
         expected_run_requests=[run_request(asset_keys=["asset2"])],
     ),
-    "freshness_overlapping_defer_propogate2": AssetReconciliationScenario(
+    "freshness_overlapping_defer_propagate2": AssetReconciliationScenario(
         assets=overlapping_freshness_none,
         cursor_from=AssetReconciliationScenario(
             assets=overlapping_freshness_inf,

--- a/python_modules/dagster/dagster_tests/utils_tests/test_calculate_materialization_times.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_calculate_materialization_times.py
@@ -16,7 +16,7 @@ from dagster import (
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_layer import build_asset_selection_job
 from dagster._core.test_utils import instance_for_test
-from dagster._utils.calculate_data_time import DataTimeInstanceQueryer
+from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 
 @pytest.mark.parametrize(
@@ -92,7 +92,7 @@ from dagster._utils.calculate_data_time import DataTimeInstanceQueryer
         ),
     ],
 )
-def test_calculate_data_time(relative_to, runs_to_expected_data_times_index):
+def test_caching_instance_queryer(relative_to, runs_to_expected_data_times_index):
     """
     A = B = D = F
      \\  //
@@ -165,7 +165,7 @@ def test_calculate_data_time(relative_to, runs_to_expected_data_times_index):
             assert result.success
 
             # rebuild the data time queryer after each run
-            data_time_queryer = DataTimeInstanceQueryer(instance)
+            data_time_queryer = CachingInstanceQueryer(instance)
 
             # build mapping of expected timestamps
             for entry in instance.all_logs(

--- a/python_modules/dagster/dagster_tests/utils_tests/test_calculate_materialization_times.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_calculate_materialization_times.py
@@ -165,7 +165,7 @@ def test_calculate_data_time(relative_to, runs_to_expected_data_times_index):
             assert result.success
 
             # rebuild the data time queryer after each run
-            data_time_queryer = DataTimeInstanceQueryer(instance, asset_graph)
+            data_time_queryer = DataTimeInstanceQueryer(instance)
 
             # build mapping of expected timestamps
             for entry in instance.all_logs(
@@ -178,8 +178,8 @@ def test_calculate_data_time(relative_to, runs_to_expected_data_times_index):
 
             for asset_keys, expected_data_times in expected_index_mapping.items():
                 for ak in asset_keys:
-                    latest_asset_record = data_time_queryer.get_most_recent_materialization_record(
-                        asset_key=AssetKey(ak)
+                    latest_asset_record = data_time_queryer.get_latest_materialization_record(
+                        AssetKey(ak)
                     )
                     if relative_to == "ROOTS":
                         relevant_upstream_keys = None
@@ -188,6 +188,7 @@ def test_calculate_data_time(relative_to, runs_to_expected_data_times_index):
                     else:
                         relevant_upstream_keys = {AssetKey(u) for u in relative_to}
                     upstream_data_times = data_time_queryer.get_used_data_times_for_record(
+                        asset_graph=asset_graph,
                         record=latest_asset_record,
                         upstream_keys=relevant_upstream_keys,
                     )


### PR DESCRIPTION
### Summary & Motivation

Adds the ability for the reconciliation sensor to kick off runs to satisfy constraints derived from freshness policies defined on assets in the repository. If the reconcilliation planned on propagating a change to downstream assets, but a freshness policy plans on propogating that change at some point within the next 12 hours, we defer propogating that constraint to minimize unnecessary work.

Also combines the functionality of TickInstanceQueryer into DataTimeInstanceQueryer to keep things simpler

### How I Tested These Changes
