### PR TITLE
Pass an instance ref and location into local grpc servers

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -353,8 +353,6 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         pytest_extra_cmds=dagster_graphql_extra_cmds,
         pytest_tox_factors=[
             "not_graphql_context_test_suite",
-            "in_memory_instance_multi_location",
-            "in_memory_instance_managed_grpc_env",
             "sqlite_instance_multi_location",
             "sqlite_instance_managed_grpc_env",
             "sqlite_instance_deployed_grpc_env",

--- a/python_modules/dagit/dagit_tests/test_app.py
+++ b/python_modules/dagit/dagit_tests/test_app.py
@@ -56,19 +56,20 @@ def test_create_app_with_workspace_and_scheduler():
 def test_notebook_view():
     notebook_path = file_relative_path(__file__, "render_uuid_notebook.ipynb")
 
-    with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(), [file_relative_path(__file__, "./workspace.yaml")]
-    ) as workspace_process_context:
-        client = TestClient(
-            create_app_from_workspace_process_context(
-                workspace_process_context,
+    with instance_for_test() as instance:
+        with load_workspace_process_context_from_yaml_paths(
+            instance, [file_relative_path(__file__, "./workspace.yaml")]
+        ) as workspace_process_context:
+            client = TestClient(
+                create_app_from_workspace_process_context(
+                    workspace_process_context,
+                )
             )
-        )
-        res = client.get(f"/dagit/notebook?path={notebook_path}&repoLocName=load_from_file")
+            res = client.get(f"/dagit/notebook?path={notebook_path}&repoLocName=load_from_file")
 
-        assert res.status_code == 200
-        # This magic guid is hardcoded in the notebook
-        assert b"6cac0c38-2c97-49ca-887c-4ac43f141213" in res.content
+            assert res.status_code == 200
+            # This magic guid is hardcoded in the notebook
+            assert b"6cac0c38-2c97-49ca-887c-4ac43f141213" in res.content
 
 
 def test_index_view():

--- a/python_modules/dagit/dagit_tests/test_smoke.py
+++ b/python_modules/dagit/dagit_tests/test_smoke.py
@@ -2,7 +2,6 @@ import pytest
 from dagit import app
 from starlette.testclient import TestClient
 
-from dagster import DagsterInstance
 from dagster._cli.workspace import get_workspace_process_context_from_kwargs
 from dagster._core.test_utils import instance_for_test
 
@@ -27,7 +26,7 @@ SMOKE_TEST_QUERY = """
 
 @pytest.mark.parametrize(
     "gen_instance",
-    [DagsterInstance.ephemeral, instance_for_test],
+    [instance_for_test],
 )
 def test_smoke_app(gen_instance):
     with gen_instance() as instance:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_reload_repository_location.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_reload_repository_location.py
@@ -89,7 +89,7 @@ def test_failure_with_query_error(mock_client: MockClient):
 
 
 BaseTestSuite: Any = make_graphql_context_test_suite(
-    context_variants=[GraphQLContextVariant.non_launchable_in_memory_instance_managed_grpc_env()]
+    context_variants=[GraphQLContextVariant.non_launchable_sqlite_instance_managed_grpc_env()]
 )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_graphql_context_test_suite.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_graphql_context_test_suite.py
@@ -78,9 +78,6 @@ def test_non_launchable_marks_filter():
     non_launchable_test_ids = {
         var.test_id
         for var in [
-            GraphQLContextVariant.non_launchable_in_memory_instance_lazy_repository(),
-            GraphQLContextVariant.non_launchable_in_memory_instance_multi_location(),
-            GraphQLContextVariant.non_launchable_in_memory_instance_managed_grpc_env(),
             GraphQLContextVariant.non_launchable_sqlite_instance_lazy_repository(),
             GraphQLContextVariant.non_launchable_sqlite_instance_multi_location(),
             GraphQLContextVariant.non_launchable_sqlite_instance_managed_grpc_env(),

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reload_repository_location.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reload_repository_location.py
@@ -78,14 +78,14 @@ mutation {
 
 
 MultiLocationTestSuite: Any = make_graphql_context_test_suite(
-    context_variants=[GraphQLContextVariant.non_launchable_in_memory_instance_multi_location()]
+    context_variants=[GraphQLContextVariant.non_launchable_sqlite_instance_multi_location()]
 )
 OutOfProcessTestSuite: Any = make_graphql_context_test_suite(
-    context_variants=[GraphQLContextVariant.non_launchable_in_memory_instance_managed_grpc_env()]
+    context_variants=[GraphQLContextVariant.non_launchable_sqlite_instance_managed_grpc_env()]
 )
 ManagedTestSuite: Any = make_graphql_context_test_suite(
     context_variants=[
-        GraphQLContextVariant.non_launchable_in_memory_instance_managed_grpc_env(),
+        GraphQLContextVariant.non_launchable_sqlite_instance_managed_grpc_env(),
     ]
 )
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
@@ -52,7 +52,7 @@ query {
 """
 
 BaseTestSuite: Any = make_graphql_context_test_suite(
-    context_variants=[GraphQLContextVariant.non_launchable_in_memory_instance_multi_location()]
+    context_variants=[GraphQLContextVariant.non_launchable_sqlite_instance_multi_location()]
 )
 
 

--- a/python_modules/dagster-graphql/pytest.ini
+++ b/python_modules/dagster-graphql/pytest.ini
@@ -1,7 +1,6 @@
 [pytest]
 markers =
     variant:
-    in_memory_instance: Uses an in-memory instance.
     sqlite_instance: Uses a sqlite instance.
     postgres_instance: Uses a postgres instance.
     sync_run_launcher: Uses the synchronous run launcher

--- a/python_modules/dagster-graphql/tox.ini
+++ b/python_modules/dagster-graphql/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{39,38,37,36}-{unix,windows}-{not_graphql_context_test_suite,in_memory_instance_multi_location,sqlite_instance_multi_location,in_memory_instance_managed_grpc_env,sqlite_instance_managed_grpc_env,sqlite_instance_deployed_grpc_env,graphql_python_client}
+  py{39,38,37,36}-{unix,windows}-{not_graphql_context_test_suite,sqlite_instance_multi_location,sqlite_instance_managed_grpc_env,sqlite_instance_deployed_grpc_env,graphql_python_client}
   py{39,38,37,36}-{unix,windows}-postgres-{graphql_context_variants,instance_multi_location,instance_managed_grpc_env,instance_deployed_grpc_env}
   mypy,pylint
 
@@ -18,9 +18,7 @@ commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   not_graphql_context_test_suite: pytest -m "not graphql_context_test_suite and not graphql_context_variants and not python_client_test_suite" -vv --junitxml=dagster_graphql_test_results.xml --cov=dagster_graphql --cov-append --cov-report= {posargs}
-  in_memory_instance_multi_location: pytest -m "graphql_context_test_suite and in_memory_instance and multi_location" -vv --junitxml=dagster_graphql_test_results.xml --cov=dagster_graphql --cov-append --cov-report= {posargs}
-  in_memory_instance_managed_grpc_env: pytest -m "graphql_context_test_suite and in_memory_instance and managed_grpc_env" -vv --junitxml=dagster_graphql_test_results.xml --cov=dagster_graphql --cov-append --cov-report= {posargs}
-  sqlite_instance_multi_location: pytest -m "graphql_context_test_suite and in_memory_instance and multi_location" -vv --junitxml=dagster_graphql_test_results.xml --cov=dagster_graphql --cov-append --cov-report= {posargs}
+  sqlite_instance_multi_location: pytest -m "graphql_context_test_suite and sqlite_instance and multi_location" -vv --junitxml=dagster_graphql_test_results.xml --cov=dagster_graphql --cov-append --cov-report= {posargs}
   sqlite_instance_managed_grpc_env: pytest -m "graphql_context_test_suite and sqlite_instance and managed_grpc_env" -vv --junitxml=dagster_graphql_test_results.xml --cov=dagster_graphql --cov-append --cov-report= {posargs}
   sqlite_instance_deployed_grpc_env: pytest -m "graphql_context_test_suite and sqlite_instance and deployed_grpc_env" -vv --junitxml=dagster_graphql_test_results.xml --cov=dagster_graphql --cov-append --cov-report= {posargs}
   graphql_python_client: pytest -m "python_client_test_suite" -vv --junitxml=dagster_graphql_test_results.xml --cov=dagster_graphql --cov-append --cov-report= {posargs}

--- a/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
@@ -100,6 +100,7 @@ class ProcessRegistryEntry(
 class ProcessGrpcServerRegistry(GrpcServerRegistry):
     def __init__(
         self,
+        instance,
         # How long each process should run before a new process should be created the next
         # time a given origin is requested (which will pick up any changes that have been
         # made to the code)
@@ -113,6 +114,9 @@ class ProcessGrpcServerRegistry(GrpcServerRegistry):
         # How long to wait for the server to start up and receive connections before timing out
         startup_timeout,
     ):
+
+        self.instance = instance
+
         # ProcessRegistryEntry map of servers being currently returned, keyed by origin ID
         self._active_entries = {}
 
@@ -209,6 +213,8 @@ class ProcessGrpcServerRegistry(GrpcServerRegistry):
             try:
                 new_server_id = str(uuid.uuid4())
                 server_process = GrpcServerProcess(
+                    instance_ref=self.instance.get_ref(),
+                    location_name=repository_location_origin.location_name,
                     loadable_target_origin=loadable_target_origin,
                     heartbeat=True,
                     heartbeat_timeout=self._heartbeat_ttl,

--- a/python_modules/dagster/dagster/_core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/host_representation/origin.py
@@ -242,7 +242,8 @@ class ManagedGrpcPythonEnvRepositoryLocationOrigin(
 
     @contextmanager
     def create_single_location(
-        self, instance: "DagsterInstance" = None
+        self,
+        instance: "DagsterInstance",
     ) -> Generator["RepositoryLocation", None, None]:
         from dagster._core.workspace.context import DAGIT_GRPC_SERVER_HEARTBEAT_TTL
 
@@ -250,6 +251,7 @@ class ManagedGrpcPythonEnvRepositoryLocationOrigin(
         from .repository_location import GrpcServerRepositoryLocation
 
         with ProcessGrpcServerRegistry(
+            instance=instance,
             reload_interval=0,
             heartbeat_ttl=DAGIT_GRPC_SERVER_HEARTBEAT_TTL,
             startup_timeout=instance.code_server_process_startup_timeout

--- a/python_modules/dagster/dagster/_core/origin.py
+++ b/python_modules/dagster/dagster/_core/origin.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, NamedTuple, Optional, Sequence
+from typing import Any, List, Mapping, NamedTuple, Optional, Sequence
 
 import dagster._check as check
 from dagster._core.code_pointer import CodePointer
@@ -8,7 +8,7 @@ from dagster._utils import frozenlist
 DEFAULT_DAGSTER_ENTRY_POINT = frozenlist(["dagster"])
 
 
-def get_python_environment_entry_point(executable_path: str) -> Sequence[str]:
+def get_python_environment_entry_point(executable_path: str) -> List[str]:
     return frozenlist([executable_path, "-m", "dagster"])
 
 

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -418,6 +418,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
         else:
             self._grpc_server_registry = self._stack.enter_context(
                 ProcessGrpcServerRegistry(
+                    instance=self._instance,
                     reload_interval=0,
                     heartbeat_ttl=DAGIT_GRPC_SERVER_HEARTBEAT_TTL,
                     startup_timeout=instance.code_server_process_startup_timeout,

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -61,6 +61,7 @@ def create_daemons_from_instance(instance):
 
 def create_daemon_grpc_server_registry(instance):
     return ProcessGrpcServerRegistry(
+        instance=instance,
         reload_interval=DAEMON_GRPC_SERVER_RELOAD_INTERVAL,
         heartbeat_ttl=DAEMON_GRPC_SERVER_HEARTBEAT_TTL,
         startup_timeout=instance.code_server_process_startup_timeout,

--- a/python_modules/dagster/dagster/_grpc/client.py
+++ b/python_modules/dagster/dagster/_grpc/client.py
@@ -514,10 +514,14 @@ def ephemeral_grpc_api_client(
     check.bool_param(force_port, "force_port")
     check.int_param(max_retries, "max_retries")
 
-    with GrpcServerProcess(
-        loadable_target_origin=loadable_target_origin,
-        force_port=force_port,
-        max_retries=max_retries,
-        max_workers=max_workers,
-    ).create_ephemeral_client() as client:
-        yield client
+    from dagster._core.test_utils import instance_for_test
+
+    with instance_for_test() as instance:
+        with GrpcServerProcess(
+            instance_ref=instance.get_ref(),
+            loadable_target_origin=loadable_target_origin,
+            force_port=force_port,
+            max_retries=max_retries,
+            max_workers=max_workers,
+        ).create_ephemeral_client() as client:
+            yield client

--- a/python_modules/dagster/dagster_tests/api_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/api_tests/utils.py
@@ -1,11 +1,12 @@
 import sys
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 
 from dagster import file_relative_path
 from dagster._core.host_representation import (
     ManagedGrpcPythonEnvRepositoryLocationOrigin,
     PipelineHandle,
 )
+from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import PythonFileTarget
@@ -27,26 +28,39 @@ def get_bar_workspace(instance):
 
 @contextmanager
 def get_bar_repo_repository_location(instance=None):
-    loadable_target_origin = LoadableTargetOrigin(
-        executable_path=sys.executable,
-        python_file=file_relative_path(__file__, "api_tests_repo.py"),
-        attribute="bar_repo",
-    )
-    location_name = "bar_repo_location"
+    with ExitStack() as stack:
+        if not instance:
+            instance = stack.enter_context(instance_for_test())
 
-    origin = ManagedGrpcPythonEnvRepositoryLocationOrigin(loadable_target_origin, location_name)
+        loadable_target_origin = LoadableTargetOrigin(
+            executable_path=sys.executable,
+            python_file=file_relative_path(__file__, "api_tests_repo.py"),
+            attribute="bar_repo",
+        )
+        location_name = "bar_repo_location"
 
-    with origin.create_single_location(instance) as location:
-        yield location
+        origin = ManagedGrpcPythonEnvRepositoryLocationOrigin(loadable_target_origin, location_name)
+
+        with origin.create_single_location(instance) as location:
+            yield location
 
 
 @contextmanager
 def get_bar_repo_handle(instance=None):
-    with get_bar_repo_repository_location(instance) as location:
-        yield location.get_repository("bar_repo").handle
+    with ExitStack() as stack:
+        if not instance:
+            instance = stack.enter_context(instance_for_test())
+
+        with get_bar_repo_repository_location(instance) as location:
+            yield location.get_repository("bar_repo").handle
 
 
 @contextmanager
 def get_foo_pipeline_handle(instance=None):
-    with get_bar_repo_handle(instance) as repo_handle:
-        yield PipelineHandle("foo", repo_handle)
+
+    with ExitStack() as stack:
+        if not instance:
+            instance = stack.enter_context(instance_for_test())
+
+        with get_bar_repo_handle(instance) as repo_handle:
+            yield PipelineHandle("foo", repo_handle)

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -328,8 +328,9 @@ def args_with_default_cli_test_instance(*args):
 
 
 @contextmanager
-def grpc_server_bar_kwargs(pipeline_name=None):
+def grpc_server_bar_kwargs(instance, pipeline_name=None):
     server_process = GrpcServerProcess(
+        instance_ref=instance.get_ref(),
         loadable_target_origin=LoadableTargetOrigin(
             executable_path=sys.executable,
             python_file=file_relative_path(__file__, "test_cli_commands.py"),
@@ -363,8 +364,9 @@ def python_bar_cli_args(job_name=None):
 
 
 @contextmanager
-def grpc_server_bar_cli_args(job_name=None):
+def grpc_server_bar_cli_args(instance, job_name=None):
     server_process = GrpcServerProcess(
+        instance.get_ref(),
         loadable_target_origin=LoadableTargetOrigin(
             executable_path=sys.executable,
             python_file=file_relative_path(__file__, "test_cli_commands.py"),
@@ -390,7 +392,7 @@ def grpc_server_bar_cli_args(job_name=None):
 @contextmanager
 def grpc_server_bar_pipeline_args():
     with default_cli_test_instance() as instance:
-        with grpc_server_bar_kwargs(pipeline_name="foo") as kwargs:
+        with grpc_server_bar_kwargs(instance, pipeline_name="foo") as kwargs:
             yield kwargs, instance
 
 
@@ -431,7 +433,7 @@ def scheduler_instance(overrides=None):
 @contextmanager
 def grpc_server_scheduler_cli_args(overrides=None):
     with scheduler_instance(overrides) as instance:
-        with grpc_server_bar_cli_args() as args:
+        with grpc_server_bar_cli_args(instance) as args:
             yield args, instance
 
 
@@ -472,7 +474,7 @@ def backfill_command_contexts():
 @contextmanager
 def grpc_server_backfill_args():
     with default_cli_test_instance() as instance:
-        with grpc_server_bar_kwargs() as args:
+        with grpc_server_bar_kwargs(instance) as args:
             yield merge_dicts(args, {"noprompt": True}), instance
 
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
@@ -10,7 +10,6 @@ from dagster._utils import file_relative_path
 
 from .test_cli_commands import (
     default_cli_test_instance,
-    grpc_server_bar_cli_args,
     launch_command_contexts,
     memoizable_job,
     non_existant_python_origin_target_args,
@@ -65,7 +64,7 @@ def test_launch_job_cli(job_cli_args):
 
 @pytest.mark.parametrize(
     "gen_pipeline_args",
-    [python_bar_cli_args("qux"), grpc_server_bar_cli_args("qux")],
+    [python_bar_cli_args("qux")],
 )
 def test_launch_with_run_id(gen_pipeline_args):
     runner = CliRunner()
@@ -100,7 +99,7 @@ def test_launch_with_run_id(gen_pipeline_args):
 
 @pytest.mark.parametrize(
     "gen_job_args",
-    [python_bar_cli_args("qux"), grpc_server_bar_cli_args("qux")],
+    [python_bar_cli_args("qux")],
 )
 def test_job_launch_with_run_id(gen_job_args):
     runner = CliRunner()
@@ -135,7 +134,7 @@ def test_job_launch_with_run_id(gen_job_args):
 
 @pytest.mark.parametrize(
     "gen_pipeline_args",
-    [python_bar_cli_args("qux"), grpc_server_bar_cli_args("qux")],
+    [python_bar_cli_args("qux")],
 )
 def test_launch_queued(gen_pipeline_args):
     runner = CliRunner()
@@ -167,7 +166,7 @@ def test_launch_queued(gen_pipeline_args):
 
 @pytest.mark.parametrize(
     "gen_pipeline_args",
-    [python_bar_cli_args("qux"), grpc_server_bar_cli_args("qux")],
+    [python_bar_cli_args("qux")],
 )
 def test_job_launch_queued(gen_pipeline_args):
     runner = CliRunner()

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_list_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_list_command.py
@@ -73,10 +73,11 @@ def assert_correct_extra_repository_output(result):
 
 @pytest.mark.skipif(_seven.IS_WINDOWS, reason="no named sockets on Windows")
 def test_list_command_grpc_socket():
-    with instance_for_test():
+    with instance_for_test() as instance:
         runner = CliRunner()
 
         server_process = GrpcServerProcess(
+            instance_ref=instance.get_ref(),
             loadable_target_origin=LoadableTargetOrigin(
                 executable_path=sys.executable,
                 python_file=file_relative_path(__file__, "test_cli_commands.py"),
@@ -107,10 +108,11 @@ def test_list_command_grpc_socket():
 
 
 def test_list_command_deployed_grpc():
-    with instance_for_test():
+    with instance_for_test() as instance:
         runner = CliRunner()
 
         server_process = GrpcServerProcess(
+            instance_ref=instance.get_ref(),
             loadable_target_origin=LoadableTargetOrigin(
                 executable_path=sys.executable,
                 python_file=file_relative_path(__file__, "test_cli_commands.py"),

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/hello_world_in_file/test_hello_world_in_file_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/hello_world_in_file/test_hello_world_in_file_workspace.py
@@ -1,27 +1,35 @@
-from dagster import DagsterInstance
+import pytest
+
+from dagster._core.test_utils import instance_for_test
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load import load_workspace_process_context_from_yaml_paths
 from dagster._utils import file_relative_path
+
+
+@pytest.fixture
+def instance():
+    with instance_for_test() as instance:
+        yield instance
 
 
 def get_hello_world_path():
     return file_relative_path(__file__, "hello_world_repository.py")
 
 
-def test_load_in_process_location_hello_world_nested_no_def():
+def test_load_in_process_location_hello_world_nested_no_def(instance):
     file_name = file_relative_path(__file__, "nested_python_file_workspace.yaml")
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(), [file_name]
+        instance, [file_name]
     ) as workspace_process_context:
         assert isinstance(workspace_process_context, WorkspaceProcessContext)
         assert workspace_process_context.repository_locations_count == 1
         assert workspace_process_context.repository_location_names[0] == "hello_world_repository.py"
 
 
-def test_load_in_process_location_hello_world_nested_with_def():
+def test_load_in_process_location_hello_world_nested_with_def(instance):
     file_name = file_relative_path(__file__, "nested_with_def_python_file_workspace.yaml")
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(), [file_name]
+        instance, [file_name]
     ) as workspace_process_context:
         assert isinstance(workspace_process_context, WorkspaceProcessContext)
         assert workspace_process_context.repository_locations_count == 1
@@ -31,11 +39,11 @@ def test_load_in_process_location_hello_world_nested_with_def():
         )
 
 
-def test_load_in_process_location_hello_world_terse():
+def test_load_in_process_location_hello_world_terse(instance):
     file_name = file_relative_path(__file__, "terse_python_file_workspace.yaml")
 
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(), [file_name]
+        instance, [file_name]
     ) as workspace_process_context:
         assert isinstance(workspace_process_context, WorkspaceProcessContext)
         assert workspace_process_context.repository_locations_count == 1

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/hello_world_in_module/test_hello_world_in_module_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/hello_world_in_module/test_hello_world_in_module_workspace.py
@@ -1,12 +1,20 @@
-from dagster import DagsterInstance
+import pytest
+
+from dagster._core.test_utils import instance_for_test
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load import load_workspace_process_context_from_yaml_paths
 from dagster._utils import file_relative_path
 
 
-def test_load_in_process_location_hello_world_terse():
+@pytest.fixture
+def instance():
+    with instance_for_test() as instance:
+        yield instance
+
+
+def test_load_in_process_location_hello_world_terse(instance):
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(),
+        instance,
         [file_relative_path(__file__, "terse_python_module_workspace.yaml")],
     ) as workspace:
         assert isinstance(workspace, WorkspaceProcessContext)
@@ -14,9 +22,9 @@ def test_load_in_process_location_hello_world_terse():
         assert workspace.repository_location_names[0] == "dagster.utils.test.hello_world_repository"
 
 
-def test_load_in_process_location_hello_world_nested():
+def test_load_in_process_location_hello_world_nested(instance):
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(),
+        instance,
         [file_relative_path(__file__, "nested_python_module_workspace.yaml")],
     ) as workspace:
         assert isinstance(workspace, WorkspaceProcessContext)
@@ -24,9 +32,9 @@ def test_load_in_process_location_hello_world_nested():
         assert workspace.repository_location_names[0] == "dagster.utils.test.hello_world_repository"
 
 
-def test_load_in_process_location_hello_world_nested_with_def():
+def test_load_in_process_location_hello_world_nested_with_def(instance):
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(),
+        instance,
         [file_relative_path(__file__, "nested_with_def_python_module_workspace.yaml")],
     ) as workspace:
         assert isinstance(workspace, WorkspaceProcessContext)

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/multi_location/test_load_failure_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/multi_location/test_load_failure_workspace.py
@@ -1,12 +1,20 @@
-from dagster import DagsterInstance
+import pytest
+
+from dagster._core.test_utils import instance_for_test
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load import load_workspace_process_context_from_yaml_paths
 from dagster._utils import file_relative_path
 
 
-def test_multi_location_error():
+@pytest.fixture
+def instance():
+    with instance_for_test() as instance:
+        yield instance
+
+
+def test_multi_location_error(instance):
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(),
+        instance,
         [file_relative_path(__file__, "multi_location_with_error.yaml")],
     ) as cli_workspace:
         assert isinstance(cli_workspace, WorkspaceProcessContext)
@@ -30,9 +38,9 @@ def test_multi_location_error():
 
 
 # A workspace still loads even if there's an error loading all of its locations
-def test_workspace_with_only_error():
+def test_workspace_with_only_error(instance):
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(),
+        instance,
         [file_relative_path(__file__, "workspace_with_only_error.yaml")],
     ) as cli_workspace:
         assert isinstance(cli_workspace, WorkspaceProcessContext)

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/multi_location/test_multi_location_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/multi_location/test_multi_location_workspace.py
@@ -4,7 +4,6 @@ from contextlib import ExitStack
 import pytest
 import yaml
 
-from dagster import DagsterInstance
 from dagster._core.host_representation import GrpcServerRepositoryLocation
 from dagster._core.test_utils import instance_for_test
 from dagster._core.workspace.context import WorkspaceProcessContext
@@ -15,9 +14,15 @@ from dagster._core.workspace.load import (
 from dagster._utils import file_relative_path
 
 
-def test_multi_location_workspace_foo():
+@pytest.fixture
+def instance():
+    with instance_for_test() as instance:
+        yield instance
+
+
+def test_multi_location_workspace_foo(instance):
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(),
+        instance,
         [file_relative_path(__file__, "multi_location.yaml")],
     ) as grpc_workspace:
         assert isinstance(grpc_workspace, WorkspaceProcessContext)
@@ -27,9 +32,9 @@ def test_multi_location_workspace_foo():
         assert grpc_workspace.has_repository_location("loaded_from_package")
 
 
-def test_multi_file_extend_workspace():
+def test_multi_file_extend_workspace(instance):
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(),
+        instance,
         [
             file_relative_path(__file__, "multi_location.yaml"),
             file_relative_path(__file__, "extra_location.yaml"),
@@ -43,9 +48,9 @@ def test_multi_file_extend_workspace():
         assert workspace.has_repository_location("extra_location")
 
 
-def test_multi_file_override_workspace():
+def test_multi_file_override_workspace(instance):
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(),
+        instance,
         [
             file_relative_path(__file__, "multi_location.yaml"),
             file_relative_path(__file__, "override_location.yaml"),
@@ -67,9 +72,9 @@ def test_multi_file_override_workspace():
         assert "extra_repository" in external_repositories
 
 
-def test_multi_file_extend_and_override_workspace():
+def test_multi_file_extend_and_override_workspace(instance):
     with load_workspace_process_context_from_yaml_paths(
-        DagsterInstance.ephemeral(),
+        instance,
         [
             file_relative_path(__file__, "multi_location.yaml"),
             file_relative_path(__file__, "override_location.yaml"),

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_workspace_load.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_workspace_load.py
@@ -3,24 +3,25 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
-from dagster import DagsterInstance
 from dagster._check import CheckError
+from dagster._core.test_utils import instance_for_test
 from dagster._core.workspace.load import load_workspace_process_context_from_yaml_paths
 from dagster._utils import touch_file
 
 
 def test_bad_workspace_yaml_load():
-    with TemporaryDirectory() as temp_dir:
-        touch_file(os.path.join(temp_dir, "foo.yaml"))
+    with instance_for_test() as instance:
+        with TemporaryDirectory() as temp_dir:
+            touch_file(os.path.join(temp_dir, "foo.yaml"))
 
-        with pytest.raises(
-            CheckError,
-            match=(
-                "Invariant failed. Description: Could not parse a workspace config from the "
-                "yaml file at"
-            ),
-        ):
-            with load_workspace_process_context_from_yaml_paths(
-                DagsterInstance.ephemeral(), [os.path.join(temp_dir, "foo.yaml")]
+            with pytest.raises(
+                CheckError,
+                match=(
+                    "Invariant failed. Description: Could not parse a workspace config from the "
+                    "yaml file at"
+                ),
             ):
-                pass
+                with load_workspace_process_context_from_yaml_paths(
+                    instance, [os.path.join(temp_dir, "foo.yaml")]
+                ):
+                    pass

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
@@ -62,7 +62,9 @@ def workspace_process_context_fixture(instance):
         executable_path=sys.executable,
         python_file=file_relative_path(__file__, "test_custom_repository_data.py"),
     )
-    server_process = GrpcServerProcess(loadable_target_origin=loadable_target_origin)
+    server_process = GrpcServerProcess(
+        instance_ref=instance.get_ref(), loadable_target_origin=loadable_target_origin
+    )
     try:
         with server_process.create_ephemeral_client():  # shuts down when leaves this context
             with WorkspaceProcessContext(

--- a/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_persistent_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_persistent_grpc_run_launcher.py
@@ -28,7 +28,9 @@ def test_run_always_finishes():  # pylint: disable=redefined-outer-name
             python_file=file_relative_path(__file__, "test_default_run_launcher.py"),
         )
         server_process = GrpcServerProcess(
-            loadable_target_origin=loadable_target_origin, max_workers=4
+            instance_ref=instance.get_ref(),
+            loadable_target_origin=loadable_target_origin,
+            max_workers=4,
         )
         with server_process.create_ephemeral_client():  # Shuts down when leaves context
             with WorkspaceProcessContext(
@@ -86,7 +88,9 @@ def test_run_from_pending_repository():
             python_file=file_relative_path(__file__, "pending_repository.py"),
         )
         server_process = GrpcServerProcess(
-            loadable_target_origin=loadable_target_origin, max_workers=4
+            instance_ref=instance.get_ref(),
+            loadable_target_origin=loadable_target_origin,
+            max_workers=4,
         )
         with server_process.create_ephemeral_client():  # Shuts down when leaves context
             with WorkspaceProcessContext(
@@ -252,7 +256,10 @@ def test_server_down():
         )
 
         server_process = GrpcServerProcess(
-            loadable_target_origin=loadable_target_origin, max_workers=4, force_port=True
+            instance_ref=instance.get_ref(),
+            loadable_target_origin=loadable_target_origin,
+            max_workers=4,
+            force_port=True,
         )
 
         with server_process.create_ephemeral_client() as api_client:

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_health_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_health_check.py
@@ -2,6 +2,7 @@ import sys
 
 import pytest
 
+from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.client import DagsterGrpcClient
 from dagster._grpc.server import GrpcServerProcess
@@ -9,20 +10,22 @@ from dagster._utils import file_relative_path
 
 
 def test_health_check_success():
-    loadable_target_origin = LoadableTargetOrigin(
-        executable_path=sys.executable,
-        attribute="bar_repo",
-        python_file=file_relative_path(__file__, "grpc_repo.py"),
-    )
-    server = GrpcServerProcess(
-        loadable_target_origin=loadable_target_origin,
-        max_workers=2,
-        heartbeat=True,
-        heartbeat_timeout=1,
-    )
-    with server.create_ephemeral_client() as client:
-        assert client.health_check_query() == "SERVING"
-    server.wait()
+    with instance_for_test() as instance:
+        loadable_target_origin = LoadableTargetOrigin(
+            executable_path=sys.executable,
+            attribute="bar_repo",
+            python_file=file_relative_path(__file__, "grpc_repo.py"),
+        )
+        server = GrpcServerProcess(
+            instance_ref=instance.get_ref(),
+            loadable_target_origin=loadable_target_origin,
+            max_workers=2,
+            heartbeat=True,
+            heartbeat_timeout=1,
+        )
+        with server.create_ephemeral_client() as client:
+            assert client.health_check_query() == "SERVING"
+        server.wait()
 
 
 def test_health_check_fail():

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_heartbeat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_heartbeat.py
@@ -1,38 +1,41 @@
 import sys
 import time
 
+from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.server import GrpcServerProcess
 from dagster._utils import file_relative_path
 
 
 def test_heartbeat():
-    loadable_target_origin = LoadableTargetOrigin(
-        executable_path=sys.executable,
-        attribute="bar_repo",
-        python_file=file_relative_path(__file__, "grpc_repo.py"),
-    )
-    server = GrpcServerProcess(
-        loadable_target_origin=loadable_target_origin,
-        max_workers=2,
-        heartbeat=True,
-        heartbeat_timeout=1,
-    )
-    with server.create_ephemeral_client() as client:
-        assert server.server_process.poll() is None
+    with instance_for_test() as instance:
+        loadable_target_origin = LoadableTargetOrigin(
+            executable_path=sys.executable,
+            attribute="bar_repo",
+            python_file=file_relative_path(__file__, "grpc_repo.py"),
+        )
+        server = GrpcServerProcess(
+            instance_ref=instance.get_ref(),
+            loadable_target_origin=loadable_target_origin,
+            max_workers=2,
+            heartbeat=True,
+            heartbeat_timeout=1,
+        )
+        with server.create_ephemeral_client() as client:
+            assert server.server_process.poll() is None
 
-        # heartbeat keeps the server alive
-        time.sleep(0.5)
-        client.heartbeat()
-        time.sleep(0.5)
-        client.heartbeat()
-        time.sleep(0.5)
-        assert server.server_process.poll() is None
+            # heartbeat keeps the server alive
+            time.sleep(0.5)
+            client.heartbeat()
+            time.sleep(0.5)
+            client.heartbeat()
+            time.sleep(0.5)
+            assert server.server_process.poll() is None
 
-        start_time = time.time()
-        while (time.time() - start_time) < 10:
-            if server.server_process.poll() is not None:
-                return
-            time.sleep(0.1)
+            start_time = time.time()
+            while (time.time() - start_time) < 10:
+                if server.server_process.poll() is not None:
+                    return
+                time.sleep(0.1)
 
-        raise Exception("Timed out waiting for server to terminate after heartbeat stopped")
+            raise Exception("Timed out waiting for server to terminate after heartbeat stopped")

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -1963,8 +1963,9 @@ def test_large_schedule(instance, workspace_context, external_repo, executor):
 
 
 @contextmanager
-def _grpc_server_external_repo(port):
+def _grpc_server_external_repo(port, instance):
     server_process = open_server_process(
+        instance.get_ref(),
         port=port,
         socket=None,
         loadable_target_origin=loadable_target_origin(),
@@ -2030,7 +2031,7 @@ def test_grpc_server_down(instance, executor):
 
     initial_datetime = create_pendulum_time(year=2019, month=2, day=27, hour=0, minute=0, second=0)
     stack = ExitStack()
-    external_repo = stack.enter_context(_grpc_server_external_repo(port))
+    external_repo = stack.enter_context(_grpc_server_external_repo(port, instance))
     workspace_context = stack.enter_context(
         create_test_daemon_workspace_context(
             GrpcServerTarget(
@@ -2066,7 +2067,7 @@ def test_grpc_server_down(instance, executor):
             )
 
         # Server starts back up, tick now succeeds
-        with _grpc_server_external_repo(port) as external_repo:
+        with _grpc_server_external_repo(port, instance) as external_repo:
             evaluate_schedules(server_up_ctx, executor, pendulum.now("UTC"))
             assert instance.get_runs_count() == 1
             ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)


### PR DESCRIPTION
Summary:
This is to lay groundwork for https://github.com/dagster-io/dagster/pull/10491/files - fixes up a whole bunch of tests that were assuming that you could run a grpc server using an in memory instance (including a couple of whole graphql test suites), and pass in the local instance ref into the grpc server constructor. This isn't something that a user has actually been able to do for a while.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
