### PR TITLE
[dagster-airbyte] Allow setting primary key, cursor field for managed streams

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/types.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/types.py
@@ -8,7 +8,10 @@ import dagster._check as check
 
 class AirbyteSyncMode(ABC):
     """
-    Represents the sync mode for a given Airbyte stream.
+    Represents the sync mode for a given Airbyte stream, which governs how Airbyte reads
+    from a source and writes to a destination.
+
+    For more information, see https://docs.airbyte.com/understanding-airbyte/connections/.
     """
 
     def __eq__(self, other: Any) -> bool:
@@ -32,10 +35,21 @@ class AirbyteSyncMode(ABC):
 
     @classmethod
     def full_refresh_append(cls) -> "AirbyteSyncMode":
+        """
+        Syncs the entire data stream from the source, appending to the destination.
+
+        https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append/
+        """
         return cls({"syncMode": "full_refresh", "destinationSyncMode": "append"})
 
     @classmethod
     def full_refresh_overwrite(cls) -> "AirbyteSyncMode":
+        """
+        Syncs the entire data stream from the source, replaces data in the destination by
+        overwriting it.
+
+        https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite
+        """
         return cls({"syncMode": "full_refresh", "destinationSyncMode": "overwrite"})
 
     @classmethod
@@ -43,6 +57,13 @@ class AirbyteSyncMode(ABC):
         cls,
         cursor_field: Optional[str] = None,
     ) -> "AirbyteSyncMode":
+        """
+        Syncs only new records from the source, appending to the destination.
+        May optionally specify the cursor field used to determine which records
+        are new.
+
+        https://docs.airbyte.com/understanding-airbyte/connections/incremental-append/
+        """
         cursor_field = check.opt_str_param(cursor_field, "cursor_field")
 
         return cls(
@@ -59,6 +80,16 @@ class AirbyteSyncMode(ABC):
         cursor_field: Optional[str] = None,
         primary_key: Optional[Union[str, List[str]]] = None,
     ) -> "AirbyteSyncMode":
+        """
+        Syncs new records from the source, appending to an append-only history
+        table in the destination. Also generates a deduplicated view mirroring the
+        source table. May optionally specify the cursor field used to determine
+        which records are new, and the primary key used to determine which records
+        are duplicates.
+
+        https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-dedup/
+        """
+
         cursor_field = check.opt_str_param(cursor_field, "cursor_field")
         if isinstance(primary_key, str):
             primary_key = [primary_key]

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/types.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/types.py
@@ -1,6 +1,5 @@
 import json
 from abc import ABC
-from enum import Enum
 from typing import Any, Dict, List, Mapping, Optional, Union
 
 import dagster._check as check
@@ -118,8 +117,7 @@ class AirbyteSource:
         )
 
     def must_be_recreated(self, other: "AirbyteSource") -> bool:
-        return False
-        # return self.name != other.name or self.source_configuration != other.source_configuration
+        return self.name != other.name or self.source_configuration != other.source_configuration
 
 
 class InitializedAirbyteSource:
@@ -160,11 +158,10 @@ class AirbyteDestination:
         )
 
     def must_be_recreated(self, other: "AirbyteDestination") -> bool:
-        return False
-        # return (
-        #     self.name != other.name
-        #     or self.destination_configuration != other.destination_configuration
-        # )
+        return (
+            self.name != other.name
+            or self.destination_configuration != other.destination_configuration
+        )
 
 
 class InitializedAirbyteDestination:

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/types.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/types.py
@@ -1,5 +1,6 @@
 import json
 from abc import ABC
+from enum import Enum
 from typing import Any, Dict, List, Mapping, Optional, Union
 
 import dagster._check as check

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/example_stacks/example_airbyte_stack.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/example_stacks/example_airbyte_stack.py
@@ -123,7 +123,7 @@ dest_default_local_json_conn = AirbyteConnection(
     source=local_json_source,
     destination=local_json_destination,
     stream_config={
-        "my_data_stream": AirbyteSyncMode.FULL_REFRESH_APPEND,
+        "my_data_stream": AirbyteSyncMode.full_refresh_append(),
     },
     normalize_data=False,
     destination_namespace=AirbyteDestinationNamespace.DESTINATION_DEFAULT,
@@ -145,7 +145,7 @@ custom_namespace_local_json_conn = AirbyteConnection(
     source=local_json_source,
     destination=local_json_destination,
     stream_config={
-        "my_data_stream": AirbyteSyncMode.FULL_REFRESH_APPEND,
+        "my_data_stream": AirbyteSyncMode.full_refresh_append(),
     },
     normalize_data=False,
     destination_namespace="my-cool-namespace",

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/example_stacks/example_airbyte_stack.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/example_stacks/example_airbyte_stack.py
@@ -41,7 +41,7 @@ local_json_conn = AirbyteConnection(
     source=local_json_source,
     destination=local_json_destination,
     stream_config={
-        "my_data_stream": AirbyteSyncMode.FULL_REFRESH_APPEND,
+        "my_data_stream": AirbyteSyncMode.full_refresh_append(),
     },
     normalize_data=False,
 )
@@ -74,7 +74,7 @@ alt_source_local_json_conn = AirbyteConnection(
     source=alternate_local_json_source,
     destination=local_json_destination,
     stream_config={
-        "my_data_stream": AirbyteSyncMode.FULL_REFRESH_APPEND,
+        "my_data_stream": AirbyteSyncMode.full_refresh_append(),
     },
     normalize_data=False,
 )
@@ -102,7 +102,7 @@ alt_dest_local_json_conn = AirbyteConnection(
     source=local_json_source,
     destination=alternate_local_json_destination,
     stream_config={
-        "my_data_stream": AirbyteSyncMode.FULL_REFRESH_APPEND,
+        "my_data_stream": AirbyteSyncMode.full_refresh_append(),
     },
     normalize_data=False,
 )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/example_stacks/example_airbyte_stack.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/example_stacks/example_airbyte_stack.py
@@ -159,3 +159,25 @@ reconciler_custom_namespace = AirbyteManagedElementReconciler(
     ],
     delete_unmentioned_resources=True,
 )
+
+
+# Version with different sync mode
+
+
+alt_sync_mode_local_json_conn = AirbyteConnection(
+    name="local-json-conn",
+    source=local_json_source,
+    destination=local_json_destination,
+    stream_config={
+        "my_data_stream": AirbyteSyncMode.incremental_append(cursor_field="foo"),
+    },
+    normalize_data=False,
+)
+
+reconciler_alt_sync_mode = AirbyteManagedElementReconciler(
+    airbyte=airbyte_instance,
+    connections=[
+        alt_sync_mode_local_json_conn,
+    ],
+    delete_unmentioned_resources=True,
+)

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/example_stacks/example_airbyte_stack_generated.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/example_stacks/example_airbyte_stack_generated.py
@@ -31,7 +31,7 @@ local_json_conn = AirbyteConnection(
         destination_path="/local/destination_file.json",
     ),
     stream_config={
-        "my_data_stream": AirbyteSyncMode.FULL_REFRESH_APPEND,
+        "my_data_stream": AirbyteSyncMode.full_refresh_append(),
     },
     normalize_data=False,
 )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/test_managed_elements.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/test_managed_elements.py
@@ -369,3 +369,42 @@ def test_change_destination_namespace(empty_airbyte_instance, airbyte_source_fil
 
     check_result = check(TEST_ROOT_DIR, "example_airbyte_stack:reconciler_custom_namespace")
     assert check_result == ManagedElementDiff()
+
+
+def test_sync_modes(docker_compose_airbyte_instance, airbyte_source_files):
+
+    # First, apply a stack and check that there's no diff after applying it
+    apply(TEST_ROOT_DIR, "example_airbyte_stack:reconciler")
+
+    check_result = check(TEST_ROOT_DIR, "example_airbyte_stack:reconciler")
+    assert ManagedElementDiff() == check_result
+
+    # Ensure that a different config has a diff
+    check_result = check(TEST_ROOT_DIR, "example_airbyte_stack:reconciler_alt_sync_mode")
+
+    config_dict = {
+        "local-json-conn": {
+            "streams": {
+                "my_data_stream": {
+                    "syncMode": "incremental",
+                    "cursorField": ["foo"],
+                }
+            },
+        },
+    }
+    dest_dict = {
+        "local-json-conn": {
+            "streams": {
+                "my_data_stream": {
+                    "syncMode": "full_refresh",
+                    "cursorField": [],
+                }
+            },
+        },
+    }
+    expected_result = diff_dicts(
+        config_dict,
+        dest_dict,
+    )
+
+    assert check_result == expected_result

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/test_managed_elements.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/test_managed_elements.py
@@ -142,7 +142,7 @@ def test_basic_integration(empty_airbyte_instance, airbyte_source_files, filenam
             "destination": "local-json-output",
             "normalize data": False,
             "streams": {
-                "my_data_stream": "FULL_REFRESH_APPEND",
+                "my_data_stream": {"syncMode": "full_refresh", "destinationSyncMode": "append"}
             },
             "destination namespace": "SAME_AS_SOURCE",
         },

--- a/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/utils.py
+++ b/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/utils.py
@@ -2,11 +2,13 @@ from typing import Any, Callable, Mapping, Optional
 
 from .types import ManagedElementDiff
 
+UNSET = object()
+
 
 def diff_dicts(
     config_dict: Optional[Mapping[str, Any]],
     dst_dict: Optional[Mapping[str, Any]],
-    custom_compare_fn: Optional[Callable[[str, Any, Any], bool]] = None,
+    custom_compare_fn: Optional[Callable[[str, Any, Any], Optional[bool]]] = None,
 ) -> ManagedElementDiff:
     """
     Utility function which builds a ManagedElementDiff given two dictionaries.
@@ -15,8 +17,10 @@ def diff_dicts(
         config_dict (Optional[Dict[str, Any]]): The dictionary from the user config.
         dst_dict (Optional[Dict[str, Any]]): The dictionary from the destination.
         custom_compare_fn (Optional[Callable[[Any, Any], bool]]): A custom comparison function to
-            use for comparing values in the dictionaries. Return True if the two values are the same.
-            Only used for non-None, non-dict values.
+            use for comparing values in the dictionaries. Passed both values, either of which might be
+            the sentinel "UNSET" value. Return True if the two values are the same.
+            Return False if the two values are different. Return None if the function should not
+            handle the comparison.
     """
     diff = ManagedElementDiff()
 
@@ -45,12 +49,21 @@ def diff_dicts(
             if not nested_diff.is_empty():
                 diff = diff.with_nested(key, nested_diff)
         # Handle non-dict values
-        elif key not in config_dict:
-            diff = diff.delete(key, dst_dict[key])
-        elif key not in dst_dict:
-            diff = diff.add(key, config_dict[key])
-        elif config_dict[key] != dst_dict[key] and (
-            not custom_compare_fn or not custom_compare_fn(key, config_dict[key], dst_dict[key])
-        ):
-            diff = diff.modify(key, dst_dict[key], config_dict[key])
+        else:
+            custom_compare_result = (
+                custom_compare_fn(key, config_dict.get(key, UNSET), dst_dict.get(key, UNSET))
+                if custom_compare_fn
+                else None
+            )
+            if custom_compare_result is False:
+                diff = diff.modify(key, dst_dict[key], config_dict[key])
+            elif custom_compare_result is True:
+                pass
+            else:
+                if key not in config_dict:
+                    diff = diff.delete(key, dst_dict[key])
+                elif key not in dst_dict:
+                    diff = diff.add(key, config_dict[key])
+                elif config_dict[key] != dst_dict[key]:
+                    diff = diff.modify(key, dst_dict[key], config_dict[key])
     return diff

--- a/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/utils.py
+++ b/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/utils.py
@@ -56,7 +56,12 @@ def diff_dicts(
                 else None
             )
             if custom_compare_result is False:
-                diff = diff.modify(key, dst_dict[key], config_dict[key])
+                if key not in config_dict:
+                    diff = diff.delete(key, dst_dict[key])
+                elif key not in dst_dict:
+                    diff = diff.add(key, config_dict[key])
+                else:
+                    diff = diff.modify(key, dst_dict[key], config_dict[key])
             elif custom_compare_result is True:
                 pass
             else:


### PR DESCRIPTION
## Summary

Moves the list of sync modes from an enum to a list of class methods, some of which take parameters, to allow a user to specify the cursor field and primary key for an Airbyte managed connection.

Before:

```python
local_json_comm = AirbyteConnection(
    name="local-json-conn",
    source=local_json_source,
    destination=local_json_destination,
    stream_config={
        "my_data_stream": AirbyteSyncMode.INCREMENTAL_APPEND
    },
    normalize_data=False,
)
```

After:
```python
local_json_comm = AirbyteConnection(
    name="local-json-conn",
    source=local_json_source,
    destination=local_json_destination,
    stream_config={
        "my_data_stream": AirbyteSyncMode.incremental_append(cursor_field="foo"),
    },
    normalize_data=False,
)
```

## Test Plan

New integration test.
