### PR TITLE
Pull out k8s_job_op implementation into its own function for use in other ops

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-k8s.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-k8s.rst
@@ -22,6 +22,8 @@ Ops
 
 .. autoconfigurable:: k8s_job_op
 
+.. autofunction:: execute_k8s_job
+
 Python API
 ^^^^^^^^^^
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/__init__.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/__init__.py
@@ -3,7 +3,7 @@ from dagster._core.utils import check_dagster_package_version
 from .executor import k8s_job_executor
 from .job import DagsterK8sJobConfig, construct_dagster_k8s_job
 from .launcher import K8sRunLauncher
-from .ops.k8s_job_op import k8s_job_op
+from .ops import execute_k8s_job, k8s_job_op
 from .version import __version__
 
 check_dagster_package_version("dagster-k8s", __version__)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/__init__.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/__init__.py
@@ -1,1 +1,1 @@
-from .k8s_job_op import k8s_job_op
+from .k8s_job_op import execute_k8s_job, k8s_job_op

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -1,8 +1,9 @@
 import time
+from typing import Any, Dict, List, Optional
 
 import kubernetes
 
-from dagster import Field, In, Noneable, Nothing, Permissive, StringSource, op
+from dagster import Field, In, Noneable, Nothing, OpExecutionContext, Permissive, StringSource, op
 from dagster._annotations import experimental
 from dagster._utils import merge_dicts
 
@@ -21,105 +22,168 @@ from ..utils import (
     wait_for_running_job_to_succeed,
 )
 
-
-@op(
-    ins={"start_after": In(Nothing)},
-    config_schema=merge_dicts(
-        DagsterK8sJobConfig.config_type_container(),
-        {
-            "image": Field(
-                StringSource,
-                is_required=True,
-                description="The image in which to launch the k8s job.",
-            ),
-            "command": Field(
-                [str],
-                is_required=False,
-                description="The command to run in the container within the launched k8s job.",
-            ),
-            "args": Field(
-                [str],
-                is_required=False,
-                description="The args for the command for the container.",
-            ),
-            "namespace": Field(StringSource, is_required=False),
-            "load_incluster_config": Field(
-                bool,
-                is_required=False,
-                default_value=True,
-                description="""Set this value if you are running the launcher
+K8S_JOB_OP_CONFIG = merge_dicts(
+    DagsterK8sJobConfig.config_type_container(),
+    {
+        "image": Field(
+            StringSource,
+            is_required=True,
+            description="The image in which to launch the k8s job.",
+        ),
+        "command": Field(
+            [str],
+            is_required=False,
+            description="The command to run in the container within the launched k8s job.",
+        ),
+        "args": Field(
+            [str],
+            is_required=False,
+            description="The args for the command for the container.",
+        ),
+        "namespace": Field(StringSource, is_required=False),
+        "load_incluster_config": Field(
+            bool,
+            is_required=False,
+            default_value=True,
+            description="""Set this value if you are running the launcher
             within a k8s cluster. If ``True``, we assume the launcher is running within the target
             cluster and load config using ``kubernetes.config.load_incluster_config``. Otherwise,
             we will use the k8s config specified in ``kubeconfig_file`` (using
             ``kubernetes.config.load_kube_config``) or fall back to the default kubeconfig.""",
-            ),
-            "kubeconfig_file": Field(
-                Noneable(str),
-                is_required=False,
-                default_value=None,
-                description="The kubeconfig file from which to load config. Defaults to using the default kubeconfig.",
-            ),
-            "timeout": Field(
-                int,
-                is_required=False,
-                description="How long to wait for the job to succeed before raising an exception",
-            ),
-            "container_config": Field(
-                Permissive(),
-                is_required=False,
-                description="Raw k8s config for the k8s pod's main container (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core). Keys can either snake_case or camelCase.",
-            ),
-            "pod_template_spec_metadata": Field(
-                Permissive(),
-                is_required=False,
-                description="Raw k8s config for the k8s pod's metadata (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta). Keys can either snake_case or camelCase.",
-            ),
-            "pod_spec_config": Field(
-                Permissive(),
-                is_required=False,
-                description="Raw k8s config for the k8s pod's pod spec (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podspec-v1-core). Keys can either snake_case or camelCase.",
-            ),
-            "job_metadata": Field(
-                Permissive(),
-                is_required=False,
-                description="Raw k8s config for the k8s job's metadata (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta). Keys can either snake_case or camelCase.",
-            ),
-            "job_spec_config": Field(
-                Permissive(),
-                is_required=False,
-                description="Raw k8s config for the k8s job's job spec (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#jobspec-v1-batch). Keys can either snake_case or camelCase.",
-            ),
-        },
-    ),
+        ),
+        "kubeconfig_file": Field(
+            Noneable(str),
+            is_required=False,
+            default_value=None,
+            description="The kubeconfig file from which to load config. Defaults to using the default kubeconfig.",
+        ),
+        "timeout": Field(
+            int,
+            is_required=False,
+            description="How long to wait for the job to succeed before raising an exception",
+        ),
+        "container_config": Field(
+            Permissive(),
+            is_required=False,
+            description="Raw k8s config for the k8s pod's main container (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core). Keys can either snake_case or camelCase.",
+        ),
+        "pod_template_spec_metadata": Field(
+            Permissive(),
+            is_required=False,
+            description="Raw k8s config for the k8s pod's metadata (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta). Keys can either snake_case or camelCase.",
+        ),
+        "pod_spec_config": Field(
+            Permissive(),
+            is_required=False,
+            description="Raw k8s config for the k8s pod's pod spec (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podspec-v1-core). Keys can either snake_case or camelCase.",
+        ),
+        "job_metadata": Field(
+            Permissive(),
+            is_required=False,
+            description="Raw k8s config for the k8s job's metadata (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta). Keys can either snake_case or camelCase.",
+        ),
+        "job_spec_config": Field(
+            Permissive(),
+            is_required=False,
+            description="Raw k8s config for the k8s job's job spec (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#jobspec-v1-batch). Keys can either snake_case or camelCase.",
+        ),
+    },
 )
+
+
 @experimental
-def k8s_job_op(context):
+def execute_k8s_job(
+    context: OpExecutionContext,
+    image: str,
+    command: Optional[List[str]] = None,
+    args: Optional[List[str]] = None,
+    namespace: Optional[str] = None,
+    image_pull_policy: Optional[str] = None,
+    image_pull_secrets: Optional[List[Dict[str, str]]] = None,
+    service_account_name: Optional[str] = None,
+    env_config_maps: Optional[List[str]] = None,
+    env_secrets: Optional[List[str]] = None,
+    env_vars: Optional[List[str]] = None,
+    volume_mounts: Optional[List[Dict[str, Any]]] = None,
+    volumes: Optional[List[Dict[str, Any]]] = None,
+    labels: Optional[Dict[str, str]] = None,
+    resources: Optional[Dict[str, Any]] = None,
+    scheduler_name: Optional[str] = None,
+    load_incluster_config: bool = True,
+    kubeconfig_file: Optional[str] = None,
+    timeout: Optional[int] = None,
+    container_config: Optional[Dict[str, Any]] = None,
+    pod_template_spec_metadata: Optional[Dict[str, Any]] = None,
+    pod_spec_config: Optional[Dict[str, Any]] = None,
+    job_metadata: Optional[Dict[str, Any]] = None,
+    job_spec_config: Optional[Dict[str, Any]] = None,
+):
     """
-    An op that runs a Kubernetes job using the k8s API.
+    This function is a utility for executing a Kubernetes job from within a Dagster op.
 
-    Contrast with the `k8s_job_executor`, which runs each Dagster op in a Dagster job in its
-    own k8s job.
-
-    This op may be useful when:
-      - You need to orchestrate a command that isn't a Dagster op (or isn't written in Python)
-      - You want to run the rest of a Dagster job using a specific executor, and only a single
-        op in k8s.
-
-    For example:
-
-    .. literalinclude:: ../../../../../../python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_example_k8s_job_op.py
-      :start-after: start_marker
-      :end-before: end_marker
-      :language: python
-
-    The service account that is used to run this job should have the following RBAC permissions:
-
-    .. literalinclude:: ../../../../../../examples/docs_snippets/docs_snippets/deploying/kubernetes/k8s_job_op_rbac.yaml
-       :language: YAML
+    Args:
+        image (str): The image in which to launch the k8s job.
+        command (Optional[List[str]]): The command to run in the container within the launched
+            k8s job. Default: None.
+        args (Optional[List[str]]): The args for the command for the container. Default: None.
+        namespace (Optional[str]): Override the kubernetes namespace in which to run the k8s job.
+            Default: None.
+        image_pull_policy (Optional[str]): Allows the image pull policy to be overridden, e.g. to
+            facilitate local testing with `kind <https://kind.sigs.k8s.io/>`_. Default:
+            ``"Always"``. See:
+            https://kubernetes.io/docs/concepts/containers/images/#updating-images.
+        image_pull_secrets (Optional[List[Dict[str, str]]]): Optionally, a list of dicts, each of
+            which corresponds to a Kubernetes ``LocalObjectReference`` (e.g.,
+            ``{'name': 'myRegistryName'}``). This allows you to specify the ```imagePullSecrets`` on
+            a pod basis. Typically, these will be provided through the service account, when needed,
+            and you will not need to pass this argument. See:
+            https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+            and https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#podspec-v1-core
+        service_account_name (Optional[str]): The name of the Kubernetes service account under which
+            to run the Job. Defaults to "default"        env_config_maps (Optional[List[str]]): A list of custom ConfigMapEnvSource names from which to
+            draw environment variables (using ``envFrom``) for the Job. Default: ``[]``. See:
+            https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#define-an-environment-variable-for-a-container
+        env_secrets (Optional[List[str]]): A list of custom Secret names from which to
+            draw environment variables (using ``envFrom``) for the Job. Default: ``[]``. See:
+            https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
+        env_vars (Optional[List[str]]): A list of environment variables to inject into the Job.
+            Default: ``[]``. See: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
+        volume_mounts (Optional[List[Permissive]]): A list of volume mounts to include in the job's
+            container. Default: ``[]``. See:
+            https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core
+        volumes (Optional[List[Permissive]]): A list of volumes to include in the Job's Pod. Default: ``[]``. See:
+            https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core
+        labels (Optional[Dict[str, str]]): Additional labels that should be included in the Job's Pod. See:
+            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+        resources (Optional[Dict[str, Any]]) Compute resource requirements for the container. See:
+            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        scheduler_name (Optional[str]): Use a custom Kubernetes scheduler for launched Pods. See:
+            https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/
+        load_incluster_config (bool): Whether the op is running within a k8s cluster. If ``True``,
+            we assume the launcher is running within the target cluster and load config using
+            ``kubernetes.config.load_incluster_config``. Otherwise, we will use the k8s config
+            specified in ``kubeconfig_file`` (using ``kubernetes.config.load_kube_config``) or fall
+            back to the default kubeconfig. Default: True,
+        kubeconfig_file (Optional[str]): The kubeconfig file from which to load config. Defaults to
+            using the default kubeconfig. Default: None.
+        timeout (Optional[int]): Raise an exception if the op takes longer than this timeout in
+            seconds to execute. Default: None.
+        container_config (Optional[Dict[str, Any]]): Raw k8s config for the k8s pod's main container
+            (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core).
+            Keys can either snake_case or camelCase.Default: None.
+        pod_template_spec_metadata (Optional[Dict[str, Any]]): Raw k8s config for the k8s pod's
+            metadata (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta).
+            Keys can either snake_case or camelCase. Default: None.
+        pod_spec_config (Optional[Dict[str, Any]]): Raw k8s config for the k8s pod's pod spec
+            (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podspec-v1-core).
+            Keys can either snake_case or camelCase. Default: None.
+        job_metadata (Optional[Dict[str, Any]]): aw k8s config for the k8s job's metadata
+            (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta).
+            Keys can either snake_case or camelCase. Default: None.
+        job_spec_config (Optional[Dict[str, Any]]): Raw k8s config for the k8s job's job spec
+            (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#jobspec-v1-batch).
+            Keys can either snake_case or camelCase.Default: None.
     """
-
-    config = context.op_config
-
     run_container_context = K8sContainerContext.create_for_run(
         context.pipeline_run,
         context.instance.run_launcher
@@ -128,38 +192,38 @@ def k8s_job_op(context):
     )
 
     op_container_context = K8sContainerContext(
-        image_pull_policy=config.get("image_pull_policy"),  # type: ignore
-        image_pull_secrets=config.get("image_pull_secrets"),  # type: ignore
-        service_account_name=config.get("service_account_name"),  # type: ignore
-        env_config_maps=config.get("env_config_maps"),  # type: ignore
-        env_secrets=config.get("env_secrets"),  # type: ignore
-        env_vars=config.get("env_vars"),  # type: ignore
-        volume_mounts=config.get("volume_mounts"),  # type: ignore
-        volumes=config.get("volumes"),  # type: ignore
-        labels=config.get("labels"),  # type: ignore
-        namespace=config.get("namespace"),  # type: ignore
-        resources=config.get("resources"),  # type: ignore
+        image_pull_policy=image_pull_policy,
+        image_pull_secrets=image_pull_secrets,
+        service_account_name=service_account_name,
+        env_config_maps=env_config_maps,
+        env_secrets=env_secrets,
+        env_vars=env_vars,
+        volume_mounts=volume_mounts,
+        volumes=volumes,
+        labels=labels,
+        namespace=namespace,
+        resources=resources,
+        scheduler_name=scheduler_name,
     )
 
     container_context = run_container_context.merge(op_container_context)
 
     namespace = container_context.namespace
 
-    container_config = config.get("container_config", {})
-    command = config.get("command")
+    container_config = container_config or {}
     if command:
         container_config["command"] = command
 
     user_defined_k8s_config = UserDefinedDagsterK8sConfig(
         container_config=container_config,
-        pod_template_spec_metadata=config.get("pod_template_spec_metadata"),
-        pod_spec_config=config.get("pod_spec_config"),
-        job_metadata=config.get("job_metadata"),
-        job_spec_config=config.get("job_spec_config"),
+        pod_template_spec_metadata=pod_template_spec_metadata,
+        pod_spec_config=pod_spec_config,
+        job_metadata=job_metadata,
+        job_spec_config=job_spec_config,
     )
 
     k8s_job_config = DagsterK8sJobConfig(
-        job_image=config["image"],
+        job_image=image,
         dagster_home=None,
         image_pull_policy=container_context.image_pull_policy,
         image_pull_secrets=container_context.image_pull_secrets,
@@ -179,7 +243,7 @@ def k8s_job_op(context):
 
     job = construct_dagster_k8s_job(
         job_config=k8s_job_config,
-        args=config.get("args"),
+        args=args,
         job_name=job_name,
         pod_name=job_name,
         component="k8s_job_op",
@@ -191,10 +255,10 @@ def k8s_job_op(context):
         },
     )
 
-    if config["load_incluster_config"]:
+    if load_incluster_config:
         kubernetes.config.load_incluster_config()
     else:
-        kubernetes.config.load_kube_config(config.get("kubeconfig_file"))
+        kubernetes.config.load_kube_config(kubeconfig_file)
 
     context.log.info(f"Creating Kubernetes job {job_name} in namespace {namespace}...")
 
@@ -206,7 +270,7 @@ def k8s_job_op(context):
 
     context.log.info("Waiting for Kubernetes job to finish...")
 
-    timeout = config.get("timeout", 0)
+    timeout = timeout or 0
 
     wait_for_job(
         job_name=job_name,
@@ -253,3 +317,35 @@ def k8s_job_op(context):
         wait_timeout=timeout,
         start_time=start_time,
     )
+
+
+@op(ins={"start_after": In(Nothing)}, config_schema=K8S_JOB_OP_CONFIG)
+@experimental
+def k8s_job_op(context):
+    """
+    An op that runs a Kubernetes job using the k8s API.
+
+    Contrast with the `k8s_job_executor`, which runs each Dagster op in a Dagster job in its
+    own k8s job.
+
+    This op may be useful when:
+      - You need to orchestrate a command that isn't a Dagster op (or isn't written in Python)
+      - You want to run the rest of a Dagster job using a specific executor, and only a single
+        op in k8s.
+
+    You can create your own op with the same implementation by calling the `execute_k8s_job` function
+    inside your own op.
+
+    For example:
+
+    .. literalinclude:: ../../../../../../python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_example_k8s_job_op.py
+      :start-after: start_marker
+      :end-before: end_marker
+      :language: python
+
+    The service account that is used to run this job should have the following RBAC permissions:
+
+    .. literalinclude:: ../../../../../../examples/docs_snippets/docs_snippets/deploying/kubernetes/k8s_job_op_rbac.yaml
+       :language: YAML
+    """
+    execute_k8s_job(context, **context.op_config)


### PR DESCRIPTION
Summary:
There have been several requests to write ops that are like k8s_job_op but different - e.g. using inputs from other ops, adding a retry policy, etc. - this is one attempt to satisfy those requests, by pulling out the actual meat of k8s_job_op into its own method.

We could alternately consider some way of composing or adjusting an op definition into a new op definition, kind of like configured but for other definition fields.

### Summary & Motivation

### How I Tested These Changes
