### PR TITLE
feat(dbt-cloud): forward selector options to compile step

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -407,7 +407,7 @@ class DbtCloudResourceV2:
 
             # completed successfully
             if status == "Success":
-                return self.get_run(run_id, include_related=["job", "trigger"])
+                return self.get_run(run_id, include_related=["job", "trigger", "run_steps"])
             elif status in ["Error", "Cancelled"]:
                 break
             elif status not in ["Queued", "Starting", "Running"]:


### PR DESCRIPTION
### Summary & Motivation
The ad hoc `dbt compile` step should respect any filters that are passed in as arguments into the dbt Cloud job's `dbt run` or `dbt build` step.

Here, we follow up on https://github.com/dagster-io/dagster/pull/10487#issuecomment-1313992947.

### How I Tested These Changes
pytest