### PR TITLE
fix pandas test using dagstermill solid

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/notebooks.py
+++ b/python_modules/dagster-test/dagster_test/toys/notebooks.py
@@ -1,8 +1,8 @@
-from dagstermill.factory import define_dagstermill_solid
+from dagstermill.factory import define_dagstermill_op
 
 from dagster._legacy import pipeline
 
-hello_world_notebook_solid = define_dagstermill_solid(
+hello_world_notebook_solid = define_dagstermill_op(
     "hello_world_notebook_solid", "hello_world.ipynb"
 )
 

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/examples/pandas_hello_world/ops.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/examples/pandas_hello_world/ops.py
@@ -2,7 +2,6 @@ import dagster_pandas as dagster_pd
 import dagstermill
 
 from dagster import In, Out, file_relative_path, op
-from dagster._legacy import InputDefinition, OutputDefinition
 
 from ...data_frame import DataFrame
 
@@ -39,9 +38,9 @@ def nb_test_path(name):
     return file_relative_path(__file__, "../notebooks/{name}.ipynb".format(name=name))
 
 
-papermill_pandas_hello_world = dagstermill.factory.define_dagstermill_solid(
+papermill_pandas_hello_world = dagstermill.factory.define_dagstermill_op(
     name="papermill_pandas_hello_world",
     notebook_path=nb_test_path("papermill_pandas_hello_world"),
-    input_defs=[InputDefinition(name="df", dagster_type=DataFrame)],
-    output_defs=[OutputDefinition(DataFrame)],
+    ins={"df": In(DataFrame)},
+    outs={"result": Out(DataFrame)},
 )


### PR DESCRIPTION
### Summary & Motivation
a test in dagster-pandas uses dagstermill, update to use `define_dagstermill_op` instead of `define_dagstermill_solid`. I also found another instance in the toys repo, so switched that too

### How I Tested These Changes
