### PR TITLE
Add experimental register_definitions

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -281,6 +281,9 @@ from dagster._core.definitions.reconstruct import (
     build_reconstructable_job as build_reconstructable_job,
     reconstructable as reconstructable,
 )
+from dagster._core.definitions.register_definitions import (
+    register_definitions as register_definitions,
+)
 from dagster._core.definitions.repository_definition import (
     RepositoryData as RepositoryData,
     RepositoryDefinition as RepositoryDefinition,

--- a/python_modules/dagster/dagster/_core/definitions/register_definitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/register_definitions.py
@@ -6,6 +6,7 @@ from types import ModuleType
 from typing import Any, Dict, Iterable, Mapping, Optional, Union
 
 import dagster._check as check
+from dagster._annotations import experimental
 from dagster._core.execution.with_resources import with_resources
 
 from .assets import AssetsDefinition, SourceAsset
@@ -43,6 +44,7 @@ def get_module_name_of_caller() -> str:
     return back_back_frame.f_globals["__name__"]
 
 
+# @experimental
 def register_definitions(
     *,
     assets: Optional[

--- a/python_modules/dagster/dagster/_core/definitions/register_definitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/register_definitions.py
@@ -3,24 +3,19 @@ import sys
 from collections.abc import Generator
 from contextlib import contextmanager
 from types import ModuleType
-from typing import Any, Iterable, Mapping, Optional, Union, Dict
+from typing import Any, Dict, Iterable, Mapping, Optional, Union
 
 import dagster._check as check
-
 from dagster._core.execution.with_resources import with_resources
 
 from .assets import AssetsDefinition, SourceAsset
 from .cacheable_assets import CacheableAssetsDefinition
-
 from .decorators import repository
 from .job_definition import JobDefinition
-
+from .repository_definition import PendingRepositoryDefinition, RepositoryDefinition
 from .resource_definition import ResourceDefinition
 from .schedule_definition import ScheduleDefinition
 from .sensor_definition import SensorDefinition
-
-from .repository_definition import PendingRepositoryDefinition, RepositoryDefinition
-
 
 MAGIC_REGISTERED_DEFINITIONS_KEY = "__registered_definitions"
 
@@ -73,13 +68,6 @@ def register_definitions(
     or
 
     (2) A module that contains an explicit call to register_definitions.
-
-    alts:
-    dagsterify_module
-    make_module_loadable
-    defined_loadable_module
-    definitions_in_module
-    register_definitions
 
     For anything beyond lightweight testing and exploration, the use of register_definitions
     is strongly recommended.

--- a/python_modules/dagster/dagster/_core/definitions/register_definitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/register_definitions.py
@@ -1,9 +1,7 @@
 import inspect
 import sys
-from collections.abc import Generator
 from contextlib import contextmanager
-from types import ModuleType
-from typing import Any, Dict, Iterable, Mapping, Optional, Union
+from typing import Any, Dict, Generator, Iterable, Mapping, Optional, Union
 
 import dagster._check as check
 from dagster._annotations import experimental

--- a/python_modules/dagster/dagster/_core/definitions/register_definitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/register_definitions.py
@@ -29,7 +29,7 @@ class ModuleHasRegisteredDefinitionsError(Exception):
 # scope
 def get_module_name_of_caller() -> str:
     # based on https://stackoverflow.com/questions/2000861/retrieve-module-object-from-stack-frame
-    # two f_backs to get past get_module_name_of_caller frame
+    # three f_backs to get past get_module_name_of_caller and @experimental frame
 
     # Need to do none checking because of:
     # https://docs.python.org/3/library/inspect.html#inspect.currentframe
@@ -39,12 +39,13 @@ def get_module_name_of_caller() -> str:
     # Python stack frame support this function returns None.
 
     frame = check.not_none(inspect.currentframe(), NO_STACK_FRAME_ERROR_MSG)
-    back_frame = check.not_none(frame.f_back, NO_STACK_FRAME_ERROR_MSG)
-    back_back_frame = check.not_none(back_frame.f_back, NO_STACK_FRAME_ERROR_MSG)
-    return back_back_frame.f_globals["__name__"]
+    register_definitions_frame = check.not_none(frame.f_back, NO_STACK_FRAME_ERROR_MSG)
+    experimental_frame = check.not_none(register_definitions_frame.f_back, NO_STACK_FRAME_ERROR_MSG)
+    caller_frame = check.not_none(experimental_frame.f_back, NO_STACK_FRAME_ERROR_MSG)
+    return caller_frame.f_globals["__name__"]
 
 
-# @experimental
+@experimental
 def register_definitions(
     *,
     assets: Optional[

--- a/python_modules/dagster/dagster/_core/definitions/register_definitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/register_definitions.py
@@ -25,14 +25,15 @@ class ModuleHasRegisteredDefinitionsError(Exception):
     pass
 
 
-# invoke this function to get the module name the function that called the current
-# scope
-def get_module_name_of_caller() -> str:
+# invoke this function to get the module name the function
+# that called regsiter_definitions
+def get_module_name_of_registered_definitions_caller() -> str:
     # based on https://stackoverflow.com/questions/2000861/retrieve-module-object-from-stack-frame
-    # three f_backs to get past get_module_name_of_caller and @experimental frame
+    # three f_backs to get past registered_definitions and @experimental frame
 
-    # Need to do none checking because of:
+    # Need to do None checking because of:
     # https://docs.python.org/3/library/inspect.html#inspect.currentframe
+    # Relevant comment is:
     # CPython implementation detail: This function relies on Python stack frame
     # support in the interpreter, which isn’t guaranteed to exist in all
     # implementations of Python. If running in an implementation without
@@ -61,9 +62,8 @@ def register_definitions(
 
     Dagster separates user-defined code from system tools such the web server and
     the daemon. These tools must be able to locate and load this code when they start.
-    Python modules that dagster tools can load are known as "code locations".
 
-    A code location is defined as a python module that has either:
+    A python module is loadable by dagster tools if:
 
     (1) Has one or more dagster definitions as module-level attributes (e.g. a function
     declared at the top-level of a module decorated with @asset).
@@ -87,7 +87,7 @@ def register_definitions(
     Invoking this function dynamically injects an attribute named "__registered_definitions" into
     the calling module that contains a handle to the definitions.
     """
-    module_name = get_module_name_of_caller()
+    module_name = get_module_name_of_registered_definitions_caller()
     python_module = sys.modules[module_name]
 
     if MAGIC_REGISTERED_DEFINITIONS_KEY in python_module.__dict__:

--- a/python_modules/dagster/dagster/_core/definitions/register_definitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/register_definitions.py
@@ -1,23 +1,51 @@
 import inspect
+import sys
+from collections.abc import Generator
+from contextlib import contextmanager
 from types import ModuleType
-from typing import Any, Iterable, Mapping, Optional, Union
+from typing import Any, Iterable, Mapping, Optional, Union, Dict
 
 import dagster._check as check
+
+from dagster._core.execution.with_resources import with_resources
 
 from .assets import AssetsDefinition, SourceAsset
 from .cacheable_assets import CacheableAssetsDefinition
 
-# from .decorators import repository
+from .decorators import repository
 from .job_definition import JobDefinition
 
-# from .resource_definition import ResourceDefinition
+from .resource_definition import ResourceDefinition
 from .schedule_definition import ScheduleDefinition
 from .sensor_definition import SensorDefinition
 
-# from .repository_definition import PendingRepositoryDefinition, RepositoryDefinition
+from .repository_definition import PendingRepositoryDefinition, RepositoryDefinition
 
 
 MAGIC_REGISTERED_DEFINITIONS_KEY = "__registered_definitions"
+
+
+class ModuleHasRegisteredDefinitionsError(Exception):
+    pass
+
+
+# invoke this function to get the module name the function that called the current
+# scope
+def get_module_name_of_caller() -> str:
+    # based on https://stackoverflow.com/questions/2000861/retrieve-module-object-from-stack-frame
+    # two f_backs to get past get_module_name_of_caller frame
+
+    # Need to do none checking because of:
+    # https://docs.python.org/3/library/inspect.html#inspect.currentframe
+    # CPython implementation detail: This function relies on Python stack frame
+    # support in the interpreter, which isn’t guaranteed to exist in all
+    # implementations of Python. If running in an implementation without
+    # Python stack frame support this function returns None.
+
+    frame = check.not_none(inspect.currentframe(), NO_STACK_FRAME_ERROR_MSG)
+    back_frame = check.not_none(frame.f_back, NO_STACK_FRAME_ERROR_MSG)
+    back_back_frame = check.not_none(back_frame.f_back, NO_STACK_FRAME_ERROR_MSG)
+    return back_back_frame.f_globals["__name__"]
 
 
 def register_definitions(
@@ -68,25 +96,74 @@ def register_definitions(
     Invoking this function dynamically injects an attribute named "__registered_definitions" into
     the calling module that contains a handle to the definitions.
     """
-    raise NotImplementedError("Not implemented yet")
+    module_name = get_module_name_of_caller()
+    python_module = sys.modules[module_name]
+
+    if MAGIC_REGISTERED_DEFINITIONS_KEY in python_module.__dict__:
+        raise ModuleHasRegisteredDefinitionsError(
+            f"Python module {module_name} already has registered definitions, likely because of a previous call to register_definitions"
+        )
+
+    # This grabs last component of a module name (typically the name
+    # of the file) and uses it for the repository name. Code locations
+    # defined with register_definitions will only have 1 repository defined. And
+    # the web UI will not expose the concept of repository anywhere. In those
+    # cases the name of the repository is immaterial. If the legacy UI is loaded
+    # the repository will have a sensible enough name, but explicitly overriding
+    # that name is not worth polluting this new, cleaner API.
+    repo_name = module_name.split(".")[-1] if "." in module_name else module_name
+
+    resource_defs = coerce_resources_to_defs(resources or {})
+
+    @repository(name=repo_name)
+    def registered_repository():
+        return [
+            *with_resources(assets or [], resource_defs),
+            *(schedules or []),
+            *(sensors or []),
+            *(jobs or []),
+        ]
+
+    python_module.__dict__[MAGIC_REGISTERED_DEFINITIONS_KEY] = registered_repository
 
 
 NO_STACK_FRAME_ERROR_MSG = "Python interpreter must support Python stack frames. Python interpreters that are not CPython do not necessarily implement the necessary APIs."
 
-# invoke this function to get the module name the function that called the current
-# scope
-def get_module_name_of_caller() -> str:
-    # based on https://stackoverflow.com/questions/2000861/retrieve-module-object-from-stack-frame
-    # two f_backs to get past get_module_name_of_caller frame
 
-    # Need to do none checking because of:
-    # https://docs.python.org/3/library/inspect.html#inspect.currentframe
-    # CPython implementation detail: This function relies on Python stack frame
-    # support in the interpreter, which isn’t guaranteed to exist in all
-    # implementations of Python. If running in an implementation without
-    # Python stack frame support this function returns None.
+@contextmanager
+def register_definitions_test_scope(dundername: str) -> Generator[None, None, None]:
+    """
+    A testing utility. Intended usage:
 
-    frame = check.not_none(inspect.currentframe(), NO_STACK_FRAME_ERROR_MSG)
-    back_frame = check.not_none(frame.f_back, NO_STACK_FRAME_ERROR_MSG)
-    back_back_frame = check.not_none(back_frame.f_back, NO_STACK_FRAME_ERROR_MSG)
-    return back_back_frame.f_globals["__name__"]
+    with register_definitions_test_scope(__name__):
+        register_definitions(...)
+
+    This function ensures that no definitions have been registered
+    in the current module. Then in the with block the test can invoke
+    register_definitions. Upon exiting the with both the registered definitions
+    in that module are "unregistered" by deleting the magic attribute.
+    """
+    parent_mod = sys.modules[dundername]
+    assert MAGIC_REGISTERED_DEFINITIONS_KEY not in parent_mod.__dict__
+    try:
+        yield
+    finally:
+        if MAGIC_REGISTERED_DEFINITIONS_KEY in parent_mod.__dict__:
+            del parent_mod.__dict__[MAGIC_REGISTERED_DEFINITIONS_KEY]
+
+
+def get_registered_repository_in_module(
+    module_name: str,
+) -> Union[RepositoryDefinition, PendingRepositoryDefinition]:
+    return sys.modules[module_name].__dict__[MAGIC_REGISTERED_DEFINITIONS_KEY]
+
+
+def coerce_resources_to_defs(resources: Mapping[str, Any]) -> Dict[str, ResourceDefinition]:
+    resource_defs = {}
+    for key, resource_obj in resources.items():
+        resource_defs[key] = (
+            resource_obj
+            if isinstance(resource_obj, ResourceDefinition)
+            else ResourceDefinition.hardcoded_resource(resource_obj)
+        )
+    return resource_defs

--- a/python_modules/dagster/dagster/_core/definitions/register_definitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/register_definitions.py
@@ -1,0 +1,92 @@
+import inspect
+from types import ModuleType
+from typing import Any, Iterable, Mapping, Optional, Union
+
+import dagster._check as check
+
+from .assets import AssetsDefinition, SourceAsset
+from .cacheable_assets import CacheableAssetsDefinition
+
+# from .decorators import repository
+from .job_definition import JobDefinition
+
+# from .resource_definition import ResourceDefinition
+from .schedule_definition import ScheduleDefinition
+from .sensor_definition import SensorDefinition
+
+# from .repository_definition import PendingRepositoryDefinition, RepositoryDefinition
+
+
+MAGIC_REGISTERED_DEFINITIONS_KEY = "__registered_definitions"
+
+
+def register_definitions(
+    *,
+    assets: Optional[
+        Iterable[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]
+    ] = None,
+    schedules: Optional[Iterable[ScheduleDefinition]] = None,
+    sensors: Optional[Iterable[SensorDefinition]] = None,
+    jobs: Optional[Iterable[JobDefinition]] = None,
+    resources: Optional[Mapping[str, Any]] = None,
+) -> None:
+    """
+    Make a set of definitions explicitly available and loadable by dagster tools.
+
+    Dagster separates user-defined code from system tools such the web server and
+    the daemon. These tools must be able to locate and load this code when they start.
+    Python modules that dagster tools can load are known as "code locations".
+
+    A code location is defined as a python module that has either:
+
+    (1) Has one or more dagster definitions as module-level attributes (e.g. a function
+    declared at the top-level of a module decorated with @asset).
+
+    or
+
+    (2) A module that contains an explicit call to register_definitions.
+
+    alts:
+    dagsterify_module
+    make_module_loadable
+    defined_loadable_module
+    definitions_in_module
+    register_definitions
+
+    For anything beyond lightweight testing and exploration, the use of register_definitions
+    is strongly recommended.
+
+    This function provides a few conveniences for the user that do not apply to vanilla dagster
+    definitions:
+
+    (1) It takes a dictionary of top-level resources which are automatically bound
+    (via with_resources) to any asset passed to it. If you need to apply different
+    resources to different assets, use legacy @repository and use with_resources as before.
+
+    (2) The resources dictionary takes raw python objects, not just resource definitions.
+
+    Invoking this function dynamically injects an attribute named "__registered_definitions" into
+    the calling module that contains a handle to the definitions.
+    """
+    raise NotImplementedError("Not implemented yet")
+
+
+NO_STACK_FRAME_ERROR_MSG = "Python interpreter must support Python stack frames. Python interpreters that are not CPython do not necessarily implement the necessary APIs."
+
+# invoke this function to get the module name the function that called the current
+# scope
+def get_module_name_of_caller() -> str:
+    # based on https://stackoverflow.com/questions/2000861/retrieve-module-object-from-stack-frame
+    # two f_backs to get past get_module_name_of_caller frame
+
+    # Need to do none checking because of:
+    # https://docs.python.org/3/library/inspect.html#inspect.currentframe
+    # CPython implementation detail: This function relies on Python stack frame
+    # support in the interpreter, which isn’t guaranteed to exist in all
+    # implementations of Python. If running in an implementation without
+    # Python stack frame support this function returns None.
+
+    frame = check.not_none(inspect.currentframe(), NO_STACK_FRAME_ERROR_MSG)
+    back_frame = check.not_none(frame.f_back, NO_STACK_FRAME_ERROR_MSG)
+    back_back_frame = check.not_none(back_frame.f_back, NO_STACK_FRAME_ERROR_MSG)
+    return back_back_frame.f_globals["__name__"]

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_register_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_register_definitions.py
@@ -1,6 +1,33 @@
-from dagster import register_definitions
+import sys
+import pytest
 
-from dagster._core.definitions.register_definitions import get_module_name_of_caller
+from dagster import (
+    op,
+    AssetKey,
+    asset,
+    register_definitions,
+    ScheduleDefinition,
+    define_asset_job,
+    sensor,
+    repository,
+    AssetsDefinition,
+    ResourceDefinition,
+)
+from dagster._core.definitions.register_definitions import (
+    MAGIC_REGISTERED_DEFINITIONS_KEY,
+    get_module_name_of_caller,
+    register_definitions_test_scope,
+    ModuleHasRegisteredDefinitionsError,
+    get_registered_repository_in_module,
+)
+from dagster._core.definitions.repository_definition import (
+    PendingRepositoryDefinition,
+    RepositoryDefinition,
+)
+from dagster._core.definitions.cacheable_assets import (
+    AssetsDefinitionCacheableData,
+    CacheableAssetsDefinition,
+)
 
 
 def test_include_register_definition_works():
@@ -16,3 +43,192 @@ def test_module_name_of_caller():
     assert (
         test_module_name == "dagster_tests.core_tests.definitions_tests.test_register_definitions"
     )
+
+
+def test_register_definitions_magic_global():
+    register_definitions()
+    assert MAGIC_REGISTERED_DEFINITIONS_KEY in sys.modules[__name__].__dict__
+    # clean up so subsequent test cases work
+    del sys.modules[__name__].__dict__[MAGIC_REGISTERED_DEFINITIONS_KEY]
+    assert MAGIC_REGISTERED_DEFINITIONS_KEY not in sys.modules[__name__].__dict__
+
+
+def test_register_definitions_test_scope():
+    assert MAGIC_REGISTERED_DEFINITIONS_KEY not in sys.modules[__name__].__dict__
+    with register_definitions_test_scope(__name__):
+        register_definitions()
+        assert MAGIC_REGISTERED_DEFINITIONS_KEY in sys.modules[__name__].__dict__
+
+    assert MAGIC_REGISTERED_DEFINITIONS_KEY not in sys.modules[__name__].__dict__
+
+    with pytest.raises(Exception, match="test cleanup"):
+        with register_definitions_test_scope(__name__):
+            register_definitions()
+            raise Exception("test cleanup")
+
+    assert MAGIC_REGISTERED_DEFINITIONS_KEY not in sys.modules[__name__].__dict__
+
+
+def test_register_definitions_called_twice():
+    with register_definitions_test_scope(__name__):
+        register_definitions()
+        with pytest.raises(ModuleHasRegisteredDefinitionsError):
+            register_definitions()
+
+
+def get_all_assets_from_repo(repo):
+    # could not find public method on repository to do this
+    return list(repo._assets_defs_by_key.values())  # pylint: disable=protected-access
+
+
+def get_resolved_repository_in_scope() -> RepositoryDefinition:
+    repo_or_caching_repo = get_registered_repository_in_module(__name__)
+    return (
+        repo_or_caching_repo.compute_repository_definition()
+        if isinstance(repo_or_caching_repo, PendingRepositoryDefinition)
+        else repo_or_caching_repo
+    )
+
+
+def test_basic_asset_definitions():
+    with register_definitions_test_scope(__name__):
+
+        @asset
+        def an_asset():
+            pass
+
+        register_definitions(assets=[an_asset])
+
+        repo = get_resolved_repository_in_scope()
+        all_assets = get_all_assets_from_repo(repo)
+        # all_assets = list(repo._assets_defs_by_key.values())  # pylint: disable=protected-access
+        assert len(all_assets) == 1
+        assert all_assets[0].key.to_user_string() == "an_asset"
+
+
+def test_basic_schedule_definition():
+    with register_definitions_test_scope(__name__):
+
+        @asset
+        def an_asset():
+            pass
+
+        register_definitions(
+            assets=[an_asset],
+            schedules=[
+                ScheduleDefinition(
+                    name="daily_an_asset_schedule",
+                    job=define_asset_job(name="an_asset_job"),
+                    cron_schedule="@daily",
+                )
+            ],
+        )
+
+        repo = get_resolved_repository_in_scope()
+        assert repo.get_schedule_def("daily_an_asset_schedule")
+
+
+def test_basic_sensor_definition():
+    with register_definitions_test_scope(__name__):
+
+        @asset
+        def an_asset():
+            pass
+
+        an_asset_job = define_asset_job(name="an_asset_job")
+
+        @sensor(name="an_asset_sensor", job=an_asset_job)
+        def a_sensor():
+            raise NotImplementedError()
+
+        register_definitions(
+            assets=[an_asset],
+            sensors=[a_sensor],
+        )
+
+        repo = get_resolved_repository_in_scope()
+
+        assert repo.get_sensor_def("an_asset_sensor")
+
+
+def test_with_resource_binding():
+    with register_definitions_test_scope(__name__):
+
+        executed = {}
+
+        @asset(required_resource_keys={"foo"})
+        def requires_foo(context):
+            assert context.resources.foo == "wrapped"
+            executed["yes"] = True
+
+        register_definitions(
+            assets=[requires_foo],
+            resources={"foo": ResourceDefinition.hardcoded_resource("wrapped")},
+        )
+
+        repo = get_resolved_repository_in_scope()
+
+        asset_job = repo.get_all_jobs()[0]
+        asset_job.execute_in_process()
+        assert executed["yes"]
+
+
+def test_resource_coercion():
+    with register_definitions_test_scope(__name__):
+
+        executed = {}
+
+        @asset(required_resource_keys={"foo"})
+        def requires_foo(context):
+            assert context.resources.foo == "object-to-coerce"
+            executed["yes"] = True
+
+        register_definitions(
+            assets=[requires_foo],
+            resources={"foo": "object-to-coerce"},
+        )
+
+        repo = get_resolved_repository_in_scope()
+
+        asset_job = repo.get_all_jobs()[0]
+        asset_job.execute_in_process()
+        assert executed["yes"]
+
+
+def test_pending_definitions():
+    class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
+        def compute_cacheable_data(self):
+            return [
+                AssetsDefinitionCacheableData(
+                    keys_by_input_name={}, keys_by_output_name={"result": AssetKey(self.unique_id)}
+                )
+            ]
+
+        def build_definitions(self, data):
+            @op
+            def my_op():
+                return 1
+
+            return [
+                AssetsDefinition.from_op(
+                    my_op,
+                    keys_by_input_name=cd.keys_by_input_name,
+                    keys_by_output_name=cd.keys_by_output_name,
+                )
+                for cd in data
+            ]
+
+    @repository
+    def a_pending_repo():
+        return [MyCacheableAssetsDefinition("foobar")]
+
+    assert isinstance(a_pending_repo, PendingRepositoryDefinition)
+
+    assert isinstance(a_pending_repo.compute_repository_definition(), RepositoryDefinition)
+
+    with register_definitions_test_scope(__name__):
+        register_definitions(assets=[MyCacheableAssetsDefinition("foobar")])
+        repo = get_resolved_repository_in_scope()
+        all_assets = get_all_assets_from_repo(repo)
+        assert len(all_assets) == 1
+        assert all_assets[0].key.to_user_string() == "foobar"

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_register_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_register_definitions.py
@@ -36,11 +36,18 @@ def test_include_register_definition_works():
     assert register_definitions
 
 
-def invoke_get_module_name_of_caller():
-    return get_module_name_of_caller()
-
-
 def test_module_name_of_caller():
+
+    # register_definitions is experimental and mark with a decorator
+    # we have to add another level to the stack in order to replicate
+    # the structure for a test case
+
+    def invoke_get_module_name_of_caller():
+        return add_stack_frame_to_mimic_experimental()
+
+    def add_stack_frame_to_mimic_experimental():
+        return get_module_name_of_caller()
+
     test_module_name = invoke_get_module_name_of_caller()
     assert (
         test_module_name == "dagster_tests.core_tests.definitions_tests.test_register_definitions"

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_register_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_register_definitions.py
@@ -1,0 +1,18 @@
+from dagster import register_definitions
+
+from dagster._core.definitions.register_definitions import get_module_name_of_caller
+
+
+def test_include_register_definition_works():
+    assert register_definitions
+
+
+def invoke_get_module_name_of_caller():
+    return get_module_name_of_caller()
+
+
+def test_module_name_of_caller():
+    test_module_name = invoke_get_module_name_of_caller()
+    assert (
+        test_module_name == "dagster_tests.core_tests.definitions_tests.test_register_definitions"
+    )

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_register_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_register_definitions.py
@@ -22,7 +22,7 @@ from dagster._core.definitions.cacheable_assets import (
 from dagster._core.definitions.register_definitions import (
     MAGIC_REGISTERED_DEFINITIONS_KEY,
     ModuleHasRegisteredDefinitionsError,
-    get_module_name_of_caller,
+    get_module_name_of_registered_definitions_caller,
     get_registered_repository_in_module,
     register_definitions_test_scope,
 )
@@ -42,13 +42,13 @@ def test_module_name_of_caller():
     # we have to add another level to the stack in order to replicate
     # the structure for a test case
 
-    def invoke_get_module_name_of_caller():
+    def invoke_get_module_name_of_registered_definitions_caller():
         return add_stack_frame_to_mimic_experimental()
 
     def add_stack_frame_to_mimic_experimental():
-        return get_module_name_of_caller()
+        return get_module_name_of_registered_definitions_caller()
 
-    test_module_name = invoke_get_module_name_of_caller()
+    test_module_name = invoke_get_module_name_of_registered_definitions_caller()
     assert (
         test_module_name == "dagster_tests.core_tests.definitions_tests.test_register_definitions"
     )

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_register_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_register_definitions.py
@@ -7,6 +7,7 @@ from dagster import (
     AssetsDefinition,
     ResourceDefinition,
     ScheduleDefinition,
+    SourceAsset,
     asset,
     define_asset_job,
     op,
@@ -102,7 +103,6 @@ def test_basic_asset_definitions():
 
         repo = get_resolved_repository_in_scope()
         all_assets = get_all_assets_from_repo(repo)
-        # all_assets = list(repo._assets_defs_by_key.values())  # pylint: disable=protected-access
         assert len(all_assets) == 1
         assert all_assets[0].key.to_user_string() == "an_asset"
 
@@ -197,7 +197,13 @@ def test_resource_coercion():
 
 
 def test_source_asset():
-    pass
+    with register_definitions_test_scope(__name__):
+        register_definitions(assets=[SourceAsset("a-source-asset")])
+
+        repo = get_resolved_repository_in_scope()
+        all_assets = list(repo.source_assets_by_key.values())
+        assert len(all_assets) == 1
+        assert all_assets[0].key.to_user_string() == "a-source-asset"
 
 
 def test_pending_definitions():

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_register_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_register_definitions.py
@@ -1,32 +1,33 @@
 import sys
+
 import pytest
 
 from dagster import (
-    op,
     AssetKey,
-    asset,
-    register_definitions,
-    ScheduleDefinition,
-    define_asset_job,
-    sensor,
-    repository,
     AssetsDefinition,
     ResourceDefinition,
-)
-from dagster._core.definitions.register_definitions import (
-    MAGIC_REGISTERED_DEFINITIONS_KEY,
-    get_module_name_of_caller,
-    register_definitions_test_scope,
-    ModuleHasRegisteredDefinitionsError,
-    get_registered_repository_in_module,
-)
-from dagster._core.definitions.repository_definition import (
-    PendingRepositoryDefinition,
-    RepositoryDefinition,
+    ScheduleDefinition,
+    asset,
+    define_asset_job,
+    op,
+    register_definitions,
+    repository,
+    sensor,
 )
 from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
     CacheableAssetsDefinition,
+)
+from dagster._core.definitions.register_definitions import (
+    MAGIC_REGISTERED_DEFINITIONS_KEY,
+    ModuleHasRegisteredDefinitionsError,
+    get_module_name_of_caller,
+    get_registered_repository_in_module,
+    register_definitions_test_scope,
+)
+from dagster._core.definitions.repository_definition import (
+    PendingRepositoryDefinition,
+    RepositoryDefinition,
 )
 
 
@@ -193,6 +194,10 @@ def test_resource_coercion():
         asset_job = repo.get_all_jobs()[0]
         asset_job.execute_in_process()
         assert executed["yes"]
+
+
+def test_source_asset():
+    pass
 
 
 def test_pending_definitions():


### PR DESCRIPTION
### Summary & Motivation

This is a refinement, ready to commit, of the API proposed in https://github.com/dagster-io/dagster/pull/10504.

As we all know, one of the biggest problems with dagster is the redundant, overlapping, and confusing concepts that makes the spin up more difficult and also incurs cognitive load even to existing users. While there are few different parts where this is true, one of the more painful parts is the workspace --> code location --> repository ontology. Also mix in the somewhat-but-not-really-orthogonal instance and deployment concepts, and you have quite the confusing stew.

This PR proposes adding a new entry point function `register_definitions` that would be used instead of `repository` going forward. It is typed and enforces that there is only one repository per python process, which enables the collapsing of code location and repository into a single concept for tooling purposes.

This injects a repository definition as an attribute into the entry point module using python internals, so all auto-discovery features and entry points should work as is.

The user-facing language around this focuses on making the current python module loadable by dagster tools, rather than introducing the code location concept. See the docblock on `register_definitions`

A few additional ergonomic here:

1) `resources` becomes a top-level argument to `register_definitions` and `with_resources` is automatically invoked on the user's behalf
2) `resources` also accepts any python object, not just resource definitions. All vanilla objects are coerced to resource definitions via `ResourceDefinition.hardcoded_resource`.
3) Typed api: At this point `repository` is a pretty rough and loosely defined API that can accept a dizzying array of object types. Types and argument self-document to some degree, stay up to date, and improve discoverability.

**Non-invasive goodbye to repository**

This change can make repository "disappear" for new users. The mental model here is that a call to definitions defines all the definitions for a code location, not a repository. This PR currently enforces this at the module level. We could make it more strict.

For existing users this doesn't really change much either. They will simply think "this is how I define the things in my repo". The function name definitions allows for both interpretations, which is why it was chosen.

If we move forward with this, we can mark code locations that only have a single repository and that were constructed that way as special, and proceed to fork our UI to make the entire concept of repository disappear. Only code location would remain.

For existing users that do have multiple repositories in a single code location, they would instead have to multiple code locations that happen to share the same python dependencies.

### How I Tested These Changes

Included unit tests and converted examples in follow on PRs (to be actually committed later) once we are ready to flip over the tutorial and user-facing content to lead with this new API
