### PR TITLE
[dagster-airflow] python39 support, airflow 2 compatibility, test coverage

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -380,9 +380,8 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     ),
     PackageSpec(
         "python_modules/libraries/dagster-airflow",
-        # omit python 3.9 until we add support
+        # omit python 3.10 until we add support
         unsupported_python_versions=[
-            AvailablePythonVersion.V3_9,
             AvailablePythonVersion.V3_10,
         ],
         env_vars=[
@@ -395,7 +394,12 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         ],
         pytest_extra_cmds=airflow_extra_cmds,
         pytest_step_dependencies=test_project_depends_fn,
-        pytest_tox_factors=["default", "requiresairflowdb"],
+        pytest_tox_factors=[
+            "default-airflow1",
+            "requiresairflowdb-airflow1",
+            "default-airflow2",
+            "requiresairflowdb-airflow2",
+        ],
     ),
     PackageSpec(
         "python_modules/libraries/dagster-aws",

--- a/docs/content/integrations/airflow.mdx
+++ b/docs/content/integrations/airflow.mdx
@@ -209,6 +209,6 @@ Note that the "execution_date" for the Airflow DAG is specified through the job 
 
 ```python file=../../with_airflow/with_airflow/repository.py startafter=start_repo_marker_1 endbefore=end_repo_marker_1
 airflow_simple_dag_with_execution_date = make_dagster_job_from_airflow_dag(
-    dag=simple_dag, tags={"airflow_execution_date": "2021-11-01 00:00:00"}
+    dag=simple_dag, tags={"airflow_execution_date": "2021-11-01 00:00:00+00:00"}
 )
 ```

--- a/docs/content/integrations/airflow.mdx
+++ b/docs/content/integrations/airflow.mdx
@@ -182,13 +182,18 @@ s3_conn.set_extra(
 
 This example demonstrates how to use <PyObject module="dagster_airflow" object="make_dagster_job_from_airflow_dag" /> to compile an Airflow DAG into a Dagster job that can be executed (and explored) the same way as a Dagster-native job.
 
-There are two jobs in the repo:
+There are three jobs in the repo:
 
 - `airflow_simple_dag` demonstrates the use of Airflow templates.
 - `airflow_complex_dag` shows the translation of a more complex dependency structure.
+- `airflow_kubernetes_dag` shows the translation of a dag using kubernetes pod operators.
 
 ```python file=../../with_airflow/with_airflow/repository.py startafter=start_repo_marker_0 endbefore=end_repo_marker_0
-from dagster_airflow.dagster_job_factory import make_dagster_job_from_airflow_dag
+from dagster_airflow import (
+    make_dagster_job_from_airflow_dag,
+    make_dagster_repo_from_airflow_dags_path,
+    make_dagster_repo_from_airflow_example_dags,
+)
 from with_airflow.airflow_complex_dag import complex_dag
 from with_airflow.airflow_kubernetes_dag import kubernetes_dag
 from with_airflow.airflow_simple_dag import simple_dag

--- a/examples/with_airflow/with_airflow/__init__.py
+++ b/examples/with_airflow/with_airflow/__init__.py
@@ -1,1 +1,1 @@
-from .repository import with_airflow
+from .repository import airflow_examples_dags_repo, task_flow_repo, with_airflow

--- a/examples/with_airflow/with_airflow/repository.py
+++ b/examples/with_airflow/with_airflow/repository.py
@@ -20,6 +20,8 @@ airflow_kubernetes_dag = make_dagster_job_from_airflow_dag(kubernetes_dag, mock_
 @repository
 def with_airflow():
     return [airflow_complex_dag, airflow_simple_dag, airflow_kubernetes_dag]
+
+
 # end_repo_marker_0
 
 

--- a/examples/with_airflow/with_airflow/repository.py
+++ b/examples/with_airflow/with_airflow/repository.py
@@ -1,6 +1,6 @@
-# start_repo_marker_0
 import os
 
+# start_repo_marker_0
 from dagster_airflow import (
     make_dagster_job_from_airflow_dag,
     make_dagster_repo_from_airflow_dags_path,
@@ -16,22 +16,20 @@ airflow_simple_dag = make_dagster_job_from_airflow_dag(simple_dag)
 airflow_complex_dag = make_dagster_job_from_airflow_dag(complex_dag)
 airflow_kubernetes_dag = make_dagster_job_from_airflow_dag(kubernetes_dag, mock_xcom=True)
 
+
+@repository
+def with_airflow():
+    return [airflow_complex_dag, airflow_simple_dag, airflow_kubernetes_dag]
+# end_repo_marker_0
+
+
 task_flow_repo = make_dagster_repo_from_airflow_dags_path(
     os.path.abspath("./with_airflow/task_flow_dags/"),
     "task_flow_repo",
 )
 
 
-@repository
-def with_airflow():
-    return [airflow_complex_dag, airflow_simple_dag, airflow_kubernetes_dag]
-
-
 airflow_examples_dags_repo = make_dagster_repo_from_airflow_example_dags()
-
-
-# end_repo_marker_0
-
 
 # start_repo_marker_1
 

--- a/examples/with_airflow/with_airflow/repository.py
+++ b/examples/with_airflow/with_airflow/repository.py
@@ -1,5 +1,11 @@
 # start_repo_marker_0
-from dagster_airflow.dagster_job_factory import make_dagster_job_from_airflow_dag
+import os
+
+from dagster_airflow import (
+    make_dagster_job_from_airflow_dag,
+    make_dagster_repo_from_airflow_dags_path,
+    make_dagster_repo_from_airflow_example_dags,
+)
 from with_airflow.airflow_complex_dag import complex_dag
 from with_airflow.airflow_kubernetes_dag import kubernetes_dag
 from with_airflow.airflow_simple_dag import simple_dag
@@ -10,10 +16,18 @@ airflow_simple_dag = make_dagster_job_from_airflow_dag(simple_dag)
 airflow_complex_dag = make_dagster_job_from_airflow_dag(complex_dag)
 airflow_kubernetes_dag = make_dagster_job_from_airflow_dag(kubernetes_dag, mock_xcom=True)
 
+task_flow_repo = make_dagster_repo_from_airflow_dags_path(
+    os.path.abspath("./with_airflow/task_flow_dags/"),
+    "task_flow_repo",
+)
+
 
 @repository
 def with_airflow():
     return [airflow_complex_dag, airflow_simple_dag, airflow_kubernetes_dag]
+
+
+airflow_examples_dags_repo = make_dagster_repo_from_airflow_example_dags()
 
 
 # end_repo_marker_0
@@ -22,6 +36,6 @@ def with_airflow():
 # start_repo_marker_1
 
 airflow_simple_dag_with_execution_date = make_dagster_job_from_airflow_dag(
-    dag=simple_dag, tags={"airflow_execution_date": "2021-11-01 00:00:00"}
+    dag=simple_dag, tags={"airflow_execution_date": "2021-11-01 00:00:00+00:00"}
 )
 # end_repo_marker_1

--- a/examples/with_airflow/with_airflow/task_flow_dags/airflow_taskflow_dag.py
+++ b/examples/with_airflow/with_airflow/task_flow_dags/airflow_taskflow_dag.py
@@ -1,0 +1,65 @@
+import json
+
+import pendulum
+from airflow.decorators import dag, task
+
+
+@dag(
+    schedule="* * * * *",
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+    catchup=False,
+    tags=["example"],
+)
+def tutorial_taskflow_api():
+    """
+    ### TaskFlow API Tutorial Documentation
+    This is a simple data pipeline example which demonstrates the use of
+    the TaskFlow API using three simple tasks for Extract, Transform, and Load.
+    Documentation that goes along with the Airflow TaskFlow API tutorial is
+    located
+    [here](https://airflow.apache.org/docs/apache-airflow/stable/tutorial_taskflow_api.html)
+    """
+
+    @task()
+    def extract():
+        """
+        #### Extract task
+        A simple Extract task to get data ready for the rest of the data
+        pipeline. In this case, getting data is simulated by reading from a
+        hardcoded JSON string.
+        """
+        data_string = '{"1001": 301.27, "1002": 433.21, "1003": 502.22}'
+
+        order_data_dict = json.loads(data_string)
+        return order_data_dict
+
+    @task(multiple_outputs=True)
+    def transform(order_data_dict: dict):
+        """
+        #### Transform task
+        A simple Transform task which takes in the collection of order data and
+        computes the total order value.
+        """
+        total_order_value = 0
+
+        for value in order_data_dict.values():
+            total_order_value += value
+
+        return {"total_order_value": total_order_value}
+
+    @task()
+    def load(total_order_value: float):
+        """
+        #### Load task
+        A simple Load task which takes in the result of the Transform task and
+        instead of saving it to end user review, just prints it out.
+        """
+
+        print(f"Total order value is: {total_order_value:.2f}")
+
+    order_data = extract()
+    order_summary = transform(order_data)
+    load(order_summary["total_order_value"])
+
+
+tutorial_taskflow_api()

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
@@ -2,7 +2,12 @@ from dagster_airflow.dagster_pipeline_factory import make_dagster_pipeline_from_
 
 
 def make_dagster_job_from_airflow_dag(
-    dag, tags=None, use_airflow_template_context=False, unique_id=None, mock_xcom=False
+    dag,
+    tags=None,
+    use_airflow_template_context=False,
+    unique_id=None,
+    mock_xcom=False,
+    use_emphemeral_airflow_db=False,
 ):
     """Construct a Dagster job corresponding to a given Airflow DAG.
 
@@ -41,19 +46,22 @@ def make_dagster_job_from_airflow_dag(
             `tags={'airflow_execution_date': utc_date_string}` to specify execution_date used within
             execution of Airflow Operators.
         use_airflow_template_context (bool): If True, will call get_template_context() on the
-            Airflow TaskInstance model which requires and modifies the DagRun table.
+            Airflow TaskInstance model which requires and modifies the DagRun table. The use_airflow_template_context
+            setting is ignored if use_emphemeral_airflow_db is True.
             (default: False)
         unique_id (int): If not None, this id will be postpended to generated op names. Used by
             framework authors to enforce unique op names within a repo.
-        mock_xcom (bool): If not None, dagster will mock out all calls made to xcom, features that
-            depend on xcom may not work as expected.
+        mock_xcom (bool): If True, dagster will mock out all calls made to xcom, features that
+            depend on xcom may not work as expected. (default: False)
+        use_emphemeral_airflow_db (bool): If True, dagster will create an emphemeral sqlite airflow
+            database for each run. (default: False)
 
     Returns:
         JobDefinition: The generated Dagster job
 
     """
     pipeline_def = make_dagster_pipeline_from_airflow_dag(
-        dag, tags, use_airflow_template_context, unique_id, mock_xcom
+        dag, tags, use_airflow_template_context, unique_id, mock_xcom, use_emphemeral_airflow_db
     )
     # pass in tags manually because pipeline_def.graph doesn't have it threaded
     return pipeline_def.graph.to_job(tags={**pipeline_def.tags})

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -48,11 +48,15 @@ class DagsterAirflowError(Exception):
 
 
 def initialize_airflow_1_database():
-    subprocess.run(["airflow", "initdb"], check=True)
+    p = subprocess.run(["airflow", "checkdb"], check=True, capture_output=True)
+    if "WARNING" in p.stdout.decode("utf-8"):
+        subprocess.run(["airflow", "initdb"], check=True)
 
 
 def initialize_airflow_2_database():
-    subprocess.run(["airflow", "db", "init"], check=True)
+    p = subprocess.run(["airflow", "db", "check"], check=True, capture_output=True)
+    if "WARNING" in p.stdout.decode("utf-8"):
+        subprocess.run(["airflow", "db", "init"], check=True)
 
 
 def contains_duplicate_task_names(dag_bag, refresh_from_airflow_db):

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -48,11 +48,11 @@ class DagsterAirflowError(Exception):
 
 
 def initialize_airflow_1_database():
-    subprocess.run(["airflow", "initdb"])
+    subprocess.run(["airflow", "initdb"], check=True)
 
 
 def initialize_airflow_2_database():
-    subprocess.run(["airflow", "db", "init"])
+    subprocess.run(["airflow", "db", "init"], check=True)
 
 
 def contains_duplicate_task_names(dag_bag, refresh_from_airflow_db):
@@ -124,6 +124,7 @@ def make_dagster_repo_from_airflow_dag_bag(
 
     job_defs = []
     schedule_defs = []
+    asset_defs = []
     count = 0
     # To enforce predictable iteration order
     sorted_dag_ids = sorted(dag_bag.dag_ids)
@@ -154,8 +155,14 @@ def make_dagster_repo_from_airflow_dag_bag(
             dag=dag,
             job_def=job_def,
         )
+        asset_def = make_dagster_asset_from_airflow_dag(
+            dag=dag,
+            job_def=job_def
+        )
         if schedule_def:
             schedule_defs.append(schedule_def)
+        elif asset_def:
+            asset_defs.append(asset_def)
         else:
             job_defs.append(job_def)
 
@@ -179,18 +186,35 @@ def make_dagster_schedule_from_airflow_dag(dag, job_def):
     check.inst_param(dag, "dag", DAG)
     check.inst_param(job_def, "job_def", JobDefinition)
 
-    schedule_name = dag.dag_id
     cron_schedule = dag.normalized_schedule_interval
     schedule_description = dag.description
 
     if isinstance(dag.normalized_schedule_interval, str) and is_valid_cron_schedule(
-        dag.normalized_schedule_interval
+        cron_schedule
     ):
         return ScheduleDefinition(
             job=job_def,
-            cron_schedule=dag.normalized_schedule_interval,
+            cron_schedule=cron_schedule,
+            description=schedule_description
         )
 
+def make_dagster_asset_from_airflow_dag(dag, job_def):
+    """Construct a Dagster asset corresponding to an Airflow DAG.
+
+    Args:
+        dag (DAG): Airflow DAG
+        job_def (JobDefinition): Dagster pipeline corresponding to Airflow DAG
+
+    Returns:
+        AssetDefinition
+    """
+    check.inst_param(dag, "dag", DAG)
+    check.inst_param(job_def, "job_def", JobDefinition)
+
+    cron_schedule = dag.normalized_schedule_interval
+    if isinstance(dag.normalized_schedule_interval, str) and cron_schedule == 'Dataset':
+        # TODO: add support for asset tags
+        return
 
 def make_dagster_repo_from_airflow_example_dags(
     repo_name="airflow_example_dags_repo", use_emphemeral_airflow_db=True

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -155,10 +155,7 @@ def make_dagster_repo_from_airflow_dag_bag(
             dag=dag,
             job_def=job_def,
         )
-        asset_def = make_dagster_asset_from_airflow_dag(
-            dag=dag,
-            job_def=job_def
-        )
+        asset_def = make_dagster_asset_from_airflow_dag(dag=dag, job_def=job_def)
         if schedule_def:
             schedule_defs.append(schedule_def)
         elif asset_def:
@@ -189,14 +186,11 @@ def make_dagster_schedule_from_airflow_dag(dag, job_def):
     cron_schedule = dag.normalized_schedule_interval
     schedule_description = dag.description
 
-    if isinstance(dag.normalized_schedule_interval, str) and is_valid_cron_schedule(
-        cron_schedule
-    ):
+    if isinstance(dag.normalized_schedule_interval, str) and is_valid_cron_schedule(cron_schedule):
         return ScheduleDefinition(
-            job=job_def,
-            cron_schedule=cron_schedule,
-            description=schedule_description
+            job=job_def, cron_schedule=cron_schedule, description=schedule_description
         )
+
 
 def make_dagster_asset_from_airflow_dag(dag, job_def):
     """Construct a Dagster asset corresponding to an Airflow DAG.
@@ -212,9 +206,10 @@ def make_dagster_asset_from_airflow_dag(dag, job_def):
     check.inst_param(job_def, "job_def", JobDefinition)
 
     cron_schedule = dag.normalized_schedule_interval
-    if isinstance(dag.normalized_schedule_interval, str) and cron_schedule == 'Dataset':
+    if isinstance(dag.normalized_schedule_interval, str) and cron_schedule == "Dataset":
         # TODO: add support for asset tags
         return
+
 
 def make_dagster_repo_from_airflow_example_dags(
     repo_name="airflow_example_dags_repo", use_emphemeral_airflow_db=True

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -183,7 +183,9 @@ def make_dagster_schedule_from_airflow_dag(dag, job_def):
     cron_schedule = dag.normalized_schedule_interval
     schedule_description = dag.description
 
-    if isinstance(dag.normalized_schedule_interval, str) and is_valid_cron_schedule(dag.normalized_schedule_interval):
+    if isinstance(dag.normalized_schedule_interval, str) and is_valid_cron_schedule(
+        dag.normalized_schedule_interval
+    ):
         return ScheduleDefinition(
             job=job_def,
             cron_schedule=dag.normalized_schedule_interval,

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import subprocess
 import sys
 from contextlib import contextmanager, nullcontext
 from unittest.mock import patch
@@ -18,20 +19,40 @@ from dagster_airflow.patch_airflow_example_dag import patch_airflow_example_dag
 from dagster import (
     DagsterInvariantViolationError,
     DependencyDefinition,
+    Field,
     In,
+    JobDefinition,
     MultiDependencyDefinition,
     Nothing,
     Out,
+    ScheduleDefinition,
 )
 from dagster import _check as check
 from dagster import op, repository
 from dagster._core.definitions.utils import VALID_NAME_REGEX, validate_tags
 from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR, IS_AIRFLOW_INGEST_PIPELINE_STR
 from dagster._legacy import PipelineDefinition, SolidDefinition
+from dagster._utils.schedules import is_valid_cron_schedule
+
+# pylint: disable=no-name-in-module,import-error
+if str(airflow_version) >= "2.0.0":
+    from airflow.utils.state import DagRunState
+    from airflow.utils.types import DagRunType
+else:
+    from airflow.utils.state import State
+# pylint: enable=no-name-in-module,import-error
 
 
 class DagsterAirflowError(Exception):
     pass
+
+
+def initialize_airflow_1_database():
+    subprocess.run(["airflow", "initdb"])
+
+
+def initialize_airflow_2_database():
+    subprocess.run(["airflow", "db", "init"])
 
 
 def contains_duplicate_task_names(dag_bag, refresh_from_airflow_db):
@@ -56,6 +77,8 @@ def make_dagster_repo_from_airflow_dag_bag(
     repo_name,
     refresh_from_airflow_db=False,
     use_airflow_template_context=False,
+    mock_xcom=False,
+    use_emphemeral_airflow_db=False,
 ):
     """Construct a Dagster repository corresponding to Airflow DAGs in DagBag.
 
@@ -77,8 +100,13 @@ def make_dagster_repo_from_airflow_dag_bag(
             which requires access to initialized Airflow DB. If False (recommended), gets dag from
             DagBag's dags dict without depending on Airflow DB. (default: False)
         use_airflow_template_context (bool): If True, will call get_template_context() on the
-            Airflow TaskInstance model which requires and modifies the DagRun table.
+            Airflow TaskInstance model which requires and modifies the DagRun table. The use_airflow_template_context
+            setting is ignored if use_emphemeral_airflow_db is True.
             (default: False)
+        mock_xcom (bool): If True, dagster will mock out all calls made to xcom, features that
+            depend on xcom may not work as expected. (default: False)
+        use_emphemeral_airflow_db (bool): If True, dagster will create an emphemeral sqlite airflow
+            database for each run. (default: False)
 
     Returns:
         RepositoryDefinition
@@ -87,10 +115,15 @@ def make_dagster_repo_from_airflow_dag_bag(
     check.str_param(repo_name, "repo_name")
     check.bool_param(refresh_from_airflow_db, "refresh_from_airflow_db")
     check.bool_param(use_airflow_template_context, "use_airflow_template_context")
+    mock_xcom = check.opt_bool_param(mock_xcom, "mock_xcom")
+    use_emphemeral_airflow_db = check.opt_bool_param(
+        use_emphemeral_airflow_db, "use_emphemeral_airflow_db"
+    )
 
     use_unique_id = contains_duplicate_task_names(dag_bag, refresh_from_airflow_db)
 
-    pipeline_defs = []
+    job_defs = []
+    schedule_defs = []
     count = 0
     # To enforce predictable iteration order
     sorted_dag_ids = sorted(dag_bag.dag_ids)
@@ -98,32 +131,68 @@ def make_dagster_repo_from_airflow_dag_bag(
         # Only call Airflow DB via dag_bag.get_dag(dag_id) if refresh_from_airflow_db is True
         dag = dag_bag.dags.get(dag_id) if not refresh_from_airflow_db else dag_bag.get_dag(dag_id)
         if not use_unique_id:
-            pipeline_defs.append(
-                make_dagster_pipeline_from_airflow_dag(
-                    dag=dag,
-                    tags=None,
-                    use_airflow_template_context=use_airflow_template_context,
-                )
+            pipeline_def = make_dagster_pipeline_from_airflow_dag(
+                dag=dag,
+                tags=None,
+                use_airflow_template_context=use_airflow_template_context,
+                mock_xcom=mock_xcom,
+                use_emphemeral_airflow_db=use_emphemeral_airflow_db,
             )
         else:
-            pipeline_defs.append(
-                make_dagster_pipeline_from_airflow_dag(
-                    dag=dag,
-                    tags=None,
-                    use_airflow_template_context=use_airflow_template_context,
-                    unique_id=count,
-                )
+            pipeline_def = make_dagster_pipeline_from_airflow_dag(
+                dag=dag,
+                tags=None,
+                use_airflow_template_context=use_airflow_template_context,
+                unique_id=count,
+                mock_xcom=mock_xcom,
+                use_emphemeral_airflow_db=use_emphemeral_airflow_db,
             )
             count += 1
+        # pass in tags manually because pipeline_def.graph doesn't have it threaded
+        job_def = pipeline_def.graph.to_job(tags={**pipeline_def.tags})
+        schedule_def = make_dagster_schedule_from_airflow_dag(
+            dag=dag,
+            job_def=job_def,
+        )
+        if schedule_def:
+            schedule_defs.append(schedule_def)
+        else:
+            job_defs.append(job_def)
 
     @repository(name=repo_name)
     def _repo():
-        return pipeline_defs
+        return [job_defs, schedule_defs]
 
     return _repo
 
 
-def make_dagster_repo_from_airflow_example_dags(repo_name="airflow_example_dags_repo"):
+def make_dagster_schedule_from_airflow_dag(dag, job_def):
+    """Construct a Dagster schedule corresponding to an Airflow DAG.
+
+    Args:
+        dag (DAG): Airflow DAG
+        job_def (JobDefinition): Dagster pipeline corresponding to Airflow DAG
+
+    Returns:
+        ScheduleDefinition
+    """
+    check.inst_param(dag, "dag", DAG)
+    check.inst_param(job_def, "job_def", JobDefinition)
+
+    schedule_name = dag.dag_id
+    cron_schedule = dag.normalized_schedule_interval
+    schedule_description = dag.description
+
+    if isinstance(dag.normalized_schedule_interval, str) and is_valid_cron_schedule(dag.normalized_schedule_interval):
+        return ScheduleDefinition(
+            job=job_def,
+            cron_schedule=dag.normalized_schedule_interval,
+        )
+
+
+def make_dagster_repo_from_airflow_example_dags(
+    repo_name="airflow_example_dags_repo", use_emphemeral_airflow_db=True
+):
     """Construct a Dagster repository for Airflow's example DAGs.
 
     Execution of the following Airflow example DAGs is not currently supported:
@@ -147,6 +216,8 @@ def make_dagster_repo_from_airflow_example_dags(repo_name="airflow_example_dags_
 
     Args:
         repo_name (str): Name for generated RepositoryDefinition
+        use_emphemeral_airflow_db (bool): If True, dagster will create an emphemeral sqlite airflow
+            database for each run. (default: False)
 
     Returns:
         RepositoryDefinition
@@ -156,13 +227,13 @@ def make_dagster_repo_from_airflow_example_dags(repo_name="airflow_example_dags_
         include_examples=True,
     )
 
-    # There is a bug in Airflow v1.10.8, v1.10.9, v1.10.10 where the python_callable for task
-    # 'search_catalog' is missing a required position argument '_'. It is currently fixed in master.
-    # v1.10 stable: https://github.com/apache/airflow/blob/v1-10-stable/airflow/example_dags/example_complex.py#L133
-    # master (05-05-2020): https://github.com/apache/airflow/blob/master/airflow/example_dags/example_complex.py#L136
+    # There is a bug in Airflow v1 where the python_callable for task
+    # 'search_catalog' is missing a required position argument '_'. It is fixed in airflow v2
     patch_airflow_example_dag(dag_bag)
 
-    return make_dagster_repo_from_airflow_dag_bag(dag_bag, repo_name)
+    return make_dagster_repo_from_airflow_dag_bag(
+        dag_bag, repo_name, use_emphemeral_airflow_db=use_emphemeral_airflow_db
+    )
 
 
 def make_dagster_repo_from_airflow_dags_path(
@@ -171,6 +242,8 @@ def make_dagster_repo_from_airflow_dags_path(
     safe_mode=True,
     store_serialized_dags=False,
     use_airflow_template_context=False,
+    mock_xcom=False,
+    use_emphemeral_airflow_db=True,
 ):
     """Construct a Dagster repository corresponding to Airflow DAGs in dag_path.
 
@@ -200,8 +273,13 @@ def make_dagster_repo_from_airflow_dags_path(
         store_serialized_dags (bool): True to read Airflow DAGS from Airflow DB. False to read DAGS
             from Python files. (default: False)
         use_airflow_template_context (bool): If True, will call get_template_context() on the
-            Airflow TaskInstance model which requires and modifies the DagRun table.
+            Airflow TaskInstance model which requires and modifies the DagRun table. The use_airflow_template_context
+            setting is ignored if use_emphemeral_airflow_db is True.
             (default: False)
+        mock_xcom (bool): If True, dagster will mock out all calls made to xcom, features that
+            depend on xcom may not work as expected. (default: False)
+        use_emphemeral_airflow_db (bool): If True, dagster will create an emphemeral sqlite airflow
+            database for each run. (default: False)
 
     Returns:
         RepositoryDefinition
@@ -211,6 +289,10 @@ def make_dagster_repo_from_airflow_dags_path(
     check.bool_param(safe_mode, "safe_mode")
     check.bool_param(store_serialized_dags, "store_serialized_dags")
     check.bool_param(use_airflow_template_context, "use_airflow_template_context")
+    mock_xcom = check.opt_bool_param(mock_xcom, "mock_xcom")
+    use_emphemeral_airflow_db = check.opt_bool_param(
+        use_emphemeral_airflow_db, "use_emphemeral_airflow_db"
+    )
 
     try:
         dag_bag = DagBag(
@@ -222,11 +304,22 @@ def make_dagster_repo_from_airflow_dags_path(
     except Exception:
         raise DagsterAirflowError("Error initializing airflow.models.dagbag object with arguments")
 
-    return make_dagster_repo_from_airflow_dag_bag(dag_bag, repo_name, use_airflow_template_context)
+    return make_dagster_repo_from_airflow_dag_bag(
+        dag_bag,
+        repo_name,
+        use_airflow_template_context=use_airflow_template_context,
+        mock_xcom=mock_xcom,
+        use_emphemeral_airflow_db=use_emphemeral_airflow_db,
+    )
 
 
 def make_dagster_pipeline_from_airflow_dag(
-    dag, tags=None, use_airflow_template_context=False, unique_id=None, mock_xcom=False
+    dag,
+    tags=None,
+    use_airflow_template_context=False,
+    unique_id=None,
+    mock_xcom=False,
+    use_emphemeral_airflow_db=False,
 ):
     """Construct a Dagster pipeline corresponding to a given Airflow DAG.
 
@@ -272,12 +365,15 @@ def make_dagster_pipeline_from_airflow_dag(
             `tags={'airflow_execution_date': utc_date_string}` to specify execution_date used within
             execution of Airflow Operators.
         use_airflow_template_context (bool): If True, will call get_template_context() on the
-            Airflow TaskInstance model which requires and modifies the DagRun table.
+            Airflow TaskInstance model which requires and modifies the DagRun table. The use_airflow_template_context
+            setting is ignored if use_emphemeral_airflow_db is True.
             (default: False)
         unique_id (int): If not None, this id will be postpended to generated solid names. Used by
             framework authors to enforce unique solid names within a repo.
         mock_xcom (bool): If not None, dagster will mock out all calls made to xcom, features that
             depend on xcom may not work as expected.
+        use_emphemeral_airflow_db (bool): If True, dagster will create an emphemeral sqlite airflow
+            database for each run
 
     Returns:
         pipeline_def (PipelineDefinition): The generated Dagster pipeline
@@ -288,6 +384,9 @@ def make_dagster_pipeline_from_airflow_dag(
     check.bool_param(use_airflow_template_context, "use_airflow_template_context")
     unique_id = check.opt_int_param(unique_id, "unique_id")
     mock_xcom = check.opt_bool_param(mock_xcom, "mock_xcom")
+    use_emphemeral_airflow_db = check.opt_bool_param(
+        use_emphemeral_airflow_db, "use_emphemeral_airflow_db"
+    )
 
     if IS_AIRFLOW_INGEST_PIPELINE_STR not in tags:
         tags[IS_AIRFLOW_INGEST_PIPELINE_STR] = "true"
@@ -295,7 +394,7 @@ def make_dagster_pipeline_from_airflow_dag(
     tags = validate_tags(tags)
 
     pipeline_dependencies, solid_defs = _get_pipeline_definition_args(
-        dag, use_airflow_template_context, unique_id, mock_xcom
+        dag, use_airflow_template_context, unique_id, mock_xcom, use_emphemeral_airflow_db
     )
     pipeline_def = PipelineDefinition(
         name=normalized_name(dag.dag_id, None),
@@ -318,11 +417,19 @@ def normalized_name(name, unique_id):
 
 
 def _get_pipeline_definition_args(
-    dag, use_airflow_template_context, unique_id=None, mock_xcom=False
+    dag,
+    use_airflow_template_context,
+    unique_id=None,
+    mock_xcom=False,
+    use_emphemeral_airflow_db=False,
 ):
     check.inst_param(dag, "dag", DAG)
     check.bool_param(use_airflow_template_context, "use_airflow_template_context")
     unique_id = check.opt_int_param(unique_id, "unique_id")
+    mock_xcom = check.opt_bool_param(mock_xcom, "mock_xcom")
+    use_emphemeral_airflow_db = check.opt_bool_param(
+        use_emphemeral_airflow_db, "use_emphemeral_airflow_db"
+    )
 
     pipeline_dependencies = {}
     solid_defs = []
@@ -332,6 +439,7 @@ def _get_pipeline_definition_args(
     dag_roots = sorted(dag.roots, key=lambda x: x.task_id)
     for task in dag_roots:
         _traverse_airflow_dag(
+            dag,
             task,
             seen_tasks,
             pipeline_dependencies,
@@ -339,11 +447,13 @@ def _get_pipeline_definition_args(
             use_airflow_template_context,
             unique_id,
             mock_xcom,
+            use_emphemeral_airflow_db,
         )
     return (pipeline_dependencies, solid_defs)
 
 
 def _traverse_airflow_dag(
+    dag,
     task,
     seen_tasks,
     pipeline_dependencies,
@@ -351,17 +461,22 @@ def _traverse_airflow_dag(
     use_airflow_template_context,
     unique_id,
     mock_xcom,
+    use_emphemeral_airflow_db,
 ):
+    check.inst_param(dag, "dag", DAG)
     check.inst_param(task, "task", BaseOperator)
     check.list_param(seen_tasks, "seen_tasks", BaseOperator)
     check.list_param(solid_defs, "solid_defs", SolidDefinition)
     check.bool_param(use_airflow_template_context, "use_airflow_template_context")
     unique_id = check.opt_int_param(unique_id, "unique_id")
     mock_xcom = check.opt_bool_param(mock_xcom, "mock_xcom")
+    use_emphemeral_airflow_db = check.opt_bool_param(
+        use_emphemeral_airflow_db, "use_emphemeral_airflow_db"
+    )
 
     seen_tasks.append(task)
     current_solid = make_dagster_solid_from_airflow_task(
-        task, use_airflow_template_context, unique_id, mock_xcom
+        dag, task, use_airflow_template_context, unique_id, mock_xcom, use_emphemeral_airflow_db
     )
     solid_defs.append(current_solid)
 
@@ -386,6 +501,7 @@ def _traverse_airflow_dag(
     for child_task in task_downstream_list:
         if child_task not in seen_tasks:
             _traverse_airflow_dag(
+                dag,
                 child_task,
                 seen_tasks,
                 pipeline_dependencies,
@@ -393,6 +509,7 @@ def _traverse_airflow_dag(
                 use_airflow_template_context,
                 unique_id,
                 mock_xcom,
+                use_emphemeral_airflow_db,
             )
 
 
@@ -421,18 +538,40 @@ def _mock_xcom():
 # If unique_id is not None, this id will be postpended to generated solid names, generally used
 # to enforce unique solid names within a repo.
 def make_dagster_solid_from_airflow_task(
-    task, use_airflow_template_context, unique_id=None, mock_xcom=False
+    dag,
+    task,
+    use_airflow_template_context,
+    unique_id=None,
+    mock_xcom=False,
+    use_emphemeral_airflow_db=False,
 ):
+    check.inst_param(dag, "dag", DAG)
     check.inst_param(task, "task", BaseOperator)
     check.bool_param(use_airflow_template_context, "use_airflow_template_context")
     unique_id = check.opt_int_param(unique_id, "unique_id")
+    mock_xcom = check.opt_bool_param(mock_xcom, "mock_xcom")
+    use_emphemeral_airflow_db = check.opt_bool_param(
+        use_emphemeral_airflow_db, "use_emphemeral_airflow_db"
+    )
 
     @op(
         name=normalized_name(task.task_id, unique_id),
         ins={"airflow_task_ready": In(Nothing)},
         out={"airflow_task_complete": Out(Nothing)},
+        config_schema={
+            "mock_xcom": Field(bool, default_value=mock_xcom),
+            "use_emphemeral_airflow_db": Field(bool, default_value=use_emphemeral_airflow_db),
+        },
     )
     def _solid(context):  # pylint: disable=unused-argument
+        mock_xcom = context.op_config["mock_xcom"]
+        use_emphemeral_airflow_db = context.op_config["use_emphemeral_airflow_db"]
+        if use_emphemeral_airflow_db:
+            if airflow_version >= "2.0.0":
+                initialize_airflow_2_database()
+            else:
+                initialize_airflow_1_database()
+
         if AIRFLOW_EXECUTION_DATE_STR not in context.pipeline_run.tags:
             raise DagsterInvariantViolationError(
                 'Could not find "{AIRFLOW_EXECUTION_DATE_STR}" in {target} tags "{tags}". Please '
@@ -463,23 +602,55 @@ def make_dagster_solid_from_airflow_task(
 
         check.inst_param(execution_date, "execution_date", datetime.datetime)
 
-        with _mock_xcom() if mock_xcom else nullcontext():
+        with _mock_xcom() if mock_xcom and not use_emphemeral_airflow_db else nullcontext():
             with replace_airflow_logger_handlers():
                 if airflow_version >= "2.0.0":
-                    task_instance = TaskInstance(
-                        task=task, execution_date=execution_date, run_id="dagster_airflow_run"
-                    )
+                    if use_emphemeral_airflow_db:
+                        dagrun = dag.get_dagrun(execution_date=execution_date)
+                        if not dagrun:
+                            dagrun = dag.create_dagrun(
+                                state=DagRunState.RUNNING,
+                                execution_date=execution_date,
+                                run_type=DagRunType.MANUAL,
+                            )
+                        ti = dagrun.get_task_instance(task_id=task.task_id)
+                        ti.task = dag.get_task(task_id=task.task_id)
+                        ti.run(ignore_ti_state=True)
+                    else:
+                        # the airflow db is not initialized so no dagrun or task instance exists
+                        ti = TaskInstance(
+                            task=task,
+                            execution_date=execution_date,
+                            run_id=f"dagster_airflow_run_{execution_date}",
+                        )
+                        ti_context = (
+                            dagster_get_template_context(ti, task, execution_date)
+                            if not use_airflow_template_context
+                            else ti.get_template_context()
+                        )
+                        task.render_template_fields(ti_context)
+                        task.execute(ti_context)
                 else:
-                    task_instance = TaskInstance(task=task, execution_date=execution_date)
-                ti_context = (
-                    dagster_get_template_context(task_instance, task, execution_date)
-                    if not use_airflow_template_context
-                    else task_instance.get_template_context()
-                )
-                task.render_template_fields(ti_context)
-
-                task.execute(ti_context)
-
+                    if use_emphemeral_airflow_db:
+                        dagrun = dag.get_dagrun(execution_date=execution_date)
+                        if not dagrun:
+                            dagrun = dag.create_dagrun(
+                                run_id=f"dagster_airflow_run_{execution_date}",
+                                state=State.RUNNING,
+                                execution_date=execution_date,
+                            )
+                        ti = dagrun.get_task_instance(task_id=task.task_id)
+                        ti.task = dag.get_task(task_id=task.task_id)
+                        ti.run(ignore_ti_state=True)
+                    else:
+                        ti = TaskInstance(task=task, execution_date=execution_date)
+                        ti_context = (
+                            dagster_get_template_context(ti, task, execution_date)
+                            if not use_airflow_template_context
+                            else ti.get_template_context()
+                        )
+                        task.render_template_fields(ti_context)
+                        task.execute(ti_context)
                 return None
 
     return _solid

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/operators/docker_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/operators/docker_operator.py
@@ -36,7 +36,7 @@ class DagsterDockerOperator(DockerOperator):
         be mapped to tmp_dir. If not provided defaults to using the standard system temp directory.
     """
 
-    def __init__(self, dagster_operator_parameters, *args):
+    def __init__(self, dagster_operator_parameters, *args, **kwargs):
         kwargs = dagster_operator_parameters.op_kwargs
         tmp_dir = kwargs.pop("tmp_dir", DOCKER_TEMPDIR)
         host_tmp_dir = kwargs.pop("host_tmp_dir", seven.get_system_temp_directory())
@@ -80,7 +80,7 @@ class DagsterDockerOperator(DockerOperator):
             # just check the last log line to see if it's JSON.
             xcom_all=True,
             *args,
-            **kwargs,
+            **dagster_operator_parameters.op_kwargs,
         )
 
     @contextmanager

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/operators/docker_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/operators/docker_operator.py
@@ -68,19 +68,18 @@ class DagsterDockerOperator(DockerOperator):
                 kwargs["docker_conn_id"] = True
 
         if "environment" not in kwargs:
-            kwargs["environment"] = get_aws_environment()
+            kwargs["environment"] = get_aws_environment()\
 
         super(DagsterDockerOperator, self).__init__(
             task_id=dagster_operator_parameters.task_id,
             dag=dagster_operator_parameters.dag,
             tmp_dir=tmp_dir,
-            host_tmp_dir=host_tmp_dir,
             xcom_push=True,
             # We do this because log lines won't necessarily be emitted in order (!) -- so we can't
             # just check the last log line to see if it's JSON.
             xcom_all=True,
             *args,
-            **dagster_operator_parameters.op_kwargs,
+            **kwargs,
         )
 
     @contextmanager

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/operators/docker_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/operators/docker_operator.py
@@ -68,8 +68,7 @@ class DagsterDockerOperator(DockerOperator):
                 kwargs["docker_conn_id"] = True
 
         if "environment" not in kwargs:
-            kwargs["environment"] = get_aws_environment()\
-
+            kwargs["environment"] = get_aws_environment()
         super(DagsterDockerOperator, self).__init__(
             task_id=dagster_operator_parameters.task_id,
             dag=dagster_operator_parameters.dag,

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/operators/python_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/operators/python_operator.py
@@ -5,7 +5,7 @@ from dagster_airflow.vendor.python_operator import PythonOperator
 
 class DagsterPythonOperator(PythonOperator):
     def __init__(self, dagster_operator_parameters, *args, **kwargs):
-        def python_callable(ts, dag_run, **kwargs):  # pylint: disable=unused-argument
+        def python_callable(ts, dag_run, *_args, **kwargs):
             return invoke_steps_within_python_operator(
                 dagster_operator_parameters.invocation_args, ts, dag_run, **kwargs
             )

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/patch_airflow_example_dag.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/patch_airflow_example_dag.py
@@ -1,13 +1,13 @@
 import pkg_resources
 
 
-# There is a bug in Airflow v1.10.8, v1.10.9, v1.10.10 where the python_callable for task
-# 'search_catalog' is missing a required position argument '_'. It is currently fixed in master.
+# There is a bug in airflow v1
+# 'search_catalog' is missing a required position argument '_'. It is fixed in airflow v2.
 # v1.10 stable: https://github.com/apache/airflow/blob/v1-10-stable/airflow/example_dags/example_complex.py#L133
 # master (05-05-2020): https://github.com/apache/airflow/blob/master/airflow/example_dags/example_complex.py#L136s
 def patch_airflow_example_dag(dag_bag):
     airflow_version = pkg_resources.get_distribution("apache-airflow").version
-    if airflow_version not in ["1.10.8", "1.10.9", "1.10.10"]:
+    if airflow_version >= "2.0.0":
         return
 
     dag = dag_bag.dags.get("example_complex")

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/vendor/docker_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/vendor/docker_operator.py
@@ -126,7 +126,6 @@ class DockerOperator(BaseOperator):
         image,
         api_version=None,
         command=None,
-        task_id=None,
         cpus=1.0,
         docker_url="unix://var/run/docker.sock",
         environment=None,
@@ -150,9 +149,9 @@ class DockerOperator(BaseOperator):
         auto_remove=False,
         shm_size=None,
         *args,
-        **_kwargs,
+        **kwargs,
     ):
-        super(DockerOperator, self).__init__(task_id=task_id, *args)
+        super(DockerOperator, self).__init__(*args, **kwargs)
         self.api_version = api_version
         self.auto_remove = auto_remove
         self.command = command

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/vendor/docker_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/vendor/docker_operator.py
@@ -124,9 +124,9 @@ class DockerOperator(BaseOperator):
     def __init__(  # pylint: disable=keyword-arg-before-vararg
         self,
         image,
-        task_id=None,
         api_version=None,
         command=None,
+        task_id=None,
         cpus=1.0,
         docker_url="unix://var/run/docker.sock",
         environment=None,
@@ -149,10 +149,10 @@ class DockerOperator(BaseOperator):
         dns_search=None,
         auto_remove=False,
         shm_size=None,
-        # *args,
-        **kwargs,
+        *args,
+        **_kwargs,
     ):
-        super(DockerOperator, self).__init__(**kwargs)
+        super(DockerOperator, self).__init__(task_id=task_id, *args)
         self.api_version = api_version
         self.auto_remove = auto_remove
         self.command = command

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/vendor/docker_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/vendor/docker_operator.py
@@ -124,6 +124,7 @@ class DockerOperator(BaseOperator):
     def __init__(  # pylint: disable=keyword-arg-before-vararg
         self,
         image,
+        task_id=None,
         api_version=None,
         command=None,
         cpus=1.0,
@@ -148,11 +149,10 @@ class DockerOperator(BaseOperator):
         dns_search=None,
         auto_remove=False,
         shm_size=None,
-        *args,
+        # *args,
         **kwargs,
     ):
-
-        super(DockerOperator, self).__init__(*args, **kwargs)
+        super(DockerOperator, self).__init__(**kwargs)
         self.api_version = api_version
         self.auto_remove = auto_remove
         self.command = command

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/vendor/kubernetes_pod_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/vendor/kubernetes_pod_operator.py
@@ -19,8 +19,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from airflow.contrib.kubernetes import kube_client, pod_generator, pod_launcher
-from airflow.contrib.kubernetes.pod import Resources
+from airflow import __version__ as airflow_version
+
+# pylint: disable=no-name-in-module,import-error
+if airflow_version >= "2.0.0":
+    from airflow.providers.cncf.kubernetes import Resources, kube_client, pod_generator
+    from airflow.providers.cncf.kubernetes.pod import Resources
+    from airflow.providers.cncf.kubernetes.utils.pod_launcher import pod_launcher
+else:
+    from airflow.contrib.kubernetes import kube_client, pod_generator, pod_launcher
+    from airflow.contrib.kubernetes.pod import Resources
+# pylint: enable=no-name-in-module,import-error
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_build_dags.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_build_dags.py
@@ -44,7 +44,8 @@ def test_build_dags(clean_airflow_home, cli_args):
     """
     runner = CliRunner()
 
-    runner.invoke(scaffold, cli_args)
+    result = runner.invoke(scaffold, cli_args)
+    assert result.exit_code == 0
 
     # This forces Airflow to refresh DAGs; see https://stackoverflow.com/a/50356956/11295366
     from airflow.models import DagBag

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_docker_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_docker_operator.py
@@ -57,7 +57,7 @@ def test_init_modified_docker_operator(dagster_docker_image):
             instance_ref=instance.get_ref(),
             recon_repo=recon_repo_for_tests,
         )
-        DagsterDockerOperator(dagster_operator_parameters)
+        DagsterDockerOperator(dagster_operator_parameters=dagster_operator_parameters)
 
 
 @requires_airflow_db
@@ -78,7 +78,7 @@ def test_modified_docker_operator_bad_docker_conn(dagster_docker_image):
             instance_ref=instance.get_ref(),
             recon_repo=recon_repo_for_tests,
         )
-        operator = DagsterDockerOperator(dagster_operator_parameters)
+        operator = DagsterDockerOperator(dagster_operator_parameters=dagster_operator_parameters)
 
         with pytest.raises(AirflowException, match="The conn_id `foo_conn` isn't defined"):
             operator.execute({})
@@ -100,7 +100,7 @@ def test_modified_docker_operator_env(dagster_docker_image):
             instance_ref=instance.get_ref(),
             recon_repo=recon_repo_for_tests,
         )
-        operator = DagsterDockerOperator(dagster_operator_parameters)
+        operator = DagsterDockerOperator(dagster_operator_parameters=dagster_operator_parameters)
         with pytest.raises(AirflowException, match="Could not parse response"):
             operator.execute({})
 
@@ -121,7 +121,7 @@ def test_modified_docker_operator_bad_command(dagster_docker_image):
             instance_ref=instance.get_ref(),
             recon_repo=recon_repo_for_tests,
         )
-        operator = DagsterDockerOperator(dagster_operator_parameters)
+        operator = DagsterDockerOperator(dagster_operator_parameters=dagster_operator_parameters)
         with pytest.raises(AirflowException, match="Usage: dagster"):
             operator.execute({})
 
@@ -154,7 +154,9 @@ def test_modified_docker_operator_url(dagster_docker_image):
                 instance_ref=instance.get_ref(),
                 recon_repo=recon_repo_for_tests,
             )
-            operator = DagsterDockerOperator(dagster_operator_parameters)
+            operator = DagsterDockerOperator(
+                dagster_operator_parameters=dagster_operator_parameters
+            )
 
             with pytest.raises(AirflowException, match="Could not parse response"):
                 operator.execute({})

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_operator.py
@@ -1,13 +1,37 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest import mock
 
+import pendulum
 import pytest
 from airflow import DAG
 from airflow import __version__ as airflow_version
 from airflow.models import Connection, TaskInstance
 from dagster_airflow import DagsterCloudOperator
 from dagster_airflow_tests.marks import requires_airflow_db
+
+# pylint: disable=no-name-in-module,import-error
+if airflow_version >= "2.0.0":
+    from airflow.utils.state import DagRunState, TaskInstanceState
+    from airflow.utils.types import DagRunType
+# pylint: enable=no-name-in-module,import-error
+
+
+DATA_INTERVAL_START = pendulum.datetime(2021, 9, 13)  # pylint: disable=pendulum-create
+DATA_INTERVAL_END = DATA_INTERVAL_START + timedelta(days=1)
+if airflow_version >= "2.0.0":
+    MOCK_DAGSTER_CONNECTION = Connection(
+        conn_type="dagster",
+        host="prod",
+        password="test-token",
+        description="test-org",
+    )
+else:
+    MOCK_DAGSTER_CONNECTION = Connection(
+        conn_type="dagster",
+        host="prod",
+        password="test-token",
+    )
 
 
 @requires_airflow_db
@@ -24,33 +48,48 @@ class TestDagsterOperator(unittest.TestCase):
             run_config=run_config,
             user_token="token",
             organization_id="test-org",
+            dagster_conn_id=None,
         )
-        ti = TaskInstance(task=task, execution_date=datetime.now())
-        ctx = ti.get_template_context()
-        task.execute(ctx)
+        if airflow_version >= "2.0.0":
+            dagrun = dag.create_dagrun(
+                state=DagRunState.RUNNING,
+                execution_date=datetime.now(),
+                data_interval=(DATA_INTERVAL_START, DATA_INTERVAL_END),
+                start_date=DATA_INTERVAL_END,
+                run_type=DagRunType.MANUAL,
+            )
+            ti = dagrun.get_task_instance(task_id="anytask")
+            ti.task = dag.get_task(task_id="anytask")
+            ti.run(ignore_ti_state=True)
+            assert ti.state == TaskInstanceState.SUCCESS
+        else:
+            ti = TaskInstance(task=task, execution_date=datetime.now())
+            ctx = ti.get_template_context()
+            task.execute(ctx)
         launch_run.assert_called_once()
         wait_for_run.assert_called_once()
 
-    @mock.patch("dagster_airflow.hooks.dagster_hook.DagsterHook.launch_run")
+    @mock.patch("dagster_airflow.hooks.dagster_hook.DagsterHook.launch_run", return_value="run_id")
     @mock.patch("dagster_airflow.hooks.dagster_hook.DagsterHook.wait_for_run")
-    @mock.patch("dagster_airflow.hooks.dagster_hook.DagsterHook.get_connection")
+    @mock.patch(
+        "dagster_airflow.hooks.dagster_hook.DagsterHook.get_connection",
+        return_value=MOCK_DAGSTER_CONNECTION,
+    )
     @pytest.mark.skipif(airflow_version < "2.0.0", reason="dagster connection requires airflow 2")
-    def test_operator_with_connection(self, launch_run, wait_for_run, mock_get_conn):
-        mock_connection = Connection(
-            conn_type="dagster",
-            host="prod",
-            password="test-token",
-            description="test-org",
-        )
-        mock_get_conn.return_value = mock_connection
-
+    def test_operator_with_connection(self, launch_run, wait_for_run, _mock_get_conn):
         dag = DAG(dag_id="anydag", start_date=datetime.now())
         run_config = {"foo": "bar"}
-        task = DagsterCloudOperator(
-            dag=dag, task_id="anytask", job_name="anyjob", run_config=run_config
+        DagsterCloudOperator(dag=dag, task_id="anytask", job_name="anyjob", run_config=run_config)
+        dagrun = dag.create_dagrun(
+            state=DagRunState.RUNNING,
+            execution_date=datetime.now(),
+            data_interval=(DATA_INTERVAL_START, DATA_INTERVAL_END),
+            start_date=DATA_INTERVAL_END,
+            run_type=DagRunType.MANUAL,
         )
-        ti = TaskInstance(task=task, execution_date=datetime.now())
-        ctx = ti.get_template_context()
-        task.execute(ctx)
+        ti = dagrun.get_task_instance(task_id="anytask")
+        ti.task = dag.get_task(task_id="anytask")
+        ti.run(ignore_ti_state=True)
+        assert ti.state == TaskInstanceState.SUCCESS
         launch_run.assert_called_once()
         wait_for_run.assert_called_once()

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/snapshots/snap_test_dependency_structure_translation.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/snapshots/snap_test_dependency_structure_translation.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots[

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_dependency_structure_translation.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_dependency_structure_translation.py
@@ -1,9 +1,17 @@
 # pylint: disable=pointless-statement
 
+from airflow import __version__ as airflow_version
 from airflow.models.dag import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.dates import days_ago
-from airflow.utils.helpers import chain
+
+# pylint: disable=no-name-in-module,import-error
+if airflow_version >= "2.0.0":
+    from airflow.models.baseoperator import chain
+else:
+    from airflow.utils.helpers import chain
+# pylint: enable=no-name-in-module,import-error
+
 from dagster_airflow.dagster_job_factory import make_dagster_job_from_airflow_dag
 from dagster_airflow.dagster_pipeline_factory import make_dagster_pipeline_from_airflow_dag
 
@@ -17,11 +25,18 @@ default_args = {
 
 
 def test_one_task_dag(snapshot):
-    dag = DAG(
-        dag_id="one_task_dag",
-        default_args=default_args,
-        schedule_interval=None,
-    )
+    if airflow_version >= "2.0.0":
+        dag = DAG(
+            dag_id="one_task_dag",
+            default_args=default_args,
+            schedule=None,
+        )
+    else:
+        dag = DAG(
+            dag_id="one_task_dag",
+            default_args=default_args,
+            schedule_interval=None,
+        )
     dummy_operator = DummyOperator(
         task_id="dummy_operator",
         dag=dag,
@@ -37,11 +52,18 @@ def test_one_task_dag(snapshot):
 
 
 def test_two_task_dag_no_dep(snapshot):
-    dag = DAG(
-        dag_id="two_task_dag_no_dep",
-        default_args=default_args,
-        schedule_interval=None,
-    )
+    if airflow_version >= "2.0.0":
+        dag = DAG(
+            dag_id="two_task_dag_no_dep",
+            default_args=default_args,
+            schedule=None,
+        )
+    else:
+        dag = DAG(
+            dag_id="two_task_dag_no_dep",
+            default_args=default_args,
+            schedule_interval=None,
+        )
     dummy_operator_1 = DummyOperator(
         task_id="dummy_operator_1",
         dag=dag,
@@ -61,11 +83,19 @@ def test_two_task_dag_no_dep(snapshot):
 
 
 def test_two_task_dag_with_dep(snapshot):
-    dag = DAG(
-        dag_id="two_task_dag_with_dep",
-        default_args=default_args,
-        schedule_interval=None,
-    )
+    if airflow_version >= "2.0.0":
+        dag = DAG(
+            dag_id="two_task_dag_with_dep",
+            default_args=default_args,
+            schedule=None,
+        )
+    else:
+        dag = DAG(
+            dag_id="two_task_dag_with_dep",
+            default_args=default_args,
+            schedule_interval=None,
+        )
+
     dummy_operator_1 = DummyOperator(
         task_id="dummy_operator_1",
         dag=dag,
@@ -86,11 +116,18 @@ def test_two_task_dag_with_dep(snapshot):
 
 
 def test_diamond_task_dag(snapshot):
-    dag = DAG(
-        dag_id="diamond_task_dag",
-        default_args=default_args,
-        schedule_interval=None,
-    )
+    if airflow_version >= "2.0.0":
+        dag = DAG(
+            dag_id="diamond_task_dag",
+            default_args=default_args,
+            schedule=None,
+        )
+    else:
+        dag = DAG(
+            dag_id="diamond_task_dag",
+            default_args=default_args,
+            schedule_interval=None,
+        )
     dummy_operator_1 = DummyOperator(
         task_id="dummy_operator_1",
         dag=dag,
@@ -122,11 +159,18 @@ def test_diamond_task_dag(snapshot):
 
 
 def test_multi_root_dag(snapshot):
-    dag = DAG(
-        dag_id="multi_root_dag",
-        default_args=default_args,
-        schedule_interval=None,
-    )
+    if airflow_version >= "2.0.0":
+        dag = DAG(
+            dag_id="multi_root_dag",
+            default_args=default_args,
+            schedule=None,
+        )
+    else:
+        dag = DAG(
+            dag_id="multi_root_dag",
+            default_args=default_args,
+            schedule_interval=None,
+        )
     dummy_operator_1 = DummyOperator(
         task_id="dummy_operator_1",
         dag=dag,
@@ -158,11 +202,18 @@ def test_multi_root_dag(snapshot):
 
 
 def test_multi_leaf_dag(snapshot):
-    dag = DAG(
-        dag_id="multi_leaf_dag",
-        default_args=default_args,
-        schedule_interval=None,
-    )
+    if airflow_version >= "2.0.0":
+        dag = DAG(
+            dag_id="multi_leaf_dag",
+            default_args=default_args,
+            schedule=None,
+        )
+    else:
+        dag = DAG(
+            dag_id="multi_leaf_dag",
+            default_args=default_args,
+            schedule_interval=None,
+        )
     dummy_operator_1 = DummyOperator(
         task_id="dummy_operator_1",
         dag=dag,
@@ -193,7 +244,18 @@ def test_multi_leaf_dag(snapshot):
 
 
 def test_complex_dag(snapshot):
-    dag = DAG(dag_id="complex_dag", default_args=default_args, schedule_interval=None)
+    if airflow_version >= "2.0.0":
+        dag = DAG(
+            dag_id="complex_dag",
+            default_args=default_args,
+            schedule=None,
+        )
+    else:
+        dag = DAG(
+            dag_id="complex_dag",
+            default_args=default_args,
+            schedule_interval=None,
+        )
 
     # Create
     create_entry_group = DummyOperator(
@@ -249,10 +311,6 @@ def test_complex_dag(snapshot):
         dag=dag,
     )
     create_tag_template_field_result = DummyOperator(
-        task_id="create_tag_template_field_result",
-        dag=dag,
-    )
-    create_tag_template_field_result2 = DummyOperator(
         task_id="create_tag_template_field_result",
         dag=dag,
     )
@@ -386,7 +444,6 @@ def test_complex_dag(snapshot):
 
     create_tag_template_field >> delete_tag_template_field
     create_tag_template_field >> create_tag_template_field_result
-    create_tag_template_field >> create_tag_template_field_result2
 
     create_tag >> delete_tag
     create_tag >> create_tag_result
@@ -443,11 +500,18 @@ def test_complex_dag(snapshot):
 
 
 def test_one_task_dag_to_job():
-    dag = DAG(
-        dag_id="dag-with.dot-dash",
-        default_args=default_args,
-        schedule_interval=None,
-    )
+    if airflow_version >= "2.0.0":
+        dag = DAG(
+            dag_id="dag-with.dot-dash",
+            default_args=default_args,
+            schedule=None,
+        )
+    else:
+        dag = DAG(
+            dag_id="dag-with.dot-dash",
+            default_args=default_args,
+            schedule_interval=None,
+        )
     dummy_operator = DummyOperator(
         task_id="dummy_operator",
         dag=dag,

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_solid_execution.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_solid_execution.py
@@ -1,9 +1,16 @@
 import datetime
 import os
-import subprocess
 from unittest import mock
 
-from airflow.contrib.operators.spark_submit_operator import SparkSubmitOperator
+from airflow import __version__ as airflow_version
+
+# pylint: disable=no-name-in-module,import-error
+if airflow_version >= "2.0.0":
+    from airflow.providers.apache.spark.operators.spark_submit import SparkSubmitOperator
+else:
+    from airflow.contrib.operators.spark_submit_operator import SparkSubmitOperator
+# pylint: enable=no-name-in-module,import-error
+
 from airflow.models.dag import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
@@ -27,11 +34,18 @@ default_args = {
 # dashes, dots and underscores) than Dagster's naming conventions (alphanumeric characters,
 # underscores), so Dagster will strip invalid characters and replace with '_'
 def test_normalize_name():
-    dag = DAG(
-        dag_id="dag-with.dot-dash",
-        default_args=default_args,
-        schedule_interval=None,
-    )
+    if airflow_version >= "2.0.0":
+        dag = DAG(
+            dag_id="dag-with.dot-dash",
+            default_args=default_args,
+            schedule=None,
+        )
+    else:
+        dag = DAG(
+            dag_id="dag-with.dot-dash",
+            default_args=default_args,
+            schedule_interval=None,
+        )
     dummy_operator = DummyOperator(
         task_id="task-with.dot-dash",
         dag=dag,
@@ -52,11 +66,18 @@ def test_normalize_name():
 # Test names with 250 characters, Airflow's max allowed length
 def test_long_name():
     dag_name = "dag-with.dot-dash-lo00ong" * 10
-    dag = DAG(
-        dag_id=dag_name,
-        default_args=default_args,
-        schedule_interval=None,
-    )
+    if airflow_version >= "2.0.0":
+        dag = DAG(
+            dag_id=dag_name,
+            default_args=default_args,
+            schedule=None,
+        )
+    else:
+        dag = DAG(
+            dag_id=dag_name,
+            default_args=default_args,
+            schedule_interval=None,
+        )
     long_name = "task-with.dot-dash2-loong" * 10  # 250 characters, Airflow's max allowed length
     dummy_operator = DummyOperator(
         task_id=long_name,
@@ -83,11 +104,18 @@ def test_long_name():
 
 
 def test_one_task_dag():
-    dag = DAG(
-        dag_id="dag",
-        default_args=default_args,
-        schedule_interval=None,
-    )
+    if airflow_version >= "2.0.0":
+        dag = DAG(
+            dag_id="dag",
+            default_args=default_args,
+            schedule=None,
+        )
+    else:
+        dag = DAG(
+            dag_id="dag",
+            default_args=default_args,
+            schedule_interval=None,
+        )
     dummy_operator = DummyOperator(
         task_id="dummy_operator",
         dag=dag,
@@ -106,11 +134,18 @@ def normalize_file_content(s):
 
 
 def test_template_task_dag():
-    dag = DAG(
-        dag_id="dag",
-        default_args=default_args,
-        schedule_interval=None,
-    )
+    if airflow_version >= "2.0.0":
+        dag = DAG(
+            dag_id="dag",
+            default_args=default_args,
+            schedule=None,
+        )
+    else:
+        dag = DAG(
+            dag_id="dag",
+            default_args=default_args,
+            schedule_interval=None,
+        )
 
     t1 = BashOperator(
         task_id="print_hello",
@@ -148,8 +183,7 @@ def test_template_task_dag():
 
         execution_date = get_current_datetime_in_utc()
         execution_date_add_one_week = execution_date + datetime.timedelta(days=7)
-        execution_date_iso = execution_date.strftime("%Y-%m-%d")
-        execution_date_add_one_week_iso = execution_date_add_one_week.strftime("%Y-%m-%d")
+        execution_date_iso = execution_date.isoformat()
 
         result = execute_pipeline(
             make_dagster_pipeline_from_airflow_dag(
@@ -178,65 +212,49 @@ def test_template_task_dag():
         file_contents = normalize_file_content(stdout_file.read())
         stdout_file.close()
 
-        assert file_contents.count("INFO - Running command: echo hello dagsir\n") == 1
-        assert file_contents.count("INFO - Running command: sleep 2\n") == 1
-        assert (
-            file_contents.count(
-                "INFO - Running command: \n    \n        "
-                "echo '{execution_date_iso}'\n        "
-                "echo '{execution_date_add_one_week_iso}'\n        "
-                "echo 'Parameter I passed in'\n    \n        "
-                "echo '{execution_date_iso}'\n        "
-                "echo '{execution_date_add_one_week_iso}'\n        "
-                "echo 'Parameter I passed in'\n    \n        "
-                "echo '{execution_date_iso}'\n        "
-                "echo '{execution_date_add_one_week_iso}'\n        "
-                "echo 'Parameter I passed in'\n    \n        "
-                "echo '{execution_date_iso}'\n        "
-                "echo '{execution_date_add_one_week_iso}'\n        "
-                "echo 'Parameter I passed in'\n    \n        "
-                "echo '{execution_date_iso}'\n        "
-                "echo '{execution_date_add_one_week_iso}'\n        "
-                "echo 'Parameter I passed in'\n    \n    \n".format(
-                    execution_date_iso=execution_date_iso,
-                    execution_date_add_one_week_iso=execution_date_add_one_week_iso,
+        if airflow_version >= "2.0.0":
+            assert (
+                file_contents.count("Running command: ['/bin/bash', '-c', 'echo hello dagsir']")
+                == 1
+            )
+            assert file_contents.count("Running command: ['/bin/bash', '-c', 'sleep 2']") == 1
+        else:
+            assert file_contents.count("INFO - Running command: echo hello dagsir\n") == 1
+            assert file_contents.count("INFO - Running command: sleep 2\n") == 1
+            assert (
+                file_contents.count(
+                    "INFO - Running command: \n    \n        "
+                    "echo '{execution_date_iso}'\n        "
+                    "echo '{execution_date_add_one_week_iso}'\n        "
+                    "echo 'Parameter I passed in'\n    \n        "
+                    "echo '{execution_date_iso}'\n        "
+                    "echo '{execution_date_add_one_week_iso}'\n        "
+                    "echo 'Parameter I passed in'\n    \n        "
+                    "echo '{execution_date_iso}'\n        "
+                    "echo '{execution_date_add_one_week_iso}'\n        "
+                    "echo 'Parameter I passed in'\n    \n        "
+                    "echo '{execution_date_iso}'\n        "
+                    "echo '{execution_date_add_one_week_iso}'\n        "
+                    "echo 'Parameter I passed in'\n    \n        "
+                    "echo '{execution_date_iso}'\n        "
+                    "echo '{execution_date_add_one_week_iso}'\n        "
+                    "echo 'Parameter I passed in'\n    \n    \n".format(
+                        execution_date_iso=execution_date.strftime("%Y-%m-%d"),
+                        execution_date_add_one_week_iso=execution_date_add_one_week.strftime(
+                            "%Y-%m-%d"
+                        ),
+                    )
                 )
+                == 1
             )
-            == 1
-        )
-        assert (
-            file_contents.count(
-                "INFO - {execution_date_iso}\n".format(execution_date_iso=execution_date_iso)
-            )
-            == 5
-        )
-        assert (
-            file_contents.count(
-                "INFO - {execution_date_add_one_week_iso}\n".format(
-                    execution_date_add_one_week_iso=execution_date_add_one_week_iso
-                )
-            )
-            == 5
-        )
-        assert file_contents.count("INFO - Parameter I passed in\n") == 5
-        assert file_contents.count("INFO - Command exited with return code 0") == 3
+        assert file_contents.count("Command exited with return code 0") == 3
 
 
-def intercept_spark_submit(*args, **kwargs):
-    if args[0] == [
-        "spark-submit",
-        "--master",
-        "",
-        "--name",
-        "airflow-spark",
-        "some_path.py",
-    ]:
-        m = mock.MagicMock()
-        m.stdout.readline.return_value = ""
-        m.wait.return_value = 0
-        return m
-    else:
-        return subprocess.Popen(*args, **kwargs)
+def intercept_spark_submit(*_args, **_kwargs):
+    m = mock.MagicMock()
+    m.stdout.readline.return_value = ""
+    m.wait.return_value = 0
+    return m
 
 
 @mock.patch("subprocess.Popen", side_effect=intercept_spark_submit)
@@ -244,13 +262,19 @@ def test_spark_dag(mock_subproc_popen):
     # Hack to get around having a Connection
     os.environ["AIRFLOW_CONN_SPARK"] = "something"
 
-    dag = DAG(
-        dag_id="spark_dag",
-        default_args=default_args,
-        schedule_interval=None,
-    )
-    # pylint: disable=unused-variable
-    clean_data = SparkSubmitOperator(
+    if airflow_version >= "2.0.0":
+        dag = DAG(
+            dag_id="spark_dag",
+            default_args=default_args,
+            schedule=None,
+        )
+    else:
+        dag = DAG(
+            dag_id="spark_dag",
+            default_args=default_args,
+            schedule_interval=None,
+        )
+    SparkSubmitOperator(
         task_id="run_spark",
         application="some_path.py",
         conn_id="SPARK",
@@ -261,8 +285,13 @@ def test_spark_dag(mock_subproc_popen):
         dag=dag,
         tags={AIRFLOW_EXECUTION_DATE_STR: get_current_datetime_in_utc().isoformat()},
     )
-    execute_pipeline(pipeline)  # , instance=instance,)
+    execute_pipeline(pipeline)
 
-    assert mock_subproc_popen.call_args_list[0][0] == (
-        ["spark-submit", "--master", "", "--name", "airflow-spark", "some_path.py"],
-    )
+    if airflow_version >= "2.0.0":
+        assert mock_subproc_popen.call_args_list[0][0] == (
+            ["spark-submit", "--master", "", "--name", "arrow-spark", "some_path.py"],
+        )
+    else:
+        assert mock_subproc_popen.call_args_list[0][0] == (
+            ["spark-submit", "--master", "", "--name", "airflow-spark", "some_path.py"],
+        )

--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -34,11 +34,9 @@ setup(
     packages=find_packages(exclude=["dagster_airflow_tests*"]),
     install_requires=[
         f"dagster{pin}",
-        "docker",
-        "python-dateutil>=2.8.0",
+        "docker>=5.0.3,<6.0.0",
         "lazy_object_proxy",
-        # https://issues.apache.org/jira/browse/AIRFLOW-6854
-        'typing_extensions; python_version>="3.8"',
+        "pendulum",
     ],
     project_urls={
         # airflow will embed a link this in the providers page UI
@@ -46,21 +44,25 @@ setup(
     },
     extras_require={
         "kubernetes": ["kubernetes>=3.0.0", "cryptography>=2.0.0"],
-        "test": [
-            # Airflow should be provided by the end user, not us. For example, GCP Cloud
-            # Composer ships a fork of Airflow; we don't want to override it with our install.
-            # See https://github.com/dagster-io/dagster/issues/2701
-            "apache-airflow==1.10.10",
-            # https://github.com/dagster-io/dagster/issues/3858
-            "sqlalchemy>=1.0,<1.4.0",
-            "marshmallow-sqlalchemy<0.26.0",
-            "boto3==1.9.*",
-            "kubernetes==10.0.1",
-            # New WTForms release breaks the version of airflow used by tests
-            "WTForms<3.0.0",
+        "test_airflow_2": [
+            "apache-airflow>=2.0.0,<3.0.0",
+            "boto3>=1.26.7",
+            "kubernetes>=10.0.1",
+            "apache-airflow-providers-docker>=3.2.0,<4",
+            "apache-airflow-providers-apache-spark>=3.0.0,<4",
+        ],
+        "test_airflow_1": [
+            "apache-airflow>=1.0.0,<2.0.0",
+            "boto3>=1.26.7",
+            "kubernetes>=10.0.1",
             # pinned based on certain incompatible versions of Jinja2, which is itself pinned
             # by apache-airflow==1.10.10
             "markupsafe<=2.0.1",
+            # New WTForms release breaks the version of airflow used by tests
+            "WTForms<3.0.0",
+            # https://github.com/dagster-io/dagster/issues/3858
+            "sqlalchemy>=1.0,<1.4.0",
+            "marshmallow-sqlalchemy<0.26.0",
         ],
     },
     entry_points={

--- a/python_modules/libraries/dagster-airflow/tox.ini
+++ b/python_modules/libraries/dagster-airflow/tox.ini
@@ -24,8 +24,8 @@ commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   requiresairflowdb-airflow1: airflow initdb
   requiresairflowdb-airflow2: airflow db init
-  !requiresairflowdb: pytest -m "not requires_airflow_db" dagster_airflow_tests/test_dagster_docker_operator.py -vv --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report= {posargs}
-  requiresairflowdb: pytest -m requires_airflow_db dagster_airflow_tests/test_dagster_docker_operator.py -vv --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report= {posargs}
+  !requiresairflowdb: pytest -m "not requires_airflow_db" -vv --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report= {posargs}
+  requiresairflowdb: pytest -m requires_airflow_db -vv --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-airflow/tox.ini
+++ b/python_modules/libraries/dagster-airflow/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}-{default,requiresairflowdb}-airflow{1.10.15,2.4.1},pylint
+envlist = py{39,38,37,36}-{unix,windows}-{default,requiresairflowdb}-airflow{1,2},pylint
 
 [testenv]
 usedevelop = true
 extras =
-  test
+  airflow1: test_airflow_1
+  airflow2: test_airflow_2
 setenv =
   VIRTUALENV_PIP=21.3.1
   SLUGIFY_USES_TEXT_UNIDECODE = yes
@@ -17,14 +18,12 @@ deps =
   -e ../dagster-gcp
   -e ../dagster-postgres
   -e ../../dagster-test
-
 allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  airflow1.10.15: pip install apache-airflow==1.10.15
-  airflow2.4.1: pip install apache-airflow==2.4.1
-  requiresairflowdb: airflow initdb
+  requiresairflowdb-airflow1: airflow initdb
+  requiresairflowdb-airflow2: airflow db init
   !requiresairflowdb: pytest -m "not requires_airflow_db" -vv --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report= {posargs}
   requiresairflowdb: pytest -m requires_airflow_db -vv --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
@@ -36,5 +35,7 @@ commands =
   mypy --config=../../../pyproject.toml --non-interactive --install-types {posargs} .
 
 [testenv:pylint]
+extras =
+  test_airflow_1
 commands =
   pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_airflow dagster_airflow_tests

--- a/python_modules/libraries/dagster-airflow/tox.ini
+++ b/python_modules/libraries/dagster-airflow/tox.ini
@@ -24,8 +24,8 @@ commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   requiresairflowdb-airflow1: airflow initdb
   requiresairflowdb-airflow2: airflow db init
-  !requiresairflowdb: pytest -m "not requires_airflow_db" -vv --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report= {posargs}
-  requiresairflowdb: pytest -m requires_airflow_db -vv --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report= {posargs}
+  !requiresairflowdb: pytest -m "not requires_airflow_db" dagster_airflow_tests/test_dagster_docker_operator.py -vv --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report= {posargs}
+  requiresairflowdb: pytest -m requires_airflow_db dagster_airflow_tests/test_dagster_docker_operator.py -vv --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'


### PR DESCRIPTION
### Summary & Motivation

This PR adds test coverage for Airflow 2 and py39. It also adds support for using an Airflow db when running rendered Airflow dags in Dagster. 

Using an Airflow db allows Dagster to successfully run any Airflow dag that does not rely on state external to what is generated during a DagRun. 

### How I Tested These Changes
