### PR TITLE
use random string for compute log file key instead of pid which will collide

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/compute_log_manager.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/compute_log_manager.py
@@ -21,6 +21,7 @@ class AzureBlobComputeLogManager(BaseModel):
     secretKey: StringSource
     localDir: Optional[StringSource]
     prefix: Optional[StringSource]
+    uploadInterval: Optional[int]
 
 
 class GCSComputeLogManager(BaseModel):
@@ -28,6 +29,7 @@ class GCSComputeLogManager(BaseModel):
     localDir: Optional[StringSource]
     prefix: Optional[StringSource]
     jsonCredentialsEnvvar: Optional[StringSource]
+    uploadInterval: Optional[int]
 
 
 class S3ComputeLogManager(BaseModel):
@@ -39,6 +41,7 @@ class S3ComputeLogManager(BaseModel):
     verifyCertPath: Optional[StringSource]
     endpointUrl: Optional[StringSource]
     skipEmptyFiles: Optional[bool]
+    uploadInterval: Optional[int]
 
 
 class ComputeLogManagerConfig(BaseModel):

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -467,6 +467,7 @@ def test_azure_blob_compute_log_manager(template: HelmTemplate):
     secret_key = "secret_key"
     local_dir = "/dir"
     prefix = "prefix"
+    upload_interval = 30
     helm_values = DagsterHelmValues.construct(
         computeLogManager=ComputeLogManager.construct(
             type=ComputeLogManagerType.AZURE,
@@ -477,6 +478,7 @@ def test_azure_blob_compute_log_manager(template: HelmTemplate):
                     secretKey=secret_key,
                     localDir=local_dir,
                     prefix=prefix,
+                    uploadInterval=upload_interval,
                 )
             ),
         )
@@ -494,6 +496,7 @@ def test_azure_blob_compute_log_manager(template: HelmTemplate):
         "secret_key": secret_key,
         "local_dir": local_dir,
         "prefix": prefix,
+        "upload_interval": upload_interval,
     }
 
     # Test all config fields in configurable class
@@ -505,6 +508,7 @@ def test_gcs_compute_log_manager(template: HelmTemplate):
     local_dir = "/dir"
     prefix = "prefix"
     json_credentials_envvar = "ENV_VAR"
+    upload_interval = 30
     helm_values = DagsterHelmValues.construct(
         computeLogManager=ComputeLogManager.construct(
             type=ComputeLogManagerType.GCS,
@@ -514,6 +518,7 @@ def test_gcs_compute_log_manager(template: HelmTemplate):
                     localDir=local_dir,
                     prefix=prefix,
                     jsonCredentialsEnvvar=json_credentials_envvar,
+                    uploadInterval=upload_interval,
                 )
             ),
         )
@@ -530,6 +535,7 @@ def test_gcs_compute_log_manager(template: HelmTemplate):
         "local_dir": local_dir,
         "prefix": prefix,
         "json_credentials_envvar": json_credentials_envvar,
+        "upload_interval": upload_interval,
     }
 
     # Test all config fields in configurable class
@@ -545,6 +551,7 @@ def test_s3_compute_log_manager(template: HelmTemplate):
     verify_cert_path = "/path"
     endpoint_url = "endpoint.com"
     skip_empty_files = True
+    upload_interval = 30
     helm_values = DagsterHelmValues.construct(
         computeLogManager=ComputeLogManager.construct(
             type=ComputeLogManagerType.S3,
@@ -558,6 +565,7 @@ def test_s3_compute_log_manager(template: HelmTemplate):
                     verifyCertPath=verify_cert_path,
                     endpointUrl=endpoint_url,
                     skipEmptyFiles=skip_empty_files,
+                    uploadInterval=upload_interval,
                 )
             ),
         )
@@ -578,6 +586,7 @@ def test_s3_compute_log_manager(template: HelmTemplate):
         "verify_cert_path": verify_cert_path,
         "endpoint_url": endpoint_url,
         "skip_empty_files": skip_empty_files,
+        "upload_interval": upload_interval,
     }
 
     # Test all config fields in configurable class

--- a/helm/dagster/templates/helpers/instance/_compute-log-manager.tpl
+++ b/helm/dagster/templates/helpers/instance/_compute-log-manager.tpl
@@ -29,6 +29,10 @@ config:
   {{- if $azureBlobComputeLogManagerConfig.prefix }}
   prefix: {{ include "stringSource" $azureBlobComputeLogManagerConfig.prefix }}
   {{- end }}
+
+  {{- if $azureBlobComputeLogManagerConfig.uploadInterval }}
+  upload_interval: {{ $azureBlobComputeLogManagerConfig.uploadInterval }}
+  {{- end }}
 {{- end }}
 
 {{- define "dagsterYaml.computeLogManager.gcs" }}
@@ -48,6 +52,10 @@ config:
 
   {{- if $gcsComputeLogManagerConfig.jsonCredentialsEnvvar }}
   json_credentials_envvar: {{ include "stringSource" $gcsComputeLogManagerConfig.jsonCredentialsEnvvar }}
+  {{- end }}
+
+  {{- if $gcsComputeLogManagerConfig.uploadInterval }}
+  upload_interval: {{ $gcsComputeLogManagerConfig.uploadInterval }}
   {{- end }}
 {{- end }}
 
@@ -84,6 +92,10 @@ config:
 
   {{- if $s3ComputeLogManagerConfig.skipEmptyFiles }}
   skip_empty_files: {{ $s3ComputeLogManagerConfig.skipEmptyFiles }}
+  {{- end }}
+
+  {{- if $s3ComputeLogManagerConfig.uploadInterval }}
+  upload_interval: {{ $s3ComputeLogManagerConfig.uploadInterval }}
   {{- end }}
 {{- end }}
 

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1219,6 +1219,17 @@
                             "type": "null"
                         }
                     ]
+                },
+                "uploadInterval": {
+                    "title": "Uploadinterval",
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [
@@ -1278,6 +1289,17 @@
                         },
                         {
                             "$ref": "#/definitions/Source"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "uploadInterval": {
+                    "title": "Uploadinterval",
+                    "anyOf": [
+                        {
+                            "type": "integer"
                         },
                         {
                             "type": "null"
@@ -1387,6 +1409,17 @@
                     "anyOf": [
                         {
                             "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "uploadInterval": {
+                    "title": "Uploadinterval",
+                    "anyOf": [
+                        {
+                            "type": "integer"
                         },
                         {
                             "type": "null"

--- a/python_modules/dagster/dagster/_core/execution/compute_logs.py
+++ b/python_modules/dagster/dagster/_core/execution/compute_logs.py
@@ -1,5 +1,7 @@
 import io
 import os
+import random
+import string
 import subprocess
 import sys
 import tempfile
@@ -14,6 +16,10 @@ from dagster._seven import IS_WINDOWS, wait_for_process
 from dagster._utils import ensure_file
 
 WIN_PY36_COMPUTE_LOG_DISABLED_MSG = """\u001b[33mWARNING: Compute log capture is disabled for the current environment. Set the environment variable `PYTHONLEGACYWINDOWSSTDIO` to enable.\n\u001b[0m"""
+
+
+def create_compute_log_file_key():
+    return "".join(random.choice(string.ascii_lowercase) for x in range(8))
 
 
 @contextmanager

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from contextlib import ExitStack
 from typing import Iterator, Sequence, cast
@@ -14,6 +13,7 @@ from dagster._core.errors import (
     user_code_error_boundary,
 )
 from dagster._core.events import DagsterEvent, EngineEventData
+from dagster._core.execution.compute_logs import create_compute_log_file_key
 from dagster._core.execution.context.system import PlanExecutionContext, StepExecutionContext
 from dagster._core.execution.plan.execute_step import core_dagster_event_sequence_for_step
 from dagster._core.execution.plan.objects import (
@@ -42,8 +42,8 @@ def inner_plan_execution_iterator(
 
         # begin capturing logs for the whole process if this is a captured log manager
         if isinstance(compute_log_manager, CapturedLogManager):
-            pid = str(os.getpid())
-            log_key = compute_log_manager.build_log_key_for_run(pipeline_context.run_id, pid)
+            file_key = create_compute_log_file_key()
+            log_key = compute_log_manager.build_log_key_for_run(pipeline_context.run_id, file_key)
             log_context = plan_stack.enter_context(compute_log_manager.capture_logs(log_key))
             yield DagsterEvent.capture_logs(pipeline_context, step_keys, log_key, log_context)
 

--- a/python_modules/dagster/dagster/_core/storage/cloud_storage_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/cloud_storage_compute_log_manager.py
@@ -1,0 +1,387 @@
+import json
+import os
+import threading
+import time
+from abc import abstractmethod
+from collections import defaultdict
+from contextlib import contextmanager
+from typing import IO, Generator, Optional, Sequence, Union
+
+from dagster import _check as check
+from dagster._core.storage.captured_log_manager import (
+    CapturedLogContext,
+    CapturedLogData,
+    CapturedLogManager,
+    CapturedLogMetadata,
+    CapturedLogSubscription,
+)
+from dagster._core.storage.compute_log_manager import (
+    MAX_BYTES_FILE_READ,
+    ComputeIOType,
+    ComputeLogFileData,
+    ComputeLogManager,
+    ComputeLogSubscription,
+)
+from dagster._core.storage.local_compute_log_manager import (
+    IO_TYPE_EXTENSION,
+    LocalComputeLogManager,
+)
+
+SUBSCRIPTION_POLLING_INTERVAL = 5
+
+
+class CloudStorageComputeLogManager(CapturedLogManager, ComputeLogManager):
+    """Abstract class that uses the local compute log manager to capture logs and stores them in
+    remote cloud storage
+    """
+
+    @property
+    @abstractmethod
+    def local_manager(self) -> LocalComputeLogManager:
+        """
+        Returns a LocalComputeLogManager
+        """
+
+    @property
+    @abstractmethod
+    def upload_interval(self) -> Optional[int]:
+        """
+        Returns the interval in which partial compute logs are uploaded to cloud storage
+        """
+
+    @abstractmethod
+    def delete_logs(self, log_key: Sequence[str]):
+        """
+        Deletes logs for a given log_key
+        """
+
+    @abstractmethod
+    def download_url_for_type(self, log_key: Sequence[str], io_type: ComputeIOType):
+        """
+        Calculates a download url given a log key and compute io type
+        """
+
+    @abstractmethod
+    def display_path_for_type(self, log_key: Sequence[str], io_type: ComputeIOType):
+        """
+        Returns a display path given a log key and compute io type
+        """
+
+    @abstractmethod
+    def cloud_storage_has_logs(
+        self, log_key: Sequence[str], io_type: ComputeIOType, partial: bool = False
+    ) -> bool:
+        """
+        Returns whether the cloud storage contains logs for a given log key
+        """
+
+    @abstractmethod
+    def upload_to_cloud_storage(
+        self, log_key: Sequence[str], io_type: ComputeIOType, partial=False
+    ):
+        """
+        Uploads the logs for a given log key from local storage to cloud storage
+        """
+
+    def download_from_cloud_storage(
+        self, log_key: Sequence[str], io_type: ComputeIOType, partial=False
+    ):
+        """
+        Downloads the logs for a given log key from cloud storage to local storage
+        """
+
+    @contextmanager
+    def capture_logs(self, log_key: Sequence[str]) -> Generator[CapturedLogContext, None, None]:
+        with self._poll_for_local_upload(log_key):
+            with self.local_manager.capture_logs(log_key) as context:
+                yield context
+        self._on_capture_complete(log_key)
+
+    @contextmanager
+    def open_log_stream(
+        self, log_key: Sequence[str], io_type: ComputeIOType
+    ) -> Generator[Optional[IO], None, None]:
+        with self.local_manager.open_log_stream(log_key, io_type) as f:
+            yield f
+        self._on_capture_complete(log_key)
+
+    def _on_capture_complete(self, log_key: Sequence[str]):
+        self.upload_to_cloud_storage(log_key, ComputeIOType.STDOUT)
+        self.upload_to_cloud_storage(log_key, ComputeIOType.STDERR)
+
+    def is_capture_complete(self, log_key: Sequence[str]) -> bool:
+        return self.local_manager.is_capture_complete(log_key)
+
+    def _log_data_for_type(self, log_key, io_type, offset, max_bytes):
+        if self._has_local_file(log_key, io_type):
+            local_path = self.local_manager.get_captured_local_path(
+                log_key, IO_TYPE_EXTENSION[io_type]
+            )
+            return self.local_manager.read_path(local_path, offset=offset, max_bytes=max_bytes)
+        if self.cloud_storage_has_logs(log_key, io_type):
+            self.download_from_cloud_storage(log_key, io_type)
+            local_path = self.local_manager.get_captured_local_path(
+                log_key, IO_TYPE_EXTENSION[io_type]
+            )
+            return self.local_manager.read_path(local_path, offset=offset, max_bytes=max_bytes)
+        if self.cloud_storage_has_logs(log_key, io_type, partial=True):
+            self.download_from_cloud_storage(log_key, io_type, partial=True)
+            local_path = self.local_manager.get_captured_local_path(
+                log_key, IO_TYPE_EXTENSION[io_type], partial=True
+            )
+            return self.local_manager.read_path(local_path, offset=offset, max_bytes=max_bytes)
+
+        return None, offset
+
+    def get_log_data(
+        self,
+        log_key: Sequence[str],
+        cursor: str = None,
+        max_bytes: int = None,
+    ) -> CapturedLogData:
+        stdout_offset, stderr_offset = self.local_manager.parse_cursor(cursor)
+        stdout, new_stdout_offset = self._log_data_for_type(
+            log_key, ComputeIOType.STDOUT, stdout_offset, max_bytes
+        )
+        stderr, new_stderr_offset = self._log_data_for_type(
+            log_key, ComputeIOType.STDERR, stderr_offset, max_bytes
+        )
+        return CapturedLogData(
+            log_key=log_key,
+            stdout=stdout,
+            stderr=stderr,
+            cursor=self.local_manager.build_cursor(new_stdout_offset, new_stderr_offset),
+        )
+
+    def get_log_metadata(self, log_key: Sequence[str]) -> CapturedLogMetadata:
+        return CapturedLogMetadata(
+            stdout_location=self.display_path_for_type(log_key, ComputeIOType.STDOUT),
+            stderr_location=self.display_path_for_type(log_key, ComputeIOType.STDERR),
+            stdout_download_url=self.download_url_for_type(log_key, ComputeIOType.STDOUT),
+            stderr_download_url=self.download_url_for_type(log_key, ComputeIOType.STDERR),
+        )
+
+    def on_progress(self, log_key):
+        # should be called at some interval, to be used for streaming upload implementations
+        if self.is_capture_complete(log_key):
+            return
+
+        self.upload_to_cloud_storage(log_key, ComputeIOType.STDOUT, partial=True)
+        self.upload_to_cloud_storage(log_key, ComputeIOType.STDERR, partial=True)
+
+    def subscribe(
+        self, log_key: Sequence[str], cursor: Optional[str] = None
+    ) -> CapturedLogSubscription:
+        subscription = CapturedLogSubscription(self, log_key, cursor)
+        self.on_subscribe(subscription)
+        return subscription
+
+    def unsubscribe(self, subscription):
+        self.on_unsubscribe(subscription)
+
+    def _has_local_file(self, log_key, io_type):
+        local_path = self.local_manager.get_captured_local_path(log_key, IO_TYPE_EXTENSION[io_type])
+        return os.path.exists(local_path)
+
+    def _should_download(self, log_key, io_type):
+        return not self._has_local_file(log_key, io_type) and self.cloud_storage_has_logs(
+            log_key, io_type
+        )
+
+    @contextmanager
+    def _poll_for_local_upload(self, log_key):
+        if not self.upload_interval:
+            yield
+            return
+
+        thread_exit = threading.Event()
+        thread = threading.Thread(
+            target=_upload_partial_logs,
+            args=(self, log_key, thread_exit, self.upload_interval),
+            name="upload-watch",
+        )
+        thread.daemon = True
+        thread.start()
+        yield
+        thread_exit.set()
+
+    ###############################################
+    #
+    # Methods for the ComputeLogManager interface
+    #
+    ###############################################
+    @contextmanager
+    def _watch_logs(self, pipeline_run, step_key=None):
+        # proxy watching to the local compute log manager, interacting with the filesystem
+        log_key = self.local_manager.build_log_key_for_run(
+            pipeline_run.run_id, step_key or pipeline_run.pipeline_name
+        )
+        with self.local_manager.capture_logs(log_key):
+            yield
+        self.upload_to_cloud_storage(log_key, ComputeIOType.STDOUT)
+        self.upload_to_cloud_storage(log_key, ComputeIOType.STDERR)
+
+    def get_local_path(self, run_id, key, io_type):
+        return self.local_manager.get_local_path(run_id, key, io_type)
+
+    def on_watch_start(self, pipeline_run, step_key):
+        self.local_manager.on_watch_start(pipeline_run, step_key)
+
+    def on_watch_finish(self, pipeline_run, step_key):
+        self.local_manager.on_watch_finish(pipeline_run, step_key)
+
+    def is_watch_completed(self, run_id, key):
+        return self.local_manager.is_watch_completed(run_id, key) or self.cloud_storage_has_logs(
+            self.local_manager.build_log_key_for_run(run_id, key), ComputeIOType.STDERR
+        )
+
+    def download_url(self, run_id, key, io_type):
+        if not self.is_watch_completed(run_id, key):
+            return self.local_manager.download_url(run_id, key, io_type)
+
+        log_key = self.local_manager.build_log_key_for_run(run_id, key)
+        return self.download_url_for_type(log_key, io_type)
+
+    def read_logs_file(self, run_id, key, io_type, cursor=0, max_bytes=MAX_BYTES_FILE_READ):
+        log_key = self.local_manager.build_log_key_for_run(run_id, key)
+
+        if self._has_local_file(log_key, io_type):
+            data = self.local_manager.read_logs_file(run_id, key, io_type, cursor, max_bytes)
+            return self._from_local_file_data(run_id, key, io_type, data)
+        elif self.cloud_storage_has_logs(log_key, io_type):
+            self.download_from_cloud_storage(log_key, io_type)
+            data = self.local_manager.read_logs_file(run_id, key, io_type, cursor, max_bytes)
+            return self._from_local_file_data(run_id, key, io_type, data)
+        elif self.cloud_storage_has_logs(log_key, io_type, partial=True):
+            self.download_from_cloud_storage(log_key, io_type, partial=True)
+            partial_path = self.local_manager.get_captured_local_path(
+                log_key, IO_TYPE_EXTENSION[io_type], partial=True
+            )
+            captured_data, new_cursor = self.local_manager.read_path(
+                partial_path, offset=cursor or 0
+            )
+            return ComputeLogFileData(
+                path=partial_path,
+                data=captured_data.decode("utf-8") if captured_data else None,
+                cursor=new_cursor or 0,
+                size=len(captured_data) if captured_data else 0,
+                download_url=None,
+            )
+        local_path = self.local_manager.get_captured_local_path(log_key, IO_TYPE_EXTENSION[io_type])
+        return ComputeLogFileData(path=local_path, data=None, cursor=0, size=0, download_url=None)
+
+    def on_subscribe(self, subscription):
+        pass
+
+    def on_unsubscribe(self, subscription):
+        pass
+
+    def dispose(self):
+        self.local_manager.dispose()
+
+    def _from_local_file_data(self, run_id, key, io_type, local_file_data):
+        log_key = self.local_manager.build_log_key_for_run(run_id, key)
+
+        return ComputeLogFileData(
+            self.display_path_for_type(log_key, io_type),
+            local_file_data.data,
+            local_file_data.cursor,
+            local_file_data.size,
+            self.download_url_for_type(log_key, io_type),
+        )
+
+
+class PollingComputeLogSubscriptionManager:
+    def __init__(self, manager):
+        self._manager = manager
+        self._subscriptions = defaultdict(list)
+        self._polling_thread = threading.Thread(
+            target=self._poll,
+            name="polling-compute-log-subscription",
+        )
+        self._shutdown_event = threading.Event()
+        self._polling_thread.daemon = True
+        self._polling_thread.start()
+
+    def _log_key(self, subscription):
+        check.inst_param(
+            subscription, "subscription", (ComputeLogSubscription, CapturedLogSubscription)
+        )
+
+        if isinstance(subscription, ComputeLogSubscription):
+            return self._manager.build_log_key_for_run(subscription.run_id, subscription.key)
+        return subscription.log_key
+
+    def _watch_key(self, log_key: Sequence[str]) -> str:
+        return json.dumps(log_key)
+
+    def add_subscription(
+        self, subscription: Union[ComputeLogSubscription, CapturedLogSubscription]
+    ):
+        check.inst_param(
+            subscription, "subscription", (ComputeLogSubscription, CapturedLogSubscription)
+        )
+
+        if self.is_complete(subscription):
+            subscription.fetch()
+            subscription.complete()
+        else:
+            log_key = self._log_key(subscription)
+            watch_key = self._watch_key(log_key)
+            self._subscriptions[watch_key].append(subscription)
+
+    def is_complete(self, subscription: Union[ComputeLogSubscription, CapturedLogSubscription]):
+        check.inst_param(
+            subscription, "subscription", (ComputeLogSubscription, CapturedLogSubscription)
+        )
+
+        if isinstance(subscription, ComputeLogSubscription):
+            return self._manager.is_watch_completed(subscription.run_id, subscription.key)
+        return self._manager.is_capture_complete(subscription.log_key)
+
+    def remove_subscription(self, subscription):
+        check.inst_param(
+            subscription, "subscription", (ComputeLogSubscription, CapturedLogSubscription)
+        )
+        watch_key = self._watch_key(subscription.run_id, subscription.key)
+        if subscription in self._subscriptions[watch_key]:
+            self._subscriptions[watch_key].remove(subscription)
+            subscription.complete()
+
+    def remove_all_subscriptions(self, log_key):
+        watch_key = self._watch_key(log_key)
+        for subscription in self._subscriptions.pop(watch_key, []):
+            subscription.complete()
+
+    def notify_subscriptions(self, log_key):
+        watch_key = self._watch_key(log_key)
+        for subscription in self._subscriptions[watch_key]:
+            subscription.fetch()
+
+    def _poll(self):
+        while True:
+            if self._shutdown_event.is_set():
+                return
+            # need to do something smarter here that keeps track of updates
+            for _, subscriptions in self._subscriptions.items():
+                for subscription in subscriptions:
+                    if self._shutdown_event.is_set():
+                        return
+                    subscription.fetch()
+            time.sleep(SUBSCRIPTION_POLLING_INTERVAL)
+
+    def dispose(self):
+        self._shutdown_event.set()
+
+
+def _upload_partial_logs(
+    compute_log_manager: CloudStorageComputeLogManager,
+    log_key: Sequence[str],
+    thread_exit: threading.Event,
+    interval: int,
+):
+    while True:
+        time.sleep(interval)
+        if thread_exit.is_set() or compute_log_manager.is_capture_complete(log_key):
+            return
+        compute_log_manager.on_progress(log_key)

--- a/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
@@ -115,8 +115,8 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
             stderr_location=self.get_captured_local_path(
                 log_key, IO_TYPE_EXTENSION[ComputeIOType.STDERR]
             ),
-            stdout_download_url=self._captured_log_download_url(log_key, ComputeIOType.STDOUT),
-            stderr_download_url=self._captured_log_download_url(log_key, ComputeIOType.STDERR),
+            stdout_download_url=self.get_captured_log_download_url(log_key, ComputeIOType.STDOUT),
+            stderr_download_url=self.get_captured_log_download_url(log_key, ComputeIOType.STDERR),
         )
 
     def delete_logs(self, log_key: Sequence[str]):
@@ -181,7 +181,7 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
             new_offset = f.tell()
         return data, new_offset
 
-    def _captured_log_download_url(self, log_key, io_type):
+    def get_captured_log_download_url(self, log_key, io_type):
         check.inst_param(io_type, "io_type", ComputeIOType)
         url = "/logs"
         for part in log_key:

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -380,18 +380,20 @@ def ensure_gen(
     return thing_or_gen
 
 
-def ensure_dir(file_path):
+def ensure_dir(file_path: str) -> str:
     try:
         os.makedirs(file_path)
     except OSError as e:
         if e.errno != errno.EEXIST:
             raise
+    return file_path
 
 
-def ensure_file(path):
+def ensure_file(path: str) -> str:
     ensure_dir(os.path.dirname(path))
     if not os.path.exists(path):
         touch_file(path)
+    return path
 
 
 def touch_file(path):

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/captured_log_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/captured_log_manager.py
@@ -1,10 +1,13 @@
 import random
 import string
 import sys
+import time
 
+import pendulum
 import pytest
 
 from dagster._core.execution.compute_logs import should_disable_io_stream_redirect
+from dagster._core.storage.compute_log_manager import ComputeIOType
 
 
 class TestCapturedLogManager:
@@ -29,6 +32,14 @@ class TestCapturedLogManager:
 
     @pytest.fixture(name="captured_log_manager")
     def captured_log_manager(self):
+        yield
+
+    @pytest.fixture(name="write_manager")
+    def write_manager(self):
+        yield
+
+    @pytest.fixture(name="read_manager")
+    def read_manager(self):
         yield
 
     @pytest.mark.skipif(
@@ -80,3 +91,42 @@ class TestCapturedLogManager:
         assert log_metadata.stderr_location
         assert log_metadata.stdout_download_url
         assert log_metadata.stderr_download_url
+
+    @pytest.mark.skipif(
+        should_disable_io_stream_redirect(), reason="compute logs disabled for win / py3.6+"
+    )
+    def test_streaming(self, write_manager, read_manager):
+        from dagster._core.storage.cloud_storage_compute_log_manager import (
+            CloudStorageComputeLogManager,
+        )
+
+        if (
+            not isinstance(write_manager, CloudStorageComputeLogManager)
+            or not isinstance(read_manager, CloudStorageComputeLogManager)
+            or not write_manager.upload_interval
+        ):
+            pytest.skip("does not support streaming")
+
+        now = pendulum.now("UTC")
+        log_key = ["arbitrary", "log", "key", now.strftime("%Y_%m_%d__%H_%M_%S")]
+        with write_manager.capture_logs(log_key):
+            print("hello stdout")  # pylint: disable=print-call
+            print("hello stderr", file=sys.stderr)  # pylint: disable=print-call
+
+            # read before the write manager has a chance to upload partial results
+            log_data = read_manager.get_log_data(log_key)
+            assert not log_data.stdout
+            assert not log_data.stderr
+
+            # wait past the upload interval and then read again
+            time.sleep(write_manager.upload_interval + 1)
+            log_data = read_manager.get_log_data(log_key)
+            # print('WTF', log_data.stdout)
+            assert log_data.stdout == b"hello stdout\n"
+            assert log_data.stderr == b"hello stderr\n"
+
+            # check the cloud storage directly that only partial keys have been uploaded
+            assert not read_manager.cloud_storage_has_logs(log_key, ComputeIOType.STDOUT)
+            assert not read_manager.cloud_storage_has_logs(log_key, ComputeIOType.STDOUT)
+            assert read_manager.cloud_storage_has_logs(log_key, ComputeIOType.STDERR, partial=True)
+            assert read_manager.cloud_storage_has_logs(log_key, ComputeIOType.STDERR, partial=True)

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
@@ -1,5 +1,5 @@
 import os
-from contextlib import contextmanager
+from typing import Optional, Sequence
 
 import boto3
 from botocore.errorfactory import ClientError
@@ -7,12 +7,12 @@ from botocore.errorfactory import ClientError
 import dagster._seven as seven
 from dagster import Field, StringSource
 from dagster import _check as check
-from dagster._core.storage.compute_log_manager import (
-    MAX_BYTES_FILE_READ,
-    ComputeIOType,
-    ComputeLogFileData,
-    ComputeLogManager,
+from dagster._config.config_type import Noneable
+from dagster._core.storage.cloud_storage_compute_log_manager import (
+    CloudStorageComputeLogManager,
+    PollingComputeLogSubscriptionManager,
 )
+from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.storage.local_compute_log_manager import (
     IO_TYPE_EXTENSION,
     LocalComputeLogManager,
@@ -20,8 +20,10 @@ from dagster._core.storage.local_compute_log_manager import (
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 from dagster._utils import ensure_dir, ensure_file
 
+POLLING_INTERVAL = 5
 
-class S3ComputeLogManager(ComputeLogManager, ConfigurableClass):
+
+class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
     """Logs compute function stdout and stderr to S3.
 
     Users should not instantiate this class directly. Instead, use a YAML block in ``dagster.yaml``
@@ -41,6 +43,7 @@ class S3ComputeLogManager(ComputeLogManager, ConfigurableClass):
             verify_cert_path: "/path/to/cert/bundle.pem"
             endpoint_url: "http://alternate-s3-host.io"
             skip_empty_files: true
+            upload_interval: 30
 
     Args:
         bucket (str): The name of the s3 bucket to which to log.
@@ -53,6 +56,7 @@ class S3ComputeLogManager(ComputeLogManager, ConfigurableClass):
             `verify` set to False.
         endpoint_url (Optional[str]): Override for the S3 endpoint url.
         skip_empty_files: (Optional[bool]): Skip upload of empty log files.
+        upload_interval: (Optional[int]): Interval in seconds to upload partial log files to S3. By default, will only upload when the capture is complete.
         inst_data (Optional[ConfigurableClassData]): Serializable representation of the compute
             log manager when newed up from config.
     """
@@ -68,6 +72,7 @@ class S3ComputeLogManager(ComputeLogManager, ConfigurableClass):
         verify_cert_path=None,
         endpoint_url=None,
         skip_empty_files=False,
+        upload_interval=None,
     ):
         _verify = False if not verify else verify_cert_path
         self._s3_session = boto3.resource(
@@ -80,17 +85,11 @@ class S3ComputeLogManager(ComputeLogManager, ConfigurableClass):
         if not local_dir:
             local_dir = seven.get_system_temp_directory()
 
-        self.local_manager = LocalComputeLogManager(local_dir)
+        self._local_manager = LocalComputeLogManager(local_dir)
+        self._subscription_manager = PollingComputeLogSubscriptionManager(self)
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self._skip_empty_files = check.bool_param(skip_empty_files, "skip_empty_files")
-
-    @contextmanager
-    def _watch_logs(self, pipeline_run, step_key=None):
-        # proxy watching to the local compute log manager, interacting with the filesystem
-        with self.local_manager._watch_logs(  # pylint: disable=protected-access
-            pipeline_run, step_key
-        ):
-            yield
+        self._upload_interval = check.opt_int_param(upload_interval, "upload_interval")
 
     @property
     def inst_data(self):
@@ -107,109 +106,97 @@ class S3ComputeLogManager(ComputeLogManager, ConfigurableClass):
             "verify_cert_path": Field(StringSource, is_required=False),
             "endpoint_url": Field(StringSource, is_required=False),
             "skip_empty_files": Field(bool, is_required=False, default_value=False),
+            "upload_interval": Field(Noneable(int), is_required=False, default_value=None),
         }
 
     @staticmethod
     def from_config_value(inst_data, config_value):
         return S3ComputeLogManager(inst_data=inst_data, **config_value)
 
-    def get_local_path(self, run_id, key, io_type):
-        return self.local_manager.get_local_path(run_id, key, io_type)
+    @property
+    def local_manager(self) -> LocalComputeLogManager:
+        return self._local_manager
 
-    def on_watch_start(self, pipeline_run, step_key):
-        self.local_manager.on_watch_start(pipeline_run, step_key)
+    @property
+    def upload_interval(self) -> Optional[int]:
+        return self._upload_interval if self._upload_interval else None
 
-    def on_watch_finish(self, pipeline_run, step_key):
-        self.local_manager.on_watch_finish(pipeline_run, step_key)
-        key = self.local_manager.get_key(pipeline_run, step_key)
-        self._upload_from_local(pipeline_run.run_id, key, ComputeIOType.STDOUT)
-        self._upload_from_local(pipeline_run.run_id, key, ComputeIOType.STDERR)
-
-    def is_watch_completed(self, run_id, key):
-        return self.local_manager.is_watch_completed(run_id, key)
-
-    def download_url(self, run_id, key, io_type):
-        if not self.is_watch_completed(run_id, key):
-            return self.local_manager.download_url(run_id, key, io_type)
-        key = self._bucket_key(run_id, key, io_type)
-
-        url = self._s3_session.generate_presigned_url(
-            ClientMethod="get_object", Params={"Bucket": self._s3_bucket, "Key": key}
-        )
-
-        return url
-
-    def read_logs_file(self, run_id, key, io_type, cursor=0, max_bytes=MAX_BYTES_FILE_READ):
-        if self._should_download(run_id, key, io_type):
-            self._download_to_local(run_id, key, io_type)
-        data = self.local_manager.read_logs_file(run_id, key, io_type, cursor, max_bytes)
-        return self._from_local_file_data(run_id, key, io_type, data)
-
-    def on_subscribe(self, subscription):
-        self.local_manager.on_subscribe(subscription)
-
-    def on_unsubscribe(self, subscription):
-        self.local_manager.on_unsubscribe(subscription)
-
-    def _should_download(self, run_id, key, io_type):
-        local_path = self.get_local_path(run_id, key, io_type)
-        if os.path.exists(local_path):
-            return False
-
-        try:  # https://stackoverflow.com/a/38376288/14656695
-            self._s3_session.head_object(
-                Bucket=self._s3_bucket, Key=self._bucket_key(run_id, key, io_type)
-            )
-        except ClientError:
-            return False
-
-        return True
-
-    def _from_local_file_data(self, run_id, key, io_type, local_file_data):
-        is_complete = self.is_watch_completed(run_id, key)
-        path = (
-            "s3://{}/{}".format(self._s3_bucket, self._bucket_key(run_id, key, io_type))
-            if is_complete
-            else local_file_data.path
-        )
-
-        return ComputeLogFileData(
-            path,
-            local_file_data.data,
-            local_file_data.cursor,
-            local_file_data.size,
-            self.download_url(run_id, key, io_type),
-        )
-
-    def _upload_from_local(self, run_id, key, io_type):
-        path = self.get_local_path(run_id, key, io_type)
-        ensure_file(path)
-        if self._skip_empty_files and os.stat(path).st_size == 0:
-            return
-
-        key = self._bucket_key(run_id, key, io_type)
-        with open(path, "rb") as data:
-            self._s3_session.upload_fileobj(data, self._s3_bucket, key)
-
-    def _download_to_local(self, run_id, key, io_type):
-        path = self.get_local_path(run_id, key, io_type)
-        ensure_dir(os.path.dirname(path))
-        with open(path, "wb") as fileobj:
-            self._s3_session.download_fileobj(
-                self._s3_bucket, self._bucket_key(run_id, key, io_type), fileobj
-            )
-
-    def _bucket_key(self, run_id, key, io_type):
+    def _s3_key(self, log_key, io_type, partial=False):
         check.inst_param(io_type, "io_type", ComputeIOType)
         extension = IO_TYPE_EXTENSION[io_type]
-        paths = [
-            self._s3_prefix,
-            "storage",
-            run_id,
-            "compute_logs",
-            "{}.{}".format(key, extension),
-        ]
+        [*namespace, filebase] = log_key
+        filename = f"{filebase}.{extension}"
+        if partial:
+            filename = f"{filename}.partial"
+        paths = [self._s3_prefix, "storage", *namespace, filename]
         return "/".join(paths)  # s3 path delimiter
 
+    def delete_logs(self, log_key: Sequence[str]):
+        self.local_manager.delete_logs(log_key)
+        s3_keys_to_remove = [
+            self._s3_key(log_key, ComputeIOType.STDOUT),
+            self._s3_key(log_key, ComputeIOType.STDERR),
+            self._s3_key(log_key, ComputeIOType.STDOUT, partial=True),
+            self._s3_key(log_key, ComputeIOType.STDERR, partial=True),
+        ]
+        s3_objects = [{"Key": key} for key in s3_keys_to_remove]
+        self._s3_session.delete_objects(Bucket=self._s3_bucket, Delete={"Objects": s3_objects})
+
+    def download_url_for_type(self, log_key: Sequence[str], io_type: ComputeIOType):
+        if not self.is_capture_complete(log_key):
+            return None
+
+        s3_key = self._s3_key(log_key, io_type)
+        return self._s3_session.generate_presigned_url(
+            ClientMethod="get_object", Params={"Bucket": self._s3_bucket, "Key": s3_key}
+        )
+
+    def display_path_for_type(self, log_key: Sequence[str], io_type: ComputeIOType):
+        if not self.is_capture_complete(log_key):
+            return None
+        s3_key = self._s3_key(log_key, io_type)
+        return f"s3://{self._s3_bucket}/{s3_key}"
+
+    def cloud_storage_has_logs(
+        self, log_key: Sequence[str], io_type: ComputeIOType, partial: bool = False
+    ) -> bool:
+        s3_key = self._s3_key(log_key, io_type, partial=partial)
+        try:  # https://stackoverflow.com/a/38376288/14656695
+            self._s3_session.head_object(Bucket=self._s3_bucket, Key=s3_key)
+        except ClientError:
+            return False
+        return True
+
+    def upload_to_cloud_storage(
+        self, log_key: Sequence[str], io_type: ComputeIOType, partial=False
+    ):
+        path = self.local_manager.get_captured_local_path(log_key, IO_TYPE_EXTENSION[io_type])
+        ensure_file(path)
+
+        if (self._skip_empty_files or partial) and os.stat(path).st_size == 0:
+            return
+
+        s3_key = self._s3_key(log_key, io_type, partial=partial)
+        with open(path, "rb") as data:
+            self._s3_session.upload_fileobj(data, self._s3_bucket, s3_key)
+
+    def download_from_cloud_storage(
+        self, log_key: Sequence[str], io_type: ComputeIOType, partial=False
+    ):
+        path = self._local_manager.get_captured_local_path(
+            log_key, IO_TYPE_EXTENSION[io_type], partial=partial
+        )
+        ensure_dir(os.path.dirname(path))
+        s3_key = self._s3_key(log_key, io_type, partial=partial)
+        with open(path, "wb") as fileobj:
+            self._s3_session.download_fileobj(self._s3_bucket, s3_key, fileobj)
+
+    def on_subscribe(self, subscription):
+        self._subscription_manager.add_subscription(subscription)
+
+    def on_unsubscribe(self, subscription):
+        self._subscription_manager.remove_subscription(subscription)
+
     def dispose(self):
-        self.local_manager.dispose()
+        self._subscription_manager.dispose()
+        self._local_manager.dispose()

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
@@ -1,3 +1,5 @@
+# pylint: disable=protected-access
+
 import os
 import sys
 import tempfile
@@ -5,6 +7,7 @@ import tempfile
 import pytest
 from botocore.exceptions import ClientError
 from dagster_aws.s3 import S3ComputeLogManager
+from dagster_tests.core_tests.storage_tests.test_captured_log_manager import TestCapturedLogManager
 
 from dagster import DagsterEventType, job, op
 from dagster._core.instance import DagsterInstance, InstanceRef, InstanceType
@@ -12,6 +15,7 @@ from dagster._core.launcher import DefaultRunLauncher
 from dagster._core.run_coordinator import DefaultRunCoordinator
 from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.storage.event_log import SqliteEventLogStorage
+from dagster._core.storage.local_compute_log_manager import IO_TYPE_EXTENSION
 from dagster._core.storage.root import LocalArtifactStorage
 from dagster._core.storage.runs import SqliteRunStorage
 from dagster._core.test_utils import environ
@@ -54,40 +58,45 @@ def test_compute_log_manager(mock_s3_bucket):
                 ref=InstanceRef.from_dir(temp_dir),
             )
             result = simple.execute_in_process(instance=instance)
-            compute_steps = [
-                event.step_key
-                for event in result.all_node_events
-                if event.event_type == DagsterEventType.STEP_START
+            capture_events = [
+                event
+                for event in result.all_events
+                if event.event_type == DagsterEventType.LOGS_CAPTURED
             ]
-            assert len(compute_steps) == 1
-            step_key = compute_steps[0]
+            assert len(capture_events) == 1
+            event = capture_events[0]
+            file_key = event.logs_captured_data.file_key
+            log_key = manager.build_log_key_for_run(result.run_id, file_key)
+            log_data = manager.get_log_data(log_key)
+            stdout = log_data.stdout.decode("utf-8")
+            assert stdout == HELLO_WORLD + SEPARATOR
 
-            stdout = manager.read_logs_file(result.run_id, step_key, ComputeIOType.STDOUT)
-            assert stdout.data == HELLO_WORLD + SEPARATOR
-
-            stderr = manager.read_logs_file(result.run_id, step_key, ComputeIOType.STDERR)
+            stderr = log_data.stderr.decode("utf-8")
             for expected in EXPECTED_LOGS:
-                assert expected in stderr.data
+                assert expected in stderr
 
             # Check S3 directly
-            s3_object = mock_s3_bucket.Object(
-                key=f"my_prefix/storage/{result.run_id}/compute_logs/easy.err"
-            )
+            s3_object = mock_s3_bucket.Object(key=manager._s3_key(log_key, ComputeIOType.STDERR))
             stderr_s3 = s3_object.get()["Body"].read().decode("utf-8")
             for expected in EXPECTED_LOGS:
                 assert expected in stderr_s3
 
             # Check download behavior by deleting locally cached logs
-            compute_logs_dir = os.path.join(temp_dir, result.run_id, "compute_logs")
-            for filename in os.listdir(compute_logs_dir):
-                os.unlink(os.path.join(compute_logs_dir, filename))
+            local_dir = os.path.dirname(
+                manager._local_manager.get_captured_local_path(
+                    log_key, IO_TYPE_EXTENSION[ComputeIOType.STDOUT]
+                )
+            )
+            for filename in os.listdir(local_dir):
+                os.unlink(os.path.join(local_dir, filename))
 
-            stdout = manager.read_logs_file(result.run_id, step_key, ComputeIOType.STDOUT)
-            assert stdout.data == HELLO_WORLD + SEPARATOR
+            log_data = manager.get_log_data(log_key)
+            stdout = log_data.stdout.decode("utf-8")
+            assert stdout == HELLO_WORLD + SEPARATOR
 
-            stderr = manager.read_logs_file(result.run_id, step_key, ComputeIOType.STDERR)
+            stderr = log_data.stderr.decode("utf-8")
             for expected in EXPECTED_LOGS:
-                assert expected in stderr.data
+                assert expected in stderr
 
 
 def test_compute_log_manager_from_config(mock_s3_bucket):
@@ -145,17 +154,23 @@ def test_compute_log_manager_skip_empty_upload(mock_s3_bucket):
                 ref=InstanceRef.from_dir(temp_dir),
             )
             result = simple.execute_in_process(instance=instance)
-
+            capture_events = [
+                event
+                for event in result.all_events
+                if event.event_type == DagsterEventType.LOGS_CAPTURED
+            ]
+            assert len(capture_events) == 1
+            event = capture_events[0]
+            file_key = event.logs_captured_data.file_key
+            log_key = manager.build_log_key_for_run(result.run_id, file_key)
             stderr_object = mock_s3_bucket.Object(
-                key=f"{PREFIX}/storage/{result.run_id}/compute_logs/easy.err"
-            ).get()
+                key=manager._s3_key(log_key, ComputeIOType.STDERR)
+            )
             assert stderr_object
 
             with pytest.raises(ClientError):
                 # stdout is not uploaded because we do not print anything to stdout
-                mock_s3_bucket.Object(
-                    key=f"{PREFIX}/storage/{result.run_id}/compute_logs/easy.out"
-                ).get()
+                mock_s3_bucket.Object(key=manager._s3_key(log_key, ComputeIOType.STDOUT)).get()
 
 
 def test_blank_compute_logs(mock_s3_bucket):
@@ -170,3 +185,34 @@ def test_blank_compute_logs(mock_s3_bucket):
 
         assert not stdout.data
         assert not stderr.data
+
+
+class TestS3ComputeLogManager(TestCapturedLogManager):
+    __test__ = True
+
+    @pytest.fixture(name="captured_log_manager")
+    def captured_log_manager(self, mock_s3_bucket):  # pylint: disable=arguments-differ
+        with tempfile.TemporaryDirectory() as temp_dir:
+            yield S3ComputeLogManager(
+                bucket=mock_s3_bucket.name, prefix="my_prefix", local_dir=temp_dir
+            )
+
+    # for streaming tests
+    @pytest.fixture(name="write_manager")
+    def write_manager(self, mock_s3_bucket):  # pylint: disable=arguments-differ
+        # should be a different local directory as the read manager
+        with tempfile.TemporaryDirectory() as temp_dir:
+            yield S3ComputeLogManager(
+                bucket=mock_s3_bucket.name,
+                prefix="my_prefix",
+                local_dir=temp_dir,
+                upload_interval=1,
+            )
+
+    @pytest.fixture(name="read_manager")
+    def read_manager(self, mock_s3_bucket):  # pylint: disable=arguments-differ
+        # should be a different local directory as the write manager
+        with tempfile.TemporaryDirectory() as temp_dir:
+            yield S3ComputeLogManager(
+                bucket=mock_s3_bucket.name, prefix="my_prefix", local_dir=temp_dir
+            )

--- a/python_modules/libraries/dagster-azure/dagster_azure/blob/compute_log_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/blob/compute_log_manager.py
@@ -1,16 +1,15 @@
-import itertools
 import os
 from contextlib import contextmanager
+from typing import Optional, Sequence
 
 import dagster._seven as seven
-from dagster import Field, StringSource
+from dagster import Field, Noneable, StringSource
 from dagster import _check as check
-from dagster._core.storage.compute_log_manager import (
-    MAX_BYTES_FILE_READ,
-    ComputeIOType,
-    ComputeLogFileData,
-    ComputeLogManager,
+from dagster._core.storage.cloud_storage_compute_log_manager import (
+    CloudStorageComputeLogManager,
+    PollingComputeLogSubscriptionManager,
 )
+from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.storage.local_compute_log_manager import (
     IO_TYPE_EXTENSION,
     LocalComputeLogManager,
@@ -21,7 +20,7 @@ from dagster._utils import ensure_dir, ensure_file
 from .utils import create_blob_client, generate_blob_sas
 
 
-class AzureBlobComputeLogManager(ComputeLogManager, ConfigurableClass):
+class AzureBlobComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
     """Logs op compute function stdout and stderr to Azure Blob Storage.
 
     This is also compatible with Azure Data Lake Storage.
@@ -40,6 +39,7 @@ class AzureBlobComputeLogManager(ComputeLogManager, ConfigurableClass):
             credential: sas-token-or-secret-key
             prefix: "dagster-test-"
             local_dir: "/tmp/cool"
+            upload_interval: 30
 
     Args:
         storage_account (str): The storage account name to which to log.
@@ -49,6 +49,7 @@ class AzureBlobComputeLogManager(ComputeLogManager, ConfigurableClass):
         local_dir (Optional[str]): Path to the local directory in which to stage logs. Default:
             ``dagster._seven.get_system_temp_directory()``.
         prefix (Optional[str]): Prefix for the log file keys.
+        upload_interval: (Optional[int]): Interval in seconds to upload partial log files blob storage. By default, will only upload when the capture is complete.
         inst_data (Optional[ConfigurableClassData]): Serializable representation of the compute
             log manager when newed up from config.
     """
@@ -61,6 +62,7 @@ class AzureBlobComputeLogManager(ComputeLogManager, ConfigurableClass):
         local_dir=None,
         inst_data=None,
         prefix="dagster",
+        upload_interval=None,
     ):
         self._storage_account = check.str_param(storage_account, "storage_account")
         self._container = check.str_param(container, "container")
@@ -75,7 +77,9 @@ class AzureBlobComputeLogManager(ComputeLogManager, ConfigurableClass):
         if not local_dir:
             local_dir = seven.get_system_temp_directory()
 
-        self.local_manager = LocalComputeLogManager(local_dir)
+        self._local_manager = LocalComputeLogManager(local_dir)
+        self._subscription_manager = PollingComputeLogSubscriptionManager(self)
+        self._upload_interval = check.opt_int_param(upload_interval, "upload_interval")
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
 
     @contextmanager
@@ -98,113 +102,102 @@ class AzureBlobComputeLogManager(ComputeLogManager, ConfigurableClass):
             "secret_key": StringSource,
             "local_dir": Field(StringSource, is_required=False),
             "prefix": Field(StringSource, is_required=False, default_value="dagster"),
+            "upload_interval": Field(Noneable(int), is_required=False, default_value=None),
         }
 
     @staticmethod
     def from_config_value(inst_data, config_value):
         return AzureBlobComputeLogManager(inst_data=inst_data, **config_value)
 
-    def get_local_path(self, run_id, key, io_type):
-        return self.local_manager.get_local_path(run_id, key, io_type)
+    @property
+    def local_manager(self) -> LocalComputeLogManager:
+        return self._local_manager
 
-    def on_watch_start(self, pipeline_run, step_key):
-        self.local_manager.on_watch_start(pipeline_run, step_key)
+    @property
+    def upload_interval(self) -> Optional[int]:
+        return self._upload_interval if self._upload_interval else None
 
-    def on_watch_finish(self, pipeline_run, step_key):
-        self.local_manager.on_watch_finish(pipeline_run, step_key)
-        key = self.local_manager.get_key(pipeline_run, step_key)
-        self._upload_from_local(pipeline_run.run_id, key, ComputeIOType.STDOUT)
-        self._upload_from_local(pipeline_run.run_id, key, ComputeIOType.STDERR)
+    def _blob_key(self, log_key, io_type, partial=False):
+        check.inst_param(io_type, "io_type", ComputeIOType)
+        extension = IO_TYPE_EXTENSION[io_type]
+        [*namespace, filebase] = log_key
+        filename = f"{filebase}.{extension}"
+        if partial:
+            filename = f"{filename}.partial"
+        paths = [self._blob_prefix, "storage", *namespace, filename]
+        return "/".join(paths)  # blob path delimiter
 
-    def is_watch_completed(self, run_id, key):
-        return self.local_manager.is_watch_completed(run_id, key)
+    def delete_logs(self, log_key: Sequence[str]):
+        prefix = "/".join(self._blob_key(log_key, ComputeIOType.STDERR).split("/")[:-1])
+        blob_list = {
+            b.name for b in list(self._container_client.list_blobs(name_starts_with=prefix))
+        }
+        known_keys = [
+            self._blob_key(log_key, ComputeIOType.STDOUT),
+            self._blob_key(log_key, ComputeIOType.STDERR),
+            self._blob_key(log_key, ComputeIOType.STDOUT, partial=True),
+            self._blob_key(log_key, ComputeIOType.STDERR, partial=True),
+        ]
+        to_remove = [key for key in known_keys if key in blob_list]
+        self._container_client.delete_blobs(*to_remove)
 
-    def download_url(self, run_id, key, io_type):
-        if not self.is_watch_completed(run_id, key):
-            return self.local_manager.download_url(run_id, key, io_type)
-        key = self._blob_key(run_id, key, io_type)
-        if key in self._download_urls:
-            return self._download_urls[key]
-        blob = self._container_client.get_blob_client(key)
+    def download_url_for_type(self, log_key: Sequence[str], io_type: ComputeIOType):
+        if not self.is_capture_complete(log_key):
+            return None
+
+        blob_key = self._blob_key(log_key, io_type)
+        if blob_key in self._download_urls:
+            return self._download_urls[blob_key]
+        blob = self._container_client.get_blob_client(blob_key)
         sas = generate_blob_sas(
             self._storage_account,
             self._container,
-            key,
+            blob_key,
             account_key=self._blob_client.credential.account_key,
         )
         url = blob.url + sas
-        self._download_urls[key] = url
+        self._download_urls[blob_key] = url
         return url
 
-    def read_logs_file(self, run_id, key, io_type, cursor=0, max_bytes=MAX_BYTES_FILE_READ):
-        if self._should_download(run_id, key, io_type):
-            self._download_to_local(run_id, key, io_type)
-        data = self.local_manager.read_logs_file(run_id, key, io_type, cursor, max_bytes)
-        return self._from_local_file_data(run_id, key, io_type, data)
+    def display_path_for_type(self, log_key: Sequence[str], io_type: ComputeIOType):
+        if not self.is_capture_complete(log_key):
+            return self.local_manager.get_captured_local_path(log_key, IO_TYPE_EXTENSION[io_type])
 
-    def on_subscribe(self, subscription):
-        self.local_manager.on_subscribe(subscription)
+        blob_key = self._blob_key(log_key, io_type)
+        return f"https://{self._storage_account}.blob.core.windows.net/{self._container}/{blob_key}"
 
-    def on_unsubscribe(self, subscription):
-        self.local_manager.on_unsubscribe(subscription)
+    def cloud_storage_has_logs(
+        self, log_key: Sequence[str], io_type: ComputeIOType, partial: bool = False
+    ) -> bool:
+        blob_key = self._blob_key(log_key, io_type, partial=partial)
+        blob_objects = self._container_client.list_blobs(blob_key)
+        exact_matches = [blob for blob in blob_objects if blob.name == blob_key]
+        return len(exact_matches) > 0
 
-    def _should_download(self, run_id, key, io_type):
-        local_path = self.get_local_path(run_id, key, io_type)
-        if os.path.exists(local_path):
-            return False
-        blob_objects = self._container_client.list_blobs(self._blob_key(run_id, key, io_type))
-        # Limit the generator to avoid paging since we only need one element
-        # to return True
-        limited_blob_objects = itertools.islice(blob_objects, 1)
-        return len(list(limited_blob_objects)) > 0
-
-    def _from_local_file_data(self, run_id, key, io_type, local_file_data):
-        is_complete = self.is_watch_completed(run_id, key)
-        path = (
-            "https://{account}.blob.core.windows.net/{container}/{key}".format(
-                account=self._storage_account,
-                container=self._container,
-                key=self._blob_key(run_id, key, io_type),
-            )
-            if is_complete
-            else local_file_data.path
-        )
-
-        return ComputeLogFileData(
-            path,
-            local_file_data.data,
-            local_file_data.cursor,
-            local_file_data.size,
-            self.download_url(run_id, key, io_type),
-        )
-
-    def _upload_from_local(self, run_id, key, io_type):
-        path = self.get_local_path(run_id, key, io_type)
+    def upload_to_cloud_storage(
+        self, log_key: Sequence[str], io_type: ComputeIOType, partial=False
+    ):
+        path = self.local_manager.get_captured_local_path(log_key, IO_TYPE_EXTENSION[io_type])
         ensure_file(path)
-        key = self._blob_key(run_id, key, io_type)
+        blob_key = self._blob_key(log_key, io_type, partial=partial)
         with open(path, "rb") as data:
-            blob = self._container_client.get_blob_client(key)
+            blob = self._container_client.get_blob_client(blob_key)
             blob.upload_blob(data)
 
-    def _download_to_local(self, run_id, key, io_type):
-        path = self.get_local_path(run_id, key, io_type)
+    def download_from_cloud_storage(
+        self, log_key: Sequence[str], io_type: ComputeIOType, partial=False
+    ):
+        path = self.local_manager.get_captured_local_path(
+            log_key, IO_TYPE_EXTENSION[io_type], partial=partial
+        )
         ensure_dir(os.path.dirname(path))
-        key = self._blob_key(run_id, key, io_type)
+        blob_key = self._blob_key(log_key, io_type, partial=partial)
         with open(path, "wb") as fileobj:
-            blob = self._container_client.get_blob_client(key)
+            blob = self._container_client.get_blob_client(blob_key)
             blob.download_blob().readinto(fileobj)
 
-    def _blob_key(self, run_id, key, io_type):
-        check.inst_param(io_type, "io_type", ComputeIOType)
-        extension = IO_TYPE_EXTENSION[io_type]
-        paths = [
-            self._blob_prefix,
-            "storage",
-            run_id,
-            "compute_logs",
-            "{}.{}".format(key, extension),
-        ]
-        return "/".join(paths)  # blob path delimiter
+    def on_subscribe(self, subscription):
+        self._subscription_manager.add_subscription(subscription)
 
-    def dispose(self):
-        self.local_manager.dispose()
+    def on_unsubscribe(self, subscription):
+        self._subscription_manager.remove_subscription(subscription)

--- a/python_modules/libraries/dagster-azure/dagster_azure/blob/fake_blob_client.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/blob/fake_blob_client.py
@@ -1,7 +1,7 @@
 import io
 import random
-from collections import defaultdict
 from contextlib import contextmanager
+from dataclasses import dataclass
 from unittest import mock
 
 from .utils import ResourceNotFoundError
@@ -41,11 +41,17 @@ class FakeBlobServiceClient:
         return self.get_container_client(container).get_blob_client(blob)
 
 
+@dataclass
+class FakeBlob:
+    name: str
+    url: str
+
+
 class FakeBlobContainerClient:
     """Stateful mock of an Blob container client for testing."""
 
     def __init__(self, account_name, container_name):
-        self._container = defaultdict(FakeBlobClient)
+        self._container = {}
         self._account_name = account_name
         self._container_name = container_name
 
@@ -63,29 +69,30 @@ class FakeBlobContainerClient:
     def get_container_properties(self):
         return {"account_name": self.account_name, "container_name": self.container_name}
 
-    def has_blob(self, path):
-        return bool(self._container.get(path))
+    def has_blob(self, blob_key):
+        return bool(self._container.get(blob_key))
 
-    def get_blob_client(self, blob):
-        return self._container[blob]
+    def get_blob_client(self, blob_key):
+        if blob_key not in self._container:
+            blob = self.create_blob(blob_key)
+        else:
+            blob = self._container[blob_key]
+        return blob
 
-    def create_blob(self, blob):
-        return self._container[blob]
+    def create_blob(self, blob_key):
+        blob = FakeBlobClient()
+        self._container[blob_key] = blob
+        return blob
 
     def list_blobs(self, name_starts_with=None):
         for k, v in self._container.items():
             if name_starts_with is None or k.startswith(name_starts_with):
-                yield {
-                    "name": k,
-                    # This clearly isn't actually the URL but we need a way of copying contents
-                    # across blobs and this allows us to do it
-                    "url": v.contents,
-                }
+                yield FakeBlob(name=k, url=v.contents)
 
-    def delete_blob(self, blob):
+    def delete_blob(self, prefix):
         # Use list to avoid mutating dict as we iterate
         for k in list(self._container.keys()):
-            if k.startswith(blob):
+            if k.startswith(prefix):
                 del self._container[k]
 
 

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/conftest.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from dagster_azure.blob.fake_blob_client import FakeBlobServiceClient
 
 
 @pytest.fixture(scope="session")
@@ -14,3 +15,8 @@ def container():
 @pytest.fixture(scope="session")
 def credential():
     yield "super-secret-creds"
+
+
+@pytest.fixture(scope="session")
+def blob_client(storage_account):
+    yield FakeBlobServiceClient(storage_account)

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
@@ -3,7 +3,9 @@ import sys
 import tempfile
 from unittest import mock
 
+import pytest
 from dagster_azure.blob import AzureBlobComputeLogManager, FakeBlobServiceClient
+from dagster_tests.core_tests.storage_tests.test_captured_log_manager import TestCapturedLogManager
 
 from dagster import DagsterEventType, graph, op
 from dagster._core.instance import DagsterInstance, InstanceRef, InstanceType
@@ -65,27 +67,36 @@ def test_compute_log_manager(
                 ref=InstanceRef.from_dir(temp_dir),
             )
             result = simple.execute_in_process(instance=instance)
-            compute_steps = [
-                event.step_key
-                for event in result.all_node_events
-                if event.event_type == DagsterEventType.STEP_START
+            capture_events = [
+                event
+                for event in result.all_events
+                if event.event_type == DagsterEventType.LOGS_CAPTURED
             ]
-            assert len(compute_steps) == 1
-            step_key = compute_steps[0]
+            assert len(capture_events) == 1
+            event = capture_events[0]
+            file_key = event.logs_captured_data.file_key
+            log_key = manager.build_log_key_for_run(result.run_id, file_key)
 
-            stdout = manager.read_logs_file(result.run_id, step_key, ComputeIOType.STDOUT)
+            # Capture API
+            log_data = manager.get_log_data(log_key)
+            stdout = log_data.stdout.decode("utf-8")
+            assert stdout == HELLO_WORLD + SEPARATOR
+            stderr = log_data.stderr.decode("utf-8")
+            for expected in EXPECTED_LOGS:
+                assert expected in stderr
+
+            # Legacy API
+            stdout = manager.read_logs_file(result.run_id, file_key, ComputeIOType.STDOUT)
             assert stdout.data == HELLO_WORLD + SEPARATOR
 
-            stderr = manager.read_logs_file(result.run_id, step_key, ComputeIOType.STDERR)
+            stderr = manager.read_logs_file(result.run_id, file_key, ComputeIOType.STDERR)
             for expected in EXPECTED_LOGS:
                 assert expected in stderr.data
 
             # Check ADLS2 directly
             adls2_object = fake_client.get_blob_client(
                 container=container,
-                blob="{prefix}/storage/{run_id}/compute_logs/easy.err".format(
-                    prefix="my_prefix", run_id=result.run_id
-                ),
+                blob=f"my_prefix/storage/{result.run_id}/compute_logs/{file_key}.err",
             )
             adls2_stderr = adls2_object.download_blob().readall().decode("utf-8")
             for expected in EXPECTED_LOGS:
@@ -96,10 +107,19 @@ def test_compute_log_manager(
             for filename in os.listdir(compute_logs_dir):
                 os.unlink(os.path.join(compute_logs_dir, filename))
 
-            stdout = manager.read_logs_file(result.run_id, step_key, ComputeIOType.STDOUT)
+            # Capture API
+            log_data = manager.get_log_data(log_key)
+            stdout = log_data.stdout.decode("utf-8")
+            assert stdout == HELLO_WORLD + SEPARATOR
+            stderr = log_data.stderr.decode("utf-8")
+            for expected in EXPECTED_LOGS:
+                assert expected in stderr
+
+            # Legacy API
+            stdout = manager.read_logs_file(result.run_id, file_key, ComputeIOType.STDOUT)
             assert stdout.data == HELLO_WORLD + SEPARATOR
 
-            stderr = manager.read_logs_file(result.run_id, step_key, ComputeIOType.STDERR)
+            stderr = manager.read_logs_file(result.run_id, file_key, ComputeIOType.STDERR)
             for expected in EXPECTED_LOGS:
                 assert expected in stderr.data
 
@@ -132,3 +152,61 @@ compute_logs:
     )
     assert instance.compute_log_manager._container == container  # pylint: disable=protected-access
     assert instance.compute_log_manager._blob_prefix == prefix  # pylint: disable=protected-access
+
+
+class TestAzureComputeLogManager(TestCapturedLogManager):
+    __test__ = True
+
+    @pytest.fixture(name="captured_log_manager")
+    def captured_log_manager(
+        self,
+        blob_client,
+        storage_account,
+        container,
+        credential,
+    ):  # pylint: disable=arguments-differ
+        with mock.patch(
+            "dagster_azure.blob.compute_log_manager.generate_blob_sas"
+        ) as generate_blob_sas, mock.patch(
+            "dagster_azure.blob.compute_log_manager.create_blob_client"
+        ) as create_blob_client, tempfile.TemporaryDirectory() as temp_dir:
+            generate_blob_sas.return_value = "fake-url"
+            create_blob_client.return_value = blob_client
+
+            yield AzureBlobComputeLogManager(
+                storage_account=storage_account,
+                container=container,
+                prefix="my_prefix",
+                local_dir=temp_dir,
+                secret_key=credential,
+            )
+
+    # for streaming tests
+    @pytest.fixture(name="write_manager")
+    def write_manager(
+        self,
+        blob_client,
+        storage_account,
+        container,
+        credential,
+    ):  # pylint: disable=arguments-differ
+        with mock.patch(
+            "dagster_azure.blob.compute_log_manager.generate_blob_sas"
+        ) as generate_blob_sas, mock.patch(
+            "dagster_azure.blob.compute_log_manager.create_blob_client"
+        ) as create_blob_client, tempfile.TemporaryDirectory() as temp_dir:
+            generate_blob_sas.return_value = "fake-url"
+            create_blob_client.return_value = blob_client
+
+            yield AzureBlobComputeLogManager(
+                storage_account=storage_account,
+                container=container,
+                prefix="my_prefix",
+                local_dir=temp_dir,
+                secret_key=credential,
+                upload_interval=1,
+            )
+
+    @pytest.fixture(name="read_manager")
+    def read_manager(self, captured_log_manager):  # pylint: disable=arguments-differ
+        yield captured_log_manager

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/compute_log_manager.py
@@ -1,18 +1,18 @@
 import json
 import os
-from contextlib import contextmanager
+from typing import Optional, Sequence
 
 from google.cloud import storage  # type: ignore
 
 import dagster._seven as seven
 from dagster import Field, StringSource
 from dagster import _check as check
-from dagster._core.storage.compute_log_manager import (
-    MAX_BYTES_FILE_READ,
-    ComputeIOType,
-    ComputeLogFileData,
-    ComputeLogManager,
+from dagster._config.config_type import Noneable
+from dagster._core.storage.cloud_storage_compute_log_manager import (
+    CloudStorageComputeLogManager,
+    PollingComputeLogSubscriptionManager,
 )
+from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.storage.local_compute_log_manager import (
     IO_TYPE_EXTENSION,
     LocalComputeLogManager,
@@ -21,7 +21,7 @@ from dagster._serdes import ConfigurableClass, ConfigurableClassData
 from dagster._utils import ensure_dir, ensure_file
 
 
-class GCSComputeLogManager(ComputeLogManager, ConfigurableClass):
+class GCSComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
     """Logs op compute function stdout and stderr to GCS.
 
     Users should not instantiate this class directly. Instead, use a YAML block in ``dagster.yaml``
@@ -36,6 +36,7 @@ class GCSComputeLogManager(ComputeLogManager, ConfigurableClass):
             bucket: "mycorp-dagster-compute-logs"
             local_dir: "/tmp/cool"
             prefix: "dagster-test-"
+            upload_interval: 30
 
     Args:
         bucket (str): The name of the gcs bucket to which to log.
@@ -45,6 +46,7 @@ class GCSComputeLogManager(ComputeLogManager, ConfigurableClass):
         json_credentials_envvar (Optional[str]): Env variable that contain the JSON with a private key
             and other credentials information. If this is set GOOGLE_APPLICATION_CREDENTIALS will be ignored.
             Can be used when the private key cannot be used as a file.
+        upload_interval: (Optional[int]): Interval in seconds to upload partial log files to S3. By default, will only upload when the capture is complete.
         inst_data (Optional[ConfigurableClassData]): Serializable representation of the compute
             log manager when newed up from config.
     """
@@ -56,6 +58,7 @@ class GCSComputeLogManager(ComputeLogManager, ConfigurableClass):
         inst_data=None,
         prefix="dagster",
         json_credentials_envvar=None,
+        upload_interval=None,
     ):
         self._bucket_name = check.str_param(bucket, "bucket")
         self._prefix = check.str_param(prefix, "prefix")
@@ -78,16 +81,10 @@ class GCSComputeLogManager(ComputeLogManager, ConfigurableClass):
         if not local_dir:
             local_dir = seven.get_system_temp_directory()
 
-        self.local_manager = LocalComputeLogManager(local_dir)
+        self._upload_interval = check.opt_int_param(upload_interval, "upload_interval")
+        self._local_manager = LocalComputeLogManager(local_dir)
+        self._subscription_manager = PollingComputeLogSubscriptionManager(self)
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
-
-    @contextmanager
-    def _watch_logs(self, pipeline_run, step_key=None):
-        # proxy watching to the local compute log manager, interacting with the filesystem
-        with self.local_manager._watch_logs(  # pylint: disable=protected-access
-            pipeline_run, step_key
-        ):
-            yield
 
     @property
     def inst_data(self):
@@ -100,95 +97,94 @@ class GCSComputeLogManager(ComputeLogManager, ConfigurableClass):
             "local_dir": Field(StringSource, is_required=False),
             "prefix": Field(StringSource, is_required=False, default_value="dagster"),
             "json_credentials_envvar": Field(StringSource, is_required=False),
+            "upload_interval": Field(Noneable(int), is_required=False, default_value=None),
         }
 
     @staticmethod
     def from_config_value(inst_data, config_value):
         return GCSComputeLogManager(inst_data=inst_data, **config_value)
 
-    def get_local_path(self, run_id, key, io_type):
-        return self.local_manager.get_local_path(run_id, key, io_type)
+    @property
+    def local_manager(self) -> LocalComputeLogManager:
+        return self._local_manager
 
-    def on_watch_start(self, pipeline_run, step_key):
-        self.local_manager.on_watch_start(pipeline_run, step_key)
+    @property
+    def upload_interval(self) -> Optional[int]:
+        return self._upload_interval if self._upload_interval else None
 
-    def on_watch_finish(self, pipeline_run, step_key):
-        self.local_manager.on_watch_finish(pipeline_run, step_key)
-        key = self.local_manager.get_key(pipeline_run, step_key)
-        self._upload_from_local(pipeline_run.run_id, key, ComputeIOType.STDOUT)
-        self._upload_from_local(pipeline_run.run_id, key, ComputeIOType.STDERR)
+    def _gcs_key(self, log_key, io_type, partial=False):
+        check.inst_param(io_type, "io_type", ComputeIOType)
+        extension = IO_TYPE_EXTENSION[io_type]
+        [*namespace, filebase] = log_key
+        filename = f"{filebase}.{extension}"
+        if partial:
+            filename = f"{filename}.partial"
+        paths = [self._prefix, "storage", *namespace, filename]
+        return "/".join(paths)
 
-    def is_watch_completed(self, run_id, key):
-        return self.local_manager.is_watch_completed(run_id, key)
+    def delete_logs(self, log_key: Sequence[str]):
+        self._local_manager.delete_logs(log_key)
+        gcs_keys_to_remove = [
+            self._gcs_key(log_key, ComputeIOType.STDOUT),
+            self._gcs_key(log_key, ComputeIOType.STDERR),
+            self._gcs_key(log_key, ComputeIOType.STDOUT, partial=True),
+            self._gcs_key(log_key, ComputeIOType.STDERR, partial=True),
+        ]
+        # if the blob doesn't exist, do nothing instead of raising a not found exception
+        self._bucket.delete_blobs(gcs_keys_to_remove, on_error=lambda _: None)
 
-    def download_url(self, run_id, key, io_type):
-        if not self.is_watch_completed(run_id, key):
-            return self.local_manager.download_url(run_id, key, io_type)
+    def download_url_for_type(self, log_key: Sequence[str], io_type: ComputeIOType):
+        if not self.is_capture_complete(log_key):
+            return None
 
-        url = self._bucket.blob(self._bucket_key(run_id, key, io_type)).generate_signed_url(
+        gcs_key = self._gcs_key(log_key, io_type)
+        return self._bucket.blob(gcs_key).generate_signed_url(
             expiration=3600  # match S3 default expiration
         )
 
-        return url
+    def display_path_for_type(self, log_key: Sequence[str], io_type: ComputeIOType):
+        if not self.is_capture_complete(log_key):
+            return self.local_manager.get_captured_local_path(log_key, IO_TYPE_EXTENSION[io_type])
+        gcs_key = self._gcs_key(log_key, io_type)
+        return f"gs://{self._bucket_name}/{gcs_key}"
 
-    def read_logs_file(self, run_id, key, io_type, cursor=0, max_bytes=MAX_BYTES_FILE_READ):
-        if self._should_download(run_id, key, io_type):
-            self._download_to_local(run_id, key, io_type)
-        data = self.local_manager.read_logs_file(run_id, key, io_type, cursor, max_bytes)
-        return self._from_local_file_data(run_id, key, io_type, data)
+    def cloud_storage_has_logs(
+        self, log_key: Sequence[str], io_type: ComputeIOType, partial: bool = False
+    ) -> bool:
+        gcs_key = self._gcs_key(log_key, io_type, partial)
+        return self._bucket.blob(gcs_key).exists()
+
+    def upload_to_cloud_storage(
+        self, log_key: Sequence[str], io_type: ComputeIOType, partial=False
+    ):
+        path = self.local_manager.get_captured_local_path(log_key, IO_TYPE_EXTENSION[io_type])
+        ensure_file(path)
+
+        if partial and os.stat(path).st_size == 0:
+            return
+
+        gcs_key = self._gcs_key(log_key, io_type, partial=partial)
+        with open(path, "rb") as data:
+            self._bucket.blob(gcs_key).upload_from_file(data)
+
+    def download_from_cloud_storage(
+        self, log_key: Sequence[str], io_type: ComputeIOType, partial=False
+    ):
+        path = self.local_manager.get_captured_local_path(
+            log_key, IO_TYPE_EXTENSION[io_type], partial=partial
+        )
+        ensure_dir(os.path.dirname(path))
+
+        gcs_key = self._gcs_key(log_key, io_type, partial=partial)
+        with open(path, "wb") as fileobj:
+            self._bucket.blob(gcs_key).download_to_file(fileobj)
 
     def on_subscribe(self, subscription):
-        self.local_manager.on_subscribe(subscription)
+        self._subscription_manager.add_subscription(subscription)
 
     def on_unsubscribe(self, subscription):
-        self.local_manager.on_unsubscribe(subscription)
-
-    def _should_download(self, run_id, key, io_type):
-        local_path = self.get_local_path(run_id, key, io_type)
-        if os.path.exists(local_path):
-            return False
-        return self._bucket.blob(self._bucket_key(run_id, key, io_type)).exists()
-
-    def _from_local_file_data(self, run_id, key, io_type, local_file_data):
-        is_complete = self.is_watch_completed(run_id, key)
-        path = (
-            "gs://{}/{}".format(self._bucket_name, self._bucket_key(run_id, key, io_type))
-            if is_complete
-            else local_file_data.path
-        )
-
-        return ComputeLogFileData(
-            path,
-            local_file_data.data,
-            local_file_data.cursor,
-            local_file_data.size,
-            self.download_url(run_id, key, io_type),
-        )
-
-    def _upload_from_local(self, run_id, key, io_type):
-        path = self.get_local_path(run_id, key, io_type)
-        ensure_file(path)
-        with open(path, "rb") as data:
-            self._bucket.blob(self._bucket_key(run_id, key, io_type)).upload_from_file(data)
-
-    def _download_to_local(self, run_id, key, io_type):
-        path = self.get_local_path(run_id, key, io_type)
-        ensure_dir(os.path.dirname(path))
-        with open(path, "wb") as fileobj:
-            self._bucket.blob(self._bucket_key(run_id, key, io_type)).download_to_file(fileobj)
-
-    def _bucket_key(self, run_id, key, io_type):
-        check.inst_param(io_type, "io_type", ComputeIOType)
-        extension = IO_TYPE_EXTENSION[io_type]
-        paths = [
-            self._prefix,
-            "storage",
-            run_id,
-            "compute_logs",
-            "{}.{}".format(key, extension),
-        ]
-
-        return "/".join(paths)  # path delimiter
+        self._subscription_manager.remove_subscription(subscription)
 
     def dispose(self):
-        self.local_manager.dispose()
+        self._subscription_manager.dispose()
+        self._local_manager.dispose()


### PR DESCRIPTION
### Summary & Motivation
K8s cluster tests in cloud hit some test failures because the pids for recently spun up tasks were all colliding.

### How I Tested These Changes
Ran cloud k8s test suite, where all runs will have `pid == 1`.
