### PR TITLE
[dagster-fivetran] Fivetran managed elements implementation

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
@@ -12,7 +12,7 @@ try:
     from .managed import FivetranConnector, FivetranDestination, FivetranManagedElementReconciler
 
 except ImportError:
-    raise
+    pass
 
 
 check_dagster_package_version("dagster-fivetran", __version__)

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
@@ -6,6 +6,15 @@ from .resources import FivetranResource, fivetran_resource
 from .types import FivetranOutput
 from .version import __version__
 
+try:
+    import dagster_managed_elements
+
+    from .managed import FivetranConnector, FivetranDestination, FivetranManagedElementReconciler
+
+except ImportError:
+    raise
+
+
 check_dagster_package_version("dagster-fivetran", __version__)
 
 __all__ = [

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/cli.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/cli.py
@@ -1,0 +1,20 @@
+import click
+
+try:
+    from dagster_managed_elements.cli import apply_cmd, check_cmd
+
+    @click.group()
+    def main():
+        pass
+
+    main.add_command(check_cmd)
+    main.add_command(apply_cmd)
+
+
+except ImportError:
+
+    @click.group(
+        help="In order to use managed Fivetran config, the dagster-managed-elements package must be installed."
+    )
+    def main():
+        pass

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/managed/__init__.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/managed/__init__.py
@@ -1,0 +1,2 @@
+from .reconciliation import FivetranManagedElementReconciler
+from .types import FivetranConnector, FivetranDestination

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/managed/reconciliation.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/managed/reconciliation.py
@@ -3,7 +3,6 @@ from itertools import chain
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 from dagster_fivetran import FivetranResource
-from dagster_fivetran.resources import FivetranResource
 from dagster_managed_elements import ManagedElementCheckResult, ManagedElementDiff
 from dagster_managed_elements.types import ManagedElementReconciler, is_key_secret
 from dagster_managed_elements.utils import diff_dicts

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/managed/reconciliation.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/managed/reconciliation.py
@@ -1,0 +1,384 @@
+import json
+from itertools import chain
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+from dagster_fivetran import FivetranResource
+from dagster_fivetran.resources import FivetranResource
+from dagster_managed_elements import ManagedElementCheckResult, ManagedElementDiff
+from dagster_managed_elements.types import ManagedElementReconciler, is_key_secret
+from dagster_managed_elements.utils import diff_dicts
+
+import dagster._check as check
+from dagster import ResourceDefinition
+from dagster._annotations import experimental
+from dagster._core.execution.context.init import build_init_resource_context
+
+from .types import (
+    FivetranConnector,
+    FivetranDestination,
+    InitializedFivetranConnector,
+    InitializedFivetranDestination,
+)
+
+FIVETRAN_SECRET_MASK = "******"
+
+
+def _ignore_secrets_compare_fn(k: str, _cv: Any, dv: Any) -> Optional[bool]:
+    if is_key_secret(k):
+        return dv == FIVETRAN_SECRET_MASK
+    return None
+
+
+def _diff_configs(
+    config_dict: Dict[str, Any], dst_dict: Dict[str, Any], ignore_secrets: bool = True
+) -> ManagedElementDiff:
+    return diff_dicts(
+        config_dict=config_dict,
+        dst_dict=dst_dict,
+        custom_compare_fn=_ignore_secrets_compare_fn if ignore_secrets else None,
+    )
+
+
+def diff_destinations(
+    config_dst: Optional[FivetranDestination],
+    curr_dst: Optional[FivetranDestination],
+    ignore_secrets: bool = True,
+) -> ManagedElementCheckResult:
+    """
+    Utility to diff two FivetranDestination objects.
+    """
+    diff = _diff_configs(
+        config_dst.destination_configuration if config_dst else {},
+        curr_dst.destination_configuration if curr_dst else {},
+        ignore_secrets,
+    )
+    if not diff.is_empty():
+        name = config_dst.name if config_dst else curr_dst.name if curr_dst else "Unknown"
+        return ManagedElementDiff().with_nested(name, diff)
+
+    return ManagedElementDiff()
+
+
+def diff_connectors(
+    config_conn: Optional[FivetranConnector],
+    curr_conn: Optional[FivetranConnector],
+    ignore_secrets: bool = True,
+) -> ManagedElementCheckResult:
+    """
+    Utility to diff two FivetranDestination objects.
+    """
+    diff = _diff_configs(
+        config_conn.source_configuration if config_conn else {},
+        curr_conn.source_configuration if curr_conn else {},
+        ignore_secrets,
+    )
+    if not diff.is_empty():
+        name = (
+            config_conn.schema_name
+            if config_conn
+            else curr_conn.schema_name
+            if curr_conn
+            else "Unknown"
+        )
+        return ManagedElementDiff().with_nested(name, diff)
+
+    return ManagedElementDiff()
+
+
+def reconcile_connectors(
+    res: FivetranResource,
+    config_connectors: Mapping[str, FivetranConnector],
+    existing_connectors: Mapping[str, InitializedFivetranConnector],
+    all_destinations: Mapping[str, InitializedFivetranDestination],
+    dry_run: bool,
+    should_delete: bool,
+    ignore_secrets: bool,
+) -> ManagedElementCheckResult:
+
+    diff = ManagedElementDiff()
+
+    for connector_name in set(config_connectors.keys()).union(existing_connectors.keys()):
+        configured_connector = config_connectors.get(connector_name)
+        existing_connector = existing_connectors.get(connector_name)
+
+        # Ignore connectors not mentioned in the user config unless the user specifies to delete
+        if not should_delete and existing_connector and not configured_connector:
+            continue
+
+        diff = diff.join(
+            diff_connectors(
+                configured_connector,
+                existing_connector.connector if existing_connector else None,
+                ignore_secrets,
+            )
+        )
+
+        if existing_connector and (
+            not configured_connector
+            or (configured_connector.must_be_recreated(existing_connector.connector))
+        ):
+            if not dry_run:
+                res.make_request(
+                    method="DELETE",
+                    endpoint=f"connectors/{existing_connector.connector_id}",
+                )
+            existing_connector = None
+
+        if configured_connector:
+            group_id = all_destinations[configured_connector.destination.name].destination_id
+            config = {
+                **configured_connector.source_configuration,
+                "schema": configured_connector.schema_name,
+            }
+            base_connector_dict = {
+                "schedule_type": "MANUAL",
+                "config": config,
+                "auth": configured_connector.auth_configuration,
+            }
+            if not dry_run:
+                if existing_connector:
+                    connector_id = existing_connector.connector_id
+                    if not dry_run:
+                        res.make_request(
+                            method="PATCH",
+                            endpoint=f"connectors/{connector_id}",
+                            data=json.dumps(base_connector_dict),
+                        )
+                else:
+                    if not dry_run:
+                        res.make_request(
+                            method="POST",
+                            endpoint="connectors",
+                            data=json.dumps(
+                                {
+                                    "service": configured_connector.source_type,
+                                    "group_id": group_id,
+                                    **base_connector_dict,
+                                }
+                            ),
+                        )
+
+    return diff
+
+
+def reconcile_destinations(
+    res: FivetranResource,
+    config_destinations: Mapping[str, FivetranDestination],
+    existing_destinations: Mapping[str, InitializedFivetranDestination],
+    dry_run: bool,
+    should_delete: bool,
+    ignore_secrets: bool,
+) -> Tuple[Mapping[str, InitializedFivetranDestination], ManagedElementCheckResult]:
+    """
+    Generates a diff of the configured and existing destinations and reconciles them to match the
+    configured state if dry_run is False.
+    """
+
+    diff = ManagedElementDiff()
+
+    initialized_destinations: Dict[str, InitializedFivetranDestination] = {}
+    for destination_name in set(config_destinations.keys()).union(existing_destinations.keys()):
+        configured_destination = config_destinations.get(destination_name)
+        existing_destination = existing_destinations.get(destination_name)
+
+        # Ignore destinations not mentioned in the user config unless the user specifies to delete
+        if not should_delete and existing_destination and not configured_destination:
+            initialized_destinations[destination_name] = existing_destination
+            continue
+
+        diff = diff.join(
+            diff_destinations(
+                configured_destination,
+                existing_destination.destination if existing_destination else None,
+                ignore_secrets,
+            )
+        )
+
+        if existing_destination and (
+            not configured_destination
+            or (configured_destination.must_be_recreated(existing_destination.destination))
+        ):
+            initialized_destinations[destination_name] = existing_destination
+            if not dry_run:
+                connectors = [
+                    conn["id"]
+                    for conn in res.make_request(
+                        "GET", f"groups/{existing_destination.destination_id}/connectors"
+                    )["items"]
+                ]
+                for connector_id in connectors:
+                    res.make_request(
+                        method="DELETE",
+                        endpoint=f"connectors/{connector_id}",
+                    )
+                res.make_request(
+                    method="DELETE",
+                    endpoint=f"destinations/{existing_destination.destination_id}",
+                )
+                res.make_request(
+                    method="DELETE",
+                    endpoint=f"groups/{existing_destination.destination_id}",
+                )
+            existing_destination = None
+
+        if configured_destination:
+
+            base_destination_dict = {
+                "region": configured_destination.region,
+                "time_zone_offset": configured_destination.time_zone_offset,
+                "config": configured_destination.destination_configuration,
+            }
+            destination_id = "TBD"
+            if not dry_run:
+                if existing_destination:
+                    destination_id = existing_destination.destination_id
+                    if not dry_run:
+                        res.make_request(
+                            method="PATCH",
+                            endpoint=f"destinations/{destination_id}",
+                            data=json.dumps(base_destination_dict),
+                        )
+                else:
+                    if not dry_run:
+                        group_res = res.make_request(
+                            method="POST",
+                            endpoint="groups",
+                            data=json.dumps(
+                                {
+                                    "name": configured_destination.name,
+                                }
+                            ),
+                        )
+                        destination_id = group_res["id"]
+
+                        res.make_request(
+                            method="POST",
+                            endpoint="destinations",
+                            data=json.dumps(
+                                {
+                                    "group_id": destination_id,
+                                    "service": configured_destination.destination_type,
+                                    **base_destination_dict,
+                                }
+                            ),
+                        )
+
+            initialized_destinations[destination_name] = InitializedFivetranDestination(
+                destination=configured_destination,
+                destination_id=destination_id,
+            )
+    return initialized_destinations, diff
+
+
+def get_connectors_for_group(res: FivetranResource, group_id: str) -> List[Dict[str, Any]]:
+    connector_ids = {
+        conn["id"] for conn in res.make_request("GET", f"groups/{group_id}/connectors")["items"]
+    }
+    connectors = [
+        res.make_request("GET", f"connectors/{connector_id}") for connector_id in connector_ids
+    ]
+    return connectors
+
+
+def reconcile_config(
+    res: FivetranResource,
+    objects: List[FivetranConnector],
+    dry_run: bool = False,
+    should_delete: bool = False,
+    ignore_secrets: bool = True,
+) -> ManagedElementCheckResult:
+    """
+    Main entry point for the reconciliation process. Takes a list of FivetranConnection objects
+    and a pointer to an Fivetran instance and returns a diff, along with applying the diff
+    if dry_run is False.
+    """
+    config_dests = {conn.destination.name: conn.destination for conn in objects}
+    config_connectors = {conn.schema_name: conn for conn in objects}
+
+    existing_groups = res.make_request("GET", "groups")["items"]
+    existing_dests_raw = {
+        group["name"]: res.make_request("GET", f"destinations/{group['id']}")
+        for group in existing_groups
+    }
+    existing_dests: Dict[str, InitializedFivetranDestination] = {
+        dest_name: InitializedFivetranDestination.from_api_json(dest_name, dest_json)
+        for dest_name, dest_json in existing_dests_raw.items()
+    }
+
+    existing_connectors_raw = list(
+        chain.from_iterable(get_connectors_for_group(res, group["id"]) for group in existing_groups)
+    )
+    existing_connectors_list = [
+        InitializedFivetranConnector.from_api_json(conn) for conn in existing_connectors_raw
+    ]
+    existing_connectors = {conn.connector.schema_name: conn for conn in existing_connectors_list}
+
+    all_dests, dests_diff = reconcile_destinations(
+        res,
+        config_dests,
+        existing_dests,
+        dry_run,
+        should_delete,
+        ignore_secrets,
+    )
+
+    connectors_diff = reconcile_connectors(
+        res,
+        config_connectors,
+        existing_connectors,
+        all_dests,
+        dry_run,
+        should_delete,
+        ignore_secrets,
+    )
+
+    return ManagedElementDiff().join(dests_diff).join(connectors_diff)
+
+
+@experimental
+class FivetranManagedElementReconciler(ManagedElementReconciler):
+    def __init__(
+        self,
+        fivetran: ResourceDefinition,
+        connectors: Iterable[FivetranConnector],
+        delete_unmentioned_resources: bool = False,
+    ):
+        """
+        Reconciles Python-specified Fivetran resources with an Fivetran instance.
+
+        Args:
+            fivetran (ResourceDefinition): The Fivetran resource definition to reconcile against.
+            connectors (Iterable[FivetranConnector]): The Fivetran connector objects to reconcile.
+            delete_unmentioned_resources (bool): Whether to delete resources that are not mentioned in
+                the set of connectors provided. When True, all Fivetran instance contents are effectively
+                managed by the reconciler. Defaults to False.
+        """
+        fivetran = check.inst_param(fivetran, "fivetran", ResourceDefinition)
+
+        self._fivetran_instance: FivetranResource = fivetran(build_init_resource_context())
+        self._connectors = list(
+            check.iterable_param(connectors, "connectors", of_type=FivetranConnector)
+        )
+        self._delete_unmentioned_resources = check.bool_param(
+            delete_unmentioned_resources, "delete_unmentioned_resources"
+        )
+
+        super().__init__()
+
+    def check(self, **kwargs) -> ManagedElementCheckResult:
+        return reconcile_config(
+            self._fivetran_instance,
+            self._connectors,
+            dry_run=True,
+            should_delete=self._delete_unmentioned_resources,
+            ignore_secrets=(not kwargs.get("include_all_secrets", False)),
+        )
+
+    def apply(self, **kwargs) -> ManagedElementCheckResult:
+        return reconcile_config(
+            self._fivetran_instance,
+            self._connectors,
+            dry_run=False,
+            should_delete=self._delete_unmentioned_resources,
+            ignore_secrets=(not kwargs.get("include_all_secrets", False)),
+        )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/managed/types.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/managed/types.py
@@ -1,0 +1,90 @@
+from typing import Any, Dict, Optional
+
+import dagster._check as check
+
+
+class FivetranDestination:
+    """
+    Represents a user-defined Fivetran destination.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        destination_type: str,
+        region: str,
+        destination_configuration: Dict[str, Any],
+        time_zone_offset: Optional[int] = None,
+    ):
+        self.name = check.str_param(name, "name")
+        self.region = check.str_param(region, "region")
+        self.time_zone_offset = check.opt_int_param(time_zone_offset, "time_zone_offset") or 0
+        self.destination_type = check.str_param(destination_type, "destination_type")
+        self.destination_configuration = check.dict_param(
+            destination_configuration, "destination_configuration", key_type=str
+        )
+
+    def must_be_recreated(self, other: "FivetranDestination") -> bool:
+        return self.name != other.name or self.destination_type != other.destination_type
+
+
+class InitializedFivetranDestination:
+    def __init__(self, destination: FivetranDestination, destination_id: str):
+        self.destination = destination
+        self.destination_id = destination_id
+
+    @classmethod
+    def from_api_json(cls, name: str, api_json: Dict[str, Any]):
+        return cls(
+            destination=FivetranDestination(
+                name=name,
+                destination_type=api_json["service"],
+                region=api_json["region"],
+                time_zone_offset=int(api_json["time_zone_offset"]),
+                destination_configuration=api_json["config"],
+            ),
+            destination_id=api_json["id"],
+        )
+
+
+class FivetranConnector:
+    def __init__(
+        self,
+        schema_name: str,
+        source_type: str,
+        source_configuration: Dict[str, Any],
+        destination: FivetranDestination,
+        auth_configuration: Optional[Dict[str, Any]] = None,
+    ):
+        self.schema_name = check.str_param(schema_name, "schema_name")
+        self.source_type = check.str_param(source_type, "source_type")
+        self.source_configuration = check.dict_param(
+            source_configuration, "source_configuration", key_type=str
+        )
+        self.auth_configuration = check.opt_dict_param(
+            auth_configuration, "auth_configuration", key_type=str
+        )
+        self.paused = True
+        self.destination = check.opt_inst_param(destination, "destination", FivetranDestination)
+
+    def must_be_recreated(self, other: "FivetranConnector") -> bool:
+        return self.schema_name != other.schema_name or self.source_type != other.source_type
+
+
+class InitializedFivetranConnector:
+    def __init__(self, connector: FivetranConnector, connector_id: str):
+        self.connector = connector
+        self.connector_id = connector_id
+
+    @classmethod
+    def from_api_json(cls, api_json: Dict[str, Any]):
+        return cls(
+            connector=FivetranConnector(
+                schema_name=api_json["schema"],
+                source_type=api_json["service"],
+                source_configuration=api_json["config"] or {},
+                auth_configuration=api_json.get("auth") or {},
+                destination=None,
+            ),
+            connector_id=api_json["id"],
+        )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/managed/types.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/managed/types.py
@@ -53,7 +53,7 @@ class FivetranConnector:
         schema_name: str,
         source_type: str,
         source_configuration: Dict[str, Any],
-        destination: FivetranDestination,
+        destination: Optional[FivetranDestination],
         auth_configuration: Optional[Dict[str, Any]] = None,
     ):
         self.schema_name = check.str_param(schema_name, "schema_name")

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -89,6 +89,7 @@ class FivetranResource:
                     auth=self._auth,
                     data=data,
                 )
+                # print(response.text)
                 response.raise_for_status()
                 resp_dict = response.json()
                 return resp_dict["data"] if "data" in resp_dict else resp_dict

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -89,7 +89,6 @@ class FivetranResource:
                     auth=self._auth,
                     data=data,
                 )
-                # print(response.text)
                 response.raise_for_status()
                 resp_dict = response.json()
                 return resp_dict["data"] if "data" in resp_dict else resp_dict

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_managed_elements.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_managed_elements.py
@@ -1,34 +1,34 @@
-from typing import Dict, List, Tuple, Any
-from dagster_managed_elements.types import ManagedElementDiff
-from dagster_managed_elements.utils import diff_dicts
+import json
+import re
+from contextlib import AbstractContextManager
+from typing import Any, Dict, List, Tuple
+
 import pytest
 import responses
-from dagster_fivetran import fivetran_resource
+from dagster_fivetran import (
+    FivetranConnector,
+    FivetranDestination,
+    FivetranManagedElementReconciler,
+    fivetran_resource,
+)
 from dagster_fivetran.asset_defs import load_assets_from_fivetran_instance
+from dagster_fivetran.managed.types import (
+    InitializedFivetranConnector,
+    InitializedFivetranDestination,
+)
 from dagster_fivetran_tests.utils import (
     DEFAULT_CONNECTOR_ID,
     get_complex_sample_connector_schema_config,
     get_sample_connectors_response,
     get_sample_groups_response,
 )
-from dagster_fivetran import (
-    FivetranManagedElementReconciler,
-    FivetranConnector,
-    FivetranDestination,
-)
-
-from dagster_fivetran.managed.types import (
-    InitializedFivetranConnector,
-    InitializedFivetranDestination,
-)
-import json
+from dagster_managed_elements.types import ManagedElementDiff
+from dagster_managed_elements.utils import diff_dicts
+from requests import PreparedRequest
 
 from dagster import AssetKey, build_init_resource_context
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.metadata.table import TableColumn, TableSchema
-from contextlib import AbstractContextManager
-from requests import PreparedRequest
-import re
 
 
 def ok(contents: Dict[str, Any]) -> Any:

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_managed_elements.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_managed_elements.py
@@ -3,7 +3,6 @@ import re
 from contextlib import AbstractContextManager
 from typing import Any, Dict, List, Tuple
 
-import pytest
 import responses
 from dagster_fivetran import (
     FivetranConnector,
@@ -11,24 +10,15 @@ from dagster_fivetran import (
     FivetranManagedElementReconciler,
     fivetran_resource,
 )
-from dagster_fivetran.asset_defs import load_assets_from_fivetran_instance
 from dagster_fivetran.managed.types import (
     InitializedFivetranConnector,
     InitializedFivetranDestination,
-)
-from dagster_fivetran_tests.utils import (
-    DEFAULT_CONNECTOR_ID,
-    get_complex_sample_connector_schema_config,
-    get_sample_connectors_response,
-    get_sample_groups_response,
 )
 from dagster_managed_elements.types import ManagedElementDiff
 from dagster_managed_elements.utils import diff_dicts
 from requests import PreparedRequest
 
-from dagster import AssetKey, build_init_resource_context
-from dagster._core.definitions.metadata import MetadataValue
-from dagster._core.definitions.metadata.table import TableColumn, TableSchema
+from dagster import build_init_resource_context
 
 
 def ok(contents: Dict[str, Any]) -> Any:
@@ -370,14 +360,6 @@ def add_groups_connectors(
 @responses.activate
 def test_basic_end_to_end():
 
-    ft_resource = fivetran_resource(
-        build_init_resource_context(
-            config={
-                "api_key": "some_key",
-                "api_secret": "some_secret",
-            }
-        )
-    )
     ft_instance = fivetran_resource.configured(
         {
             "api_key": "some_key",

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_managed_elements.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_managed_elements.py
@@ -18,8 +18,6 @@ from dagster_managed_elements.types import ManagedElementDiff
 from dagster_managed_elements.utils import diff_dicts
 from requests import PreparedRequest
 
-from dagster import build_init_resource_context
-
 
 def ok(contents: Dict[str, Any]) -> Any:
     return (200, {}, json.dumps(contents))

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_managed_elements.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_managed_elements.py
@@ -1,7 +1,7 @@
 import json
 import re
 from contextlib import AbstractContextManager
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, cast
 
 import responses
 from dagster_fivetran import (
@@ -43,13 +43,13 @@ class MockFivetran(AbstractContextManager):
         self.rsps = responses.RequestsMock(assert_all_requests_are_fired=False)
         self.connectors = connectors
         self.destinations = destinations
-        self.created_groups = {}
+        self.created_groups: Dict[str, str] = {}
         self.group_id = 1
         self.connectors_by_destination = {
             dest_id: [
                 conn_id
                 for conn_id, conn in connectors.items()
-                if conn.destination.name == dest.name
+                if cast(FivetranDestination, conn.destination).name == dest.name
             ]
             for dest_id, dest in destinations.items()
         }

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_managed_elements.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_managed_elements.py
@@ -1,0 +1,453 @@
+from typing import Dict, List, Tuple, Any
+from dagster_managed_elements.types import ManagedElementDiff
+from dagster_managed_elements.utils import diff_dicts
+import pytest
+import responses
+from dagster_fivetran import fivetran_resource
+from dagster_fivetran.asset_defs import load_assets_from_fivetran_instance
+from dagster_fivetran_tests.utils import (
+    DEFAULT_CONNECTOR_ID,
+    get_complex_sample_connector_schema_config,
+    get_sample_connectors_response,
+    get_sample_groups_response,
+)
+from dagster_fivetran import (
+    FivetranManagedElementReconciler,
+    FivetranConnector,
+    FivetranDestination,
+)
+
+from dagster_fivetran.managed.types import (
+    InitializedFivetranConnector,
+    InitializedFivetranDestination,
+)
+import json
+
+from dagster import AssetKey, build_init_resource_context
+from dagster._core.definitions.metadata import MetadataValue
+from dagster._core.definitions.metadata.table import TableColumn, TableSchema
+from contextlib import AbstractContextManager
+from requests import PreparedRequest
+import re
+
+
+def ok(contents: Dict[str, Any]) -> Any:
+    return (200, {}, json.dumps(contents))
+
+
+def format_callback(callback):
+    def wrapper(request: PreparedRequest):
+        return ok(
+            callback(
+                request.method, request.url, json.loads(request.body) if request.body else None
+            )
+        )
+
+    return wrapper
+
+
+class MockFivetran(AbstractContextManager):
+    def __init__(
+        self, connectors: Dict[str, FivetranConnector], destinations: Dict[str, FivetranDestination]
+    ):
+        self.rsps = responses.RequestsMock(assert_all_requests_are_fired=False)
+        self.connectors = connectors
+        self.destinations = destinations
+        self.created_groups = {}
+        self.group_id = 1
+        self.connectors_by_destination = {
+            dest_id: [
+                conn_id
+                for conn_id, conn in connectors.items()
+                if conn.destination.name == dest.name
+            ]
+            for dest_id, dest in destinations.items()
+        }
+        self.operations_log: List[Tuple[str, str]] = []
+
+    def __enter__(self):
+        self.rsps.__enter__()
+        self.rsps.add_callback(
+            responses.GET,
+            "https://api.fivetran.com/v1/groups",
+            callback=format_callback(self.mock_groups),
+        )
+        self.rsps.add_callback(
+            responses.GET,
+            re.compile(r"https://api.fivetran.com/v1/destinations/.*"),
+            callback=format_callback(self.mock_destination),
+        )
+        self.rsps.add_callback(
+            responses.GET,
+            re.compile(r"https://api.fivetran.com/v1/groups/.*/connectors"),
+            callback=format_callback(self.mock_connectors),
+        )
+        self.rsps.add_callback(
+            responses.GET,
+            re.compile(r"https://api.fivetran.com/v1/connectors/.*"),
+            callback=format_callback(self.mock_connector),
+        )
+
+        self.rsps.add_callback(
+            responses.PATCH,
+            re.compile(r"https://api.fivetran.com/v1/destinations/.*"),
+            callback=format_callback(self.mock_patch_destination),
+        )
+        self.rsps.add_callback(
+            responses.PATCH,
+            re.compile(r"https://api.fivetran.com/v1/connectors/.*"),
+            callback=format_callback(self.mock_patch_connector),
+        )
+
+        self.rsps.add_callback(
+            responses.POST,
+            "https://api.fivetran.com/v1/groups",
+            callback=format_callback(self.mock_post_groups),
+        )
+        self.rsps.add_callback(
+            responses.POST,
+            "https://api.fivetran.com/v1/destinations",
+            callback=format_callback(self.mock_post_destinations),
+        )
+        self.rsps.add_callback(
+            responses.POST,
+            "https://api.fivetran.com/v1/connectors",
+            callback=format_callback(self.mock_post_connectors),
+        )
+
+        return self
+
+    def mock_post_groups(self, _method, _url, contents):
+        self.operations_log.append(("post_groups", contents["name"]))
+
+        new_group_id = str(self.group_id)
+        self.created_groups[new_group_id] = contents["name"]
+        self.group_id += 1
+        return {"code": "Success", "data": {"id": new_group_id}}
+
+    def mock_post_destinations(self, _method, _url, contents):
+        group_id = contents["group_id"]
+        self.operations_log.append(("post_destinations", group_id))
+
+        self.destinations[group_id] = InitializedFivetranDestination.from_api_json(
+            name=self.created_groups[group_id], api_json={**contents, "id": "my_new_dest_id"}
+        ).destination
+        self.connectors_by_destination[group_id] = []
+        return {"code": "Success"}
+
+    def mock_post_connectors(self, _method, _url, contents):
+        group_id = contents["group_id"]
+        self.operations_log.append(("post_connectors", group_id))
+
+        conn = InitializedFivetranConnector.from_api_json(
+            api_json={**contents, "id": "my_new_conn_id", "schema": contents["config"]["schema"]}
+        ).connector
+        conn.destination = self.destinations[group_id]
+        self.connectors["my_new_conn_id"] = conn
+
+        self.connectors_by_destination[group_id].append("my_new_conn_id")
+
+        return {"code": "Success"}
+
+    def mock_patch_destination(self, _method, url, contents):
+        destination_id = url.split("/")[-1]
+        destination = self.destinations[destination_id]
+        destination.destination_configuration = contents["config"]
+
+        self.operations_log.append(("patch_destination", destination_id))
+
+        return {"code": "Success"}
+
+    def mock_patch_connector(self, _method, url, contents):
+        connector_id = url.split("/")[-1]
+        connector = self.connectors[connector_id]
+        connector.source_configuration = contents["config"]
+
+        self.operations_log.append(("patch_connector", connector_id))
+
+        return {"code": "Success"}
+
+    def mock_connector(self, _method, url, _contents):
+        connector_id = url.split("/")[-1]
+        connector = self.connectors[connector_id]
+        return {
+            "code": "Success",
+            "data": {
+                "id": connector_id,
+                "group_id": connector.destination.name,
+                "service": connector.source_type,
+                "service_version": 1,
+                "schema": connector.schema_name,
+                "connected_by": "concerning_batch",
+                "created_at": "2018-07-21T22:55:21.724201Z",
+                "succeeded_at": "2018-12-26T17:58:18.245Z",
+                "failed_at": "2018-08-24T15:24:58.872491Z",
+                "sync_frequency": 60,
+                "status": {
+                    "setup_state": "connected",
+                    "sync_state": "paused",
+                    "update_state": "delayed",
+                    "is_historical_sync": False,
+                    "tasks": [],
+                    "warnings": [],
+                },
+                "config": connector.source_configuration,
+            },
+        }
+
+    def mock_connectors(self, _method, url, _contents):
+        destination_id = url.split("/")[-2]
+        connector_ids = self.connectors_by_destination[destination_id]
+        connectors = {conn_id: self.connectors[conn_id] for conn_id in connector_ids}
+
+        return {
+            "code": "Success",
+            "data": {
+                "items": [
+                    {
+                        "id": conn_id,
+                        "group_id": destination_id,
+                        "service": conn.source_type,
+                        "service_version": 1,
+                        "schema": conn.schema_name,
+                        "connected_by": "concerning_batch",
+                        "created_at": "2018-07-21T22:55:21.724201Z",
+                        "succeeded_at": "2018-12-26T17:58:18.245Z",
+                        "failed_at": "2018-08-24T15:24:58.872491Z",
+                        "sync_frequency": 60,
+                        "status": {
+                            "setup_state": "connected",
+                            "sync_state": "paused",
+                            "update_state": "delayed",
+                            "is_historical_sync": False,
+                            "tasks": [],
+                            "warnings": [],
+                        },
+                    }
+                    for conn_id, conn in connectors.items()
+                ],
+                "next_cursor": "eyJza2lwIjoxfQ",
+            },
+        }
+
+    def mock_destination(self, _method, url, _contents):
+        destination_id = url.split("/")[-1]
+        destination = self.destinations[destination_id]
+
+        return {
+            "code": "Success",
+            "data": {
+                "id": destination_id,
+                "group_id": destination_id,
+                "service": destination.destination_type,
+                "region": destination.region,
+                "time_zone_offset": destination.time_zone_offset,
+                "setup_status": "connected",
+                "config": destination.destination_configuration,
+            },
+        }
+
+    def mock_groups(self, _method, _url, _contents):
+        return {
+            "items": [
+                {
+                    "id": dest_id,
+                    "name": dest.name,
+                }
+                for dest_id, dest in self.destinations.items()
+            ]
+        }
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.rsps.__exit__(exc_type, exc_val, exc_tb)
+
+
+def add_groups_response(res: responses.RequestsMock, groups: List[Tuple[str, str]]):
+    res.add(
+        responses.GET,
+        "https://api.fivetran.com/v1/groups",
+        json={
+            "items": [
+                {
+                    "id": group_id,
+                    "name": group_name,
+                }
+                for group_id, group_name in groups
+            ]
+        },
+    )
+
+
+def add_groups_destinations(
+    res: responses.RequestsMock, dest_id: str, destination: FivetranDestination
+):
+    res.add(
+        responses.GET,
+        f"https://api.fivetran.com/v1/destinations/{dest_id}",
+        json={
+            "code": "Success",
+            "data": {
+                "id": dest_id,
+                "group_id": dest_id,
+                "service": destination.destination_type,
+                "region": destination.region,
+                "time_zone_offset": destination.time_zone_offset,
+                "setup_status": "connected",
+                "config": destination.destination_configuration,
+            },
+        },
+    )
+
+
+def add_groups_connectors(
+    res: responses.RequestsMock, group_id: str, connectors: Dict[str, FivetranConnector]
+):
+    res.add(
+        responses.GET,
+        f"https://api.fivetran.com/v1/groups/{group_id}/connectors",
+        json={
+            "code": "Success",
+            "data": {
+                "items": [
+                    {
+                        "id": conn_id,
+                        "group_id": group_id,
+                        "service": conn.source_type,
+                        "service_version": 1,
+                        "schema": conn.schema_name,
+                        "connected_by": "concerning_batch",
+                        "created_at": "2018-07-21T22:55:21.724201Z",
+                        "succeeded_at": "2018-12-26T17:58:18.245Z",
+                        "failed_at": "2018-08-24T15:24:58.872491Z",
+                        "sync_frequency": 60,
+                        "status": {
+                            "setup_state": "connected",
+                            "sync_state": "paused",
+                            "update_state": "delayed",
+                            "is_historical_sync": False,
+                            "tasks": [],
+                            "warnings": [],
+                        },
+                    }
+                    for conn_id, conn in connectors.items()
+                ],
+                "next_cursor": "eyJza2lwIjoxfQ",
+            },
+        },
+    )
+
+    for conn_id, conn in connectors.items():
+        res.add(
+            responses.GET,
+            f"https://api.fivetran.com/v1/connectors/{conn_id}",
+            json={
+                "code": "Success",
+                "data": {
+                    "id": conn_id,
+                    "group_id": group_id,
+                    "service": conn.source_type,
+                    "service_version": 1,
+                    "schema": conn.schema_name,
+                    "connected_by": "concerning_batch",
+                    "created_at": "2018-07-21T22:55:21.724201Z",
+                    "succeeded_at": "2018-12-26T17:58:18.245Z",
+                    "failed_at": "2018-08-24T15:24:58.872491Z",
+                    "sync_frequency": 60,
+                    "status": {
+                        "setup_state": "connected",
+                        "sync_state": "paused",
+                        "update_state": "delayed",
+                        "is_historical_sync": False,
+                        "tasks": [],
+                        "warnings": [],
+                    },
+                    "config": conn.source_configuration,
+                },
+            },
+        )
+
+
+@responses.activate
+def test_basic_end_to_end():
+
+    ft_resource = fivetran_resource(
+        build_init_resource_context(
+            config={
+                "api_key": "some_key",
+                "api_secret": "some_secret",
+            }
+        )
+    )
+    ft_instance = fivetran_resource.configured(
+        {
+            "api_key": "some_key",
+            "api_secret": "some_secret",
+        }
+    )
+
+    snowflake_destination = FivetranDestination(
+        name="my_destination",
+        destination_type="Snowflake",
+        region="GCP_US_EAST4",
+        time_zone_offset=0,
+        destination_configuration={
+            "baz": "qux",
+        },
+    )
+
+    github_conn = FivetranConnector(
+        schema_name="my_connector",
+        source_type="GitHub",
+        source_configuration={
+            "foo": "bar",
+        },
+        destination=snowflake_destination,
+    )
+
+    reconciler = FivetranManagedElementReconciler(
+        fivetran=ft_instance,
+        connectors=[github_conn],
+    )
+
+    with MockFivetran(
+        connectors={"my_connector": github_conn},
+        destinations={"my_destination": snowflake_destination},
+    ) as mock_ft:
+
+        assert reconciler.check() == ManagedElementDiff()
+        assert reconciler.apply() == ManagedElementDiff()
+
+        assert mock_ft.operations_log == [
+            ("patch_destination", "my_destination"),
+            ("patch_connector", "my_connector"),
+        ]
+
+    with MockFivetran(
+        connectors={},
+        destinations={},
+    ) as mock_ft:
+
+        expected_diff = diff_dicts(
+            {
+                "my_destination": {"baz": "qux"},
+                "my_connector": {"schema": "my_connector", "foo": "bar"},
+            },
+            {},
+        )
+
+        assert reconciler.check() == expected_diff
+        assert reconciler.apply() == expected_diff
+
+        assert mock_ft.operations_log == [
+            ("post_groups", "my_destination"),
+            ("post_destinations", "1"),
+            ("post_connectors", "1"),
+        ]
+
+        assert reconciler.check() == ManagedElementDiff()
+        assert reconciler.apply() == ManagedElementDiff()
+
+        assert mock_ft.operations_log[-2:] == [
+            ("patch_destination", "1"),
+            ("patch_connector", "my_new_conn_id"),
+        ]

--- a/python_modules/libraries/dagster-fivetran/setup.py
+++ b/python_modules/libraries/dagster-fivetran/setup.py
@@ -34,4 +34,9 @@ setup(
     packages=find_packages(exclude=["dagster_fivetran_tests*"]),
     install_requires=[f"dagster{pin}"],
     zip_safe=False,
+    entry_points={
+        "console_scripts": [
+            "dagster-fivetran = dagster_fivetran.cli:main",
+        ]
+    },
 )

--- a/python_modules/libraries/dagster-fivetran/tox.ini
+++ b/python_modules/libraries/dagster-fivetran/tox.ini
@@ -6,6 +6,7 @@ usedevelop = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e ../dagster-managed-elements
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/types.py
+++ b/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/types.py
@@ -12,6 +12,7 @@ class ManagedElementError(enum.Enum):
 
 
 SANITIZE_KEY_KEYWORDS = ["password", "token", "secret", "ssh_key"]
+SANITIZE_KEY_EXACT_MATCHES = ["pat"]
 
 SECRET_MASK_VALUE = "**********"
 
@@ -20,7 +21,9 @@ def is_key_secret(key: str):
     """
     Rudamentary check to see if a config key is a secret value.
     """
-    return any(keyword in key for keyword in SANITIZE_KEY_KEYWORDS)
+    return any(keyword in key for keyword in SANITIZE_KEY_KEYWORDS) or any(
+        match == key for match in SANITIZE_KEY_EXACT_MATCHES
+    )
 
 
 def _sanitize(key: str, value: str):


### PR DESCRIPTION
## Summary

Initial implementation of Fivetran managed elements, patterned off our approach for Airbyte.

Introduces a `FivetranManagedElementReconciler` reconciler implementation, which takes a list of `FivetranConnector`s. Each connector points at a `FivetranDestination`. The reconciler implementation will attempt to reconcile the set of Fivetran groups, then destinations, then connectors to match the passed in list.

```python
snowflake_destination = FivetranDestination(
    name="my_destination",
    destination_type="Snowflake",
    region="GCP_US_EAST4",
    time_zone_offset=0,
    destination_configuration={
        "baz": "qux",
    },
)

github_conn = FivetranConnector(
    schema_name="my_connector",
    source_type="GitHub",
    source_configuration={
        "foo": "bar",
    },
    destination=snowflake_destination,
)

reconciler = FivetranManagedElementReconciler(
    fivetran=ft_instance,
    connectors=[github_conn],
)
```

## Test Plan

Mocked out Fivetran for some unit tests, along with testing against our instance.