### PR TITLE
Add method to add_asset_event_tags

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1477,7 +1477,10 @@ class DagsterInstance:
 
     @traced
     def get_event_tags_for_asset(
-        self, asset_key: AssetKey, filter_tags: Optional[Mapping[str, str]] = None
+        self,
+        asset_key: AssetKey,
+        filter_tags: Optional[Mapping[str, str]] = None,
+        filter_event_id: Optional[int] = None,
     ) -> Sequence[Mapping[str, str]]:
         """
         Fetches asset event tags for the given asset key.
@@ -1487,10 +1490,12 @@ class DagsterInstance:
         partition tags with a fixed dimension value, e.g. all of the tags for events where
         "country" == "US".
 
+        If filter_event_id is provided, searches for the event with the provided event_id.
+
         Returns a list of dicts, where each dict is a mapping of tag key to tag value for a
         single event.
         """
-        return self._event_storage.get_event_tags_for_asset(asset_key, filter_tags)
+        return self._event_storage.get_event_tags_for_asset(asset_key, filter_tags, filter_event_id)
 
     @traced
     def run_ids_for_asset_key(self, asset_key):

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -296,7 +296,10 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
 
     @abstractmethod
     def get_event_tags_for_asset(
-        self, asset_key: AssetKey, filter_tags: Optional[Mapping[str, str]] = None
+        self,
+        asset_key: AssetKey,
+        filter_tags: Optional[Mapping[str, str]] = None,
+        filter_event_id: Optional[int] = None,
     ) -> Sequence[Mapping[str, str]]:
         pass
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -294,6 +294,19 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
     ) -> Mapping[AssetKey, Optional[EventLogEntry]]:
         pass
 
+    def supports_add_asset_event_tags(self) -> bool:
+        return False
+
+    @abstractmethod
+    def add_asset_event_tags(
+        self,
+        event_id: int,
+        event_timestamp: float,
+        asset_key: AssetKey,
+        new_tags: Mapping[str, str],
+    ) -> None:
+        pass
+
     @abstractmethod
     def get_event_tags_for_asset(
         self,

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -297,7 +297,6 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
     def supports_add_asset_event_tags(self) -> bool:
         return False
 
-    @abstractmethod
     def add_asset_event_tags(
         self,
         event_id: int,
@@ -305,7 +304,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
         asset_key: AssetKey,
         new_tags: Mapping[str, str],
     ) -> None:
-        pass
+        raise NotImplementedError()
 
     @abstractmethod
     def get_event_tags_for_asset(

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -213,7 +213,7 @@ class SqlEventLogStorage(EventLogStorage):
 
         return entry_values
 
-    def has_asset_event_tags_table(self) -> bool:
+    def supports_add_asset_event_tags(self) -> bool:
         return self.has_table(AssetEventTagsTable.name)
 
     def add_asset_event_tags(
@@ -228,7 +228,7 @@ class SqlEventLogStorage(EventLogStorage):
         check.inst_param(asset_key, "asset_key", AssetKey)
         check.mapping_param(new_tags, "new_tags", key_type=str, value_type=str)
 
-        if not self.has_asset_event_tags_table:
+        if not self.supports_add_asset_event_tags:
             raise DagsterInvalidInvocationError(
                 "In order to add asset event tags, you must run `dagster instance migrate` to "
                 "create the AssetEventTags table."

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -213,6 +213,79 @@ class SqlEventLogStorage(EventLogStorage):
 
         return entry_values
 
+    def has_asset_event_tags_table(self) -> bool:
+        return self.has_table(AssetEventTagsTable.name)
+
+    def add_asset_event_tags(
+        self, event_record: EventLogRecord, new_tags: Mapping[str, str]
+    ) -> None:
+        check.inst_param(event_record, "event_record", EventLogRecord)
+
+        if not self.has_asset_event_tags_table:
+            raise DagsterInvalidInvocationError(
+                "In order to add asset event tags, you must run `dagster instance migrate` to "
+                "create the AssetEventTags table."
+            )
+
+        if not (
+            event_record.event_log_entry.dagster_event
+            and event_record.event_log_entry.dagster_event.asset_key
+            and event_record.event_log_entry.dagster_event.is_step_materialization
+            and isinstance(
+                event_record.event_log_entry.dagster_event.step_materialization_data.materialization,
+                AssetMaterialization,
+            ),
+        ):
+            return
+
+        asset_key_str = event_record.asset_key.to_string()
+        current_tags_list = self.get_event_tags_for_asset(
+            event_record.asset_key, event_id=event_record.storage_id
+        )
+        if len(current_tags_list) == 0:
+            current_tags = {}
+        else:
+            current_tags = current_tags_list[0]
+
+        with self.index_connection() as conn:
+            current_tags_set = set(current_tags.keys())
+            new_tags_set = set(new_tags.keys())
+
+            existing_tags = current_tags_set & new_tags_set
+            added_tags = new_tags_set.difference(existing_tags)
+
+            for tag in existing_tags:
+                conn.execute(
+                    AssetEventTagsTable.update()  # pylint: disable=no-value-for-parameter
+                    .where(
+                        db.and_(
+                            AssetEventTagsTable.c.event_id == event_record.storage_id,
+                            AssetEventTagsTable.c.asset_key == asset_key_str,
+                            AssetEventTagsTable.c.key == tag,
+                        )
+                    )
+                    .values(value=new_tags[tag])
+                )
+
+            if added_tags:
+                conn.execute(
+                    AssetEventTagsTable.insert(),  # pylint: disable=no-value-for-parameter
+                    [
+                        dict(
+                            event_id=event_record.storage_id,
+                            asset_key=asset_key_str,
+                            key=tag,
+                            value=new_tags[tag],
+                            # Postgres requires a datetime that is in UTC but has no timezone info
+                            # set in order to be stored correctly
+                            event_timestamp=datetime.utcfromtimestamp(
+                                event_record.event_log_entry.timestamp
+                            ),
+                        )
+                        for tag in added_tags
+                    ],
+                )
+
     def store_asset_event_tags(self, event: EventLogEntry, event_id: int) -> None:
         check.inst_param(event, "event", EventLogEntry)
         check.int_param(event_id, "event_id")
@@ -1217,7 +1290,10 @@ class SqlEventLogStorage(EventLogStorage):
         return query
 
     def get_event_tags_for_asset(
-        self, asset_key: AssetKey, filter_tags: Optional[Mapping[str, str]] = None
+        self,
+        asset_key: AssetKey,
+        filter_tags: Optional[Mapping[str, str]] = None,
+        event_id: Optional[int] = None,
     ) -> Sequence[Mapping[str, str]]:
         """
         Fetches asset event tags for the given asset key.
@@ -1227,6 +1303,8 @@ class SqlEventLogStorage(EventLogStorage):
         partition tags with a fixed dimension value, e.g. all of the tags for events where
         "country" == "US".
 
+        If event_id is provided, fetches only tags applied to the given event.
+
         Returns a list of dicts, where each dict is a mapping of tag key to tag value for a
         single event.
         """
@@ -1234,6 +1312,7 @@ class SqlEventLogStorage(EventLogStorage):
         filter_tags = check.opt_mapping_param(
             filter_tags, "filter_tags", key_type=str, value_type=str
         )
+        event_id = check.opt_int_param(event_id, "event_id")
 
         if not self.has_table(AssetEventTagsTable.name):
             raise DagsterInvalidInvocationError(
@@ -1294,6 +1373,9 @@ class SqlEventLogStorage(EventLogStorage):
                     AssetEventTagsTable.c.event_id.in_(db.intersect(*intersections)),
                 )
             )
+
+        if event_id is not None:
+            tags_query = tags_query.where(AssetEventTagsTable.c.event_id == event_id)
 
         with self.index_connection() as conn:
             results = conn.execute(tags_query).fetchall()

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -2461,7 +2461,7 @@ class TestEventLogStorage:
             assert len(materializations) == 1
             mat_record = materializations[0]
 
-            assert storage.get_event_tags_for_asset(key, event_id=mat_record.storage_id) == [
+            assert storage.get_event_tags_for_asset(key, filter_event_id=mat_record.storage_id) == [
                 {
                     "dagster/partition/country": "US",
                     "dagster/partition/date": "2022-10-13",

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -2469,7 +2469,9 @@ class TestEventLogStorage:
             ]
 
             storage.add_asset_event_tags(
-                mat_record,
+                event_id=mat_record.storage_id,
+                event_timestamp=mat_record.event_log_entry.timestamp,
+                asset_key=mat_record.asset_key,
                 new_tags={
                     "a": "apple",
                     "b": "boot",
@@ -2486,7 +2488,9 @@ class TestEventLogStorage:
             ]
 
             storage.add_asset_event_tags(
-                mat_record,
+                event_id=mat_record.storage_id,
+                event_timestamp=mat_record.event_log_entry.timestamp,
+                asset_key=mat_record.asset_key,
                 new_tags={"a": "something_new"},
             )
 
@@ -2525,7 +2529,12 @@ class TestEventLogStorage:
                 storage.get_event_tags_for_asset(key, filter_event_id=mat_record.storage_id) == []
             )
 
-            storage.add_asset_event_tags(mat_record, new_tags={"a": "apple", "b": "boot"})
+            storage.add_asset_event_tags(
+                event_id=mat_record.storage_id,
+                event_timestamp=mat_record.event_log_entry.timestamp,
+                asset_key=mat_record.asset_key,
+                new_tags={"a": "apple", "b": "boot"},
+            )
 
             assert storage.get_event_tags_for_asset(key, filter_event_id=mat_record.storage_id) == [
                 {"a": "apple", "b": "boot"}

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -2432,7 +2432,10 @@ class TestEventLogStorage:
                 {"dagster/partition/country": "US", "dagster/partition/date": "2022-10-13"}
             ]
 
-    def test_add_materialization_tags(self, storage, instance):
+    def test_add_asset_event_tags(self, storage, instance):
+        if not storage.supports_add_asset_event_tags():
+            pytest.skip("storage does not support adding asset event tags")
+
         key = AssetKey("hello")
 
         @op
@@ -2503,7 +2506,9 @@ class TestEventLogStorage:
                 }
             ]
 
-    def test_add_materialization_tags_initially_empty(self, storage, instance):
+    def test_add_asset_event_tags_initially_empty(self, storage, instance):
+        if not storage.supports_add_asset_event_tags():
+            pytest.skip("storage does not support adding asset event tags")
         key = AssetKey("hello")
 
         @op


### PR DESCRIPTION
### Summary & Motivation

Gives the ability to add tags post-hoc to a given record, as well as query for the tags of a given record id. If you add tags to a record after it's been stored, these will not be reflected on the EventLogRecord itself, so the tags table is the source of truth for the set of tags on an asset. This is pretty inconsequential, as the tags we want to add post-hoc are currently all for internal machinery.

### How I Tested These Changes
