### PR TITLE
[dagit] test_event_log_subscription_chunked fix

### DIFF
--- a/python_modules/dagit/dagit_tests/test_subscriptions.py
+++ b/python_modules/dagit/dagit_tests/test_subscriptions.py
@@ -116,8 +116,8 @@ def test_event_log_subscription_chunked():
 
                 end_subscription(ws)
 
-            gc.collect()
-            assert len(objgraph.by_type("async_generator")) == 0
+        gc.collect()
+        assert len(objgraph.by_type("async_generator")) == 0
 
 
 @mock.patch(


### PR DESCRIPTION
move the gc and leak check to after the asgi client is closed instead of just after the socket connection is closed. 

### How I Tested These Changes

pytest -n 100 python_modules/dagit/dagit_tests/test_subscriptions.py::test_event_log_subscription_chunked