### PR TITLE
[freshness-policies] fix source asset freshness

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1733,7 +1733,7 @@ def untyped_asset(typed_asset):
     return typed_asset
 
 
-@asset
+@asset(non_argument_deps={AssetKey("diamond_source")})
 def fresh_diamond_top():
     return 1
 
@@ -1869,6 +1869,7 @@ def define_asset_jobs():
             AssetSelection.assets(multipartitions_1, multipartitions_2),
             partitions_def=multipartitions_def,
         ),
+        SourceAsset("diamond_source"),
         fresh_diamond_top,
         fresh_diamond_left,
         fresh_diamond_right,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_all_snapshot_ids.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_all_snapshot_ids.py
@@ -1315,7 +1315,14 @@ snapshots['test_all_snapshot_ids 1'] = '''{
       },
       {
         "__class__": "SolidInvocationSnap",
-        "input_dep_snaps": [],
+        "input_dep_snaps": [
+          {
+            "__class__": "InputDependencySnap",
+            "input_name": "diamond_source",
+            "is_dynamic_collect": false,
+            "upstream_output_snaps": []
+          }
+        ],
         "is_dynamic_mapped": false,
         "solid_def_name": "fresh_diamond_top",
         "solid_name": "fresh_diamond_top",
@@ -1570,7 +1577,14 @@ snapshots['test_all_snapshot_ids 1'] = '''{
           "type_key": "Any"
         },
         "description": null,
-        "input_def_snaps": [],
+        "input_def_snaps": [
+          {
+            "__class__": "InputDefSnap",
+            "dagster_type_key": "Nothing",
+            "description": null,
+            "name": "diamond_source"
+          }
+        ],
         "name": "fresh_diamond_top",
         "output_def_snaps": [
           {
@@ -24127,7 +24141,7 @@ snapshots['test_all_snapshot_ids 19'] = '''{
   "tags": {}
 }'''
 
-snapshots['test_all_snapshot_ids 2'] = '456c52fc3762d51ecb455462c70ec46bc29d26ee'
+snapshots['test_all_snapshot_ids 2'] = 'bab456b676e37a478e372bacce6402298c71bf63'
 
 snapshots['test_all_snapshot_ids 20'] = '40c4bcc1d6e381a7c61f2203a913493af2f6ff97'
 
@@ -35886,7 +35900,14 @@ snapshots['test_all_snapshot_ids 35'] = '''{
       },
       {
         "__class__": "SolidInvocationSnap",
-        "input_dep_snaps": [],
+        "input_dep_snaps": [
+          {
+            "__class__": "InputDependencySnap",
+            "input_name": "diamond_source",
+            "is_dynamic_collect": false,
+            "upstream_output_snaps": []
+          }
+        ],
         "is_dynamic_mapped": false,
         "solid_def_name": "fresh_diamond_top",
         "solid_name": "fresh_diamond_top",
@@ -36062,7 +36083,14 @@ snapshots['test_all_snapshot_ids 35'] = '''{
           "type_key": "Any"
         },
         "description": null,
-        "input_def_snaps": [],
+        "input_def_snaps": [
+          {
+            "__class__": "InputDefSnap",
+            "dagster_type_key": "Nothing",
+            "description": null,
+            "name": "diamond_source"
+          }
+        ],
         "name": "fresh_diamond_top",
         "output_def_snaps": [
           {
@@ -36082,7 +36110,7 @@ snapshots['test_all_snapshot_ids 35'] = '''{
   "tags": {}
 }'''
 
-snapshots['test_all_snapshot_ids 36'] = '82158c7343c900cbe8be2684116540a3be9fe9e4'
+snapshots['test_all_snapshot_ids 36'] = 'e8a31912230f0520312173c4713ffa693ff23d24'
 
 snapshots['test_all_snapshot_ids 37'] = '''{
   "__class__": "PipelineSnapshot",

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_assets.py
@@ -7,6 +7,1186 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots['TestAssetAwareEventLog.test_all_asset_keys[postgres_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetsOrError': {
+        '__typename': 'AssetConnection',
+        'nodes': [
+            {
+                'key': {
+                    'path': [
+                        'a'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_3'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_one'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_two'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_yields_observation'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'b'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'bar'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'baz'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'c'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'diamond_source'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_static_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_time_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'dummy_source_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'first_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'foo'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'foo_bar'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_bottom'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_left'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_right'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_top'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_4'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_graph'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'int_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'never_runs_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'str_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'typed_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'unconnected'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'ungrouped_asset_3'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'ungrouped_asset_5'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'untyped_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_static_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_time_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'yield_partition_materialization'
+                    ]
+                }
+            }
+        ]
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_all_asset_keys[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
+    'assetsOrError': {
+        '__typename': 'AssetConnection',
+        'nodes': [
+            {
+                'key': {
+                    'path': [
+                        'a'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_3'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_one'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_two'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_yields_observation'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'b'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'bar'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'baz'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'c'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'diamond_source'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_static_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_time_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'dummy_source_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'first_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'foo'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'foo_bar'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_bottom'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_left'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_right'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_top'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_4'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_graph'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'int_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'never_runs_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'str_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'typed_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'unconnected'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'ungrouped_asset_3'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'ungrouped_asset_5'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'untyped_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_static_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_time_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'yield_partition_materialization'
+                    ]
+                }
+            }
+        ]
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_all_asset_keys[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetsOrError': {
+        '__typename': 'AssetConnection',
+        'nodes': [
+            {
+                'key': {
+                    'path': [
+                        'a'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_3'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_one'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_two'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_yields_observation'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'b'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'bar'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'baz'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'c'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'diamond_source'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_static_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_time_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'dummy_source_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'first_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'foo'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'foo_bar'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_bottom'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_left'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_right'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_top'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_4'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_graph'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'int_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'never_runs_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'str_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'typed_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'unconnected'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'ungrouped_asset_3'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'ungrouped_asset_5'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'untyped_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_static_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_time_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'yield_partition_materialization'
+                    ]
+                }
+            }
+        ]
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_all_asset_keys[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
+    'assetsOrError': {
+        '__typename': 'AssetConnection',
+        'nodes': [
+            {
+                'key': {
+                    'path': [
+                        'a'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_3'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_one'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_two'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_yields_observation'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'b'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'bar'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'baz'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'c'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'diamond_source'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_static_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_time_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'dummy_source_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'first_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'foo'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'foo_bar'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_bottom'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_left'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_right'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_top'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_4'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_graph'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'int_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'never_runs_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'str_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'typed_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'unconnected'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'ungrouped_asset_3'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'ungrouped_asset_5'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'untyped_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_static_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_time_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'yield_partition_materialization'
+                    ]
+                }
+            }
+        ]
+    }
+}
+
 snapshots['TestAssetAwareEventLog.test_asset_op[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
     'assetOrError': {
         'definition': {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_assets.py
@@ -7,870 +7,6 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['TestAssetAwareEventLog.test_all_asset_keys[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
-    'assetsOrError': {
-        '__typename': 'AssetConnection',
-        'nodes': [
-            {
-                'key': {
-                    'path': [
-                        'a'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_1'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_2'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_3'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_one'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_two'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_yields_observation'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'b'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'bar'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'baz'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'c'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'downstream_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'downstream_static_partitioned_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'downstream_time_partitioned_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'dummy_source_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'first_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'foo'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'foo_bar'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'fresh_diamond_bottom'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'fresh_diamond_left'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'fresh_diamond_right'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'fresh_diamond_top'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'grouped_asset_1'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'grouped_asset_2'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'grouped_asset_4'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'hanging_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'hanging_graph'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'int_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'multipartitions_1'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'multipartitions_2'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'never_runs_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'str_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'typed_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'unconnected'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'ungrouped_asset_3'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'ungrouped_asset_5'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'untyped_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'upstream_static_partitioned_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'upstream_time_partitioned_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'yield_partition_materialization'
-                    ]
-                }
-            }
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_all_asset_keys[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
-    'assetsOrError': {
-        '__typename': 'AssetConnection',
-        'nodes': [
-            {
-                'key': {
-                    'path': [
-                        'a'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_1'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_2'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_3'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_one'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_two'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_yields_observation'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'b'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'bar'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'baz'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'c'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'downstream_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'downstream_static_partitioned_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'downstream_time_partitioned_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'dummy_source_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'first_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'foo'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'foo_bar'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'fresh_diamond_bottom'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'fresh_diamond_left'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'fresh_diamond_right'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'fresh_diamond_top'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'grouped_asset_1'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'grouped_asset_2'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'grouped_asset_4'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'hanging_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'hanging_graph'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'int_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'multipartitions_1'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'multipartitions_2'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'never_runs_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'str_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'typed_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'unconnected'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'ungrouped_asset_3'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'ungrouped_asset_5'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'untyped_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'upstream_static_partitioned_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'upstream_time_partitioned_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'yield_partition_materialization'
-                    ]
-                }
-            }
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_all_asset_keys[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
-    'assetsOrError': {
-        '__typename': 'AssetConnection',
-        'nodes': [
-            {
-                'key': {
-                    'path': [
-                        'a'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_1'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_2'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_3'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_one'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_two'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'asset_yields_observation'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'b'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'bar'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'baz'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'c'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'downstream_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'downstream_static_partitioned_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'downstream_time_partitioned_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'dummy_source_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'first_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'foo'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'foo_bar'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'fresh_diamond_bottom'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'fresh_diamond_left'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'fresh_diamond_right'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'fresh_diamond_top'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'grouped_asset_1'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'grouped_asset_2'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'grouped_asset_4'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'hanging_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'hanging_graph'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'int_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'multipartitions_1'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'multipartitions_2'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'never_runs_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'str_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'typed_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'unconnected'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'ungrouped_asset_3'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'ungrouped_asset_5'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'untyped_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'upstream_static_partitioned_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'upstream_time_partitioned_asset'
-                    ]
-                }
-            },
-            {
-                'key': {
-                    'path': [
-                        'yield_partition_materialization'
-                    ]
-                }
-            }
-        ]
-    }
-}
-
 snapshots['TestAssetAwareEventLog.test_asset_op[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
     'assetOrError': {
         'definition': {
@@ -913,12 +49,439 @@ snapshots['TestAssetAwareEventLog.test_asset_op[sqlite_with_default_run_launcher
     }
 }
 
+snapshots['TestAssetAwareEventLog.test_freshness_info[postgres_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetNodes': [
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["dummy_source_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["diamond_source"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["a"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["b"]'
+        },
+        {
+            'freshnessInfo': {
+                'currentMinutesLate': 0.0,
+                'latestMaterializationMinutesLate': 0.0
+            },
+            'freshnessPolicy': {
+                'cronSchedule': None,
+                'maximumLagMinutes': 30.0
+            },
+            'id': 'test.test_repo.["fresh_diamond_bottom"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fresh_diamond_left"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fresh_diamond_right"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fresh_diamond_top"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["int_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["str_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["multipartitions_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["multipartitions_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["typed_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["untyped_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_3"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["bar"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["baz"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["foo"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["foo_bar"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["unconnected"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["hanging_graph"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["first_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["hanging_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["never_runs_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["grouped_asset_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["grouped_asset_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["grouped_asset_4"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["ungrouped_asset_3"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["ungrouped_asset_5"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_yields_observation"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["yield_partition_materialization"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_static_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["upstream_static_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_time_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["upstream_time_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_one"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_two"]'
+        }
+    ]
+}
+
+snapshots['TestAssetAwareEventLog.test_freshness_info[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
+    'assetNodes': [
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["dummy_source_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["diamond_source"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["a"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["b"]'
+        },
+        {
+            'freshnessInfo': {
+                'currentMinutesLate': 0.0,
+                'latestMaterializationMinutesLate': 0.0
+            },
+            'freshnessPolicy': {
+                'cronSchedule': None,
+                'maximumLagMinutes': 30.0
+            },
+            'id': 'test.test_repo.["fresh_diamond_bottom"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fresh_diamond_left"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fresh_diamond_right"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fresh_diamond_top"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["int_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["str_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["multipartitions_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["multipartitions_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["typed_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["untyped_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_3"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["bar"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["baz"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["foo"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["foo_bar"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["unconnected"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["hanging_graph"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["first_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["hanging_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["never_runs_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["grouped_asset_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["grouped_asset_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["grouped_asset_4"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["ungrouped_asset_3"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["ungrouped_asset_5"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_yields_observation"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["yield_partition_materialization"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_static_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["upstream_static_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_time_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["upstream_time_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_one"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_two"]'
+        }
+    ]
+}
+
 snapshots['TestAssetAwareEventLog.test_freshness_info[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
     'assetNodes': [
         {
             'freshnessInfo': None,
             'freshnessPolicy': None,
             'id': 'test.test_repo.["dummy_source_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["diamond_source"]'
         },
         {
             'freshnessInfo': None,
@@ -1125,6 +688,11 @@ snapshots['TestAssetAwareEventLog.test_freshness_info[sqlite_with_default_run_la
             'freshnessInfo': None,
             'freshnessPolicy': None,
             'id': 'test.test_repo.["dummy_source_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["diamond_source"]'
         },
         {
             'freshnessInfo': None,

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -110,11 +110,14 @@ class AssetGraph(
     def from_external_assets(external_asset_nodes: Sequence["ExternalAssetNode"]) -> "AssetGraph":
         upstream = {}
         downstream = {}
+        source_asset_keys = set()
         partitions_defs_by_key = {}
         group_names_by_key = {}
         freshness_policies_by_key = {}
 
         for node in external_asset_nodes:
+            if node.is_source:
+                source_asset_keys.add(node.asset_key)
             upstream[node.asset_key] = {dep.upstream_asset_key for dep in node.dependencies}
             downstream[node.asset_key] = {dep.downstream_asset_key for dep in node.depended_by}
             partitions_defs_by_key[node.asset_key] = (
@@ -127,7 +130,7 @@ class AssetGraph(
 
         return AssetGraph(
             asset_dep_graph={"upstream": upstream, "downstream": downstream},
-            source_asset_keys=set(),
+            source_asset_keys=source_asset_keys,
             partitions_defs_by_key=partitions_defs_by_key,
             partition_mappings_by_key=None,
             group_names_by_key=group_names_by_key,
@@ -310,11 +313,23 @@ class AssetGraph(
 
         return parent_partitions_def.get_partition_keys_in_range(upstream_partition_key_range)
 
-    def get_roots(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
-        """Returns all root assets that the given asset depends on"""
-        if not self.get_parents(asset_key):
+    def has_non_source_parents(self, asset_key: AssetKey) -> bool:
+        """Determines if an asset has any parents which are not source assets"""
+        if asset_key in self.source_asset_keys:
+            return False
+        return bool(self.get_parents(asset_key) - self.source_asset_keys)
+
+    def get_non_source_roots(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
+        """Returns all assets upstream of the given asset which do not consume any other
+        AssetsDefinitions (but may consume SourceAssets).
+        """
+        if not self.has_non_source_parents(asset_key):
             return {asset_key}
-        return {key for key in self.upstream_key_iterator(asset_key) if not self.get_parents(key)}
+        return {
+            key
+            for key in self.upstream_key_iterator(asset_key)
+            if not self.has_non_source_parents(key)
+        }
 
     def upstream_key_iterator(self, asset_key: AssetKey) -> Iterator[AssetKey]:
         """Iterates through all asset keys which are upstream of the given key."""
@@ -322,6 +337,8 @@ class AssetGraph(
         queue = deque([asset_key])
         while queue:
             current_key = queue.popleft()
+            if current_key in self.source_asset_keys:
+                continue
             for parent_key in self.get_parents(current_key):
                 if parent_key not in visited:
                     yield parent_key

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -414,7 +414,7 @@ def get_freshness_constraints_by_key(
         if freshness_policy is None:
             continue
         has_freshness_policy = True
-        upstream_keys = asset_graph.get_roots(key)
+        upstream_keys = asset_graph.get_non_source_roots(key)
         latest_record = instance_queryer.get_latest_materialization_record(key)
         used_data_times = (
             instance_queryer.get_used_data_times_for_record(
@@ -443,6 +443,8 @@ def get_freshness_constraints_by_key(
     # upstream of another asset.
     for level in reversed(asset_graph.toposort_asset_keys()):
         for key in level:
+            if key in asset_graph.source_asset_keys:
+                continue
             for upstream_key in asset_graph.get_parents(key):
                 # pass along all of your constraints to your parents
                 constraints_by_key[upstream_key] |= constraints_by_key[key]
@@ -452,22 +454,15 @@ def get_freshness_constraints_by_key(
 def get_current_data_times_for_key(
     instance_queryer: CachingInstanceQueryer,
     asset_graph: AssetGraph,
-    constraints: AbstractSet[FreshnessConstraint],
-    expected_data_times: Mapping[AssetKey, datetime.datetime],
+    relevant_upstream_keys: AbstractSet[AssetKey],
     asset_key: AssetKey,
 ) -> Mapping[AssetKey, Optional[datetime.datetime]]:
-    relevant_upstream_keys = set()
-    for constraint in constraints:
-        # we take in expected data times as a trick to keep track of which constraint keys are
-        # actually relevant to this asset
-        if constraint.asset_key in expected_data_times:
-            relevant_upstream_keys.add(constraint.asset_key)
 
     # calculate the data time for this record in relation to the upstream keys which are
     # set to be updated this tick and are involved in some constraint
     latest_record = instance_queryer.get_latest_materialization_record(asset_key)
     if latest_record is None:
-        return {}
+        return {upstream_key: None for upstream_key in relevant_upstream_keys}
     else:
         return instance_queryer.get_used_data_times_for_record(
             asset_graph=asset_graph,
@@ -479,13 +474,18 @@ def get_current_data_times_for_key(
 def get_expected_data_times_for_key(
     asset_graph: AssetGraph,
     current_time: datetime.datetime,
-    expected_data_times_by_key: Mapping[AssetKey, Mapping[AssetKey, datetime.datetime]],
+    expected_data_times_by_key: Mapping[AssetKey, Mapping[AssetKey, Optional[datetime.datetime]]],
     asset_key: AssetKey,
-) -> Mapping[AssetKey, datetime.datetime]:
+) -> Mapping[AssetKey, Optional[datetime.datetime]]:
     """Returns the data times for the given asset key if this asset were to be executed in this
     tick.
     """
     expected_data_times: Dict[AssetKey, datetime.datetime] = {asset_key: current_time}
+
+    def _min_or_none(a, b):
+        if a is None or b is None:
+            return None
+        return min(a, b)
 
     # get the expected data time for each upstream asset key if you were to run this asset on
     # this tick
@@ -494,7 +494,7 @@ def get_expected_data_times_for_key(
             upstream_key
         ].items():
             # take the minimum data time from each of your parents that uses this key
-            expected_data_times[upstream_upstream_key] = min(
+            expected_data_times[upstream_upstream_key] = _min_or_none(
                 expected_data_times.get(upstream_upstream_key, expected_data_time),
                 expected_data_time,
             )
@@ -507,7 +507,7 @@ def get_execution_time_window_for_constraints(
     constraints: AbstractSet[FreshnessConstraint],
     current_time: datetime.datetime,
     current_data_times: Mapping[AssetKey, Optional[datetime.datetime]],
-    expected_data_times: Mapping[AssetKey, datetime.datetime],
+    expected_data_times: Mapping[AssetKey, Optional[datetime.datetime]],
     asset_key: AssetKey,
 ) -> Tuple[Optional[datetime.datetime], Optional[datetime.datetime]]:
     """Determines a range of times for which you can kick off an execution of this asset to solve
@@ -524,20 +524,22 @@ def get_execution_time_window_for_constraints(
     execution_window_end = None
     for constraint in sorted(constraints, key=lambda c: c.required_by_time):
         current_data_time = current_data_times.get(constraint.asset_key)
+        expected_data_time = expected_data_times.get(constraint.asset_key)
 
         if not (
             # this constraint is irrelevant, as it is satisfied by the current data time
             (current_data_time is not None and current_data_time > constraint.required_data_time)
+            # this constraint is irrelevant, as materializing on this tick will not solve it
+            or (expected_data_time is None)
+            # this constraint is irrelevant, as materializing on this tick will not make progress
+            # towards solving it
+            or (current_data_time is not None and expected_data_time <= current_data_time)
             # this constraint is irrelevant, as a currently-executing run will satisfy it
             or (
                 constraint.asset_key in currently_materializing
                 # if the run hasn't started yet, assume it'll get data from the current time
                 and (current_run_data_time or current_time) > constraint.required_data_time
             )
-            # this constraint is irrelevant, as it does not correspond to an asset which is
-            # directly upstream of this asset, nor to an asset which is transitively
-            # upstream of this asset and will be materialized this tick
-            or constraint.asset_key not in expected_data_times
         ):
             if execution_window_start is None:
                 execution_window_start = constraint.required_data_time
@@ -589,49 +591,63 @@ def determine_asset_partitions_to_reconcile_for_freshness(
     # now we have a full set of constraints, we can find solutions for them as we move down
     to_materialize: Set[AssetKeyPartitionKey] = set()
     eventually_materialize: Set[AssetKeyPartitionKey] = set()
-    expected_data_times_by_key: Dict[AssetKey, Mapping[AssetKey, datetime.datetime]] = defaultdict(
-        dict
-    )
+    expected_data_times_by_key: Dict[
+        AssetKey, Mapping[AssetKey, Optional[datetime.datetime]]
+    ] = defaultdict(dict)
     for level in asset_graph.toposort_asset_keys():
         for key in level:
+            if key in asset_graph.source_asset_keys:
+                continue
             # no need to evaluate this key, as it has no constraints
             constraints = constraints_by_key[key]
             if not constraints:
                 continue
-            # this key has constraints within the plan window, so must be updated within it
-            eventually_materialize.add(AssetKeyPartitionKey(key, None))
 
-            # figure out the data times you'd expect for this key if you were to run it on this tick
-            expected_data_times = get_expected_data_times_for_key(
-                asset_graph, current_time, expected_data_times_by_key, key
-            )
+            constraint_keys = {constraint.asset_key for constraint in constraints}
+
+            # the set of asset keys which are involved in some constraint and are actually upstream
+            # of this asset
+            relevant_upstream_keys = (
+                set().union(
+                    *(
+                        expected_data_times_by_key[parent_key].keys()
+                        for parent_key in asset_graph.get_parents(key)
+                    )
+                )
+                & constraint_keys
+            ) | {key}
 
             # figure out the current contents of this asset with respect to its constraints
             current_data_times = get_current_data_times_for_key(
-                instance_queryer, asset_graph, constraints, expected_data_times, key
+                instance_queryer, asset_graph, relevant_upstream_keys, key
             )
 
             if key not in target_asset_keys:
                 # cannot execute this asset, so if something consumes it, it should expect to
                 # recieve the current contents of the asset
-                expected_data_times_by_key[key] = {
-                    key: time for key, time in current_data_times.items() if time is not None
-                }
-                continue
+                execution_window_start = None
+                expected_data_times: Mapping[AssetKey, Optional[datetime.datetime]] = {}
+            else:
+                # figure out the data times you'd expect for this key if you were to run it
+                expected_data_times = get_expected_data_times_for_key(
+                    asset_graph, current_time, expected_data_times_by_key, key
+                )
+                # this key has constraints within the plan window, so must be updated within it
+                eventually_materialize.add(AssetKeyPartitionKey(key, None))
 
-            # figure out a time window that you can execute this asset within to solve a maximum
-            # number of constraints
-            (
-                execution_window_start,
-                _execution_window_end,
-            ) = get_execution_time_window_for_constraints(
-                instance_queryer,
-                constraints,
-                current_time,
-                current_data_times,
-                expected_data_times,
-                key,
-            )
+                # figure out a time window that you can execute this asset within to solve a maximum
+                # number of constraints
+                (
+                    execution_window_start,
+                    _execution_window_end,
+                ) = get_execution_time_window_for_constraints(
+                    instance_queryer,
+                    constraints,
+                    current_time,
+                    current_data_times,
+                    expected_data_times,
+                    key,
+                )
 
             # this key should be updated on this tick, as we are within the allowable window
             if execution_window_start is not None and execution_window_start <= current_time:
@@ -640,9 +656,7 @@ def determine_asset_partitions_to_reconcile_for_freshness(
             else:
                 # if downstream assets consume this, they should expect data times equal to the
                 # current times for this asset, as it's not going to be updated
-                expected_data_times_by_key[key] = {
-                    key: time for key, time in current_data_times.items() if time is not None
-                }
+                expected_data_times_by_key[key] = current_data_times
 
     return to_materialize, eventually_materialize
 

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -271,6 +271,9 @@ class CachingInstanceQueryer:
 
             # find the upstream times of each of the parents of this asset
             for parent_key in asset_graph.get_parents(asset_key):
+                if parent_key in asset_graph.source_asset_keys:
+                    continue
+
                 # the set of required keys which are upstream of this parent
                 upstream_required_keys = set()
                 if parent_key in unknown_required_keys:
@@ -322,7 +325,7 @@ class CachingInstanceQueryer:
                 "Can only calculate data times for records with an `asset_key`."
             )
         if upstream_keys is None:
-            upstream_keys = asset_graph.get_roots(record.asset_key)
+            upstream_keys = asset_graph.get_non_source_roots(record.asset_key)
 
         data = self.calculate_used_data(
             asset_graph=asset_graph,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_reconciliation_sensor.py
@@ -45,7 +45,7 @@ class RunSpec(NamedTuple):
 
 class AssetReconciliationScenario(NamedTuple):
     unevaluated_runs: Sequence[RunSpec]
-    assets: Sequence[AssetsDefinition]
+    assets: Sequence[Union[SourceAsset, AssetsDefinition]]
     evaluation_delta: Optional[datetime.timedelta] = None
     cursor_from: Optional["AssetReconciliationScenario"] = None  # type: ignore
 
@@ -273,7 +273,9 @@ overlapping_freshness = diamond + [
 overlapping_freshness_with_source = [
     SourceAsset("source_asset"),
     asset_def("asset1", ["source_asset"]),
-] + overlapping_freshness[1:]
+] + overlapping_freshness[
+    1:
+]  # type: ignore
 overlapping_freshness_inf = diamond + [
     asset_def("asset5", ["asset3"], freshness_policy=freshness_30m),
     asset_def("asset6", ["asset4"], freshness_policy=freshness_inf),
@@ -621,12 +623,12 @@ scenarios = {
         expected_run_requests=[],
     ),
     "freshness_overlapping_with_source": AssetReconciliationScenario(
-        assets=overlapping_freshness_with_source,
+        assets=overlapping_freshness_with_source,  # type: ignore
         unevaluated_runs=[run(["asset1", "asset3", "asset5"]), run(["asset2", "asset4", "asset6"])],
         expected_run_requests=[],
     ),
     "freshness_overlapping_runs_half_stale": AssetReconciliationScenario(
-        assets=overlapping_freshness_with_source,
+        assets=overlapping_freshness_with_source,  # type: ignore
         unevaluated_runs=[run(["asset1", "asset3", "asset5"]), run(["asset2", "asset4", "asset6"])],
         # evaluate 35 minutes later, only need to refresh the assets on the shorter freshness policy
         evaluation_delta=datetime.timedelta(minutes=35),


### PR DESCRIPTION
### Summary & Motivation

When calculating how fresh a given asset is, this must be done relative to the most upstream AssetsDefinitions in the repository (SourceAsset updates are currently not factored into this calculation, but should be in the future). These updates do some refactoring, and ensure that when calculating which upstream assets to consider, we only factor in non source assets.

### How I Tested These Changes
