### PR TITLE
[freshness-policy] Use asset_event_tags instead of kvs

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -243,13 +243,6 @@ class SqlEventLogStorage(EventLogStorage):
         else:
             current_tags = current_tags_list[0]
 
-            asset_key_str = asset_key.to_string()
-
-            if len(current_tags_list) == 0:
-                current_tags: Mapping[str, str] = {}
-            else:
-                current_tags = current_tags_list[0]
-
         with self.index_connection() as conn:
             current_tags_set = set(current_tags.keys())
             new_tags_set = set(new_tags.keys())
@@ -266,8 +259,9 @@ class SqlEventLogStorage(EventLogStorage):
                             AssetEventTagsTable.c.asset_key == asset_key_str,
                             AssetEventTagsTable.c.key == tag,
                         )
-                        .values(value=new_tags[tag])
                     )
+                    .values(value=new_tags[tag])
+                )
 
             if added_tags:
                 conn.execute(

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -243,6 +243,13 @@ class SqlEventLogStorage(EventLogStorage):
         else:
             current_tags = current_tags_list[0]
 
+            asset_key_str = asset_key.to_string()
+
+            if len(current_tags_list) == 0:
+                current_tags: Mapping[str, str] = {}
+            else:
+                current_tags = current_tags_list[0]
+
         with self.index_connection() as conn:
             current_tags_set = set(current_tags.keys())
             new_tags_set = set(new_tags.keys())
@@ -259,9 +266,8 @@ class SqlEventLogStorage(EventLogStorage):
                             AssetEventTagsTable.c.asset_key == asset_key_str,
                             AssetEventTagsTable.c.key == tag,
                         )
+                        .values(value=new_tags[tag])
                     )
-                    .values(value=new_tags[tag])
-                )
 
             if added_tags:
                 conn.execute(

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -6,7 +6,8 @@ import dagster._check as check
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster._core.storage.event_log import EventLogRecord
+from dagster._core.storage.event_log import EventLogRecord, SqlEventLogStorage
+from dagster._core.storage.event_log.sql_event_log import AssetEventTagsTable
 from dagster._core.storage.pipeline_run import (
     IN_PROGRESS_RUN_STATUSES,
     DagsterRun,
@@ -19,6 +20,8 @@ from dagster._utils.merger import merge_dicts
 
 if TYPE_CHECKING:
     from dagster import DagsterInstance
+
+USED_DATA_TAG = ".dagster/used_data"
 
 
 class CachingInstanceQueryer:
@@ -215,32 +218,46 @@ class CachingInstanceQueryer:
 
         return True
 
-    def _kvs_key_for_record_id(self, record_id: int) -> str:
-        return f".dagster/used_data/{record_id}"
-
     def set_known_used_data(
         self,
-        record_id: int,
+        record: EventLogRecord,
         new_known_data: Dict[AssetKey, Tuple[Optional[int], Optional[float]]],
     ):
-        if self._instance.run_storage.supports_kvs():
-            current_known_data = self.get_known_used_data(record_id)
+        event_log_storage = self._instance.event_log_storage
+        if (
+            event_log_storage.supports_add_asset_event_tags
+            and record.asset_key is not None
+            and record.storage_id is not None
+            and record.event_log_entry.timestamp is not None
+        ):
+            current_known_data = self.get_known_used_data(record.asset_key, record.storage_id)
             known_data = merge_dicts(current_known_data, new_known_data)
             serialized_times = json.dumps(
                 {key.to_user_string(): value for key, value in known_data.items()}
             )
-            self._instance.run_storage.kvs_set(
-                {self._kvs_key_for_record_id(record_id): serialized_times}
+            event_log_storage.add_asset_event_tags(
+                event_id=record.storage_id,
+                event_timestamp=record.event_log_entry.timestamp,
+                asset_key=record.asset_key,
+                new_tags={USED_DATA_TAG: serialized_times},
             )
 
     def get_known_used_data(
-        self, record_id: int
+        self, asset_key: AssetKey, record_id: int
     ) -> Dict[AssetKey, Tuple[Optional[int], Optional[float]]]:
         """Returns the known upstream ids and timestamps stored on the instance"""
-        if self._instance.run_storage.supports_kvs():
-            # otherwise, attempt to fetch from the instance key-value store
-            kvs_key = self._kvs_key_for_record_id(record_id)
-            serialized_times = self._instance.run_storage.kvs_get({kvs_key}).get(kvs_key, "{}")
+        event_log_storage = self._instance.event_log_storage
+        if isinstance(event_log_storage, SqlEventLogStorage) and event_log_storage.has_table(
+            AssetEventTagsTable.name
+        ):
+            # attempt to fetch from the instance asset event tags
+            tags_list = event_log_storage.get_event_tags_for_asset(
+                asset_key=asset_key, filter_event_id=record_id
+            )
+            if len(tags_list) == 0:
+                return {}
+
+            serialized_times = tags_list[0].get(USED_DATA_TAG, "{}")
             return {
                 AssetKey.from_user_string(key): tuple(value)  # type:ignore
                 for key, value in json.loads(serialized_times).items()
@@ -261,7 +278,7 @@ class CachingInstanceQueryer:
             return {key: (None, None) for key in required_keys}
 
         # grab the existing upstream data times already calculated for this record (if any)
-        known_data = self.get_known_used_data(record_id)
+        known_data = self.get_known_used_data(asset_key, record_id)
         if asset_key in required_keys:
             known_data[asset_key] = (record_id, record_timestamp)
 
@@ -334,7 +351,7 @@ class CachingInstanceQueryer:
             record_timestamp=record.event_log_entry.timestamp,
             required_keys=frozenset(upstream_keys),
         )
-        self.set_known_used_data(record.storage_id, new_known_data=data)
+        self.set_known_used_data(record, new_known_data=data)
 
         return {
             key: datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)


### PR DESCRIPTION
### Summary & Motivation

Use https://github.com/dagster-io/dagster/pull/10544 as a place to cache freshness info.

### How I Tested These Changes
