### PR TITLE
[dagit] add op version to sidebar and asset details

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -22,11 +22,11 @@ import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntry';
 import {Description} from '../pipelines/Description';
 import {SidebarSection, SidebarTitle} from '../pipelines/SidebarComponents';
 import {pluginForMetadata} from '../plugins';
+import {Version} from '../versions/Version';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 import {LiveDataForNode, displayNameForAssetKey} from './Utils';
 import {SidebarAssetQuery, SidebarAssetQueryVariables} from './types/SidebarAssetQuery';
-import {Version} from '../versions/Version';
 
 export const SidebarAssetInfo: React.FC<{
   assetKey: AssetKey;

--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -26,6 +26,7 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 import {LiveDataForNode, displayNameForAssetKey} from './Utils';
 import {SidebarAssetQuery, SidebarAssetQueryVariables} from './types/SidebarAssetQuery';
+import {Version} from '../versions/Version';
 
 export const SidebarAssetInfo: React.FC<{
   assetKey: AssetKey;
@@ -84,6 +85,14 @@ export const SidebarAssetInfo: React.FC<{
           {asset.op && OpMetadataPlugin?.SidebarComponent && (
             <OpMetadataPlugin.SidebarComponent definition={asset.op} repoAddress={repoAddress} />
           )}
+        </SidebarSection>
+      )}
+
+      {asset.opVersion && (
+        <SidebarSection title="Code Version">
+          <Box padding={{vertical: 16, horizontal: 24}}>
+            <Version>{asset.opVersion}</Version>
+          </Box>
         </SidebarSection>
       )}
 
@@ -187,6 +196,7 @@ export const SIDEBAR_ASSET_FRAGMENT = gql`
         value
       }
     }
+    opVersion
     repository {
       id
       name

--- a/js_modules/dagit/packages/core/src/asset-graph/types/SidebarAssetFragment.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/SidebarAssetFragment.ts
@@ -3135,6 +3135,7 @@ export interface SidebarAssetFragment {
   partitionDefinition: SidebarAssetFragment_partitionDefinition | null;
   assetKey: SidebarAssetFragment_assetKey;
   op: SidebarAssetFragment_op | null;
+  opVersion: string | null;
   repository: SidebarAssetFragment_repository;
   type: SidebarAssetFragment_type | null;
 }

--- a/js_modules/dagit/packages/core/src/asset-graph/types/SidebarAssetQuery.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/SidebarAssetQuery.ts
@@ -3141,6 +3141,7 @@ export interface SidebarAssetQuery_assetNodeOrError_AssetNode {
   partitionDefinition: SidebarAssetQuery_assetNodeOrError_AssetNode_partitionDefinition | null;
   assetKey: SidebarAssetQuery_assetNodeOrError_AssetNode_assetKey;
   op: SidebarAssetQuery_assetNodeOrError_AssetNode_op | null;
+  opVersion: string | null;
   repository: SidebarAssetQuery_assetNodeOrError_AssetNode_repository;
   type: SidebarAssetQuery_assetNodeOrError_AssetNode_type | null;
 }

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -28,6 +28,7 @@ import {
 import {AssetNodeList} from './AssetNodeList';
 import {CurrentMinutesLateTag, freshnessPolicyDescription} from './CurrentMinutesLateTag';
 import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinitionFragment';
+import {Version} from '../versions/Version';
 
 export const AssetNodeDefinition: React.FC<{
   assetNode: AssetNodeDefinitionFragment;
@@ -74,6 +75,19 @@ export const AssetNodeDefinition: React.FC<{
               maxHeight={260}
             />
           </Box>
+          {assetNode.opVersion && (
+            <>
+              <Box
+                padding={{vertical: 16, horizontal: 24}}
+                border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+              >
+                <Subheading>Code version</Subheading>
+              </Box>
+              <Box padding={{vertical: 16, horizontal: 24}} flex={{gap: 12, alignItems: 'center'}}>
+                <Version>{assetNode.opVersion}</Version>
+              </Box>
+            </>
+          )}
           {liveDataForNode?.freshnessPolicy && (
             <>
               <Box
@@ -257,6 +271,7 @@ export const ASSET_NODE_DEFINITION_FRAGMENT = gql`
     description
     graphName
     opNames
+    opVersion
     jobNames
     partitionDefinition {
       description

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -14,6 +14,7 @@ import {AssetGraphQuery_assetNodes} from '../asset-graph/types/AssetGraphQuery';
 import {DagsterTypeSummary} from '../dagstertype/DagsterType';
 import {Description} from '../pipelines/Description';
 import {PipelineReference} from '../pipelines/PipelineReference';
+import {Version} from '../versions/Version';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
@@ -28,7 +29,6 @@ import {
 import {AssetNodeList} from './AssetNodeList';
 import {CurrentMinutesLateTag, freshnessPolicyDescription} from './CurrentMinutesLateTag';
 import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinitionFragment';
-import {Version} from '../versions/Version';
 
 export const AssetNodeDefinition: React.FC<{
   assetNode: AssetNodeDefinitionFragment;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
@@ -3120,10 +3120,10 @@ export interface AssetNodeDefinitionFragment {
   description: string | null;
   graphName: string | null;
   opNames: string[];
+  opVersion: string | null;
   jobNames: string[];
   partitionDefinition: AssetNodeDefinitionFragment_partitionDefinition | null;
   repository: AssetNodeDefinitionFragment_repository;
-  opVersion: string | null;
   computeKind: string | null;
   isSource: boolean;
   assetKey: AssetNodeDefinitionFragment_assetKey;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetViewDefinitionQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetViewDefinitionQuery.ts
@@ -3185,8 +3185,8 @@ export interface AssetViewDefinitionQuery_assetOrError_Asset_definition {
   description: string | null;
   graphName: string | null;
   opNames: string[];
-  jobNames: string[];
   opVersion: string | null;
+  jobNames: string[];
   computeKind: string | null;
   isSource: boolean;
   assetKey: AssetViewDefinitionQuery_assetOrError_Asset_definition_assetKey;

--- a/js_modules/dagit/packages/core/src/versions/Version.tsx
+++ b/js_modules/dagit/packages/core/src/versions/Version.tsx
@@ -1,0 +1,9 @@
+import {FontFamily} from '@dagster-io/ui';
+import styled from 'styled-components/macro';
+
+export const Version = styled.div`
+  font-family: ${FontFamily.monospace};
+  font-size: 16px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;


### PR DESCRIPTION
### Summary & Motivation

Adds op version under the asset explorer sidebar and asset details page. Only displays if it exists.

I chose the heading "Code Version" to be future proof for when we add this info for more complex non-single op versions, i.e. for graph-backed assets.

<img width="822" alt="image" src="https://user-images.githubusercontent.com/1531373/202284670-8f2568de-779d-4959-b975-501af1b8ec49.png">

<img width="1106" alt="image" src="https://user-images.githubusercontent.com/1531373/202284765-b47f48ef-0d9a-4e48-81fe-d1b48915c464.png">

### How I Tested These Changes

BK, manually in dagit
