### PR TITLE
[dagster-airbyte] Alias dagster-managed-elements CLI under dagster-airbyte

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/cli.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/cli.py
@@ -1,7 +1,7 @@
 import click
 
 try:
-    from dagster_managed_elements.cli import check_cmd, apply_cmd
+    from dagster_managed_elements.cli import apply_cmd, check_cmd
 
     @click.group()
     def main():

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/cli.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/cli.py
@@ -1,0 +1,20 @@
+import click
+
+try:
+    from dagster_managed_elements.cli import check_cmd, apply_cmd
+
+    @click.group()
+    def main():
+        pass
+
+    main.add_command(check_cmd)
+    main.add_command(apply_cmd)
+
+
+except ImportError:
+
+    @click.group(
+        help="In order to use managed Airbyte config, the dagster-managed-elements package must be installed."
+    )
+    def main():
+        pass

--- a/python_modules/libraries/dagster-airbyte/setup.py
+++ b/python_modules/libraries/dagster-airbyte/setup.py
@@ -36,4 +36,9 @@ setup(
         "requests",
     ],
     zip_safe=False,
+    entry_points={
+        "console_scripts": [
+            "dagster-airbyte = dagster_airbyte.cli:main",
+        ]
+    },
 )


### PR DESCRIPTION
## Summary

Allows `dagster-airbyte` to be used as a command alias for `dagster-managed-elements`/`dagster-me`, raising a help message if the managed elements package isn't installed.

## Test Plan

Tested locally.
