### PR TITLE
[dagit] Small Asset UI adjustments for the 1.1 release

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -278,7 +278,6 @@ export const AssetGraphExplorerWithData: React.FC<
 
   const allowExperimentalZoom =
     flags.flagAssetGraphExperimentalZoom && layout && Object.keys(layout.groups).length;
-  const selectionContext = selectedGraphNodes.length ? 'selected' : 'all';
 
   return (
     <SplitPanelContainer
@@ -424,7 +423,8 @@ export const AssetGraphExplorerWithData: React.FC<
                 dataDescription="materializations"
               />
               <LaunchAssetObservationButton
-                context={selectionContext}
+                intent="none"
+                context={selectedGraphNodes.length > 0 ? 'selected' : 'all'}
                 assetKeys={(selectedGraphNodes.length
                   ? selectedGraphNodes.filter((a) => a.definition.isObservable)
                   : Object.values(assetGraphData.nodes).filter((a) => a.definition.isObservable)
@@ -432,15 +432,21 @@ export const AssetGraphExplorerWithData: React.FC<
                 preferredJobName={explorerPath.pipelineName}
               />
               <LaunchAssetExecutionButton
-                context={selectionContext}
-                assetKeys={(selectedGraphNodes.length
-                  ? selectedGraphNodes.filter((a) => !a.definition.isSource)
-                  : Object.values(assetGraphData.nodes).filter(
-                      (a) =>
-                        !a.definition.isSource && includeInMaterializeAll(liveDataByNode[a.id]),
-                    )
-                ).map((n) => n.assetKey)}
                 preferredJobName={explorerPath.pipelineName}
+                selectedAssetKeys={selectedGraphNodes
+                  .filter((a) => !a.definition.isSource)
+                  .map((n) => n.assetKey)}
+                allAssetKeys={Object.values(assetGraphData.nodes)
+                  .filter((a) => !a.definition.isSource)
+                  .map((n) => n.assetKey)}
+                staleAssetKeys={(selectedGraphNodes.length
+                  ? selectedGraphNodes
+                  : Object.values(assetGraphData.nodes)
+                )
+                  .filter(
+                    (a) => !a.definition.isSource && includeInMaterializeAll(liveDataByNode[a.id]),
+                  )
+                  .map((n) => n.assetKey)}
               />
             </Box>
           </Box>

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -136,13 +136,16 @@ export const AssetNodeStatusRow: React.FC<{
     projectedLogicalVersion,
     lastMaterialization,
     runWhichFailedToMaterialize,
+    freshnessInfo,
   } = liveData || MISSING_LIVE_DATA;
 
   if (definition.isSource) {
     return <span />;
   }
 
-  if (runWhichFailedToMaterialize) {
+  const late = freshnessInfo && (freshnessInfo.currentMinutesLate || 0) > 0;
+
+  if (runWhichFailedToMaterialize || late) {
     return (
       <Box
         padding={{horizontal: 8}}
@@ -150,10 +153,13 @@ export const AssetNodeStatusRow: React.FC<{
         flex={{justifyContent: 'space-between', alignItems: 'center'}}
         background={Colors.Red50}
       >
-        <Caption color={Colors.Red700}>Failed</Caption>
+        <Caption color={Colors.Red700}>
+          {runWhichFailedToMaterialize && late ? `Failed (Late)` : late ? 'Late' : 'Failed'}
+        </Caption>
       </Box>
     );
   }
+
   if (!lastMaterialization) {
     return (
       <Box
@@ -179,6 +185,7 @@ export const AssetNodeStatusRow: React.FC<{
       </Box>
     );
   }
+
   return (
     <Box
       padding={{horizontal: 8}}

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import styled from 'styled-components/macro';
 
 import {withMiddleTruncation} from '../app/Util';
-import {NodeHighlightColors} from '../graph/OpNode';
 import {OpTags} from '../graph/OpTags';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';
@@ -323,8 +322,13 @@ const AssetNodeShowOnHover = styled.span`
 export const AssetNodeBox = styled.div<{$isSource: boolean; $selected: boolean}>`
   ${(p) =>
     p.$isSource
-      ? `border: 2px dashed ${p.$selected ? Colors.Gray500 : Colors.Gray300};`
-      : `border: 2px solid ${p.$selected ? Colors.Blue500 : Colors.Blue200};`}
+      ? `border: 2px dashed ${p.$selected ? Colors.Gray600 : Colors.Gray300}`
+      : `border: 2px solid ${p.$selected ? Colors.Blue500 : Colors.Blue200}`};
+
+  ${(p) =>
+    p.$isSource
+      ? `outline: 3px solid ${p.$selected ? Colors.Gray300 : 'transparent'}`
+      : `outline: 3px solid ${p.$selected ? Colors.Blue200 : 'transparent'}`};
 
   background: ${Colors.White};
   border-radius: 5px;
@@ -349,10 +353,6 @@ const Name = styled.div<{$isSource: boolean}>`
 `;
 
 const MinimalAssetNodeContainer = styled(AssetNodeContainer)`
-  outline: ${(p) => (p.$selected ? `2px dashed ${NodeHighlightColors.Border}` : 'none')};
-  border-radius: 12px;
-  outline-offset: 2px;
-  outline-width: 4px;
   height: 100%;
 `;
 
@@ -365,8 +365,14 @@ const MinimalAssetNodeBox = styled.div<{
   background: ${(p) => p.$background};
   ${(p) =>
     p.$isSource
-      ? `border: 4px dashed ${p.$selected ? Colors.Gray500 : p.$border};`
-      : `border: 4px solid ${p.$selected ? Colors.Blue500 : p.$border};`}
+      ? `border: 4px dashed ${p.$selected ? Colors.Gray500 : p.$border}`
+      : `border: 4px solid ${p.$selected ? Colors.Blue500 : p.$border}`};
+
+  ${(p) =>
+    p.$isSource
+      ? `outline: 8px solid ${p.$selected ? Colors.Gray300 : 'transparent'}`
+      : `outline: 8px solid ${p.$selected ? Colors.Blue200 : 'transparent'}`};
+
   border-radius: 10px;
   position: relative;
   padding: 4px;

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -1,5 +1,5 @@
 import {gql} from '@apollo/client';
-import {Colors, Icon, FontFamily, Box, CaptionMono, Caption} from '@dagster-io/ui';
+import {Colors, Icon, FontFamily, Box, CaptionMono, Caption, Spinner} from '@dagster-io/ui';
 import isEqual from 'lodash/isEqual';
 import React from 'react';
 import styled from 'styled-components/macro';
@@ -10,7 +10,7 @@ import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';
 
 import {AssetLatestRunSpinner, AssetLatestRunWithNotices, AssetRunLink} from './AssetRunLinking';
-import {LiveDataForNode, MISSING_LIVE_DATA} from './Utils';
+import {LiveDataForNode} from './Utils';
 import {ASSET_NODE_ANNOTATIONS_MAX_WIDTH, ASSET_NODE_NAME_MAX_LENGTH} from './layout';
 import {AssetNodeFragment} from './types/AssetNodeFragment';
 
@@ -130,18 +130,30 @@ export const AssetNodeStatusRow: React.FC<{
   liveData: LiveDataForNode | undefined;
   stepKey: string;
 }> = ({definition, liveData, stepKey}) => {
+  if (definition.isSource) {
+    return <span />;
+  }
+
+  if (!liveData) {
+    return (
+      <Box
+        padding={{horizontal: 8}}
+        style={{borderBottomLeftRadius: 4, borderBottomRightRadius: 4, height: 24}}
+        flex={{justifyContent: 'space-between', alignItems: 'center'}}
+        background={Colors.Gray100}
+      >
+        <Spinner purpose="caption-text" />
+      </Box>
+    );
+  }
+
   const {
     currentLogicalVersion,
     projectedLogicalVersion,
     lastMaterialization,
     runWhichFailedToMaterialize,
     freshnessInfo,
-  } = liveData || MISSING_LIVE_DATA;
-
-  if (definition.isSource) {
-    return <span />;
-  }
-
+  } = liveData;
   const late = freshnessInfo && (freshnessInfo.currentMinutesLate || 0) > 0;
 
   if (runWhichFailedToMaterialize || late) {

--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -83,7 +83,9 @@ export const SidebarAssetInfo: React.FC<{
             <Description description={asset.description || 'No description provided.'} />
           </Box>
           {asset.op && OpMetadataPlugin?.SidebarComponent && (
-            <OpMetadataPlugin.SidebarComponent definition={asset.op} repoAddress={repoAddress} />
+            <Box padding={{bottom: 16, horizontal: 24}}>
+              <OpMetadataPlugin.SidebarComponent definition={asset.op} repoAddress={repoAddress} />
+            </Box>
           )}
         </SidebarSection>
       )}

--- a/js_modules/dagit/packages/core/src/assets/AssetActionMenu.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetActionMenu.tsx
@@ -21,7 +21,7 @@ export const AssetActionMenu: React.FC<Props> = (props) => {
   const {canWipeAssets, canLaunchPipelineExecution} = usePermissions();
   const {path} = asset.key;
 
-  const {onClick, loading, launchpadElement} = useMaterializationAction([asset.key]);
+  const {onClick, loading, launchpadElement} = useMaterializationAction();
 
   return (
     <>
@@ -34,7 +34,7 @@ export const AssetActionMenu: React.FC<Props> = (props) => {
                 text="Materialize"
                 icon={loading ? <Spinner purpose="body-text" /> : 'materialization'}
                 disabled={!canLaunchPipelineExecution || loading}
-                onClick={onClick}
+                onClick={(e) => onClick([asset.key], e)}
               />
             </Tooltip>
             <MenuLink

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
@@ -67,11 +67,10 @@ export const AssetNodeLineage: React.FC<{
         <div style={{flex: 1}} />
         {Object.values(assetGraphData.nodes).length > 1 ? (
           <LaunchAssetExecutionButton
-            assetKeys={Object.values(assetGraphData.nodes)
-              .filter((n) => n.definition.isSource)
+            allAssetKeys={Object.values(assetGraphData.nodes)
+              .filter((n) => !n.definition.isSource)
               .map((n) => n.assetKey)}
             intent="none"
-            context="all"
           />
         ) : (
           <Button icon={<Icon name="materialization" />} disabled>

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -107,7 +107,7 @@ export const AssetTable = ({
               </Button>
             </Tooltip>
           ) : (
-            <LaunchAssetExecutionButton assetKeys={checkedAssets.map((c) => c.key)} />
+            <LaunchAssetExecutionButton selectedAssetKeys={checkedAssets.map((c) => c.key)} />
           )}
           <MoreActionsDropdown selected={checkedAssets} clearSelection={() => onToggleAll(false)} />
         </Box>
@@ -255,7 +255,7 @@ const AssetEntryRow: React.FC<{
         </td>
         <td>
           {liveData ? (
-            <Box flex={{gap: 8, alignItems: 'center'}}>
+            <Box flex={{gap: 8, alignItems: 'center', justifyContent: 'space-between'}}>
               {liveData.lastMaterialization ? (
                 <Mono style={{flex: 1}}>
                   <AssetRunLink

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -188,7 +188,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
         right={
           <Box style={{margin: '-4px 0'}}>
             {definition && definition.jobNames.length > 0 && upstream && (
-              <LaunchAssetExecutionButton assetKeys={[definition.assetKey]} />
+              <LaunchAssetExecutionButton allAssetKeys={[definition.assetKey]} />
             )}
           </Box>
         }

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -162,7 +162,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
               <Tab
                 id="events"
                 title="Events"
-                onClick={() => setParams({...params, view: 'events'})}
+                onClick={() => setParams({...params, view: 'events', partition: undefined})}
               />
               <Tab id="plots" title="Plots" onClick={() => setParams({...params, view: 'plots'})} />
               <Tab

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -88,7 +88,7 @@ export const LaunchAssetExecutionButton: React.FC<{
     if (staleAssetKeys) {
       options.push({
         assetKeys: staleAssetKeys,
-        label: `Stale and missing${countOrBlank(staleAssetKeys)}`,
+        label: `Materialize stale and missing${countOrBlank(staleAssetKeys)}`,
       });
     }
   }

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetObservationButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetObservationButton.tsx
@@ -45,15 +45,13 @@ export const LaunchAssetObservationButton: React.FC<{
   const count = assetKeys.length > 1 ? ` (${assetKeys.length})` : '';
   const label = `Observe source ${count}`;
 
-  if (!assetKeys.length || !canLaunchPipelineExecution.enabled) {
+  if (!assetKeys.length) {
+    return <span />;
+  }
+
+  if (!canLaunchPipelineExecution.enabled) {
     return (
-      <Tooltip
-        content={
-          !canLaunchPipelineExecution.enabled
-            ? 'You do not have permission to observe source assets'
-            : 'Select one or more source assets to observe.'
-        }
-      >
+      <Tooltip content="You do not have permission to observe source assets">
         <Button intent={intent} icon={<Icon name="observation" />} disabled>
           {label}
         </Button>

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetObservationButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetObservationButton.tsx
@@ -43,7 +43,7 @@ export const LaunchAssetObservationButton: React.FC<{
   const client = useApolloClient();
 
   const count = assetKeys.length > 1 ? ` (${assetKeys.length})` : '';
-  const label = `Observe source ${count}`;
+  const label = `Observe sources ${count}`;
 
   if (!assetKeys.length) {
     return <span />;

--- a/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
@@ -96,7 +96,6 @@ const PanAndZoomInteractor: SVGViewportInteractor = {
     };
     document.addEventListener('mousemove', onMove);
     document.addEventListener('mouseup', onUp);
-    event.stopPropagation();
   },
 
   onWheel(viewport: SVGViewport, event: WheelEvent) {

--- a/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
@@ -82,8 +82,7 @@ export const AssetJobPartitionsView: React.FC<{
             {showAssets ? 'Hide per-asset status' : 'Show per-asset status'}
           </Button>
           <LaunchAssetExecutionButton
-            context="all"
-            assetKeys={assetGraph.graphAssetKeys}
+            allAssetKeys={assetGraph.graphAssetKeys}
             preferredJobName={pipelineName}
           />
         </Box>

--- a/js_modules/dagit/packages/core/src/plugins/ipynb.tsx
+++ b/js_modules/dagit/packages/core/src/plugins/ipynb.tsx
@@ -1,4 +1,3 @@
-import {Box} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {IPluginSidebarProps} from '../plugins';
@@ -10,12 +9,10 @@ export const SidebarComponent: React.FC<IPluginSidebarProps> = (props) => {
   const repoLocName = props.repoAddress?.location;
 
   return (
-    <Box padding={16}>
-      <NotebookButton
-        path={notebookPath?.value}
-        repoLocation={repoLocName || ''}
-        label="View Source Notebook"
-      />
-    </Box>
+    <NotebookButton
+      path={notebookPath?.value}
+      repoLocation={repoLocName || ''}
+      label="View Source Notebook"
+    />
   );
 };


### PR DESCRIPTION
### Summary & Motivation

This PR makes the following small changes:

- Asset nodes have a more visible selection highlight (in zoomed out mode as well)
![image](https://user-images.githubusercontent.com/1037212/202315804-c42f889d-018e-4404-92cf-54a193a60425.png)

- The Materialize button on the asset graph now only shows Observe source IF there are observable source assets, and is completely hidden otherwise.

- The Materialize button is split the same way the "Re-execute" button is. It shows a primary action and "Stale and missing" in the dropdown.
    + If you select nodes, it shows just the selected option
    + If you have no stale assets, the dropdown is still there and the option is grayed out
    + Shift-click to add config still works for all modes, including choosing from the dropdown

![image](https://user-images.githubusercontent.com/1037212/202315966-2cc09311-fcac-44f8-a299-21175e5cba20.png)


- The "Show notebook" button padding has been fixed here:

![image](https://user-images.githubusercontent.com/1037212/202316386-952586b2-21ad-4846-8456-8f52871b2a79.png)


- The Stale tag placement has been changed here so it's right justified:
![image](https://user-images.githubusercontent.com/1037212/202316433-5ede54ae-8c5b-4e10-ab44-236b5fe27b6a.png)

- Late assets are shown on the asset graph
![image](https://user-images.githubusercontent.com/1037212/202316507-0c470b49-7f7f-4d0c-93f1-04120554166e.png)

- For large graphs where the live data takes time to load, there's now a loading state instead of "Never materialized"
![image](https://user-images.githubusercontent.com/1037212/202316731-7e0f4758-d2e9-4586-bfcb-c026c30428c2.png)
