### PR TITLE
[bugfix] fix multi-repo projected logical version bug

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -596,8 +596,12 @@ class GrapheneDagitQuery(graphene.ObjectType):
             repos = []
             used = set()
             for node in results:
-                if not node.external_repository.name in used:
-                    used.add(node.external_repository.name)
+                repo_id = (
+                    node.external_repository.handle.location_name,
+                    node.external_repository.name,
+                )
+                if not repo_id in used:
+                    used.add(repo_id)
                     repos.append(node.external_repository)
 
         projected_logical_version_loader = ProjectedLogicalVersionLoader(


### PR DESCRIPTION
### Summary & Motivation

Fixes bug with projected logical version resolution when two repos have the same name. Now uniquely identifies repos with (location name, name).

### How I Tested These Changes

Prior to fix, GraphQL errors are thrown on `/instance/assets/myasset?view=lineage` when myasset has a cross-repo dependency where the external asset is in a repo of the same name as myasset. The errors no longer occur with this fix.
