### PR TITLE
Correct typo in docs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -473,7 +473,7 @@ class MetadataValue(ABC):
                     metadata={
                         "errors": MetadataValue.table(
                             records=[
-                                TableRecord(code="invalid-data-type", row=2, col="name"}]
+                                TableRecord(code="invalid-data-type", row=2, col="name"),
                             ],
                             schema=TableSchema(
                                 columns=[
@@ -1271,7 +1271,7 @@ class MetadataEntry(
                         MetadataEntry.table(
                             label="errors",
                             records=[
-                                TableRecord(code="invalid-data-type", row=2, col="name"}]
+                                TableRecord(code="invalid-data-type", row=2, col="name"),
                             ],
                             schema=TableSchema(
                                 columns=[


### PR DESCRIPTION
### Summary & Motivation

There was a small typo in the documentation

### How I Tested These Changes

As this is merely documentation, it's not really that testable, so io just looked at the before and after versions. Now it looks like valid python code.
