### PR TITLE
Change dagster project scaffold help text to indicate new folder is created

### DIFF
--- a/python_modules/dagster/dagster/_cli/project.py
+++ b/python_modules/dagster/dagster/_cli/project.py
@@ -23,8 +23,8 @@ scaffold_repository_command_help_text = (
 
 scaffold_command_help_text = (
     "Create a folder structure with a single Dagster repository and other files such as "
-    "workspace.yaml, in the current directory. This CLI enables you to quickly start building "
-    "a new Dagster project with everything set up."
+    "workspace.yaml, in the target directory set by the --name option. This CLI enables "
+    "you to quickly start building a new Dagster project with everything set up."
 )
 
 from_example_command_help_text = (


### PR DESCRIPTION
### Summary & Motivation

`dagster project scaffold` creates a new folder. However the help text said it creates it in the current directory. This PR changes the help text to reflect the reality of the command.

### How I Tested These Changes

Read the help text.

