### PR TITLE
allow op context to asset partition key

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -261,7 +261,7 @@ class UnboundOpExecutionContext(OpExecutionContext):
             user_events=self._user_events,
             output_metadata=self._output_metadata,
             mapping_key=self._mapping_key,
-            partition_key=self._partition_key
+            partition_key=self._partition_key,
         )
 
     def get_events(self) -> Sequence[UserEvent]:
@@ -387,7 +387,7 @@ class BoundOpExecutionContext(OpExecutionContext):
         user_events: List[UserEvent],
         output_metadata: Dict[str, Any],
         mapping_key: Optional[str],
-        partition_key: Optional[str]
+        partition_key: Optional[str],
     ):
         self._op_def = op_def
         self._op_config = op_config
@@ -402,9 +402,8 @@ class BoundOpExecutionContext(OpExecutionContext):
         self._user_events = user_events
         self._seen_outputs = {}
         self._output_metadata = output_metadata
-        self._mapping_key = mapping_key,
+        self._mapping_key = mapping_key
         self._partition_key = partition_key
-        
 
     @property
     def solid_config(self) -> Any:
@@ -537,7 +536,7 @@ class BoundOpExecutionContext(OpExecutionContext):
                 output_name in self._seen_outputs and mapping_key in self._seen_outputs[output_name]
             )
         return output_name in self._seen_outputs
-    
+
     def asset_partition_key_for_output(self, output_name: str = "result") -> str:
         if self._partition_key is not None:
             return self._partition_key

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -214,8 +214,10 @@ class UnboundOpExecutionContext(OpExecutionContext):
     def partition_key(self) -> str:
         if self._partition_key:
             return self._partition_key
-        else:
-            check.failed("Tried to access partition_key for a non-partitioned run")
+        check.failed("Tried to access partition_key for a non-partitioned run")
+
+    def asset_partition_key_for_output(self, output_name: str = "result") -> str:
+        return self.partition_key
 
     def has_tag(self, key: str) -> bool:
         raise DagsterInvalidPropertyError(_property_msg("has_tag", "method"))
@@ -537,11 +539,14 @@ class BoundOpExecutionContext(OpExecutionContext):
             )
         return output_name in self._seen_outputs
 
-    def asset_partition_key_for_output(self, output_name: str = "result") -> str:
+    @property
+    def partition_key(self) -> str:
         if self._partition_key is not None:
             return self._partition_key
-        else:
-            check.failed("Tried to access partition_key for a non-partitioned asset")
+        check.failed("Tried to access partition_key for a non-partitioned asset")
+
+    def asset_partition_key_for_output(self, output_name: str = "result") -> str:
+        return self.partition_key
 
     def add_output_metadata(
         self,

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -261,6 +261,7 @@ class UnboundOpExecutionContext(OpExecutionContext):
             user_events=self._user_events,
             output_metadata=self._output_metadata,
             mapping_key=self._mapping_key,
+            partition_key=self._partition_key
         )
 
     def get_events(self) -> Sequence[UserEvent]:
@@ -369,6 +370,7 @@ class BoundOpExecutionContext(OpExecutionContext):
     _seen_outputs: Dict[str, Union[str, Set[str]]]
     _output_metadata: Dict[str, Any]
     _mapping_key: Optional[str]
+    _partition_key: Optional[str]
 
     def __init__(
         self,
@@ -385,6 +387,7 @@ class BoundOpExecutionContext(OpExecutionContext):
         user_events: List[UserEvent],
         output_metadata: Dict[str, Any],
         mapping_key: Optional[str],
+        partition_key: Optional[str]
     ):
         self._op_def = op_def
         self._op_config = op_config
@@ -399,7 +402,9 @@ class BoundOpExecutionContext(OpExecutionContext):
         self._user_events = user_events
         self._seen_outputs = {}
         self._output_metadata = output_metadata
-        self._mapping_key = mapping_key
+        self._mapping_key = mapping_key,
+        self._partition_key = partition_key
+        
 
     @property
     def solid_config(self) -> Any:
@@ -532,6 +537,12 @@ class BoundOpExecutionContext(OpExecutionContext):
                 output_name in self._seen_outputs and mapping_key in self._seen_outputs[output_name]
             )
         return output_name in self._seen_outputs
+    
+    def asset_partition_key_for_output(self, output_name: str = "result") -> str:
+        if self._partition_key is not None:
+            return self._partition_key
+        else:
+            check.failed("Tried to access partition_key for a non-partitioned asset")
 
     def add_output_metadata(
         self,

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
@@ -14,11 +14,11 @@ from dagster import (
     Output,
     SourceAsset,
     StaticPartitionsDefinition,
+    build_op_context,
     daily_partitioned_config,
     define_asset_job,
     hourly_partitioned_config,
     materialize,
-    build_op_context
 )
 from dagster._check import CheckError
 from dagster._core.definitions import asset, build_assets_job, multi_asset
@@ -141,6 +141,7 @@ def test_assets_job_with_different_partitions_defs():
 
         build_assets_job("my_job", assets=[upstream, downstream])
 
+
 def test_access_partition_keys_from_context_direct_invocation():
     partitions_def = StaticPartitionsDefinition(["a"])
 
@@ -150,6 +151,7 @@ def test_access_partition_keys_from_context_direct_invocation():
 
     context = build_op_context(partition_key="a")
     partitioned_asset(context)
+
 
 def test_access_partition_keys_from_context_only_one_asset_partitioned():
     upstream_partitions_def = StaticPartitionsDefinition(["a", "b", "c"])

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
@@ -18,6 +18,7 @@ from dagster import (
     define_asset_job,
     hourly_partitioned_config,
     materialize,
+    build_op_context
 )
 from dagster._check import CheckError
 from dagster._core.definitions import asset, build_assets_job, multi_asset
@@ -140,6 +141,15 @@ def test_assets_job_with_different_partitions_defs():
 
         build_assets_job("my_job", assets=[upstream, downstream])
 
+def test_access_partition_keys_from_context_direct_invocation():
+    partitions_def = StaticPartitionsDefinition(["a"])
+
+    @asset(partitions_def=partitions_def)
+    def partitioned_asset(context):
+        assert context.asset_partition_key_for_output() == "a"
+
+    context = build_op_context(partition_key="a")
+    partitioned_asset(context)
 
 def test_access_partition_keys_from_context_only_one_asset_partitioned():
     upstream_partitions_def = StaticPartitionsDefinition(["a", "b", "c"])

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
@@ -150,7 +150,23 @@ def test_access_partition_keys_from_context_direct_invocation():
         assert context.asset_partition_key_for_output() == "a"
 
     context = build_op_context(partition_key="a")
+
+    # check unbound context
+    assert context.asset_partition_key_for_output() == "a"
+
+    # check bound context
     partitioned_asset(context)
+
+    # check failure for non-partitioned asset
+    @asset
+    def non_partitioned_asset(context):
+        with pytest.raises(
+            CheckError, match="Tried to access partition_key for a non-partitioned asset"
+        ):
+            context.asset_partition_key_for_output()
+
+    context = build_op_context()
+    non_partitioned_asset(context)
 
 
 def test_access_partition_keys_from_context_only_one_asset_partitioned():


### PR DESCRIPTION
### Summary & Motivation

Resolves #10586 

### How I Tested These Changes
- added a test that directly invokes the asset with an op context

Question: Is it safe to ignore the output_name argument in this context?