### PR TITLE
K8s tags are needed in ops to propagate to steps

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -80,6 +80,9 @@ def k8s_job_executor(init_context: InitExecutorContext) -> Executor:
 
     Configuration set on the Kubernetes Jobs and Pods created by the `K8sRunLauncher` will also be
     set on Kubernetes Jobs and Pods created by the `k8s_job_executor`.
+    
+    Configuration set using `tags` on a `@job` will only apply to the `run` level. For configuration 
+    to apply at each `step` it must be set using `tags` for each `@op`.
     """
 
     run_launcher = init_context.instance.run_launcher


### PR DESCRIPTION
### Summary & Motivation

I raised a [support request](https://dagster.slack.com/archives/C01U954MEER/p1668643577955129) on slack where it wasn't clear to me why  k8s `tags` specified at the `@job` level weren't propagating to individual steps when using the `k8s_job_executor`.

This update to the docs includes a note that will hopefully help others understand that k8s `tags` need to be defined at the `op` level for a given `step` to use them.

My primary use case for this feature is to have ops run on specific node groups.

### How I Tested These Changes

Local build of docs.
