### PR TITLE
add missing projected version loader when loading workspace/repo page

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -22,6 +22,7 @@ from ...implementation.fetch_assets import (
     get_asset_node_definition_collisions,
     get_asset_nodes,
     get_assets,
+    unique_repos,
 )
 from ...implementation.fetch_backfills import get_backfill, get_backfills
 from ...implementation.fetch_instigators import (
@@ -593,16 +594,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
         if repo is not None:
             repos = [repo]
         else:
-            repos = []
-            used = set()
-            for node in results:
-                repo_id = (
-                    node.external_repository.handle.location_name,
-                    node.external_repository.name,
-                )
-                if not repo_id in used:
-                    used.add(repo_id)
-                    repos.append(node.external_repository)
+            repos = unique_repos(result.external_repository for result in results)
 
         projected_logical_version_loader = ProjectedLogicalVersionLoader(
             instance=graphene_info.context.instance,


### PR DESCRIPTION
### Summary & Motivation

I'm a bit out of my depth on this part of the codebase, but this appeared to fix the issue.

### How I Tested These Changes

Loaded the repo page under the Workspace page and observed no graphql errors

```
from dagster import asset


@asset
def asset1():
    ...
```