### PR TITLE
fix ptest skipif on test_event_log_subscription_chunked

### DIFF
--- a/python_modules/dagit/dagit_tests/test_subscriptions.py
+++ b/python_modules/dagit/dagit_tests/test_subscriptions.py
@@ -103,7 +103,7 @@ def test_event_log_subscription():
 
 
 @pytest.mark.skipif(
-    sys.version_info <= (3, 7),
+    sys.version_info < (3, 8),
     reason="Inconsistent GC on the async_generator in 3.7",
 )
 def test_event_log_subscription_chunked():


### PR DESCRIPTION
foolishly did `<=` but the `==` wont work since the full version info is more than just the first two tuple entries


### How I Tested These Changes
locally verify with 3.9 
```
>>> sys.version_info <= (3, 9)
False
>>> sys.version_info
sys.version_info(major=3, minor=9, micro=11, releaselevel='final', serial=0)
```
