### PR TITLE
[graphql] fix GrapheneJob

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -801,6 +801,18 @@ class GrapheneJob(GraphenePipeline):
         interfaces = (GrapheneSolidContainer, GrapheneIPipelineSnapshot)
         name = "Job"
 
+    # doesn't inherit from base class
+    def __init__(self, external_pipeline, batch_loader=None):
+        super().__init__()
+        self._external_pipeline = check.inst_param(
+            external_pipeline, "external_pipeline", ExternalPipeline
+        )
+        # optional run loader, provided by a parent GrapheneRepository object that instantiates
+        # multiple pipelines
+        self._batch_loader = check.opt_inst_param(
+            batch_loader, "batch_loader", RepositoryScopedBatchLoader
+        )
+
 
 class GrapheneGraph(graphene.ObjectType):
     class Meta:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_graph.py
@@ -18,7 +18,7 @@ query {
                 name
                 repositories {
                     name
-                    pipelines {
+                    jobs {
                         name
                         graphName
                     }
@@ -76,9 +76,7 @@ class TestGraphs(NonLaunchableGraphQLContextTestMatrix):
 
         jobs = {
             blob["name"]: blob
-            for blob in repo_locations["test"]["locationOrLoadError"]["repositories"][0][
-                "pipelines"
-            ]
+            for blob in repo_locations["test"]["locationOrLoadError"]["repositories"][0]["jobs"]
         }
 
         assert "simple_job_a" in jobs


### PR DESCRIPTION
missed in https://github.com/dagster-io/dagster/pull/9334 - the `__init__` methods no longer inherit 

### How I Tested These Changes
updated test from `pipelines` to `jobs` that previously failed 
```
query GetRepositoryConnections {
  repositoriesOrError {
    ... on RepositoryConnection {
      nodes {
        location {
          repositories {
            jobs {
              id
              name
            }
          }
        }
      }
    }
  }
}
```
no longer errors
