### PR TITLE
Ignore yanked releases when finding latest

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/defines.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/defines.py
@@ -10,7 +10,11 @@ def _get_latest_dagster_release() -> str:
     res = requests.get("https://pypi.org/pypi/dagster/json")
     module_json = res.json()
     releases = module_json["releases"]
-    release_versions = [packaging.version.parse(release) for release in releases.keys()]
+    release_versions = [
+        packaging.version.parse(version)
+        for version, files in releases.items()
+        if not any(file.get("yanked") for file in files)
+    ]
     for release_version in reversed(sorted(release_versions)):
         if not release_version.is_prerelease:
             return str(release_version)

--- a/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
+++ b/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
@@ -63,7 +63,11 @@ def dagster_most_recent_release():
     res = requests.get("https://pypi.org/pypi/dagster/json")
     module_json = res.json()
     releases = module_json["releases"]
-    release_versions = [parse_package_version(release) for release in releases.keys()]
+    release_versions = [
+        parse_package_version(version)
+        for version, files in releases.items()
+        if not any(file.get("yanked") for file in files)
+    ]
     for release_version in reversed(sorted(release_versions)):
         if not release_version.is_prerelease:
             return str(release_version)


### PR DESCRIPTION
When we yanked 1.1.0, our backcompat tests continued failing because they kept trying to install from the now yanked version.