### PR TITLE
Ping dagit during backcompat tests

### DIFF
--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/Dockerfile_user_code_legacy_release
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/Dockerfile_user_code_legacy_release
@@ -10,7 +10,7 @@ RUN pip install \
     dagster=="${USER_CODE_BACKCOMPAT_VERSION}" \
     dagster-postgres=="${USER_CODE_BACKCOMPAT_LIBRARY_VERSION}" \
     dagster-docker=="${USER_CODE_BACKCOMPAT_LIBRARY_VERSION}" \
-    dagster-graphql=="${USER_CODE_BACKCOMPAT_LIBRARY_VERSION}"
+    dagster-graphql=="${USER_CODE_BACKCOMPAT_VERSION}"
 
 WORKDIR /opt/dagster/app
 

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/Dockerfile_user_code_legacy_release
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/Dockerfile_user_code_legacy_release
@@ -9,7 +9,8 @@ RUN pip install \
     -r pins.txt \
     dagster=="${USER_CODE_BACKCOMPAT_VERSION}" \
     dagster-postgres=="${USER_CODE_BACKCOMPAT_LIBRARY_VERSION}" \
-    dagster-docker=="${USER_CODE_BACKCOMPAT_LIBRARY_VERSION}"
+    dagster-docker=="${USER_CODE_BACKCOMPAT_LIBRARY_VERSION}" \
+    dagster-graphql=="${USER_CODE_BACKCOMPAT_LIBRARY_VERSION}"
 
 WORKDIR /opt/dagster/app
 

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/Dockerfile_user_code_release
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/Dockerfile_user_code_release
@@ -10,7 +10,7 @@ RUN pip install \
     dagster=="${USER_CODE_BACKCOMPAT_VERSION}" \
     dagster-postgres=="${USER_CODE_BACKCOMPAT_LIBRARY_VERSION}" \
     dagster-docker=="${USER_CODE_BACKCOMPAT_LIBRARY_VERSION}" \
-    dagster-graphql=="${USER_CODE_BACKCOMPAT_LIBRARY_VERSION}"
+    dagster-graphql=="${USER_CODE_BACKCOMPAT_VERSION}"
 
 WORKDIR /opt/dagster/app
 

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/Dockerfile_user_code_release
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/Dockerfile_user_code_release
@@ -9,7 +9,8 @@ RUN pip install \
     -r pins.txt \
     dagster=="${USER_CODE_BACKCOMPAT_VERSION}" \
     dagster-postgres=="${USER_CODE_BACKCOMPAT_LIBRARY_VERSION}" \
-    dagster-docker=="${USER_CODE_BACKCOMPAT_LIBRARY_VERSION}"
+    dagster-docker=="${USER_CODE_BACKCOMPAT_LIBRARY_VERSION}" \
+    dagster-graphql=="${USER_CODE_BACKCOMPAT_LIBRARY_VERSION}"
 
 WORKDIR /opt/dagster/app
 

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/Dockerfile_user_code_source
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/Dockerfile_user_code_source
@@ -7,7 +7,8 @@ WORKDIR /tmp
 RUN pip install \
     -e python_modules/dagster \
     -e python_modules/libraries/dagster-postgres \
-    -e python_modules/libraries/dagster-docker
+    -e python_modules/libraries/dagster-docker \
+    -e python_modules/libraries/dagster-graphql
 
 # Ensure all dagster installs were local
 RUN ! (pip list --exclude-editable | grep -e dagster -e dagit)

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/Dockerfile_user_code_source
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/Dockerfile_user_code_source
@@ -6,9 +6,9 @@ WORKDIR /tmp
 
 RUN pip install \
     -e python_modules/dagster \
+    -e python_modules/dagster-graphql \ 
     -e python_modules/libraries/dagster-postgres \
-    -e python_modules/libraries/dagster-docker \
-    -e python_modules/libraries/dagster-graphql
+    -e python_modules/libraries/dagster-docker
 
 # Ensure all dagster installs were local
 RUN ! (pip list --exclude-editable | grep -e dagster -e dagit)

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/legacy_repo.py
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/legacy_repo.py
@@ -1,4 +1,6 @@
 # pylint: skip-file
+from dagster_graphql import DagsterGraphQLClient
+
 from dagster import graph, op, pipeline, repository, solid
 
 
@@ -32,9 +34,23 @@ def basic():
     ingest(my_op())
 
 
+@solid
+def ping_dagit(context):
+    client = DagsterGraphQLClient(
+        "dagit",
+        port_number=3000,
+    )
+    return client._execute("{__typename}")  # pylint: disable=protected-access
+
+
+@pipeline
+def test_graphql():
+    ping_dagit()
+
+
 the_job = basic.to_job(name="the_job")
 
 
 @repository
 def basic_repo():
-    return [the_job, the_pipeline]
+    return [the_job, the_pipeline, test_graphql]

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/legacy_repo.py
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/legacy_repo.py
@@ -35,7 +35,7 @@ def basic():
 
 
 @solid
-def ping_dagit(context):
+def ping_dagit():
     client = DagsterGraphQLClient(
         "dagit",
         port_number=3000,

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/repo.py
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/repo.py
@@ -14,7 +14,7 @@ def ingest(x):
 
 
 @op
-def ping_dagit(context):
+def ping_dagit():
     client = DagsterGraphQLClient(
         "dagit",
         port_number=3000,

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/repo.py
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/repo.py
@@ -1,5 +1,4 @@
 from dagster_graphql import DagsterGraphQLClient
-from gql.transport.requests import RequestsHTTPTransport
 
 from dagster import graph, job, op, repository
 
@@ -16,13 +15,9 @@ def ingest(x):
 
 @op
 def ping_dagit(context):
-    hostname = context.op_config["hostname"]
-    url = f"http://{hostname}:3000/graphql"
     client = DagsterGraphQLClient(
-        url,
-        transport=RequestsHTTPTransport(
-            url=url,
-        ),
+        "dagit",
+        port_number=3000,
     )
     return client._execute("{__typename}")  # pylint: disable=protected-access
 

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/repo.py
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/repo.py
@@ -1,4 +1,7 @@
-from dagster import graph, op, repository
+from dagster_graphql import DagsterGraphQLClient
+from gql.transport.requests import RequestsHTTPTransport
+
+from dagster import graph, job, op, repository
 
 
 @op
@@ -11,9 +14,27 @@ def ingest(x):
     return x + 5
 
 
+@op
+def ping_dagit(context):
+    hostname = context.op_config["hostname"]
+    url = f"http://{hostname}:3000/graphql"
+    client = DagsterGraphQLClient(
+        url,
+        transport=RequestsHTTPTransport(
+            url=url,
+        ),
+    )
+    return client._execute("{__typename}")  # pylint: disable=protected-access
+
+
 @graph
 def basic():
     ingest(my_op())
+
+
+@job
+def test_graphql():
+    ping_dagit()
 
 
 the_job = basic.to_job(name="the_job")
@@ -21,4 +42,4 @@ the_job = basic.to_job(name="the_job")
 
 @repository
 def basic_repo():
-    return [the_job]
+    return [the_job, test_graphql]

--- a/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
+++ b/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
@@ -222,11 +222,26 @@ def test_backcompat_deployed_job_subset(graphql_client):
     assert_runs_and_exists(graphql_client, "the_job", subset_selection=["my_op"])
 
 
-def assert_runs_and_exists(client: DagsterGraphQLClient, name, subset_selection=None):
+def test_backcompat_ping_dagit(graphql_client):
+    dagit_host = os.environ.get("BACKCOMPAT_TESTS_DAGIT_HOST", "localhost")
+    assert_runs_and_exists(
+        graphql_client,
+        "test_graphql",
+        run_config={
+            "ops": {
+                "ping_dagit": {"config": {"hostname": dagit_host}},
+            }
+        },
+    )
+
+
+def assert_runs_and_exists(
+    client: DagsterGraphQLClient, name, subset_selection=None, run_config=None
+):
     run_id = client.submit_pipeline_execution(
         pipeline_name=name,
         mode="default",
-        run_config={},
+        run_config=run_config,
         solid_selection=subset_selection,
     )
     assert_run_success(client, run_id)

--- a/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
+++ b/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
@@ -223,7 +223,6 @@ def test_backcompat_deployed_job_subset(graphql_client):
 
 
 def test_backcompat_ping_dagit(graphql_client):
-    dagit_host = os.environ.get("BACKCOMPAT_TESTS_DAGIT_HOST", "localhost")
     assert_runs_and_exists(
         graphql_client,
         "test_graphql",

--- a/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
+++ b/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
@@ -227,21 +227,14 @@ def test_backcompat_ping_dagit(graphql_client):
     assert_runs_and_exists(
         graphql_client,
         "test_graphql",
-        run_config={
-            "ops": {
-                "ping_dagit": {"config": {"hostname": dagit_host}},
-            }
-        },
     )
 
 
-def assert_runs_and_exists(
-    client: DagsterGraphQLClient, name, subset_selection=None, run_config=None
-):
+def assert_runs_and_exists(client: DagsterGraphQLClient, name, subset_selection=None):
     run_id = client.submit_pipeline_execution(
         pipeline_name=name,
         mode="default",
-        run_config=run_config,
+        run_config={},
         solid_selection=subset_selection,
     )
     assert_run_success(client, run_id)


### PR DESCRIPTION
Use our graphql client in our backcompat tests to catch the types of issues we had when upgrading to graphene 3.