### PR TITLE
ignore warnings when creating LogicalVersion constants

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/logical_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/logical_version.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from hashlib import sha256
 from typing import TYPE_CHECKING, Mapping, NamedTuple, Optional, Union
 
@@ -7,6 +8,7 @@ from typing_extensions import Final
 
 from dagster import _check as check
 from dagster._annotations import experimental
+from dagster._utils.backcompat import ExperimentalWarning
 
 if TYPE_CHECKING:
     from dagster._core.definitions.events import (
@@ -49,8 +51,10 @@ class LogicalVersion(
         )
 
 
-UNKNOWN_LOGICAL_VERSION: Final[LogicalVersion] = LogicalVersion("UNKNOWN")
-DEFAULT_LOGICAL_VERSION: Final[LogicalVersion] = LogicalVersion("INITIAL")
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", category=ExperimentalWarning)
+    UNKNOWN_LOGICAL_VERSION: Final[LogicalVersion] = LogicalVersion("UNKNOWN")
+    DEFAULT_LOGICAL_VERSION: Final[LogicalVersion] = LogicalVersion("INITIAL")
 
 
 class LogicalVersionProvenance(

--- a/python_modules/dagster/dagster_tests/general_tests/test_api.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_api.py
@@ -1,10 +1,18 @@
 import importlib
 import re
+import subprocess
 import sys
 
 import pytest
 
 from dagster._module_alias_map import AliasedModuleFinder, get_meta_path_insertion_index
+
+
+def test_no_experimental_warnings():
+    process = subprocess.run(
+        [sys.executable, "-c", "import dagster"], check=False, capture_output=True
+    )
+    assert not re.search(r"ExperimentalWarning", process.stderr.decode("utf-8"))
 
 
 def test_deprecated_imports():


### PR DESCRIPTION
### Summary & Motivation

See title.

### How I Tested These Changes

I added a new test that ensures no experimental warnings are generated from `import dagster`. This should prevent this ever happening from another addition.
