### PR TITLE
Add build_snowflake_pandas_io_manager wrapper to eliminate use of type handlers in the common case

### DIFF
--- a/examples/assets_smoke_test/assets_smoke_test/python_and_dbt_assets.py
+++ b/examples/assets_smoke_test/assets_smoke_test/python_and_dbt_assets.py
@@ -1,6 +1,5 @@
 from dagster_dbt import dbt_cli_resource, load_assets_from_dbt_project
-from dagster_snowflake import build_snowflake_io_manager
-from dagster_snowflake_pandas import SnowflakePandasTypeHandler
+from dagster_snowflake_pandas import build_snowflake_pandas_io_manager
 from pandas import DataFrame
 
 from dagster import (
@@ -49,7 +48,7 @@ def repo():
     return with_resources(
         load_assets_from_current_module(),
         resource_defs={
-            "io_manager": build_snowflake_io_manager([SnowflakePandasTypeHandler()]).configured(
+            "io_manager": build_snowflake_pandas_io_manager().configured(
                 {
                     "account": {"env": "SNOWFLAKE_ACCOUNT"},
                     "user": {"env": "SNOWFLAKE_USER"},

--- a/examples/assets_smoke_test/assets_smoke_test/python_and_dbt_assets.py
+++ b/examples/assets_smoke_test/assets_smoke_test/python_and_dbt_assets.py
@@ -1,14 +1,14 @@
 from dagster_dbt import dbt_cli_resource, load_assets_from_dbt_project
-from dagster_snowflake_pandas import build_snowflake_pandas_io_manager
+from dagster_snowflake_pandas import snowflake_pandas_io_manager
 from pandas import DataFrame
 
 from dagster import (
     SourceAsset,
-    TableSchema,
-    asset,
     load_assets_from_current_module,
+    TableSchema,
     repository,
     with_resources,
+    asset,
 )
 from dagster._utils import file_relative_path
 
@@ -48,7 +48,7 @@ def repo():
     return with_resources(
         load_assets_from_current_module(),
         resource_defs={
-            "io_manager": build_snowflake_pandas_io_manager().configured(
+            "io_manager": snowflake_pandas_io_manager.configured(
                 {
                     "account": {"env": "SNOWFLAKE_ACCOUNT"},
                     "user": {"env": "SNOWFLAKE_USER"},

--- a/examples/assets_smoke_test/assets_smoke_test/python_and_dbt_assets.py
+++ b/examples/assets_smoke_test/assets_smoke_test/python_and_dbt_assets.py
@@ -4,11 +4,11 @@ from pandas import DataFrame
 
 from dagster import (
     SourceAsset,
-    load_assets_from_current_module,
     TableSchema,
+    asset,
+    load_assets_from_current_module,
     repository,
     with_resources,
-    asset,
 )
 from dagster._utils import file_relative_path
 

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/__init__.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/__init__.py
@@ -1,9 +1,6 @@
 from dagster._core.utils import check_dagster_package_version
 
-from .snowflake_pandas_type_handler import (
-    SnowflakePandasTypeHandler,
-    snowflake_pandas_io_manager,
-)
+from .snowflake_pandas_type_handler import SnowflakePandasTypeHandler, snowflake_pandas_io_manager
 from .version import __version__
 
 check_dagster_package_version("dagster-snowflake-pandas", __version__)

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/__init__.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/__init__.py
@@ -1,6 +1,9 @@
 from dagster._core.utils import check_dagster_package_version
 
-from .snowflake_pandas_type_handler import SnowflakePandasTypeHandler
+from .snowflake_pandas_type_handler import (
+    SnowflakePandasTypeHandler,
+    build_snowflake_pandas_io_manager,
+)
 from .version import __version__
 
 check_dagster_package_version("dagster-snowflake-pandas", __version__)

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/__init__.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/__init__.py
@@ -2,7 +2,7 @@ from dagster._core.utils import check_dagster_package_version
 
 from .snowflake_pandas_type_handler import (
     SnowflakePandasTypeHandler,
-    build_snowflake_pandas_io_manager,
+    snowflake_pandas_io_manager,
 )
 from .version import __version__
 

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -1,11 +1,19 @@
 from typing import Mapping, Union, cast
 
 import pandas as pd
+from dagster_snowflake import build_snowflake_io_manager
 from dagster_snowflake.resources import SnowflakeConnection
 from dagster_snowflake.snowflake_io_manager import SnowflakeDbClient
 from snowflake.connector.pandas_tools import pd_writer
 
-from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
+from dagster import (
+    IOManagerDefinition,
+    InputContext,
+    MetadataValue,
+    OutputContext,
+    TableColumn,
+    TableSchema,
+)
 from dagster._core.definitions.metadata import RawMetadataValue
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 
@@ -113,3 +121,65 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
     @property
     def supported_types(self):
         return [pd.DataFrame]
+
+
+def build_snowflake_pandas_io_manager() -> IOManagerDefinition:
+    """
+    Builds an IO manager definition that reads inputs from and writes outputs to Snowflake.
+
+    Returns:
+        IOManagerDefinition
+
+    Examples:
+
+        .. code-block:: python
+
+            from dagster_snowflake_pandas import build_snowflake_pandas_io_manager()
+
+            @asset(
+                key_prefix=["my_schema"]  # will be used as the schema in snowflake
+            )
+            def my_table() -> pd.DataFrame:  # the name of the asset will be the table name
+                ...
+
+            snowflake_io_manager = build_snowflake_pandas_io_manager()
+
+            @repository
+            def my_repo():
+                return with_resources(
+                    [my_table],
+                    {"io_manager": snowflake_io_manager.configured({
+                        "database": "my_database",
+                        "account" : {"env": "SNOWFLAKE_ACCOUNT"}
+                        ...
+                    })}
+                )
+
+        If you do not provide a schema, Dagster will determine a schema based on the assets and ops using
+        the IO Manager. For assets, the schema will be determined from the asset key.
+        For ops, the schema can be specified by including a "schema" entry in output metadata. If "schema" is not provided
+        via config or on the asset/op, "public" will be used for the schema.
+
+        .. code-block:: python
+
+            @op(
+                out={"my_table": Out(metadata={"schema": "my_schema"})}
+            )
+            def make_my_table() -> pd.DataFrame:
+                # the returned value will be stored at my_schema.my_table
+                ...
+
+        To only use specific columns of a table as input to a downstream op or asset, add the metadata "columns" to the
+        In or AssetIn.
+
+        .. code-block:: python
+
+            @asset(
+                ins={"my_table": AssetIn("my_table", metadata={"columns": ["a"]})}
+            )
+            def my_table_a(my_table: pd.DataFrame) -> pd.DataFrame:
+                # my_table will just contain the data from column "a"
+                ...
+
+    """
+    return build_snowflake_io_manager([SnowflakePandasTypeHandler()])

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -123,9 +123,19 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
         return [pd.DataFrame]
 
 
-def build_snowflake_pandas_io_manager() -> IOManagerDefinition:
+# Helper function used as a decorator below
+# The only purpose in doing this is so that
+# we have a symbol to hang the snowflake_pandas_io_manager
+# docblock off of. Otherwise we would just invoke build_snowflake_io_manager
+# directly and assign to module-scoped variable
+def wrap_io_manager(fn) -> IOManagerDefinition:
+    return fn()
+
+
+@wrap_io_manager
+def snowflake_pandas_io_manager():
     """
-    Builds an IO manager definition that reads inputs from and writes outputs to Snowflake.
+    An IO manager definition that reads inputs from and writes pandas dataframes to Snowflake.
 
     Returns:
         IOManagerDefinition

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -9,7 +9,7 @@ import pandas
 import pytest
 from dagster_snowflake import build_snowflake_io_manager
 from dagster_snowflake.resources import SnowflakeConnection
-from dagster_snowflake_pandas import SnowflakePandasTypeHandler
+from dagster_snowflake_pandas import SnowflakePandasTypeHandler, build_snowflake_pandas_io_manager
 from dagster_snowflake_pandas.snowflake_pandas_type_handler import (
     _convert_string_to_timestamp,
     _convert_timestamp_to_string,
@@ -133,6 +133,10 @@ def test_type_conversions():
     assert (_convert_string_to_timestamp(string_data) == string_data).all()
 
 
+def test_build_snowflake_pandas_io_manager():
+    assert build_snowflake_pandas_io_manager()
+
+
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
 def test_io_manager_with_snowflake_pandas():
     with temporary_snowflake_table(
@@ -159,7 +163,7 @@ def test_io_manager_with_snowflake_pandas():
             assert set(df.columns) == {"foo", "quux"}
             assert len(df.index) == 2
 
-        snowflake_io_manager = build_snowflake_io_manager([SnowflakePandasTypeHandler()])
+        snowflake_io_manager = build_snowflake_pandas_io_manager()
 
         @job(
             resource_defs={"snowflake": snowflake_io_manager},
@@ -214,7 +218,7 @@ def test_io_manager_with_snowflake_pandas_timestamp_data():
             assert set(df.columns) == {"foo", "date"}
             assert (df["date"] == time_df["date"]).all()
 
-        snowflake_io_manager = build_snowflake_io_manager([SnowflakePandasTypeHandler()])
+        snowflake_io_manager = build_snowflake_pandas_io_manager()
 
         @job(
             resource_defs={"snowflake": snowflake_io_manager},

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -17,8 +17,8 @@ from dagster_snowflake_pandas.snowflake_pandas_type_handler import (
 from pandas import DataFrame
 
 from dagster import (
-    MetadataValue,
     IOManagerDefinition,
+    MetadataValue,
     Out,
     TableColumn,
     TableSchema,

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -9,7 +9,7 @@ import pandas
 import pytest
 from dagster_snowflake import build_snowflake_io_manager
 from dagster_snowflake.resources import SnowflakeConnection
-from dagster_snowflake_pandas import SnowflakePandasTypeHandler, build_snowflake_pandas_io_manager
+from dagster_snowflake_pandas import SnowflakePandasTypeHandler, snowflake_pandas_io_manager
 from dagster_snowflake_pandas.snowflake_pandas_type_handler import (
     _convert_string_to_timestamp,
     _convert_timestamp_to_string,
@@ -18,6 +18,7 @@ from pandas import DataFrame
 
 from dagster import (
     MetadataValue,
+    IOManagerDefinition,
     Out,
     TableColumn,
     TableSchema,
@@ -134,7 +135,11 @@ def test_type_conversions():
 
 
 def test_build_snowflake_pandas_io_manager():
-    assert build_snowflake_pandas_io_manager()
+    assert isinstance(
+        build_snowflake_io_manager([SnowflakePandasTypeHandler()]), IOManagerDefinition
+    )
+    # test wrapping decorator to make sure that works as expected
+    assert isinstance(snowflake_pandas_io_manager, IOManagerDefinition)
 
 
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
@@ -163,10 +168,8 @@ def test_io_manager_with_snowflake_pandas():
             assert set(df.columns) == {"foo", "quux"}
             assert len(df.index) == 2
 
-        snowflake_io_manager = build_snowflake_pandas_io_manager()
-
         @job(
-            resource_defs={"snowflake": snowflake_io_manager},
+            resource_defs={"snowflake": snowflake_pandas_io_manager},
             config={
                 "resources": {
                     "snowflake": {
@@ -218,10 +221,8 @@ def test_io_manager_with_snowflake_pandas_timestamp_data():
             assert set(df.columns) == {"foo", "date"}
             assert (df["date"] == time_df["date"]).all()
 
-        snowflake_io_manager = build_snowflake_pandas_io_manager()
-
         @job(
-            resource_defs={"snowflake": snowflake_io_manager},
+            resource_defs={"snowflake": snowflake_pandas_io_manager},
             config={
                 "resources": {
                     "snowflake": {


### PR DESCRIPTION
### Summary & Motivation

To use our built in i/o managers for duckdb and snowflake, one has to import two libraries and be introduced to the concept of "type handlers", which are pretty arcane implementation detail that most people don't have to know about it. This PR introduces a function `build_snowflake_pandas_io_manager` that obviates the need to introduce SnowflakePandasTypeHandler in the common case. It also converts one example to this new function as a demo. If we move forward, we would also do this for duckdb and convert all examples.

### How I Tested These Changes

Unit tests