### PR TITLE
Session scope backcompat tests

### DIFF
--- a/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
+++ b/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
@@ -80,6 +80,7 @@ def dagster_most_recent_release():
         pytest.param(value, marks=getattr(pytest.mark, key), id=key)
         for key, value in MARK_TO_VERSIONS_MAP.items()
     ],
+    scope="session",
 )
 def release_test_map(request, dagster_most_recent_release):
     dagit_version = request.param[0]
@@ -178,7 +179,7 @@ def docker_service_up(docker_compose_file, build_args=None):
         subprocess.check_output(["docker-compose", "-f", docker_compose_file, "rm", "-f"])
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def graphql_client(release_test_map, retrying_requests):
     dagit_host = os.environ.get("BACKCOMPAT_TESTS_DAGIT_HOST", "localhost")
 

--- a/python_modules/dagster-test/dagster_test/fixtures/utils.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/utils.py
@@ -21,7 +21,7 @@ def sigterm_handler():
     signal.signal(signal.SIGTERM, original)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def retrying_requests():
     session = requests.Session()
     session.mount(


### PR DESCRIPTION
So they don't need to docker build/compose up/down multiple times.

I think making retrying_requests session scoped should generally be safe since you cause typically use broader scoped fixtures inside of narrower scoped fixtures - but I'll let buildkite be the judge of that.
