### PR TITLE
Include PartitionMappings on ExternalAssetNode

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -36,6 +36,7 @@ from .resource_definition import ResourceDefinition
 if TYPE_CHECKING:
     from dagster._core.definitions.assets import AssetsDefinition, SourceAsset
     from dagster._core.definitions.job_definition import JobDefinition
+    from dagster._core.definitions.partition_mapping import PartitionMapping
     from dagster._core.definitions.resolved_asset_defs import ResolvedAssetDependencies
     from dagster._core.execution.context.output import OutputContext
 
@@ -782,6 +783,14 @@ class AssetLayer:
                 return source_asset.partitions_def
 
         return None
+
+    def partition_mapping_for_asset_dep(
+        self, asset_key: AssetKey, upstream_asset_key: AssetKey
+    ) -> Optional["PartitionMapping"]:
+        assets_def = self._assets_defs_by_key.get(asset_key)
+        if not assets_def:
+            return None
+        return assets_def.get_partition_mapping(upstream_asset_key)
 
     def downstream_dep_assets(self, node_handle: NodeHandle, output_name: str) -> Set[AssetKey]:
         """

--- a/python_modules/dagster/dagster/_core/definitions/asset_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_partitions.py
@@ -20,7 +20,7 @@ def get_upstream_partitions_for_partition_range(
     if upstream_partitions_def is None:
         check.failed("upstream asset is not partitioned")
 
-    downstream_partition_mapping = downstream_assets_def.get_partition_mapping(upstream_asset_key)
+    downstream_partition_mapping = downstream_assets_def.infer_partition_mapping(upstream_asset_key)
     return downstream_partition_mapping.get_upstream_partitions_for_partition_range(
         downstream_partition_key_range,
         downstream_assets_def.partitions_def,
@@ -43,7 +43,7 @@ def get_downstream_partitions_for_partition_range(
     if upstream_assets_def.partitions_def is None:
         check.failed("upstream asset is not partitioned")
 
-    downstream_partition_mapping = downstream_assets_def.get_partition_mapping(upstream_asset_key)
+    downstream_partition_mapping = downstream_assets_def.infer_partition_mapping(upstream_asset_key)
     return downstream_partition_mapping.get_downstream_partitions_for_partition_range(
         upstream_partition_key_range,
         downstream_assets_def.partitions_def,

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -35,7 +35,11 @@ from .events import AssetKey, CoercibleToAssetKeyPrefix
 from .node_definition import NodeDefinition
 from .op_definition import OpDefinition
 from .partition import PartitionsDefinition
-from .partition_mapping import PartitionMapping, infer_partition_mapping
+from .partition_mapping import (
+    PartitionMapping,
+    get_builtin_partition_mapping_types,
+    infer_partition_mapping,
+)
 from .resource_definition import ResourceDefinition
 from .resource_requirement import (
     ResourceAddable,
@@ -119,6 +123,20 @@ class AssetsDefinition(ResourceAddable):
 
         self._partitions_def = partitions_def
         self._partition_mappings = partition_mappings or {}
+        builtin_partition_mappings = get_builtin_partition_mapping_types()
+        for partition_mapping in self._partition_mappings.values():
+            if not isinstance(partition_mapping, builtin_partition_mappings):
+                warnings.warn(
+                    f"Non-built-in PartitionMappings, such as {type(partition_mapping).__name__} "
+                    "are deprecated and will not work with asset reconciliation. The built-in "
+                    "partition mappings are "
+                    + ", ".join(
+                        builtin_partition_mapping.__name__
+                        for builtin_partition_mapping in builtin_partition_mappings
+                    )
+                    + ".",
+                    category=DeprecationWarning,
+                )
 
         # if not specified assume all output assets depend on all input assets
         all_asset_keys = set(keys_by_output_name.values())
@@ -546,7 +564,10 @@ class AssetsDefinition(ResourceAddable):
         return self._code_versions_by_key
 
     @public
-    def get_partition_mapping(self, in_asset_key: AssetKey) -> PartitionMapping:
+    def get_partition_mapping(self, in_asset_key: AssetKey) -> Optional[PartitionMapping]:
+        return self._partition_mappings.get(in_asset_key)
+
+    def infer_partition_mapping(self, in_asset_key: AssetKey) -> PartitionMapping:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=ExperimentalWarning)
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -308,7 +308,7 @@ class _Asset:
         partition_mappings = {
             keys_by_input_name[input_name]: asset_in.partition_mapping
             for input_name, asset_in in self.ins.items()
-            if asset_in.partition_mapping
+            if asset_in.partition_mapping is not None
         }
 
         return AssetsDefinition(
@@ -481,7 +481,7 @@ def multi_asset(
         partition_mappings = {
             keys_by_input_name[input_name]: asset_in.partition_mapping
             for input_name, asset_in in (ins or {}).items()
-            if asset_in.partition_mapping
+            if asset_in.partition_mapping is not None
         }
 
         return AssetsDefinition(

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -712,7 +712,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
                 f"Asset key {from_asset_key} is not partitioned. Cannot get partition keys."
             )
 
-        partition_mapping = to_asset.get_partition_mapping(from_asset_key)
+        partition_mapping = to_asset.infer_partition_mapping(from_asset_key)
         downstream_partition_key_range = (
             partition_mapping.get_downstream_partitions_for_partition_range(
                 PartitionKeyRange(partition_key, partition_key),

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -1,10 +1,11 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import NamedTuple, Optional
 
 import dagster._check as check
 from dagster._annotations import experimental, public
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
+from dagster._serdes import whitelist_for_serdes
 
 
 @experimental
@@ -55,7 +56,8 @@ class PartitionMapping(ABC):
 
 
 @experimental
-class IdentityPartitionMapping(PartitionMapping):
+@whitelist_for_serdes
+class IdentityPartitionMapping(PartitionMapping, NamedTuple("_IdentityPartitionMapping", [])):
     def get_upstream_partitions_for_partition_range(
         self,
         downstream_partition_key_range: Optional[PartitionKeyRange],
@@ -77,7 +79,8 @@ class IdentityPartitionMapping(PartitionMapping):
 
 
 @experimental
-class AllPartitionMapping(PartitionMapping):
+@whitelist_for_serdes
+class AllPartitionMapping(PartitionMapping, NamedTuple("_AllPartitionMapping", [])):
     def get_upstream_partitions_for_partition_range(
         self,
         downstream_partition_key_range: Optional[PartitionKeyRange],
@@ -99,7 +102,8 @@ class AllPartitionMapping(PartitionMapping):
 
 
 @experimental
-class LastPartitionMapping(PartitionMapping):
+@whitelist_for_serdes
+class LastPartitionMapping(PartitionMapping, NamedTuple("_LastPartitionMapping", [])):
     def get_upstream_partitions_for_partition_range(
         self,
         downstream_partition_key_range: Optional[PartitionKeyRange],
@@ -127,3 +131,14 @@ def infer_partition_mapping(
         return partitions_def.get_default_partition_mapping()
     else:
         return AllPartitionMapping()
+
+
+def get_builtin_partition_mapping_types():
+    from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
+
+    return (
+        AllPartitionMapping,
+        IdentityPartitionMapping,
+        LastPartitionMapping,
+        TimeWindowPartitionMapping,
+    )

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import NamedTuple, Optional, cast
 
 import dagster._check as check
 from dagster._core.definitions.partition import PartitionsDefinition
@@ -6,9 +6,11 @@ from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
+from dagster._serdes import whitelist_for_serdes
 
 
-class TimeWindowPartitionMapping(PartitionMapping):
+@whitelist_for_serdes
+class TimeWindowPartitionMapping(PartitionMapping, NamedTuple("_TimeWindowPartitionMapping", [])):
     """
     The default mapping between two TimeWindowPartitionsDefinitions.
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_graph.py
@@ -1,13 +1,33 @@
 # pylint: disable=unused-argument
+import pendulum
+import pytest
 
 from dagster import (
+    AssetIn,
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    LastPartitionMapping,
+    PartitionMapping,
     StaticPartitionsDefinition,
     asset,
+    repository,
 )
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.partition_key_range import PartitionKeyRange
+from dagster._core.host_representation.external_data import external_asset_graph_from_defs
+from dagster._seven.compat.pendulum import create_pendulum_time
+
+
+def to_external_asset_graph(assets) -> AssetGraph:
+    @repository
+    def repo():
+        return assets
+
+    external_asset_nodes = external_asset_graph_from_defs(
+        repo.get_all_pipelines(), source_assets_by_key={}
+    )
+    return AssetGraph.from_external_assets(external_asset_nodes)
 
 
 def test_basics():
@@ -27,14 +47,21 @@ def test_basics():
     def asset3(asset1, asset2):
         ...
 
-    asset_graph = AssetGraph.from_assets([asset0, asset1, asset2, asset3])
-    assert asset_graph.all_asset_keys == {asset0.key, asset1.key, asset2.key, asset3.key}
-    assert not asset_graph.is_partitioned(asset0.key)
-    assert asset_graph.is_partitioned(asset1.key)
-    assert asset_graph.have_same_partitioning(asset1.key, asset2.key)
-    assert not asset_graph.have_same_partitioning(asset1.key, asset3.key)
-    assert asset_graph.get_children(asset0.key) == {asset1.key, asset2.key}
-    assert asset_graph.get_parents(asset3.key) == {asset1.key, asset2.key}
+    assets = [asset0, asset1, asset2, asset3]
+    internal_asset_graph = AssetGraph.from_assets(assets)
+    external_asset_graph = to_external_asset_graph(assets)
+
+    def assert_stuff(asset_graph):
+        assert asset_graph.all_asset_keys == {asset0.key, asset1.key, asset2.key, asset3.key}
+        assert not asset_graph.is_partitioned(asset0.key)
+        assert asset_graph.is_partitioned(asset1.key)
+        assert asset_graph.have_same_partitioning(asset1.key, asset2.key)
+        assert not asset_graph.have_same_partitioning(asset1.key, asset3.key)
+        assert asset_graph.get_children(asset0.key) == {asset1.key, asset2.key}
+        assert asset_graph.get_parents(asset3.key) == {asset1.key, asset2.key}
+
+    assert_stuff(internal_asset_graph)
+    assert_stuff(external_asset_graph)
 
 
 def test_get_children_partitions_unpartitioned_parent_partitioned_child():
@@ -46,8 +73,12 @@ def test_get_children_partitions_unpartitioned_parent_partitioned_child():
     def child(parent):
         ...
 
-    asset_graph = AssetGraph.from_assets([parent, child])
-    assert asset_graph.get_children_partitions(parent.key) == set(
+    internal_asset_graph = AssetGraph.from_assets([parent, child])
+    external_asset_graph = to_external_asset_graph([parent, child])
+    assert internal_asset_graph.get_children_partitions(parent.key) == set(
+        [AssetKeyPartitionKey(child.key, "a"), AssetKeyPartitionKey(child.key, "b")]
+    )
+    assert external_asset_graph.get_children_partitions(parent.key) == set(
         [AssetKeyPartitionKey(child.key, "a"), AssetKeyPartitionKey(child.key, "b")]
     )
 
@@ -61,8 +92,12 @@ def test_get_parent_partitions_unpartitioned_child_partitioned_parent():
     def child(parent):
         ...
 
-    asset_graph = AssetGraph.from_assets([parent, child])
-    assert asset_graph.get_parents_partitions(child.key) == set(
+    internal_asset_graph = AssetGraph.from_assets([parent, child])
+    external_asset_graph = to_external_asset_graph([parent, child])
+    assert internal_asset_graph.get_parents_partitions(child.key) == set(
+        [AssetKeyPartitionKey(parent.key, "a"), AssetKeyPartitionKey(parent.key, "b")]
+    )
+    assert external_asset_graph.get_parents_partitions(child.key) == set(
         [AssetKeyPartitionKey(parent.key, "a"), AssetKeyPartitionKey(parent.key, "b")]
     )
 
@@ -76,8 +111,16 @@ def test_get_children_partitions_fan_out():
     def child(parent):
         ...
 
-    asset_graph = AssetGraph.from_assets([parent, child])
-    assert asset_graph.get_children_partitions(parent.key, "2022-01-03") == set(
+    internal_asset_graph = AssetGraph.from_assets([parent, child])
+    external_asset_graph = to_external_asset_graph([parent, child])
+    assert internal_asset_graph.get_children_partitions(parent.key, "2022-01-03") == set(
+        [
+            AssetKeyPartitionKey(child.key, f"2022-01-03-{str(hour).zfill(2)}:00")
+            for hour in range(24)
+        ]
+    )
+
+    assert external_asset_graph.get_children_partitions(parent.key, "2022-01-03") == set(
         [
             AssetKeyPartitionKey(child.key, f"2022-01-03-{str(hour).zfill(2)}:00")
             for hour in range(24)
@@ -94,10 +137,84 @@ def test_get_parent_partitions_fan_in():
     def child(parent):
         ...
 
-    asset_graph = AssetGraph.from_assets([parent, child])
-    assert asset_graph.get_parents_partitions(child.key, "2022-01-03") == set(
+    internal_asset_graph = AssetGraph.from_assets([parent, child])
+    external_asset_graph = to_external_asset_graph([parent, child])
+    assert internal_asset_graph.get_parents_partitions(child.key, "2022-01-03") == set(
         [
             AssetKeyPartitionKey(parent.key, f"2022-01-03-{str(hour).zfill(2)}:00")
             for hour in range(24)
         ]
     )
+    assert external_asset_graph.get_parents_partitions(child.key, "2022-01-03") == set(
+        [
+            AssetKeyPartitionKey(parent.key, f"2022-01-03-{str(hour).zfill(2)}:00")
+            for hour in range(24)
+        ]
+    )
+
+
+def test_get_parent_partitions_non_default_partition_mapping():
+    @asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
+    def parent():
+        ...
+
+    @asset(ins={"parent": AssetIn(partition_mapping=LastPartitionMapping())})
+    def child(parent):
+        ...
+
+    internal_asset_graph = AssetGraph.from_assets([parent, child])
+    external_asset_graph = to_external_asset_graph([parent, child])
+
+    with pendulum.test(create_pendulum_time(year=2022, month=1, day=3, hour=4)):
+        assert internal_asset_graph.get_parents_partitions(child.key) == {
+            AssetKeyPartitionKey(parent.key, "2022-01-02")
+        }
+        assert external_asset_graph.get_parents_partitions(child.key) == {
+            AssetKeyPartitionKey(parent.key, "2022-01-02")
+        }
+
+
+def test_custom_unsupported_partition_mapping():
+    class TrailingWindowPartitionMapping(PartitionMapping):
+        def get_upstream_partitions_for_partition_range(
+            self, downstream_partition_key_range, downstream_partitions_def, upstream_partitions_def
+        ) -> PartitionKeyRange:
+            assert downstream_partitions_def
+            assert upstream_partitions_def
+
+            start, end = downstream_partition_key_range
+            return PartitionKeyRange(str(max(1, int(start) - 1)), end)
+
+        def get_downstream_partitions_for_partition_range(
+            self, upstream_partition_key_range, downstream_partitions_def, upstream_partitions_def
+        ) -> PartitionKeyRange:
+            raise NotImplementedError()
+
+    @asset(partitions_def=StaticPartitionsDefinition(["1", "2", "3"]))
+    def parent():
+        ...
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="Non-built-in PartitionMappings, such as TrailingWindowPartitionMapping are "
+        "deprecated and will not work with asset reconciliation. The built-in partition mappings "
+        "are AllPartitionMapping, IdentityPartitionMapping",
+    ):
+
+        @asset(
+            partitions_def=StaticPartitionsDefinition(["1", "2", "3"]),
+            ins={"parent": AssetIn(partition_mapping=TrailingWindowPartitionMapping())},
+        )
+        def child(parent):
+            ...
+
+    internal_asset_graph = AssetGraph.from_assets([parent, child])
+    external_asset_graph = to_external_asset_graph([parent, child])
+    assert internal_asset_graph.get_parents_partitions(child.key, "2") == {
+        AssetKeyPartitionKey(parent.key, "1"),
+        AssetKeyPartitionKey(parent.key, "2"),
+    }
+    # external falls back to default PartitionMapping
+    assert external_asset_graph.get_parents_partitions(child.key, "2") == {
+        AssetKeyPartitionKey(parent.key, "2")
+    }


### PR DESCRIPTION
### Summary & Motivation

This will enable the asset reconciliation sensor to become the asset reconciliation daemon and allow projected logical version logic in host processes to work with partitions.

### How I Tested These Changes
