### PR TITLE
coerce cronSchedule to str

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -57,7 +57,9 @@ class GrapheneSchedule(graphene.ObjectType):
 
         super().__init__(
             name=external_schedule.name,
-            cron_schedule=external_schedule.cron_schedule,
+            cron_schedule=str(
+                external_schedule.cron_schedule
+            ),  # can be sequence, coercing to str for now
             pipeline_name=external_schedule.pipeline_name,
             solid_selection=external_schedule.solid_selection,
             mode=external_schedule.mode,


### PR DESCRIPTION

### How I Tested These Changes

`dagit -f /tmp/repro.py` containing: 

```
from dagster import schedule, job, repository

@job
def empty():
    pass

@schedule(
    job_name="empty",
    cron_schedule=["0 0 * * 4", "0 0 * * 5", "0 0,12 * * 5"],
    execution_timezone="UTC",
)
def sched(context):
    return {}

@repository
def repo():
    return [sched, empty]
```
