### PR TITLE
fix inaccurate staleness for assets that were materialized before log…

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -10,7 +10,7 @@ import {GraphQueryItem} from '../app/GraphQueryImpl';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
 import {LaunchAssetObservationButton} from '../assets/LaunchAssetObservationButton';
-import {isAssetStale} from '../assets/StaleTag';
+import {isAssetMissing, isAssetStale} from '../assets/StaleTag';
 import {AssetKey} from '../assets/types';
 import {SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
@@ -434,7 +434,11 @@ export const AssetGraphExplorerWithData: React.FC<
                   ? selectedGraphNodes
                   : Object.values(assetGraphData.nodes)
                 )
-                  .filter((a) => !a.definition.isSource && isAssetStale(liveDataByNode[a.id]))
+                  .filter(
+                    (a) =>
+                      !a.definition.isSource &&
+                      (isAssetMissing(liveDataByNode[a.id]) || isAssetStale(liveDataByNode[a.id])),
+                  )
                   .map((n) => n.assetKey)}
               />
             </Box>

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -10,6 +10,7 @@ import {GraphQueryItem} from '../app/GraphQueryImpl';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
 import {LaunchAssetObservationButton} from '../assets/LaunchAssetObservationButton';
+import {isAssetStale} from '../assets/StaleTag';
 import {AssetKey} from '../assets/types';
 import {SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
@@ -37,14 +38,7 @@ import {AssetGroupNode} from './AssetGroupNode';
 import {AssetNode, AssetNodeMinimal} from './AssetNode';
 import {AssetNodeLink} from './ForeignNode';
 import {SidebarAssetInfo} from './SidebarAssetInfo';
-import {
-  GraphData,
-  graphHasCycles,
-  LiveData,
-  GraphNode,
-  tokenForAssetKey,
-  LiveDataForNode,
-} from './Utils';
+import {GraphData, graphHasCycles, LiveData, GraphNode, tokenForAssetKey} from './Utils';
 import {AssetGraphLayout} from './layout';
 import {AssetGraphQuery_assetNodes} from './types/AssetGraphQuery';
 import {AssetGraphFetchScope, useAssetGraphData} from './useAssetGraphData';
@@ -67,11 +61,6 @@ interface Props {
 
 export const MINIMAL_SCALE = 0.5;
 export const EXPERIMENTAL_SCALE = 0.1;
-
-const includeInMaterializeAll = (liveData?: LiveDataForNode) =>
-  liveData &&
-  liveData?.currentLogicalVersion !== 'INITIAL' &&
-  liveData.currentLogicalVersion !== liveData.projectedLogicalVersion;
 
 export const AssetGraphExplorer: React.FC<Props> = (props) => {
   const {
@@ -445,9 +434,7 @@ export const AssetGraphExplorerWithData: React.FC<
                   ? selectedGraphNodes
                   : Object.values(assetGraphData.nodes)
                 )
-                  .filter(
-                    (a) => !a.definition.isSource && includeInMaterializeAll(liveDataByNode[a.id]),
-                  )
+                  .filter((a) => !a.definition.isSource && isAssetStale(liveDataByNode[a.id]))
                   .map((n) => n.assetKey)}
               />
             </Box>

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -69,7 +69,9 @@ export const MINIMAL_SCALE = 0.5;
 export const EXPERIMENTAL_SCALE = 0.1;
 
 const includeInMaterializeAll = (liveData?: LiveDataForNode) =>
-  liveData && liveData.currentLogicalVersion !== liveData.projectedLogicalVersion;
+  liveData &&
+  liveData?.currentLogicalVersion !== 'INITIAL' &&
+  liveData.currentLogicalVersion !== liveData.projectedLogicalVersion;
 
 export const AssetGraphExplorer: React.FC<Props> = (props) => {
   const {

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -184,7 +184,7 @@ export const AssetNodeStatusRow: React.FC<{
     );
   }
 
-  if (currentLogicalVersion !== projectedLogicalVersion) {
+  if (currentLogicalVersion !== 'INITIAL' && currentLogicalVersion !== projectedLogicalVersion) {
     return (
       <Box
         padding={{horizontal: 8}}
@@ -240,7 +240,8 @@ export const AssetNodeMinimal: React.FC<{
               ? Colors.Red50
               : !liveData?.lastMaterialization
               ? Colors.Gray100
-              : liveData?.currentLogicalVersion !== liveData?.projectedLogicalVersion
+              : liveData?.currentLogicalVersion !== 'INITIAL' &&
+                liveData?.currentLogicalVersion !== liveData?.projectedLogicalVersion
               ? Colors.Yellow50
               : Colors.Green50
           }

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import styled from 'styled-components/macro';
 
 import {withMiddleTruncation} from '../app/Util';
+import {isAssetStale} from '../assets/StaleTag';
 import {OpTags} from '../graph/OpTags';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';
@@ -147,13 +148,7 @@ export const AssetNodeStatusRow: React.FC<{
     );
   }
 
-  const {
-    currentLogicalVersion,
-    projectedLogicalVersion,
-    lastMaterialization,
-    runWhichFailedToMaterialize,
-    freshnessInfo,
-  } = liveData;
+  const {lastMaterialization, runWhichFailedToMaterialize, freshnessInfo} = liveData;
   const late = freshnessInfo && (freshnessInfo.currentMinutesLate || 0) > 0;
 
   if (runWhichFailedToMaterialize || late) {
@@ -184,7 +179,7 @@ export const AssetNodeStatusRow: React.FC<{
     );
   }
 
-  if (currentLogicalVersion !== 'INITIAL' && currentLogicalVersion !== projectedLogicalVersion) {
+  if (isAssetStale(liveData)) {
     return (
       <Box
         padding={{horizontal: 8}}
@@ -240,8 +235,7 @@ export const AssetNodeMinimal: React.FC<{
               ? Colors.Red50
               : !liveData?.lastMaterialization
               ? Colors.Gray100
-              : liveData?.currentLogicalVersion !== 'INITIAL' &&
-                liveData?.currentLogicalVersion !== liveData?.projectedLogicalVersion
+              : isAssetStale(liveData)
               ? Colors.Yellow50
               : Colors.Green50
           }
@@ -250,7 +244,7 @@ export const AssetNodeMinimal: React.FC<{
               ? Colors.Red500
               : !liveData?.lastMaterialization
               ? Colors.Gray500
-              : liveData?.currentLogicalVersion !== liveData?.projectedLogicalVersion
+              : isAssetStale(liveData)
               ? Colors.Yellow500
               : Colors.Green500
           }

--- a/js_modules/dagit/packages/core/src/assets/StaleTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/StaleTag.tsx
@@ -3,9 +3,13 @@ import React from 'react';
 
 import {LiveDataForNode} from '../asset-graph/Utils';
 
+export const isAssetMissing = (liveData?: LiveDataForNode) =>
+  liveData && liveData.currentLogicalVersion === null;
+
 export const isAssetStale = (liveData?: LiveDataForNode) =>
   liveData &&
-  liveData?.currentLogicalVersion !== 'INITIAL' &&
+  liveData.currentLogicalVersion !== null &&
+  liveData.currentLogicalVersion !== 'INITIAL' &&
   liveData.currentLogicalVersion !== liveData.projectedLogicalVersion;
 
 export const StaleTag: React.FC<{liveData?: LiveDataForNode; onClick?: () => void}> = ({

--- a/js_modules/dagit/packages/core/src/assets/StaleTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/StaleTag.tsx
@@ -7,6 +7,7 @@ export const StaleTag: React.FC<{liveData?: LiveDataForNode; onClick?: () => voi
   liveData,
   onClick,
 }) =>
+  liveData?.currentLogicalVersion !== 'INITIAL' &&
   liveData?.currentLogicalVersion !== liveData?.projectedLogicalVersion ? (
     <Box onClick={onClick}>
       <BaseTag

--- a/js_modules/dagit/packages/core/src/assets/StaleTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/StaleTag.tsx
@@ -3,12 +3,16 @@ import React from 'react';
 
 import {LiveDataForNode} from '../asset-graph/Utils';
 
+export const isAssetStale = (liveData?: LiveDataForNode) =>
+  liveData &&
+  liveData?.currentLogicalVersion !== 'INITIAL' &&
+  liveData.currentLogicalVersion !== liveData.projectedLogicalVersion;
+
 export const StaleTag: React.FC<{liveData?: LiveDataForNode; onClick?: () => void}> = ({
   liveData,
   onClick,
 }) =>
-  liveData?.currentLogicalVersion !== 'INITIAL' &&
-  liveData?.currentLogicalVersion !== liveData?.projectedLogicalVersion ? (
+  isAssetStale(liveData) ? (
     <Box onClick={onClick}>
       <BaseTag
         fillColor={Colors.Yellow50}


### PR DESCRIPTION
…ical versions were added

### Summary & Motivation

All assets that were materialized before the logical version change rolled out are marked "Stale" in Dagit.

### How I Tested These Changes

* Made a single-asset graph.
* Commented out the code that records the version tags.
* Materialized the asset.
* Noticed it was marked "Stale".
* Made these JS changes.
* Noticed it was marked "Materialized"