### PR TITLE
backcompat is_source_asset

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -326,7 +326,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         return self.graphName is not None
 
     def is_source_asset(self) -> bool:
-        return len(self._external_asset_node.job_names) == 0
+        return self._external_asset_node.is_source
 
     def resolve_assetMaterializations(
         self, graphene_info, **kwargs

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -326,7 +326,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         return self.graphName is not None
 
     def is_source_asset(self) -> bool:
-        return self._external_asset_node.is_source
+        return len(self._external_asset_node.job_names) == 0
 
     def resolve_assetMaterializations(
         self, graphene_info, **kwargs

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -876,12 +876,18 @@ class ExternalAssetNode(
         metadata_entries: Optional[Sequence[MetadataEntry]] = None,
         group_name: Optional[str] = None,
         freshness_policy: Optional[FreshnessPolicy] = None,
-        is_source: bool = False,
+        is_source: Optional[bool] = None,
         is_observable: bool = False,
     ):
         # backcompat logic to handle ExternalAssetNodes serialized without op_names/graph_name
         if not op_names:
             op_names = list(filter(None, [op_name]))
+
+        # backcompat logic to handle ExternalAssetNodes serialzied without is_source
+        if is_source is None:
+            # prior to this field being added, all non-source assets must be part of at least one
+            # job, and no source assets could be part of any job
+            is_source = len(job_names) == 0
 
         return super(ExternalAssetNode, cls).__new__(
             cls,

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -887,7 +887,7 @@ class ExternalAssetNode(
         if is_source is None:
             # prior to this field being added, all non-source assets must be part of at least one
             # job, and no source assets could be part of any job
-            is_source = len(job_names) == 0
+            is_source = len(job_names or []) == 0
 
         return super(ExternalAssetNode, cls).__new__(
             cls,


### PR DESCRIPTION
### Summary & Motivation

ExternalAssetNodes serialized on old versions of dagster will have is_source_asset=False

### How I Tested These Changes
