### PR TITLE
Lazy load run launcher

### DIFF
--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -167,7 +167,8 @@ def cleanup_test_instance(instance):
     # To avoid filesystem contention when we close the temporary directory, wait for
     # all runs to reach a terminal state, and close any subprocesses or threads
     # that might be accessing the run history DB.
-    instance.run_launcher.join()
+    if instance._run_launcher:
+        instance._run_launcher.join()
 
 
 TEST_PIPELINE_NAME = "_test_pipeline_"

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -349,8 +349,8 @@ def test_invalid_configurable_class():
     ):
         with instance_for_test(
             overrides={"run_launcher": {"module": "dagster", "class": "MadeUpRunLauncher"}}
-        ):
-            pass
+        ) as instance:
+            print(instance.run_launcher)  # pylint: disable=print-call
 
 
 def test_invalid_configurable_module():
@@ -368,8 +368,8 @@ def test_invalid_configurable_module():
                     "class": "MadeUpRunLauncher",
                 }
             }
-        ):
-            pass
+        ) as instance:
+            print(instance.run_launcher)  # pylint: disable=print-call
 
 
 @pytest.mark.parametrize("dirname", (".", ".."))
@@ -499,5 +499,5 @@ def test_configurable_class_missing_methods():
                     "class": "InvalidRunLauncher",
                 }
             }
-        ):
-            pass
+        ) as instance:
+            print(instance.run_launcher)  # pylint: disable=print-call

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_run_launcher_lazy_load.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_run_launcher_lazy_load.py
@@ -1,0 +1,64 @@
+# pylint: disable=redefined-outer-name
+
+
+import pytest
+
+from dagster._core.launcher import RunLauncher
+from dagster._core.test_utils import instance_for_test
+from dagster._serdes import ConfigurableClass
+
+
+class InitFailRunLauncher(RunLauncher, ConfigurableClass):
+    def __init__(self, inst_data=None):
+        super().__init__()
+        self._inst_data = inst_data
+        raise Exception("Expected init fail")
+
+    @property
+    def inst_data(self):
+        return self._inst_data
+
+    @classmethod
+    def config_type(cls):
+        return {}
+
+    @staticmethod
+    def from_config_value(inst_data, config_value):
+        return InitFailRunLauncher(inst_data=inst_data)
+
+    def launch_run(self, context):
+        ...
+
+    def resume_run(self, context):
+        ...
+
+    def join(self, timeout=30):
+        pass
+
+    def terminate(self, run_id):
+        raise NotImplementedError()
+
+    @property
+    def supports_resume_run(self):
+        return True
+
+    @property
+    def supports_check_run_worker_health(self):
+        return True
+
+    def check_run_worker_health(self, _run):
+        ...
+
+
+def test_lazy_load():
+    with instance_for_test(
+        overrides={
+            "run_launcher": {
+                "module": "dagster_tests.core_tests.instance_tests.test_run_launcher_lazy_load",
+                "class": "InitFailRunLauncher",
+                "config": {},
+            }
+        }
+    ) as instance:
+        with pytest.raises(Exception, match="Expected init fail"):
+            print(instance.run_launcher)  # pylint: disable=print-call

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_instance.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_instance.py
@@ -25,22 +25,22 @@ def test_run_task_kwargs(instance_cm):
 def test_invalid_kwargs_field(instance_cm):
 
     with pytest.raises(Exception, match="Found an unexpected key foo in run_task_kwargs"):
-        with instance_cm(config={"run_task_kwargs": {"foo": "bar"}}):
-            pass
+        with instance_cm(config={"run_task_kwargs": {"foo": "bar"}}) as instance:
+            print(instance.run_launcher)  # pylint: disable=print-call
 
     with pytest.raises(Exception):
         with instance_cm(
             config={"taskDefinition": "my-task-def"},
             match="Use the `taskDefinition` config field to pass in a task definition to run",
-        ):
-            pass
+        ) as instance:
+            print(instance.run_launcher)  # pylint: disable=print-call
 
     with pytest.raises(Exception):
         with instance_cm(
             config={"overrides": {"containerOverrides": {}}},
             match="Task overrides are set by the run launcher and cannot be set in run_task_kwargs.",
-        ):
-            pass
+        ) as instance:
+            print(instance.run_launcher)  # pylint: disable=print-call
 
 
 def test_task_definition_config(instance_cm, task_definition):
@@ -56,7 +56,7 @@ def test_task_definition_config(instance_cm, task_definition):
         with instance_cm(
             config={"task_definition": {"env": "FOO"}, "container_name": "dagster"}
         ) as instance:
-            pass
+            print(instance.run_launcher)  # pylint: disable=print-call
 
     with environ({"FOO": "dagster"}):
         with instance_cm(

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -518,18 +518,18 @@ def test_launching_custom_task_definition(
     family = task_definition["family"]
 
     # The task definition doesn't exist
-    with pytest.raises(Exception), instance_cm({"task_definition": "does not exist"}):
-        pass
+    with pytest.raises(Exception), instance_cm({"task_definition": "does not exist"}) as instance:
+        print(instance.run_launcher)  # pylint: disable=print-call
 
     # The task definition doesn't include the default container name
-    with pytest.raises(CheckError), instance_cm({"task_definition": family}):
-        pass
+    with pytest.raises(CheckError), instance_cm({"task_definition": family}) as instance:
+        print(instance.run_launcher)  # pylint: disable=print-call
 
     # The task definition doesn't include the container name
     with pytest.raises(CheckError), instance_cm(
         {"task_definition": family, "container_name": "does not exist"}
-    ):
-        pass
+    ) as instance:
+        print(instance.run_launcher)  # pylint: disable=print-call
 
     # You can provide a family or a task definition ARN
     with instance_cm(

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
@@ -355,8 +355,8 @@ def test_cant_combine_network_and_networks(aws_env):
                     "config": launcher_config,
                 }
             }
-        ):
-            pass
+        ) as instance:
+            print(instance.run_launcher)  # pylint: disable=print-call
 
 
 def test_terminate(aws_env):


### PR DESCRIPTION
Avoid erroring when we load an instance somewhere that doesn't need the run launcher and doesn't have the  deps to load it

Closes https://github.com/dagster-io/dagster/issues/9019