### PR TITLE
Add duckdb_pandas_io_manager API to avoid use of type handlers.

### DIFF
--- a/docs/content/integrations/dbt/using-dbt-with-dagster/part-three.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/part-three.mdx
@@ -111,16 +111,13 @@ from dagster_dbt import dbt_cli_resource
 from tutorial_dbt_dagster import assets
 from tutorial_dbt_dagster.assets import DBT_PROFILES, DBT_PROJECT_PATH
 
-from dagster_duckdb import build_duckdb_io_manager
-from dagster_duckdb_pandas import DuckDBPandasTypeHandler
+from dagster_duckdb_pandas import duckdb_pandas_io_manager
 
 from dagster import load_assets_from_package_module, repository, with_resources
 
 
 @repository
 def tutorial_dbt_dagster():
-    duckdb_io_manager = build_duckdb_io_manager([DuckDBPandasTypeHandler()])
-
     return with_resources(
         load_assets_from_package_module(assets),
         {
@@ -130,7 +127,7 @@ def tutorial_dbt_dagster():
                     "profiles_dir": DBT_PROFILES,
                 },
             ),
-            "io_manager": duckdb_io_manager.configured(
+            "io_manager": duckdb_pandas_io_manager.configured(
                 {"database": os.path.join(DBT_PROJECT_PATH, "tutorial.duckdb")}
             ),
         },

--- a/examples/assets_dbt_python/assets_dbt_python/repository.py
+++ b/examples/assets_dbt_python/assets_dbt_python/repository.py
@@ -2,8 +2,7 @@ import os
 
 from assets_dbt_python.assets import forecasting, raw_data
 from dagster_dbt import dbt_cli_resource, load_assets_from_dbt_project
-from dagster_duckdb import build_duckdb_io_manager
-from dagster_duckdb_pandas import DuckDBPandasTypeHandler
+from dagster_duckdb_pandas import duckdb_pandas_io_manager
 
 from dagster import (
     ScheduleDefinition,
@@ -48,12 +47,11 @@ forecast_job = define_asset_job("refresh_forecast_model_job", selection="*order_
 
 @repository
 def assets_dbt_python():
-    duckdb_io_manager = build_duckdb_io_manager(type_handlers=[DuckDBPandasTypeHandler()])
     return with_resources(
         dbt_assets + raw_data_assets + forecasting_assets,
         resource_defs={
             # this io_manager allows us to load dbt models as pandas dataframes
-            "io_manager": duckdb_io_manager.configured(
+            "io_manager": duckdb_pandas_io_manager.configured(
                 {"database": os.path.join(DBT_PROJECT_DIR, "example.duckdb")}
             ),
             # this io_manager is responsible for storing/loading our pickled machine learning model

--- a/examples/tutorial_dbt_dagster/tutorial_finished/tutorial_dbt_dagster/repository.py
+++ b/examples/tutorial_dbt_dagster/tutorial_finished/tutorial_dbt_dagster/repository.py
@@ -1,8 +1,7 @@
 import os
 
 from dagster_dbt import dbt_cli_resource
-from dagster_duckdb import build_duckdb_io_manager
-from dagster_duckdb_pandas import DuckDBPandasTypeHandler
+from dagster_duckdb_pandas import duckdb_pandas_io_manager
 from tutorial_dbt_dagster import assets
 from tutorial_dbt_dagster.assets import DBT_PROFILES, DBT_PROJECT_PATH
 
@@ -11,8 +10,6 @@ from dagster import load_assets_from_package_module, repository, with_resources
 
 @repository
 def tutorial_dbt_dagster():
-    duckdb_io_manager = build_duckdb_io_manager([DuckDBPandasTypeHandler()])
-
     return with_resources(
         load_assets_from_package_module(assets),
         {
@@ -22,7 +19,7 @@ def tutorial_dbt_dagster():
                     "profiles_dir": DBT_PROFILES,
                 },
             ),
-            "io_manager": duckdb_io_manager.configured(
+            "io_manager": duckdb_pandas_io_manager.configured(
                 {"database": os.path.join(DBT_PROJECT_PATH, "tutorial.duckdb")}
             ),
         },

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/__init__.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/__init__.py
@@ -1,1 +1,2 @@
 from .duckdb_pandas_type_handler import DuckDBPandasTypeHandler as DuckDBPandasTypeHandler
+from .duckdb_pandas_type_handler import duckdb_pandas_io_manager as duckdb_pandas_io_manager

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
@@ -1,7 +1,14 @@
 import pandas as pd
-from dagster_duckdb.io_manager import DuckDbClient, _connect_duckdb
+from dagster_duckdb.io_manager import DuckDbClient, _connect_duckdb, build_duckdb_io_manager
 
-from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
+from dagster import (
+    IOManagerDefinition,
+    InputContext,
+    MetadataValue,
+    OutputContext,
+    TableColumn,
+    TableSchema,
+)
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 
 
@@ -66,3 +73,69 @@ class DuckDBPandasTypeHandler(DbTypeHandler[pd.DataFrame]):
     @property
     def supported_types(self):
         return [pd.DataFrame]
+
+
+# Helper function used as a decorator below
+# The only purpose in doing this is so that
+# we have a symbol to hang the duckdb_pandas_io_manager
+# docblock off of. Otherwise we would just invoke
+# build_duckdb_io_manager directly and assign to module-scoped variable
+def wrap_io_manager(fn) -> IOManagerDefinition:
+    return fn()
+
+
+@wrap_io_manager
+def duckdb_pandas_io_manager():
+    """
+    An IO manager definition that reads inputs from and writes pandas dataframes to DuckDB.
+
+    Returns:
+        IOManagerDefinition
+
+    Examples:
+
+        .. code-block:: python
+
+            from dagster_duckdb_pandas import duckdb_pandas_io_manager
+
+            @asset(
+                key_prefix=["my_schema"]  # will be used as the schema in DuckDB
+            )
+            def my_table() -> pd.DataFrame:  # the name of the asset will be the table name
+                ...
+
+            @repository
+            def my_repo():
+                return with_resources(
+                    [my_table],
+                    {"io_manager": duckdb_pandas_io_manager.configured({"database": "my_db.duckdb"})}
+                )
+
+        If you do not provide a schema, Dagster will determine a schema based on the assets and ops using
+        the IO Manager. For assets, the schema will be determined from the asset key.
+        For ops, the schema can be specified by including a "schema" entry in output metadata. If "schema" is not provided
+        via config or on the asset/op, "public" will be used for the schema.
+
+        .. code-block:: python
+
+            @op(
+                out={"my_table": Out(metadata={"schema": "my_schema"})}
+            )
+            def make_my_table() -> pd.DataFrame:
+                # the returned value will be stored at my_schema.my_table
+                ...
+
+        To only use specific columns of a table as input to a downstream op or asset, add the metadata "columns" to the
+        In or AssetIn.
+
+        .. code-block:: python
+
+            @asset(
+                ins={"my_table": AssetIn("my_table", metadata={"columns": ["a"]})}
+            )
+            def my_table_a(my_table: pd.DataFrame) -> pd.DataFrame:
+                # my_table will just contain the data from column "a"
+                ...
+
+    """
+    return build_duckdb_io_manager([DuckDBPandasTypeHandler()])

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -3,8 +3,7 @@ import os
 import duckdb
 import pandas as pd
 import pytest
-from dagster_duckdb.io_manager import build_duckdb_io_manager
-from dagster_duckdb_pandas import DuckDBPandasTypeHandler
+from dagster_duckdb_pandas import duckdb_pandas_io_manager
 
 from dagster import AssetIn, DailyPartitionsDefinition, Out, asset, graph, materialize, op
 from dagster._check import CheckError
@@ -26,9 +25,8 @@ def add_one_to_dataframe():
 
 
 def test_duckdb_io_manager_with_ops(tmp_path):
-    duckdb_io_manager = build_duckdb_io_manager([DuckDBPandasTypeHandler()])
     resource_defs = {
-        "io_manager": duckdb_io_manager.configured(
+        "io_manager": duckdb_pandas_io_manager.configured(
             {"database": os.path.join(tmp_path, "unit_test.duckdb")}
         ),
     }
@@ -62,9 +60,8 @@ def b_plus_one(b_df: pd.DataFrame):
 
 
 def test_duckdb_io_manager_with_assets(tmp_path):
-    duckdb_io_manager = build_duckdb_io_manager([DuckDBPandasTypeHandler()])
     resource_defs = {
-        "io_manager": duckdb_io_manager.configured(
+        "io_manager": duckdb_pandas_io_manager.configured(
             {"database": os.path.join(tmp_path, "unit_test.duckdb")}
         ),
     }
@@ -91,9 +88,8 @@ def b_plus_one_columns(b_df: pd.DataFrame):
 
 
 def test_loading_columns(tmp_path):
-    duckdb_io_manager = build_duckdb_io_manager([DuckDBPandasTypeHandler()])
     resource_defs = {
-        "io_manager": duckdb_io_manager.configured(
+        "io_manager": duckdb_pandas_io_manager.configured(
             {"database": os.path.join(tmp_path, "unit_test.duckdb")}
         ),
     }
@@ -127,9 +123,8 @@ def not_supported():
 
 
 def test_not_supported_type(tmp_path):
-    duckdb_io_manager = build_duckdb_io_manager([DuckDBPandasTypeHandler()])
     resource_defs = {
-        "io_manager": duckdb_io_manager.configured(
+        "io_manager": duckdb_pandas_io_manager.configured(
             {"database": os.path.join(tmp_path, "unit_test.duckdb")}
         ),
     }
@@ -162,7 +157,7 @@ def daily_partitioned(context):
 
 
 def test_partitioned_asset(tmp_path):
-    duckdb_io_manager = build_duckdb_io_manager([DuckDBPandasTypeHandler()]).configured(
+    duckdb_io_manager = duckdb_pandas_io_manager.configured(
         {"database": os.path.join(tmp_path, "unit_test.duckdb")}
     )
     resource_defs = {"io_manager": duckdb_io_manager}


### PR DESCRIPTION
Similar to #10615 but for duckdb. This is a simpler API and avoids introducing the user to the notion of a type handler

Test Plan: Unit tests
