### PR TITLE
Propagate environment variables through container overrides on ECSRunLauncher

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -316,10 +316,13 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
 
         task_overrides = self._get_task_overrides(run)
 
+        environment = self._environment(container_context)
+
         container_overrides: List[Dict[str, Any]] = [
             {
                 "name": self._get_container_name(container_context),
                 "command": command,
+                "environment": environment,
                 # containerOverrides expects cpu/memory as integers
                 **{k: int(v) for k, v in cpu_and_memory_overrides.items()},
             }


### PR DESCRIPTION
### Summary & Motivation

When using ECSRunLauncher with a fixed task_definition via config, environment variables set through env_vars config are not propagated to worker ecs task. It behaves as expected if task definition is synthesized from launching task, as the variables are included only in the task definition.

This change sets the propagated environment variables also via containerOverrides on `run_task`.

### How I Tested These Changes

Ran dag on our internal deployment with `dagster.yaml` containing something like this:

```yaml
run_launcher:
  module: dagster_aws.ecs
  class: EcsRunLauncher
  config:
    env_vars:
      - A_VERY_IMPORTANT_VARIABLE
    task_definition:
      env: WORKER_TASK_DEFINITION
```