### PR TITLE
[dagit] Increase border radius on asset and op nodes to match new tags

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -195,7 +195,7 @@ export const AssetNodeStatusRow: React.FC<{
   return (
     <Box
       padding={{horizontal: 8}}
-      style={{borderBottomLeftRadius: 4, borderBottomRightRadius: 4, height: 24}}
+      style={{borderBottomLeftRadius: 7, borderBottomRightRadius: 7, height: 24}}
       flex={{justifyContent: 'space-between', alignItems: 'center'}}
       background={Colors.Green50}
     >
@@ -339,7 +339,7 @@ export const AssetNodeBox = styled.div<{$isSource: boolean; $selected: boolean}>
       : `outline: 3px solid ${p.$selected ? Colors.Blue200 : 'transparent'}`};
 
   background: ${Colors.White};
-  border-radius: 5px;
+  border-radius: 8px;
   position: relative;
   &:hover {
     box-shadow: rgba(0, 0, 0, 0.12) 0px 2px 12px 0px;
@@ -354,8 +354,8 @@ const Name = styled.div<{$isSource: boolean}>`
   padding: 3px 6px;
   background: ${(p) => (p.$isSource ? Colors.Gray100 : Colors.Blue50)};
   font-family: ${FontFamily.monospace};
-  border-top-left-radius: 5px;
-  border-top-right-radius: 5px;
+  border-top-left-radius: 7px;
+  border-top-right-radius: 7px;
   font-weight: 600;
   gap: 4px;
 `;
@@ -408,12 +408,14 @@ const Description = styled.div`
   text-overflow: ellipsis;
   color: ${Colors.Gray700};
   border-top: 1px solid ${Colors.Blue50};
+  background: ${Colors.White};
   font-size: 12px;
 `;
 
 const Stats = styled.div`
   padding: 4px 8px;
   border-top: 1px solid ${Colors.Blue50};
+  background: ${Colors.White};
   font-size: 12px;
   line-height: 20px;
 `;

--- a/js_modules/dagit/packages/core/src/graph/OpIOBox.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpIOBox.tsx
@@ -87,10 +87,14 @@ export const OpIOBox: React.FC<OpIOBoxProps> = ({
 const OpIOContainer = styled.div<{$colorKey: string; $highlighted: boolean}>`
   display: inline-flex;
   align-items: center;
-  border-top-right-radius: 6px;
-  border-bottom-right-radius: 6px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   background: ${(p) => (p.$highlighted ? 'rgba(255, 255, 255, 1)' : 'rgba(255, 255, 255, 0.75)')};
   font-size: 12px;
+
+  &:last-child {
+    border-bottom-left-radius: 8px;
+  }
 
   .circle {
     width: 14px;

--- a/js_modules/dagit/packages/core/src/graph/OpNode.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpNode.tsx
@@ -148,17 +148,6 @@ export class OpNode extends React.Component<IOpNodeProps> {
           />
         ))}
 
-        {definition.outputDefinitions.map((item, idx) => (
-          <OpIOBox
-            {...this.props}
-            {...metadataForIO(item, invocation)}
-            key={idx}
-            item={item}
-            layoutInfo={layout.outputs[item.name]}
-            colorKey="output"
-          />
-        ))}
-
         <div className="node-box" style={{...position(layout.op)}}>
           <div className="name">
             {!minified && <Icon name="op" size={16} />}
@@ -185,6 +174,17 @@ export class OpNode extends React.Component<IOpNodeProps> {
             tags={tags}
           />
         )}
+
+        {definition.outputDefinitions.map((item, idx) => (
+          <OpIOBox
+            {...this.props}
+            {...metadataForIO(item, invocation)}
+            key={idx}
+            item={item}
+            layoutInfo={layout.outputs[item.name]}
+            colorKey="output"
+          />
+        ))}
       </NodeContainer>
     );
   }
@@ -326,7 +326,7 @@ const NodeContainer = styled.div<{
   pointer-events: auto;
 
   .highlight-box {
-    border-radius: 6px;
+    border-radius: 13px;
     background: ${(p) => (p.$selected ? NodeHighlightColors.Background : 'transparent')};
   }
   .node-box {
@@ -338,7 +338,7 @@ const NodeContainer = styled.div<{
         : '2px solid #dcd5ca'};
 
     border-width: ${(p) => (p.$minified ? '3px' : '2px')};
-    border-radius: 5px;
+    border-radius: 8px;
     background: ${(p) => (p.$minified ? Colors.Gray50 : Colors.White)};
   }
   .composite-marker {
@@ -366,8 +366,8 @@ const NodeContainer = styled.div<{
     padding: 4px ${(p) => (p.$minified ? '8px' : '3px')};
     font-size: ${(p) => (p.$minified ? '32px' : '14px')};
     font-family: ${FontFamily.monospace};
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px;
     align-items: center;
     font-weight: 600;
     .label {
@@ -398,8 +398,8 @@ const NodeContainer = styled.div<{
     text-overflow: ellipsis;
     background: #f5f3ef;
     border-top: 1px solid #e6e1d8;
-    border-bottom-left-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
     font-size: 12px;
   }
 `;


### PR DESCRIPTION
### Summary & Motivation
https://linear.app/elementl/issue/DAGIT-206/increase-the-asset-node-border-radius-from-5px-to-8px

<img width="459" alt="image" src="https://user-images.githubusercontent.com/1037212/203108277-a6b5b1db-42bc-4800-9a28-032b61189e62.png">
<img width="382" alt="image" src="https://user-images.githubusercontent.com/1037212/203108300-6eee0023-c4c1-4a6e-866b-1a95c3865b38.png">

### How I Tested These Changes
