### PR TITLE
[dagit] Fix asset details page compacting badly on small screens

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetEventMetadataEntriesTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventMetadataEntriesTable.tsx
@@ -25,64 +25,72 @@ export const AssetEventMetadataEntriesTable: React.FC<{
   const {metadataEntries, timestamp} = event;
 
   return (
-    <DetailsTable>
-      <tbody>
-        {metadataEntries.map((entry) => (
-          <tr key={`metadata-${entry.label}`}>
-            <td>
-              <Mono>{entry.label}</Mono>
-            </td>
-            <td>
-              <Mono>
-                <MetadataEntry entry={entry} expandSmallValues={true} />
-              </Mono>
-            </td>
-            <td style={{opacity: 0.7}}>{entry.description}</td>
-          </tr>
-        ))}
+    <AssetEventMetadataScrollContainer>
+      <AssetEventMetadataTable>
+        <tbody>
+          {metadataEntries.map((entry) => (
+            <tr key={`metadata-${entry.label}`}>
+              <td>
+                <Mono>{entry.label}</Mono>
+              </td>
+              <td>
+                <Mono>
+                  <MetadataEntry entry={entry} expandSmallValues={true} />
+                </Mono>
+              </td>
+              <td style={{opacity: 0.7}}>{entry.description}</td>
+            </tr>
+          ))}
 
-        {(observations || []).map((obs) => (
-          <React.Fragment key={obs.timestamp}>
-            {obs.metadataEntries.map((entry) => (
-              <tr key={`metadata-${obs.timestamp}-${entry.label}`}>
-                <td>
-                  <Mono>{entry.label}</Mono>
-                </td>
-                <td>
-                  <Mono>
-                    <MetadataEntry entry={entry} expandSmallValues={true} />
-                  </Mono>
-                </td>
-                <td style={{opacity: 0.7}}>
-                  <Box flex={{gap: 8}}>
-                    <Icon name="observation" size={16} style={{marginTop: 2}} />
-                    <span>
-                      {`${obs.stepKey} in `}
-                      <Link to={`/instance/runs/${obs.runId}?timestamp=${obs.timestamp}`}>
-                        <Mono>{titleForRun({runId: obs.runId})}</Mono>
-                      </Link>
-                    </span>
-                  </Box>
-                  <Caption style={{marginLeft: 24}}>
-                    {` (${moment(Number(obs.timestamp)).from(Number(timestamp), true)} later)`}
-                  </Caption>
-                  {entry.description}
-                </td>
-              </tr>
-            ))}
-          </React.Fragment>
-        ))}
-      </tbody>
-    </DetailsTable>
+          {(observations || []).map((obs) => (
+            <React.Fragment key={obs.timestamp}>
+              {obs.metadataEntries.map((entry) => (
+                <tr key={`metadata-${obs.timestamp}-${entry.label}`}>
+                  <td>
+                    <Mono>{entry.label}</Mono>
+                  </td>
+                  <td>
+                    <Mono>
+                      <MetadataEntry entry={entry} expandSmallValues={true} />
+                    </Mono>
+                  </td>
+                  <td style={{opacity: 0.7}}>
+                    <Box flex={{gap: 8}}>
+                      <Icon name="observation" size={16} style={{marginTop: 2}} />
+                      <span>
+                        {`${obs.stepKey} in `}
+                        <Link to={`/instance/runs/${obs.runId}?timestamp=${obs.timestamp}`}>
+                          <Mono>{titleForRun({runId: obs.runId})}</Mono>
+                        </Link>
+                      </span>
+                    </Box>
+                    <Caption style={{marginLeft: 24}}>
+                      {` (${moment(Number(obs.timestamp)).from(Number(timestamp), true)} later)`}
+                    </Caption>
+                    {entry.description}
+                  </td>
+                </tr>
+              ))}
+            </React.Fragment>
+          ))}
+        </tbody>
+      </AssetEventMetadataTable>
+    </AssetEventMetadataScrollContainer>
   );
 };
 
-const DetailsTable = styled.table`
+const AssetEventMetadataScrollContainer = styled.div`
+  width: 100%;
+  overflow-x: auto;
+`;
+
+const AssetEventMetadataTable = styled.table`
   width: 100%;
   border-spacing: 0;
   border-collapse: collapse;
   tr td:first-child {
     max-width: 300px;
+    word-wrap: break-word;
     width: 25%;
   }
   tr td {

--- a/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
@@ -139,7 +139,7 @@ export const AssetEvents: React.FC<Props> = ({
         tabIndex={-1}
       >
         <Box
-          style={{display: 'flex', flex: 1}}
+          style={{display: 'flex', flex: 1, minWidth: 200}}
           flex={{direction: 'column'}}
           background={Colors.Gray50}
         >
@@ -158,7 +158,7 @@ export const AssetEvents: React.FC<Props> = ({
         </Box>
 
         <Box
-          style={{flex: 3}}
+          style={{flex: 3, minWidth: 0}}
           flex={{direction: 'column'}}
           border={{side: 'left', color: Colors.KeylineGray, width: 1}}
         >

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
@@ -134,7 +134,7 @@ export const AssetPartitions: React.FC<Props> = ({
         {ranges.map((range, idx) => (
           <Box
             key={range.dimension.name}
-            style={{display: 'flex', flex: 1, paddingRight: 1}}
+            style={{display: 'flex', flex: 1, paddingRight: 1, minWidth: 200}}
             flex={{direction: 'column'}}
             border={{side: 'right', color: Colors.KeylineGray, width: 1}}
             background={Colors.Gray50}
@@ -179,7 +179,7 @@ export const AssetPartitions: React.FC<Props> = ({
           </Box>
         ))}
 
-        <Box style={{flex: 3}} flex={{direction: 'column'}}>
+        <Box style={{flex: 3, minWidth: 0}} flex={{direction: 'column'}}>
           {params.partition && focusedDimensionKeys.length === ranges.length ? (
             <AssetPartitionDetailLoader assetKey={assetKey} partitionKey={params.partition} />
           ) : (


### PR DESCRIPTION
### Summary & Motivation
https://linear.app/elementl/issue/DAGIT-219/[bug]-asset-detail-page-looks-broken-on-small-screens-partitions-only


<img width="547" alt="image" src="https://user-images.githubusercontent.com/1037212/203124796-f257305b-6149-4880-a011-8749ae31e0ed.png">
