### PR TITLE
[dagit] Move Workspace under Deployment

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppTopNav.test.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.test.tsx
@@ -88,7 +88,6 @@ describe('AppTopNav', () => {
         );
       });
 
-      expect(screen.getByText(/workspace/i)).toBeVisible();
       expect(
         screen.queryByRole('img', {
           name: /warning/i,
@@ -113,7 +112,6 @@ describe('AppTopNav', () => {
         );
       });
 
-      expect(screen.getByText(/workspace/i)).toBeVisible();
       expect(
         screen.getByRole('img', {
           name: /warning/i,
@@ -163,7 +161,6 @@ describe('AppTopNav', () => {
         );
       });
 
-      expect(screen.getByText(/workspace/i)).toBeVisible();
       const link = screen.getByRole('link', {name: /deployment/i});
       expect(within(link).queryByText(/warning/i)).toBeNull();
     });
@@ -201,7 +198,6 @@ describe('AppTopNav', () => {
         );
       });
 
-      expect(screen.getByText(/workspace/i)).toBeVisible();
       const link = screen.getByRole('link', {name: /deployment/i});
       expect(within(link).queryByText(/warning/i)).toBeNull();
     });

--- a/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
@@ -51,6 +51,7 @@ export const AppTopNav: React.FC<Props> = ({
         title: 'runs',
         element: (
           <ShortcutHandler
+            key="runs"
             onShortcut={() => history.push('/runs')}
             shortcutLabel="⌥2"
             shortcutFilter={(e) => e.altKey && e.code === 'Digit2'}
@@ -65,6 +66,7 @@ export const AppTopNav: React.FC<Props> = ({
         title: 'assets',
         element: (
           <ShortcutHandler
+            key="assets"
             onShortcut={() => history.push('/assets')}
             shortcutLabel="⌥3"
             shortcutFilter={(e) => e.altKey && e.code === 'Digit3'}
@@ -76,28 +78,13 @@ export const AppTopNav: React.FC<Props> = ({
         ),
       },
       {
-        title: 'workspace',
-        element: (
-          <ShortcutHandler
-            key="workspace"
-            onShortcut={() => history.push('/workspace')}
-            shortcutLabel="⌥4"
-            shortcutFilter={(e) => e.altKey && e.code === 'Digit4'}
-          >
-            <TopNavLink to="/workspace" data-cy="AppTopNav_WorkspaceLink">
-              Workspace
-            </TopNavLink>
-          </ShortcutHandler>
-        ),
-      },
-      {
         title: 'deployment',
         element: (
           <ShortcutHandler
             key="deployment"
             onShortcut={() => history.push('/code-locations')}
-            shortcutLabel="⌥5"
-            shortcutFilter={(e) => e.altKey && e.code === 'Digit5'}
+            shortcutLabel="⌥4"
+            shortcutFilter={(e) => e.altKey && e.code === 'Digit4'}
           >
             <TopNavLink
               to="/code-locations"
@@ -106,6 +93,7 @@ export const AppTopNav: React.FC<Props> = ({
                 const {pathname} = location;
                 return (
                   pathname.startsWith('/code-locations') ||
+                  pathname.startsWith('/workspace') ||
                   pathname.startsWith('/health') ||
                   pathname.startsWith('/config')
                 );
@@ -126,10 +114,8 @@ export const AppTopNav: React.FC<Props> = ({
     <AppTopNavContainer>
       <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
         <AppTopNavLogo />
-        <Box margin={{left: 8}}>
-          <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
-            {getNavLinks ? getNavLinks(navLinks()) : navLinks().map((link) => link.element)}
-          </Box>
+        <Box margin={{left: 8}} flex={{direction: 'row', alignItems: 'center', gap: 16}}>
+          {getNavLinks ? getNavLinks(navLinks()) : navLinks().map((link) => link.element)}
         </Box>
         {rightOfSearchBar}
       </Box>

--- a/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
@@ -31,6 +31,7 @@ export const InstanceTabs = <TData extends Record<string, any>>(props: Props<TDa
           to="/code-locations"
           icon={<WorkspaceStatus placeholder={false} />}
         />
+        <TabLink id="workspace" title="Workspace" to="/workspace" />
         <TabLink id="health" title={healthTitle} to="/health" icon={<InstanceWarningIcon />} />
         {canSeeConfig ? <TabLink id="config" title="Configuration" to="/config" /> : null}
       </Tabs>

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceHeader.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceHeader.tsx
@@ -26,7 +26,7 @@ export const WorkspaceHeader = <TData extends Record<string, any>>(props: Props<
         <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
           <Heading>
             <Link to="/workspace" style={{color: Colors.Dark}}>
-              Workspace
+              Deployment
             </Link>
           </Heading>
           <Heading>/</Heading>

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewWithGrid.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewWithGrid.tsx
@@ -14,6 +14,7 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
+import {InstanceTabs} from '../instance/InstanceTabs';
 
 import {DagsterRepoOption, useRepositoryOptions} from './WorkspaceContext';
 import {buildRepoAddress} from './buildRepoAddress';
@@ -74,7 +75,7 @@ export const WorkspaceOverviewWithGrid = () => {
 
   return (
     <Page>
-      <PageHeader title={<Heading>Workspace</Heading>} />
+      <PageHeader title={<Heading>Deployment</Heading>} tabs={<InstanceTabs tab="workspace" />} />
       {content()}
     </Page>
   );


### PR DESCRIPTION
### Summary & Motivation

Move the "Workspace" section of Dagit to be a tab under Deployment, and remove it from the top nav.

### How I Tested These Changes

Load Dagit, verify that the top nav and Deployment pages look correct. Navigate to some workspace objects, verify that "Deployment" is highlighted in the top nav.
