### PR TITLE
[dagit] Replace "Repository location" with "Code location"

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/RepositoryLocationStateObserver.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepositoryLocationStateObserver.tsx
@@ -66,9 +66,9 @@ export const RepositoryLocationStateObserver = () => {
           <Icon name="warning" color={Colors.Gray700} />
           <Caption color={Colors.Gray800}>
             {updatedLocations.length === 1
-              ? `Repository location ${updatedLocations[0]} has been updated,` // Be specific when there's only one repository location updated
-              : 'One or more repository locations have been updated,'}{' '}
-            and new data is available.{' '}
+              ? `Code location ${updatedLocations[0]} has been updated,` // Be specific when there's only one code location updated
+              : 'One or more code locations have been updated,'}
+            {' and new data is available. '}
             <ButtonLink
               color={{
                 link: Colors.Gray800,

--- a/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
@@ -207,9 +207,7 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
       type: 'warning',
       content: (
         <div style={{whiteSpace: 'nowrap'}}>{`${repoErrors.length} ${
-          repoErrors.length === 1
-            ? 'repository location failed to load'
-            : 'repository locations failed to load'
+          repoErrors.length === 1 ? 'code location failed to load' : 'code locations failed to load'
         }`}</div>
       ),
     };

--- a/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.test.tsx
@@ -100,7 +100,7 @@ describe('useRepositoryReloadLocation', () => {
     });
   });
 
-  it('surfaces repository location errors', async () => {
+  it('surfaces code location errors', async () => {
     const mocks = {
       RepositoryLocationOrLoadError: () => ({
         __typename: 'PythonError',
@@ -220,7 +220,7 @@ describe('useRepositoryReloadLocation', () => {
       }),
     };
 
-    // Set an error on the repository location and use the `LOADED` state from the
+    // Set an error on the code location and use the `LOADED` state from the
     // default mocks to end polling.
     rerender(
       <TestProvider apolloProps={{mocks: [defaultMocks, mocksWithError]}}>

--- a/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
@@ -167,7 +167,7 @@ export const useRepositoryLocationReload = ({
 
         // On success, show the successful toast, hide the dialog (if open), and reset Apollo.
         SharedToaster.show({
-          message: `${scope === 'location' ? 'Repository location' : 'Workspace'} reloaded!`,
+          message: `${scope === 'location' ? 'Code location' : 'Workspace'} reloaded!`,
           timeout: 3000,
           icon: 'check_circle',
           intent: Intent.SUCCESS,

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryLocationErrorDialog.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryLocationErrorDialog.tsx
@@ -18,7 +18,7 @@ export const RepositoryLocationErrorDialog: React.FC<Props> = (props) => {
   return (
     <Dialog
       icon="error"
-      title="Repository location error"
+      title="Code location error"
       isOpen={isOpen}
       canEscapeKeyClose={false}
       canOutsideClickClose={false}
@@ -42,7 +42,7 @@ export const RepositoryLocationNonBlockingErrorDialog: React.FC<Props> = (props)
   return (
     <Dialog
       icon="error"
-      title="Repository location error"
+      title="Code location error"
       isOpen={isOpen}
       style={{width: '90%'}}
       onClose={onDismiss}
@@ -66,8 +66,8 @@ const ErrorContents: React.FC<{
 }> = ({location, error}) => (
   <>
     <Box margin={{bottom: 12}}>
-      Error loading <strong>{location}</strong>. Try reloading the repository location after
-      resolving the issue.
+      Error loading <strong>{location}</strong>. Try reloading the code location after resolving the
+      issue.
     </Box>
     {error ? <PythonErrorInfo error={error} /> : null}
   </>

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryLocationsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryLocationsList.tsx
@@ -128,8 +128,8 @@ export const RepositoryLocationsList = () => {
       <Box padding={{vertical: 32}}>
         <NonIdealState
           icon="folder"
-          title="No repository locations"
-          description="When you add a repository location to this workspace, it will appear here."
+          title="No code locations"
+          description="When you add a code location to this workspace, it will appear here."
         />
       </Box>
     );
@@ -139,7 +139,7 @@ export const RepositoryLocationsList = () => {
     <Table>
       <thead>
         <tr>
-          <th>Repository location</th>
+          <th>Code location</th>
           <th>Status</th>
           <th colSpan={2}>Updated</th>
         </tr>

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceHeader.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceHeader.tsx
@@ -50,7 +50,7 @@ export const WorkspaceHeader = <TData extends Record<string, any>>(props: Props<
                 loading={reloading}
                 icon={<Icon name="refresh" />}
               >
-                Reload repository location
+                Reload code location
               </Button>
             );
           }}

--- a/js_modules/dagit/packages/ui/src/components/Toaster.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Toaster.stories.tsx
@@ -23,7 +23,7 @@ export const Sizes = () => {
         onClick={() =>
           SharedToaster.show({
             intent: Intent.NONE,
-            message: 'Repository location reloaded',
+            message: 'Code location reloaded',
             timeout: 300000,
             icon: 'done',
           })


### PR DESCRIPTION
### Summary & Motivation

Use "code location" for "repository location" in copy throughout Dagit.

### How I Tested These Changes

View a couple places in Dagit where the copy should be different, sanity check.
