### PR TITLE
strip empty prefix parts for cloud-based compute log manager

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
@@ -79,7 +79,7 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
             "s3", use_ssl=use_ssl, verify=_verify, endpoint_url=endpoint_url
         ).meta.client
         self._s3_bucket = check.str_param(bucket, "bucket")
-        self._s3_prefix = check.str_param(prefix, "prefix")
+        self._s3_prefix = self._clean_prefix(check.str_param(prefix, "prefix"))
 
         # proxy calls to local compute log manager (for subscriptions, etc)
         if not local_dir:
@@ -120,6 +120,10 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
     @property
     def upload_interval(self) -> Optional[int]:
         return self._upload_interval if self._upload_interval else None
+
+    def _clean_prefix(self, prefix):
+        parts = prefix.split("/")
+        return "/".join([part for part in parts if part])
 
     def _s3_key(self, log_key, io_type, partial=False):
         check.inst_param(io_type, "io_type", ComputeIOType)

--- a/python_modules/libraries/dagster-azure/dagster_azure/blob/compute_log_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/blob/compute_log_manager.py
@@ -66,7 +66,7 @@ class AzureBlobComputeLogManager(CloudStorageComputeLogManager, ConfigurableClas
     ):
         self._storage_account = check.str_param(storage_account, "storage_account")
         self._container = check.str_param(container, "container")
-        self._blob_prefix = check.str_param(prefix, "prefix")
+        self._blob_prefix = self._clean_prefix(check.str_param(prefix, "prefix"))
         check.str_param(secret_key, "secret_key")
 
         self._blob_client = create_blob_client(storage_account, secret_key)
@@ -116,6 +116,10 @@ class AzureBlobComputeLogManager(CloudStorageComputeLogManager, ConfigurableClas
     @property
     def upload_interval(self) -> Optional[int]:
         return self._upload_interval if self._upload_interval else None
+
+    def _clean_prefix(self, prefix):
+        parts = prefix.split("/")
+        return "/".join([part for part in parts if part])
 
     def _blob_key(self, log_key, io_type, partial=False):
         check.inst_param(io_type, "io_type", ComputeIOType)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/compute_log_manager.py
@@ -61,7 +61,7 @@ class GCSComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
         upload_interval=None,
     ):
         self._bucket_name = check.str_param(bucket, "bucket")
-        self._prefix = check.str_param(prefix, "prefix")
+        self._prefix = self._clean_prefix(check.str_param(prefix, "prefix"))
 
         if json_credentials_envvar:
             json_info_str = os.environ.get(json_credentials_envvar)
@@ -111,6 +111,10 @@ class GCSComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
     @property
     def upload_interval(self) -> Optional[int]:
         return self._upload_interval if self._upload_interval else None
+
+    def _clean_prefix(self, prefix):
+        parts = prefix.split("/")
+        return "/".join([part for part in parts if part])
 
     def _gcs_key(self, log_key, io_type, partial=False):
         check.inst_param(io_type, "io_type", ComputeIOType)


### PR DESCRIPTION
### Summary & Motivation
Some cloud storage clients get confused with bonkers paths like `s3://bucket/foo//bar.err`.

This change sanitizes the custom prefix by stripping out trailing-slashes, or infix `//`.

### How I Tested These Changes
BK