### PR TITLE
[dagit] Show ellipsis on the Materialize button for partitioned assets

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -10,7 +10,6 @@ import {GraphQueryItem} from '../app/GraphQueryImpl';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
 import {LaunchAssetObservationButton} from '../assets/LaunchAssetObservationButton';
-import {isAssetMissing, isAssetStale} from '../assets/StaleTag';
 import {AssetKey} from '../assets/types';
 import {SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
@@ -414,32 +413,22 @@ export const AssetGraphExplorerWithData: React.FC<
                 dataDescription="materializations"
               />
               <LaunchAssetObservationButton
-                intent="none"
-                context={selectedGraphNodes.length > 0 ? 'selected' : 'all'}
+                preferredJobName={explorerPath.pipelineName}
                 assetKeys={(selectedGraphNodes.length
-                  ? selectedGraphNodes.filter((a) => a.definition.isObservable)
-                  : Object.values(assetGraphData.nodes).filter((a) => a.definition.isObservable)
-                ).map((n) => n.assetKey)}
-                preferredJobName={explorerPath.pipelineName}
-              />
-              <LaunchAssetExecutionButton
-                preferredJobName={explorerPath.pipelineName}
-                selectedAssetKeys={selectedGraphNodes
-                  .filter((a) => !a.definition.isSource)
-                  .map((n) => n.assetKey)}
-                allAssetKeys={Object.values(assetGraphData.nodes)
-                  .filter((a) => !a.definition.isSource)
-                  .map((n) => n.assetKey)}
-                staleAssetKeys={(selectedGraphNodes.length
                   ? selectedGraphNodes
                   : Object.values(assetGraphData.nodes)
                 )
-                  .filter(
-                    (a) =>
-                      !a.definition.isSource &&
-                      (isAssetMissing(liveDataByNode[a.id]) || isAssetStale(liveDataByNode[a.id])),
-                  )
+                  .filter((a) => a.definition.isObservable)
                   .map((n) => n.assetKey)}
+              />
+              <LaunchAssetExecutionButton
+                preferredJobName={explorerPath.pipelineName}
+                liveDataForStale={liveDataByNode}
+                scope={
+                  selectedGraphNodes.length
+                    ? {selected: selectedGraphNodes.map((a) => a.definition)}
+                    : {all: Object.values(assetGraphData.nodes).map((a) => a.definition)}
+                }
               />
             </Box>
           </Box>

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -305,11 +305,12 @@ export const ASSET_NODE_FRAGMENT = gql`
     opVersion
     description
     computeKind
+    isPartitioned
+    isObservable
     isSource
     assetKey {
       path
     }
-    isObservable
   }
 `;
 

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphQuery.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetGraphQuery.ts
@@ -50,9 +50,10 @@ export interface AssetGraphQuery_assetNodes {
   opVersion: string | null;
   description: string | null;
   computeKind: string | null;
+  isPartitioned: boolean;
+  isObservable: boolean;
   isSource: boolean;
   assetKey: AssetGraphQuery_assetNodes_assetKey;
-  isObservable: boolean;
 }
 
 export interface AssetGraphQuery {

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetNodeFragment.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetNodeFragment.ts
@@ -21,7 +21,8 @@ export interface AssetNodeFragment {
   opVersion: string | null;
   description: string | null;
   computeKind: string | null;
+  isPartitioned: boolean;
+  isObservable: boolean;
   isSource: boolean;
   assetKey: AssetNodeFragment_assetKey;
-  isObservable: boolean;
 }

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
@@ -67,10 +67,9 @@ export const AssetNodeLineage: React.FC<{
         <div style={{flex: 1}} />
         {Object.values(assetGraphData.nodes).length > 1 ? (
           <LaunchAssetExecutionButton
-            allAssetKeys={Object.values(assetGraphData.nodes)
-              .filter((n) => !n.definition.isSource)
-              .map((n) => n.assetKey)}
             intent="none"
+            liveDataForStale={liveDataByNode}
+            scope={{all: Object.values(assetGraphData.nodes).map((n) => n.definition)}}
           />
         ) : (
           <Button icon={<Icon name="materialization" />} disabled>

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -107,7 +107,9 @@ export const AssetTable = ({
               </Button>
             </Tooltip>
           ) : (
-            <LaunchAssetExecutionButton selectedAssetKeys={checkedAssets.map((c) => c.key)} />
+            <LaunchAssetExecutionButton
+              scope={{selected: checkedAssets.map((a) => ({...a.definition!, assetKey: a.key}))}}
+            />
           )}
           <MoreActionsDropdown selected={checkedAssets} clearSelection={() => onToggleAll(false)} />
         </Box>
@@ -348,6 +350,7 @@ export const ASSET_TABLE_DEFINITION_FRAGMENT = gql`
   fragment AssetTableDefinitionFragment on AssetNode {
     id
     groupName
+    isSource
     partitionDefinition {
       description
     }

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -188,7 +188,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
         right={
           <Box style={{margin: '-4px 0'}}>
             {definition && definition.jobNames.length > 0 && upstream && (
-              <LaunchAssetExecutionButton allAssetKeys={[definition.assetKey]} />
+              <LaunchAssetExecutionButton scope={{all: [definition]}} />
             )}
           </Box>
         }
@@ -347,6 +347,7 @@ const ASSET_VIEW_DEFINITION_QUERY = gql`
           id
           groupName
           partitionDefinition {
+            __typename
             description
           }
           partitionKeysByDimension {

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetObservationButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetObservationButton.tsx
@@ -32,10 +32,9 @@ type ObserveAssetsState =
 
 export const LaunchAssetObservationButton: React.FC<{
   assetKeys: AssetKey[]; // Memoization not required
-  context?: 'all' | 'selected';
   intent?: 'primary' | 'none';
   preferredJobName?: string;
-}> = ({assetKeys, preferredJobName, intent = 'primary'}) => {
+}> = ({assetKeys, preferredJobName, intent = 'none'}) => {
   const {canLaunchPipelineExecution} = usePermissions();
   const launchWithTelemetry = useLaunchWithTelemetry();
 
@@ -112,9 +111,9 @@ export const LaunchAssetObservationButton: React.FC<{
 };
 
 async function stateForObservingAssets(
-  client: ApolloClient<any>,
+  _client: ApolloClient<any>,
   assets: LaunchAssetExecutionAssetNodeFragment[],
-  forceLaunchpad: boolean,
+  _forceLaunchpad: boolean,
   preferredJobName?: string,
 ): Promise<ObserveAssetsState> {
   if (assets.some((x) => !x.isSource)) {

--- a/js_modules/dagit/packages/core/src/assets/types/AssetCatalogGroupTableQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetCatalogGroupTableQuery.ts
@@ -37,6 +37,7 @@ export interface AssetCatalogGroupTableQuery_assetNodes {
   id: string;
   assetKey: AssetCatalogGroupTableQuery_assetNodes_assetKey;
   groupName: string | null;
+  isSource: boolean;
   partitionDefinition: AssetCatalogGroupTableQuery_assetNodes_partitionDefinition | null;
   description: string | null;
   repository: AssetCatalogGroupTableQuery_assetNodes_repository;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetCatalogTableQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetCatalogTableQuery.ts
@@ -34,6 +34,7 @@ export interface AssetCatalogTableQuery_assetsOrError_AssetConnection_nodes_defi
   __typename: "AssetNode";
   id: string;
   groupName: string | null;
+  isSource: boolean;
   partitionDefinition: AssetCatalogTableQuery_assetsOrError_AssetConnection_nodes_definition_partitionDefinition | null;
   description: string | null;
   repository: AssetCatalogTableQuery_assetsOrError_AssetConnection_nodes_definition_repository;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
@@ -3125,9 +3125,10 @@ export interface AssetNodeDefinitionFragment {
   partitionDefinition: AssetNodeDefinitionFragment_partitionDefinition | null;
   repository: AssetNodeDefinitionFragment_repository;
   computeKind: string | null;
+  isPartitioned: boolean;
+  isObservable: boolean;
   isSource: boolean;
   assetKey: AssetNodeDefinitionFragment_assetKey;
-  isObservable: boolean;
   metadataEntries: AssetNodeDefinitionFragment_metadataEntries[];
   type: AssetNodeDefinitionFragment_type | null;
 }

--- a/js_modules/dagit/packages/core/src/assets/types/AssetTableDefinitionFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetTableDefinitionFragment.ts
@@ -29,6 +29,7 @@ export interface AssetTableDefinitionFragment {
   __typename: "AssetNode";
   id: string;
   groupName: string | null;
+  isSource: boolean;
   partitionDefinition: AssetTableDefinitionFragment_partitionDefinition | null;
   description: string | null;
   repository: AssetTableDefinitionFragment_repository;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetTableFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetTableFragment.ts
@@ -34,6 +34,7 @@ export interface AssetTableFragment_definition {
   __typename: "AssetNode";
   id: string;
   groupName: string | null;
+  isSource: boolean;
   partitionDefinition: AssetTableFragment_definition_partitionDefinition | null;
   description: string | null;
   repository: AssetTableFragment_definition_repository;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetViewDefinitionQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetViewDefinitionQuery.ts
@@ -3188,9 +3188,10 @@ export interface AssetViewDefinitionQuery_assetOrError_Asset_definition {
   opVersion: string | null;
   jobNames: string[];
   computeKind: string | null;
+  isPartitioned: boolean;
+  isObservable: boolean;
   isSource: boolean;
   assetKey: AssetViewDefinitionQuery_assetOrError_Asset_definition_assetKey;
-  isObservable: boolean;
   metadataEntries: AssetViewDefinitionQuery_assetOrError_Asset_definition_metadataEntries[];
   type: AssetViewDefinitionQuery_assetOrError_Asset_definition_type | null;
 }

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -666,6 +666,7 @@ type AssetNode {
   groupName: String
   id: ID!
   isObservable: Boolean!
+  isPartitioned: Boolean!
   isSource: Boolean!
   jobNames: [String!]!
   jobs: [Pipeline!]!

--- a/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
@@ -82,7 +82,7 @@ export const AssetJobPartitionsView: React.FC<{
             {showAssets ? 'Hide per-asset status' : 'Show per-asset status'}
           </Button>
           <LaunchAssetExecutionButton
-            allAssetKeys={assetGraph.graphAssetKeys}
+            scope={{all: assetGraph.graphQueryItems.map((g) => g.node), skipAllTerm: true}}
             preferredJobName={pipelineName}
           />
         </Box>

--- a/js_modules/dagit/packages/core/src/workspace/types/SingleAssetQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/SingleAssetQuery.ts
@@ -74,6 +74,7 @@ export interface SingleAssetQuery_assetOrError_Asset_definition {
   __typename: "AssetNode";
   id: string;
   groupName: string | null;
+  isSource: boolean;
   partitionDefinition: SingleAssetQuery_assetOrError_Asset_definition_partitionDefinition | null;
   description: string | null;
   repository: SingleAssetQuery_assetOrError_Asset_definition_repository;

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -169,6 +169,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     groupName = graphene.String()
     id = graphene.NonNull(graphene.ID)
     isObservable = graphene.NonNull(graphene.Boolean)
+    isPartitioned = graphene.NonNull(graphene.Boolean)
     isSource = graphene.NonNull(graphene.Boolean)
     jobNames = non_null_list(graphene.String)
     jobs = non_null_list(GraphenePipeline)
@@ -546,6 +547,9 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     def resolve_isSource(self, _graphene_info) -> bool:
         return self.is_source_asset()
+
+    def resolve_isPartitioned(self, _graphene_info) -> bool:
+        return self._external_asset_node.partitions_def_data is not None
 
     def resolve_isObservable(self, _graphene_info) -> bool:
         return self._external_asset_node.is_observable


### PR DESCRIPTION
### Summary & Motivation

This PR adds ellipsis to the launch asset modal if one or more partitioned assets is in the selection. It also makes a few changes:

1) I cleaned up the props of `LaunchAssetMaterializationButton`

2) I made the button handle the `isSource` check and the determination of the "stale & missing", because I didn't like having "isSource" called in a lot of places.

3) I added an `AssetNode.isPartitioned` resolver because I didn't want to ask for `asset.partitionDefinition` for every asset in the graph. Just getting the typename wouldn't be bad, but on the backend it inflates a whole object and stringifies a description, etc. even if you just ask for the typename.

Results:

![image](https://user-images.githubusercontent.com/1037212/203166371-0aab0d6a-7c06-4bd2-8473-1df493e9069c.png)
![image](https://user-images.githubusercontent.com/1037212/203166414-85c9a601-bc44-47b3-91c0-927105cd35f9.png)

### How I Tested These Changes
