### PR TITLE
add regression test for #10632

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -71,6 +71,7 @@ from dagster import (
     op,
     repository,
     resource,
+    schedule,
     static_partitioned_config,
     usable_as_dagster_type,
 )
@@ -1226,6 +1227,13 @@ def define_schedules():
         run_config={"solids": {"takes_an_enum": {"config": "invalid"}}},
     )
 
+    @schedule(
+        job_name="nested_job",
+        cron_schedule=["45 23 * * 6", "30 9 * * 0"],
+    )
+    def composite_cron_schedule(_context):
+        return {}
+
     return [
         run_config_error_schedule,
         no_config_pipeline_hourly_schedule,
@@ -1246,6 +1254,7 @@ def define_schedules():
         timezone_schedule,
         invalid_config_schedule,
         running_in_code_schedule,
+        composite_cron_schedule,
     ]
 
 


### PR DESCRIPTION

### How I Tested These Changes

`pytest python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py::test_get_schedule_definitions_for_repository`
fails with #10632 reverted 