### PR TITLE
[dagit] Remove the “Partial” checkbox on the asset details + backfill

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
@@ -45,7 +45,6 @@ export const AssetPartitions: React.FC<Props> = ({
 
   const [stateFilters, setStateFilters] = React.useState<PartitionState[]>([
     PartitionState.MISSING,
-    PartitionState.SUCCESS_MISSING,
     PartitionState.SUCCESS,
   ]);
 
@@ -78,14 +77,27 @@ export const AssetPartitions: React.FC<Props> = ({
     }
     return dimensionKeysOrdered(range)
       .map((dimensionKey) => {
+        // Note: If you have clicked dimension 1, dimension 2 shows the state of each subkey. If
+        // you have not clicked dimension 1, dimension 2 shows the merged state of all the keys
+        // in that dimension (for all values of dimension 1)
         const state =
-          focusedDimensionKeys.length >= idx
+          idx > 0 && focusedDimensionKeys.length >= idx
             ? assetHealth.stateForPartialKey([...focusedDimensionKeys.slice(0, idx), dimensionKey])
-            : assetHealth.stateForSingleDimension(idx, dimensionKey, ranges[idx - 1]?.selected);
+            : assetHealth.stateForSingleDimension(
+                idx,
+                dimensionKey,
+                range !== timeRange ? timeRange?.selected : undefined,
+              );
 
         return {dimensionKey, state};
       })
-      .filter((row) => stateFilters.includes(row.state));
+      .filter(
+        (row) =>
+          stateFilters.includes(row.state) ||
+          (row.state === PartitionState.SUCCESS_MISSING &&
+            (stateFilters.includes(PartitionState.SUCCESS) ||
+              stateFilters.includes(PartitionState.MISSING))),
+      );
   };
 
   return (
@@ -125,7 +137,7 @@ export const AssetPartitions: React.FC<Props> = ({
         <div>{allSelected.length.toLocaleString()} Partitions Selected</div>
         <PartitionStateCheckboxes
           partitionKeysForCounts={allInRanges}
-          allowed={[PartitionState.MISSING, PartitionState.SUCCESS_MISSING, PartitionState.SUCCESS]}
+          allowed={[PartitionState.MISSING, PartitionState.SUCCESS]}
           value={stateFilters}
           onChange={setStateFilters}
         />

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -114,7 +114,6 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
 
   const [stateFilters, setStateFilters] = React.useState<PartitionState[]>([
     PartitionState.MISSING,
-    PartitionState.SUCCESS_MISSING,
   ]);
 
   const allInRanges = React.useMemo(
@@ -268,11 +267,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
           ))}
           <PartitionStateCheckboxes
             partitionKeysForCounts={allInRanges}
-            allowed={[
-              PartitionState.MISSING,
-              PartitionState.SUCCESS_MISSING,
-              PartitionState.SUCCESS,
-            ]}
+            allowed={[PartitionState.MISSING, PartitionState.SUCCESS]}
             value={stateFilters}
             onChange={setStateFilters}
           />

--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
@@ -81,14 +81,25 @@ async function loadPartitionHealthData(client: ApolloClient<any>, loadKey: Asset
   const stateForSingleDimension = (
     dimensionIdx: number,
     dimensionKey: string,
-    withinParentDimensions?: string[],
+    otherDimensionSelectedKeys?: string[],
   ) => {
+    if (dimensionIdx === 0 && dimensions.length === 1) {
+      return stateForKey([dimensionKey]);
+    }
     if (dimensionIdx === 0) {
-      return stateForPartialKey([dimensionKey]);
+      return mergedStates(
+        Object.entries<PartitionState>(stateByKey[dimensionKey])
+          .filter(
+            ([key]) => !otherDimensionSelectedKeys || otherDimensionSelectedKeys.includes(key),
+          )
+          .map(([_, val]) => val),
+      );
     } else if (dimensionIdx === 1) {
       return mergedStates(
         Object.entries<{[subdimensionKey: string]: PartitionState}>(stateByKey)
-          .filter(([key]) => !withinParentDimensions || withinParentDimensions.includes(key))
+          .filter(
+            ([key]) => !otherDimensionSelectedKeys || otherDimensionSelectedKeys.includes(key),
+          )
           .map(([_, val]) => val[dimensionKey]),
       );
     } else {


### PR DESCRIPTION
### Summary & Motivation

The Partial checkbox was never really supposed to exist, I just couldn't figure out a UI bug.

The correct behavior is that top-level partition dimensions containing partially success or partially missing partition keys should be shown when you have either of those selected.

This PR also fixes a subtle bug where if you constrained the time axis, the status dots in the partitions page would reflect the "all" selection if the time dimension was not dimension index 0.

![image](https://user-images.githubusercontent.com/1037212/203177352-6de9d795-79a0-436d-8c38-f469ed641fe1.png)
![image](https://user-images.githubusercontent.com/1037212/203177364-c8ed1975-3e37-4419-852b-0361b9f3d9ac.png)


### How I Tested These Changes
