### PR TITLE
[dagit] Fix partition health bar becoming “stale” in asset details

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
@@ -36,11 +36,13 @@ interface Props {
 export const AssetPartitions: React.FC<Props> = ({
   assetKey,
   assetPartitionNames,
+  assetLastMaterializedAt,
   params,
   setParams,
   liveData,
 }) => {
-  const [assetHealth] = usePartitionHealthData([assetKey]);
+  console.log(assetLastMaterializedAt);
+  const [assetHealth] = usePartitionHealthData([assetKey], assetLastMaterializedAt);
   const [ranges, setRanges] = usePartitionDimensionRanges(assetHealth, assetPartitionNames, 'view');
 
   const [stateFilters, setStateFilters] = React.useState<PartitionState[]>([


### PR DESCRIPTION
### Summary & Motivation

This PR fixes an issue with running backfills from the Asset Partitions page. If you sit and watch the backfill run, events come in to the events tab but the partitions tab did not update. This was caused by the `useAssetHealthData` hook not having a refresh mechanism.

I think we'll be revisiting this hook fairly soon to load details on multiple assets at once.