### PR TITLE
dagster-airbyte: make job cancellation on termination optional

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -45,6 +45,7 @@ class AirbyteResource:
         request_additional_params: Optional[Mapping[str, Any]] = None,
         log: logging.Logger = get_dagster_logger(),
         forward_logs: bool = True,
+        cancel_airbyte_sync_on_abnormal_termination: bool = True,
         username: Optional[str] = None,
         password: Optional[str] = None,
     ):
@@ -65,6 +66,10 @@ class AirbyteResource:
 
         self._username = username
         self._password = password
+
+        self._cancel_airbyte_sync_on_abnormal_termination = (
+            cancel_airbyte_sync_on_abnormal_termination
+        )
 
     @property
     def api_base_url(self) -> str:
@@ -334,7 +339,10 @@ class AirbyteResource:
         finally:
             # if Airbyte sync has not completed, make sure to cancel it so that it doesn't outlive
             # the python process
-            if state not in (AirbyteState.SUCCEEDED, AirbyteState.ERROR, AirbyteState.CANCELLED):
+            if (
+                state not in (AirbyteState.SUCCEEDED, AirbyteState.ERROR, AirbyteState.CANCELLED)
+                and self._cancel_airbyte_sync_on_abnormal_termination
+            ):
                 self.cancel_job(job_id)
 
         return AirbyteOutput(job_details=job_details, connection_details=connection_details)
@@ -392,6 +400,11 @@ class AirbyteResource:
             default_value=True,
             description="Whether to forward Airbyte logs to the compute log, can be expensive for long-running syncs.",
         ),
+        "cancel_airbyte_sync_on_abnormal_termination": Field(
+            bool,
+            default_value=True,
+            description="Whether to cancel a sync in Airbyte if the Dagster runner experiences an abnormal termination. This may be useful to disable if using airbyte sources that cannot be cancelled and resumed easily, or if your Dagster deployment may experience runner interruptions that do not impact your Airbyte deployment.",
+        ),
     },
     description="This resource helps manage Airbyte connectors",
 )
@@ -439,6 +452,9 @@ def airbyte_resource(context) -> AirbyteResource:
         request_additional_params=context.resource_config["request_additional_params"],
         log=context.log,
         forward_logs=context.resource_config["forward_logs"],
+        cancel_airbyte_sync_on_abnormal_termination=context.resource_config[
+            "cancel_airbyte_sync_on_abnormal_termination"
+        ],
         username=context.resource_config.get("username"),
         password=context.resource_config.get("password"),
     )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
@@ -3,7 +3,7 @@ import responses
 from dagster_airbyte import AirbyteOutput, AirbyteState, airbyte_resource
 from dagster_airbyte.utils import generate_materializations
 
-from dagster import Failure, MetadataEntry
+from dagster import DagsterExecutionInterruptedError, Failure, MetadataEntry
 from dagster import _check as check
 from dagster import build_init_resource_context
 
@@ -148,7 +148,11 @@ def test_get_connection_details_bad_out_fail():
 
 
 @responses.activate
-def test_get_job_status_bad_out_fail():
+@pytest.mark.parametrize(
+    "forward_logs",
+    [True, False],
+)
+def test_get_job_status_bad_out_fail(forward_logs):
     ab_resource = airbyte_resource(
         build_init_resource_context(
             config={
@@ -157,42 +161,43 @@ def test_get_job_status_bad_out_fail():
             }
         )
     )
-    responses.add(
-        method=responses.POST,
-        url=ab_resource.api_base_url + "/jobs/get",
-        json=None,
-        status=204,
-    )
-    with pytest.raises(check.CheckError):
-        ab_resource.get_job_status("some_connection", 5)
-
-    # Test no-forward-logs config
-    ab_resource = airbyte_resource(
-        build_init_resource_context(
-            config={
-                "host": "some_host",
-                "port": "8000",
-                "forward_logs": False,
-            }
+    if forward_logs:
+        responses.add(
+            method=responses.POST,
+            url=ab_resource.api_base_url + "/jobs/get",
+            json=None,
+            status=204,
         )
-    )
-    responses.add(
-        method=responses.POST,
-        url=ab_resource.api_base_url + "/jobs/list",
-        json=None,
-        status=204,
-    )
-    with pytest.raises(check.CheckError):
-        ab_resource.get_job_status("some_connection", 5)
+        with pytest.raises(check.CheckError):
+            ab_resource.get_job_status("some_connection", 5)
+    else:
+        # Test no-forward-logs config
+        ab_resource = airbyte_resource(
+            build_init_resource_context(
+                config={
+                    "host": "some_host",
+                    "port": "8000",
+                    "forward_logs": False,
+                }
+            )
+        )
+        responses.add(
+            method=responses.POST,
+            url=ab_resource.api_base_url + "/jobs/list",
+            json=None,
+            status=204,
+        )
+        with pytest.raises(check.CheckError):
+            ab_resource.get_job_status("some_connection", 5)
 
-    responses.add(
-        method=responses.POST,
-        url=ab_resource.api_base_url + "/jobs/list",
-        json={"jobs": []},
-        status=200,
-    )
-    with pytest.raises(check.CheckError):
-        ab_resource.get_job_status("some_connection", 5)
+        responses.add(
+            method=responses.POST,
+            url=ab_resource.api_base_url + "/jobs/list",
+            json={"jobs": []},
+            status=200,
+        )
+        with pytest.raises(check.CheckError):
+            ab_resource.get_job_status("some_connection", 5)
 
 
 @responses.activate
@@ -328,7 +333,7 @@ def test_assets(forward_logs):
 
 @responses.activate
 @pytest.mark.parametrize(
-    "forward_logs,cancel_airbyte_sync_on_abnormal_termination",
+    "forward_logs,cancel_sync_on_run_termination",
     [
         (True, True),
         (True, False),
@@ -336,14 +341,75 @@ def test_assets(forward_logs):
         (False, False),
     ],
 )
-def test_sync_and_poll_timeout(forward_logs, cancel_airbyte_sync_on_abnormal_termination):
+def test_sync_and_poll_termination(forward_logs, cancel_sync_on_run_termination):
     ab_resource = airbyte_resource(
         build_init_resource_context(
             config={
                 "host": "some_host",
                 "port": "8000",
                 "forward_logs": forward_logs,
-                "cancel_airbyte_sync_on_abnormal_termination": cancel_airbyte_sync_on_abnormal_termination,
+                "cancel_sync_on_run_termination": cancel_sync_on_run_termination,
+            }
+        )
+    )
+    responses.add(
+        method=responses.POST,
+        url=ab_resource.api_base_url + "/connections/get",
+        json={},
+        status=200,
+    )
+    responses.add(
+        method=responses.POST,
+        url=ab_resource.api_base_url + "/connections/sync",
+        json={"job": {"id": 1}},
+        status=200,
+    )
+
+    # Simulate job interruption when we poll for job status
+    def callback(*_, **__):
+        raise DagsterExecutionInterruptedError()
+
+    if forward_logs:
+        responses.add_callback(
+            method=responses.POST,
+            url=ab_resource.api_base_url + "/jobs/get",
+            callback=callback,
+        )
+    else:
+        responses.add_callback(
+            method=responses.POST,
+            url=ab_resource.api_base_url + "/jobs/list",
+            callback=callback,
+        )
+    responses.add(responses.POST, f"{ab_resource.api_base_url}/jobs/cancel", status=204)
+    poll_wait_second = 2
+    timeout = 1
+    with pytest.raises(DagsterExecutionInterruptedError):
+        ab_resource.sync_and_poll("some_connection", poll_wait_second, timeout)
+        if cancel_sync_on_run_termination:
+            assert responses.assert_call_count(f"{ab_resource.api_base_url}/jobs/cancel", 1) is True
+        else:
+            assert responses.assert_call_count(f"{ab_resource.api_base_url}/jobs/cancel", 0) is True
+
+
+@responses.activate
+@pytest.mark.parametrize(
+    "forward_logs,cancel_sync_on_run_termination",
+    [
+        (True, True),
+        (True, False),
+        (False, True),
+        (False, False),
+    ],
+)
+def test_sync_and_poll_timeout(forward_logs, cancel_sync_on_run_termination):
+    ab_resource = airbyte_resource(
+        build_init_resource_context(
+            config={
+                "host": "some_host",
+                "port": "8000",
+                "forward_logs": forward_logs,
+                "cancel_sync_on_run_termination": cancel_sync_on_run_termination,
             }
         )
     )
@@ -402,7 +468,7 @@ def test_sync_and_poll_timeout(forward_logs, cancel_airbyte_sync_on_abnormal_ter
     timeout = 1
     with pytest.raises(Failure, match="Timeout: Airbyte job"):
         ab_resource.sync_and_poll("some_connection", poll_wait_second, timeout)
-        if cancel_airbyte_sync_on_abnormal_termination:
+        if cancel_sync_on_run_termination:
             assert responses.assert_call_count(f"{ab_resource.api_base_url}/jobs/cancel", 1) is True
         else:
             assert responses.assert_call_count(f"{ab_resource.api_base_url}/jobs/cancel", 0) is True


### PR DESCRIPTION
### Summary & Motivation
Our dagster jobs run in an autoscaling node group in EKS. Occasionally, the dagster job pod will be killed while downscaling. Our airbyte workers run without autoscaling (to ensure syncs are not interrupted, among other reasons). Rather than killing the airbyte job when a dagster pod terminates mid-sync, we'd like the airbyte job to complete. This, of course, won't trigger asset materializations or other downstream jobs, but it will ensure we don't lose data and can easily pick up the next time that dagster triggers this job.

To accomplish this, I've added a new config parameter to the airbyte resource. It's definitely a long name, but I'm not sure how to shorten it without losing clarity. @benpankow - any suggestions?

### How I Tested These Changes
Updated unit tests to validate that the airbyte API cancel route isn't called when a job abnormally terminates, if the option is disabled. Additionally added validation that it is called when enabled (default).