### PR TITLE
[dagit] Fix clicking “Per-asset status” before health is loaded, always use timeseries axis

### DIFF
--- a/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
@@ -3,7 +3,11 @@ import React from 'react';
 
 import {useAssetGraphData} from '../asset-graph/useAssetGraphData';
 import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
-import {mergedAssetHealth, explodePartitionKeysInRanges} from '../assets/MultipartitioningSupport';
+import {
+  mergedAssetHealth,
+  explodePartitionKeysInRanges,
+  isTimeseriesPartition,
+} from '../assets/MultipartitioningSupport';
 import {usePartitionHealthData} from '../assets/usePartitionHealthData';
 import {useViewport} from '../gantt/useViewport';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
@@ -59,7 +63,10 @@ export const AssetJobPartitionsView: React.FC<{
     }
   }, [viewport.width, showAssets, setPageSize]);
 
-  const rangeDimension = merged.dimensions[0];
+  const rangeDimensionIdx = merged.dimensions.findIndex((d) =>
+    isTimeseriesPartition(d.partitionKeys[0]),
+  );
+  const rangeDimension = merged.dimensions[rangeDimensionIdx];
   const rangePartitionKeys = rangeDimension?.partitionKeys || [];
 
   const selectedPartitions = showAssets
@@ -99,7 +106,7 @@ export const AssetJobPartitionsView: React.FC<{
         <div {...containerProps}>
           <PartitionStatus
             partitionNames={rangePartitionKeys}
-            partitionStateForKey={(key) => merged.stateForSingleDimension(0, key)}
+            partitionStateForKey={(key) => merged.stateForSingleDimension(rangeDimensionIdx, key)}
             selected={showAssets ? selectedPartitions : undefined}
             selectionWindowSize={pageSize}
             onClick={(partitionName) => {
@@ -117,10 +124,11 @@ export const AssetJobPartitionsView: React.FC<{
             tooltipMessage="Click to view per-asset status"
           />
         </div>
-        {showAssets && (
+        {showAssets && rangeDimension && (
           <Box margin={{top: 16}}>
             <PartitionPerAssetStatus
-              partitionNames={rangePartitionKeys}
+              rangeDimensionIdx={rangeDimensionIdx}
+              rangeDimension={rangeDimension}
               assetHealth={assetHealth}
               assetQueryItems={assetGraph.graphQueryItems}
               pipelineName={pipelineName}


### PR DESCRIPTION
### Summary & Motivation

This PR fixes a bug Alex reported that caused a full-page crash if you clicked "Per-asset status" before the page had loaded the health of each asset.

This PR also updates this page to show the time-series axis regardless of whether it is the first or second dimension, consistent with the asset partitions view. This is important because showing the matrix with "states" or some other axis doesn't make much sense, and because the order we receive partition dimensions is alphabetical so "time | astate" and "time | zstate" produce different internal orderings, which we don't want to be a user concern in Dagit.

### How I Tested These Changes

Before:
![image](https://user-images.githubusercontent.com/1037212/203183200-1ba90f34-2622-4748-9b54-bd3f7428e933.png)


After: 
![image](https://user-images.githubusercontent.com/1037212/203183177-538f70e8-f530-48de-b266-ed2024271e7d.png)

