### PR TITLE
avoid setting the asset reconciliation cursor to none when there are …

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -122,8 +122,14 @@ class AssetReconciliationCursor(NamedTuple):
             | requested_non_partitioned_root_assets
         )
 
+        if latest_storage_id and self.latest_storage_id:
+            check.invariant(
+                latest_storage_id >= self.latest_storage_id,
+                "Latest storage ID should be >= previous latest storage ID",
+            )
+
         return AssetReconciliationCursor(
-            latest_storage_id=latest_storage_id,
+            latest_storage_id=latest_storage_id or self.latest_storage_id,
             materialized_or_requested_root_asset_keys=result_materialized_or_requested_root_asset_keys,
             materialized_or_requested_root_partitions_by_asset_key=result_materialized_or_requested_root_partitions_by_asset_key,
         )

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_reconciliation_sensor.py
@@ -573,6 +573,28 @@ scenarios = {
             run_request(asset_keys=["asset2"], partition_key="a_3"),
         ],
     ),
+    "fan_out_partitions_upstream_materialized_next_tick": AssetReconciliationScenario(
+        assets=two_assets_in_sequence_fan_out_partitions,
+        unevaluated_runs=[],
+        expected_run_requests=[],
+        cursor_from=AssetReconciliationScenario(
+            assets=two_assets_in_sequence_fan_out_partitions,
+            unevaluated_runs=[single_asset_run(asset_key="asset1", partition_key="a")],
+        ),
+    ),
+    "fan_out_partitions_upstream_materialize_two_more_ticks": AssetReconciliationScenario(
+        assets=two_assets_in_sequence_fan_out_partitions,
+        unevaluated_runs=[],
+        expected_run_requests=[],
+        cursor_from=AssetReconciliationScenario(
+            assets=two_assets_in_sequence_fan_out_partitions,
+            unevaluated_runs=[],
+            cursor_from=AssetReconciliationScenario(
+                assets=two_assets_in_sequence_fan_out_partitions,
+                unevaluated_runs=[single_asset_run(asset_key="asset1", partition_key="a")],
+            ),
+        ),
+    ),
     ################################################################################################
     # Freshness policies
     ################################################################################################


### PR DESCRIPTION
…no new events

### Summary & Motivation

We got a bug report that duplicate runs were being launched in some situations when a downstream asset has different partitions than the upstream asset.

### How I Tested These Changes

#### Unit test
Without this PR, the second test I added fails. The first one succeeds either way, but added it as a sanity check.

#### Manual test
Ran the following and observed duplicate runs of asset1 get launched. Afterward the fix, only a single run would get launched per partition

```python
from dagster import (
    asset,
    repository,
    StaticPartitionsDefinition,
    AssetSelection,
    build_asset_reconciliation_sensor,
    load_assets_from_current_module,
)

import time


@asset
def upstream():
    ...


@asset(partitions_def=StaticPartitionsDefinition(["a", "b", "c"]))
def asset1(context, upstream):
    context.asset_partition_key_for_output()
    time.sleep(90)


@repository
def repo():
    return [
        load_assets_from_current_module(),
        build_asset_reconciliation_sensor(AssetSelection.all()),
    ]
```