### PR TITLE
[dagit] Colorize “late” assets in the minimal asset DAG

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import styled from 'styled-components/macro';
 
 import {withMiddleTruncation} from '../app/Util';
+import {isAssetLate} from '../assets/CurrentMinutesLateTag';
 import {isAssetStale} from '../assets/StaleTag';
 import {OpTags} from '../graph/OpTags';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
@@ -148,8 +149,8 @@ export const AssetNodeStatusRow: React.FC<{
     );
   }
 
-  const {lastMaterialization, runWhichFailedToMaterialize, freshnessInfo} = liveData;
-  const late = freshnessInfo && (freshnessInfo.currentMinutesLate || 0) > 0;
+  const {lastMaterialization, runWhichFailedToMaterialize} = liveData;
+  const late = isAssetLate(liveData);
 
   if (runWhichFailedToMaterialize || late) {
     return (
@@ -231,7 +232,7 @@ export const AssetNodeMinimal: React.FC<{
           $selected={selected}
           $isSource={isSource}
           $background={
-            liveData?.runWhichFailedToMaterialize
+            liveData?.runWhichFailedToMaterialize || isAssetLate(liveData)
               ? Colors.Red50
               : !liveData?.lastMaterialization
               ? Colors.Gray100
@@ -240,7 +241,7 @@ export const AssetNodeMinimal: React.FC<{
               : Colors.Green50
           }
           $border={
-            liveData?.runWhichFailedToMaterialize
+            liveData?.runWhichFailedToMaterialize || isAssetLate(liveData)
               ? Colors.Red500
               : !liveData?.lastMaterialization
               ? Colors.Gray500

--- a/js_modules/dagit/packages/core/src/assets/CurrentMinutesLateTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/CurrentMinutesLateTag.tsx
@@ -9,6 +9,9 @@ import {humanCronString} from '../schedules/humanCronString';
 const STALE_OVERDUE_MSG = `A materialization incorporating more recent upstream data is overdue.`;
 const STALE_UNMATERIALIZED_MSG = `This asset has never been materialized.`;
 
+export const isAssetLate = (liveData?: LiveDataForNode) =>
+  liveData?.freshnessInfo && (liveData?.freshnessInfo.currentMinutesLate || 0) > 0;
+
 export const CurrentMinutesLateTag: React.FC<{
   liveData: LiveDataForNode;
   policyOnHover?: boolean;


### PR DESCRIPTION
### Summary & Motivation
This breaks the late check out into a helper to follow the pattern used for `isAssetStale` and makes the minimal asset dag match the zoomed in version's use of a red color for these nodes.

### How I Tested These Changes
