### PR TITLE
Don't use an inclusive BETWEEN when identifing partitions

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -154,4 +154,6 @@ def _time_window_where_clause(table_partition: TablePartition) -> str:
     start_dt, end_dt = table_partition.time_window
     start_dt_str = start_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
     end_dt_str = end_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
-    return f"""WHERE {table_partition.partition_expr} BETWEEN '{start_dt_str}' AND '{end_dt_str}'"""
+    # Snowflake BETWEEN is inclusive; start <= partition expr <= end. We don't want to remove the next partition so we instead
+    # write this as start <= partition expr < end.
+    return f"""WHERE {table_partition.partition_expr} >= '{start_dt_str}' AND {table_partition.partition_expr} < '{end_dt_str}'"""

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
@@ -42,7 +42,7 @@ def test_get_select_statement_partitioned():
         )
     ) == (
         "SELECT apple, banana FROM database_abc.schema1.table1\n"
-        "WHERE my_timestamp_col BETWEEN '2020-01-02 00:00:00' AND '2020-02-03 00:00:00'"
+        "WHERE my_timestamp_col >= '2020-01-02 00:00:00' AND my_timestamp_col < '2020-02-03 00:00:00'"
     )
 
 
@@ -68,5 +68,5 @@ def test_get_cleanup_statement_partitioned():
         )
     ) == (
         "DELETE FROM database_abc.schema1.table1\n"
-        "WHERE my_timestamp_col BETWEEN '2020-01-02 00:00:00' AND '2020-02-03 00:00:00'"
+        "WHERE my_timestamp_col >= '2020-01-02 00:00:00' AND my_timestamp_col < '2020-02-03 00:00:00'"
     )


### PR DESCRIPTION
Snowflake's BETWEEN is inclusive meaning we're deleting the _next_ partition instead of everything up until the next partition.

https://docs.snowflake.com/en/sql-reference/functions/between.html