### PR TITLE
[dagit] Enable “groups-only” zoom level with auto-minimum zoom

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Flags.tsx
+++ b/js_modules/dagit/packages/core/src/app/Flags.tsx
@@ -9,7 +9,6 @@ export const DAGIT_FLAGS_KEY = 'DAGIT_FLAGS';
 export const FeatureFlag = {
   flagDebugConsoleLogging: 'flagDebugConsoleLogging' as const,
   flagDisableWebsockets: 'flagDisableWebsockets' as const,
-  flagAssetGraphExperimentalZoom: 'flagAssetGraphExperimentalZoom' as const,
   flagSensorScheduleLogging: 'flagSensorScheduleLogging' as const,
 };
 export type FeatureFlagType = keyof typeof FeatureFlag;

--- a/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/UserSettingsRoot.tsx
@@ -126,16 +126,6 @@ export function getFeatureFlagRows(
       ),
     },
     {
-      key: 'Experimental "groups-only" asset graph zoom level',
-      value: (
-        <Checkbox
-          format="switch"
-          checked={flags.includes(FeatureFlag.flagAssetGraphExperimentalZoom)}
-          onChange={() => toggleFlag(FeatureFlag.flagAssetGraphExperimentalZoom)}
-        />
-      ),
-    },
-    {
       key: 'Experimental schedule/sensor logging view',
       value: (
         <Checkbox

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -264,7 +264,7 @@ export const AssetGraphExplorerWithData: React.FC<
     }
   };
 
-  const allowGroupsOnlyZoomLevel = layout && Object.keys(layout.groups).length;
+  const allowGroupsOnlyZoomLevel = !!(layout && Object.keys(layout.groups).length);
 
   return (
     <SplitPanelContainer

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -288,7 +288,7 @@ export const AssetGraphExplorerWithData: React.FC<
               interactor={SVGViewport.Interactors.PanAndZoom}
               graphWidth={layout.width}
               graphHeight={layout.height}
-              graphHasNoMinimumZoom={allowGroupsOnlyZoomLevel ? true : false}
+              graphHasNoMinimumZoom={allowGroupsOnlyZoomLevel}
               onClick={onClickBackground}
               onArrowKeyDown={onArrowKeyDown}
               onDoubleClick={(e) => {

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -5,7 +5,6 @@ import without from 'lodash/without';
 import React from 'react';
 import styled from 'styled-components/macro';
 
-import {useFeatureFlags} from '../app/Flags';
 import {GraphQueryItem} from '../app/GraphQueryImpl';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
@@ -58,8 +57,8 @@ interface Props {
   onNavigateToSourceAssetNode: (node: AssetLocation) => void;
 }
 
-export const MINIMAL_SCALE = 0.5;
-export const EXPERIMENTAL_SCALE = 0.1;
+export const MINIMAL_SCALE = 0.6;
+export const GROUPS_ONLY_SCALE = 0.15;
 
 export const AssetGraphExplorer: React.FC<Props> = (props) => {
   const {
@@ -138,7 +137,6 @@ export const AssetGraphExplorerWithData: React.FC<
   } = props;
 
   const findAssetLocation = useFindAssetLocation();
-  const flags = useFeatureFlags();
 
   const [highlighted, setHighlighted] = React.useState<string | null>(null);
 
@@ -266,8 +264,7 @@ export const AssetGraphExplorerWithData: React.FC<
     }
   };
 
-  const allowExperimentalZoom =
-    flags.flagAssetGraphExperimentalZoom && layout && Object.keys(layout.groups).length;
+  const allowGroupsOnlyZoomLevel = layout && Object.keys(layout.groups).length;
 
   return (
     <SplitPanelContainer
@@ -291,6 +288,7 @@ export const AssetGraphExplorerWithData: React.FC<
               interactor={SVGViewport.Interactors.PanAndZoom}
               graphWidth={layout.width}
               graphHeight={layout.height}
+              graphHasNoMinimumZoom={allowGroupsOnlyZoomLevel ? true : false}
               onClick={onClickBackground}
               onArrowKeyDown={onArrowKeyDown}
               onDoubleClick={(e) => {
@@ -298,7 +296,6 @@ export const AssetGraphExplorerWithData: React.FC<
                 e.stopPropagation();
               }}
               maxZoom={1.2}
-              minZoom={allowExperimentalZoom ? 0.01 : undefined}
               maxAutocenterZoom={1.0}
             >
               {({scale}) => (
@@ -306,9 +303,9 @@ export const AssetGraphExplorerWithData: React.FC<
                   <AssetEdges
                     highlighted={highlighted}
                     edges={layout.edges}
-                    strokeWidth={allowExperimentalZoom ? Math.max(4, 3 / scale) : 4}
+                    strokeWidth={allowGroupsOnlyZoomLevel ? Math.max(4, 3 / scale) : 4}
                     baseColor={
-                      allowExperimentalZoom && scale < EXPERIMENTAL_SCALE
+                      allowGroupsOnlyZoomLevel && scale < GROUPS_ONLY_SCALE
                         ? Colors.Gray400
                         : Colors.KeylineGray
                     }
@@ -339,7 +336,7 @@ export const AssetGraphExplorerWithData: React.FC<
                   {Object.values(layout.nodes).map(({id, bounds}) => {
                     const graphNode = assetGraphData.nodes[id];
                     const path = JSON.parse(id);
-                    if (allowExperimentalZoom && scale < EXPERIMENTAL_SCALE) {
+                    if (allowGroupsOnlyZoomLevel && scale < GROUPS_ONLY_SCALE) {
                       return;
                     }
                     return (

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGroupNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGroupNode.tsx
@@ -7,7 +7,7 @@ import {withMiddleTruncation} from '../app/Util';
 import {buildRepoPath} from '../workspace/buildRepoAddress';
 import {workspacePath} from '../workspace/workspacePath';
 
-import {MINIMAL_SCALE, EXPERIMENTAL_SCALE} from './AssetGraphExplorer';
+import {MINIMAL_SCALE, GROUPS_ONLY_SCALE} from './AssetGraphExplorer';
 import {GroupLayout} from './layout';
 
 export const AssetGroupNode: React.FC<{group: GroupLayout; scale: number}> = ({group, scale}) => {
@@ -20,7 +20,7 @@ export const AssetGroupNode: React.FC<{group: GroupLayout; scale: number}> = ({g
 
   return (
     <div style={{position: 'relative', width: '100%', height: '100%'}}>
-      {scale > EXPERIMENTAL_SCALE && (
+      {scale > GROUPS_ONLY_SCALE && (
         <Box flex={{alignItems: 'flex-end'}} style={{height: 70}}>
           <Mono
             style={{
@@ -66,17 +66,17 @@ export const AssetGroupNode: React.FC<{group: GroupLayout; scale: number}> = ({g
           top: 75,
           position: 'absolute',
           background:
-            scale < EXPERIMENTAL_SCALE ? `rgba(234, 234, 234, 1)` : `rgba(217, 217, 217, 0.25)`,
+            scale < GROUPS_ONLY_SCALE ? `rgba(234, 234, 234, 1)` : `rgba(217, 217, 217, 0.25)`,
         }}
       />
 
-      {scale < EXPERIMENTAL_SCALE ? (
+      {scale < GROUPS_ONLY_SCALE ? (
         <Box
           flex={{justifyContent: 'center', alignItems: 'center'}}
-          style={{inset: 0, position: 'absolute', fontSize: `${14 / scale}px`, userSelect: 'none'}}
+          style={{inset: 0, position: 'absolute', fontSize: `${12 / scale}px`, userSelect: 'none'}}
         >
           <Box
-            flex={{direction: 'column'}}
+            flex={{direction: 'column', alignItems: 'center'}}
             style={{fontWeight: 600, fontFamily: FontFamily.monospace}}
           >
             {groupName}
@@ -104,4 +104,5 @@ const GroupRepoName = styled.div`
   font-size: 0.8em;
   line-height: 0.6em;
   white-space: nowrap;
+  color: ${Colors.Gray400};
 `;


### PR DESCRIPTION
### Summary & Motivation

This PR slightly adjusts the transition threshold between "full asset nodes" and "mini asset nodes" so the mini nodes appear more quickly (per https://linear.app/elementl/issue/DAGIT-203/flip-to-zoomed-out-asset-nodes-earlier)

I also removed the feature flag for the "experimental groups-only" zoom level and enabled it for everyone. The main blocker around this was that it let you zoom out /too far/, so I adjusted the SVGViewport behavior slightly so that passing a param allows you to enable minimum zoom out to "whatever is required to see the entire DAG in view". (We were always using the default min zoom before)

Sidenote:
After this is reviewed, I might rename a few references to minZoom / minScale / etc. to use the same term. I think we flip-flop between zoom and scale and they're the same. Just didn't want to clutter up review!

### How I Tested These Changes
- Large and small op and asset DAGs