### PR TITLE
[dagit] Replace "Repository" text throughout Dagit

### DIFF
--- a/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
@@ -85,11 +85,11 @@ const FinalRedirectOrLoadingRoot = () => {
     <Box padding={{vertical: 64}}>
       <NonIdealState
         icon="no-results"
-        title={repoWithNoJob ? 'No jobs' : 'No repositories'}
+        title={repoWithNoJob ? 'No jobs' : 'No definitions'}
         description={
           repoWithNoJob
-            ? 'Your repository is loaded, but no jobs were found.'
-            : 'Add a repository to get started.'
+            ? 'Your definitions are loaded, but no jobs were found.'
+            : 'Add a job to get started.'
         }
         action={
           <ExternalAnchorButton href="https://docs.dagster.io/getting-started">

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphJobSidebar.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphJobSidebar.tsx
@@ -35,7 +35,13 @@ export const AssetGraphJobSidebar: React.FC<{
     <Loading queryResult={queryResult}>
       {({pipelineSnapshotOrError}) => {
         if (pipelineSnapshotOrError.__typename !== 'PipelineSnapshot') {
-          return <NonIdealPipelineQueryResult isGraph result={pipelineSnapshotOrError} />;
+          return (
+            <NonIdealPipelineQueryResult
+              isGraph
+              result={pipelineSnapshotOrError}
+              repoAddress={repoAddress}
+            />
+          );
         }
         return (
           <SidebarContainerOverview container={pipelineSnapshotOrError} repoAddress={repoAddress} />

--- a/js_modules/dagit/packages/core/src/assets/AssetWipeDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetWipeDialog.tsx
@@ -51,8 +51,7 @@ export const AssetWipeDialog: React.FC<{
           </ul>
           <div>
             Assets defined only by their historical materializations will disappear from the Asset
-            Catalog. Software-defined assets will remain unless their definition is also deleted
-            from the repository.
+            Catalog. Software-defined assets will remain unless their definition is also deleted.
           </div>
           <strong>This action cannot be undone.</strong>
         </Group>

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -318,6 +318,7 @@ async function stateForLaunchingAssets(
     assets[0]?.repository.name || '',
     assets[0]?.repository.location.name || '',
   );
+  const repoName = repoAddressAsString(repoAddress);
 
   if (
     !assets.every(
@@ -328,7 +329,7 @@ async function stateForLaunchingAssets(
   ) {
     return {
       type: 'error',
-      error: 'Assets must be in the same repository to be materialized together.',
+      error: `Assets must be in ${repoName} to be materialized together.`,
     };
   }
 

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetObservationButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetObservationButton.tsx
@@ -7,6 +7,7 @@ import {usePermissions} from '../app/Permissions';
 import {useLaunchWithTelemetry} from '../launchpad/LaunchRootExecutionButton';
 import {LaunchPipelineExecutionVariables} from '../runs/types/LaunchPipelineExecution';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
+import {repoAddressAsString} from '../workspace/repoAddressAsString';
 
 import {
   buildAssetCollisionsAlert,
@@ -133,6 +134,7 @@ async function stateForObservingAssets(
     assets[0]?.repository.name || '',
     assets[0]?.repository.location.name || '',
   );
+  const repoName = repoAddressAsString(repoAddress);
 
   if (
     !assets.every(
@@ -143,7 +145,7 @@ async function stateForObservingAssets(
   ) {
     return {
       type: 'error',
-      error: 'Assets must be in the same repository to be materialized together.',
+      error: `Assets must be in ${repoName} to be materialized together.`,
     };
   }
 

--- a/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
@@ -31,7 +31,7 @@ export const InstanceTabs = <TData extends Record<string, any>>(props: Props<TDa
           to="/code-locations"
           icon={<WorkspaceStatus placeholder={false} />}
         />
-        <TabLink id="workspace" title="Workspace" to="/workspace" />
+        <TabLink id="definitions" title="Definitions" to="/workspace" />
         <TabLink id="health" title={healthTitle} to="/health" icon={<InstanceWarningIcon />} />
         {canSeeConfig ? <TabLink id="config" title="Configuration" to="/config" /> : null}
       </Tabs>

--- a/js_modules/dagit/packages/core/src/instance/RepoFilterButton.tsx
+++ b/js_modules/dagit/packages/core/src/instance/RepoFilterButton.tsx
@@ -16,7 +16,7 @@ export const RepoFilterButton: React.FC = () => {
         style={{width: 'auto'}}
         onClose={() => setOpen(false)}
       >
-        <DialogHeader icon="repo" label="Repositories" />
+        <DialogHeader icon="repo" label="Filter code locations" />
         <RepoSelector
           options={allRepos}
           onBrowse={() => setOpen(false)}
@@ -38,7 +38,7 @@ export const RepoFilterButton: React.FC = () => {
         rightIcon={<Icon name="expand_more" />}
         onClick={() => setOpen(true)}
       >
-        {`${visibleRepos.length} of ${allRepos.length} Repositories`}
+        {`${visibleRepos.length} of ${allRepos.length}`}
       </Button>
     </>
   );

--- a/js_modules/dagit/packages/core/src/instigation/Unloadable.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/Unloadable.tsx
@@ -96,8 +96,8 @@ const UnloadableSensorInfo = () => (
     description={
       <div>
         The following sensors were previously started but now cannot be loaded. They may be part of
-        a different workspace or from a sensor or repository that no longer exists in code. You can
-        turn them off, but you cannot turn them back on since they can’t be loaded.
+        a different workspace or from a sensor or code location that no longer exists in code. You
+        can turn them off, but you cannot turn them back on since they can’t be loaded.
       </div>
     }
   />
@@ -114,8 +114,8 @@ const UnloadableScheduleInfo = () => (
     description={
       <div>
         The following schedules were previously started but now cannot be loaded. They may be part
-        of a different workspace or from a schedule or repository that no longer exists in code. You
-        can turn them off, but you cannot turn them back on since they can’t be loaded.
+        of a different workspace or from a schedule or code location that no longer exists in code.
+        You can turn them off, but you cannot turn them back on since they can’t be loaded.
       </div>
     }
   />

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -36,6 +36,7 @@ import {
 } from '../configeditor/ConfigEditorUtils';
 import {DagsterTag} from '../runs/RunTag';
 import {PipelineSelector, RepositorySelector} from '../types/globalTypes';
+import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
@@ -656,8 +657,8 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
                 <Group direction="row" spacing={8} alignItems="center">
                   <Icon name="warning" color={Colors.Yellow500} />
                   <div>
-                    Your repository has been manually refreshed, and this configuration may now be
-                    out of date.
+                    {repoAddressAsString(repoAddress)} has been manually refreshed, and this
+                    configuration may now be out of date.
                   </div>
                   <Button
                     intent="primary"

--- a/js_modules/dagit/packages/core/src/nav/LeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNav.tsx
@@ -24,7 +24,6 @@ const LeftNavContainer = styled.div<{$open: boolean; $smallScreen: boolean}>`
   top: 64px;
   bottom: 0;
   left: 0;
-  padding-top: 16px;
   width: ${LEFT_NAV_WIDTH}px;
   display: ${({$open, $smallScreen}) => ($open || $smallScreen ? 'flex' : 'none')};
   flex-shrink: 0;

--- a/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
@@ -1,4 +1,4 @@
-import {Colors} from '@dagster-io/ui';
+import {Body, Box, Colors} from '@dagster-io/ui';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
@@ -20,12 +20,15 @@ const LoadedRepositorySection: React.FC<{
     }
 
     if (allRepos.length > 0) {
-      return <EmptyState>Select a repository to see a list of jobs.</EmptyState>;
+      return <EmptyState>Select a code location to see a list of jobs.</EmptyState>;
     }
 
     return (
       <EmptyState>
-        There are no repositories in this workspace. Add a repository to see a list of jobs.
+        <Box flex={{direction: 'column', gap: 8}} padding={{top: 12}}>
+          <span style={{fontSize: '16px', fontWeight: 500}}>No definitions</span>
+          <Body>When you add a code location, your definitions will appear here</Body>
+        </Box>
       </EmptyState>
     );
   };

--- a/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
@@ -67,7 +67,7 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
         intent: 'success',
         message: (
           <Box flex={{direction: 'row', justifyContent: 'space-between', gap: 24, grow: 1}}>
-            <div>Workspace ready</div>
+            <div>Definitions reloaded</div>
             <ViewButton onClick={() => history.push('/workspace')} color={Colors.White}>
               View
             </ViewButton>

--- a/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
@@ -193,8 +193,8 @@ const UnloadableSchedulesAlert: React.FC<{
             <Box flex={{direction: 'column', gap: 12, alignItems: 'flex-start'}}>
               <div>
                 Schedules were previously started but now cannot be loaded. They may be part of a
-                different workspace or from a schedule or repository that no longer exists in code.
-                You can turn them off, but you cannot turn them back on.
+                different workspace or from a schedule or code location that no longer exists in
+                code. You can turn them off, but you cannot turn them back on.
               </div>
               <Button onClick={() => setIsOpen(true)}>
                 {count === 1 ? 'View unloadable schedule' : 'View unloadable schedules'}

--- a/js_modules/dagit/packages/core/src/overview/OverviewSensorsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSensorsRoot.tsx
@@ -191,7 +191,7 @@ const UnloadableSensorsAlert: React.FC<{
             <Box flex={{direction: 'column', gap: 12, alignItems: 'flex-start'}}>
               <div>
                 Sensors were previously started but now cannot be loaded. They may be part of a
-                different workspace or from a sensor or repository that no longer exists in code.
+                different workspace or from a sensor or code location that no longer exists in code.
                 You can turn them off, but you cannot turn them back on.
               </div>
               <Button onClick={() => setIsOpen(true)}>

--- a/js_modules/dagit/packages/core/src/pipelines/NonIdealPipelineQueryResult.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/NonIdealPipelineQueryResult.tsx
@@ -1,8 +1,12 @@
 import {NonIdealState} from '@dagster-io/ui';
 import React from 'react';
 
+import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {RepoAddress} from '../workspace/types';
+
 interface Props {
   isGraph: boolean;
+  repoAddress?: RepoAddress;
   result:
     | {
         __typename: 'PipelineSnapshotNotFoundError';
@@ -22,7 +26,7 @@ interface Props {
       };
 }
 
-export const NonIdealPipelineQueryResult: React.FC<Props> = ({isGraph, result}) => {
+export const NonIdealPipelineQueryResult: React.FC<Props> = ({isGraph, repoAddress, result}) => {
   if (result.__typename === 'PipelineSnapshotNotFoundError') {
     return (
       <NonIdealState
@@ -42,10 +46,16 @@ export const NonIdealPipelineQueryResult: React.FC<Props> = ({isGraph, result}) 
     );
   }
   if (result.__typename === 'RepositoryNotFoundError') {
-    return <NonIdealState icon="error" title="Repository not found" description={result.message} />;
+    return (
+      <NonIdealState
+        icon="error"
+        title={`${repoAddress ? repoAddressAsString(repoAddress) : 'Definitions'} not found`}
+        description={result.message}
+      />
+    );
   }
   if (result.__typename === 'PythonError') {
-    return <NonIdealState icon="error" title="Query Error" description={result.message} />;
+    return <NonIdealState icon="error" title="Query error" description={result.message} />;
   }
   return <span />;
 };

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
@@ -88,7 +88,13 @@ export const PipelineExplorerContainer: React.FC<{
     <Loading<PipelineExplorerRootQuery> queryResult={pipelineResult}>
       {({pipelineSnapshotOrError: result}) => {
         if (result.__typename !== 'PipelineSnapshot') {
-          return <NonIdealPipelineQueryResult isGraph={isGraph} result={result} />;
+          return (
+            <NonIdealPipelineQueryResult
+              isGraph={isGraph}
+              result={result}
+              repoAddress={repoAddress}
+            />
+          );
         }
 
         const parentHandle = result.solidHandle;

--- a/js_modules/dagit/packages/core/src/runs/RunActionButtons.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionButtons.tsx
@@ -5,7 +5,8 @@ import {SharedToaster} from '../app/DomUtils';
 import {filterByQuery, GraphQueryItem} from '../app/GraphQueryImpl';
 import {usePermissions} from '../app/Permissions';
 import {LaunchButtonConfiguration, LaunchButtonDropdown} from '../launchpad/LaunchButton';
-import {buildRepoPath} from '../workspace/buildRepoAddress';
+import {buildRepoAddress, buildRepoPath} from '../workspace/buildRepoAddress';
+import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {useRepositoryForRun} from '../workspace/useRepositoryForRun';
 
 import {IRunMetadataDict, IStepState} from './RunMetadataProvider';
@@ -290,18 +291,25 @@ function usePipelineAvailabilityErrorForRun(
 
     if (matchType === 'snapshot-only') {
       // Only the snapshot ID matched, but not the repo.
+      const originRepoName = run.repositoryOrigin
+        ? repoAddressAsString(
+            buildRepoAddress(
+              run.repositoryOrigin.repositoryName,
+              run.repositoryOrigin.repositoryLocationName,
+            ),
+          )
+        : null;
+
       return {
         icon: 'warning',
         tooltip: (
           <Group direction="column" spacing={4}>
-            <div>{`The original run loaded "${run.pipelineName}" from a different repository.`}</div>
-            {run.repositoryOrigin ? (
+            <div>{`The original run loaded "${run.pipelineName}" from ${
+              originRepoName || 'a different code location'
+            }.`}</div>
+            {originRepoName ? (
               <div>
-                Original repository:{' '}
-                <strong>
-                  {run.repositoryOrigin.repositoryName}@
-                  {run.repositoryOrigin.repositoryLocationName}
-                </strong>
+                Original definition in: <strong>{originRepoName}</strong>
               </div>
             ) : null}
           </Group>
@@ -327,7 +335,7 @@ function usePipelineAvailabilityErrorForRun(
     <Group direction="column" spacing={8}>
       <div>{`"${run.pipelineName}" is not available in the current workspace.`}</div>
       {repoForRun && repoLocationForRun ? (
-        <div>{`Load repository ${buildRepoPath(
+        <div>{`Load definitions for ${buildRepoPath(
           repoForRun,
           repoLocationForRun,
         )} and try again.`}</div>

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesRoot.tsx
@@ -9,6 +9,7 @@ import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {UnloadableSchedules} from '../instigation/Unloadable';
 import {InstigationType} from '../types/globalTypes';
 import {Loading} from '../ui/Loading';
+import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
@@ -44,6 +45,7 @@ export const SchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
       {(result) => {
         const {repositoryOrError, unloadableInstigationStatesOrError, instance} = result;
         let schedulesSection = null;
+        const repoName = repoAddressAsString(repoAddress);
 
         if (repositoryOrError.__typename === 'PythonError') {
           schedulesSection = <PythonErrorInfo error={repositoryOrError} />;
@@ -51,8 +53,8 @@ export const SchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
           schedulesSection = (
             <NonIdealState
               icon="error"
-              title="Repository not found"
-              description="Could not load this repository."
+              title="Definitions not found"
+              description={`Could not load ${repoName}.`}
             />
           );
         } else if (!repositoryOrError.schedules.length) {
@@ -62,7 +64,7 @@ export const SchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
               title="No schedules found"
               description={
                 <p>
-                  This repository does not have any schedules defined. Visit the{' '}
+                  {repoName} does not have any schedules defined. Visit the{' '}
                   <a href="https://docs.dagster.io/concepts/partitions-schedules-sensors/schedules">
                     scheduler documentation
                   </a>{' '}

--- a/js_modules/dagit/packages/core/src/sensors/SensorRoot.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorRoot.tsx
@@ -54,7 +54,7 @@ export const SensorRoot: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) 
             <Box padding={{vertical: 32}} flex={{justifyContent: 'center'}}>
               <NonIdealState
                 icon="error"
-                title={`Could not find sensor \`${sensorName}\` in repository \`${repoAddress.name}\``}
+                title={`Could not find sensor \`${sensorName}\` in definitions for \`${repoAddress.name}\``}
               />
             </Box>
           );

--- a/js_modules/dagit/packages/core/src/sensors/SensorsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorsRoot.tsx
@@ -11,6 +11,7 @@ import {INSTIGATION_STATE_FRAGMENT} from '../instigation/InstigationUtils';
 import {UnloadableSensors} from '../instigation/Unloadable';
 import {InstigationType} from '../types/globalTypes';
 import {Loading} from '../ui/Loading';
+import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
@@ -29,6 +30,7 @@ export const SensorsRoot = (props: Props) => {
 
   const {repoAddress} = props;
   const repositorySelector = repoAddressToSelector(repoAddress);
+  const repoName = repoAddressAsString(repoAddress);
 
   const queryResult = useQuery<SensorsRootQuery, SensorsRootQueryVariables>(SENSORS_ROOT_QUERY, {
     variables: {
@@ -56,8 +58,8 @@ export const SensorsRoot = (props: Props) => {
               <Box padding={{vertical: 64}}>
                 <NonIdealState
                   icon="error"
-                  title="Repository not found"
-                  description="Could not load this repository."
+                  title="Definitions not found"
+                  description={`Could not load definitions for ${repoName}`}
                 />
               </Box>
             );
@@ -66,10 +68,10 @@ export const SensorsRoot = (props: Props) => {
               <Box padding={{vertical: 64}}>
                 <NonIdealState
                   icon="sensors"
-                  title="No Sensors Found"
+                  title="No sensors defined"
                   description={
                     <p>
-                      This repository does not have any sensors defined. Visit the{' '}
+                      {repoName} does not have any sensors defined. Visit the{' '}
                       <a
                         href="https://docs.dagster.io/concepts/partitions-schedules-sensors/sensors"
                         target="_blank"

--- a/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
@@ -83,34 +83,25 @@ export const SectionedLeftNav = () => {
   }
 
   return (
-    <>
-      <Box
-        flex={{direction: 'row', alignItems: 'center', gap: 8}}
-        padding={{horizontal: 24, bottom: 12}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-      >
-        <span style={{fontSize: '16px', fontWeight: 500}}>Workspace</span>
-      </Box>
-      <Container>
-        {sortedRepos.map((repo) => {
-          const repoName = repo.repository.name;
-          const repoAddress = buildRepoAddress(repoName, repo.repositoryLocation.name);
-          const addressAsString = repoAddressAsString(repoAddress);
-          return (
-            <Section
-              key={addressAsString}
-              onToggle={onToggle}
-              option={repo}
-              repoAddress={repoAddress}
-              expanded={sortedRepos.length === 1 || expandedKeys.includes(addressAsString)}
-              collapsible={sortedRepos.length > 1}
-              showRepoLocation={duplicateRepoNames.has(repoName)}
-              match={match?.repoAddress === repoAddress ? match : null}
-            />
-          );
-        })}
-      </Container>
-    </>
+    <Container>
+      {sortedRepos.map((repo) => {
+        const repoName = repo.repository.name;
+        const repoAddress = buildRepoAddress(repoName, repo.repositoryLocation.name);
+        const addressAsString = repoAddressAsString(repoAddress);
+        return (
+          <Section
+            key={addressAsString}
+            onToggle={onToggle}
+            option={repo}
+            repoAddress={repoAddress}
+            expanded={sortedRepos.length === 1 || expandedKeys.includes(addressAsString)}
+            collapsible={sortedRepos.length > 1}
+            showRepoLocation={duplicateRepoNames.has(repoName)}
+            match={match?.repoAddress === repoAddress ? match : null}
+          />
+        );
+      })}
+    </Container>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryGraphsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryGraphsList.tsx
@@ -116,13 +116,15 @@ export const RepositoryGraphsList: React.FC<Props> = (props) => {
     return null;
   }
 
+  const repoName = repoAddressAsString(repoAddress);
+
   if (error || !graphsForTable) {
     return (
       <Box padding={{vertical: 64}}>
         <NonIdealState
           icon="error"
           title="Unable to load graphs"
-          description={`Could not load graphs for ${repoAddressAsString(repoAddress)}`}
+          description={`Could not load graphs for ${repoName}`}
         />
       </Box>
     );
@@ -134,7 +136,7 @@ export const RepositoryGraphsList: React.FC<Props> = (props) => {
         <NonIdealState
           icon="schema"
           title="No graphs found"
-          description={<div>This repository does not have any graphs defined.</div>}
+          description={`${repoName} does not have any graphs defined.`}
         />
       </Box>
     );

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryLocationsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryLocationsList.tsx
@@ -128,8 +128,8 @@ export const RepositoryLocationsList = () => {
       <Box padding={{vertical: 32}}>
         <NonIdealState
           icon="folder"
-          title="No code locations"
-          description="When you add a code location to this workspace, it will appear here."
+          title="No definitions"
+          description="When you add a code location, your definitions will appear here."
         />
       </Box>
     );

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryPipelinesList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryPipelinesList.tsx
@@ -72,13 +72,15 @@ export const RepositoryPipelinesList: React.FC<Props> = (props) => {
     return null;
   }
 
+  const repoName = repoAddressAsString(repoAddress);
+
   if (error || !pipelinesForTable) {
     return (
       <Box padding={{vertical: 64}}>
         <NonIdealState
           icon="error"
           title="Unable to load pipelines"
-          description={`Could not load pipelines for ${repoAddressAsString(repoAddress)}`}
+          description={`Could not load pipelines for ${repoName}`}
         />
       </Box>
     );
@@ -93,8 +95,8 @@ export const RepositoryPipelinesList: React.FC<Props> = (props) => {
           description={
             <div>
               {display === 'jobs'
-                ? 'This repository does not have any jobs defined.'
-                : 'This repository does not have any pipelines defined.'}
+                ? `${repoName} does not have any jobs defined.`
+                : `${repoName} does not have any pipelines defined.`}
             </div>
           }
         />

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceAssetsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceAssetsRoot.tsx
@@ -9,6 +9,7 @@ import {useAssetNodeSearch} from '../assets/useAssetSearch';
 
 import {VirtualizedAssetTable} from './VirtualizedAssetTable';
 import {WorkspaceHeader} from './WorkspaceHeader';
+import {repoAddressAsString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
 import {WorkspaceAssetsQuery, WorkspaceAssetsQueryVariables} from './types/WorkspaceAssetsQuery';
@@ -54,6 +55,8 @@ export const WorkspaceAssetsRoot = ({repoAddress}: {repoAddress: RepoAddress}) =
       );
     }
 
+    const repoName = repoAddressAsString(repoAddress);
+
     if (!filteredBySearch.length) {
       if (anySearch) {
         return (
@@ -63,7 +66,7 @@ export const WorkspaceAssetsRoot = ({repoAddress}: {repoAddress: RepoAddress}) =
               title="No matching assets"
               description={
                 <div>
-                  No assets matching <strong>{searchValue}</strong> were found in this repository
+                  No assets matching <strong>{searchValue}</strong> were found in {repoName}
                 </div>
               }
             />
@@ -76,7 +79,7 @@ export const WorkspaceAssetsRoot = ({repoAddress}: {repoAddress: RepoAddress}) =
           <NonIdealState
             icon="search"
             title="No assets"
-            description="No assets were found in this repository"
+            description={`No assets were found in ${repoName}`}
           />
         </Box>
       );

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceGraphsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceGraphsRoot.tsx
@@ -9,6 +9,7 @@ import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 
 import {Graph, VirtualizedGraphTable} from './VirtualizedGraphTable';
 import {WorkspaceHeader} from './WorkspaceHeader';
+import {repoAddressAsString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
 import {WorkspaceGraphsQuery, WorkspaceGraphsQueryVariables} from './types/WorkspaceGraphsQuery';
@@ -81,6 +82,8 @@ export const WorkspaceGraphsRoot = ({repoAddress}: {repoAddress: RepoAddress}) =
       );
     }
 
+    const repoName = repoAddressAsString(repoAddress);
+
     if (!filteredBySearch.length) {
       if (anySearch) {
         return (
@@ -90,7 +93,7 @@ export const WorkspaceGraphsRoot = ({repoAddress}: {repoAddress: RepoAddress}) =
               title="No matching graphs"
               description={
                 <div>
-                  No graphs matching <strong>{searchValue}</strong> were found in this repository
+                  No graphs matching <strong>{searchValue}</strong> were found in {repoName}
                 </div>
               }
             />
@@ -103,7 +106,7 @@ export const WorkspaceGraphsRoot = ({repoAddress}: {repoAddress: RepoAddress}) =
           <NonIdealState
             icon="search"
             title="No graphs"
-            description="No graphs were found in this repository"
+            description={`No graphs were found in ${repoName}`}
           />
         </Box>
       );

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceHeader.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceHeader.tsx
@@ -50,7 +50,7 @@ export const WorkspaceHeader = <TData extends Record<string, any>>(props: Props<
                 loading={reloading}
                 icon={<Icon name="refresh" />}
               >
-                Reload code location
+                Reload definitions
               </Button>
             );
           }}

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceJobsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceJobsRoot.tsx
@@ -9,6 +9,7 @@ import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 
 import {VirtualizedJobTable} from './VirtualizedJobTable';
 import {WorkspaceHeader} from './WorkspaceHeader';
+import {repoAddressAsString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
 import {WorkspaceJobsQuery, WorkspaceJobsQueryVariables} from './types/WorkspaceJobsQuery';
@@ -60,6 +61,8 @@ export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => 
       );
     }
 
+    const repoName = repoAddressAsString(repoAddress);
+
     if (!filteredBySearch.length) {
       if (anySearch) {
         return (
@@ -69,7 +72,7 @@ export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => 
               title="No matching jobs"
               description={
                 <div>
-                  No jobs matching <strong>{searchValue}</strong> were found in this repository
+                  No jobs matching <strong>{searchValue}</strong> were found in {repoName}
                 </div>
               }
             />
@@ -82,7 +85,7 @@ export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => 
           <NonIdealState
             icon="search"
             title="No jobs"
-            description="No jobs were found in this repository"
+            description={`No jobs were found in ${repoName}`}
           />
         </Box>
       );

--- a/js_modules/dagit/packages/core/src/workspace/WorkspacePipelineRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspacePipelineRoot.tsx
@@ -69,7 +69,9 @@ export const WorkspacePipelineRoot = () => {
         title={<Heading>{pipelineName}</Heading>}
         icon="job"
         description={
-          anyPipelines ? 'Job / pipeline in multiple repositories' : 'Job in multiple repositories'
+          anyPipelines
+            ? 'Job / pipeline in multiple code locations'
+            : 'Job in multiple code locations'
         }
       />
       <Box padding={{vertical: 16, horizontal: 24}}>
@@ -80,11 +82,11 @@ export const WorkspacePipelineRoot = () => {
               {anyPipelines ? (
                 <>
                   Jobs or pipelines named <strong>{pipelineName}</strong> were found in multiple
-                  repositories.
+                  code locations.
                 </>
               ) : (
                 <>
-                  Jobs named <strong>{pipelineName}</strong> were found in multiple repositories.
+                  Jobs named <strong>{pipelineName}</strong> were found in multiple code locations.
                 </>
               )}
             </div>
@@ -94,7 +96,7 @@ export const WorkspacePipelineRoot = () => {
       <Table>
         <thead>
           <tr>
-            <th>Repository name and location</th>
+            <th>Code location</th>
             <th>{anyPipelines ? 'Job / Pipeline' : 'Job'}</th>
           </tr>
         </thead>

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
@@ -31,13 +31,13 @@ const RepoRouteContainer = () => {
       <Box padding={{vertical: 64}}>
         <NonIdealState
           icon="error"
-          title="Invalid repository"
+          title="Invalid code location path"
           description={
             <div>
               <div>
                 <strong>{repoPath}</strong>
               </div>
-              {'  is not a valid repository path.'}
+              {'  is not a valid code location path.'}
             </div>
           }
         />
@@ -64,7 +64,7 @@ const RepoRouteContainer = () => {
       <Box padding={{vertical: 64}}>
         <NonIdealState
           icon="error"
-          title="Unknown repository"
+          title="Unknown code location"
           description={
             <div>
               <div>

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceSchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceSchedulesRoot.tsx
@@ -8,6 +8,7 @@ import {useTrackPageView} from '../app/analytics';
 
 import {VirtualizedScheduleTable} from './VirtualizedScheduleTable';
 import {WorkspaceHeader} from './WorkspaceHeader';
+import {repoAddressAsString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
 import {
@@ -59,6 +60,8 @@ export const WorkspaceSchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}
       );
     }
 
+    const repoName = repoAddressAsString(repoAddress);
+
     if (!filteredBySearch.length) {
       if (anySearch) {
         return (
@@ -68,7 +71,7 @@ export const WorkspaceSchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}
               title="No matching schedules"
               description={
                 <div>
-                  No schedules matching <strong>{searchValue}</strong> were found in this repository
+                  No schedules matching <strong>{searchValue}</strong> were found in {repoName}
                 </div>
               }
             />
@@ -81,7 +84,7 @@ export const WorkspaceSchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}
           <NonIdealState
             icon="search"
             title="No schedules"
-            description="No schedules were found in this repository"
+            description={`No schedules were found in ${repoName}`}
           />
         </Box>
       );

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceSensorsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceSensorsRoot.tsx
@@ -8,6 +8,7 @@ import {useTrackPageView} from '../app/analytics';
 
 import {VirtualizedSensorTable} from './VirtualizedSensorTable';
 import {WorkspaceHeader} from './WorkspaceHeader';
+import {repoAddressAsString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
 import {WorkspaceSensorsQuery, WorkspaceSensorsQueryVariables} from './types/WorkspaceSensorsQuery';
@@ -56,6 +57,8 @@ export const WorkspaceSensorsRoot = ({repoAddress}: {repoAddress: RepoAddress}) 
       );
     }
 
+    const repoName = repoAddressAsString(repoAddress);
+
     if (!filteredBySearch.length) {
       if (anySearch) {
         return (
@@ -65,7 +68,7 @@ export const WorkspaceSensorsRoot = ({repoAddress}: {repoAddress: RepoAddress}) 
               title="No matching sensors"
               description={
                 <div>
-                  No sensors matching <strong>{searchValue}</strong> were found in this repository
+                  No sensors matching <strong>{searchValue}</strong> were found in {repoName}
                 </div>
               }
             />
@@ -78,7 +81,7 @@ export const WorkspaceSensorsRoot = ({repoAddress}: {repoAddress: RepoAddress}) 
           <NonIdealState
             icon="search"
             title="No sensors"
-            description="No sensors were found in this repository"
+            description={`No sensors were found in ${repoName}`}
           />
         </Box>
       );


### PR DESCRIPTION
### Summary & Motivation

Replace "Repository" with "Definition" or the string version of the specific `RepoAddress` throughout Dagit. Also replace the term "Workspace" in a number of places, though not all yet.

This picks up from https://github.com/dagster-io/dagster/pull/10566 and adds a bunch more string replacements.

<img width="1476" alt="Screenshot 2022-11-22 at 2 18 45 PM" src="https://user-images.githubusercontent.com/2823852/203413163-0482eee4-d2c7-4908-8776-1ab25097942d.png">
<img width="1474" alt="Screenshot 2022-11-22 at 2 19 08 PM" src="https://user-images.githubusercontent.com/2823852/203413164-b3371733-a7a3-4ce0-b41b-bc2bfaea6d8c.png">
<img width="1141" alt="image" src="https://user-images.githubusercontent.com/2823852/203413311-5ca36bc6-f393-4c0a-876b-2a9b7035b754.png">


### How I Tested These Changes

View Dagit and verify that strings look correct throughout, including in empty states.
