### PR TITLE
docs: dagstermill -> Jupyter/Papermill (dagstermill)

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -601,7 +601,7 @@
         "path": "/integrations/great-expectations"
       },
       {
-        "title": "Jupyter/Papermill",
+        "title": "Jupyter / Papermill",
         "path": "/integrations/dagstermill"
       },
       {
@@ -786,10 +786,6 @@
         "title": "Libraries",
         "children": [
           {
-            "title": "Dagstermill",
-            "path": "/_apidocs/libraries/dagstermill"
-          },
-          {
             "title": "Airbyte (dagster-airbyte)",
             "path": "/_apidocs/libraries/dagster-airbyte"
           },
@@ -868,6 +864,10 @@
           {
             "title": "Github (dagster-github)",
             "path": "/_apidocs/libraries/dagster-github"
+          },
+          {
+            "title": "Jupyter / Papermill (dagstermill)",
+            "path": "/_apidocs/libraries/dagstermill"
           },
           {
             "title": "Kubernetes (dagster-k8s)",


### PR DESCRIPTION
### Summary & Motivation
Make this consistent with how we display other integrations. The format is `<External Service/Library> (dagster PyPI integration name)`

### How I Tested These Changes
eyes
