### PR TITLE
output-scoped code versions

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -486,7 +486,7 @@ class ProjectedLogicalVersionLoader:
                 )
             else:
                 version = DEFAULT_LOGICAL_VERSION
-        elif node.op_version is not None:
+        elif node.code_version is not None:
             version = self._compute_projected_new_materialization_logical_version(node)
         else:
             materialization = self._instance.get_latest_materialization_event(key)
@@ -519,7 +519,7 @@ class ProjectedLogicalVersionLoader:
     ) -> LogicalVersion:
         dep_keys = {dep.upstream_asset_key for dep in node.dependencies}
         return compute_logical_version(
-            node.op_version or UNKNOWN_VALUE,
+            node.code_version or UNKNOWN_VALUE,
             {dep_key: self._get_version(key=dep_key) for dep_key in dep_keys},
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -235,7 +235,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             assetKey=external_asset_node.asset_key,
             description=external_asset_node.op_description,
             opName=external_asset_node.op_name,
-            opVersion=external_asset_node.op_version,
+            opVersion=external_asset_node.code_version,
             groupName=external_asset_node.group_name,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -731,8 +731,7 @@ class AssetLayer:
     def code_version_for_asset(self, asset_key: AssetKey) -> Optional[str]:
         assets_def = self.assets_defs_by_key.get(asset_key)
         if assets_def is not None:
-            output_name = assets_def.get_output_name_for_asset_key(asset_key)
-            return assets_def.node_def.output_def_named(output_name).code_version
+            return assets_def.code_versions_by_key[asset_key]
         else:
             return None
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -639,6 +639,7 @@ class AssetLayer:
                     partitions_fn=partitions_fn if assets_def.partitions_def else None,
                     partitions_def=assets_def.partitions_def,
                     is_required=asset_key in assets_def.keys,
+                    code_version=inner_output_def.code_version,
                 )
                 io_manager_by_asset[asset_key] = inner_output_def.io_manager_key
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_out.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_out.py
@@ -26,6 +26,7 @@ class AssetOut(
             ("is_required", PublicAttr[bool]),
             ("dagster_type", PublicAttr[Union[DagsterType, Type[NoValueSentinel]]]),
             ("group_name", PublicAttr[Optional[str]]),
+            ("code_version", PublicAttr[Optional[str]]),
         ],
     )
 ):
@@ -52,6 +53,7 @@ class AssetOut(
             into the table.
         group_name (Optional[str]): A string name used to organize multiple assets into groups. If
             not provided, the name "default" is used.
+        code_version (Optional[str]): The version of the code that generates this asset.
     """
 
     def __new__(
@@ -64,6 +66,7 @@ class AssetOut(
         io_manager_key: Optional[str] = None,
         metadata: Optional[MetadataUserInput] = None,
         group_name: Optional[str] = None,
+        code_version: Optional[str] = None,
     ):
         if isinstance(key_prefix, str):
             key_prefix = [key_prefix]
@@ -82,6 +85,7 @@ class AssetOut(
             ),
             metadata=check.opt_mapping_param(metadata, "metadata", key_type=str),
             group_name=check.opt_str_param(group_name, "group_name"),
+            code_version=check.opt_str_param(code_version, "code_version"),
         )
 
     def to_out(self) -> Out:
@@ -91,4 +95,5 @@ class AssetOut(
             metadata=self.metadata,
             is_required=self.is_required,
             io_manager_key=self.io_manager_key,
+            code_version=self.code_version,
         )

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -77,6 +77,8 @@ class AssetsDefinition(ResourceAddable):
     _selected_asset_keys: AbstractSet[AssetKey]
     _can_subset: bool
     _metadata_by_key: Mapping[AssetKey, MetadataUserInput]
+    _freshness_policies_by_key: Mapping[AssetKey, FreshnessPolicy]
+    _code_versions_by_key: Mapping[AssetKey, Optional[str]]
 
     def __init__(
         self,
@@ -149,16 +151,19 @@ class AssetsDefinition(ResourceAddable):
             self._selected_asset_keys = all_asset_keys
         self._can_subset = can_subset
 
+        self._code_versions_by_key = {}
         self._metadata_by_key = dict(
             check.opt_mapping_param(
                 metadata_by_key, "metadata_by_key", key_type=AssetKey, value_type=dict
             )
         )
         for output_name, asset_key in keys_by_output_name.items():
+            output_def, _ = node_def.resolve_output_to_origin(output_name, None)
             self._metadata_by_key[asset_key] = merge_dicts(
-                node_def.resolve_output_to_origin(output_name, None)[0].metadata,
+                output_def.metadata,
                 self._metadata_by_key.get(asset_key, {}),
             )
+            self._code_versions_by_key[asset_key] = output_def.code_version
         for key, freshness_policy in (freshness_policies_by_key or {}).items():
             check.param_invariant(
                 not (freshness_policy and self._partitions_def),
@@ -535,6 +540,10 @@ class AssetsDefinition(ResourceAddable):
     @property
     def metadata_by_key(self):
         return self._metadata_by_key
+
+    @property
+    def code_versions_by_key(self):
+        return self._code_versions_by_key
 
     @public
     def get_partition_mapping(self, in_asset_key: AssetKey) -> PartitionMapping:

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -533,10 +533,6 @@ class AssetsDefinition(ResourceAddable):
         return self._partitions_def
 
     @property
-    def is_versioned(self) -> bool:
-        return self.op.version is not None
-
-    @property
     def metadata_by_key(self):
         return self._metadata_by_key
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -383,12 +383,6 @@ def multi_asset(
         group_name (Optional[str]): A string name used to organize multiple assets into groups. This
             group name will be applied to all assets produced by this multi_asset.
         retry_policy (Optional[RetryPolicy]): The retry policy for the op that computes the asset.
-        version (Optional[Union[str, Mapping[str, str]]]): (Experimental) Version of the logic
-            encapsulated by the op. Can be either a single string or a dictionary mapping output names
-            to strings. The single string form assumes the same code version for all op outputs. The
-            dictionary form allows different ops for different outputs. In general, versions should be
-            set only for code that deterministically produces the same output when given the same
-            inputs.
         code_version (Optional[str]): (Experimental) Version of the code encapsulated by the multi-asset. If set,
             this is used as a default code version for all defined assets.
     """

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -70,7 +70,7 @@ def asset(
     output_required: bool = ...,
     freshness_policy: Optional[FreshnessPolicy] = ...,
     retry_policy: Optional[RetryPolicy] = ...,
-    op_version: Optional[str] = ...,
+    code_version: Optional[str] = ...,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     ...
 
@@ -97,7 +97,7 @@ def asset(
     output_required: bool = True,
     freshness_policy: Optional[FreshnessPolicy] = None,
     retry_policy: Optional[RetryPolicy] = None,
-    op_version: Optional[str] = None,
+    code_version: Optional[str] = None,
 ) -> Union[AssetsDefinition, Callable[[Callable[..., Any]], AssetsDefinition]]:
     """Create a definition for how to compute an asset.
 
@@ -155,8 +155,9 @@ def asset(
         freshness_policy (FreshnessPolicy): A constraint telling Dagster how often this asset is intended to be updated
             with respect to its root data.
         retry_policy (Optional[RetryPolicy]): The retry policy for the op that computes the asset.
-        op_version (Optional[str]): (Experimental) Version string passed to the op underlying the
-            asset.
+        code_version (Optional[str]): (Experimental) Version of the code that generates this asset. In
+            general, versions should be set only for code that deterministically produces the same
+            output when given the same inputs.
 
     Examples:
 
@@ -199,7 +200,7 @@ def asset(
             output_required=output_required,
             freshness_policy=freshness_policy,
             retry_policy=retry_policy,
-            op_version=op_version,
+            code_version=code_version,
         )(fn)
 
     return inner
@@ -226,7 +227,7 @@ class _Asset:
         output_required: bool = True,
         freshness_policy: Optional[FreshnessPolicy] = None,
         retry_policy: Optional[RetryPolicy] = None,
-        op_version: Optional[str] = None,
+        code_version: Optional[str] = None,
     ):
         self.name = name
 
@@ -251,7 +252,7 @@ class _Asset:
         self.output_required = output_required
         self.freshness_policy = freshness_policy
         self.retry_policy = retry_policy
-        self.op_version = op_version
+        self.code_version = code_version
 
     def __call__(self, fn: Callable) -> AssetsDefinition:
         asset_name = self.name or fn.__name__
@@ -283,6 +284,7 @@ class _Asset:
                 dagster_type=self.dagster_type if self.dagster_type else NoValueSentinel,
                 description=self.description,
                 is_required=self.output_required,
+                code_version=self.code_version,
             )
 
             op = _Op(
@@ -297,7 +299,7 @@ class _Asset:
                 },
                 config_schema=self.config_schema,
                 retry_policy=self.retry_policy,
-                version=self.op_version,
+                code_version=self.code_version,
             )(fn)
 
         keys_by_input_name = {
@@ -340,6 +342,7 @@ def multi_asset(
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     group_name: Optional[str] = None,
     retry_policy: Optional[RetryPolicy] = None,
+    code_version: Optional[str] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a combined definition of multiple assets that are computed using the same op and same
     upstream assets.
@@ -380,6 +383,14 @@ def multi_asset(
         group_name (Optional[str]): A string name used to organize multiple assets into groups. This
             group name will be applied to all assets produced by this multi_asset.
         retry_policy (Optional[RetryPolicy]): The retry policy for the op that computes the asset.
+        version (Optional[Union[str, Mapping[str, str]]]): (Experimental) Version of the logic
+            encapsulated by the op. Can be either a single string or a dictionary mapping output names
+            to strings. The single string form assumes the same code version for all op outputs. The
+            dictionary form allows different ops for different outputs. In general, versions should be
+            set only for code that deterministically produces the same output when given the same
+            inputs.
+        code_version (Optional[str]): (Experimental) Version of the code encapsulated by the multi-asset. If set,
+            this is used as a default code version for all defined assets.
     """
     if resource_defs is not None:
         experimental_arg_warning("resource_defs", "multi_asset")
@@ -447,6 +458,7 @@ def multi_asset(
                 },
                 config_schema=_config_schema,
                 retry_policy=retry_policy,
+                code_version=code_version,
             )(fn)
 
         keys_by_input_name = {

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -574,7 +574,7 @@ def _build_logical_version_tags(
     asset_key: AssetKey, step_context: StepExecutionContext
 ) -> Dict[str, str]:
     asset_layer = step_context.pipeline_def.asset_layer
-    code_version = asset_layer.op_version_for_asset(asset_key) or step_context.pipeline_run.run_id
+    code_version = asset_layer.code_version_for_asset(asset_key) or step_context.pipeline_run.run_id
     input_logical_versions: Dict[AssetKey, LogicalVersion] = {}
     tags: Dict[str, str] = {}
     tags[CODE_VERSION_TAG_KEY] = code_version

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -266,13 +266,13 @@ def test_asset_with_dagster_type():
     assert my_asset.op.output_defs[0].dagster_type.display_name == "String"
 
 
-def test_asset_with_op_version():
-    @asset(op_version="foo")
+def test_asset_with_code_version():
+    @asset(code_version="foo")
     def my_asset(arg1):
         return arg1
 
-    assert my_asset.is_versioned
     assert my_asset.op.version == "foo"
+    assert my_asset.op.output_def_named("result").code_version == "foo"
 
 
 def test_asset_with_key_prefix():

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -573,6 +573,22 @@ def test_multi_asset_resource_defs():
     )
 
 
+def test_multi_asset_code_versions():
+    @multi_asset(
+        outs={
+            "key1": AssetOut(key=AssetKey("key1"), code_version="foo"),
+            "key2": AssetOut(key=AssetKey("key2"), code_version="bar"),
+        },
+    )
+    def my_asset():
+        pass
+
+    assert my_asset.code_versions_by_key == {
+        AssetKey("key1"): "foo",
+        AssetKey("key2"): "bar",
+    }
+
+
 def test_asset_io_manager_def():
     @io_manager
     def the_manager():

--- a/python_modules/dagster/dagster_tests/core_tests/test_logical_versions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_logical_versions.py
@@ -9,7 +9,7 @@ def test_logical_version_construction():
     assert ver.value == "foo"
 
     with pytest.raises(ParameterCheckError):
-        LogicalVersion(100)
+        LogicalVersion(100)  # type: ignore
 
 
 def test_logical_version_equality():

--- a/python_modules/dagster/dagster_tests/execution_tests/test_logical_versions.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_logical_versions.py
@@ -21,12 +21,9 @@ from dagster._core.definitions.logical_version import (
     CODE_VERSION_TAG_KEY,
     INPUT_LOGICAL_VERSION_TAG_KEY_PREFIX,
     LOGICAL_VERSION_TAG_KEY,
-    CODE_VERSION_TAG_KEY,
-    LOGICAL_VERSION_TAG_KEY,
     LogicalVersion,
     compute_logical_version,
 )
-
 from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
 
 # ########################
@@ -47,12 +44,10 @@ def mock_io_manager():
     return MockIOManager()
 
 
-def get_mat_from_result(
-    result: ExecuteInProcessResult, node_str: str
-) -> Sequence[AssetMaterialization]:
+def get_mat_from_result(result: ExecuteInProcessResult, node_str: str) -> AssetMaterialization:
     mats = result.asset_materializations_for_node(node_str)
     assert all(isinstance(m, AssetMaterialization) for m in mats)
-    return cast(Sequence[AssetMaterialization], mats[0])
+    return cast(AssetMaterialization, mats[0])
 
 
 def get_mats_from_result(
@@ -351,6 +346,7 @@ def test_multi_asset():
     assert_provenance_match(mat_b_2, mat_a_2)
     assert_provenance_no_match(mat_b_2, mat_a_1)
 
+
 def test_multiple_code_versions():
     @multi_asset(
         outs={
@@ -362,7 +358,9 @@ def test_multiple_code_versions():
         yield Output(1, "alpha")
         yield Output(2, "beta")
 
-    alpha_mat, beta_mat = materialize_assets([alpha_beta], DagsterInstance.ephemeral())
+    mats = materialize_assets([alpha_beta], DagsterInstance.ephemeral())
+    alpha_mat = mats[AssetKey("alpha")]
+    beta_mat = mats[AssetKey("beta")]
 
     assert_logical_version(alpha_mat, compute_logical_version("a", {}))
     assert_code_version(alpha_mat, "a")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -290,6 +290,9 @@ def _get_asset_deps(
                 metadata=_get_node_metadata(node_info),
                 is_required=False,
                 dagster_type=Nothing,
+                code_version=hashlib.sha1(
+                    (node_info.get("raw_sql") or node_info.get("raw_code", "")).encode("utf-8")
+                ).hexdigest(),
             ),
         )
 


### PR DESCRIPTION
### Summary & Motivation

- Resolves #10728 
- Resolves #10729

Update the code versioning system to scope code versions to individual outputs (as opposed to ops). This allows for ops that wrap external code (e.g. dbt models) to accurately represent versios in this external code. This in turn allows the logical versioning system to more accurately represent the staleness of assets defined in these external models. Changes include:

- Addition of `code_version` to `OutputDefinition` and associated abstractions
- Modification of `AssetLayer` to correctly map asset keys to output-scoped code versions
- Deprecation of the `version` property on `OpDefinition`-- a version passed to the constructor is merely a default for the code version set on `OutputDefinition`, so there's no need to store it on `OpDefinition` itself.
- Deprecation of the `version` arg wherever it is used to represent a code version, to be replaced with `code_version`.
- Remove old `is_versioned` property from `AssetsDefinition` (should've been removed in a previous PR)

#### Questions/Concerns

- There are a couple places that `AssetOutputInfo` is constructed to put on `OutputContext`. I did not modify these sites to pass a code version-- these `AssetOutputInfo` instances already seem incomplete, not sure what they're for.
- Doesn't yet include modifications to old memoization code that uses op versions (nonetheless, it passes tests-- I think coverage is weak there).

### How I Tested These Changes

Added/modified unit tests.