### PR TITLE
[dagit] Export WorkspaceOverviewGrid for Cloud

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewWithGrid.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewWithGrid.tsx
@@ -22,62 +22,62 @@ import {repoAddressAsString} from './repoAddressAsString';
 import {workspacePath} from './workspacePath';
 
 export const WorkspaceOverviewWithGrid = () => {
-  const {loading, error, options} = useRepositoryOptions();
-
-  const content = () => {
-    if (loading) {
-      return (
-        <Box flex={{direction: 'row', justifyContent: 'center'}} style={{paddingTop: '100px'}}>
-          <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
-            <Spinner purpose="section" />
-            <div style={{color: Colors.Gray600}}>Loading workspace…</div>
-          </Box>
-        </Box>
-      );
-    }
-
-    if (error) {
-      return (
-        <Box padding={{vertical: 64}}>
-          <NonIdealState
-            icon="error"
-            title="Error loading repositories"
-            description="Could not load repositories in this workspace."
-          />
-        </Box>
-      );
-    }
-
-    if (!options.length) {
-      return (
-        <Box padding={{vertical: 64}}>
-          <NonIdealState
-            icon="folder"
-            title="No repositories"
-            description="When you add a repository to this workspace, it will appear here."
-          />
-        </Box>
-      );
-    }
-
-    return (
-      <CardGrid>
-        {options.map((option) => {
-          const repoAddress = buildRepoAddress(
-            option.repository.name,
-            option.repositoryLocation.name,
-          );
-          return <RepositoryGridItem key={repoAddressAsString(repoAddress)} repo={option} />;
-        })}
-      </CardGrid>
-    );
-  };
-
   return (
     <Page>
       <PageHeader title={<Heading>Deployment</Heading>} tabs={<InstanceTabs tab="workspace" />} />
-      {content()}
+      <WorkspaceOverviewGrid />
     </Page>
+  );
+};
+
+export const WorkspaceOverviewGrid = () => {
+  const {loading, error, options} = useRepositoryOptions();
+
+  if (loading) {
+    return (
+      <Box flex={{direction: 'row', justifyContent: 'center'}} style={{paddingTop: '100px'}}>
+        <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
+          <Spinner purpose="section" />
+          <div style={{color: Colors.Gray600}}>Loading workspace…</div>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box padding={{vertical: 64}}>
+        <NonIdealState
+          icon="error"
+          title="Error loading definitions"
+          description="Could not load definitions in this workspace."
+        />
+      </Box>
+    );
+  }
+
+  if (!options.length) {
+    return (
+      <Box padding={{vertical: 64}}>
+        <NonIdealState
+          icon="folder"
+          title="No definitions"
+          description="When you add a definition to this workspace, it will appear here."
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <CardGrid>
+      {options.map((option) => {
+        const repoAddress = buildRepoAddress(
+          option.repository.name,
+          option.repositoryLocation.name,
+        );
+        return <RepositoryGridItem key={repoAddressAsString(repoAddress)} repo={option} />;
+      })}
+    </CardGrid>
   );
 };
 


### PR DESCRIPTION
### Summary & Motivation

Export WorkspaceOverviewGrid to make it directly available for Cloud, to move the Workspace tab under Deployment. This is temporary until we have the new Code Locations table in place.

### How I Tested These Changes

View Deployment in OSS Dagit, verify that Workspace renders correctly under Deployment. With this change in place, verify that I can do the same with a corresponding change in place in Cloud.
