### PR TITLE
[dagit] Rather than just showing groups, show tiny colorized assets when zoomed out

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetEdges.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetEdges.tsx
@@ -8,13 +8,13 @@ export const AssetEdges: React.FC<{
   edges: AssetLayoutEdge[];
   highlighted: string | null;
   strokeWidth?: number;
-  baseColor?: string;
+  baseColor?: string | null;
 }> = ({edges, highlighted, strokeWidth = 4, baseColor = Colors.KeylineGray}) => {
   // Note: we render the highlighted edges twice, but it's so that the first item with
   // all the edges in it can remain memoized.
   return (
     <React.Fragment>
-      <AssetEdgeSet color={baseColor} edges={edges} strokeWidth={strokeWidth} />
+      {baseColor && <AssetEdgeSet color={baseColor} edges={edges} strokeWidth={strokeWidth} />}
       <AssetEdgeSet
         color={Colors.Blue500}
         edges={edges.filter(({fromId, toId}) => highlighted === fromId || highlighted === toId)}

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGroupNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGroupNode.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, FontFamily, Icon, Mono} from '@dagster-io/ui';
+import {Box, Colors, Icon, Mono} from '@dagster-io/ui';
 import React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -7,7 +7,7 @@ import {withMiddleTruncation} from '../app/Util';
 import {buildRepoPath} from '../workspace/buildRepoAddress';
 import {workspacePath} from '../workspace/workspacePath';
 
-import {MINIMAL_SCALE, GROUPS_ONLY_SCALE} from './AssetGraphExplorer';
+import {MINIMAL_SCALE, TINY_SCALE} from './AssetGraphExplorer';
 import {GroupLayout} from './layout';
 
 export const AssetGroupNode: React.FC<{group: GroupLayout; scale: number}> = ({group, scale}) => {
@@ -20,7 +20,7 @@ export const AssetGroupNode: React.FC<{group: GroupLayout; scale: number}> = ({g
 
   return (
     <div style={{position: 'relative', width: '100%', height: '100%'}}>
-      {scale > GROUPS_ONLY_SCALE && (
+      {scale > TINY_SCALE && (
         <Box flex={{alignItems: 'flex-end'}} style={{height: 70}}>
           <Mono
             style={{
@@ -65,31 +65,9 @@ export const AssetGroupNode: React.FC<{group: GroupLayout; scale: number}> = ({g
           inset: 0,
           top: 75,
           position: 'absolute',
-          background:
-            scale < GROUPS_ONLY_SCALE ? `rgba(234, 234, 234, 1)` : `rgba(217, 217, 217, 0.25)`,
+          background: `rgba(217, 217, 217, 0.25)`,
         }}
       />
-
-      {scale < GROUPS_ONLY_SCALE ? (
-        <Box
-          flex={{justifyContent: 'center', alignItems: 'center'}}
-          style={{inset: 0, position: 'absolute', fontSize: `${12 / scale}px`, userSelect: 'none'}}
-        >
-          <Box
-            flex={{direction: 'column', alignItems: 'center'}}
-            style={{fontWeight: 600, fontFamily: FontFamily.monospace}}
-          >
-            {groupName}
-            {repositoryDisambiguationRequired && (
-              <GroupRepoName>
-                {withMiddleTruncation(buildRepoPath(repositoryName, repositoryLocationName), {
-                  maxLength: 45,
-                })}
-              </GroupRepoName>
-            )}
-          </Box>
-        </Box>
-      ) : undefined}
     </div>
   );
 };

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -217,48 +217,59 @@ export const AssetNodeStatusRow: React.FC<{
   );
 };
 
-export const AssetNodeMinimal: React.FC<{
+export const miniColorsForLiveData = (liveData?: LiveDataForNode) => {
+  return liveData?.runWhichFailedToMaterialize || isAssetLate(liveData)
+    ? {border: Colors.Red500, background: Colors.Red50}
+    : !liveData?.lastMaterialization
+    ? {border: Colors.Gray500, background: Colors.Gray100}
+    : isAssetStale(liveData)
+    ? {border: Colors.Yellow500, background: Colors.Yellow50}
+    : {border: Colors.Green500, background: Colors.Green50};
+};
+
+export const AssetNodeTiny: React.FC<{
   selected: boolean;
   liveData?: LiveDataForNode;
   definition: AssetNodeFragment;
+}> = ({selected, liveData, definition}) => {
+  const {isSource, assetKey} = definition;
+  const {border} = miniColorsForLiveData(liveData);
+
+  return (
+    <MinimalAssetNodeBox
+      title={assetKey.path[assetKey.path.length - 1]}
+      $selected={selected}
+      $isSource={isSource}
+      $background={border}
+      $border={border}
+    />
+  );
+};
+
+export const AssetNodeMinimal: React.FC<{
+  selected: boolean;
+  definition: AssetNodeFragment;
+  liveData?: LiveDataForNode;
 }> = ({selected, definition, liveData}) => {
   const {isSource, assetKey} = definition;
   const displayName = assetKey.path[assetKey.path.length - 1];
-
+  const {border, background} = miniColorsForLiveData(liveData);
   return (
     <AssetInsetForHoverEffect>
-      <MinimalAssetNodeContainer $selected={selected}>
-        <MinimalAssetNodeBox
-          $selected={selected}
-          $isSource={isSource}
-          $background={
-            liveData?.runWhichFailedToMaterialize || isAssetLate(liveData)
-              ? Colors.Red50
-              : !liveData?.lastMaterialization
-              ? Colors.Gray100
-              : isAssetStale(liveData)
-              ? Colors.Yellow50
-              : Colors.Green50
-          }
-          $border={
-            liveData?.runWhichFailedToMaterialize || isAssetLate(liveData)
-              ? Colors.Red500
-              : !liveData?.lastMaterialization
-              ? Colors.Gray500
-              : isAssetStale(liveData)
-              ? Colors.Yellow500
-              : Colors.Green500
-          }
-        >
-          <div style={{position: 'absolute', right: 5, top: 5}}>
-            <AssetLatestRunSpinner liveData={liveData} purpose="body-text" />
-          </div>
+      <MinimalAssetNodeBox
+        $selected={selected}
+        $isSource={isSource}
+        $background={background}
+        $border={border}
+      >
+        <div style={{position: 'absolute', right: 5, top: 5}}>
+          <AssetLatestRunSpinner liveData={liveData} purpose="body-text" />
+        </div>
 
-          <MinimalName style={{fontSize: 30}} $isSource={isSource}>
-            {withMiddleTruncation(displayName, {maxLength: 17})}
-          </MinimalName>
-        </MinimalAssetNodeBox>
-      </MinimalAssetNodeContainer>
+        <MinimalName style={{fontSize: 30}} $isSource={isSource}>
+          {withMiddleTruncation(displayName, {maxLength: 17})}
+        </MinimalName>
+      </MinimalAssetNodeBox>
     </AssetInsetForHoverEffect>
   );
 };
@@ -359,10 +370,6 @@ const Name = styled.div<{$isSource: boolean}>`
   border-top-right-radius: 7px;
   font-weight: 600;
   gap: 4px;
-`;
-
-const MinimalAssetNodeContainer = styled(AssetNodeContainer)`
-  height: 100%;
 `;
 
 const MinimalAssetNodeBox = styled.div<{


### PR DESCRIPTION
### Summary & Motivation

Instead of a "groups only" zoom level when you zoom really far out on the asset graph, we're exploring a new one that is just the colorized asset nodes. This mode is only available when you have enough assets to need it, and doesn't show any labels.

https://www.loom.com/share/ceeabe070f794e1b980a6154eb99f7fc

### How I Tested These Changes
