### PR TITLE
[dagit] Bring op graph back to the asset job partitions page

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/BackfillStepStatusDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillStepStatusDialog.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import {PartitionPerOpStatus} from '../partitions/PartitionStepStatus';
 import {usePartitionStepQuery} from '../partitions/usePartitionStepQuery';
+import {DagsterTag} from '../runs/RunTag';
 import {RunFilterToken} from '../runs/RunsFilterInput';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
@@ -74,6 +75,7 @@ export const BackfillStepStatusDialogContent = ({
 
   const partitions = usePartitionStepQuery(
     partitionSet.name,
+    DagsterTag.Partition,
     backfill.partitionNames,
     pageSize,
     runsFilter,

--- a/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
@@ -10,14 +10,17 @@ import {
 } from '../assets/MultipartitioningSupport';
 import {usePartitionHealthData} from '../assets/usePartitionHealthData';
 import {useViewport} from '../gantt/useViewport';
+import {DagsterTag} from '../runs/RunTag';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
 import {JobBackfillsTable} from './JobBackfillsTable';
-import {CountBox} from './OpJobPartitionsView';
+import {CountBox, usePartitionDurations} from './OpJobPartitionsView';
+import {PartitionGraph} from './PartitionGraph';
 import {PartitionState, PartitionStatus} from './PartitionStatus';
 import {getVisibleItemCount, PartitionPerAssetStatus} from './PartitionStepStatus';
 import {GRID_FLOATING_CONTAINER_WIDTH} from './RunMatrixUtils';
+import {usePartitionStepQuery} from './usePartitionStepQuery';
 
 export const AssetJobPartitionsView: React.FC<{
   pipelineName: string;
@@ -54,28 +57,27 @@ export const AssetJobPartitionsView: React.FC<{
   const [showAssets, setShowAssets] = React.useState(false);
 
   React.useEffect(() => {
-    if (viewport.width && !showAssets) {
+    if (viewport.width) {
       // magical numbers to approximate the size of the window, which is calculated in the step
       // status component.  This approximation is to make sure that the window does not jump as
       // the pageSize gets recalculated
       const approxPageSize = getVisibleItemCount(viewport.width - GRID_FLOATING_CONTAINER_WIDTH);
       setPageSize(approxPageSize);
     }
-  }, [viewport.width, showAssets, setPageSize]);
+  }, [viewport.width, setPageSize]);
 
-  const rangeDimensionIdx = merged.dimensions.findIndex((d) =>
-    isTimeseriesPartition(d.partitionKeys[0]),
+  let dimensionIdx = merged.dimensions.findIndex((d) => isTimeseriesPartition(d.partitionKeys[0]));
+  if (dimensionIdx === -1) {
+    dimensionIdx = 0; // may as well show something
+  }
+
+  const dimension = merged.dimensions[dimensionIdx];
+  const dimensionKeys = dimension?.partitionKeys || [];
+
+  const selectedDimensionKeys = dimensionKeys.slice(
+    Math.max(0, dimensionKeys.length - 1 - offset - pageSize),
+    dimensionKeys.length - offset,
   );
-  const rangeDimension = merged.dimensions[rangeDimensionIdx];
-  const rangePartitionKeys = rangeDimension?.partitionKeys || [];
-
-  const selectedPartitions = showAssets
-    ? rangePartitionKeys.slice(
-        Math.max(0, rangePartitionKeys.length - 1 - offset - pageSize),
-        rangePartitionKeys.length - offset,
-      )
-    : rangePartitionKeys;
-
   return (
     <div>
       <Box
@@ -105,30 +107,27 @@ export const AssetJobPartitionsView: React.FC<{
       <Box padding={{vertical: 16, horizontal: 24}}>
         <div {...containerProps}>
           <PartitionStatus
-            partitionNames={rangePartitionKeys}
-            partitionStateForKey={(key) => merged.stateForSingleDimension(rangeDimensionIdx, key)}
-            selected={showAssets ? selectedPartitions : undefined}
+            partitionNames={dimensionKeys}
+            partitionStateForKey={(key) => merged.stateForSingleDimension(dimensionIdx, key)}
+            selected={selectedDimensionKeys}
             selectionWindowSize={pageSize}
             onClick={(partitionName) => {
-              const maxIdx = rangePartitionKeys.length - 1;
-              const selectedIdx = rangePartitionKeys.indexOf(partitionName);
+              const maxIdx = dimensionKeys.length - 1;
+              const selectedIdx = dimensionKeys.indexOf(partitionName);
               const nextOffset = Math.min(
                 maxIdx,
                 Math.max(0, maxIdx - selectedIdx - 0.5 * pageSize),
               );
               setOffset(nextOffset);
-              if (!showAssets) {
-                setShowAssets(true);
-              }
             }}
             tooltipMessage="Click to view per-asset status"
           />
         </div>
-        {showAssets && rangeDimension && (
+        {showAssets && dimension && (
           <Box margin={{top: 16}}>
             <PartitionPerAssetStatus
-              rangeDimensionIdx={rangeDimensionIdx}
-              rangeDimension={rangeDimension}
+              rangeDimensionIdx={dimensionIdx}
+              rangeDimension={dimension}
               assetHealth={assetHealth}
               assetQueryItems={assetGraph.graphQueryItems}
               pipelineName={pipelineName}
@@ -139,6 +138,16 @@ export const AssetJobPartitionsView: React.FC<{
           </Box>
         )}
       </Box>
+      <AssetJobPartitionGraphs
+        pipelineName={pipelineName}
+        partitionSetName={partitionSetName}
+        multidimensional={(merged?.dimensions.length || 0) > 1}
+        dimensionName={dimension?.name}
+        dimensionKeys={dimensionKeys}
+        selected={selectedDimensionKeys}
+        offset={offset}
+        pageSize={pageSize}
+      />
       <Box
         padding={{horizontal: 24, vertical: 16}}
         border={{side: 'horizontal', color: Colors.KeylineGray, width: 1}}
@@ -150,10 +159,79 @@ export const AssetJobPartitionsView: React.FC<{
         <JobBackfillsTable
           partitionSetName={partitionSetName}
           repositorySelector={repositorySelector}
-          partitionNames={rangePartitionKeys}
+          partitionNames={dimensionKeys}
           refetchCounter={1}
         />
       </Box>
     </div>
+  );
+};
+
+export const AssetJobPartitionGraphs: React.FC<{
+  pipelineName: string;
+  partitionSetName: string;
+  multidimensional: boolean;
+  dimensionName: string;
+  dimensionKeys: string[];
+  selected: string[];
+  pageSize: number;
+  offset: number;
+}> = ({
+  dimensionKeys,
+  dimensionName,
+  selected,
+  pageSize,
+  partitionSetName,
+  multidimensional,
+  pipelineName,
+  offset,
+}) => {
+  const partitions = usePartitionStepQuery(
+    partitionSetName,
+    multidimensional ? `${DagsterTag.Partition}/${dimensionName}` : DagsterTag.Partition,
+    dimensionKeys,
+    pageSize,
+    [],
+    pipelineName,
+    offset,
+    !dimensionName,
+  );
+
+  const {stepDurationData, runDurationData} = usePartitionDurations(partitions);
+
+  return (
+    <>
+      <Box
+        padding={{horizontal: 24, vertical: 16}}
+        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+      >
+        <Subheading>Run duration</Subheading>
+      </Box>
+
+      <Box margin={24}>
+        <PartitionGraph
+          isJob={true}
+          title="Execution time by partition"
+          yLabel="Execution time (secs)"
+          partitionNames={selected}
+          jobDataByPartition={runDurationData}
+        />
+      </Box>
+      <Box
+        padding={{horizontal: 24, vertical: 16}}
+        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+      >
+        <Subheading>Step durations</Subheading>
+      </Box>
+      <Box margin={24}>
+        <PartitionGraph
+          isJob={true}
+          title="Execution time by partition"
+          yLabel="Execution time (secs)"
+          partitionNames={selected}
+          stepDataByPartition={stepDurationData}
+        />
+      </Box>
+    </>
   );
 };

--- a/js_modules/dagit/packages/core/src/partitions/OpJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/OpJobPartitionsView.tsx
@@ -62,27 +62,29 @@ export const OpJobPartitionsView: React.FC<{
 };
 
 export function usePartitionDurations(partitions: PartitionRuns[]) {
-  const stepDurationData: {[name: string]: {[key: string]: (number | undefined)[]}} = {};
-  const runDurationData: {[name: string]: number | undefined} = {};
+  return React.useMemo(() => {
+    const stepDurationData: {[name: string]: {[key: string]: (number | undefined)[]}} = {};
+    const runDurationData: {[name: string]: number | undefined} = {};
 
-  partitions.forEach((p) => {
-    if (!p.runsLoaded || p.runs.length === 0) {
-      return;
-    }
-    const sortedRuns = p.runs.sort((a, b) => a.startTime || 0 - (b.startTime || 0));
-    const lastRun = sortedRuns[sortedRuns.length - 1];
-    stepDurationData[p.name] = {};
-    runDurationData[p.name] =
-      lastRun?.endTime && lastRun?.startTime ? lastRun.endTime - lastRun.startTime : undefined;
+    partitions.forEach((p) => {
+      if (!p.runsLoaded || p.runs.length === 0) {
+        return;
+      }
+      const sortedRuns = p.runs.sort((a, b) => a.startTime || 0 - (b.startTime || 0));
+      const lastRun = sortedRuns[sortedRuns.length - 1];
+      stepDurationData[p.name] = {};
+      runDurationData[p.name] =
+        lastRun?.endTime && lastRun?.startTime ? lastRun.endTime - lastRun.startTime : undefined;
 
-    lastRun.stepStats.forEach((s) => {
-      stepDurationData[p.name][s.stepKey] = [
-        s.endTime && s.startTime ? s.endTime - s.startTime : undefined,
-      ];
+      lastRun.stepStats.forEach((s) => {
+        stepDurationData[p.name][s.stepKey] = [
+          s.endTime && s.startTime ? s.endTime - s.startTime : undefined,
+        ];
+      });
     });
-  });
 
-  return {runDurationData, stepDurationData};
+    return {runDurationData, stepDurationData};
+  }, [partitions]);
 }
 
 const OpJobPartitionsViewContent: React.FC<{


### PR DESCRIPTION
### Summary & Motivation

Hey folks! Here's a quick summary of this change: https://www.loom.com/share/d03f3d3a2c5f45efa3462eb3c0e7fb7f

- The "Run Duration" and "Step Duration" graphs are now available on the Asset Jobs page again.

- These require that we load step stats for runs in each partition via GraphQL, so they're only available if you've selected a particular time frame. Rather than make these gray out / disappear / have an empty state, etc., I made it so that the top timeline always has a selection. This *is* slightly different than the behavior of the top bar on the Op Job page, which has a "no selection" state and displays Run Duration without Step Duration in that case.

- These graphs reflect the latest run for the graphed partition dimension. If you have a multidimensional asset, which "state" is used for the "day: 2022-11-11" numbers is whichever one ran last. 

### How I Tested These Changes
