### PR TITLE
[dagit] Partition health with “split” UI for non-timeseries ranges

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
@@ -12,7 +12,7 @@ import {AssetPartitionList} from './AssetPartitionList';
 import {AssetViewParams} from './AssetView';
 import {CurrentRunsBanner} from './CurrentRunsBanner';
 import {FailedRunsSinceMaterializationBanner} from './FailedRunsSinceMaterializationBanner';
-import {explodePartitionKeysInRanges, isTimeseriesPartition} from './MultipartitioningSupport';
+import {explodePartitionKeysInRanges, isTimeseriesDimension} from './MultipartitioningSupport';
 import {AssetKey} from './types';
 import {usePartitionDimensionRanges} from './usePartitionDimensionRanges';
 import {PartitionHealthDimensionRange, usePartitionHealthData} from './usePartitionHealthData';
@@ -49,7 +49,7 @@ export const AssetPartitions: React.FC<Props> = ({
     PartitionState.SUCCESS,
   ]);
 
-  const timeRangeIdx = ranges.findIndex((r) => isTimeseriesPartition(r.dimension.partitionKeys[0]));
+  const timeRangeIdx = ranges.findIndex((r) => isTimeseriesDimension(r.dimension));
   const timeRange = timeRangeIdx !== -1 ? ranges[timeRangeIdx] : null;
 
   const allInRanges = React.useMemo(() => {
@@ -68,9 +68,7 @@ export const AssetPartitions: React.FC<Props> = ({
     : [];
 
   const dimensionKeysOrdered = (range: PartitionHealthDimensionRange) => {
-    return isTimeseriesPartition(range.selected[0])
-      ? [...range.selected].reverse()
-      : range.selected;
+    return isTimeseriesDimension(range.dimension) ? [...range.selected].reverse() : range.selected;
   };
   const dimensionRowsForRange = (range: PartitionHealthDimensionRange, idx: number) => {
     if (timeRange && timeRange.selected.length === 0) {

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -99,11 +99,13 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
   assetJobName,
   upstreamAssetKeys,
 }) => {
-  const {canLaunchPartitionBackfill} = usePermissions();
-  const [previewCount, setPreviewCount] = React.useState(0);
-  const [launching, setLaunching] = React.useState(false);
-
   const partitionedAssets = assets.filter((a) => !!a.partitionDefinition);
+
+  const {canLaunchPartitionBackfill} = usePermissions();
+  const [launching, setLaunching] = React.useState(false);
+  const [previewCount, setPreviewCount] = React.useState(0);
+  const morePreviewsCount = partitionedAssets.length - previewCount;
+
   const assetHealth = usePartitionHealthData(partitionedAssets.map((a) => a.assetKey));
   const mergedHealth = React.useMemo(() => mergedAssetHealth(assetHealth), [assetHealth]);
 
@@ -301,10 +303,10 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
                 ranges={ranges}
               />
             ))}
-            {previewCount < partitionedAssets.length && (
+            {morePreviewsCount > 0 && (
               <Box margin={{vertical: 8}}>
                 <ButtonLink onClick={() => setPreviewCount(partitionedAssets.length)}>
-                  Show {partitionedAssets.length - previewCount} more previews
+                  Show {morePreviewsCount} more {morePreviewsCount > 1 ? 'previews' : 'preview'}
                 </ButtonLink>
               </Box>
             )}

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -255,7 +255,11 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
               key={range.dimension.name}
               partitionKeys={range.dimension.partitionKeys}
               partitionStateForKey={(dimensionKey) =>
-                mergedHealth.stateForSingleDimension(idx, dimensionKey)
+                mergedHealth.stateForSingleDimension(
+                  idx,
+                  dimensionKey,
+                  ranges.length === 2 ? ranges[1 - idx].selected : undefined,
+                )
               }
               selected={range.selected}
               setSelected={(selected) =>
@@ -272,36 +276,49 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
             onChange={setStateFilters}
           />
         </Box>
-        <Box
-          flex={{direction: 'column', gap: 8}}
-          border={{side: 'top', width: 1, color: Colors.KeylineGray}}
-          style={{marginTop: 16, overflowY: 'auto', overflowX: 'visible', maxHeight: '50vh'}}
-        >
-          {partitionedAssets.slice(0, previewCount).map((a) => (
-            <PartitionHealthSummary
-              assetKey={a.assetKey}
-              showAssetKey
-              key={displayNameForAssetKey(a.assetKey)}
-              data={assetHealth}
-              selected={allSelected}
-            />
-          ))}
-          {partitionedAssets.length === 1 ? (
-            <span />
-          ) : previewCount === 0 ? (
-            <Box margin={{vertical: 8}}>
-              <ButtonLink onClick={() => setPreviewCount(5)}>
-                Show per-asset partition health
-              </ButtonLink>
-            </Box>
-          ) : previewCount < partitionedAssets.length ? (
-            <Box margin={{vertical: 8}}>
-              <ButtonLink onClick={() => setPreviewCount(partitionedAssets.length)}>
-                Show {partitionedAssets.length - previewCount} more previews
-              </ButtonLink>
-            </Box>
-          ) : undefined}
-        </Box>
+
+        {previewCount > 0 && (
+          <Box
+            margin={{top: 16}}
+            flex={{direction: 'column', gap: 8}}
+            padding={{vertical: 16, horizontal: 20}}
+            border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+            background={Colors.Gray100}
+            style={{
+              marginLeft: -20,
+              marginRight: -20,
+              overflowY: 'auto',
+              overflowX: 'visible',
+              maxHeight: '35vh',
+            }}
+          >
+            {partitionedAssets.slice(0, previewCount).map((a) => (
+              <PartitionHealthSummary
+                key={displayNameForAssetKey(a.assetKey)}
+                assetKey={a.assetKey}
+                showAssetKey
+                data={assetHealth}
+                ranges={ranges}
+              />
+            ))}
+            {previewCount < partitionedAssets.length && (
+              <Box margin={{vertical: 8}}>
+                <ButtonLink onClick={() => setPreviewCount(partitionedAssets.length)}>
+                  Show {partitionedAssets.length - previewCount} more previews
+                </ButtonLink>
+              </Box>
+            )}
+          </Box>
+        )}
+
+        {previewCount === 0 && partitionedAssets.length > 1 && (
+          <Box margin={{top: 16, bottom: 8}}>
+            <ButtonLink onClick={() => setPreviewCount(5)}>
+              Show per-asset partition health
+            </ButtonLink>
+          </Box>
+        )}
+
         <UpstreamUnavailableWarning
           upstreamAssetKeys={upstreamAssetKeys}
           ranges={ranges}

--- a/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
+++ b/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
@@ -6,6 +6,9 @@ import {
   PartitionHealthDimensionRange,
 } from './usePartitionHealthData';
 
+export function isTimeseriesDimension(dimension: PartitionHealthDimension) {
+  return isTimeseriesPartition(dimension.partitionKeys[0]);
+}
 export function isTimeseriesPartition(aPartitionKey = '') {
   return /\d{4}-\d{2}-\d{2}/.test(aPartitionKey); // cheak trick for now
 }
@@ -16,7 +19,11 @@ export function mergedAssetHealth(
   dimensions: PartitionHealthDimension[];
   stateForKey: (dimensionKeys: string[]) => PartitionState;
   stateForPartialKey: (dimensionKeys: string[]) => PartitionState;
-  stateForSingleDimension: (dimensionIdx: number, dimensionKey: string) => PartitionState;
+  stateForSingleDimension: (
+    dimensionIdx: number,
+    dimensionKey: string,
+    otherDimensionSelectedKeys?: string[],
+  ) => PartitionState;
 } {
   if (!assetHealth.length) {
     return {
@@ -54,9 +61,15 @@ export function mergedAssetHealth(
       mergedStates(assetHealth.map((health) => health.stateForKey(dimensionKeys))),
     stateForPartialKey: (dimensionKeys: string[]) =>
       mergedStates(assetHealth.map((health) => health.stateForPartialKey(dimensionKeys))),
-    stateForSingleDimension: (dimensionIdx: number, dimensionKey: string) =>
+    stateForSingleDimension: (
+      dimensionIdx: number,
+      dimensionKey: string,
+      otherDimensionSelectedKeys?: string[],
+    ) =>
       mergedStates(
-        assetHealth.map((health) => health.stateForSingleDimension(dimensionIdx, dimensionKey)),
+        assetHealth.map((health) =>
+          health.stateForSingleDimension(dimensionIdx, dimensionKey, otherDimensionSelectedKeys),
+        ),
       ),
   };
 }

--- a/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
@@ -1,24 +1,19 @@
-import {Spinner, Box, Colors, Tooltip} from '@dagster-io/ui';
+import {Spinner, Box, Colors, Caption} from '@dagster-io/ui';
 import React from 'react';
 
 import {displayNameForAssetKey} from '../asset-graph/Utils';
-import {assembleIntoSpans} from '../partitions/PartitionRangeInput';
-import {
-  PartitionState,
-  partitionStateToStyle,
-  partitionStatusToText,
-} from '../partitions/PartitionStatus';
+import {PartitionState, PartitionStatus} from '../partitions/PartitionStatus';
 
-import {isTimeseriesPartition} from './MultipartitioningSupport';
+import {isTimeseriesDimension} from './MultipartitioningSupport';
 import {AssetKey} from './types';
-import {PartitionHealthData} from './usePartitionHealthData';
+import {PartitionHealthData, PartitionHealthDimensionRange} from './usePartitionHealthData';
 
 export const PartitionHealthSummary: React.FC<{
   assetKey: AssetKey;
-  selected?: {partitionKey: string}[];
   showAssetKey?: boolean;
   data: PartitionHealthData[];
-}> = ({showAssetKey, assetKey, selected, data}) => {
+  ranges?: PartitionHealthDimensionRange[];
+}> = ({showAssetKey, assetKey, data, ranges}) => {
   const assetData = data.find((d) => JSON.stringify(d.assetKey) === JSON.stringify(assetKey));
 
   if (!assetData) {
@@ -29,113 +24,46 @@ export const PartitionHealthSummary: React.FC<{
     );
   }
 
-  const timeDimension = assetData.dimensions.find((d) => isTimeseriesPartition(d.partitionKeys[0]));
-  if (!timeDimension) {
-    return <div />;
-  }
+  const keysForTotals = ranges
+    ? ranges.map((r) => r.selected)
+    : assetData.dimensions.map((d) => d.partitionKeys);
 
-  const keys = assetData.dimensions[0].partitionKeys;
-  const spans = assembleIntoSpans(keys, (key) => assetData.stateForPartialKey([key]));
+  const total = keysForTotals.reduce((total, d) => d.length * total, 1);
 
-  const selectedKeys = selected?.map((s) => s.partitionKey);
-  const selectedSpans = selectedKeys
-    ? assembleIntoSpans(keys, (key) => selectedKeys.includes(key)).filter((s) => s.status)
-    : [];
-
-  const total = assetData.dimensions.reduce((total, d) => d.partitionKeys.length * total, 1);
-  const success = assetData.dimensions
+  const success = keysForTotals
     .reduce(
       (combinations, d) =>
         combinations.length
-          ? combinations.flatMap((keys) => d.partitionKeys.map((key) => [...keys, key]))
-          : d.partitionKeys.map((key) => [key]),
+          ? combinations.flatMap((keys) => d.map((key) => [...keys, key]))
+          : d.map((key) => [key]),
       [] as string[][],
     )
     .filter((dkeys) => assetData.stateForKey(dkeys) === PartitionState.SUCCESS).length;
 
-  const indexToPct = (idx: number) => `${((idx * 100) / keys.length).toFixed(3)}%`;
-  const highestIndex = spans.map((s) => s.endIdx).reduce((prev, cur) => Math.max(prev, cur), 0);
-
   return (
-    <div>
-      <Box
-        flex={{justifyContent: 'space-between'}}
-        margin={{bottom: 4}}
-        style={{fontSize: '0.8rem', color: Colors.Gray500}}
-      >
-        {showAssetKey && <span>{displayNameForAssetKey(assetKey)}</span>}
-        <span>{`${success.toLocaleString()}/${total.toLocaleString()}`}</span>
+    <Box color={Colors.Gray500}>
+      <Box flex={{justifyContent: 'space-between'}} style={{fontWeight: 600}} margin={{bottom: 4}}>
+        <Caption>{showAssetKey ? displayNameForAssetKey(assetKey) : 'Materialized'}</Caption>
+        <Caption>{`${success.toLocaleString()}/${total.toLocaleString()}`}</Caption>
       </Box>
-      {selected && (
-        <div style={{position: 'relative', width: '100%', overflowX: 'hidden', height: 10}}>
-          {selectedSpans.map((s) => (
-            <div
-              key={s.startIdx}
-              style={{
-                left: `min(calc(100% - 2px), ${indexToPct(s.startIdx)})`,
-                width: indexToPct(s.endIdx - s.startIdx + 1),
-                position: 'absolute',
-                top: 0,
-                height: 8,
-                border: `2px solid ${Colors.Blue500}`,
-                borderBottom: 0,
-              }}
-            />
-          ))}
-        </div>
-      )}
-      <div
-        style={{
-          position: 'relative',
-          width: '100%',
-          height: 14,
-          borderRadius: 6,
-          overflow: 'hidden',
-        }}
-      >
-        {spans.map((s) => (
-          <div
-            key={s.startIdx}
-            style={{
-              left: `min(calc(100% - 2px), ${indexToPct(s.startIdx)})`,
-              width: indexToPct(s.endIdx - s.startIdx + 1),
-              minWidth: s.status ? 2 : undefined,
-              position: 'absolute',
-              zIndex: s.startIdx === 0 || s.endIdx === highestIndex ? 3 : s.status ? 2 : 1, //End-caps, then statuses, then missing
-              top: 0,
-            }}
-          >
-            <Tooltip
-              display="block"
-              content={
-                s.startIdx === s.endIdx
-                  ? `Partition ${keys[s.startIdx]} is ${s.status ? 'up-to-date' : 'missing'}`
-                  : `Partitions ${keys[s.startIdx]} through ${
-                      keys[s.endIdx]
-                    } are ${partitionStatusToText(s.status).toLowerCase()}
-                    `
-              }
-            >
-              <div
-                style={{
-                  width: '100%',
-                  height: 14,
-                  outline: 'none',
-                  ...partitionStateToStyle(s.status),
-                }}
-              />
-            </Tooltip>
-          </div>
-        ))}
-      </div>
-      <Box
-        flex={{justifyContent: 'space-between'}}
-        margin={{top: 4}}
-        style={{fontSize: '0.8rem', color: Colors.Gray500}}
-      >
-        <span>{keys[0]}</span>
-        <span>{keys[keys.length - 1]}</span>
-      </Box>
-    </div>
+      {assetData.dimensions.map((dimension, dimensionIdx) => (
+        <Box key={dimensionIdx} margin={{bottom: 4}}>
+          {assetData.dimensions.length > 1 && <Caption>{dimension.name}</Caption>}
+          <PartitionStatus
+            small
+            partitionNames={dimension.partitionKeys}
+            splitPartitions={!isTimeseriesDimension(dimension)}
+            selected={ranges ? ranges[dimensionIdx].selected : undefined}
+            partitionStateForKey={(key) =>
+              assetData.stateForSingleDimension(
+                dimensionIdx,
+                key,
+                ranges?.length === 2 ? ranges[1 - dimensionIdx].selected : undefined,
+              )
+            }
+          />
+        </Box>
+      ))}
+    </Box>
   );
 };

--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
@@ -25,7 +25,7 @@ export interface PartitionHealthData {
   stateForSingleDimension: (
     dimensionIdx: number,
     dimensionKey: string,
-    withinParentDimensions?: string[],
+    otherDimensionSelectedKeys?: string[],
   ) => PartitionState;
 }
 

--- a/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
@@ -6,7 +6,7 @@ import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
 import {
   mergedAssetHealth,
   explodePartitionKeysInRanges,
-  isTimeseriesPartition,
+  isTimeseriesDimension,
 } from '../assets/MultipartitioningSupport';
 import {usePartitionHealthData} from '../assets/usePartitionHealthData';
 import {useViewport} from '../gantt/useViewport';
@@ -66,7 +66,7 @@ export const AssetJobPartitionsView: React.FC<{
     }
   }, [viewport.width, setPageSize]);
 
-  let dimensionIdx = merged.dimensions.findIndex((d) => isTimeseriesPartition(d.partitionKeys[0]));
+  let dimensionIdx = merged.dimensions.findIndex(isTimeseriesDimension);
   if (dimensionIdx === -1) {
     dimensionIdx = 0; // may as well show something
   }
@@ -108,9 +108,11 @@ export const AssetJobPartitionsView: React.FC<{
         <div {...containerProps}>
           <PartitionStatus
             partitionNames={dimensionKeys}
+            splitPartitions={!isTimeseriesDimension(dimension)}
             partitionStateForKey={(key) => merged.stateForSingleDimension(dimensionIdx, key)}
             selected={selectedDimensionKeys}
             selectionWindowSize={pageSize}
+            tooltipMessage="Click to view per-asset status"
             onClick={(partitionName) => {
               const maxIdx = dimensionKeys.length - 1;
               const selectedIdx = dimensionKeys.indexOf(partitionName);
@@ -120,7 +122,6 @@ export const AssetJobPartitionsView: React.FC<{
               );
               setOffset(nextOffset);
             }}
-            tooltipMessage="Click to view per-asset status"
           />
         </div>
         {showAssets && dimension && (

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRangeWizard.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRangeWizard.tsx
@@ -34,16 +34,15 @@ export const PartitionRangeWizard: React.FC<{
           All
         </Button>
       </Box>
-      {isTimeseries && (
-        <Box margin={{bottom: 8}}>
-          <PartitionStatus
-            partitionNames={partitionKeys}
-            partitionStateForKey={partitionStateForKey}
-            selected={selected}
-            onSelect={setSelected}
-          />
-        </Box>
-      )}
+      <Box margin={{bottom: 8}}>
+        <PartitionStatus
+          partitionNames={partitionKeys}
+          partitionStateForKey={partitionStateForKey}
+          splitPartitions={!isTimeseries}
+          selected={selected}
+          onSelect={setSelected}
+        />
+      </Box>
     </>
   );
 };


### PR DESCRIPTION
### Summary & Motivation

This PR makes a few improvements to the asset partition selection modal to address https://github.com/dagster-io/dagster/issues/10650:

- The `<PartitionStatus>` component is now shown for non-time based partitions using the `splitPartitions` option, which renders a hairline divider between each partition to imply that they are not an ordered series.

<img width="781" alt="image" src="https://user-images.githubusercontent.com/1037212/204161226-368e7cb9-bd4b-4610-b108-e5135c06212d.png">


- The modal uses the new "other dimension partition keys" option to make the two range selections of a multidimensional asset reflect each other. If you specify "Time: Jan->Feb", the colors shown on the other bar indicate the status of the second dimension *in that time frame*. (Video of this in action: https://www.loom.com/share/4e92bef24d0447fdba8ad0d200798587)

- The `PartitionHealthSummary` component calls out to PartitionStatus rather than re-implementing it's behavior, so there's only one component that renders the "asset health bar".

- If you choose to show "per-asset health" in the backfill modal, it's inside an inset gray area so it's more clear it's a separate scrollable container. This is especially necessary for multi-dimensional assets I think:

<img width="807" alt="image" src="https://user-images.githubusercontent.com/1037212/204161074-a24fe4aa-096c-4579-a337-8f6d136ca034.png">

<img width="779" alt="image" src="https://user-images.githubusercontent.com/1037212/204161069-4b4d63fc-aff9-4aed-a61c-db5e09c6b583.png">


### How I Tested These Changes
