### PR TITLE
Speed up TimeWindowPartitionsSubset.with_partition_keys

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_reconciliation_sensor.py
@@ -506,6 +506,17 @@ scenarios = {
             run_request(asset_keys=["asset1"], partition_key="2013-01-06"),
         ],
     ),
+    "one_asset_daily_partitions_two_years_never_materialized": AssetReconciliationScenario(
+        assets=one_asset_daily_partitions,
+        unevaluated_runs=[],
+        current_time=create_pendulum_time(year=2015, month=1, day=7, hour=4),
+        expected_run_requests=[
+            run_request(asset_keys=["asset1"], partition_key=partition_key)
+            for partition_key in daily_partitions_def.get_partition_keys(
+                current_time=create_pendulum_time(year=2015, month=1, day=7, hour=4)
+            )
+        ],
+    ),
     ################################################################################################
     # Exotic partition-mappings
     ################################################################################################

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_time_window_partitions.py
@@ -395,10 +395,13 @@ def test_partition_subset_get_partition_keys_not_in_subset(case_str: str):
         )
         == expected_keys_not_in_subset
     )
-    assert partitions_def.deserialize_subset(subset.serialize()).key_ranges == subset.key_ranges
+    assert (
+        partitions_def.deserialize_subset(subset.serialize()).included_time_windows
+        == subset.included_time_windows
+    )
 
     expected_range_count = case_str.count("-+") + (1 if case_str[0] == "+" else 0)
-    assert len(subset.key_ranges) == expected_range_count, case_str
+    assert len(subset.included_time_windows) == expected_range_count, case_str
 
 
 @pytest.mark.parametrize(
@@ -500,4 +503,4 @@ def test_partition_subset_with_partition_keys(initial: str, added: str):
     expected_range_count = updated_subset_str.count("-+") + (
         1 if updated_subset_str[0] == "+" else 0
     )
-    assert len(updated_subset.key_ranges) == expected_range_count, updated_subset_str
+    assert len(updated_subset.included_time_windows) == expected_range_count, updated_subset_str


### PR DESCRIPTION
This change brings down the runtime of the added test_asset_reconciliation_sensor scenario from 52.6 seconds to 1.6 seconds. Prior to this change, partitions would get inserted out of order into the subset which meant creating lots of fragmented ranges and then merging them.

Fixes https://github.com/dagster-io/dagster/issues/10760.
