### PR TITLE
captured logs fallback to query when websockets unavailable

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -3238,6 +3238,11 @@ type DagitQuery {
   Retrieve the captured log metadata for a given log key.
   """
   capturedLogsMetadata(logKey: [String!]!): CapturedLogsMetadata!
+
+  """
+  Captured logs are the stdout/stderr logs for a given log key
+  """
+  capturedLogs(logKey: [String!]!): CapturedLogs!
 }
 
 union WorkspaceOrError = Workspace | PythonError

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -3242,7 +3242,7 @@ type DagitQuery {
   """
   Captured logs are the stdout/stderr logs for a given log key
   """
-  capturedLogs(logKey: [String!]!): CapturedLogs!
+  capturedLogs(logKey: [String!]!, cursor: String, limit: Int): CapturedLogs!
 }
 
 union WorkspaceOrError = Workspace | PythonError

--- a/js_modules/dagit/packages/core/src/types/CapturedLogsQuery.ts
+++ b/js_modules/dagit/packages/core/src/types/CapturedLogsQuery.ts
@@ -1,0 +1,25 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: CapturedLogsQuery
+// ====================================================
+
+export interface CapturedLogsQuery_capturedLogs {
+  __typename: "CapturedLogs";
+  stdout: string | null;
+  stderr: string | null;
+  cursor: string | null;
+}
+
+export interface CapturedLogsQuery {
+  capturedLogs: CapturedLogsQuery_capturedLogs;
+}
+
+export interface CapturedLogsQueryVariables {
+  logKey: string[];
+  cursor?: string | null;
+  limit?: number | null;
+}

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -92,7 +92,11 @@ from ..instigation import (
     GrapheneInstigationStatesOrError,
     GrapheneInstigationType,
 )
-from ..logs.compute_logs import GrapheneCapturedLogsMetadata, GrapheneCapturedLogs, from_captured_log_data
+from ..logs.compute_logs import (
+    GrapheneCapturedLogs,
+    GrapheneCapturedLogsMetadata,
+    from_captured_log_data,
+)
 from ..partition_sets import GraphenePartitionSetOrError, GraphenePartitionSetsOrError
 from ..permissions import GraphenePermission
 from ..pipelines.config_result import GraphenePipelineConfigValidationResult
@@ -681,5 +685,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
         return get_captured_log_metadata(graphene_info, logKey)
 
     def resolve_capturedLogs(self, graphene_info, logKey, cursor=None, limit=None):
-        log_data = graphene_info.context.instance.compute_log_manager.get_log_data(logKey, cursor=cursor, max_bytes=limit)
+        log_data = graphene_info.context.instance.compute_log_manager.get_log_data(
+            logKey, cursor=cursor, max_bytes=limit
+        )
         return from_captured_log_data(log_data)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_captured_logs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_captured_logs.py
@@ -10,14 +10,11 @@ from .graphql_context_test_suite import ExecutingGraphQLContextTestMatrix
 from .utils import sync_execute_get_run_log_data
 
 CAPTURED_LOGS_QUERY = """
-  query CapturedLogsQuery($runId: ID!, $fileKey: String!) {
-    pipelineRunOrError(runId: $runId) {
-      ... on PipelineRun {
-        runId
-        capturedLogs(fileKey: $fileKey) {
-          stdout
-        }
-      }
+  query CapturedLogsQuery($logKey: [String!]!) {
+    capturedLogs(logKey: $logKey) {
+      stdout
+      stderr
+      cursor
     }
   }
 """
@@ -45,13 +42,16 @@ class TestCapturedLogs(ExecutingGraphQLContextTestMatrix):
         logs = graphql_context.instance.all_logs(run_id, of_type=DagsterEventType.LOGS_CAPTURED)
         assert len(logs) == 1
         entry = logs[0]
+        log_key = [run_id, "compute_logs", entry.dagster_event.logs_captured_data.file_key]
+
         result = execute_dagster_graphql(
             graphql_context,
             CAPTURED_LOGS_QUERY,
-            variables={"runId": run_id, "fileKey": entry.dagster_event.logs_captured_data.file_key},
+            variables={"logKey": log_key},
         )
-        stdout = result.data["pipelineRunOrError"]["capturedLogs"]["stdout"]
-        snapshot.assert_match(stdout)
+        stdout = result.data["capturedLogs"]["stdout"]
+        assert stdout == "HELLO WORLD\n"
+
 
     def test_captured_logs_subscription_graphql(self, graphql_context):
         selector = infer_pipeline_selector(graphql_context, "spew_pipeline")

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_captured_logs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_captured_logs.py
@@ -31,7 +31,7 @@ CAPTURED_LOGS_SUBSCRIPTION = """
 
 
 class TestCapturedLogs(ExecutingGraphQLContextTestMatrix):
-    def test_get_captured_logs_over_graphql(self, graphql_context, snapshot):
+    def test_get_captured_logs_over_graphql(self, graphql_context):
         selector = infer_pipeline_selector(graphql_context, "spew_pipeline")
         payload = sync_execute_get_run_log_data(
             context=graphql_context,
@@ -51,7 +51,6 @@ class TestCapturedLogs(ExecutingGraphQLContextTestMatrix):
         )
         stdout = result.data["capturedLogs"]["stdout"]
         assert stdout == "HELLO WORLD\n"
-
 
     def test_captured_logs_subscription_graphql(self, graphql_context):
         selector = infer_pipeline_selector(graphql_context, "spew_pipeline")


### PR DESCRIPTION
### Summary & Motivation
When websockets are unavailable (or turned off via user prefs), we still try to use websockets to load compute logs.  This PR attempts to change the compute log panel to work like the LogProvider component in falling back to query-based log loading.

Addresses https://github.com/dagster-io/dagster/issues/10676

### How I Tested These Changes
Turned off websockets in user prefs, turned back on again.