### PR TITLE
[useStateWithStorage] Remove `validate` as dependency to setter.

### DIFF
--- a/js_modules/dagit/packages/core/src/hooks/useStateWithStorage.tsx
+++ b/js_modules/dagit/packages/core/src/hooks/useStateWithStorage.tsx
@@ -23,10 +23,12 @@ const DID_WRITE_LOCALSTORAGE = '';
 export function useStateWithStorage<T>(key: string, validate: (json: any) => T) {
   const [version, setVersion] = React.useState(0);
 
+  const validateRef = React.useRef(validate);
+  validateRef.current = validate;
+
   const listener = React.useCallback(
     (event: Event) => {
       if (event instanceof CustomEvent && event.detail === key) {
-        console.log('set via event');
         setVersion((v) => v + 1);
       }
     },
@@ -49,7 +51,8 @@ export function useStateWithStorage<T>(key: string, validate: (json: any) => T) 
 
   const setState = React.useCallback(
     (input: React.SetStateAction<T>) => {
-      const next = input instanceof Function ? input(validate(getJSONForKey(key))) : input;
+      const next =
+        input instanceof Function ? input(validateRef.current(getJSONForKey(key))) : input;
       if (next === undefined) {
         window.localStorage.removeItem(key);
       } else {
@@ -63,7 +66,7 @@ export function useStateWithStorage<T>(key: string, validate: (json: any) => T) 
 
       return next;
     },
-    [validate, key, listener],
+    [key, listener],
   );
 
   const value = React.useMemo(() => [state, setState], [state, setState]);


### PR DESCRIPTION
### Summary & Motivation

Removing `validate` as a dependency and instead relying on a ref to make sure we have the latest version of the callback.

This avoids a render loop when the `setState` function is a dependency of a `useEffect` that causes the component to rerender (and when `validate` callback reference changes on every render due to lack of `React.useCallback`)

### How I Tested These Changes
Used this hook In cloud and saw infinite loop disappear.