### PR TITLE
Fix asset subset launchpad bug

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2282,6 +2282,7 @@ input PipelineSelector {
   repositoryName: String!
   repositoryLocationName: String!
   solidSelection: [String!]
+  assetSelection: [AssetKeyInput!]
 }
 
 """

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -184,7 +184,8 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
   const pipelineSelector: PipelineSelector = {
     ...repoAddressToSelector(repoAddress),
     pipelineName: pipeline.name,
-    solidSelection: currentSession?.solidSelection || undefined,
+    solidSelection: currentSession.solidSelection || undefined,
+    assetSelection: currentSession.assetSelection?.map(({assetKey: {path}}) => ({path})),
   };
 
   const configResult = useQuery<

--- a/js_modules/dagit/packages/core/src/types/globalTypes.ts
+++ b/js_modules/dagit/packages/core/src/types/globalTypes.ts
@@ -244,6 +244,7 @@ export interface PipelineSelector {
   repositoryName: string;
   repositoryLocationName: string;
   solidSelection?: string[] | null;
+  assetSelection?: AssetKeyInput[] | null;
 }
 
 export interface ReexecutionParams {

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -80,6 +80,7 @@ class GraphenePipelineSelector(graphene.InputObjectType):
     repositoryName = graphene.NonNull(graphene.String)
     repositoryLocationName = graphene.NonNull(graphene.String)
     solidSelection = graphene.List(graphene.NonNull(graphene.String))
+    assetSelection = graphene.List(graphene.NonNull(GrapheneAssetKeyInput))
 
     class Meta:
         description = """This type represents the fields necessary to identify a


### PR DESCRIPTION
### Summary & Motivation

Fixes #10587.

Passes the `assetSelection` to the backend. This required modifying the PipelineSelector object in the GQL schema to match its equivalent on the backend.

### How I Tested These Changes

Replicated bug in linked issue, made changes, observed bug no longer occurs.
