### PR TITLE
[dagit] /workspace -> /locations

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppTopNav.test.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.test.tsx
@@ -56,7 +56,7 @@ describe('AppTopNav', () => {
     render(
       <TestProvider
         apolloProps={{mocks: [defaultMocks]}}
-        routerProps={{initialEntries: ['/workspace/my_repository@my_location']}}
+        routerProps={{initialEntries: ['/locations/my_repository@my_location']}}
       >
         <Test>
           <AppTopNav searchPlaceholder="Test..." rightOfSearchBar={<div>RightOfSearchBar</div>} />

--- a/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
@@ -93,7 +93,8 @@ export const AppTopNav: React.FC<Props> = ({
                 const {pathname} = location;
                 return (
                   pathname.startsWith('/code-locations') ||
-                  pathname.startsWith('/workspace') ||
+                  pathname.startsWith('/locations') ||
+                  pathname.startsWith('/definitions') ||
                   pathname.startsWith('/health') ||
                   pathname.startsWith('/config')
                 );

--- a/js_modules/dagit/packages/core/src/app/ContentRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/ContentRoot.tsx
@@ -2,6 +2,7 @@ import {MainContent} from '@dagster-io/ui';
 import * as React from 'react';
 import {Redirect, Route, Switch, useLocation} from 'react-router-dom';
 
+const WorkspaceOverviewRoot = React.lazy(() => import('../workspace/WorkspaceOverviewRoot'));
 const UserSettingsRoot = React.lazy(() => import('./UserSettingsRoot'));
 const WorkspaceRoot = React.lazy(() => import('../workspace/WorkspaceRoot'));
 const OverviewRoot = React.lazy(() => import('../overview/OverviewRoot'));
@@ -38,6 +39,18 @@ export const ContentRoot = React.memo(() => {
           render={({match}) => {
             const {url} = match;
             return <Redirect to={url.replace('/instance', '')} />;
+          }}
+        />
+        {/* todo dish: These /workspace routes are for backward compatibility. Remove them
+        in November or December 2022. */}
+        <Route path="/workspace" exact render={() => <Redirect to="/definitions" />} />
+        <Route path="/locations" exact render={() => <Redirect to="/definitions" />} />
+        <Route
+          path="/workspace/*"
+          exact
+          render={({match}) => {
+            const {url} = match;
+            return <Redirect to={url.replace('/workspace', '/locations')} />;
           }}
         />
         <Route path="/asset-groups(/?.*)">
@@ -85,7 +98,12 @@ export const ContentRoot = React.memo(() => {
             <CodeLocationsPage />
           </React.Suspense>
         </Route>
-        <Route path="/workspace">
+        <Route path="/definitions">
+          <React.Suspense fallback={<div />}>
+            <WorkspaceOverviewRoot />
+          </React.Suspense>
+        </Route>
+        <Route path="/locations">
           <React.Suspense fallback={<div />}>
             <WorkspaceRoot />
           </React.Suspense>

--- a/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
@@ -37,7 +37,7 @@ const FinalRedirectOrLoadingRoot = () => {
   // If we have location entries but no repos, we have no useful objects to show.
   // Redirect to Workspace overview to surface relevant errors to the user.
   if (locationEntries.length && allRepos.length === 0) {
-    return <Redirect to="/workspace" />;
+    return <Redirect to="/locations" />;
   }
 
   const reposWithVisibleJobs = allRepos.filter((r) => getVisibleJobs(r).length > 0);

--- a/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
@@ -31,7 +31,7 @@ export const InstanceTabs = <TData extends Record<string, any>>(props: Props<TDa
           to="/code-locations"
           icon={<WorkspaceStatus placeholder={false} />}
         />
-        <TabLink id="definitions" title="Definitions" to="/workspace" />
+        <TabLink id="definitions" title="Definitions" to="/definitions" />
         <TabLink id="health" title={healthTitle} to="/health" icon={<InstanceWarningIcon />} />
         {canSeeConfig ? <TabLink id="config" title="Configuration" to="/config" /> : null}
       </Tabs>

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
@@ -66,7 +66,7 @@ export const JobLaunchpad: React.FC<{repoAddress: RepoAddress}> = (props) => {
   const {canLaunchPipelineExecution} = usePermissions();
 
   if (!canLaunchPipelineExecution.enabled) {
-    return <Redirect to={`/workspace/${repoPath}/pipeline_or_job/${pipelinePath}`} />;
+    return <Redirect to={`/locations/${repoPath}/pipeline_or_job/${pipelinePath}`} />;
   }
 
   return (

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupFromRunRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupFromRunRoot.tsx
@@ -29,7 +29,7 @@ export const LaunchpadSetupFromRunRoot: React.FC<{repoAddress: RepoAddress}> = (
   }>();
 
   if (!canLaunchPipelineExecution.enabled) {
-    return <Redirect to={`/workspace/${repoPath}/pipeline_or_job/${pipelinePath}`} />;
+    return <Redirect to={`/locations/${repoPath}/pipeline_or_job/${pipelinePath}`} />;
   }
   return (
     <LaunchpadSetupFromRunAllowedRoot

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupRoot.tsx
@@ -20,7 +20,7 @@ export const LaunchpadSetupRoot: React.FC<{repoAddress: RepoAddress}> = (props) 
   const {repoPath, pipelinePath} = useParams<{repoPath: string; pipelinePath: string}>();
 
   if (!canLaunchPipelineExecution.enabled) {
-    return <Redirect to={`/workspace/${repoPath}/pipeline_or_job/${pipelinePath}`} />;
+    return <Redirect to={`/locations/${repoPath}/pipeline_or_job/${pipelinePath}`} />;
   }
   return <LaunchpadSetupAllowedRoot pipelinePath={pipelinePath} repoAddress={repoAddress} />;
 };

--- a/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.test.tsx
@@ -53,7 +53,7 @@ describe('Repository options', () => {
       render(
         <TestProvider
           apolloProps={{mocks: [defaultMocks, mocks]}}
-          routerProps={{initialEntries: ['/workspace/foo@bar/etc']}}
+          routerProps={{initialEntries: ['/locations/foo@bar/etc']}}
         >
           <LeftNavRepositorySection />
         </TestProvider>,
@@ -372,7 +372,7 @@ describe('Repository options', () => {
         render(
           <TestProvider
             apolloProps={{mocks: [defaultMocks, mocks]}}
-            routerProps={{initialEntries: ['/workspace/foo@bar/etc']}}
+            routerProps={{initialEntries: ['/locations/foo@bar/etc']}}
           >
             <LeftNavRepositorySection />
           </TestProvider>,

--- a/js_modules/dagit/packages/core/src/nav/PipelineNav.tsx
+++ b/js_modules/dagit/packages/core/src/nav/PipelineNav.tsx
@@ -79,9 +79,9 @@ export const PipelineNav: React.FC<Props> = (props) => {
   const permissions = usePermissions();
 
   const match = useRouteMatch<{tab?: string; selector: string}>([
-    '/workspace/:repoPath/pipelines/:selector/:tab?',
-    '/workspace/:repoPath/jobs/:selector/:tab?',
-    '/workspace/:repoPath/pipeline_or_job/:selector/:tab?',
+    '/locations/:repoPath/pipelines/:selector/:tab?',
+    '/locations/:repoPath/jobs/:selector/:tab?',
+    '/locations/:repoPath/pipeline_or_job/:selector/:tab?',
   ]);
 
   const active = tabForPipelinePathComponent(match!.params.tab);

--- a/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
@@ -68,7 +68,7 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
         message: (
           <Box flex={{direction: 'row', justifyContent: 'space-between', gap: 24, grow: 1}}>
             <div>Definitions reloaded</div>
-            <ViewButton onClick={() => history.push('/workspace')} color={Colors.White}>
+            <ViewButton onClick={() => history.push('/locations')} color={Colors.White}>
               View
             </ViewButton>
           </Box>
@@ -138,7 +138,7 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
             ) : (
               <span>{addedEntries.length} code locations added</span>
             )}
-            <ViewButton onClick={() => history.push('/workspace')} color={Colors.White}>
+            <ViewButton onClick={() => history.push('/locations')} color={Colors.White}>
               View
             </ViewButton>
           </Box>

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineReference.test.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineReference.test.tsx
@@ -49,7 +49,7 @@ describe('PipelineReference', () => {
       await waitFor(() => {
         const link = screen.getByRole('link', {name: /foobar/i});
         expect(link).toBeVisible();
-        expect(link.getAttribute('href')).toBe('/workspace/jobs/foobar/');
+        expect(link.getAttribute('href')).toBe('/locations/jobs/foobar/');
       });
     });
 
@@ -58,7 +58,7 @@ describe('PipelineReference', () => {
       await waitFor(() => {
         const link = screen.getByRole('link', {name: /foobar/i});
         expect(link).toBeVisible();
-        expect(link.getAttribute('href')).toBe('/workspace/lorem@ipsum/jobs/foobar/');
+        expect(link.getAttribute('href')).toBe('/locations/lorem@ipsum/jobs/foobar/');
       });
     });
 

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineRoot.test.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineRoot.test.tsx
@@ -57,7 +57,7 @@ describe('PipelineRoot', () => {
 
   const repoAddress = buildRepoAddress(REPO_NAME, REPO_LOCATION);
   const pipelineName = 'pipez';
-  const path = `/workspace/${repoAddressAsString(repoAddress)}/pipelines/${pipelineName}:default`;
+  const path = `/locations/${repoAddressAsString(repoAddress)}/pipelines/${pipelineName}:default`;
 
   it('renders overview by default', async () => {
     const routerProps = {

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineRoot.tsx
@@ -31,37 +31,37 @@ export const PipelineRoot: React.FC<Props> = (props) => {
     >
       <PipelineNav repoAddress={repoAddress} />
       <Switch>
-        <Route path="/workspace/:repoPath/pipeline_or_job/:pipelinePath/(/?.*)">
+        <Route path="/locations/:repoPath/pipeline_or_job/:pipelinePath/(/?.*)">
           <PipelineOrJobDisambiguationRoot repoAddress={repoAddress} />
         </Route>
         <Route
           path={[
-            '/workspace/:repoPath/pipelines/:pipelinePath/playground/setup',
-            '/workspace/:repoPath/jobs/:pipelinePath/playground/setup',
+            '/locations/:repoPath/pipelines/:pipelinePath/playground/setup',
+            '/locations/:repoPath/jobs/:pipelinePath/playground/setup',
           ]}
         >
           <LaunchpadSetupRoot repoAddress={repoAddress} />
         </Route>
         <Route
           path={[
-            '/workspace/:repoPath/pipelines/:pipelinePath/playground/setup-from-run/:runId',
-            '/workspace/:repoPath/jobs/:pipelinePath/playground/setup-from-run/:runId',
+            '/locations/:repoPath/pipelines/:pipelinePath/playground/setup-from-run/:runId',
+            '/locations/:repoPath/jobs/:pipelinePath/playground/setup-from-run/:runId',
           ]}
         >
           <LaunchpadSetupFromRunRoot repoAddress={repoAddress} />
         </Route>
         <Route
           path={[
-            '/workspace/:repoPath/pipelines/:pipelinePath/playground',
-            '/workspace/:repoPath/jobs/:pipelinePath/playground',
+            '/locations/:repoPath/pipelines/:pipelinePath/playground',
+            '/locations/:repoPath/jobs/:pipelinePath/playground',
           ]}
         >
           <JobLaunchpad repoAddress={repoAddress} />
         </Route>
         <Route
           path={[
-            '/workspace/:repoPath/pipelines/:pipelinePath/runs/:runId',
-            '/workspace/:repoPath/jobs/:pipelinePath/runs/:runId',
+            '/locations/:repoPath/pipelines/:pipelinePath/runs/:runId',
+            '/locations/:repoPath/jobs/:pipelinePath/runs/:runId',
           ]}
           render={(props: RouteComponentProps<{runId: string}>) => (
             <Redirect to={`/runs/${props.match.params.runId}`} />
@@ -69,30 +69,30 @@ export const PipelineRoot: React.FC<Props> = (props) => {
         />
         <Route
           path={[
-            '/workspace/:repoPath/pipelines/:pipelinePath/runs',
-            '/workspace/:repoPath/jobs/:pipelinePath/runs',
+            '/locations/:repoPath/pipelines/:pipelinePath/runs',
+            '/locations/:repoPath/jobs/:pipelinePath/runs',
           ]}
         >
           <PipelineRunsRoot repoAddress={repoAddress} />
         </Route>
         <Route
           path={[
-            '/workspace/:repoPath/pipelines/:pipelinePath/partitions',
-            '/workspace/:repoPath/jobs/:pipelinePath/partitions',
+            '/locations/:repoPath/pipelines/:pipelinePath/partitions',
+            '/locations/:repoPath/jobs/:pipelinePath/partitions',
           ]}
         >
           <PipelinePartitionsRoot repoAddress={repoAddress} />
         </Route>
         <Route
           path={[
-            '/workspace/:repoPath/pipelines/:pipelinePath/overview',
-            '/workspace/:repoPath/jobs/:pipelinePath/overview',
+            '/locations/:repoPath/pipelines/:pipelinePath/overview',
+            '/locations/:repoPath/jobs/:pipelinePath/overview',
           ]}
           render={(props) => (
-            <Redirect to={`/workspace/${props.match.url.replace(/\/overview$/i, '')}`} />
+            <Redirect to={`/locations/${props.match.url.replace(/\/overview$/i, '')}`} />
           )}
         />
-        <Route path={['/workspace/:repoPath/pipelines/(/?.*)', '/workspace/:repoPath/jobs/(/?.*)']}>
+        <Route path={['/locations/:repoPath/pipelines/(/?.*)', '/locations/:repoPath/jobs/(/?.*)']}>
           <PipelineOverviewRoot repoAddress={repoAddress} />
         </Route>
       </Switch>

--- a/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
@@ -222,8 +222,8 @@ type PathMatch = {
 
 const usePathMatch = () => {
   const match = useRouteMatch<PathMatch>([
-    '/workspace/:repoPath/(jobs|pipelines)/:pipelinePath',
-    '/workspace/:repoPath/asset-groups/:groupName',
+    '/locations/:repoPath/(jobs|pipelines)/:pipelinePath',
+    '/locations/:repoPath/asset-groups/:groupName',
   ]);
   const {groupName, repoPath, pipelinePath} = match?.params || {};
 

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceHeader.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceHeader.tsx
@@ -25,7 +25,7 @@ export const WorkspaceHeader = <TData extends Record<string, any>>(props: Props<
       title={
         <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
           <Heading>
-            <Link to="/workspace" style={{color: Colors.Dark}}>
+            <Link to="/definitions" style={{color: Colors.Dark}}>
               Deployment
             </Link>
           </Heading>

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewRoot.tsx
@@ -9,3 +9,7 @@ export const WorkspaceOverviewRoot = () => {
 
   return <WorkspaceOverviewWithGrid />;
 };
+
+// Imported via React.lazy, which requires a default export.
+// eslint-disable-next-line import/no-default-export
+export default WorkspaceOverviewRoot;

--- a/js_modules/dagit/packages/core/src/workspace/WorkspacePipelineRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspacePipelineRoot.tsx
@@ -17,7 +17,7 @@ export const WorkspacePipelineRoot = () => {
   const params = useParams<{pipelinePath: string}>();
   const {pipelinePath} = params;
 
-  const entireMatch = useRouteMatch(['/workspace/pipelines/(/?.*)', '/workspace/jobs/(/?.*)']);
+  const entireMatch = useRouteMatch(['/locations/pipelines/(/?.*)', '/locations/jobs/(/?.*)']);
   const location = useLocation();
 
   const toAppend = entireMatch!.params[0];

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceRepoRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceRepoRoot.tsx
@@ -91,32 +91,32 @@ export const WorkspaceRepoRoot: React.FC<Props> = (props) => {
       />
       <Container>
         <Switch>
-          <Route path="/workspace/:repoPath/schedules">
+          <Route path="/locations/:repoPath/schedules">
             <SchedulesRoot repoAddress={repoAddress} />
           </Route>
-          <Route path="/workspace/:repoPath/sensors">
+          <Route path="/locations/:repoPath/sensors">
             <SensorsRoot repoAddress={repoAddress} />
           </Route>
-          <Route path="/workspace/:repoPath/assets(/?.*)">
+          <Route path="/locations/:repoPath/assets(/?.*)">
             <RepositoryAssetsList repoAddress={repoAddress} />
           </Route>
-          <Route path="/workspace/:repoPath/ops/:name?">
+          <Route path="/locations/:repoPath/ops/:name?">
             <OpsRoot repoAddress={repoAddress} />
           </Route>
           <Route
-            path="/workspace/:repoPath/solids/:name?"
+            path="/locations/:repoPath/solids/:name?"
             render={(props) => <Redirect to={props.match.url.replace(/\/solids\/?/, '/ops/')} />}
           />
-          <Route path="/workspace/:repoPath/pipelines">
+          <Route path="/locations/:repoPath/pipelines">
             <RepositoryPipelinesList display="pipelines" repoAddress={repoAddress} />
           </Route>
-          <Route path="/workspace/:repoPath/jobs">
+          <Route path="/locations/:repoPath/jobs">
             <RepositoryPipelinesList display="jobs" repoAddress={repoAddress} />
           </Route>
-          <Route path="/workspace/:repoPath/graphs" exact>
+          <Route path="/locations/:repoPath/graphs" exact>
             <RepositoryGraphsList repoAddress={repoAddress} />
           </Route>
-          <Route path="/workspace/:repoPath/(.*)?" render={() => <Redirect to={tabs[0].href} />} />
+          <Route path="/locations/:repoPath/(.*)?" render={() => <Redirect to={tabs[0].href} />} />
         </Switch>
       </Container>
     </Box>

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
@@ -1,6 +1,6 @@
 import {Box, MainContent, NonIdealState} from '@dagster-io/ui';
 import * as React from 'react';
-import {Route, Switch, useParams} from 'react-router-dom';
+import {Redirect, Route, Switch, useParams} from 'react-router-dom';
 
 import {AssetGroupRoot} from '../assets/AssetGroupRoot';
 import {PipelineRoot} from '../pipelines/PipelineRoot';
@@ -13,7 +13,6 @@ import {WorkspaceContext} from './WorkspaceContext';
 import {WorkspaceGraphsRoot} from './WorkspaceGraphsRoot';
 import {WorkspaceJobsRoot} from './WorkspaceJobsRoot';
 import {WorkspaceOpsRoot} from './WorkspaceOpsRoot';
-import {WorkspaceOverviewRoot} from './WorkspaceOverviewRoot';
 import {WorkspacePipelineRoot} from './WorkspacePipelineRoot';
 import {WorkspaceRepoRoot} from './WorkspaceRepoRoot';
 import {WorkspaceSchedulesRoot} from './WorkspaceSchedulesRoot';
@@ -80,54 +79,54 @@ const RepoRouteContainer = () => {
 
   return (
     <Switch>
-      <Route path="/workspace/:repoPath/assets" exact>
+      <Route path="/locations/:repoPath/assets" exact>
         <WorkspaceAssetsRoot repoAddress={addressForPath} />
       </Route>
-      <Route path="/workspace/:repoPath/jobs" exact>
+      <Route path="/locations/:repoPath/jobs" exact>
         <WorkspaceJobsRoot repoAddress={addressForPath} />
       </Route>
-      <Route path="/workspace/:repoPath/schedules" exact>
+      <Route path="/locations/:repoPath/schedules" exact>
         <WorkspaceSchedulesRoot repoAddress={addressForPath} />
       </Route>
-      <Route path="/workspace/:repoPath/sensors" exact>
+      <Route path="/locations/:repoPath/sensors" exact>
         <WorkspaceSensorsRoot repoAddress={addressForPath} />
       </Route>
-      <Route path="/workspace/:repoPath/graphs" exact>
+      <Route path="/locations/:repoPath/graphs" exact>
         <WorkspaceGraphsRoot repoAddress={addressForPath} />
       </Route>
-      <Route path="/workspace/:repoPath/ops/:name?" exact>
+      <Route path="/locations/:repoPath/ops/:name?" exact>
         <WorkspaceOpsRoot repoAddress={addressForPath} />
       </Route>
-      <Route path="/workspace/:repoPath/graphs/(/?.*)">
+      <Route path="/locations/:repoPath/graphs/(/?.*)">
         <GraphRoot repoAddress={addressForPath} />
       </Route>
       <Route
         path={[
-          '/workspace/:repoPath/pipelines/(/?.*)',
-          '/workspace/:repoPath/jobs/(/?.*)',
-          '/workspace/:repoPath/pipeline_or_job/(/?.*)',
+          '/locations/:repoPath/pipelines/(/?.*)',
+          '/locations/:repoPath/jobs/(/?.*)',
+          '/locations/:repoPath/pipeline_or_job/(/?.*)',
         ]}
       >
         <PipelineRoot repoAddress={addressForPath} />
       </Route>
-      <Route path="/workspace/:repoPath/schedules/:scheduleName/:runTab?">
+      <Route path="/locations/:repoPath/schedules/:scheduleName/:runTab?">
         <ScheduleRoot repoAddress={addressForPath} />
       </Route>
-      <Route path="/workspace/:repoPath/sensors/:sensorName">
+      <Route path="/locations/:repoPath/sensors/:sensorName">
         <SensorRoot repoAddress={addressForPath} />
       </Route>
-      <Route path={['/workspace/:repoPath/asset-groups/:groupName/list(/?.*)']}>
+      <Route path={['/locations/:repoPath/asset-groups/:groupName/list(/?.*)']}>
         <AssetGroupRoot repoAddress={addressForPath} tab="list" />
       </Route>
       <Route
         path={[
-          '/workspace/:repoPath/asset-groups/:groupName/(/?.*)',
-          '/workspace/:repoPath/asset-groups/:groupName',
+          '/locations/:repoPath/asset-groups/:groupName/(/?.*)',
+          '/locations/:repoPath/asset-groups/:groupName',
         ]}
       >
         <AssetGroupRoot repoAddress={addressForPath} tab="lineage" />
       </Route>
-      <Route path="/workspace/:repoPath/:tab?">
+      <Route path="/locations/:repoPath/:tab?">
         <WorkspaceRepoRoot repoAddress={addressForPath} />
       </Route>
     </Switch>
@@ -138,13 +137,11 @@ export const WorkspaceRoot = () => {
   return (
     <MainContent>
       <Switch>
-        <Route path="/workspace" exact>
-          <WorkspaceOverviewRoot />
-        </Route>
-        <Route path={['/workspace/pipelines/:pipelinePath', '/workspace/jobs/:pipelinePath']}>
+        <Route path="/locations" exact render={() => <Redirect to="/definitions" />} />
+        <Route path={['/locations/pipelines/:pipelinePath', '/locations/jobs/:pipelinePath']}>
           <WorkspacePipelineRoot />
         </Route>
-        <Route path="/workspace/:repoPath">
+        <Route path="/locations/:repoPath">
           <RepoRouteContainer />
         </Route>
       </Switch>

--- a/js_modules/dagit/packages/core/src/workspace/workspacePath.ts
+++ b/js_modules/dagit/packages/core/src/workspace/workspacePath.ts
@@ -3,7 +3,7 @@ import {RepoAddress} from './types';
 
 export const workspacePath = (repoName: string, repoLocation: string, path = '') => {
   const finalPath = path.startsWith('/') ? path : `/${path}`;
-  return `/workspace/${buildRepoPath(repoName, repoLocation)}${finalPath}`;
+  return `/locations/${buildRepoPath(repoName, repoLocation)}${finalPath}`;
 };
 
 type PathConfig = {
@@ -22,14 +22,14 @@ export const workspacePipelinePath = ({
   path = '',
 }: PathConfig) => {
   const finalPath = path.startsWith('/') ? path : `/${path}`;
-  return `/workspace/${buildRepoPath(repoName, repoLocation)}/${
+  return `/locations/${buildRepoPath(repoName, repoLocation)}/${
     isJob ? 'jobs' : 'pipelines'
   }/${pipelineName}${finalPath}`;
 };
 
 export const workspacePipelinePathGuessRepo = (pipelineName: string, isJob = false, path = '') => {
   const finalPath = path.startsWith('/') ? path : `/${path}`;
-  return `/workspace/${isJob ? 'jobs' : 'pipelines'}/${pipelineName}${finalPath}`;
+  return `/locations/${isJob ? 'jobs' : 'pipelines'}/${pipelineName}${finalPath}`;
 };
 
 export const workspacePathFromAddress = (repoAddress: RepoAddress, path = '') => {


### PR DESCRIPTION
### Summary & Motivation

Modify all Dagit URLs that currently use `/workspace` to use `/locations` instead.

Any existing `/workspace/...` URLs will redirect to `/locations/...`.

### How I Tested These Changes

Load Dagit, navigate through definition objects (jobs, schedules, sensors) and all definition tables under "Deployment". Verify that navigation works correctly.
