### PR TITLE
handle captured log failures without failing runs

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
@@ -89,7 +89,7 @@ def inner_plan_execution_iterator(
                                 )
                             )
                             yield DagsterEvent.legacy_compute_log_step_event(step_context)
-                        except Exception as e:
+                        except Exception:
                             yield from _handle_compute_log_setup_error(step_context, sys.exc_info())
 
                         for step_event in check.generator(

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
@@ -105,7 +105,9 @@ def inner_plan_execution_iterator(
                         try:
                             step_stack.close()
                         except Exception:
-                            yield from _handle_compute_log_teardown_error(step_context, sys.exc_info())
+                            yield from _handle_compute_log_teardown_error(
+                                step_context, sys.exc_info()
+                            )
                     else:
                         # we have already set up the log capture at the process level, just handle the
                         # step events
@@ -133,23 +135,22 @@ def inner_plan_execution_iterator(
             except Exception:
                 yield from _handle_compute_log_teardown_error(pipeline_context, sys.exc_info())
 
+
 def _handle_compute_log_setup_error(context, exc_info):
     yield DagsterEvent.engine_event(
         plan_context=context,
         message="Exception while setting up compute log capture",
-        event_specific_data=EngineEventData(
-            error=serializable_error_info_from_exc_info(exc_info)
-        ),
+        event_specific_data=EngineEventData(error=serializable_error_info_from_exc_info(exc_info)),
     )
+
 
 def _handle_compute_log_teardown_error(context, exc_info):
     yield DagsterEvent.engine_event(
         plan_context=context,
         message="Exception while cleaning up compute log capture",
-        event_specific_data=EngineEventData(
-            error=serializable_error_info_from_exc_info(exc_info)
-        ),
+        event_specific_data=EngineEventData(error=serializable_error_info_from_exc_info(exc_info)),
     )
+
 
 def _trigger_hook(
     step_context: StepExecutionContext, step_event_list: Sequence[DagsterEvent]

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
@@ -35,106 +35,132 @@ def inner_plan_execution_iterator(
     check.inst_param(execution_plan, "execution_plan", ExecutionPlan)
     compute_log_manager = pipeline_context.instance.compute_log_manager
     step_keys = [step.key for step in execution_plan.get_steps_to_execute_in_topo_order()]
-    with ExitStack() as plan_stack:
-        active_execution = plan_stack.enter_context(
-            execution_plan.start(retry_mode=pipeline_context.retry_mode)
-        )
+    with execution_plan.start(retry_mode=pipeline_context.retry_mode) as active_execution:
+        with ExitStack() as capture_stack:
+            # begin capturing logs for the whole process if this is a captured log manager
+            if isinstance(compute_log_manager, CapturedLogManager):
+                file_key = create_compute_log_file_key()
+                log_key = compute_log_manager.build_log_key_for_run(
+                    pipeline_context.run_id, file_key
+                )
+                try:
+                    log_context = capture_stack.enter_context(
+                        compute_log_manager.capture_logs(log_key)
+                    )
+                    yield DagsterEvent.capture_logs(
+                        pipeline_context, step_keys, log_key, log_context
+                    )
+                except Exception as e:
+                    yield DagsterEvent.engine_event(
+                        plan_context=pipeline_context,
+                        message="Exception while setting up compute log capture",
+                        event_specific_data=EngineEventData(
+                            error=serializable_error_info_from_exc_info(sys.exc_info())
+                        ),
+                    )
+                    log_capture_error = e
 
-        # begin capturing logs for the whole process if this is a captured log manager
-        if isinstance(compute_log_manager, CapturedLogManager):
-            file_key = create_compute_log_file_key()
-            log_key = compute_log_manager.build_log_key_for_run(pipeline_context.run_id, file_key)
-            log_context = plan_stack.enter_context(compute_log_manager.capture_logs(log_key))
-            yield DagsterEvent.capture_logs(pipeline_context, step_keys, log_key, log_context)
+            # It would be good to implement a reference tracking algorithm here to
+            # garbage collect results that are no longer needed by any steps
+            # https://github.com/dagster-io/dagster/issues/811
+            while not active_execution.is_complete:
+                step = active_execution.get_next_step()
+                step_context = cast(
+                    StepExecutionContext,
+                    pipeline_context.for_step(step, active_execution.get_known_state()),
+                )
+                step_event_list = []
 
-        # It would be good to implement a reference tracking algorithm here to
-        # garbage collect results that are no longer needed by any steps
-        # https://github.com/dagster-io/dagster/issues/811
-        while not active_execution.is_complete:
-            step = active_execution.get_next_step()
-            step_context = cast(
-                StepExecutionContext,
-                pipeline_context.for_step(step, active_execution.get_known_state()),
-            )
-            step_event_list = []
+                missing_resources = [
+                    resource_key
+                    for resource_key in step_context.required_resource_keys
+                    if not hasattr(step_context.resources, resource_key)
+                ]
+                check.invariant(
+                    len(missing_resources) == 0,
+                    (
+                        "Expected step context for solid {solid_name} to have all required resources, but "
+                        "missing {missing_resources}."
+                    ).format(
+                        solid_name=step_context.solid.name, missing_resources=missing_resources
+                    ),
+                )
 
-            missing_resources = [
-                resource_key
-                for resource_key in step_context.required_resource_keys
-                if not hasattr(step_context.resources, resource_key)
-            ]
-            check.invariant(
-                len(missing_resources) == 0,
-                (
-                    "Expected step context for solid {solid_name} to have all required resources, but "
-                    "missing {missing_resources}."
-                ).format(solid_name=step_context.solid.name, missing_resources=missing_resources),
-            )
-
-            with ExitStack() as step_stack:
-                if not isinstance(compute_log_manager, CapturedLogManager):
-                    # capture all of the logs for individual steps
-                    log_capture_error = None
-                    try:
-                        step_stack.enter_context(
-                            pipeline_context.instance.compute_log_manager.watch(
-                                step_context.pipeline_run, step_context.step.key
+                with ExitStack() as step_stack:
+                    if not isinstance(compute_log_manager, CapturedLogManager):
+                        # capture all of the logs for individual steps
+                        log_capture_error = None
+                        try:
+                            step_stack.enter_context(
+                                pipeline_context.instance.compute_log_manager.watch(
+                                    step_context.pipeline_run, step_context.step.key
+                                )
                             )
-                        )
-                    except Exception as e:
-                        yield DagsterEvent.engine_event(
-                            plan_context=step_context,
-                            message="Exception while setting up compute log capture",
-                            event_specific_data=EngineEventData(
-                                error=serializable_error_info_from_exc_info(sys.exc_info())
-                            ),
-                        )
-                        log_capture_error = e
+                        except Exception as e:
+                            yield DagsterEvent.engine_event(
+                                plan_context=step_context,
+                                message="Exception while setting up compute log capture",
+                                event_specific_data=EngineEventData(
+                                    error=serializable_error_info_from_exc_info(sys.exc_info())
+                                ),
+                            )
+                            log_capture_error = e
 
-                    if not log_capture_error:
-                        yield DagsterEvent.legacy_compute_log_step_event(step_context)
+                        if not log_capture_error:
+                            yield DagsterEvent.legacy_compute_log_step_event(step_context)
 
-                    for step_event in check.generator(
-                        dagster_event_sequence_for_step(step_context)
-                    ):
-                        check.inst(step_event, DagsterEvent)
-                        step_event_list.append(step_event)
-                        yield step_event
-                        active_execution.handle_event(step_event)
+                        for step_event in check.generator(
+                            dagster_event_sequence_for_step(step_context)
+                        ):
+                            check.inst(step_event, DagsterEvent)
+                            step_event_list.append(step_event)
+                            yield step_event
+                            active_execution.handle_event(step_event)
 
-                    active_execution.verify_complete(pipeline_context, step.key)
+                        active_execution.verify_complete(pipeline_context, step.key)
 
-                    try:
-                        step_stack.close()
-                    except Exception:
-                        yield DagsterEvent.engine_event(
-                            plan_context=step_context,
-                            message="Exception while cleaning up compute log capture",
-                            event_specific_data=EngineEventData(
-                                error=serializable_error_info_from_exc_info(sys.exc_info())
-                            ),
-                        )
-                else:
-                    # we have already set up the log capture at the process level, just handle the
-                    # step events
-                    for step_event in check.generator(
-                        dagster_event_sequence_for_step(step_context)
-                    ):
-                        check.inst(step_event, DagsterEvent)
-                        step_event_list.append(step_event)
-                        yield step_event
-                        active_execution.handle_event(step_event)
+                        try:
+                            step_stack.close()
+                        except Exception:
+                            yield DagsterEvent.engine_event(
+                                plan_context=step_context,
+                                message="Exception while cleaning up compute log capture",
+                                event_specific_data=EngineEventData(
+                                    error=serializable_error_info_from_exc_info(sys.exc_info())
+                                ),
+                            )
+                    else:
+                        # we have already set up the log capture at the process level, just handle the
+                        # step events
+                        for step_event in check.generator(
+                            dagster_event_sequence_for_step(step_context)
+                        ):
+                            check.inst(step_event, DagsterEvent)
+                            step_event_list.append(step_event)
+                            yield step_event
+                            active_execution.handle_event(step_event)
 
-                    active_execution.verify_complete(pipeline_context, step.key)
+                        active_execution.verify_complete(pipeline_context, step.key)
 
-            # process skips from failures or uncovered inputs
-            for event in active_execution.plan_events_iterator(pipeline_context):
-                step_event_list.append(event)
-                yield event
+                # process skips from failures or uncovered inputs
+                for event in active_execution.plan_events_iterator(pipeline_context):
+                    step_event_list.append(event)
+                    yield event
 
-            # pass a list of step events to hooks
-            for hook_event in _trigger_hook(step_context, step_event_list):
-                yield hook_event
+                # pass a list of step events to hooks
+                for hook_event in _trigger_hook(step_context, step_event_list):
+                    yield hook_event
+
+            try:
+                capture_stack.close()
+            except Exception:
+                yield DagsterEvent.engine_event(
+                    plan_context=pipeline_context,
+                    message="Exception while cleaning up compute log capture",
+                    event_specific_data=EngineEventData(
+                        error=serializable_error_info_from_exc_info(sys.exc_info())
+                    ),
+                )
 
 
 def _trigger_hook(

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_compute_log_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_compute_log_manager.py
@@ -42,10 +42,10 @@ class BrokenCapturedLogManager(CapturedLogManager, ComputeLogManager):
     @contextmanager
     def capture_logs(self, log_key: Sequence[str]) -> Generator[CapturedLogContext, None, None]:
         if self._fail_on_setup:
-            raise Exception("wahhh")
+            raise Exception("fail on setup")
         yield CapturedLogContext(log_key=log_key)
         if self._fail_on_teardown:
-            raise Exception("blahhh")
+            raise Exception("fail on teardown")
 
     @contextmanager
     def open_log_stream(
@@ -75,10 +75,10 @@ class BrokenCapturedLogManager(CapturedLogManager, ComputeLogManager):
     def subscribe(
         self, log_key: Sequence[str], cursor: Optional[str] = None
     ) -> CapturedLogSubscription:
-        pass
+        return CapturedLogSubscription(self, log_key, cursor)
 
     def unsubscribe(self, subscription: CapturedLogSubscription):
-        pass
+        return
 
     @contextmanager
     def _watch_logs(self, pipeline_run, step_key=None):

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_compute_log_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_compute_log_manager.py
@@ -1,13 +1,24 @@
 import tempfile
 from contextlib import contextmanager
+from typing import IO, Generator, Optional, Sequence
+
+import pytest
 
 import dagster._check as check
 from dagster import job, op
 from dagster._core.instance import DagsterInstance, InstanceRef, InstanceType
 from dagster._core.launcher import DefaultRunLauncher
 from dagster._core.run_coordinator import DefaultRunCoordinator
+from dagster._core.storage.captured_log_manager import (
+    CapturedLogContext,
+    CapturedLogData,
+    CapturedLogManager,
+    CapturedLogMetadata,
+    CapturedLogSubscription,
+)
 from dagster._core.storage.compute_log_manager import (
     MAX_BYTES_FILE_READ,
+    ComputeIOType,
     ComputeLogFileData,
     ComputeLogManager,
 )
@@ -21,6 +32,80 @@ def test_compute_log_manager_instance():
     with instance_for_test() as instance:
         assert instance.compute_log_manager
         assert instance.compute_log_manager._instance  # pylint: disable=protected-access
+
+
+class BrokenCapturedLogManager(CapturedLogManager, ComputeLogManager):
+    def __init__(self, fail_on_setup=False, fail_on_teardown=False):
+        self._fail_on_setup = check.opt_bool_param(fail_on_setup, "fail_on_setup")
+        self._fail_on_teardown = check.opt_bool_param(fail_on_teardown, "fail_on_teardown")
+
+    @contextmanager
+    def capture_logs(self, log_key: Sequence[str]) -> Generator[CapturedLogContext, None, None]:
+        if self._fail_on_setup:
+            raise Exception("wahhh")
+        yield CapturedLogContext(log_key=log_key)
+        if self._fail_on_teardown:
+            raise Exception("blahhh")
+
+    @contextmanager
+    def open_log_stream(
+        self, log_key: Sequence[str], io_type: ComputeIOType
+    ) -> Generator[Optional[IO], None, None]:
+        yield None
+
+    def is_capture_complete(self, log_key: Sequence[str]) -> bool:
+        return True
+
+    def get_log_data(
+        self,
+        log_key: Sequence[str],
+        cursor: Optional[str] = None,
+        max_bytes: Optional[int] = None,
+    ) -> CapturedLogData:
+        return CapturedLogData(log_key=log_key)
+
+    def get_log_metadata(self, log_key: Sequence[str]) -> CapturedLogMetadata:
+        return CapturedLogMetadata()
+
+    def delete_logs(
+        self, log_key: Optional[Sequence[str]] = None, prefix: Optional[Sequence[str]] = None
+    ):
+        pass
+
+    def subscribe(
+        self, log_key: Sequence[str], cursor: Optional[str] = None
+    ) -> CapturedLogSubscription:
+        pass
+
+    def unsubscribe(self, subscription: CapturedLogSubscription):
+        pass
+
+    @contextmanager
+    def _watch_logs(self, pipeline_run, step_key=None):
+        pass
+
+    def is_watch_completed(self, run_id, key):
+        return True
+
+    def on_watch_start(self, pipeline_run, step_key):
+        pass
+
+    def on_watch_finish(self, pipeline_run, step_key):
+        pass
+
+    def download_url(self, run_id, key, io_type):
+        return None
+
+    def read_logs_file(
+        self, run_id, key, io_type, cursor=0, max_bytes=MAX_BYTES_FILE_READ
+    ) -> ComputeLogFileData:
+        return ComputeLogFileData(path="", data=None, cursor=0, size=0, download_url=None)
+
+    def on_subscribe(self, subscription):
+        pass
+
+    def on_unsubscribe(self, subscription):
+        pass
 
 
 class BrokenComputeLogManager(ComputeLogManager):
@@ -73,6 +158,32 @@ def broken_compute_log_manager_instance(fail_on_setup=False, fail_on_teardown=Fa
             )
 
 
+@contextmanager
+def broken_captured_log_manager_instance(fail_on_setup=False, fail_on_teardown=False):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with environ({"DAGSTER_HOME": temp_dir}):
+            yield DagsterInstance(
+                instance_type=InstanceType.PERSISTENT,
+                local_artifact_storage=LocalArtifactStorage(temp_dir),
+                run_storage=SqliteRunStorage.from_local(temp_dir),
+                event_storage=SqliteEventLogStorage(temp_dir),
+                compute_log_manager=BrokenCapturedLogManager(
+                    fail_on_setup=fail_on_setup, fail_on_teardown=fail_on_teardown
+                ),
+                run_coordinator=DefaultRunCoordinator(),
+                run_launcher=DefaultRunLauncher(),
+                ref=InstanceRef.from_dir(temp_dir),
+            )
+
+
+@pytest.fixture(
+    name="instance_cm",
+    params=[broken_compute_log_manager_instance, broken_captured_log_manager_instance],
+)
+def instance_cm_fixture(request):
+    return request.param
+
+
 def _has_setup_exception(execute_result):
     return any(
         [
@@ -91,28 +202,32 @@ def _has_teardown_exception(execute_result):
     )
 
 
-def test_broken_compute_log_manager():
-    @op
-    def yay(context):
-        context.log.info("yay")
-        print("HELLOOO")  # pylint: disable=print-call
-        return "yay"
+@op
+def yay(context):
+    context.log.info("yay")
+    print("HELLOOO")  # pylint: disable=print-call
+    return "yay"
 
-    @op
-    def boo(context):
-        context.log.info("boo")
-        print("HELLOOO")  # pylint: disable=print-call
-        raise Exception("booo")
 
-    @job
-    def yay_job():
-        yay()
+@op
+def boo(context):
+    context.log.info("boo")
+    print("HELLOOO")  # pylint: disable=print-call
+    raise Exception("booo")
 
-    @job
-    def boo_job():
-        boo()
 
-    with broken_compute_log_manager_instance(fail_on_setup=True) as instance:
+@job
+def yay_job():
+    yay()
+
+
+@job
+def boo_job():
+    boo()
+
+
+def test_broken_compute_log_manager(instance_cm):
+    with instance_cm(fail_on_setup=True) as instance:
         yay_result = yay_job.execute_in_process(instance=instance)
         assert yay_result.success
         assert _has_setup_exception(yay_result)
@@ -121,7 +236,7 @@ def test_broken_compute_log_manager():
         assert not boo_result.success
         assert _has_setup_exception(boo_result)
 
-    with broken_compute_log_manager_instance(fail_on_teardown=True) as instance:
+    with instance_cm(fail_on_teardown=True) as instance:
         yay_result = yay_job.execute_in_process(instance=instance)
         assert yay_result.success
         assert _has_teardown_exception(yay_result)
@@ -131,7 +246,7 @@ def test_broken_compute_log_manager():
         assert not boo_result.success
         assert _has_teardown_exception(boo_result)
 
-    with broken_compute_log_manager_instance() as instance:
+    with instance_cm() as instance:
         yay_result = yay_job.execute_in_process(instance=instance)
         assert yay_result.success
         assert not _has_setup_exception(yay_result)


### PR DESCRIPTION
### Summary & Motivation
Runs are failing with compute log manager failures.

### How I Tested These Changes
Added exclusive captured log manager implementation with the appropriate exception hooks.  The existing tests only implemented the legacy compute log manager interface