### PR TITLE
Remove typing_compat dependency

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -11,7 +11,7 @@ from typing import (
     cast,
 )
 
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, get_origin
 
 import dagster._check as check
 from dagster._annotations import public
@@ -19,7 +19,6 @@ from dagster._config.config_schema import UserConfigSchema
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.errors import DagsterInvariantViolationError
 
-from ..._seven.typing import get_origin
 from .definition_config_schema import IDefinitionConfigSchema
 from .hook_definition import HookDefinition
 from .inference import infer_output_props

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -3,6 +3,8 @@ import warnings
 from functools import wraps
 from typing import Any, Generator, Iterator, Sequence, Tuple, Union, cast
 
+from typing_extensions import get_args
+
 from dagster._core.definitions import (
     AssetMaterialization,
     DynamicOutput,
@@ -15,7 +17,6 @@ from dagster._core.definitions import (
 from dagster._core.definitions.decorators.solid_decorator import DecoratedSolidFunction
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.types.dagster_type import DagsterTypeKind, is_generic_output_annotation
-from dagster._seven.typing import get_args
 
 from ..context.compute import OpExecutionContext
 

--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -10,7 +10,7 @@ from typing import Sequence
 from typing import Type as TypingType
 from typing import cast
 
-from typing_compat import get_args, get_origin
+from typing_extensions import get_args, get_origin
 
 import dagster._check as check
 from dagster._annotations import public

--- a/python_modules/dagster/dagster/_seven/typing.py
+++ b/python_modules/dagster/dagster/_seven/typing.py
@@ -1,1 +1,0 @@
-from typing_compat import get_args, get_origin  # pylint: disable=unused-import

--- a/python_modules/dagster/dagster/_utils/typing_api.py
+++ b/python_modules/dagster/dagster/_utils/typing_api.py
@@ -3,8 +3,9 @@ order to do metaprogramming and reflection on the built-in typing module"""
 
 import typing
 
+from typing_extensions import get_args, get_origin
+
 import dagster._check as check
-from dagster._seven.typing import get_args, get_origin
 
 
 def is_closed_python_optional_type(ttype):

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -88,7 +88,6 @@ setup(
         "tabulate",
         "tomli",
         "tqdm",
-        "typing_compat",
         "typing_extensions>=4.0.1",
         "sqlalchemy>=1.0",
         "toposort>=1.0",


### PR DESCRIPTION
### Summary & Motivation

This removes the `typing_compat` dependency. The same functionality is provided by the `typing_extensions` package, which we already use for other things.

### How I Tested These Changes

Existing tests.
