### PR TITLE
Make launchWithTelemetry return inner data

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -207,7 +207,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
       );
 
       setLaunching(false);
-      if (result?.launchPipelineExecution.__typename === 'LaunchRunSuccess') {
+      if (result?.__typename === 'LaunchRunSuccess') {
         setOpen(false);
       }
     } else {

--- a/js_modules/dagit/packages/core/src/launchpad/useLaunchWithTelemetry.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/useLaunchWithTelemetry.ts
@@ -47,7 +47,7 @@ export function useLaunchWithTelemetry() {
         showLaunchError(error as Error);
       }
 
-      return result.data;
+      return result.data?.launchPipelineExecution;
     },
     [canLaunchPipelineExecution, history, launchPipelineExecution, logTelemetry],
   );


### PR DESCRIPTION
### Summary & Motivation

Making `launchWithTelemetry` return the inner data rather than the whole mutation result so that a different mutation can return a result of the same shape when overriding `launchWithTelemetry`.

### How I Tested These Changes

Saw error in cloud go away