### PR TITLE
[dagit] Don't include repo tag when filtering snapshot runs

### DIFF
--- a/js_modules/dagit/packages/core/src/pipelines/PipelineRunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineRunsRoot.tsx
@@ -66,11 +66,14 @@ export const PipelineRunsRoot: React.FC<Props> = (props) => {
     ].filter(Boolean) as TokenizingFieldValue[];
   }, [isJob, pipelineName, snapshotId]);
 
-  const repoToken = {
-    token: 'tag',
-    value: `${DagsterTag.RepositoryLabelTag}=${repoAddress?.name}@${repoAddress?.location}`,
-  };
-  const allTokens = [...filterTokens, ...permanentTokens, repoToken];
+  const allTokens = [...filterTokens, ...permanentTokens];
+  if (repoAddress) {
+    const repoToken = {
+      token: 'tag',
+      value: `${DagsterTag.RepositoryLabelTag}=${repoAddress.name}@${repoAddress.location}`,
+    };
+    allTokens.push(repoToken);
+  }
 
   const {queryResult, paginationProps} = useCursorPaginatedQuery<
     PipelineRunsRootQuery,


### PR DESCRIPTION
### Summary & Motivation

When viewing the Runs tab in a job snapshot view, the query fails because we try to apply a filter tag that has the repo and location -- a snapshot doesn't have a code location, and the resulting tag is `undefined@undefined`.

I think we can just omit this tag in the snapshot case, because we have a snapshot ID already, and that works well enough for our filtering.

In the Runs tab for a job that is loaded, it will continue to use the repo tag to ensure that we get the correct list of runs.

### How I Tested These Changes

View Runs tab for a snapshot, verify that the query does not include a repo tag.

View Runs tab for a loaded job, verify that it does.
