### PR TITLE
[code-location-concept-page-1] Concept page for code locations [WIP]

### DIFF
--- a/docs/content/concepts/code-locations.mdx
+++ b/docs/content/concepts/code-locations.mdx
@@ -70,16 +70,32 @@ defs = Definitions(
 <TabGroup>
     <TabItem name="Local Development">
 
+### Load definitions in a file
+
+Example: `$ dagit -f foo.py`
+
 `dagit` and other Dagster tools can load a file directly as a code location. The command `dagit -f foo.py` is loading a code location: it will load the definitions in `foo.py` as a code location in the same python environment where Dagit resides.
 
-Installed python packages can also be loaded directly. For Dagster projects deployed to production we recommend this style of development, as it eliminates an entire class of python import errors. Create a Dagster project with the `dagster project scaffold` command or by using one of our templates. This project can then be installed using `pip install -e .` to make it an editable install for local development.
+### Load definitions in an installed package
+
+Example: `$ dagit -m your_package_name`
+
+Installed python packages can also be loaded by Dagster tools. It will load the definitions defined as the top-level of that package, in its root `__init__.py` file. For Dagster projects deployed to production we recommend this style of development, as it eliminates an entire class of python import errors. Create a Dagster project with the `dagster project scaffold` command or by using one of our templates. This project can then be installed using `pip install -e .` to make it an editable install for local development.
 
 Once installed, this package can be loaded typing `dagit -m your_package_name`. This should be read as "load definitions in the `defs` symbol in this package (defined as its root `__init__.py` file) in the same virtual environment as Dagit itself.
 
+### Load definitions without any command line arguments
+
+Example: `$ dagit`
+
 Our project templates also create a `pyproject.toml` file with a `tool.dagster` section an assignment to the `python_package` variable in that section. This allows users to type just `dagit` without any parameters and the package name is defined in that variable. This is very convenient for local development.
 
+```
     [tool.dagster]
     python_package = "your_package_name"
+```
+
+When one runs a dagster CLI in the same directory as this toml file, it is equivalent of running `dagit -m your_package_name`.
 
 </TabItem>
 <TabItem name="Cloud Deployment">

--- a/docs/content/concepts/code-locations.mdx
+++ b/docs/content/concepts/code-locations.mdx
@@ -5,14 +5,21 @@ description: ""
 
 # Code Locations
 
-A code location is set of dagster definitions loadable and accessible by Dagster's tools, such as the CLI, Dagit, and Dagster Cloud. A code location comprises:
+A code location is collection of Dagster definitions loadable and accessible by Dagster's tools, such as the CLI, Dagit, and Dagster Cloud. A code location comprises:
 
-- A reference to a python module or package that has an instance of `Definitions` at the "defs" variable. We will refer to that as the "entry point".
-- A Python environment that can successfully load the entry point.
+- A reference to a python module or package that has an instance of `Definitions` at the "defs" variable.
+- A Python environment that can successfully load that module or package.
 
 Definitions within a code location have a common namespace and must have unique names. This allows them to be grouped and organized by code location in tools.
 
-Before the introduction of the <PyObject object="Definitions" /> API, definitions were grouped into repositories, and there could be many repostories in a particular code location. See the [guide](/concepts/repositories-workspaces/repositories) on Repositories for this previous API and mental model.
+<Note>
+  Before the introduction of the <PyObject object="Definitions" />
+  API, definitions were grouped into repositories, and there could be many repostories
+  in a particular code location. See the <a href="/concepts/repositories-workspaces/repositories">
+    {" "}
+    guide{" "}
+  </a> on Repositories for this previous API and mental model.
+</Note>
 
 <!-- Introduction
 	Make sure to include:
@@ -60,11 +67,12 @@ defs = Definitions(
 )
 ```
 
-### Local Development
+<TabGroup>
+    <TabItem name="Local Development">
 
-`dagit` and other Dagster tools can load a file directly as a code location. `dagit -f foo.py` is saying that Dagit should load the definitions in `foo.py` as a code location in the same python environment where Dagit resides.
+`dagit` and other Dagster tools can load a file directly as a code location. The command `dagit -f foo.py` is loading a code location: it will load the definitions in `foo.py` as a code location in the same python environment where Dagit resides.
 
-Installed python modules can also be loaded directly. For Dagster projects deployed to production we recommend this style of development, as it eliminates an entire class of python import errors. Create a Dagster project with the `dagster project scaffold` command or by using one of our templates. This project can then be installed using `pip install -e .` to make it an editable install for local development.
+Installed python packages can also be loaded directly. For Dagster projects deployed to production we recommend this style of development, as it eliminates an entire class of python import errors. Create a Dagster project with the `dagster project scaffold` command or by using one of our templates. This project can then be installed using `pip install -e .` to make it an editable install for local development.
 
 Once installed, this package can be loaded typing `dagit -m your_package_name`. This should be read as "load definitions in the `defs` symbol in this package (defined as its root `__init__.py` file) in the same virtual environment as Dagit itself.
 
@@ -73,13 +81,18 @@ Our project templates also create a `pyproject.toml` file with a `tool.dagster` 
     [tool.dagster]
     python_package = "your_package_name"
 
-### Cloud Deployment
+</TabItem>
+<TabItem name="Cloud Deployment">
 
-In cloud, instructions for creating and deploying code locations are specified in the `dagster_cloud.yaml` file. See LINK.
+In cloud, instructions for creating and deploying code locations are specified in the `dagster_cloud.yaml` file. TODO: insert link to dagster_cloud.yaml page here.
 
-### OSS Deployment
+</TabItem>
+<TabItem name="OSS Deployment">
 
-OSS deployment uses the workspace.yaml file to load code locations. See particular guides for how to do that.
+OSS deployment uses the workspace.yaml file to load code locations. A workspace file specifies how to load a collection of code locations and is used in advanced use cases. See particular guides for how to do that.
+
+</TabItem>
+</TabGroup>
 
 ---
 

--- a/docs/content/concepts/code-locations.mdx
+++ b/docs/content/concepts/code-locations.mdx
@@ -90,10 +90,8 @@ Example: `$ dagit`
 
 Our project templates also create a `pyproject.toml` file with a `tool.dagster` section an assignment to the `python_package` variable in that section. This allows users to type just `dagit` without any parameters and the package name is defined in that variable. This is very convenient for local development.
 
-```
-    [tool.dagster]
-    python_package = "your_package_name"
-```
+        [tool.dagster]
+        python_package = "your_package_name"
 
 When one runs a dagster CLI in the same directory as this toml file, it is equivalent of running `dagit -m your_package_name`.
 

--- a/docs/content/concepts/code-locations.mdx
+++ b/docs/content/concepts/code-locations.mdx
@@ -1,0 +1,126 @@
+---
+title: "CONCEPT | Dagster Docs"
+description: ""
+---
+
+# Code Locations
+
+- This guide refers to code locations when paired with the `Definitions` API.
+
+A code location is set of dagster definitions loadable and accessible by
+Dagster's tools, such as the CLI, Dagit, and Dagster Cloud. A code location comprises:
+
+* A reference a python module that has an instance of `Definitions` at the "defs" variable. We
+will refer to that as the "entry point".
+* A Python environment that can successfully load the entry point.
+
+Definitions within a code location have a common namespace and must have
+unique names. This allows them to be grouped and organized by code location
+in tools.
+
+Before the introduction of the `Definitions` UI, definitions were grouped into
+repositories, and there could be many repostories in a particular code location. See
+LINK for this previous mental model.
+
+<!-- Introduction
+	Make sure to include:
+
+	- What the concept is
+	- What it does
+	- When to use it
+	- How it ties into a Dagster project overall
+
+	For example: https://docs.dagster.io/concepts/ops-jobs-graphs/ops#ops
+	Ops includes the what, when, why, and a nifty diagram. Diagrams are huge for users.
+-->
+
+---
+
+## Relevant APIs
+
+<!-- See example: https://docs.dagster.io/concepts/ops-jobs-graphs/ops#relevant-apis -->
+
+| Name                                  | Description                                                                                                                                                                                                                  |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <PyObject object="" /> |                                                                                                                                                                                            |
+
+---
+
+
+## Creating/Applying/Using [CONCEPT]
+
+<!-- See example: https://docs.dagster.io/concepts/ops-jobs-graphs/ops#defining-an-op
+
+	This section outlines the 'how' part of applying the concept in code
+	Currently our docs go between the basics and some more complex use cases, but
+	I'd opt for going simple here and getting more complex in the Examples section
+
+	Additionally, if this concept will be surfaced in Dagit, consider covering that. Ex: Describe
+	how to navigate to viewing the relevant page in Dagit.
+-->
+
+---
+
+## Examples
+
+<!-- Common use cases and other more complex examples, each separated by a heading.
+	Examples should also include an explanation of what the code is doing / why
+	it's done this way. Link to other docs where pertinent.
+
+### Heading-for-this-example
+
+[description]
+
+```python file=
+```
+
+[code explanation]
+-->
+
+
+---
+
+## Troubleshooting
+
+<!-- Common issues or error messages specific to the concept.
+
+	See example: https://docs.dagster.io/guides/dagster/using-environment-variables-and-secrets#troubleshooting
+	While not a concept page, this guide ^ demonstrates how to interpret errors + resolve issues
+
+	The table used in that guide:
+<table
+  className="table"
+  style={{
+    width: "100%",
+  }}
+>
+  <thead>
+    <tr>
+      <th
+        style={{
+          width: "30%",
+        }}
+      >
+        Error
+      </th>
+      <th>Description and resolution</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <strong>[ERROR]</strong>
+      </td>
+      <td>
+        Description of the error and how to resolve it
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+	Headings can be used if an error isn't surfaced, or if a table will make readability difficult. Ex:
+
+### Brief-description-of-issue
+
+Describe when/why this happens and how to fix it. Include code examples if needed.
+-->


### PR DESCRIPTION
Summary & Motivation: This is a WIP, but I wanted to throw up the intro verbiage
to kickstart the conversation here.

The decision I want to discuss here is separating the notion of a python module the has a `Definitions` object defined at module-scope in the `defs` from an entity that is loadable by our tools. This is a subtle but important point. It means that a location doesn't really exist until it it loadable by our tools. So when you type `dagit -f foo.py` it is meant to mean "I am loading this code location in dagit with the current Python environment, communicating with that Python Environment locally, and loading the Python file foo.py as the entry point". This is different than saying that foo.py is a code location, even though undoubtedly it will be referred to it as that colloquially.

Test Plan: Read
