### PR TITLE
Internal abstraction renames (solid -> node)

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/__init__.py
@@ -5,10 +5,10 @@ from .dependency import (
     MultiDependencyDefinition,
     Node,
     NodeHandle,
+    NodeInput,
     NodeInvocation,
-    SolidInputHandle,
+    NodeOutput,
     SolidInvocation,
-    SolidOutputHandle,
 )
 from .events import (
     AssetKey,

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -128,7 +128,7 @@ def _resolve_output_to_destinations(
 
         output_def = output_node.definition.output_def_named(output_pointer.output_name)
         downstream_input_handles = (
-            node_def.dependency_structure.output_to_downstream_inputs_for_solid(
+            node_def.dependency_structure.output_to_downstream_inputs_for_node(
                 output_pointer.solid_name
             ).get(NodeOutput(output_node, output_def), [])
         )
@@ -184,7 +184,7 @@ def _build_graph_dependencies(
                 NodeHandle(output_handle.solid_name, parent=parent_handle),
                 output_handle.output_def.name,
             )
-            for output_handle in dep_struct.all_upstream_outputs_from_solid(sub_node_name)
+            for output_handle in dep_struct.all_upstream_outputs_from_node(sub_node_name)
             if NodeHandle(output_handle.solid.name, parent=parent_handle)
             not in assets_defs_by_node_handle
         ]

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -27,7 +27,7 @@ from dagster._utils.backcompat import ExperimentalWarning
 
 from ..errors import DagsterInvalidSubsetError
 from .config import ConfigMapping
-from .dependency import NodeHandle, NodeInputHandle, NodeOutputHandle, SolidOutputHandle
+from .dependency import NodeHandle, NodeInputHandle, NodeOutput, NodeOutputHandle
 from .events import AssetKey
 from .executor_definition import ExecutorDefinition
 from .graph_definition import GraphDefinition
@@ -130,7 +130,7 @@ def _resolve_output_to_destinations(
         downstream_input_handles = (
             node_def.dependency_structure.output_to_downstream_inputs_for_solid(
                 output_pointer.solid_name
-            ).get(SolidOutputHandle(output_node, output_def), [])
+            ).get(NodeOutput(output_node, output_def), [])
         )
         for input_handle in downstream_input_handles:
             all_destinations.append(

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -181,11 +181,11 @@ def _build_graph_dependencies(
             }
         non_asset_inputs_by_node_handle[curr_node_handle] = [
             NodeOutputHandle(
-                NodeHandle(output_handle.solid_name, parent=parent_handle),
-                output_handle.output_def.name,
+                NodeHandle(node_output.node_name, parent=parent_handle),
+                node_output.output_def.name,
             )
-            for output_handle in dep_struct.all_upstream_outputs_from_node(sub_node_name)
-            if NodeHandle(output_handle.solid.name, parent=parent_handle)
+            for node_output in dep_struct.all_upstream_outputs_from_node(sub_node_name)
+            if NodeHandle(node_output.node.name, parent=parent_handle)
             not in assets_defs_by_node_handle
         ]
 

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -6,6 +6,7 @@ from typing import (
     AbstractSet,
     Any,
     Dict,
+    Iterable,
     Iterator,
     List,
     Mapping,
@@ -117,8 +118,8 @@ class Node:
     _additional_tags: Mapping[str, str]
     _hook_defs: AbstractSet[HookDefinition]
     _retry_policy: Optional[RetryPolicy]
-    _input_handles: Mapping[str, "NodeInput"]
-    _output_handles: Mapping[str, "NodeOutput"]
+    _inputs: Mapping[str, "NodeInput"]
+    _outputs: Mapping[str, "NodeOutput"]
 
     def __init__(
         self,
@@ -143,31 +144,28 @@ class Node:
         self._hook_defs = check.opt_set_param(hook_defs, "hook_defs", of_type=HookDefinition)
         self._retry_policy = check.opt_inst_param(retry_policy, "retry_policy", RetryPolicy)
 
-        input_handles = {}
-        for name, input_def in self.definition.input_dict.items():
-            input_handles[name] = NodeInput(self, input_def)
+        self._inputs = {
+            name: NodeInput(self, input_def)
+            for name, input_def in self.definition.input_dict.items()
+        }
+        self._outputs = {
+            name: NodeOutput(self, output_def)
+            for name, output_def in self.definition.output_dict.items()
+        }
 
-        self._input_handles = input_handles
+    def inputs(self) -> Iterable["NodeInput"]:
+        return self._inputs.values()
 
-        output_handles = {}
-        for name, output_def in self.definition.output_dict.items():
-            output_handles[name] = NodeOutput(self, output_def)
+    def outputs(self) -> Iterable["NodeOutput"]:
+        return self._outputs.values()
 
-        self._output_handles = output_handles
-
-    def input_handles(self):
-        return self._input_handles.values()
-
-    def output_handles(self):
-        return self._output_handles.values()
-
-    def input_handle(self, name: str) -> "NodeInput":
+    def get_input(self, name: str) -> "NodeInput":
         check.str_param(name, "name")
-        return self._input_handles[name]
+        return self._inputs[name]
 
-    def output_handle(self, name: str) -> "NodeOutput":
+    def get_output(self, name: str) -> "NodeOutput":
         check.str_param(name, "name")
-        return self._output_handles[name]
+        return self._outputs[name]
 
     def has_input(self, name: str) -> bool:
         return self.definition.has_input(name)
@@ -777,24 +775,24 @@ class DynamicCollectDependencyDefinition(
         return True
 
 
-DepTypeAndOutputHandles = Tuple[
+DepTypeAndOutputs = Tuple[
     DependencyType,
     Union[NodeOutput, List[Union[NodeOutput, Type["MappedInputPlaceholder"]]]],
 ]
 
-InputToOutputHandleDict = Dict[NodeInput, DepTypeAndOutputHandles]
+InputToOutputMap = Dict[NodeInput, DepTypeAndOutputs]
 
 
 def _create_handle_dict(
     solid_dict: Mapping[str, Node],
     dep_dict: Mapping[str, Mapping[str, IDependencyDefinition]],
-) -> InputToOutputHandleDict:
+) -> InputToOutputMap:
     from .composition import MappedInputPlaceholder
 
     check.mapping_param(solid_dict, "solid_dict", key_type=str, value_type=Node)
     check.two_dim_mapping_param(dep_dict, "dep_dict", value_type=IDependencyDefinition)
 
-    handle_dict: InputToOutputHandleDict = {}
+    handle_dict: InputToOutputMap = {}
 
     for solid_name, input_dict in dep_dict.items():
         from_solid = solid_dict[solid_name]
@@ -803,7 +801,7 @@ def _create_handle_dict(
                 handles: List[Union[NodeOutput, Type[MappedInputPlaceholder]]] = []
                 for inner_dep in dep_def.get_dependencies_and_mappings():
                     if isinstance(inner_dep, DependencyDefinition):
-                        handles.append(solid_dict[inner_dep.solid].output_handle(inner_dep.output))
+                        handles.append(solid_dict[inner_dep.solid].get_output(inner_dep.output))
                     elif inner_dep is MappedInputPlaceholder:
                         handles.append(inner_dep)
                     else:
@@ -813,17 +811,17 @@ def _create_handle_dict(
                             )
                         )
 
-                handle_dict[from_solid.input_handle(input_name)] = (DependencyType.FAN_IN, handles)
+                handle_dict[from_solid.get_input(input_name)] = (DependencyType.FAN_IN, handles)
 
             elif isinstance(dep_def, DependencyDefinition):
-                handle_dict[from_solid.input_handle(input_name)] = (
+                handle_dict[from_solid.get_input(input_name)] = (
                     DependencyType.DIRECT,
-                    solid_dict[dep_def.solid].output_handle(dep_def.output),
+                    solid_dict[dep_def.solid].get_output(dep_def.output),
                 )
             elif isinstance(dep_def, DynamicCollectDependencyDefinition):
-                handle_dict[from_solid.input_handle(input_name)] = (
+                handle_dict[from_solid.get_input(input_name)] = (
                     DependencyType.DYNAMIC_COLLECT,
-                    solid_dict[dep_def.solid_name].output_handle(dep_def.output_name),
+                    solid_dict[dep_def.solid_name].get_output(dep_def.output_name),
                 )
 
             else:
@@ -837,19 +835,19 @@ class DependencyStructure:
     def from_definitions(solids: Mapping[str, Node], dep_dict: Mapping[str, Any]):
         return DependencyStructure(list(dep_dict.keys()), _create_handle_dict(solids, dep_dict))
 
-    def __init__(self, solid_names: Sequence[str], handle_dict: InputToOutputHandleDict):
-        self._solid_names = solid_names
-        self._handle_dict = handle_dict
+    def __init__(self, node_names: Sequence[str], input_to_output_map: InputToOutputMap):
+        self._node_names = node_names
+        self._input_to_output_map = input_to_output_map
 
         # Building up a couple indexes here so that one can look up all the upstream output handles
         # or downstream input handles in O(1). Without this, this can become O(N^2) where N is solid
         # count during the GraphQL query in particular
 
         # solid_name => input_handle => list[output_handle]
-        self._solid_input_index: dict = defaultdict(dict)
+        self._node_input_index: dict = defaultdict(dict)
 
         # solid_name => output_handle => list[input_handle]
-        self._solid_output_index: dict = defaultdict(lambda: defaultdict(list))
+        self._node_output_index: dict = defaultdict(lambda: defaultdict(list))
 
         # solid_name => dynamic output_handle that this solid will dupe for
         self._dynamic_fan_out_index: dict = {}
@@ -857,204 +855,200 @@ class DependencyStructure:
         # solid_name => set of dynamic output_handle this collects over
         self._collect_index: Dict[str, set] = defaultdict(set)
 
-        for input_handle, (dep_type, output_handle_or_list) in self._handle_dict.items():
+        for node_input, (dep_type, node_output_or_list) in self._input_to_output_map.items():
             if dep_type == DependencyType.FAN_IN:
-                output_handle_list = []
-                for handle in output_handle_or_list:
-                    if not isinstance(handle, NodeOutput):
+                node_output_list = []
+                for node_output in node_output_or_list:
+                    if not isinstance(node_output, NodeOutput):
                         continue
 
-                    if handle.is_dynamic:
+                    if node_output.is_dynamic:
                         raise DagsterInvalidDefinitionError(
                             "Currently, items in a fan-in dependency cannot be downstream of dynamic outputs. "
-                            f'Problematic dependency on dynamic output "{handle.describe()}".'
+                            f'Problematic dependency on dynamic output "{node_output.describe()}".'
                         )
-                    if self._dynamic_fan_out_index.get(handle.solid_name):
+                    if self._dynamic_fan_out_index.get(node_output.solid_name):
                         raise DagsterInvalidDefinitionError(
                             "Currently, items in a fan-in dependency cannot be downstream of dynamic outputs. "
-                            f'Problematic dependency on output "{handle.describe()}", downstream of '
-                            f'"{self._dynamic_fan_out_index[handle.solid_name].describe()}".'
+                            f'Problematic dependency on output "{node_output.describe()}", downstream of '
+                            f'"{self._dynamic_fan_out_index[node_output.solid_name].describe()}".'
                         )
 
-                    output_handle_list.append(handle)
+                    node_output_list.append(node_output)
             elif dep_type == DependencyType.DIRECT:
-                output_handle = cast(NodeOutput, output_handle_or_list)
+                node_output = cast(NodeOutput, node_output_or_list)
 
-                if output_handle.is_dynamic:
-                    self._validate_and_set_fan_out(input_handle, output_handle)
+                if node_output.is_dynamic:
+                    self._validate_and_set_fan_out(node_input, node_output)
 
-                if self._dynamic_fan_out_index.get(output_handle.solid_name):
+                if self._dynamic_fan_out_index.get(node_output.solid_name):
                     self._validate_and_set_fan_out(
-                        input_handle, self._dynamic_fan_out_index[output_handle.solid_name]
+                        node_input, self._dynamic_fan_out_index[node_output.solid_name]
                     )
 
-                output_handle_list = [output_handle]
+                node_output_list = [node_output]
             elif dep_type == DependencyType.DYNAMIC_COLLECT:
-                output_handle = cast(NodeOutput, output_handle_or_list)
+                node_output = cast(NodeOutput, node_output_or_list)
 
-                if output_handle.is_dynamic:
-                    self._validate_and_set_collect(input_handle, output_handle)
+                if node_output.is_dynamic:
+                    self._validate_and_set_collect(node_input, node_output)
 
-                elif self._dynamic_fan_out_index.get(output_handle.solid_name):
+                elif self._dynamic_fan_out_index.get(node_output.solid_name):
                     self._validate_and_set_collect(
-                        input_handle,
-                        self._dynamic_fan_out_index[output_handle.solid_name],
+                        node_input,
+                        self._dynamic_fan_out_index[node_output.solid_name],
                     )
                 else:
                     check.failed(
-                        f"Unexpected dynamic fan in dep created {output_handle} -> {input_handle}"
+                        f"Unexpected dynamic fan in dep created {node_output} -> {node_input}"
                     )
 
-                output_handle_list = [output_handle]
+                node_output_list = [node_output]
             else:
                 check.failed(f"Unexpected dep type {dep_type}")
 
-            self._solid_input_index[input_handle.solid.name][input_handle] = output_handle_list
-            for output_handle in output_handle_list:
-                self._solid_output_index[output_handle.solid.name][output_handle].append(
-                    input_handle
-                )
+            self._node_input_index[node_input.solid.name][node_input] = node_output_list
+            for node_output in node_output_list:
+                self._node_output_index[node_output.solid.name][node_output].append(node_input)
 
-    def _validate_and_set_fan_out(self, input_handle: NodeInput, output_handle: NodeOutput) -> Any:
+    def _validate_and_set_fan_out(self, node_input: NodeInput, node_output: NodeOutput) -> Any:
         """Helper function for populating _dynamic_fan_out_index"""
 
-        if not input_handle.solid.definition.input_supports_dynamic_output_dep(
-            input_handle.input_name
-        ):
+        if not node_input.solid.definition.input_supports_dynamic_output_dep(node_input.input_name):
             raise DagsterInvalidDefinitionError(
-                f"{input_handle.solid.describe_node()} cannot be downstream of dynamic output "
-                f'"{output_handle.describe()}" since input "{input_handle.input_name}" maps to a node '
+                f"{node_input.solid.describe_node()} cannot be downstream of dynamic output "
+                f'"{node_output.describe()}" since input "{node_input.input_name}" maps to a node '
                 "that is already downstream of another dynamic output. Nodes cannot be downstream of more "
                 "than one dynamic output"
             )
 
-        if self._collect_index.get(input_handle.solid_name):
+        if self._collect_index.get(node_input.solid_name):
             raise DagsterInvalidDefinitionError(
-                f"{input_handle.solid.describe_node()} cannot be both downstream of dynamic output "
-                f"{output_handle.describe()} and collect over dynamic output "
-                f"{list(self._collect_index[input_handle.solid_name])[0].describe()}."
+                f"{node_input.solid.describe_node()} cannot be both downstream of dynamic output "
+                f"{node_output.describe()} and collect over dynamic output "
+                f"{list(self._collect_index[node_input.solid_name])[0].describe()}."
             )
 
-        if self._dynamic_fan_out_index.get(input_handle.solid_name) is None:
-            self._dynamic_fan_out_index[input_handle.solid_name] = output_handle
+        if self._dynamic_fan_out_index.get(node_input.solid_name) is None:
+            self._dynamic_fan_out_index[node_input.solid_name] = node_output
             return
 
-        if self._dynamic_fan_out_index[input_handle.solid_name] != output_handle:
+        if self._dynamic_fan_out_index[node_input.solid_name] != node_output:
             raise DagsterInvalidDefinitionError(
-                f"{input_handle.solid.describe_node()} cannot be downstream of more than one dynamic output. "
-                f'It is downstream of both "{output_handle.describe()}" and '
-                f'"{self._dynamic_fan_out_index[input_handle.solid_name].describe()}"'
+                f"{node_input.solid.describe_node()} cannot be downstream of more than one dynamic output. "
+                f'It is downstream of both "{node_output.describe()}" and '
+                f'"{self._dynamic_fan_out_index[node_input.solid_name].describe()}"'
             )
 
     def _validate_and_set_collect(
         self,
-        input_handle: NodeInput,
-        output_handle: NodeOutput,
+        node_input: NodeInput,
+        node_output: NodeOutput,
     ) -> None:
-        if self._dynamic_fan_out_index.get(input_handle.solid_name):
+        if self._dynamic_fan_out_index.get(node_input.solid_name):
             raise DagsterInvalidDefinitionError(
-                f"{input_handle.solid.describe_node()} cannot both collect over dynamic output "
-                f"{output_handle.describe()} and be downstream of the dynamic output "
-                f"{self._dynamic_fan_out_index[input_handle.solid_name].describe()}."
+                f"{node_input.solid.describe_node()} cannot both collect over dynamic output "
+                f"{node_output.describe()} and be downstream of the dynamic output "
+                f"{self._dynamic_fan_out_index[node_input.solid_name].describe()}."
             )
 
-        self._collect_index[input_handle.solid_name].add(output_handle)
+        self._collect_index[node_input.solid_name].add(node_output)
 
         # if the output is already fanned out
-        if self._dynamic_fan_out_index.get(output_handle.solid_name):
+        if self._dynamic_fan_out_index.get(node_output.solid_name):
             raise DagsterInvalidDefinitionError(
-                f"{input_handle.solid.describe_node()} cannot be downstream of more than one dynamic output. "
-                f'It is downstream of both "{output_handle.describe()}" and '
-                f'"{self._dynamic_fan_out_index[output_handle.solid_name].describe()}"'
+                f"{node_input.solid.describe_node()} cannot be downstream of more than one dynamic output. "
+                f'It is downstream of both "{node_output.describe()}" and '
+                f'"{self._dynamic_fan_out_index[node_output.solid_name].describe()}"'
             )
 
-    def all_upstream_outputs_from_solid(self, solid_name: str) -> Sequence[NodeOutput]:
-        check.str_param(solid_name, "solid_name")
+    def all_upstream_outputs_from_node(self, node_name: str) -> Sequence[NodeOutput]:
+        check.str_param(node_name, "solid_name")
 
         # flatten out all outputs that feed into the inputs of this solid
         return [
             output_handle
-            for output_handle_list in self._solid_input_index[solid_name].values()
+            for output_handle_list in self._node_input_index[node_name].values()
             for output_handle in output_handle_list
         ]
 
-    def input_to_upstream_outputs_for_solid(self, solid_name: str) -> Any:
+    def input_to_upstream_outputs_for_node(self, node_name: str) -> Any:
         """
         Returns a Dict[NodeInput, List[NodeOutput]] that encodes
         where all the the inputs are sourced from upstream. Usually the
         List[NodeOutput] will be a list of one, except for the
         multi-dependency case.
         """
-        check.str_param(solid_name, "solid_name")
-        return self._solid_input_index[solid_name]
+        check.str_param(node_name, "node_name")
+        return self._node_input_index[node_name]
 
-    def output_to_downstream_inputs_for_solid(self, solid_name: str) -> Any:
+    def output_to_downstream_inputs_for_node(self, node_name: str) -> Any:
         """
         Returns a Dict[NodeOutput, List[NodeInput]] that
         represents all the downstream inputs for each output in the
         dictionary
         """
-        check.str_param(solid_name, "solid_name")
-        return self._solid_output_index[solid_name]
+        check.str_param(node_name, "node_name")
+        return self._node_output_index[node_name]
 
-    def has_direct_dep(self, solid_input_handle: NodeInput) -> bool:
-        check.inst_param(solid_input_handle, "solid_input_handle", NodeInput)
-        if solid_input_handle not in self._handle_dict:
+    def has_direct_dep(self, node_input: NodeInput) -> bool:
+        check.inst_param(node_input, "node_input", NodeInput)
+        if node_input not in self._input_to_output_map:
             return False
-        dep_type, _ = self._handle_dict[solid_input_handle]
+        dep_type, _ = self._input_to_output_map[node_input]
         return dep_type == DependencyType.DIRECT
 
-    def get_direct_dep(self, solid_input_handle: NodeInput) -> NodeOutput:
-        check.inst_param(solid_input_handle, "solid_input_handle", NodeInput)
-        dep_type, dep = self._handle_dict[solid_input_handle]
+    def get_direct_dep(self, node_input: NodeInput) -> NodeOutput:
+        check.inst_param(node_input, "node_input", NodeInput)
+        dep_type, dep = self._input_to_output_map[node_input]
         check.invariant(
             dep_type == DependencyType.DIRECT,
             f"Cannot call get_direct_dep when dep is not singular, got {dep_type}",
         )
         return cast(NodeOutput, dep)
 
-    def has_fan_in_deps(self, solid_input_handle: NodeInput) -> bool:
-        check.inst_param(solid_input_handle, "solid_input_handle", NodeInput)
-        if solid_input_handle not in self._handle_dict:
+    def has_fan_in_deps(self, node_input: NodeInput) -> bool:
+        check.inst_param(node_input, "node_input", NodeInput)
+        if node_input not in self._input_to_output_map:
             return False
-        dep_type, _ = self._handle_dict[solid_input_handle]
+        dep_type, _ = self._input_to_output_map[node_input]
         return dep_type == DependencyType.FAN_IN
 
     def get_fan_in_deps(
-        self, solid_input_handle: NodeInput
+        self, node_input: NodeInput
     ) -> Sequence[Union[NodeOutput, Type["MappedInputPlaceholder"]]]:
-        check.inst_param(solid_input_handle, "solid_input_handle", NodeInput)
-        dep_type, deps = self._handle_dict[solid_input_handle]
+        check.inst_param(node_input, "node_input", NodeInput)
+        dep_type, deps = self._input_to_output_map[node_input]
         check.invariant(
             dep_type == DependencyType.FAN_IN,
             f"Cannot call get_multi_dep when dep is not fan in, got {dep_type}",
         )
         return cast(List[Union[NodeOutput, Type["MappedInputPlaceholder"]]], deps)
 
-    def has_dynamic_fan_in_dep(self, solid_input_handle: NodeInput) -> bool:
-        check.inst_param(solid_input_handle, "solid_input_handle", NodeInput)
-        if solid_input_handle not in self._handle_dict:
+    def has_dynamic_fan_in_dep(self, node_input: NodeInput) -> bool:
+        check.inst_param(node_input, "node_input", NodeInput)
+        if node_input not in self._input_to_output_map:
             return False
-        dep_type, _ = self._handle_dict[solid_input_handle]
+        dep_type, _ = self._input_to_output_map[node_input]
         return dep_type == DependencyType.DYNAMIC_COLLECT
 
-    def get_dynamic_fan_in_dep(self, solid_input_handle: NodeInput) -> NodeOutput:
-        check.inst_param(solid_input_handle, "solid_input_handle", NodeInput)
-        dep_type, dep = self._handle_dict[solid_input_handle]
+    def get_dynamic_fan_in_dep(self, node_input: NodeInput) -> NodeOutput:
+        check.inst_param(node_input, "node_input", NodeInput)
+        dep_type, dep = self._input_to_output_map[node_input]
         check.invariant(
             dep_type == DependencyType.DYNAMIC_COLLECT,
             f"Cannot call get_dynamic_fan_in_dep when dep is not, got {dep_type}",
         )
         return cast(NodeOutput, dep)
 
-    def has_deps(self, solid_input_handle: NodeInput) -> bool:
-        check.inst_param(solid_input_handle, "solid_input_handle", NodeInput)
-        return solid_input_handle in self._handle_dict
+    def has_deps(self, node_input: NodeInput) -> bool:
+        check.inst_param(node_input, "node_input", NodeInput)
+        return node_input in self._input_to_output_map
 
-    def get_deps_list(self, solid_input_handle: NodeInput) -> Sequence[NodeOutput]:
-        check.inst_param(solid_input_handle, "solid_input_handle", NodeInput)
-        check.invariant(self.has_deps(solid_input_handle))
-        dep_type, handle_or_list = self._handle_dict[solid_input_handle]
+    def get_deps_list(self, node_input: NodeInput) -> Sequence[NodeOutput]:
+        check.inst_param(node_input, "node_input", NodeInput)
+        check.invariant(self.has_deps(node_input))
+        dep_type, handle_or_list = self._input_to_output_map[node_input]
         if dep_type == DependencyType.DIRECT:
             return [cast(NodeOutput, handle_or_list)]
         elif dep_type == DependencyType.DYNAMIC_COLLECT:
@@ -1064,25 +1058,25 @@ class DependencyStructure:
         else:
             check.failed(f"Unexpected dep type {dep_type}")
 
-    def input_handles(self) -> Sequence[NodeInput]:
-        return list(self._handle_dict.keys())
+    def inputs(self) -> Sequence[NodeInput]:
+        return list(self._input_to_output_map.keys())
 
-    def get_upstream_dynamic_handle_for_solid(self, solid_name: str) -> Any:
-        return self._dynamic_fan_out_index.get(solid_name)
+    def get_upstream_dynamic_output_for_node(self, node_name: str) -> Optional[NodeOutput]:
+        return self._dynamic_fan_out_index.get(node_name)
 
-    def get_dependency_type(self, solid_input_handle: NodeInput) -> Optional[DependencyType]:
-        result = self._handle_dict.get(solid_input_handle)
+    def get_dependency_type(self, node_input: NodeInput) -> Optional[DependencyType]:
+        result = self._input_to_output_map.get(node_input)
         if result is None:
             return None
         dep_type, _ = result
         return dep_type
 
-    def is_dynamic_mapped(self, solid_name: str) -> bool:
-        return solid_name in self._dynamic_fan_out_index
+    def is_dynamic_mapped(self, node_name: str) -> bool:
+        return node_name in self._dynamic_fan_out_index
 
-    def has_dynamic_downstreams(self, solid_name: str) -> bool:
-        for upstream_handle in self._dynamic_fan_out_index.values():
-            if upstream_handle.solid_name == solid_name:
+    def has_dynamic_downstreams(self, node_name: str) -> bool:
+        for node_output in self._dynamic_fan_out_index.values():
+            if node_output.solid_name == node_name:
                 return True
 
         return False

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -735,8 +735,8 @@ class MultiDependencyDefinition(
                 key = dep.node + ":" + dep.output
                 if key in seen:
                     raise DagsterInvalidDefinitionError(
-                        'Duplicate dependencies on node "{dep.solid}" output "{dep.output}" '
-                        "used in the same MultiDependencyDefinition.".format(dep=dep)
+                        f'Duplicate dependencies on node "{dep.node}" output "{dep.output}" '
+                        "used in the same MultiDependencyDefinition."
                     )
                 seen[key] = True
             elif dep is MappedInputPlaceholder:
@@ -746,12 +746,9 @@ class MultiDependencyDefinition(
 
         return super(MultiDependencyDefinition, cls).__new__(cls, deps)
 
-    def get_node_dependencies(self) -> Sequence[DependencyDefinition]:
-        return [dep for dep in self.dependencies if isinstance(dep, DependencyDefinition)]
-
     @public
     def get_node_dependencies(self) -> Sequence[DependencyDefinition]:
-        return self.get_node_dependencies()
+        return [dep for dep in self.dependencies if isinstance(dep, DependencyDefinition)]
 
     @public
     def is_fan_in(self) -> bool:

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -59,13 +59,13 @@ class NodeInvocation(
     """Identifies an instance of a node in a graph dependency structure.
 
     Args:
-        name (str): Name of the solid of which this is an instance.
-        alias (Optional[str]): Name specific to this instance of the solid. Necessary when there are
-            multiple instances of the same solid.
+        name (str): Name of the node of which this is an instance.
+        alias (Optional[str]): Name specific to this instance of the node. Necessary when there are
+            multiple instances of the same node.
         tags (Optional[Dict[str, Any]]): Optional tags values to extend or override those
-            set on the solid definition.
+            set on the node definition.
         hook_defs (Optional[AbstractSet[HookDefinition]]): A set of hook definitions applied to the
-            solid instance.
+            node instance.
 
     Examples:
 
@@ -534,7 +534,7 @@ class NodeOutput(NamedTuple("_NodeOutput", [("node", Node), ("output_def", Outpu
     def __new__(cls, node: Node, output_def: OutputDefinition):
         return super(NodeOutput, cls).__new__(
             cls,
-            check.inst_param(node, "solid", Node),
+            check.inst_param(node, "node", Node),
             check.inst_param(output_def, "output_def", OutputDefinition),
         )
 
@@ -555,7 +555,7 @@ class NodeOutput(NamedTuple("_NodeOutput", [("node", Node), ("output_def", Outpu
         return hash((self.node.name, self.output_def.name))
 
     def __eq__(self, other: Any):
-        return self.node.name == other.solid.name and self.output_def.name == other.output_def.name
+        return self.node.name == other.node.name and self.output_def.name == other.output_def.name
 
     def describe(self) -> str:
         return f"{self.node_name}:{self.output_def.name}"
@@ -582,7 +582,7 @@ class IDependencyDefinition(ABC):  # pylint: disable=no-init
 
     @abstractmethod
     def is_fan_in(self) -> bool:
-        """The result passed to the corresponding input will be a List made from different solid outputs"""
+        """The result passed to the corresponding input will be a List made from different node outputs"""
 
 
 class DependencyDefinition(
@@ -661,10 +661,6 @@ class DependencyDefinition(
 
     def is_fan_in(self) -> bool:
         return False
-
-    @property
-    def node(self) -> str:
-        return self.node
 
     def get_op_dependencies(self) -> Sequence["DependencyDefinition"]:
         return [self]

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -104,7 +104,7 @@ def _create_adjacency_lists(
         visit_dict[node_name] = True
 
         for node_output in dep_structure.all_upstream_outputs_from_node(node_name):
-            forward_node = node_output.solid.name
+            forward_node = node_output.node.name
             backward_node = node_name
             if forward_node in forward_edges:
                 forward_edges[forward_node].add(backward_node)

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -37,8 +37,8 @@ from .dependency import (
     IDependencyDefinition,
     Node,
     NodeHandle,
+    NodeInput,
     NodeInvocation,
-    SolidInputHandle,
 )
 from .hook_definition import HookDefinition
 from .input import FanInInputPointer, InputDefinition, InputMapping, InputPointer
@@ -258,7 +258,7 @@ class GraphDefinition(NodeDefinition):
             for input_def in node.definition.get_inputs_must_be_resolved_top_level(
                 asset_layer, cur_handle
             ):
-                if self.dependency_structure.has_deps(SolidInputHandle(node, input_def)):
+                if self.dependency_structure.has_deps(NodeInput(node, input_def)):
                     continue
                 elif not node.container_maps_input(input_def.name):
                     raise DagsterInvalidDefinitionError(
@@ -840,7 +840,7 @@ def _validate_in_mappings(
             )
 
         target_input_def = target_node.input_def_named(mapping.maps_to.input_name)
-        solid_input_handle = SolidInputHandle(target_node, target_input_def)
+        solid_input_handle = NodeInput(target_node, target_input_def)
 
         if mapping.maps_to_fan_in:
             maps_to = cast(FanInInputPointer, mapping.maps_to)

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -90,28 +90,28 @@ def _check_node_defs_arg(
 
 
 def _create_adjacency_lists(
-    solids: Sequence[Node],
+    nodes: Sequence[Node],
     dep_structure: DependencyStructure,
 ) -> Tuple[Mapping[str, Set[str]], Mapping[str, Set[str]]]:
-    visit_dict = {s.name: False for s in solids}
-    forward_edges: Dict[str, Set[str]] = {s.name: set() for s in solids}
-    backward_edges: Dict[str, Set[str]] = {s.name: set() for s in solids}
+    visit_dict = {s.name: False for s in nodes}
+    forward_edges: Dict[str, Set[str]] = {s.name: set() for s in nodes}
+    backward_edges: Dict[str, Set[str]] = {s.name: set() for s in nodes}
 
-    def visit(solid_name: str) -> None:
-        if visit_dict[solid_name]:
+    def visit(node_name: str) -> None:
+        if visit_dict[node_name]:
             return
 
-        visit_dict[solid_name] = True
+        visit_dict[node_name] = True
 
-        for output_handle in dep_structure.all_upstream_outputs_from_solid(solid_name):
-            forward_node = output_handle.solid.name
-            backward_node = solid_name
+        for node_output in dep_structure.all_upstream_outputs_from_node(node_name):
+            forward_node = node_output.solid.name
+            backward_node = node_name
             if forward_node in forward_edges:
                 forward_edges[forward_node].add(backward_node)
                 backward_edges[backward_node].add(forward_node)
                 visit(forward_node)
 
-    for s in solids:
+    for s in nodes:
         visit(s.name)
 
     return (forward_edges, backward_edges)
@@ -179,7 +179,7 @@ class GraphDefinition(NodeDefinition):
     _input_mappings: Sequence[InputMapping]
     _output_mappings: Sequence[OutputMapping]
     _config_mapping: Optional[ConfigMapping]
-    _solids_in_topological_order: Sequence[Node]
+    _nodes_in_topological_order: Sequence[Node]
 
     def __init__(
         self,
@@ -233,10 +233,10 @@ class GraphDefinition(NodeDefinition):
 
         # must happen after base class construction as properties are assumed to be there
         # eager computation to detect cycles
-        self._solids_in_topological_order = self._get_solids_in_topological_order()
+        self._nodes_in_topological_order = self._get_nodes_in_topological_order()
         self._dagster_type_dict = construct_dagster_type_dictionary([self])
 
-    def _get_solids_in_topological_order(self) -> Sequence[Node]:
+    def _get_nodes_in_topological_order(self) -> Sequence[Node]:
 
         _forward_edges, backward_edges = _create_adjacency_lists(
             self.solids, self.dependency_structure
@@ -296,7 +296,7 @@ class GraphDefinition(NodeDefinition):
 
     @property
     def solids_in_topological_order(self) -> Sequence[Node]:
-        return self._solids_in_topological_order
+        return self._nodes_in_topological_order
 
     def has_solid_named(self, name: str) -> bool:
         check.str_param(name, "name")
@@ -840,17 +840,17 @@ def _validate_in_mappings(
             )
 
         target_input_def = target_node.input_def_named(mapping.maps_to.input_name)
-        solid_input_handle = NodeInput(target_node, target_input_def)
+        node_input = NodeInput(target_node, target_input_def)
 
         if mapping.maps_to_fan_in:
             maps_to = cast(FanInInputPointer, mapping.maps_to)
-            if not dependency_structure.has_fan_in_deps(solid_input_handle):
+            if not dependency_structure.has_fan_in_deps(node_input):
                 raise DagsterInvalidDefinitionError(
                     f"In {class_name} '{name}' input mapping target "
                     f'"{maps_to.node_name}.{maps_to.input_name}" (index {maps_to.fan_in_index} of fan-in) '
                     f"is not a MultiDependencyDefinition."
                 )
-            inner_deps = dependency_structure.get_fan_in_deps(solid_input_handle)
+            inner_deps = dependency_structure.get_fan_in_deps(node_input)
             if (maps_to.fan_in_index >= len(inner_deps)) or (
                 inner_deps[maps_to.fan_in_index] is not MappedInputPlaceholder
             ):
@@ -864,7 +864,7 @@ def _validate_in_mappings(
                 target_input_def.dagster_type.get_inner_type_for_fan_in()
             )
         else:
-            if dependency_structure.has_deps(solid_input_handle):
+            if dependency_structure.has_deps(node_input):
                 raise DagsterInvalidDefinitionError(
                     f"In {class_name} '{name}' input mapping target "
                     f'"{mapping.maps_to.node_name}.{mapping.maps_to.input_name}" '
@@ -876,15 +876,15 @@ def _validate_in_mappings(
                 target_input_def.dagster_type
             )
 
-    for input_handle in dependency_structure.input_handles():
-        if dependency_structure.has_fan_in_deps(input_handle):
-            for idx, dep in enumerate(dependency_structure.get_fan_in_deps(input_handle)):
+    for node_input in dependency_structure.inputs():
+        if dependency_structure.has_fan_in_deps(node_input):
+            for idx, dep in enumerate(dependency_structure.get_fan_in_deps(node_input)):
                 if dep is MappedInputPlaceholder:
-                    mapping_str = f"{input_handle.node_name}.{input_handle.input_name}.{idx}"
+                    mapping_str = f"{node_input.node_name}.{node_input.input_name}.{idx}"
                     if mapping_str not in mapping_keys:
                         raise DagsterInvalidDefinitionError(
                             f"Unsatisfied MappedInputPlaceholder at index {idx} in "
-                            f"MultiDependencyDefinition for '{input_handle.node_name}.{input_handle.input_name}'"
+                            f"MultiDependencyDefinition for '{node_input.node_name}.{node_input.input_name}'"
                         )
 
     # if the dagster type on a graph input is Any and all its target inputs have the

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -767,35 +767,35 @@ def get_subselected_graph_definition(
         # build dependencies for the node. we do it for both cases because nested graphs can have
         # inputs and outputs too
         deps[_dep_key_of(node)] = {}
-        for input_handle in node.input_handles():
-            if graph.dependency_structure.has_direct_dep(input_handle):
-                output_handle = graph.dependency_structure.get_direct_dep(input_handle)
+        for node_input in node.inputs():
+            if graph.dependency_structure.has_direct_dep(node_input):
+                output_handle = graph.dependency_structure.get_direct_dep(node_input)
                 if output_handle.solid.name in resolved_op_selection_dict:
-                    deps[_dep_key_of(node)][input_handle.input_def.name] = DependencyDefinition(
+                    deps[_dep_key_of(node)][node_input.input_def.name] = DependencyDefinition(
                         solid=output_handle.solid.name, output=output_handle.output_def.name
                     )
-            elif graph.dependency_structure.has_dynamic_fan_in_dep(input_handle):
-                output_handle = graph.dependency_structure.get_dynamic_fan_in_dep(input_handle)
+            elif graph.dependency_structure.has_dynamic_fan_in_dep(node_input):
+                output_handle = graph.dependency_structure.get_dynamic_fan_in_dep(node_input)
                 if output_handle.solid.name in resolved_op_selection_dict:
                     deps[_dep_key_of(node)][
-                        input_handle.input_def.name
+                        node_input.input_def.name
                     ] = DynamicCollectDependencyDefinition(
                         solid_name=output_handle.solid.name,
                         output_name=output_handle.output_def.name,
                     )
-            elif graph.dependency_structure.has_fan_in_deps(input_handle):
-                output_handles = graph.dependency_structure.get_fan_in_deps(input_handle)
+            elif graph.dependency_structure.has_fan_in_deps(node_input):
+                outputs = graph.dependency_structure.get_fan_in_deps(node_input)
                 multi_dependencies = [
                     DependencyDefinition(
                         solid=output_handle.solid.name, output=output_handle.output_def.name
                     )
-                    for output_handle in output_handles
+                    for output_handle in outputs
                     if (
                         isinstance(output_handle, NodeOutput)
                         and output_handle.solid.name in resolved_op_selection_dict
                     )
                 ]
-                deps[_dep_key_of(node)][input_handle.input_def.name] = MultiDependencyDefinition(
+                deps[_dep_key_of(node)][node_input.input_def.name] = MultiDependencyDefinition(
                     cast(
                         List[Union[DependencyDefinition, Type[MappedInputPlaceholder]]],
                         multi_dependencies,

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -31,7 +31,7 @@ from dagster._core.definitions.dependency import (
     Node,
     NodeHandle,
     NodeInvocation,
-    SolidOutputHandle,
+    NodeOutput,
 )
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.node_definition import NodeDefinition
@@ -791,7 +791,7 @@ def get_subselected_graph_definition(
                     )
                     for output_handle in output_handles
                     if (
-                        isinstance(output_handle, SolidOutputHandle)
+                        isinstance(output_handle, NodeOutput)
                         and output_handle.solid.name in resolved_op_selection_dict
                     )
                 ]

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -769,30 +769,30 @@ def get_subselected_graph_definition(
         deps[_dep_key_of(node)] = {}
         for node_input in node.inputs():
             if graph.dependency_structure.has_direct_dep(node_input):
-                output_handle = graph.dependency_structure.get_direct_dep(node_input)
-                if output_handle.solid.name in resolved_op_selection_dict:
+                node_output = graph.dependency_structure.get_direct_dep(node_input)
+                if node_output.node.name in resolved_op_selection_dict:
                     deps[_dep_key_of(node)][node_input.input_def.name] = DependencyDefinition(
-                        solid=output_handle.solid.name, output=output_handle.output_def.name
+                        node=node_output.node.name, output=node_output.output_def.name
                     )
             elif graph.dependency_structure.has_dynamic_fan_in_dep(node_input):
-                output_handle = graph.dependency_structure.get_dynamic_fan_in_dep(node_input)
-                if output_handle.solid.name in resolved_op_selection_dict:
+                node_output = graph.dependency_structure.get_dynamic_fan_in_dep(node_input)
+                if node_output.node.name in resolved_op_selection_dict:
                     deps[_dep_key_of(node)][
                         node_input.input_def.name
                     ] = DynamicCollectDependencyDefinition(
-                        solid_name=output_handle.solid.name,
-                        output_name=output_handle.output_def.name,
+                        solid_name=node_output.node.name,
+                        output_name=node_output.output_def.name,
                     )
             elif graph.dependency_structure.has_fan_in_deps(node_input):
                 outputs = graph.dependency_structure.get_fan_in_deps(node_input)
                 multi_dependencies = [
                     DependencyDefinition(
-                        solid=output_handle.solid.name, output=output_handle.output_def.name
+                        node=output_handle.node.name, output=output_handle.output_def.name
                     )
                     for output_handle in outputs
                     if (
                         isinstance(output_handle, NodeOutput)
-                        and output_handle.solid.name in resolved_op_selection_dict
+                        and output_handle.node.name in resolved_op_selection_dict
                     )
                 ]
                 deps[_dep_key_of(node)][node_input.input_def.name] = MultiDependencyDefinition(

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -711,35 +711,35 @@ def _get_pipeline_subset_def(
         Dict[str, IDependencyDefinition],
     ] = {_dep_key_of(solid): {} for solid in solids}
 
-    for solid in solids:
-        for node_input in solid.inputs():
+    for node in solids:
+        for node_input in node.inputs():
             if graph.dependency_structure.has_direct_dep(node_input):
-                output_handle = pipeline_def.dependency_structure.get_direct_dep(node_input)
-                if output_handle.solid.name in solids_to_execute:
-                    deps[_dep_key_of(solid)][node_input.input_def.name] = DependencyDefinition(
-                        solid=output_handle.solid.name, output=output_handle.output_def.name
+                node_output = pipeline_def.dependency_structure.get_direct_dep(node_input)
+                if node_output.node.name in solids_to_execute:
+                    deps[_dep_key_of(node)][node_input.input_def.name] = DependencyDefinition(
+                        node=node_output.node.name, output=node_output.output_def.name
                     )
             elif graph.dependency_structure.has_dynamic_fan_in_dep(node_input):
-                output_handle = graph.dependency_structure.get_dynamic_fan_in_dep(node_input)
-                if output_handle.solid.name in solids_to_execute:
-                    deps[_dep_key_of(solid)][
+                node_output = graph.dependency_structure.get_dynamic_fan_in_dep(node_input)
+                if node_output.node.name in solids_to_execute:
+                    deps[_dep_key_of(node)][
                         node_input.input_def.name
                     ] = DynamicCollectDependencyDefinition(
-                        solid_name=output_handle.solid.name,
-                        output_name=output_handle.output_def.name,
+                        solid_name=node_output.node.name,
+                        output_name=node_output.output_def.name,
                     )
             elif graph.dependency_structure.has_fan_in_deps(node_input):
                 outputs = cast(
                     Sequence[NodeOutput],
                     graph.dependency_structure.get_fan_in_deps(node_input),
                 )
-                deps[_dep_key_of(solid)][node_input.input_def.name] = MultiDependencyDefinition(
+                deps[_dep_key_of(node)][node_input.input_def.name] = MultiDependencyDefinition(
                     [
                         DependencyDefinition(
-                            solid=output_handle.solid.name, output=output_handle.output_def.name
+                            node=node_output.node.name, output=node_output.output_def.name
                         )
-                        for output_handle in outputs
-                        if output_handle.solid.name in solids_to_execute
+                        for node_output in outputs
+                        if node_output.node.name in solids_to_execute
                     ]
                 )
             # else input is unconnected

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -38,7 +38,7 @@ from .dependency import (
     Node,
     NodeHandle,
     NodeInvocation,
-    SolidOutputHandle,
+    NodeOutput,
 )
 from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .hook_definition import HookDefinition
@@ -730,7 +730,7 @@ def _get_pipeline_subset_def(
                     )
             elif graph.dependency_structure.has_fan_in_deps(input_handle):
                 output_handles = cast(
-                    Sequence[SolidOutputHandle],
+                    Sequence[NodeOutput],
                     graph.dependency_structure.get_fan_in_deps(input_handle),
                 )
                 deps[_dep_key_of(solid)][input_handle.input_def.name] = MultiDependencyDefinition(

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -712,33 +712,33 @@ def _get_pipeline_subset_def(
     ] = {_dep_key_of(solid): {} for solid in solids}
 
     for solid in solids:
-        for input_handle in solid.input_handles():
-            if graph.dependency_structure.has_direct_dep(input_handle):
-                output_handle = pipeline_def.dependency_structure.get_direct_dep(input_handle)
+        for node_input in solid.inputs():
+            if graph.dependency_structure.has_direct_dep(node_input):
+                output_handle = pipeline_def.dependency_structure.get_direct_dep(node_input)
                 if output_handle.solid.name in solids_to_execute:
-                    deps[_dep_key_of(solid)][input_handle.input_def.name] = DependencyDefinition(
+                    deps[_dep_key_of(solid)][node_input.input_def.name] = DependencyDefinition(
                         solid=output_handle.solid.name, output=output_handle.output_def.name
                     )
-            elif graph.dependency_structure.has_dynamic_fan_in_dep(input_handle):
-                output_handle = graph.dependency_structure.get_dynamic_fan_in_dep(input_handle)
+            elif graph.dependency_structure.has_dynamic_fan_in_dep(node_input):
+                output_handle = graph.dependency_structure.get_dynamic_fan_in_dep(node_input)
                 if output_handle.solid.name in solids_to_execute:
                     deps[_dep_key_of(solid)][
-                        input_handle.input_def.name
+                        node_input.input_def.name
                     ] = DynamicCollectDependencyDefinition(
                         solid_name=output_handle.solid.name,
                         output_name=output_handle.output_def.name,
                     )
-            elif graph.dependency_structure.has_fan_in_deps(input_handle):
-                output_handles = cast(
+            elif graph.dependency_structure.has_fan_in_deps(node_input):
+                outputs = cast(
                     Sequence[NodeOutput],
-                    graph.dependency_structure.get_fan_in_deps(input_handle),
+                    graph.dependency_structure.get_fan_in_deps(node_input),
                 )
-                deps[_dep_key_of(solid)][input_handle.input_def.name] = MultiDependencyDefinition(
+                deps[_dep_key_of(solid)][node_input.input_def.name] = MultiDependencyDefinition(
                     [
                         DependencyDefinition(
                             solid=output_handle.solid.name, output=output_handle.output_def.name
                         )
-                        for output_handle in output_handles
+                        for output_handle in outputs
                         if output_handle.solid.name in solids_to_execute
                     ]
                 )

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -25,7 +25,7 @@ from dagster._utils import check
 
 from .configurable import ConfigurableDefinition
 from .definition_config_schema import IDefinitionConfigSchema
-from .dependency import DependencyStructure, Node, NodeHandle, SolidInputHandle
+from .dependency import DependencyStructure, Node, NodeHandle, NodeInput
 from .graph_definition import GraphDefinition
 from .logger_definition import LoggerDefinition
 from .mode import ModeDefinition
@@ -219,7 +219,7 @@ def get_inputs_field(
     direct_inputs = check.opt_mapping_param(direct_inputs, "direct_inputs")
     inputs_field_fields = {}
     for name, inp in solid.definition.input_dict.items():
-        inp_handle = SolidInputHandle(solid, inp)
+        inp_handle = NodeInput(solid, inp)
         has_upstream = input_has_upstream(dependency_structure, inp_handle, solid, name)
         if inp.input_manager_key:
             input_field = get_input_manager_input_field(solid, inp, resource_defs)
@@ -258,7 +258,7 @@ def get_inputs_field(
 
 def input_has_upstream(
     dependency_structure: DependencyStructure,
-    input_handle: SolidInputHandle,
+    input_handle: NodeInput,
     solid: Node,
     input_name: str,
 ) -> bool:

--- a/python_modules/dagster/dagster/_core/definitions/solid_container.py
+++ b/python_modules/dagster/dagster/_core/definitions/solid_container.py
@@ -198,7 +198,7 @@ def _build_pipeline_solid_dict(
 def _validate_dependencies(dependencies, solid_dict, alias_to_name):
     for from_solid, dep_by_input in dependencies.items():
         for from_input, dep_def in dep_by_input.items():
-            for dep in dep_def.get_solid_dependencies():
+            for dep in dep_def.get_op_dependencies():
 
                 if from_solid == dep.solid:
                     raise DagsterInvalidDefinitionError(

--- a/python_modules/dagster/dagster/_core/definitions/solid_container.py
+++ b/python_modules/dagster/dagster/_core/definitions/solid_container.py
@@ -1,5 +1,16 @@
 from collections import defaultdict
-from typing import TYPE_CHECKING, DefaultDict, Dict, Mapping, Optional, Sequence, Set, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    DefaultDict,
+    Dict,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
 import dagster._check as check
 from dagster._core.errors import DagsterInvalidDefinitionError
@@ -209,7 +220,7 @@ def _validate_dependencies(
     for from_node, dep_by_input in dependencies.items():
         for from_input, dep_def in dep_by_input.items():
             dep_def = cast(DependencyDefinition, dep_def)
-            for dep in dep_def.get_op_dependencies():
+            for dep in dep_def.get_node_dependencies():
 
                 if from_node == dep.node:
                     raise DagsterInvalidDefinitionError(

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -135,7 +135,7 @@ class _PlanBuilder:
         )
         self._steps: Dict[str, IExecutionStep] = OrderedDict()
         self.step_output_map: Dict[
-            NodeOutput[StepOutputHandle, UnresolvedStepOutputHandle]
+            NodeOutput, Union[StepOutputHandle, UnresolvedStepOutputHandle]
         ] = dict()
         self.known_state = check.inst_param(known_state, "known_state", KnownExecutionState)
         self._instance_ref = instance_ref
@@ -406,7 +406,7 @@ class _PlanBuilder:
             ### 3. OUTPUTS
             # Create output handles for solid outputs
             for name, output_def in solid.definition.output_dict.items():
-                output_handle = solid.output_handle(name)
+                node_output = solid.get_output(name)
 
                 # Punch through layers of composition scope to map to the output of the
                 # actual compute step
@@ -428,7 +428,7 @@ class _PlanBuilder:
                 else:
                     check.failed(f"Unexpected step type {step}")
 
-                self.set_output_handle(output_handle, step_output_handle)
+                self.set_output_handle(node_output, step_output_handle)
 
 
 def get_root_graph_input_source(
@@ -486,7 +486,7 @@ def get_step_input_source(
         of_type=(StepInput, UnresolvedMappedStepInput, UnresolvedCollectStepInput),
     )
 
-    input_handle = solid.input_handle(input_name)
+    input_handle = solid.get_input(input_name)
     solid_config = plan_builder.resolved_run_config.solids.get(str(handle))
 
     input_def = solid.definition.input_def_named(input_name)

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -23,8 +23,8 @@ from dagster._core.definitions import (
     JobDefinition,
     Node,
     NodeHandle,
+    NodeOutput,
     SolidDefinition,
-    SolidOutputHandle,
 )
 from dagster._core.definitions.composition import MappedInputPlaceholder
 from dagster._core.definitions.dependency import DependencyStructure
@@ -99,7 +99,7 @@ class _PlanBuilder:
 
     steps List[ExecutionStep]: a list of the execution steps that have been created.
 
-    step_output_map Dict[SolidOutputHandle, StepOutputHandle]:  maps logical solid outputs
+    step_output_map Dict[NodeOutput, StepOutputHandle]:  maps logical solid outputs
     (solid_name, output_name) to particular step outputs. This covers the case where a solid maps to
     multiple steps and one wants to be able to attach to the logical output of a solid during
     execution.
@@ -135,7 +135,7 @@ class _PlanBuilder:
         )
         self._steps: Dict[str, IExecutionStep] = OrderedDict()
         self.step_output_map: Dict[
-            SolidOutputHandle, Union[StepOutputHandle, UnresolvedStepOutputHandle]
+            NodeOutput[StepOutputHandle, UnresolvedStepOutputHandle]
         ] = dict()
         self.known_state = check.inst_param(known_state, "known_state", KnownExecutionState)
         self._instance_ref = instance_ref
@@ -166,15 +166,15 @@ class _PlanBuilder:
         return self._steps[handle.to_string()]
 
     def get_output_handle(
-        self, key: SolidOutputHandle
+        self, key: NodeOutput
     ) -> Union[StepOutputHandle, UnresolvedStepOutputHandle]:
-        check.inst_param(key, "key", SolidOutputHandle)
+        check.inst_param(key, "key", NodeOutput)
         return self.step_output_map[key]
 
     def set_output_handle(
-        self, key: SolidOutputHandle, val: Union[StepOutputHandle, UnresolvedStepOutputHandle]
+        self, key: NodeOutput, val: Union[StepOutputHandle, UnresolvedStepOutputHandle]
     ) -> None:
-        check.inst_param(key, "key", SolidOutputHandle)
+        check.inst_param(key, "key", NodeOutput)
         check.inst_param(val, "val", (StepOutputHandle, UnresolvedStepOutputHandle))
         self.step_output_map[key] = val
 
@@ -529,7 +529,7 @@ def get_step_input_source(
         sources: List[StepInputSource] = []
         deps = dependency_structure.get_fan_in_deps(input_handle)
         for idx, handle_or_placeholder in enumerate(deps):
-            if isinstance(handle_or_placeholder, SolidOutputHandle):
+            if isinstance(handle_or_placeholder, NodeOutput):
                 step_output_handle = plan_builder.get_output_handle(handle_or_placeholder)
                 if (
                     isinstance(step_output_handle, UnresolvedStepOutputHandle)
@@ -549,7 +549,7 @@ def get_step_input_source(
             else:
                 check.invariant(
                     handle_or_placeholder is MappedInputPlaceholder,
-                    f"Expected SolidOutputHandle or MappedInputPlaceholder, got {handle_or_placeholder}",
+                    f"Expected NodeOutput or MappedInputPlaceholder, got {handle_or_placeholder}",
                 )
                 if parent_step_inputs is None:
                     check.failed("unexpected error in composition descent during plan building")

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -160,13 +160,13 @@ def generate_dep_graph(pipeline_def: "PipelineDefinition") -> DependencyGraph:
     graph: Dict[str, Dict[str, MutableSet[str]]] = {"upstream": {}, "downstream": {}}
     for item_name in item_names:
         graph["upstream"][item_name] = set()
-        upstream_dep = dependency_structure.input_to_upstream_outputs_for_solid(item_name)
+        upstream_dep = dependency_structure.input_to_upstream_outputs_for_node(item_name)
         for upstreams in upstream_dep.values():
             for up in upstreams:
                 graph["upstream"][item_name].add(up.solid_name)
 
         graph["downstream"][item_name] = set()
-        downstream_dep = dependency_structure.output_to_downstream_inputs_for_solid(item_name)
+        downstream_dep = dependency_structure.output_to_downstream_inputs_for_node(item_name)
         for downstreams in downstream_dep.values():
             for down in downstreams:
                 graph["downstream"][item_name].add(down.solid_name)

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -163,7 +163,7 @@ def generate_dep_graph(pipeline_def: "PipelineDefinition") -> DependencyGraph:
         upstream_dep = dependency_structure.input_to_upstream_outputs_for_node(item_name)
         for upstreams in upstream_dep.values():
             for up in upstreams:
-                graph["upstream"][item_name].add(up.solid_name)
+                graph["upstream"][item_name].add(up.node_name)
 
         graph["downstream"][item_name] = set()
         downstream_dep = dependency_structure.output_to_downstream_inputs_for_node(item_name)

--- a/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
@@ -3,7 +3,7 @@ from typing import Mapping, NamedTuple, Sequence
 
 import dagster._check as check
 from dagster._core.definitions import GraphDefinition
-from dagster._core.definitions.dependency import DependencyType, Node, SolidInputHandle
+from dagster._core.definitions.dependency import DependencyType, Node, NodeInput
 from dagster._serdes import whitelist_for_serdes
 
 
@@ -17,7 +17,7 @@ def build_solid_invocation_snap(icontains_solids, solid):
     input_to_outputs_map = dep_structure.input_to_upstream_outputs_for_solid(solid.name)
 
     for input_def in solid.definition.input_defs:
-        input_handle = SolidInputHandle(solid, input_def)
+        input_handle = NodeInput(solid, input_def)
         input_def_snaps.append(
             InputDependencySnap(
                 input_def.name,

--- a/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
@@ -14,7 +14,7 @@ def build_solid_invocation_snap(icontains_solids, solid):
 
     input_def_snaps = []
 
-    input_to_outputs_map = dep_structure.input_to_upstream_outputs_for_solid(solid.name)
+    input_to_outputs_map = dep_structure.input_to_upstream_outputs_for_node(solid.name)
 
     for input_def in solid.definition.input_defs:
         input_handle = NodeInput(solid, input_def)

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composition.py
@@ -909,7 +909,7 @@ def test_with_hooks_on_invoked_solid_fails():
 
     with pytest.raises(
         DagsterInvariantViolationError,
-        match="attempted to call hook method for InvokedSolidOutputHandle.",
+        match="attempted to call hook method for InvokedNodeOutputHandle.",
     ):
 
         @job
@@ -929,7 +929,7 @@ def test_iterating_over_dynamic_outputs_fails():
 
     with pytest.raises(
         DagsterInvariantViolationError,
-        match="Attempted to iterate over an InvokedSolidOutputHandle.",
+        match="Attempted to iterate over an InvokedNodeOutputHandle.",
     ):
 
         @job
@@ -950,7 +950,7 @@ def test_indexing_into_dynamic_outputs_fails():
 
     with pytest.raises(
         DagsterInvariantViolationError,
-        match="Attempted to index in to an InvokedSolidOutputHandle.",
+        match="Attempted to index in to an InvokedNodeOutputHandle.",
     ):
 
         @job
@@ -966,7 +966,7 @@ def test_aliasing_invoked_dynamic_output_fails():
 
     with pytest.raises(
         DagsterInvariantViolationError,
-        match="attempted to call alias method for InvokedSolidOutputHandle.",
+        match="attempted to call alias method for InvokedNodeOutputHandle.",
     ):
 
         @job

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
@@ -73,7 +73,7 @@ def test_from_solid_not_there():
 def test_from_non_existant_input():
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='solid "B" does not have input "not_an_input"',
+        match='op "B" does not have input "not_an_input"',
     ):
         GraphDefinition(
             node_defs=solid_a_b_list(),

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions.py
@@ -62,19 +62,19 @@ def test_solid_def():
     assert len(solid_one_solid.output_dict) == 1
 
     assert str(solid_one_solid.get_input("input_one")) == (
-        "NodeInput(input_name=\"'input_one'\", solid_name=\"'op_one'\")"
+        "NodeInput(input_name=\"'input_one'\", node_name=\"'op_one'\")"
     )
 
     assert repr(solid_one_solid.get_input("input_one")) == (
-        "NodeInput(input_name=\"'input_one'\", solid_name=\"'op_one'\")"
+        "NodeInput(input_name=\"'input_one'\", node_name=\"'op_one'\")"
     )
 
     assert str(solid_one_solid.get_output("result")) == (
-        "NodeOutput(output_name=\"'result'\", solid_name=\"'op_one'\")"
+        "NodeOutput(node_name=\"'op_one'\", output_name=\"'result'\")"
     )
 
     assert repr(solid_one_solid.get_output("result")) == (
-        "NodeOutput(output_name=\"'result'\", solid_name=\"'op_one'\")"
+        "NodeOutput(node_name=\"'op_one'\", output_name=\"'result'\")"
     )
 
     assert solid_one_solid.get_output("result") == NodeOutput(

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions.py
@@ -48,7 +48,7 @@ def test_solid_def():
         dependencies={"op_one": {"input_one": DependencyDefinition("produce_string")}},
     )
 
-    assert len(pipeline_def.solids[0].output_handles()) == 1
+    assert len(list(pipeline_def.solids[0].outputs())) == 1
 
     assert isinstance(pipeline_def.solid_named("op_one"), Node)
 
@@ -61,38 +61,36 @@ def test_solid_def():
     assert len(solid_one_solid.input_dict) == 1
     assert len(solid_one_solid.output_dict) == 1
 
-    assert str(solid_one_solid.input_handle("input_one")) == (
+    assert str(solid_one_solid.get_input("input_one")) == (
         "NodeInput(input_name=\"'input_one'\", solid_name=\"'op_one'\")"
     )
 
-    assert repr(solid_one_solid.input_handle("input_one")) == (
+    assert repr(solid_one_solid.get_input("input_one")) == (
         "NodeInput(input_name=\"'input_one'\", solid_name=\"'op_one'\")"
     )
 
-    assert str(solid_one_solid.output_handle("result")) == (
+    assert str(solid_one_solid.get_output("result")) == (
         "NodeOutput(output_name=\"'result'\", solid_name=\"'op_one'\")"
     )
 
-    assert repr(solid_one_solid.output_handle("result")) == (
+    assert repr(solid_one_solid.get_output("result")) == (
         "NodeOutput(output_name=\"'result'\", solid_name=\"'op_one'\")"
     )
 
-    assert solid_one_solid.output_handle("result") == NodeOutput(
+    assert solid_one_solid.get_output("result") == NodeOutput(
         solid_one_solid, solid_one_solid.output_dict["result"]
     )
 
-    assert len(pipeline_def.dependency_structure.input_to_upstream_outputs_for_solid("op_one")) == 1
+    assert len(pipeline_def.dependency_structure.input_to_upstream_outputs_for_node("op_one")) == 1
 
     assert (
         len(
-            pipeline_def.dependency_structure.output_to_downstream_inputs_for_solid(
-                "produce_string"
-            )
+            pipeline_def.dependency_structure.output_to_downstream_inputs_for_node("produce_string")
         )
         == 1
     )
 
-    assert len(pipeline_def.dependency_structure.input_handles()) == 1
+    assert len(pipeline_def.dependency_structure.inputs()) == 1
 
 
 def test_solid_def_bad_input_name():

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions.py
@@ -16,7 +16,7 @@ from dagster import (
     op,
 )
 from dagster._core.definitions import AssetMaterialization, Node, create_run_config_schema
-from dagster._core.definitions.dependency import NodeHandle, SolidOutputHandle
+from dagster._core.definitions.dependency import NodeHandle, NodeOutput
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._legacy import InputDefinition
 
@@ -62,22 +62,22 @@ def test_solid_def():
     assert len(solid_one_solid.output_dict) == 1
 
     assert str(solid_one_solid.input_handle("input_one")) == (
-        "SolidInputHandle(input_name=\"'input_one'\", solid_name=\"'op_one'\")"
+        "NodeInput(input_name=\"'input_one'\", solid_name=\"'op_one'\")"
     )
 
     assert repr(solid_one_solid.input_handle("input_one")) == (
-        "SolidInputHandle(input_name=\"'input_one'\", solid_name=\"'op_one'\")"
+        "NodeInput(input_name=\"'input_one'\", solid_name=\"'op_one'\")"
     )
 
     assert str(solid_one_solid.output_handle("result")) == (
-        "SolidOutputHandle(output_name=\"'result'\", solid_name=\"'op_one'\")"
+        "NodeOutput(output_name=\"'result'\", solid_name=\"'op_one'\")"
     )
 
     assert repr(solid_one_solid.output_handle("result")) == (
-        "SolidOutputHandle(output_name=\"'result'\", solid_name=\"'op_one'\")"
+        "NodeOutput(output_name=\"'result'\", solid_name=\"'op_one'\")"
     )
 
-    assert solid_one_solid.output_handle("result") == SolidOutputHandle(
+    assert solid_one_solid.output_handle("result") == NodeOutput(
         solid_one_solid, solid_one_solid.output_dict["result"]
     )
 


### PR DESCRIPTION
### Summary & Motivation

4 significant renames:

- SolidOutputHandle -> NodeOutput
- SolidInputHandle -> NodeInput
- InvokedSolidOutputHandle -> InvokedNodeOutputHandle
- InvakedSolidDynamicOutputWrapper -> InvokedNodeDynamicOutputWrapper

These abstractions don't get serialized so I don't think there are any complicating factors for renames.

Note that `Solid{Output,Input}Handle` were renamed to `Node{Input,Output}` _without_ "Handle' for a few reasons:

- `NodeInputHandle` and `NodeOutputHandle` were already taken!
- "Handle" was not a very accurate name. Elsewhere in the codebase (and intuitively IMO), a "Handle" is an _identifier_ for an object-- it shouldn't hold big data structures, but rather just keys allowing the abstraction holding the larger data structure to be looked up. But `Solid{Input,Output}Handle` actually contained the entire `{Input,Output}Definition`-- so it actually makes more sense to call them `Node{Input,Output}` (and these names weren't taken).

I also made an effort to rename local variables and properties wherever these classes were being used, e.g. a local variable called `output_handle` that contained a `SolidOutputHandle` is now called `node_output`.

Also contains a few minor typing additions and a local variable rename (for consistency) in asset_layer.py.

### How I Tested These Changes

Existing BK.
