### PR TITLE
Fix SQLite "table asset_event_tags already exists" error

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -172,10 +172,10 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                     "table asset_keys already exists" in err_msg
                     or "table secondary_indexes already exists" in err_msg
                     or "table event_logs already exists" in err_msg
-                    or "database is locked" in err_msg
-                    or "table alembic_version already exists" in err_msg
-                    or "UNIQUE constraint failed: alembic_version.version_num" in err_msg
                     or "table asset_event_tags already exists" in err_msg
+                    or "table alembic_version already exists" in err_msg
+                    or "database is locked" in err_msg
+                    or "UNIQUE constraint failed: alembic_version.version_num" in err_msg
                 ):
                     raise
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -175,6 +175,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                     or "database is locked" in err_msg
                     or "table alembic_version already exists" in err_msg
                     or "UNIQUE constraint failed: alembic_version.version_num" in err_msg
+                    or "table asset_event_tags already exists" in err_msg
                 ):
                     raise
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_event_log.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_event_log.py
@@ -90,9 +90,6 @@ class TestSqliteEventLogStorage(TestEventLogStorage):
             exc_info = sys.exc_info()
             traceback.print_tb(exc_info[2])
 
-    @pytest.mark.skip(
-        "Consistently flakes. See https://linear.app/elementl/issue/CORE-82/test-concurrent-sqlite-event-log-connections-consistently-flakes"
-    )
     def test_concurrent_sqlite_event_log_connections(self, storage):
         tmpdir_path = storage._base_dir  # pylint: disable=protected-access
         ctx = multiprocessing.get_context("spawn")


### PR DESCRIPTION
When multiple processes (e.g. the dagit process and user code process) contend with each other to init the db in SQLite, we see a `table asset_event_tags already exists` error.

This PR updates the existing defense around table creation to handle this error.