### PR TITLE
add pep593 support for inputs

### DIFF
--- a/python_modules/dagster/dagster/_seven/typing.py
+++ b/python_modules/dagster/dagster/_seven/typing.py
@@ -1,1 +1,7 @@
-from typing_compat import get_args, get_origin  # pylint: disable=unused-import
+import sys
+
+
+if sys.version_info < (3, 9):
+    from typing_extensions import get_args, get_origin, Annotated
+else:
+    from typing import get_args, get_origin, Annotated

--- a/python_modules/dagster/dagster/_utils/typing_api.py
+++ b/python_modules/dagster/dagster/_utils/typing_api.py
@@ -4,7 +4,7 @@ order to do metaprogramming and reflection on the built-in typing module"""
 import typing
 
 import dagster._check as check
-from dagster._seven.typing import get_args, get_origin
+from dagster._seven.typing import get_args, get_origin, Annotated
 
 
 def is_closed_python_optional_type(ttype):
@@ -128,3 +128,11 @@ def is_typing_type(ttype):
         or ttype is typing.Dict
         or ttype is typing.List
     )
+
+
+def unpack_if_type_is_pep593_type_annotation(ttype: type) -> typing.Optional[typing.Tuple[type, typing.List[typing.Any]]]:
+    origin = get_origin(ttype)
+    if origin is Annotated:
+        inner_type, *annotations = get_args(ttype)
+        return (inner_type, list(annotations))
+    return None

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -88,7 +88,6 @@ setup(
         "tabulate",
         "tomli",
         "tqdm",
-        "typing_compat",
         "typing_extensions>=4.0.1",
         "sqlalchemy>=1.0",
         "toposort>=1.0",


### PR DESCRIPTION
### Summary & Motivation

I've been mainly browsing the docs so far but I think there's an opportunity to reduce boilerplate by using PEP593 annotations to allow dagster metadata to flow alongside Python typing information.

I made a pretty crude POC. I'm honestly not sure what metadata should go there `a DagsterType` directly like I did here? Or should it be an `In` object? Maybe both? What about outputs?

### How I Tested These Changes

This is a super crude POC. I'm not familiar with the codebase so I just made a `test.py` file and run it like `python test.py`:

```python
from typing import Annotated

from dagster import job, op, DagsterType

set_containing_1 = DagsterType(
    name="set_containing_1",
    description="A set containing the value 1. May contain any other values.",
    type_check_fn=lambda _context, obj: isinstance(obj, set) and 1 in obj,
)

@op
def get_data() -> set[int]:
    return {2}

SetContaining1 = Annotated[set[int], set_containing_1]

@op
def some_operation(foo: SetContaining1):
    pass

@op
def some_other_op(bar: SetContaining1):
    pass

@job
def file_sizes_job():
    data = get_data()
    some_operation(data)
    some_other_op(data)

if __name__ == "__main__":
    file_sizes_job.execute_in_process()
```
