### PR TITLE
Change CodeLocationStatusQuery to use slimmer locationStatus field

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/types/CodeLocationStatusQuery.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/CodeLocationStatusQuery.ts
@@ -9,23 +9,23 @@ import { RepositoryLocationLoadStatus } from "./../../types/globalTypes";
 // GraphQL query operation: CodeLocationStatusQuery
 // ====================================================
 
-export interface CodeLocationStatusQuery_workspaceOrError_PythonError {
+export interface CodeLocationStatusQuery_locationStatusesOrError_PythonError {
   __typename: "PythonError";
 }
 
-export interface CodeLocationStatusQuery_workspaceOrError_Workspace_locationEntries {
-  __typename: "WorkspaceLocationEntry";
+export interface CodeLocationStatusQuery_locationStatusesOrError_WorkspaceLocationStatusEntries_entries {
+  __typename: "WorkspaceLocationStatusEntry";
   id: string;
   loadStatus: RepositoryLocationLoadStatus;
 }
 
-export interface CodeLocationStatusQuery_workspaceOrError_Workspace {
-  __typename: "Workspace";
-  locationEntries: CodeLocationStatusQuery_workspaceOrError_Workspace_locationEntries[];
+export interface CodeLocationStatusQuery_locationStatusesOrError_WorkspaceLocationStatusEntries {
+  __typename: "WorkspaceLocationStatusEntries";
+  entries: CodeLocationStatusQuery_locationStatusesOrError_WorkspaceLocationStatusEntries_entries[];
 }
 
-export type CodeLocationStatusQuery_workspaceOrError = CodeLocationStatusQuery_workspaceOrError_PythonError | CodeLocationStatusQuery_workspaceOrError_Workspace;
+export type CodeLocationStatusQuery_locationStatusesOrError = CodeLocationStatusQuery_locationStatusesOrError_PythonError | CodeLocationStatusQuery_locationStatusesOrError_WorkspaceLocationStatusEntries;
 
 export interface CodeLocationStatusQuery {
-  workspaceOrError: CodeLocationStatusQuery_workspaceOrError;
+  locationStatusesOrError: CodeLocationStatusQuery_locationStatusesOrError;
 }

--- a/js_modules/dagit/packages/core/src/nav/types/CodeLocationStatusQuery.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/CodeLocationStatusQuery.ts
@@ -17,6 +17,7 @@ export interface CodeLocationStatusQuery_locationStatusesOrError_WorkspaceLocati
   __typename: "WorkspaceLocationStatusEntry";
   id: string;
   loadStatus: RepositoryLocationLoadStatus;
+  updateTimestamp: number;
 }
 
 export interface CodeLocationStatusQuery_locationStatusesOrError_WorkspaceLocationStatusEntries {

--- a/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
@@ -82,12 +82,12 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
   // and/or b) a toast indicating that a code location is being reloaded.
   React.useEffect(() => {
     const previousEntries =
-      previousData?.workspaceOrError?.__typename === 'Workspace'
-        ? previousData?.workspaceOrError.locationEntries
+      previousData?.locationStatusesOrError?.__typename === 'WorkspaceLocationStatusEntries'
+        ? previousData?.locationStatusesOrError.entries
         : [];
     const currentEntries =
-      data?.workspaceOrError?.__typename === 'Workspace'
-        ? data?.workspaceOrError.locationEntries
+      data?.locationStatusesOrError?.__typename === 'WorkspaceLocationStatusEntries'
+        ? data?.locationStatusesOrError.entries
         : [];
 
     // At least one code location has been removed. Reload, but don't make a big deal about it
@@ -222,11 +222,10 @@ const ViewButton = styled(ButtonLink)`
 
 const CODE_LOCATION_STATUS_QUERY = gql`
   query CodeLocationStatusQuery {
-    workspaceOrError {
+    locationStatusesOrError {
       __typename
-      ... on Workspace {
-        locationEntries {
-          __typename
+      ... on WorkspaceLocationStatusEntries {
+        entries {
           id
           loadStatus
         }

--- a/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
@@ -10,9 +10,14 @@ import {StatusAndMessage} from '../instance/DeploymentStatusType';
 import {RepositoryLocationLoadStatus} from '../types/globalTypes';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 
-import {CodeLocationStatusQuery} from './types/CodeLocationStatusQuery';
+import {
+  CodeLocationStatusQuery,
+  CodeLocationStatusQuery_locationStatusesOrError_WorkspaceLocationStatusEntries_entries,
+} from './types/CodeLocationStatusQuery';
 
-const POLL_INTERVAL = 3 * 1000;
+type LocationStatusEntry = CodeLocationStatusQuery_locationStatusesOrError_WorkspaceLocationStatusEntries_entries;
+
+const POLL_INTERVAL = 5 * 1000;
 
 export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null => {
   const {locationEntries, refetch} = React.useContext(WorkspaceContext);
@@ -90,9 +95,27 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
         ? data?.locationStatusesOrError.entries
         : [];
 
+    const _build_entries_by_name = (
+      entries: LocationStatusEntry[],
+    ): {[key: string]: LocationStatusEntry} => {
+      const entries_by_name = {};
+      entries.forEach((entry) => {
+        entries_by_name[entry.id] = entry;
+      });
+      return entries_by_name;
+    };
+    const previousEntriesByName = _build_entries_by_name(previousEntries);
+    const currentEntriesByName = _build_entries_by_name(currentEntries);
+    const hasUpdatedEntries = currentEntries.every(
+      (entry) =>
+        !(entry.id in previousEntriesByName) ||
+        previousEntriesByName[entry.id].updateTimestamp <
+          currentEntriesByName[entry.id].updateTimestamp,
+    );
+
     // At least one code location has been removed. Reload, but don't make a big deal about it
     // since this was probably done manually.
-    if (previousEntries.length > currentEntries.length) {
+    if (previousEntries.length > currentEntries.length && !hasUpdatedEntries) {
       reloadWorkspaceQuietly();
       return;
     }
@@ -184,6 +207,12 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
     // A location was previously loading, and no longer is. Our workspace is ready. Refetch it.
     if (anyPreviouslyLoading && !anyCurrentlyLoading) {
       reloadWorkspaceLoudly();
+      return;
+    }
+
+    if (hasUpdatedEntries) {
+      reloadWorkspaceLoudly();
+      return;
     }
 
     // It's unlikely that we've made it to this point, since being inside this effect should
@@ -228,6 +257,7 @@ const CODE_LOCATION_STATUS_QUERY = gql`
         entries {
           id
           loadStatus
+          updateTimestamp
         }
       }
     }

--- a/js_modules/dagit/packages/core/src/testing/defaultMocks.ts
+++ b/js_modules/dagit/packages/core/src/testing/defaultMocks.ts
@@ -60,6 +60,14 @@ export const defaultMocks = {
     id: randomId,
     loadStatus: () => RepositoryLocationLoadStatus.LOADED,
   }),
+  WorkspaceLocationStatusEntries: () => ({
+    entries: () => [...new Array(1)],
+  }),
+  WorkspaceLocationStatusEntry: () => ({
+    id: randomId,
+    loadStatus: () => RepositoryLocationLoadStatus.LOADED,
+    updateTimestamp: () => 0,
+  }),
   Schedule: () => ({
     id: hyphenatedName,
     name: hyphenatedName,
@@ -190,5 +198,8 @@ export const defaultMocks = {
   }),
   InstigationStatesOrError: () => ({
     __typename: 'InstigationStates',
+  }),
+  LocationStatusesOrError: () => ({
+    __typename: 'WorkspaceLocationStatusEntries',
   }),
 };


### PR DESCRIPTION
### Summary & Motivation
Changes the CodeLocationStatusQuery to query the location status using a less expensive root query field.

This should help the overall latency of this common, polling query.

The move to push this into a GraphQL subscription will happen in a separate PR

### How I Tested These Changes
Loaded dagit, changed the workspace.yaml, restarted dagit, saw the toasts pop up appropriately.
