### PR TITLE
[RFC] Update cached_status_data column 1/2

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1,4 +1,5 @@
 import copy
+import hashlib
 import inspect
 import json
 from abc import ABC, abstractmethod
@@ -260,6 +261,10 @@ class PartitionsDefinition(ABC, Generic[T]):
 
     def deserialize_subset(self, serialized: str) -> "PartitionsSubset":
         return DefaultPartitionsSubset.from_serialized(self, serialized)
+
+    @property
+    def serializable_unique_identifier(self) -> str:
+        return hashlib.sha1(json.dumps(self.get_partition_keys()).encode("utf-8")).hexdigest()
 
 
 class StaticPartitionsDefinition(

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import re
 from datetime import datetime
@@ -494,6 +495,10 @@ class TimeWindowPartitionsDefinition(
 
     def deserialize_subset(self, serialized: str) -> "TimeWindowPartitionsSubset":
         return TimeWindowPartitionsSubset.from_serialized(self, serialized)
+
+    @property
+    def serializable_unique_identifier(self) -> str:
+        return hashlib.sha1(self.__repr__().encode("utf-8")).hexdigest()
 
 
 class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -118,6 +118,7 @@ if TYPE_CHECKING:
     from dagster._core.storage.compute_log_manager import ComputeLogManager
     from dagster._core.storage.event_log import EventLogStorage
     from dagster._core.storage.event_log.base import AssetRecord, EventLogRecord, EventRecordsFilter
+    from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
     from dagster._core.storage.root import LocalArtifactStorage
     from dagster._core.storage.runs import RunStorage
     from dagster._core.storage.schedules import ScheduleStorage
@@ -1444,6 +1445,16 @@ class DagsterInstance:
         return self._event_storage.end_watch(run_id, cb)
 
     # asset storage
+
+    @traced
+    def can_cache_asset_status_data(self) -> bool:
+        return self._event_storage.can_cache_asset_status_data()
+
+    @traced
+    def update_asset_cached_status_data(
+        self, asset_key: AssetKey, cache_values: "AssetStatusCacheValue"
+    ) -> None:
+        self._event_storage.update_asset_cached_status_data(asset_key, cache_values)
 
     @traced
     def all_asset_keys(self):

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -1,7 +1,17 @@
 import base64
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Callable, Iterable, Mapping, NamedTuple, Optional, Sequence, Set, Union
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Iterable,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Union,
+)
 
 import dagster._check as check
 from dagster._core.assets import AssetDetails
@@ -17,6 +27,9 @@ from dagster._core.execution.stats import (
 from dagster._core.instance import MayHaveInstanceWeakref
 from dagster._core.storage.pipeline_run import PipelineRunStatsSnapshot
 from dagster._seven import json
+
+if TYPE_CHECKING:
+    from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
 
 class EventLogConnection(NamedTuple):
@@ -79,6 +92,7 @@ class AssetEntry(
             ("last_materialization", Optional[EventLogEntry]),
             ("last_run_id", Optional[str]),
             ("asset_details", Optional[AssetDetails]),
+            ("cached_status", Optional["AssetStatusCacheValue"]),
         ],
     )
 ):
@@ -88,7 +102,10 @@ class AssetEntry(
         last_materialization: Optional[EventLogEntry] = None,
         last_run_id: Optional[str] = None,
         asset_details: Optional[AssetDetails] = None,
+        cached_status: Optional["AssetStatusCacheValue"] = None,
     ):
+        from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
+
         return super(AssetEntry, cls).__new__(
             cls,
             asset_key=check.inst_param(asset_key, "asset_key", AssetKey),
@@ -97,6 +114,9 @@ class AssetEntry(
             ),
             last_run_id=check.opt_str_param(last_run_id, "last_run_id"),
             asset_details=check.opt_inst_param(asset_details, "asset_details", AssetDetails),
+            cached_status=check.opt_inst_param(
+                cached_status, "cached_status", AssetStatusCacheValue
+            ),
         )
 
 
@@ -253,6 +273,10 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
         raise NotImplementedError()
 
     @abstractmethod
+    def can_cache_asset_status_data(self) -> bool:
+        pass
+
+    @abstractmethod
     def get_asset_records(
         self, asset_keys: Optional[Sequence[AssetKey]] = None
     ) -> Iterable[AssetRecord]:
@@ -264,6 +288,12 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
 
     @abstractmethod
     def all_asset_keys(self) -> Iterable[AssetKey]:
+        pass
+
+    @abstractmethod
+    def update_asset_cached_status_data(
+        self, asset_key: AssetKey, cache_values: "AssetStatusCacheValue"
+    ) -> None:
         pass
 
     def get_asset_keys(

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1152,7 +1152,7 @@ class SqlEventLogStorage(EventLogStorage):
             AssetKeyTable.c.last_run_id,
             AssetKeyTable.c.asset_details,
         ]
-        if self.has_asset_key_col("cached_status_data"):
+        if self.can_cache_asset_status_data():
             columns.extend([AssetKeyTable.c.cached_status_data])
 
         is_partial_query = asset_keys is not None or bool(prefix) or bool(limit) or bool(cursor)

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2,7 +2,19 @@ import logging
 from abc import abstractmethod
 from collections import OrderedDict, defaultdict
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Union,
+    cast,
+)
 
 import pendulum
 import sqlalchemy as db
@@ -45,6 +57,9 @@ from .schema import (
     SecondaryIndexMigrationTable,
     SqlEventLogStorageTable,
 )
+
+if TYPE_CHECKING:
+    from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
 MIN_ASSET_ROWS = 25
 
@@ -117,10 +132,13 @@ class SqlEventLogStorage(EventLogStorage):
             partition=partition,
         )
 
-    def has_asset_key_index_cols(self):
+    def has_asset_key_col(self, column_name: str):
         with self.index_connection() as conn:
             column_names = [x.get("name") for x in db.inspect(conn).get_columns(AssetKeyTable.name)]
-            return "last_materialization_timestamp" in column_names
+            return column_name in column_names
+
+    def has_asset_key_index_cols(self):
+        return self.has_asset_key_col("last_materialization_timestamp")
 
     def store_asset_event(self, event: EventLogEntry):
         check.inst_param(event, "event", EventLogEntry)
@@ -157,7 +175,7 @@ class SqlEventLogStorage(EventLogStorage):
             except db.exc.IntegrityError:
                 conn.execute(update_statement)
 
-    def _get_asset_entry_values(self, event: EventLogEntry, has_asset_key_index_cols):
+    def _get_asset_entry_values(self, event: EventLogEntry, has_asset_key_index_cols: bool):
         # The AssetKeyTable contains a `last_materialization_timestamp` column that is exclusively
         # used to determine if an asset exists (last materialization timestamp > wipe timestamp).
         # This column is used nowhere else, and as of AssetObservation/AssetMaterializationPlanned
@@ -959,6 +977,8 @@ class SqlEventLogStorage(EventLogStorage):
             return result[0]
 
     def _construct_asset_record_from_row(self, row, last_materialization: Optional[EventLogEntry]):
+        from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
+
         asset_key = AssetKey.from_db_string(row[1])
         if asset_key:
             return AssetRecord(
@@ -968,6 +988,9 @@ class SqlEventLogStorage(EventLogStorage):
                     last_materialization=last_materialization,
                     last_run_id=row[3],
                     asset_details=AssetDetails.from_db_string(row[4]),
+                    cached_status=AssetStatusCacheValue.from_db_string(row[5])
+                    if self.has_asset_key_col("cached_status_data")
+                    else None,
                 ),
             )
 
@@ -1031,6 +1054,9 @@ class SqlEventLogStorage(EventLogStorage):
                     EventLogEntry, deserialize_json_to_dagster_namedtuple(row[1])
                 )
         return results
+
+    def can_cache_asset_status_data(self) -> bool:
+        return self.has_asset_key_col("cached_status_data")
 
     def get_asset_records(
         self, asset_keys: Optional[Sequence[AssetKey]] = None
@@ -1126,14 +1152,8 @@ class SqlEventLogStorage(EventLogStorage):
             AssetKeyTable.c.last_run_id,
             AssetKeyTable.c.asset_details,
         ]
-        if self.has_asset_key_index_cols():
-            columns.extend(
-                [
-                    AssetKeyTable.c.wipe_timestamp,
-                    AssetKeyTable.c.last_materialization_timestamp,
-                    AssetKeyTable.c.tags,
-                ]
-            )
+        if self.has_asset_key_col("cached_status_data"):
+            columns.extend([AssetKeyTable.c.cached_status_data])
 
         is_partial_query = asset_keys is not None or bool(prefix) or bool(limit) or bool(cursor)
         if self.has_asset_key_index_cols() and not is_partial_query:
@@ -1201,6 +1221,22 @@ class SqlEventLogStorage(EventLogStorage):
         new_cursor = rows[-1][0] if rows else None
 
         return row_by_asset_key.values(), has_more, new_cursor
+
+    def update_asset_cached_status_data(
+        self, asset_key: AssetKey, cache_values: "AssetStatusCacheValue"
+    ) -> None:
+        if self.has_asset_key_col("cached_status_data"):
+            with self.index_connection() as conn:
+                conn.execute(
+                    AssetKeyTable.update()  # pylint: disable=no-value-for-parameter
+                    .where(
+                        db.or_(
+                            AssetKeyTable.c.asset_key == asset_key.to_string(),
+                            AssetKeyTable.c.asset_key == asset_key.to_string(legacy=True),
+                        )
+                    )
+                    .values(cached_status_data=serialize_dagster_namedtuple(cache_values))
+                )
 
     def _fetch_backcompat_materialization_times(self, asset_keys):
         # fetches the latest materialization timestamp for the given asset_keys.  Uses the (slower)
@@ -1485,47 +1521,39 @@ class SqlEventLogStorage(EventLogStorage):
 
         return event_or_materialization.dagster_event.step_materialization_data.materialization
 
+    def _get_asset_key_values_on_wipe(self):
+        wipe_timestamp = pendulum.now("UTC").timestamp()
+        values = {
+            "asset_details": serialize_dagster_namedtuple(
+                AssetDetails(last_wipe_timestamp=wipe_timestamp)
+            ),
+            "last_run_id": None,
+        }
+        if self.has_asset_key_index_cols():
+            values.update(
+                dict(
+                    wipe_timestamp=utc_datetime_from_timestamp(wipe_timestamp),
+                )
+            )
+        if self.has_asset_key_col("cached_status_data"):
+            values.update(dict(cached_status_data=None))
+        return values
+
     def wipe_asset(self, asset_key):
         check.inst_param(asset_key, "asset_key", AssetKey)
+        wiped_values = self._get_asset_key_values_on_wipe()
 
-        wipe_timestamp = pendulum.now("UTC").timestamp()
-
-        if self.has_asset_key_index_cols():
-            with self.index_connection() as conn:
-                conn.execute(
-                    AssetKeyTable.update()  # pylint: disable=no-value-for-parameter
-                    .where(
-                        db.or_(
-                            AssetKeyTable.c.asset_key == asset_key.to_string(),
-                            AssetKeyTable.c.asset_key == asset_key.to_string(legacy=True),
-                        )
-                    )
-                    .values(
-                        asset_details=serialize_dagster_namedtuple(
-                            AssetDetails(last_wipe_timestamp=wipe_timestamp)
-                        ),
-                        wipe_timestamp=utc_datetime_from_timestamp(wipe_timestamp),
-                        last_run_id=None,
+        with self.index_connection() as conn:
+            conn.execute(
+                AssetKeyTable.update()  # pylint: disable=no-value-for-parameter
+                .values(**wiped_values)
+                .where(
+                    db.or_(
+                        AssetKeyTable.c.asset_key == asset_key.to_string(),
+                        AssetKeyTable.c.asset_key == asset_key.to_string(legacy=True),
                     )
                 )
-
-        else:
-            with self.index_connection() as conn:
-                conn.execute(
-                    AssetKeyTable.update()  # pylint: disable=no-value-for-parameter
-                    .where(
-                        db.or_(
-                            AssetKeyTable.c.asset_key == asset_key.to_string(),
-                            AssetKeyTable.c.asset_key == asset_key.to_string(legacy=True),
-                        )
-                    )
-                    .values(
-                        asset_details=serialize_dagster_namedtuple(
-                            AssetDetails(last_wipe_timestamp=wipe_timestamp)
-                        ),
-                        last_run_id=None,
-                    )
-                )
+            )
 
     def get_materialization_count_by_partition(
         self, asset_keys: Sequence[AssetKey]

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     )
     from dagster._core.snap.execution_plan_snapshot import ExecutionPlanSnapshot
     from dagster._core.snap.pipeline_snapshot import PipelineSnapshot
+    from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
     from dagster._core.storage.pipeline_run import (
         DagsterRun,
         JobBucket,
@@ -474,6 +475,16 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     ) -> Sequence[Mapping[str, str]]:
         return self._storage.event_log_storage.get_event_tags_for_asset(
             asset_key, filter_tags, filter_event_id
+        )
+
+    def can_cache_asset_status_data(self) -> bool:
+        return self._storage.event_log_storage.can_cache_asset_status_data()
+
+    def update_asset_cached_status_data(
+        self, asset_key: "AssetKey", cache_values: "AssetStatusCacheValue"
+    ) -> None:
+        self._storage.event_log_storage.update_asset_cached_status_data(
+            asset_key=asset_key, cache_values=cache_values
         )
 
     def get_records_for_run(

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -1,0 +1,288 @@
+from typing import List, Mapping, NamedTuple, Optional, Sequence, Union
+
+from dagster import AssetKey, DagsterEventType, DagsterInstance, EventRecordsFilter
+from dagster import _check as check
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.multi_dimensional_partitions import (
+    MultiPartitionKey,
+    MultiPartitionsDefinition,
+)
+from dagster._core.definitions.partition import (
+    PartitionsDefinition,
+    PartitionsSubset,
+    StaticPartitionsDefinition,
+)
+from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
+from dagster._core.storage.tags import (
+    MULTIDIMENSIONAL_PARTITION_PREFIX,
+    get_dimension_from_partition_tag,
+)
+from dagster._serdes import deserialize_json_to_dagster_namedtuple, whitelist_for_serdes
+
+CACHEABLE_PARTITION_TYPES = {
+    TimeWindowPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
+}
+
+
+@whitelist_for_serdes
+class AssetStatusCacheValue(
+    NamedTuple(
+        "_AssetPartitionsStatusCacheValue",
+        [
+            ("latest_storage_id", int),
+            ("partitions_def_id", Optional[str]),
+            ("serialized_materialized_partition_subset", Optional[str]),
+            # Future partition subset features will go here, e.g. stale partition subsets
+        ],
+    )
+):
+    """
+    Set of asset fields that reflect partition materialization status. This is used to display
+    global partition status in the asset view.
+
+    Properties:
+        latest_storage_id (int): The latest evaluated storage id for the asset.
+        partitions_def_id (Optional(str)): The serializable unique identifier for the partitions
+            definition. When this value differs from the new partitions definition, this cache
+            value needs to be recalculated. None if the asset is unpartitioned.
+        serialized_materialized_partition_subset (Optional(str)): The serialized representation of the
+            materialized partition subsets, up to the latest storage id. None if the asset is
+            unpartitioned.
+    """
+
+    def __new__(
+        cls,
+        latest_storage_id: int,
+        partitions_def_id: Optional[str] = None,
+        serialized_materialized_partition_subset: Optional[str] = None,
+    ):
+        check.int_param(latest_storage_id, "latest_storage_id")
+        check.opt_inst_param(
+            serialized_materialized_partition_subset,
+            "serialized_materialized_partition_subset",
+            str,
+        )
+        check.opt_str_param(partitions_def_id, "partitions_def_id")
+        return super(AssetStatusCacheValue, cls).__new__(
+            cls, latest_storage_id, partitions_def_id, serialized_materialized_partition_subset
+        )
+
+    @staticmethod
+    def from_db_string(db_string):
+        if not db_string:
+            return None
+
+        cached_data = deserialize_json_to_dagster_namedtuple(db_string)
+        if not isinstance(cached_data, AssetStatusCacheValue):
+            return None
+
+        return cached_data
+
+    def deserialize_materialized_partition_subsets(
+        self, partitions_def: PartitionsDefinition
+    ) -> PartitionsSubset:
+        if not self.serialized_materialized_partition_subset:
+            return partitions_def.empty_subset()
+
+        return partitions_def.deserialize_subset(self.serialized_materialized_partition_subset)
+
+
+def get_materialized_multipartitions(
+    instance: DagsterInstance, asset_key: AssetKey, partitions_def: MultiPartitionsDefinition
+) -> Sequence[MultiPartitionKey]:
+    dimension_names = partitions_def.partition_dimension_names
+    materialized_keys: List[MultiPartitionKey] = []
+    for event_tags in instance.get_event_tags_for_asset(asset_key):
+        event_partition_keys_by_dimension = {
+            get_dimension_from_partition_tag(key): value
+            for key, value in event_tags.items()
+            if key.startswith(MULTIDIMENSIONAL_PARTITION_PREFIX)
+        }
+
+        if all(
+            dimension_name in event_partition_keys_by_dimension.keys()
+            for dimension_name in dimension_names
+        ):
+            materialized_keys.append(
+                MultiPartitionKey(
+                    {
+                        dimension_names[0]: event_partition_keys_by_dimension[dimension_names[0]],
+                        dimension_names[1]: event_partition_keys_by_dimension[dimension_names[1]],
+                    }
+                )
+            )
+    return materialized_keys
+
+
+def _build_status_cache(
+    instance: DagsterInstance,
+    asset_key: AssetKey,
+    latest_storage_id: int,
+    partitions_def: Optional[PartitionsDefinition],
+) -> AssetStatusCacheValue:
+    """
+    This method refreshes the asset status cache for a given asset key. It recalculates
+    the materialized partition subset for the asset key and updates the cache value.
+    """
+    if not partitions_def or not any(
+        isinstance(partitions_def, partition_type) for partition_type in CACHEABLE_PARTITION_TYPES
+    ):
+        return AssetStatusCacheValue(latest_storage_id=latest_storage_id)
+
+    materialized_keys: Sequence[Union[str, MultiPartitionKey]]
+    if isinstance(partitions_def, MultiPartitionsDefinition):
+        materialized_keys = get_materialized_multipartitions(instance, asset_key, partitions_def)
+    else:
+        materialized_keys = [
+            key
+            for key, count in instance.get_materialization_count_by_partition([asset_key])
+            .get(asset_key, {})
+            .items()
+            if count > 0
+        ]
+
+    serialized_materialized_partition_subset = partitions_def.empty_subset()
+    partition_keys = partitions_def.get_partition_keys()
+
+    serialized_materialized_partition_subset = (
+        serialized_materialized_partition_subset.with_partition_keys(
+            set(materialized_keys) & set(partition_keys)
+        )
+    )
+
+    return AssetStatusCacheValue(
+        latest_storage_id=latest_storage_id,
+        partitions_def_id=partitions_def.serializable_unique_identifier,
+        serialized_materialized_partition_subset=serialized_materialized_partition_subset.serialize(),
+    )
+
+
+def _get_updated_status_cache(
+    instance: DagsterInstance,
+    asset_key: AssetKey,
+    current_status_cache_value: AssetStatusCacheValue,
+    partitions_def: Optional[PartitionsDefinition],
+) -> AssetStatusCacheValue:
+    """
+    This method accepts the current asset status cache value, and fetches unevaluated
+    records from the event log. It then updates the cache value with the new materializations.
+    """
+    unevaluated_event_records = instance.get_event_records(
+        event_records_filter=EventRecordsFilter(
+            event_type=DagsterEventType.ASSET_MATERIALIZATION,
+            asset_key=asset_key,
+            after_cursor=current_status_cache_value.latest_storage_id
+            if current_status_cache_value
+            else None,
+        )
+    )
+
+    if not unevaluated_event_records:
+        return current_status_cache_value
+
+    latest_storage_id = max([record.storage_id for record in unevaluated_event_records])
+    if not partitions_def or not any(
+        isinstance(partitions_def, partition_type) for partition_type in CACHEABLE_PARTITION_TYPES
+    ):
+        return AssetStatusCacheValue(latest_storage_id=latest_storage_id)
+
+    check.invariant(
+        current_status_cache_value.partitions_def_id
+        == partitions_def.serializable_unique_identifier
+    )
+    materialized_subset: PartitionsSubset = (
+        partitions_def.deserialize_subset(
+            current_status_cache_value.serialized_materialized_partition_subset
+        )
+        if current_status_cache_value
+        and current_status_cache_value.serialized_materialized_partition_subset
+        else partitions_def.empty_subset()
+    )
+    newly_materialized_partitions = set()
+
+    for unevaluated_materializations in unevaluated_event_records:
+        if not (
+            unevaluated_materializations.event_log_entry.dagster_event
+            and unevaluated_materializations.event_log_entry.dagster_event.is_step_materialization
+        ):
+            check.failed("Expected materialization event")
+        if unevaluated_materializations.event_log_entry.dagster_event.partition:
+            newly_materialized_partitions.add(
+                unevaluated_materializations.event_log_entry.dagster_event.partition
+            )
+    materialized_subset = materialized_subset.with_partition_keys(newly_materialized_partitions)
+    return AssetStatusCacheValue(
+        latest_storage_id=latest_storage_id,
+        partitions_def_id=current_status_cache_value.partitions_def_id,
+        serialized_materialized_partition_subset=materialized_subset.serialize(),
+    )
+
+
+def _fetch_stored_asset_status_cache_values(
+    instance: DagsterInstance, asset_key: Optional[AssetKey] = None
+) -> Mapping[AssetKey, Optional[AssetStatusCacheValue]]:
+    asset_records = (
+        instance.get_asset_records()
+        if not asset_key
+        else instance.get_asset_records(asset_keys=[asset_key])
+    )
+    return {
+        asset_record.asset_entry.asset_key: asset_record.asset_entry.cached_status
+        for asset_record in asset_records
+    }
+
+
+def _get_fresh_asset_status_cache_values(
+    instance: DagsterInstance,
+    asset_graph: AssetGraph,
+    asset_key: Optional[AssetKey] = None,  # If not provided, fetches all asset cache values
+) -> Mapping[AssetKey, AssetStatusCacheValue]:
+    cached_status_data_by_asset_key = _fetch_stored_asset_status_cache_values(instance, asset_key)
+
+    updated_cache_values_by_asset_key = {}
+    for asset_key, cached_status_data in cached_status_data_by_asset_key.items():
+        if asset_key not in asset_graph.all_asset_keys:
+            # Do not calculate new value if asset not in graph
+            continue
+
+        partitions_def = asset_graph.get_partitions_def(asset_key)
+        if cached_status_data is None or cached_status_data.partitions_def_id != (
+            partitions_def.serializable_unique_identifier if partitions_def else None
+        ):
+            event_records = instance.get_event_records(
+                event_records_filter=EventRecordsFilter(
+                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                    asset_key=asset_key,
+                ),
+                limit=1,
+            )
+            if event_records:
+                updated_cache_values_by_asset_key[asset_key] = _build_status_cache(
+                    instance=instance,
+                    asset_key=asset_key,
+                    partitions_def=partitions_def,
+                    latest_storage_id=next(iter(event_records)).storage_id,
+                )
+        else:
+            updated_cache_values_by_asset_key[asset_key] = _get_updated_status_cache(
+                instance=instance,
+                asset_key=asset_key,
+                partitions_def=partitions_def,
+                current_status_cache_value=cached_status_data,
+            )
+
+    return updated_cache_values_by_asset_key
+
+
+def get_and_update_asset_status_cache_values(
+    instance: DagsterInstance, asset_graph: AssetGraph, asset_key: Optional[AssetKey] = None
+) -> Mapping[AssetKey, AssetStatusCacheValue]:
+    updated_cache_values_by_asset_key = _get_fresh_asset_status_cache_values(
+        instance, asset_graph, asset_key
+    )
+    for asset_key, status_cache_value in updated_cache_values_by_asset_key.items():
+        instance.update_asset_cached_status_data(asset_key, status_cache_value)
+
+    return updated_cache_values_by_asset_key

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -799,6 +799,17 @@ def test_static_partition_keys_in_range():
         )
 
 
+def test_unique_identifier():
+    assert (
+        StaticPartitionsDefinition(["a", "b", "c"]).serializable_unique_identifier
+        != StaticPartitionsDefinition(["a", "b"]).serializable_unique_identifier
+    )
+    assert (
+        StaticPartitionsDefinition(["a", "b", "c"]).serializable_unique_identifier
+        == StaticPartitionsDefinition(["a", "b", "c"]).serializable_unique_identifier
+    )
+
+
 def test_static_partitions_subset():
     partitions = StaticPartitionsDefinition(["foo", "bar", "baz", "qux"])
     subset = partitions.empty_subset()

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -541,3 +541,14 @@ def test_time_window_partitions_contains():
     assert "2015-01-05" not in subset
     assert "2015-01-09" not in subset
     assert "2015-01-11" not in subset
+
+
+def test_unique_identifier():
+    assert (
+        DailyPartitionsDefinition(start_date="2015-01-01").serializable_unique_identifier
+        != DailyPartitionsDefinition(start_date="2015-01-02").serializable_unique_identifier
+    )
+    assert (
+        DailyPartitionsDefinition(start_date="2015-01-01").serializable_unique_identifier
+        == DailyPartitionsDefinition(start_date="2015-01-01").serializable_unique_identifier
+    )

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_status_cache.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_status_cache.py
@@ -1,0 +1,264 @@
+from dagster import (
+    AssetKey,
+    DagsterEventType,
+    DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    EventRecordsFilter,
+    MultiPartitionKey,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
+    asset,
+    define_asset_job,
+)
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.storage.partition_status_cache import get_and_update_asset_status_cache_values
+from dagster._core.test_utils import instance_for_test
+from dagster._utils import Counter, traced_counter
+
+
+def test_get_cached_status_unpartitioned():
+    @asset
+    def asset1():
+        return 1
+
+    asset_graph = AssetGraph.from_assets([asset1])
+    asset_job = define_asset_job("asset_job").resolve([asset1], [])
+
+    asset_key = AssetKey("asset1")
+
+    with instance_for_test() as instance:
+        asset_records = list(instance.get_asset_records([asset_key]))
+        assert len(asset_records) == 0
+
+        asset_job.execute_in_process(instance=instance)
+
+        cached_status = get_and_update_asset_status_cache_values(instance, asset_graph, asset_key)[
+            asset_key
+        ]
+
+        assert cached_status
+        assert (
+            cached_status.latest_storage_id
+            == next(
+                iter(
+                    instance.get_event_records(
+                        EventRecordsFilter(
+                            asset_key=AssetKey("asset1"),
+                            event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                        ),
+                        limit=1,
+                    )
+                )
+            ).storage_id
+        )
+        assert cached_status.partitions_def_id is None
+        assert cached_status.serialized_materialized_partition_subset is None
+
+
+def test_get_cached_partition_status_by_asset():
+    partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
+
+    @asset(partitions_def=partitions_def)
+    def asset1():
+        return 1
+
+    asset_key = AssetKey("asset1")
+    asset_graph = AssetGraph.from_assets([asset1])
+    asset_job = define_asset_job("asset_job").resolve([asset1], [])
+
+    def _swap_partitions_def(new_partitions_def, asset, asset_graph, asset_job):
+        asset._partitions_def = new_partitions_def  # pylint: disable=protected-access
+        asset_job = define_asset_job("asset_job").resolve([asset], [])
+        asset_graph = AssetGraph.from_assets([asset])
+        return asset, asset_job, asset_graph
+
+    with instance_for_test() as created_instance:
+        traced_counter.set(Counter())
+
+        asset_records = list(created_instance.get_asset_records([asset_key]))
+        assert len(asset_records) == 0
+
+        asset_job.execute_in_process(instance=created_instance, partition_key="2022-02-01")
+
+        cached_status = get_and_update_asset_status_cache_values(
+            created_instance, asset_graph, asset_key
+        )[asset_key]
+        assert cached_status
+        assert cached_status.latest_storage_id
+        assert cached_status.partitions_def_id
+        assert cached_status.serialized_materialized_partition_subset
+        materialized_keys = list(
+            partitions_def.deserialize_subset(
+                cached_status.serialized_materialized_partition_subset
+            ).get_partition_keys()
+        )
+        assert len(materialized_keys) == 1
+        assert "2022-02-01" in materialized_keys
+        counts = traced_counter.get().counts()
+        assert counts.get("DagsterInstance.get_materialization_count_by_partition") == 1
+
+        asset_job.execute_in_process(instance=created_instance, partition_key="2022-02-02")
+
+        cached_status = get_and_update_asset_status_cache_values(
+            created_instance, asset_graph, asset_key
+        )[asset_key]
+        assert cached_status
+        assert cached_status.latest_storage_id
+        assert cached_status.partitions_def_id
+        assert cached_status.serialized_materialized_partition_subset
+        materialized_keys = list(
+            partitions_def.deserialize_subset(
+                cached_status.serialized_materialized_partition_subset
+            ).get_partition_keys()
+        )
+        assert len(materialized_keys) == 2
+        assert all(
+            partition_key in materialized_keys for partition_key in ["2022-02-01", "2022-02-02"]
+        )
+        counts = traced_counter.get().counts()
+        # Assert that get_materialization_count_by_partition is not called again via cache rebuild
+        assert counts.get("DagsterInstance.get_materialization_count_by_partition") == 1
+
+        static_partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
+        asset1, asset_job, asset_graph = _swap_partitions_def(
+            static_partitions_def, asset1, asset_graph, asset_job
+        )
+        asset_job.execute_in_process(instance=created_instance, partition_key="a")
+        cached_status = get_and_update_asset_status_cache_values(
+            created_instance, asset_graph, asset_key
+        )[asset_key]
+        assert cached_status
+        assert cached_status.serialized_materialized_partition_subset
+        materialized_partition_subset = static_partitions_def.deserialize_subset(
+            cached_status.serialized_materialized_partition_subset
+        )
+        assert "a" in materialized_partition_subset.get_partition_keys()
+        assert all(
+            partition not in materialized_partition_subset.get_partition_keys()
+            for partition in ["b", "c"]
+        )
+        counts = traced_counter.get().counts()
+        # Assert that get_materialization_count_by_partition is called again when partitions_def changes
+        assert counts.get("DagsterInstance.get_materialization_count_by_partition") == 2
+
+
+def test_multipartition_get_cached_partition_status():
+    partitions_def = MultiPartitionsDefinition(
+        {
+            "ab": StaticPartitionsDefinition(["a", "b"]),
+            "12": StaticPartitionsDefinition(["1", "2"]),
+        }
+    )
+
+    @asset(partitions_def=partitions_def)
+    def asset1():
+        return 1
+
+    asset_key = AssetKey("asset1")
+    asset_graph = AssetGraph.from_assets([asset1])
+    asset_job = define_asset_job("asset_job").resolve([asset1], [])
+
+    with instance_for_test() as created_instance:
+        traced_counter.set(Counter())
+
+        asset_records = list(created_instance.get_asset_records([AssetKey("asset1")]))
+        assert len(asset_records) == 0
+
+        asset_job.execute_in_process(
+            instance=created_instance, partition_key=MultiPartitionKey({"ab": "a", "12": "1"})
+        )
+
+        cached_status = get_and_update_asset_status_cache_values(
+            created_instance, asset_graph, asset_key
+        )[asset_key]
+        assert cached_status
+        assert cached_status.latest_storage_id
+        assert cached_status.partitions_def_id
+        assert cached_status.serialized_materialized_partition_subset
+        materialized_keys = partitions_def.deserialize_subset(
+            cached_status.serialized_materialized_partition_subset
+        ).get_partition_keys()
+        assert len(list(materialized_keys)) == 1
+        assert MultiPartitionKey({"ab": "a", "12": "1"}) in materialized_keys
+
+        counts = traced_counter.get().counts()
+        assert counts.get("DagsterInstance.get_event_tags_for_asset") == 1
+
+        asset_job.execute_in_process(
+            instance=created_instance, partition_key=MultiPartitionKey({"ab": "a", "12": "2"})
+        )
+
+        cached_status = get_and_update_asset_status_cache_values(
+            created_instance, asset_graph, asset_key
+        )[asset_key]
+        assert cached_status
+        assert cached_status.serialized_materialized_partition_subset
+        materialized_keys = partitions_def.deserialize_subset(
+            cached_status.serialized_materialized_partition_subset
+        ).get_partition_keys()
+        assert len(list(materialized_keys)) == 2
+        assert all(
+            key in materialized_keys
+            for key in [
+                MultiPartitionKey({"ab": "a", "12": "1"}),
+                MultiPartitionKey({"ab": "a", "12": "2"}),
+            ]
+        )
+        counts = traced_counter.get().counts()
+        # Assert that get_event_tags_for_asset is not called again when partitions_def remains the same
+        assert counts.get("DagsterInstance.get_event_tags_for_asset") == 1
+
+
+def test_cached_status_on_wipe():
+    partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
+
+    @asset(partitions_def=partitions_def)
+    def asset1():
+        return 1
+
+    asset_key = AssetKey("asset1")
+    asset_graph = AssetGraph.from_assets([asset1])
+    asset_job = define_asset_job("asset_job").resolve([asset1], [])
+
+    with instance_for_test() as created_instance:
+        asset_records = list(created_instance.get_asset_records([AssetKey("asset1")]))
+        assert len(asset_records) == 0
+
+        asset_job.execute_in_process(instance=created_instance, partition_key="2022-02-01")
+
+        cached_status = get_and_update_asset_status_cache_values(
+            created_instance, asset_graph, asset_key
+        )[asset_key]
+        assert cached_status
+        assert cached_status.serialized_materialized_partition_subset
+        materialized_keys = list(
+            partitions_def.deserialize_subset(
+                cached_status.serialized_materialized_partition_subset
+            ).get_partition_keys()
+        )
+        assert len(materialized_keys) == 1
+        assert "2022-02-01" in materialized_keys
+
+
+def test_dynamic_partitions_status_not_cached():
+    dynamic_fn = lambda _current_time: ["a_partition"]
+    dynamic = DynamicPartitionsDefinition(dynamic_fn)
+
+    @asset(partitions_def=dynamic)
+    def asset1():
+        return 1
+
+    asset_key = AssetKey("asset1")
+    asset_graph = AssetGraph.from_assets([asset1])
+    asset_job = define_asset_job("asset_job").resolve([asset1], [])
+
+    with instance_for_test() as created_instance:
+        asset_records = list(created_instance.get_asset_records([AssetKey("asset1")]))
+        assert len(asset_records) == 0
+
+        asset_job.execute_in_process(instance=created_instance, partition_key="a_partition")
+
+        cached_status = get_and_update_asset_status_cache_values(
+            created_instance, asset_graph, asset_key
+        )[asset_key]
+        assert cached_status.serialized_materialized_partition_subset is None

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -721,7 +721,9 @@ def test_add_cached_status_data_column(hostname, conn_string):
                 target_fd.write(template)
 
         with DagsterInstance.from_config(tempdir) as instance:
+            assert instance.can_cache_asset_status_data() is False
             assert {"cached_status_data"} & get_columns(instance, "asset_keys") == set()
 
             instance.upgrade()
+            assert instance.can_cache_asset_status_data() is True
             assert {"cached_status_data"} <= get_columns(instance, "asset_keys")


### PR DESCRIPTION
Following the [cached asset partition status](https://www.notion.so/dagster/Cached-incremental-asset-partition-summaries-9afd9aa0b91940d49c3d5af5a832131a) proposal, this PR creates an `update_asset_cached_status_data` method that writes to the new cached_status_data column of the AssetKeyTable. This column now contains:

- latest evaluated storage ID of the asset
- a serialized unique identifier to represent the partitions definition. If the partitions definition is changed, the mismatch between the serialized identifier and the new identifier triggers a recalculation and update to the cached status column.
- serialized representation of the materialized partition subset. This contains partition ranges for time window partitions definitions, and a set of materialized partition keys otherwise.

The `update_asset_cached_status_data` will check if the column exists, and if it does, it will:
- read the currently cached data per asset and
- if the partition definition unique identifier differs, recalculates the partition materialization status from event log storage
- otherwise, the unique identifier remains the same and the method reads the unevaluated events
- updates the `cached_status_data` column with the new partition materialization data

PR for part 2 updates Dagit to read from the cached data: https://github.com/dagster-io/dagster/pull/10822