### PR TITLE
feat(dbt-cloud): allow subsetting on dbt cloud models

### DIFF
--- a/docs/content/integrations/dbt-cloud.mdx
+++ b/docs/content/integrations/dbt-cloud.mdx
@@ -103,6 +103,11 @@ from dagster import ScheduleDefinition, define_asset_job, repository, AssetSelec
 # Materialize all assets in the repository
 run_everything_job = define_asset_job("run_everything_job", AssetSelection.all())
 
+# Materialize only the staging assets
+run_staging_job = define_asset_job(
+    "run_staging_job", AssetSelection.groups("staging")
+)
+
 @repository
 def my_repo():
     return [
@@ -111,6 +116,10 @@ def my_repo():
         ScheduleDefinition(
             job=run_everything_job,
             cron_schedule="@daily",
+        ),
+        ScheduleDefinition(
+            job=run_staging_job,
+            cron_schedule="@hourly",
         ),
     ]
 ```

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt_cloud.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt_cloud.py
@@ -43,6 +43,11 @@ def scope_schedule_dbt_cloud_assets():
     # Materialize all assets in the repository
     run_everything_job = define_asset_job("run_everything_job", AssetSelection.all())
 
+    # Materialize only the staging assets
+    run_staging_job = define_asset_job(
+        "run_staging_job", AssetSelection.groups("staging")
+    )
+
     @repository
     def my_repo():
         return [
@@ -51,6 +56,10 @@ def scope_schedule_dbt_cloud_assets():
             ScheduleDefinition(
                 job=run_everything_job,
                 cron_schedule="@daily",
+            ),
+            ScheduleDefinition(
+                job=run_staging_job,
+                cron_schedule="@hourly",
             ),
         ]
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -255,7 +255,7 @@ def _get_asset_deps(
     Dict[AssetKey, Tuple[str, In]],
     Dict[AssetKey, Tuple[str, Out]],
     Dict[AssetKey, str],
-    Dict[str, str],
+    Dict[str, List[str]],
     Dict[str, Dict[str, Any]],
 ]:
     asset_deps: Dict[AssetKey, Set[AssetKey]] = {}
@@ -265,7 +265,7 @@ def _get_asset_deps(
     # These dicts could be refactored as a single dict, mapping from output name to arbitrary
     # metadata that we need to store for reference.
     group_names_by_key: Dict[AssetKey, str] = {}
-    fqns_by_output_name: Dict[str, str] = {}
+    fqns_by_output_name: Dict[str, List[str]] = {}
     metadata_by_output_name: Dict[str, Dict[str, Any]] = {}
 
     for unique_id, parent_unique_ids in deps.items():
@@ -325,7 +325,7 @@ def _get_dbt_op(
     select: str,
     exclude: str,
     use_build_command: bool,
-    fqns_by_output_name: Mapping[str, str],
+    fqns_by_output_name: Mapping[str, List[str]],
     node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey],
     partition_key_to_vars_fn: Optional[Callable[[str], Mapping[str, Any]]],
     runtime_metadata_fn: Optional[


### PR DESCRIPTION
### Summary & Motivation
The dbt Cloud equivalent of https://github.com/dagster-io/dagster/pull/7798.

Relax the constraint that models from the same dbt Cloud job must be materialized together. Instead, we can materialize them individually by overriding the dbt Cloud job's commands with the correct filters.

### How I Tested These Changes

pytest - I might just assert that the filter was passed properly, as mocking the different results based on the filter may not be productive. But open to opinions.

https://user-images.githubusercontent.com/16431325/204942938-2d4460a4-d0dd-400c-9e79-ea45af6e8068.mov

