### PR TITLE
Add CLI command to delete runs older than date

### DIFF
--- a/python_modules/dagster/dagster/_cli/run.py
+++ b/python_modules/dagster/dagster/_cli/run.py
@@ -1,7 +1,10 @@
+import datetime
+import re
+
 import click
 from tqdm import tqdm
 
-from dagster import __version__ as dagster_version
+from dagster import __version__ as dagster_version, RunsFilter
 from dagster._cli.workspace.cli_target import get_external_job_from_kwargs, job_target_argument
 from dagster._core.instance import DagsterInstance
 
@@ -47,6 +50,89 @@ def run_delete_command(run_id, force):
         else:
             raise click.ClickException("Exiting without deleting run.")
 
+
+@run_cli.command(
+    name="delete-range",
+    help="Delete a run and its associated event logs by date range. Warning: Cannot be undone",
+)
+@click.option(
+    "--older-than",
+    "-o",
+    is_flag=True,
+    default=False,
+    help="Deletes runs greater than the time period. Supports hours/days/weeks/months/years. For example 1 hour is 1h.",
+)
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    default=False,
+    help="Skip prompt to delete run history and event logs.",
+)
+def delete_range_command(force, date_range):
+    if not date_range:
+        raise click.ClickException("Please specify a date range to delete.")
+
+    # Date range should only contain numbers, suffixed by either h, d, w, m, y
+    if not re.match(r"^[0-9]+[hdwmy]$", date_range):
+        raise click.ClickException("Please specify a valid date range to delete.")
+
+    regexed_date_range = re.match(r"^([0-9]+)([hdwmy])$", date_range)
+    date_range_value = int(regexed_date_range.group(1))
+    date_range_unit = regexed_date_range.group(2).lower() # Handle case where user enters uppercase
+    found_date = None
+    now = datetime.datetime.now()
+
+    if date_range_unit == "m":
+        found_date = now - datetime.timedelta(minutes=date_range_value)
+    elif date_range_unit == "h":
+        found_date = now - datetime.timedelta(hours=date_range_value)
+    elif date_range_unit == "d":
+        found_date = now - datetime.timedelta(days=date_range_value)
+    elif date_range_unit == "w":
+        found_date = now - datetime.timedelta(weeks=date_range_value)
+    elif date_range_unit == "y":
+        found_date = now - datetime.timedelta(days=date_range_value * 365)
+    else:
+        raise click.ClickException("Please specify a valid date range to delete.")
+
+    # So we now take the date range value and unit and convert it to a datetime object
+    # We then use that to delete all runs that are older than that datetime object
+    # We also need to delete all event logs that are older than that datetime object
+    if force:
+        should_delete_run = True
+    else:
+        confirmation = click.prompt(
+            f"Are you sure you want to delete run history and event logs from {found_date}? Type DELETE."
+        )
+        should_delete_run = confirmation == "DELETE"
+
+    if should_delete_run:
+        # delete everything from found_date onwards
+        with DagsterInstance.get() as instance:
+            # @todo get a total count here that is quick, as loading all the runs into memory
+            # is not ideal
+            run_filter = RunsFilter(created_before=found_date)
+
+            total = instance.get_runs_count(run_filter)
+            click.echo(f"Found {total} runs to delete.")
+
+            while True:
+                runs = instance.get_runs(limit=100, filters=run_filter)
+
+                if not runs:
+                    break
+                for run in tqdm(runs, desc="Deleting runs"):
+                    instance.delete_run(run.run_id)
+
+            # for run in tqdm(instance.get_runs()):
+            #     if run.timestamp < found_date:
+            #         instance.delete_run(run.run_id)
+            # click.echo(f"Deleted run history and event logs from {found_date}.")
+
+        # click.echo("Deleted all run history and event logs.")
+    else:
+        raise click.ClickException("Exiting without deleting all run history and event logs.")
 
 @run_cli.command(
     name="wipe", help="Eliminate all run history and event logs. Warning: Cannot be undone."

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -24,6 +24,7 @@ from dagster._cli import ENV_PREFIX, cli
 from dagster._cli.job import job_execute_command
 from dagster._cli.run import (
     run_delete_command,
+    run_delete_range_command,
     run_list_command,
     run_migrate_command,
     run_wipe_command,
@@ -33,7 +34,7 @@ from dagster._core.definitions.partition import PartitionedConfig, StaticPartiti
 from dagster._core.definitions.sensor_definition import RunRequest
 from dagster._core.storage.memoizable_io_manager import versioned_filesystem_io_manager
 from dagster._core.storage.tags import MEMOIZED_RUN_TAG
-from dagster._core.test_utils import instance_for_test
+from dagster._core.test_utils import instance_for_test, create_run_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.server import GrpcServerProcess
 from dagster._legacy import (
@@ -969,3 +970,27 @@ def test_run_migrate_command():
 
         assert len(get_repo_runs(instance, old_repo_label)) == 0
         assert len(get_repo_runs(instance, new_repo_label)) == 1
+
+
+def test_run_delete_range_command():
+    with instance_for_test():
+        # Create some runs that are over an hour old.
+        with instance_for_test() as instance:
+            # @todo How do I set the created_at time on a run?
+            for n in range(10):
+                create_run_for_test(instance, pipeline_name="foo_pipeline")
+
+        runner = CliRunner()
+        result = runner.invoke(run_delete_range_command, args=["1h", "--force"])
+        assert "Found 10 runs to delete" in result.output
+        assert "Deleted run history and event logs older than" in result.output
+        assert result.exit_code == 0
+
+
+@pytest.mark.parametrize("date", ["hello", "0.2y", "1s", "432m2", "1hour", "3 weeks"])
+def test_run_delete_range_invalid_date(date):
+    with instance_for_test():
+        runner = CliRunner()
+        result = runner.invoke(run_delete_range_command, args=[date, "--force"])
+        assert "Error: Please specify a valid date range to delete" in result.output
+        assert result.exit_code == 1


### PR DESCRIPTION
### Summary & Motivation
Deleting older than a certain date is super useful in Dagster. We don't really care about jobs older than a certain date range (say 90 days), this just takes up storage space.

What would be useful is a command to delete older than a date.

See this issue https://github.com/dagster-io/dagster/issues/4497

I really like this idea: `U02B400J44U: Maybe `dagster run wipe` could take an argument like `--older-than=2w``, So I added it.

I really don't like adding this to wipe as wipe is an incredibly destructive action and I foresee users wiping their instances by mistake. Instead I've created a new command called `delete-range`. If someone has a better name for this, I'm open for suggestions as I don't like this name :).

Now you can do the following:
`dagster run delete-range 1h`

And it will ask you if you want to delete older than the date it found:
```bash
$ dagster run delete-range 1h
Are you sure you want to delete run history and event logs from 2022-12-01 18:58:57.162173? Type DELETE.
```

And after it will tell you how many deletions it made:
```bash
$ dagster run delete-range 1h
Are you sure you want to delete run history and event logs from 2022-12-01 18:58:57.162173? Type DELETE.: DELETE
Found 0 runs to delete.
0it [00:00, ?it/s]
Deleted run history and event logs older than 2022-12-01 18:58:57.162173.
```
It will also show you a progress bar which will update every run.

Questions:

1. Is there a better way to get Run IDs without having to load the entire run? I think this would be better for batching as you don't have to load more information to memory than you need.
2. How do I create runs with an arbitrary started time via tests?

Once I get #2 answered I'll finish the tests.

:thinking: Should there be a `delete_many` function added at some point to bulk delete runs? Right now you have to do run-by-run.

### How I Tested These Changes
1. Manually on a local project we have to delete old runs
2. New tests