### PR TITLE
[dagster-airflow] stronger airflow ephemeral db isolation between runs

### DIFF
--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
@@ -64,4 +64,7 @@ def make_dagster_job_from_airflow_dag(
         dag, tags, use_airflow_template_context, unique_id, mock_xcom, use_emphemeral_airflow_db
     )
     # pass in tags manually because pipeline_def.graph doesn't have it threaded
-    return pipeline_def.graph.to_job(tags={**pipeline_def.tags})
+    return pipeline_def.graph.to_job(
+        tags={**pipeline_def.tags},
+        resource_defs={"airflow_db": pipeline_def.mode_definitions[0].resource_defs["airflow_db"]},
+    )

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_load_dag_bag_airflow_2.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_load_dag_bag_airflow_2.py
@@ -458,8 +458,6 @@ test_airflow_example_dags_inputs = [
             # airflow.exceptions.DagNotFound: Dag id example_trigger_target_dag not found in DagModel
             "airflow_example_trigger_target_dag",
             "airflow_example_trigger_controller_dag",
-            # runs slow
-            "airflow_example_subdag_operator",
         ],
     ),
 ]


### PR DESCRIPTION
### Summary & Motivation

This pr switches the ephemeral airflow db to be modeled as a resource and to use temporary directory for each run. 

### How I Tested These Changes
