### PR TITLE
[DagsterKubernetesClient] get_job_status

### DIFF
--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -346,14 +346,12 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
         )
         job_name = get_job_name_from_run_id(run.run_id)
         try:
-            job = self._api_client.batch_api.read_namespaced_job(
-                namespace=job_namespace, name=job_name
-            )
+            status = self._api_client.get_job_status(namespace=job_namespace, job_name=job_name)
         except Exception:
             return CheckRunHealthResult(
                 WorkerStatus.UNKNOWN, str(serializable_error_info_from_exc_info(sys.exc_info()))
             )
-        if job.status.failed:
+        if status.failed:
             return CheckRunHealthResult(WorkerStatus.FAILED, "K8s job failed")
         return CheckRunHealthResult(WorkerStatus.RUNNING)
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -254,10 +254,11 @@ class K8sStepHandler(StepHandler):
 
         container_context = self._get_container_context(step_handler_context)
 
-        job = self._api_client.batch_api.read_namespaced_job(
-            namespace=container_context.namespace, name=job_name
+        status = self._api_client.get_job_status(
+            namespace=container_context.namespace,
+            job_name=job_name,
         )
-        if job.status.failed:
+        if status.failed:
             return CheckStepHealthResult.unhealthy(
                 reason=f"Discovered failed Kubernetes job {job_name} for step {step_key}.",
             )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -359,15 +359,16 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             run.run_id, resume_attempt_number=self._instance.count_resume_run_attempts(run.run_id)
         )
         try:
-            job = self._api_client.batch_api.read_namespaced_job(
-                namespace=container_context.namespace, name=job_name
+            status = self._api_client.get_job_status(
+                namespace=container_context.namespace,
+                job_name=job_name,
             )
         except Exception:
             return CheckRunHealthResult(
                 WorkerStatus.UNKNOWN, str(serializable_error_info_from_exc_info(sys.exc_info()))
             )
-        if job.status.failed:
+        if status.failed:
             return CheckRunHealthResult(WorkerStatus.FAILED, "K8s job failed")
-        if job.status.succeeded:
+        if status.succeeded:
             return CheckRunHealthResult(WorkerStatus.SUCCESS)
         return CheckRunHealthResult(WorkerStatus.RUNNING)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
@@ -400,8 +400,8 @@ def test_check_run_health(kubeconfig_file):
     labels = {"foo_label_key": "bar_label_value"}
 
     # Construct a K8s run launcher in a fake k8s environment.
-    mock_k8s_client_batch_api = mock.Mock(spec_set=["read_namespaced_job"])
-    mock_k8s_client_batch_api.read_namespaced_job.side_effect = [
+    mock_k8s_client_batch_api = mock.Mock(spec_set=["read_namespaced_job_status"])
+    mock_k8s_client_batch_api.read_namespaced_job_status.side_effect = [
         V1Job(status=V1JobStatus(failed=0, succeeded=0)),
         V1Job(status=V1JobStatus(failed=0, succeeded=1)),
         V1Job(status=V1JobStatus(failed=1, succeeded=0)),
@@ -448,6 +448,9 @@ def test_check_run_health(kubeconfig_file):
             k8s_run_launcher.register_instance(instance)
 
             # same order as side effects
-            assert k8s_run_launcher.check_run_worker_health(run).status == WorkerStatus.RUNNING
-            assert k8s_run_launcher.check_run_worker_health(run).status == WorkerStatus.SUCCESS
-            assert k8s_run_launcher.check_run_worker_health(run).status == WorkerStatus.FAILED
+            health = k8s_run_launcher.check_run_worker_health(run)
+            assert health.status == WorkerStatus.RUNNING, health.msg
+            health = k8s_run_launcher.check_run_worker_health(run)
+            assert health.status == WorkerStatus.SUCCESS, health.msg
+            health = k8s_run_launcher.check_run_worker_health(run)
+            assert health.status == WorkerStatus.FAILED, health.msg


### PR DESCRIPTION
add an api client around `read_namespaced_job_status` to provide retries for run monitoring checks 

### How I Tested These Changes

existing coverage