### PR TITLE
PipelineRunStatus -> DagsterRunStatus

### DIFF
--- a/examples/deploy_docker/tests/test_deploy_docker.py
+++ b/examples/deploy_docker/tests/test_deploy_docker.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 import requests
 
 from dagster import file_relative_path
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 
 IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 
@@ -188,7 +188,7 @@ def test_deploy_docker():
         run_id = run["runId"]
         assert run["status"] == "QUEUED"
 
-        _wait_for_run_status(run_id, dagit_host, PipelineRunStatus.SUCCESS)
+        _wait_for_run_status(run_id, dagit_host, DagsterRunStatus.SUCCESS)
 
         # Launch a job that uses the docker executor
 
@@ -217,7 +217,7 @@ def test_deploy_docker():
         run_id = run["runId"]
         assert run["status"] == "QUEUED"
 
-        _wait_for_run_status(run_id, dagit_host, PipelineRunStatus.SUCCESS)
+        _wait_for_run_status(run_id, dagit_host, DagsterRunStatus.SUCCESS)
 
         # Launch a hanging pipeline and terminate it
         variables = {
@@ -244,7 +244,7 @@ def test_deploy_docker():
         run = launch_res["data"]["launchPipelineExecution"]["run"]
         hanging_run_id = run["runId"]
 
-        _wait_for_run_status(hanging_run_id, dagit_host, PipelineRunStatus.STARTED)
+        _wait_for_run_status(hanging_run_id, dagit_host, DagsterRunStatus.STARTED)
 
         terminate_res = requests.post(
             "http://{dagit_host}:3000/graphql?query={query_string}&variables={variables}".format(
@@ -259,7 +259,7 @@ def test_deploy_docker():
             == "TerminateRunSuccess"
         ), str(terminate_res)
 
-        _wait_for_run_status(hanging_run_id, dagit_host, PipelineRunStatus.CANCELED)
+        _wait_for_run_status(hanging_run_id, dagit_host, DagsterRunStatus.CANCELED)
 
 
 def _wait_for_run_status(run_id, dagit_host, desired_status):

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/run_attribution_tests/test_custom_run_coordinator.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/run_attribution_tests/test_custom_run_coordinator.py
@@ -7,7 +7,7 @@ from dagster_tests.core_tests.run_coordinator_tests.test_queued_run_coordinator 
 from mock import patch
 
 from dagster._core.run_coordinator import SubmitRunContext
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from docs_snippets.guides.dagster.run_attribution.custom_run_coordinator import (
     CustomRunCoordinator,
 )
@@ -32,12 +32,12 @@ class TestCustomRunCoordinator(TestQueuedRunCoordinator):
                 instance,
                 external_pipeline,
                 run_id=run_id,
-                status=PipelineRunStatus.NOT_STARTED,
+                status=DagsterRunStatus.NOT_STARTED,
             )
             returned_run = coordinator.submit_run(SubmitRunContext(run, workspace))
 
             assert returned_run.run_id == run_id
-            assert returned_run.status == PipelineRunStatus.QUEUED
+            assert returned_run.status == DagsterRunStatus.QUEUED
             mock_warnings.warn.assert_called_once()
             assert mock_warnings.warn.call_args.args[0].startswith(
                 "Couldn't decode JWT header"
@@ -63,12 +63,12 @@ class TestCustomRunCoordinator(TestQueuedRunCoordinator):
             instance,
             external_pipeline,
             run_id=run_id,
-            status=PipelineRunStatus.NOT_STARTED,
+            status=DagsterRunStatus.NOT_STARTED,
         )
         returned_run = coordinator.submit_run(SubmitRunContext(run, workspace))
 
         assert returned_run.run_id == run_id
-        assert returned_run.status == PipelineRunStatus.QUEUED
+        assert returned_run.status == DagsterRunStatus.QUEUED
 
         fetched_run = instance.get_run_by_id(run_id)
         assert len(fetched_run.tags) == 1

--- a/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
+++ b/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
@@ -11,7 +11,7 @@ import pytest
 import requests
 from dagster_graphql import DagsterGraphQLClient
 
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._utils import (
     file_relative_path,
     library_version_from_core_version,
@@ -51,8 +51,8 @@ def assert_run_success(client, run_id):
             raise Exception("Timed out waiting for launched run to complete")
 
         status = client.get_run_status(run_id)
-        assert status and status != PipelineRunStatus.FAILURE
-        if status == PipelineRunStatus.SUCCESS:
+        assert status and status != DagsterRunStatus.FAILURE
+        if status == DagsterRunStatus.SUCCESS:
             break
 
         time.sleep(1)

--- a/integration_tests/test_suites/celery-k8s-test-suite/tests/test_integration.py
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tests/test_integration.py
@@ -18,7 +18,7 @@ from dagster_test.test_project import cleanup_memoized_results, get_test_project
 from dagster_test.test_project.test_pipelines.repo import define_memoization_pipeline
 
 from dagster import DagsterEventType
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.storage.tags import DOCKER_IMAGE_TAG
 from dagster._utils.merger import deep_merge_dicts, merge_dicts
 from dagster._utils.yaml_utils import merge_yamls
@@ -344,7 +344,7 @@ def _test_termination(dagit_url, dagster_instance, run_config):
     start_time = datetime.datetime.now()
     while datetime.datetime.now() < start_time + timeout:
         pipeline_run = dagster_instance.get_run_by_id(run_id)
-        if pipeline_run.status == PipelineRunStatus.CANCELED:
+        if pipeline_run.status == DagsterRunStatus.CANCELED:
             pipeline_run_status_canceled = True
             break
         time.sleep(5)
@@ -471,7 +471,7 @@ def test_execute_on_celery_k8s_with_hard_failure(  # pylint: disable=redefined-o
 
     while datetime.datetime.now() < start_time + timeout:
         pipeline_run = dagster_instance.get_run_by_id(run_id)
-        if pipeline_run.status == PipelineRunStatus.FAILURE:
+        if pipeline_run.status == DagsterRunStatus.FAILURE:
             pipeline_run_status_failure = True
             break
         time.sleep(5)

--- a/integration_tests/test_suites/celery-k8s-test-suite/tests/test_monitoring.py
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tests/test_monitoring.py
@@ -10,7 +10,7 @@ from dagster_k8s_test_infra.integration_utils import image_pull_policy, launch_r
 from dagster_test.test_project import get_test_project_environments_path
 from marks import mark_monitoring
 
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import poll_for_finished_run
 from dagster._utils import merge_dicts
 from dagster._utils.yaml_utils import merge_yamls
@@ -89,14 +89,14 @@ def test_run_monitoring_fails_on_interrupt(  # pylint: disable=redefined-outer-n
         start_time = time.time()
         while time.time() - start_time < 60:
             run = dagster_instance.get_run_by_id(run_id)
-            if run.status == PipelineRunStatus.STARTED:
+            if run.status == DagsterRunStatus.STARTED:
                 break
-            assert run.status == PipelineRunStatus.STARTING
+            assert run.status == DagsterRunStatus.STARTING
             time.sleep(1)
 
         assert delete_job(get_job_name_from_run_id(run_id), helm_namespace)
         poll_for_finished_run(dagster_instance, run.run_id, timeout=120)
-        assert dagster_instance.get_run_by_id(run_id).status == PipelineRunStatus.FAILURE
+        assert dagster_instance.get_run_by_id(run_id).status == DagsterRunStatus.FAILURE
     finally:
         log_run_events(dagster_instance, run_id)
 
@@ -126,13 +126,13 @@ def test_run_monitoring_startup_fail(  # pylint: disable=redefined-outer-name
         start_time = time.time()
         while time.time() - start_time < 60:
             run = dagster_instance.get_run_by_id(run_id)
-            if run.status == PipelineRunStatus.STARTED:
+            if run.status == DagsterRunStatus.STARTED:
                 break
-            assert run.status == PipelineRunStatus.STARTING
+            assert run.status == DagsterRunStatus.STARTING
             time.sleep(1)
 
         assert delete_job(get_job_name_from_run_id(run_id), helm_namespace)
         poll_for_finished_run(dagster_instance, run.run_id, timeout=120)
-        assert dagster_instance.get_run_by_id(run_id).status == PipelineRunStatus.FAILURE
+        assert dagster_instance.get_run_by_id(run_id).status == DagsterRunStatus.FAILURE
     finally:
         log_run_events(dagster_instance, run_id)

--- a/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
+++ b/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
@@ -16,7 +16,7 @@ from dagster._daemon.auto_run_reexecution.auto_run_reexecution import (
     get_reexecution_strategy,
 )
 from dagster._daemon.auto_run_reexecution.event_log_consumer import EventLogConsumerDaemon
-from dagster._legacy import PipelineRunStatus
+from dagster._legacy import DagsterRunStatus
 
 from .utils import foo, get_foo_pipeline_handle
 
@@ -41,7 +41,7 @@ def create_run(instance, **kwargs):
 def test_filter_runs_to_should_retry(instance):
     instance.wipe()
 
-    run = create_run(instance, status=PipelineRunStatus.STARTED)
+    run = create_run(instance, status=DagsterRunStatus.STARTED)
 
     assert list(filter_runs_to_should_retry([run], instance, 2)) == []
 
@@ -65,7 +65,7 @@ def test_filter_runs_to_should_retry(instance):
         len(
             list(
                 filter_runs_to_should_retry(
-                    instance.get_runs(filters=RunsFilter(statuses=[PipelineRunStatus.FAILURE])),
+                    instance.get_runs(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
                     instance,
                     2,
                 )
@@ -78,7 +78,7 @@ def test_filter_runs_to_should_retry(instance):
 def test_filter_runs_to_should_retry_tags(instance):
     instance.wipe()
 
-    run = create_run(instance, status=PipelineRunStatus.STARTED, tags={MAX_RETRIES_TAG: "0"})
+    run = create_run(instance, status=DagsterRunStatus.STARTED, tags={MAX_RETRIES_TAG: "0"})
 
     assert list(filter_runs_to_should_retry([run], instance, 2)) == []
 
@@ -88,7 +88,7 @@ def test_filter_runs_to_should_retry_tags(instance):
         len(
             list(
                 filter_runs_to_should_retry(
-                    instance.get_runs(filters=RunsFilter(statuses=[PipelineRunStatus.FAILURE])),
+                    instance.get_runs(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
                     instance,
                     2,
                 )
@@ -99,7 +99,7 @@ def test_filter_runs_to_should_retry_tags(instance):
 
     instance.wipe()
 
-    run = create_run(instance, status=PipelineRunStatus.STARTED, tags={MAX_RETRIES_TAG: "10"})
+    run = create_run(instance, status=DagsterRunStatus.STARTED, tags={MAX_RETRIES_TAG: "10"})
 
     assert list(filter_runs_to_should_retry([run], instance, 0)) == []
 
@@ -109,7 +109,7 @@ def test_filter_runs_to_should_retry_tags(instance):
         len(
             list(
                 filter_runs_to_should_retry(
-                    instance.get_runs(filters=RunsFilter(statuses=[PipelineRunStatus.FAILURE])),
+                    instance.get_runs(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
                     instance,
                     2,
                 )
@@ -121,7 +121,7 @@ def test_filter_runs_to_should_retry_tags(instance):
     instance.wipe()
 
     run = create_run(
-        instance, status=PipelineRunStatus.STARTED, tags={MAX_RETRIES_TAG: "not-an-int"}
+        instance, status=DagsterRunStatus.STARTED, tags={MAX_RETRIES_TAG: "not-an-int"}
     )
 
     assert list(filter_runs_to_should_retry([run], instance, 0)) == []
@@ -131,7 +131,7 @@ def test_filter_runs_to_should_retry_tags(instance):
     assert (
         list(
             filter_runs_to_should_retry(
-                instance.get_runs(filters=RunsFilter(statuses=[PipelineRunStatus.FAILURE])),
+                instance.get_runs(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
                 instance,
                 2,
             )
@@ -147,14 +147,14 @@ def test_consume_new_runs_for_automatic_reexecution(instance, workspace_context)
     list(
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
-            instance.get_run_records(filters=RunsFilter(statuses=[PipelineRunStatus.FAILURE])),
+            instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
         )
     )
 
     assert len(instance.run_coordinator.queue()) == 0
 
     # retries failure
-    run = create_run(instance, status=PipelineRunStatus.STARTED, tags={MAX_RETRIES_TAG: "2"})
+    run = create_run(instance, status=DagsterRunStatus.STARTED, tags={MAX_RETRIES_TAG: "2"})
     dagster_event = DagsterEvent(
         event_type_value=DagsterEventType.PIPELINE_FAILURE.value,
         pipeline_name="foo",
@@ -174,7 +174,7 @@ def test_consume_new_runs_for_automatic_reexecution(instance, workspace_context)
     list(
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
-            instance.get_run_records(filters=RunsFilter(statuses=[PipelineRunStatus.FAILURE])),
+            instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
         )
     )
     assert len(instance.run_coordinator.queue()) == 1
@@ -183,7 +183,7 @@ def test_consume_new_runs_for_automatic_reexecution(instance, workspace_context)
     list(
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
-            instance.get_run_records(filters=RunsFilter(statuses=[PipelineRunStatus.FAILURE])),
+            instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
         )
     )
     assert len(instance.run_coordinator.queue()) == 1
@@ -207,7 +207,7 @@ def test_consume_new_runs_for_automatic_reexecution(instance, workspace_context)
     list(
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
-            instance.get_run_records(filters=RunsFilter(statuses=[PipelineRunStatus.FAILURE])),
+            instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
         )
     )
     assert len(instance.run_coordinator.queue()) == 2
@@ -231,7 +231,7 @@ def test_consume_new_runs_for_automatic_reexecution(instance, workspace_context)
     list(
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
-            instance.get_run_records(filters=RunsFilter(statuses=[PipelineRunStatus.FAILURE])),
+            instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
         )
     )
     assert len(instance.run_coordinator.queue()) == 2
@@ -250,27 +250,27 @@ def test_daemon_enabled(instance):
 def test_strategy(instance: DagsterInstance):
     run = create_run(
         instance,
-        status=PipelineRunStatus.FAILURE,
+        status=DagsterRunStatus.FAILURE,
     )
     assert get_reexecution_strategy(run, instance) is None
 
     run = create_run(
         instance,
-        status=PipelineRunStatus.FAILURE,
+        status=DagsterRunStatus.FAILURE,
         tags={RETRY_STRATEGY_TAG: "FROM_FAILURE"},
     )
     assert get_reexecution_strategy(run, instance) == ReexecutionStrategy.FROM_FAILURE
 
     run = create_run(
         instance,
-        status=PipelineRunStatus.FAILURE,
+        status=DagsterRunStatus.FAILURE,
         tags={RETRY_STRATEGY_TAG: "ALL_STEPS"},
     )
     assert get_reexecution_strategy(run, instance) == ReexecutionStrategy.ALL_STEPS
 
     run = create_run(
         instance,
-        status=PipelineRunStatus.FAILURE,
+        status=DagsterRunStatus.FAILURE,
         tags={RETRY_STRATEGY_TAG: "not a strategy"},
     )
     assert get_reexecution_strategy(run, instance) is None

--- a/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/test_monitoring.py
+++ b/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/test_monitoring.py
@@ -13,7 +13,7 @@ from dagster_test.test_project import (
 )
 
 from dagster import _seven
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import instance_for_test, poll_for_finished_run
 from dagster._daemon.controller import all_daemons_healthy
 from dagster._serdes.ipc import interrupt_ipc_subprocess, open_ipc_subprocess
@@ -140,9 +140,9 @@ def test_docker_monitoring():
                     start_time = time.time()
                     while time.time() - start_time < 60:
                         run = instance.get_run_by_id(run.run_id)
-                        if run.status == PipelineRunStatus.STARTED:
+                        if run.status == DagsterRunStatus.STARTED:
                             break
-                        assert run.status == PipelineRunStatus.STARTING
+                        assert run.status == DagsterRunStatus.STARTING
                         time.sleep(1)
 
                     time.sleep(3)
@@ -153,7 +153,7 @@ def test_docker_monitoring():
 
                     # daemon resumes the run
                     poll_for_finished_run(instance, run.run_id, timeout=300)
-                    assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.SUCCESS
+                    assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.SUCCESS
 
 
 def test_docker_monitoring_run_out_of_attempts():
@@ -229,9 +229,9 @@ def test_docker_monitoring_run_out_of_attempts():
                     start_time = time.time()
                     while time.time() - start_time < 60:
                         run = instance.get_run_by_id(run.run_id)
-                        if run.status == PipelineRunStatus.STARTED:
+                        if run.status == DagsterRunStatus.STARTED:
                             break
-                        assert run.status == PipelineRunStatus.STARTING
+                        assert run.status == DagsterRunStatus.STARTING
                         time.sleep(1)
 
                     time.sleep(3)
@@ -241,4 +241,4 @@ def test_docker_monitoring_run_out_of_attempts():
                     ).stop(timeout=0)
 
                     poll_for_finished_run(instance, run.run_id, timeout=60)
-                    assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.FAILURE
+                    assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.FAILURE

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_executor.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_executor.py
@@ -31,7 +31,7 @@ from dagster_test.test_project.test_pipelines.repo import define_memoization_pip
 
 import dagster._check as check
 from dagster._core.events import DagsterEventType
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.storage.tags import DOCKER_IMAGE_TAG
 from dagster._utils import load_yaml_from_path, merge_dicts
 from dagster._utils.merger import deep_merge_dicts
@@ -334,7 +334,7 @@ def test_k8s_run_launcher_terminate(
     while True:
         assert datetime.datetime.now() < start_time + timeout, "Timed out waiting for termination"
         pipeline_run = dagster_instance_for_k8s_run_launcher.get_run_by_id(run_id)
-        if pipeline_run.status == PipelineRunStatus.CANCELED:
+        if pipeline_run.status == DagsterRunStatus.CANCELED:
             break
 
         time.sleep(5)
@@ -342,7 +342,7 @@ def test_k8s_run_launcher_terminate(
     # useful to have logs here, because the worker pods get deleted
     print(dagster_instance_for_k8s_run_launcher.all_logs(run_id))  # pylint: disable=print-call
 
-    assert pipeline_run.status == PipelineRunStatus.CANCELED
+    assert pipeline_run.status == DagsterRunStatus.CANCELED
 
     assert not can_terminate_run_over_graphql(dagit_url_for_k8s_run_launcher, run_id)
 

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_integration.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_integration.py
@@ -19,7 +19,7 @@ from dagster_test.test_project import (
 
 from dagster import DagsterEventType
 from dagster import _check as check
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.storage.tags import DOCKER_IMAGE_TAG
 from dagster._utils import load_yaml_from_path, merge_dicts
 from dagster._utils.yaml_utils import merge_yamls
@@ -119,7 +119,7 @@ def test_k8s_run_launcher_with_celery_executor_fails(
 
     assert (
         dagster_instance_for_k8s_run_launcher.get_run_by_id(run_id).status
-        == PipelineRunStatus.FAILURE
+        == DagsterRunStatus.FAILURE
     )
 
 
@@ -183,11 +183,11 @@ def test_k8s_run_launcher_terminate(
     while True:
         assert datetime.datetime.now() < start_time + timeout, "Timed out waiting for termination"
         pipeline_run = dagster_instance_for_k8s_run_launcher.get_run_by_id(run_id)
-        if pipeline_run.status == PipelineRunStatus.CANCELED:
+        if pipeline_run.status == DagsterRunStatus.CANCELED:
             break
         time.sleep(5)
 
-    assert pipeline_run.status == PipelineRunStatus.CANCELED
+    assert pipeline_run.status == DagsterRunStatus.CANCELED
 
     assert not can_terminate_run_over_graphql(dagit_url_for_k8s_run_launcher, run_id)
 

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_monitoring.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_monitoring.py
@@ -7,7 +7,7 @@ from dagster_k8s.utils import delete_job
 from dagster_k8s_test_infra.integration_utils import image_pull_policy, launch_run_over_graphql
 from dagster_test.test_project import get_test_project_environments_path
 
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import poll_for_finished_run
 from dagster._utils import load_yaml_from_path, merge_dicts
 
@@ -66,16 +66,16 @@ def _launch_run_and_wait_for_resume(
         while True:
             assert time.time() - start_time < 60, "Timed out waiting for run to start"
             run = instance.get_run_by_id(run_id)
-            if run.status == PipelineRunStatus.STARTED:
+            if run.status == DagsterRunStatus.STARTED:
                 break
-            assert run.status == PipelineRunStatus.STARTING
+            assert run.status == DagsterRunStatus.STARTING
             time.sleep(1)
 
         time.sleep(5)
         assert delete_job(get_job_name_from_run_id(run_id), namespace)
 
         poll_for_finished_run(instance, run_id, timeout=120)
-        assert instance.get_run_by_id(run_id).status == PipelineRunStatus.SUCCESS
+        assert instance.get_run_by_id(run_id).status == DagsterRunStatus.SUCCESS
     finally:
         if run_id:
             log_run_events(instance, run_id)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -15,7 +15,7 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.storage.captured_log_manager import CapturedLogManager, CapturedLogSubscription
 from dagster._core.storage.compute_log_manager import ComputeIOType, ComputeLogFileData
 from dagster._core.storage.event_log.base import EventLogCursor
-from dagster._core.storage.pipeline_run import PipelineRunStatus, RunsFilter
+from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
 from dagster._utils.error import serializable_error_info_from_exc_info
 
 from ..external import ExternalPipeline, ensure_valid_config, get_external_pipeline_or_raise
@@ -83,9 +83,7 @@ def terminate_pipeline_execution(instance: DagsterInstance, run_id, terminate_po
     run = record.pipeline_run
     graphene_run = GrapheneRun(record)
 
-    can_cancel_run = (
-        run.status == PipelineRunStatus.STARTED or run.status == PipelineRunStatus.QUEUED
-    )
+    can_cancel_run = run.status == DagsterRunStatus.STARTED or run.status == DagsterRunStatus.QUEUED
 
     valid_status = not run.is_finished and (force_mark_as_canceled or can_cancel_run)
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -9,7 +9,7 @@ from dagster._core.execution.plan.resume_retry import get_retry_steps_from_paren
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.host_representation.external import ExternalPipeline
 from dagster._core.instance import DagsterInstance
-from dagster._core.storage.pipeline_run import DagsterRun, PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.tags import RESUME_RETRY_TAG
 from dagster._core.utils import make_new_run_id
 from dagster._utils import merge_dicts
@@ -112,7 +112,7 @@ def create_valid_pipeline_run(
         tags=tags,
         root_run_id=execution_params.execution_metadata.root_run_id,
         parent_run_id=execution_params.execution_metadata.parent_run_id,
-        status=PipelineRunStatus.NOT_STARTED,
+        status=DagsterRunStatus.NOT_STARTED,
         external_pipeline_origin=external_pipeline.get_external_origin(),
         pipeline_code_origin=external_pipeline.get_python_origin(),
     )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -13,7 +13,7 @@ from dagster._core.execution.stats import RunStepKeyStatsSnapshot, StepEventStat
 from dagster._core.host_representation import PipelineSelector
 from dagster._core.storage.pipeline_run import RunRecord, RunsFilter
 from dagster._core.storage.tags import TagType, get_tag_type
-from dagster._legacy import PipelineDefinition, PipelineRunStatus
+from dagster._legacy import DagsterRunStatus, PipelineDefinition
 
 from .events import from_event_record
 from .external import ensure_valid_config, get_external_pipeline_or_raise
@@ -114,16 +114,16 @@ def get_runs(graphene_info, filters, cursor=None, limit=None):
 
 
 PENDING_STATUSES = [
-    PipelineRunStatus.STARTING,
-    PipelineRunStatus.MANAGED,
-    PipelineRunStatus.NOT_STARTED,
-    PipelineRunStatus.QUEUED,
-    PipelineRunStatus.STARTED,
-    PipelineRunStatus.CANCELING,
+    DagsterRunStatus.STARTING,
+    DagsterRunStatus.MANAGED,
+    DagsterRunStatus.NOT_STARTED,
+    DagsterRunStatus.QUEUED,
+    DagsterRunStatus.STARTED,
+    DagsterRunStatus.CANCELING,
 ]
 IN_PROGRESS_STATUSES = [
-    PipelineRunStatus.STARTED,
-    PipelineRunStatus.CANCELING,
+    DagsterRunStatus.STARTED,
+    DagsterRunStatus.CANCELING,
 ]
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -2,7 +2,7 @@ import graphene
 
 import dagster._check as check
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
-from dagster._core.storage.pipeline_run import FINISHED_STATUSES, PipelineRunStatus, RunsFilter
+from dagster._core.storage.pipeline_run import FINISHED_STATUSES, DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import BACKFILL_ID_TAG
 
 from ..implementation.fetch_partition_sets import partition_statuses_from_run_partition_data
@@ -210,7 +210,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
                     [
                         partition
                         for partition in partition_run_data
-                        if partition.status == PipelineRunStatus.SUCCESS
+                        if partition.status == DagsterRunStatus.SUCCESS
                     ]
                 )
                 if num_success == len(self._backfill_job.partition_names):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -1,7 +1,7 @@
 import graphene
 import pendulum
 
-from dagster._core.storage.pipeline_run import PipelineRunStatus, RunsFilter
+from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
 
 from .pipelines.status import GrapheneRunStatus
 from .runs import GrapheneRunConfigData
@@ -46,7 +46,7 @@ class GrapheneRunsFilter(graphene.InputObjectType):
 
         if self.statuses:
             statuses = [
-                PipelineRunStatus[status.value]  # type: ignore
+                DagsterRunStatus[status.value]  # type: ignore
                 for status in self.statuses  # pylint: disable=not-an-iterable
             ]
         else:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -8,7 +8,7 @@ import dagster._check as check
 from dagster._core.events import DagsterEventType
 from dagster._core.host_representation.external import ExternalExecutionPlan, ExternalPipeline
 from dagster._core.host_representation.external_data import ExternalPresetData
-from dagster._core.storage.pipeline_run import PipelineRunStatus, RunRecord, RunsFilter
+from dagster._core.storage.pipeline_run import DagsterRunStatus, RunRecord, RunsFilter
 from dagster._core.storage.tags import REPOSITORY_LABEL_TAG, TagType, get_tag_type
 from dagster._utils import datetime_as_float
 from dagster._utils.yaml_utils import dump_run_config_yaml
@@ -52,16 +52,16 @@ from .pipeline_run_stats import GrapheneRunStatsSnapshotOrError
 from .status import GrapheneRunStatus
 
 STARTED_STATUSES = {
-    PipelineRunStatus.STARTED,
-    PipelineRunStatus.SUCCESS,
-    PipelineRunStatus.FAILURE,
-    PipelineRunStatus.CANCELED,
+    DagsterRunStatus.STARTED,
+    DagsterRunStatus.SUCCESS,
+    DagsterRunStatus.FAILURE,
+    DagsterRunStatus.CANCELED,
 }
 
 COMPLETED_STATUSES = {
-    PipelineRunStatus.FAILURE,
-    PipelineRunStatus.SUCCESS,
-    PipelineRunStatus.CANCELED,
+    DagsterRunStatus.FAILURE,
+    DagsterRunStatus.SUCCESS,
+    DagsterRunStatus.CANCELED,
 }
 
 
@@ -415,8 +415,8 @@ class GrapheneRun(graphene.ObjectType):
         if self._pipeline_run.is_finished:
             return False
         return (
-            self._pipeline_run.status == PipelineRunStatus.QUEUED
-            or self._pipeline_run.status == PipelineRunStatus.STARTED
+            self._pipeline_run.status == DagsterRunStatus.QUEUED
+            or self._pipeline_run.status == DagsterRunStatus.STARTED
         )
 
     def resolve_assets(self, graphene_info):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_get_run_status.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_get_run_status.py
@@ -5,7 +5,7 @@ from dagster_graphql import DagsterGraphQLClientError
 from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
 from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_selector
 
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 
 from ..graphql.graphql_context_test_suite import ExecutingGraphQLContextTestMatrix
 from ..graphql.repo import csv_hello_world_solids_config
@@ -14,7 +14,7 @@ from .conftest import MockClient, python_client_test_suite
 
 @python_client_test_suite
 def test_get_run_status_success(mock_client: MockClient):
-    expected_result = PipelineRunStatus.SUCCESS
+    expected_result = DagsterRunStatus.SUCCESS
     response = {"pipelineRunOrError": {"__typename": "PipelineRun", "status": expected_result}}
     mock_client.mock_gql_client.execute.return_value = response
 
@@ -82,7 +82,7 @@ class TestGetRunStatusWithClient(ExecutingGraphQLContextTestMatrix):
 
             status = graphql_client.get_run_status(run_id)
 
-            if status == PipelineRunStatus.SUCCESS:
+            if status == DagsterRunStatus.SUCCESS:
                 break
 
             time.sleep(3)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -84,7 +84,7 @@ from dagster._core.definitions.reconstruct import ReconstructableRepository
 from dagster._core.definitions.sensor_definition import RunRequest, SkipReason
 from dagster._core.log_manager import coerce_valid_log_level
 from dagster._core.storage.fs_io_manager import fs_io_manager
-from dagster._core.storage.pipeline_run import PipelineRunStatus, RunsFilter
+from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import RESUME_RETRY_TAG
 from dagster._core.test_utils import default_mode_def_for_test, today_at_midnight
 from dagster._core.workspace.context import WorkspaceProcessContext
@@ -1067,7 +1067,7 @@ def last_empty_partition(context, partition_set_def):
     for partition in reversed(partitions):
         filters = RunsFilter.for_partition(partition_set_def, partition)
         matching = context.instance.get_runs(filters)
-        if not any(run.status == PipelineRunStatus.SUCCESS for run in matching):
+        if not any(run.status == DagsterRunStatus.SUCCESS for run in matching):
             selected = partition
             break
     return selected

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_api_backcompat.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_api_backcompat.py
@@ -3,7 +3,7 @@ import time
 from dagster_graphql.test.utils import define_out_of_process_context, execute_dagster_graphql
 
 from dagster import repository
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import instance_for_test
 from dagster._legacy import PresetDefinition, pipeline, solid
 
@@ -209,10 +209,10 @@ def test_runs_query():
     with instance_for_test() as instance:
         repo = get_repo()
         run_id_1 = instance.create_run_for_pipeline(
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.STARTED
+            repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.STARTED
         ).run_id
         run_id_2 = instance.create_run_for_pipeline(
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.FAILURE
+            repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.FAILURE
         ).run_id
         with define_out_of_process_context(__file__, "get_repo", instance) as context:
             result = execute_dagster_graphql(context, RUNS_QUERY)
@@ -227,13 +227,13 @@ def test_paginated_runs_query():
     with instance_for_test() as instance:
         repo = get_repo()
         _ = instance.create_run_for_pipeline(
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.STARTED
+            repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.STARTED
         ).run_id
         run_id_2 = instance.create_run_for_pipeline(
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.FAILURE
+            repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.FAILURE
         ).run_id
         run_id_3 = instance.create_run_for_pipeline(
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.SUCCESS
+            repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.SUCCESS
         ).run_id
         with define_out_of_process_context(__file__, "get_repo", instance) as context:
             result = execute_dagster_graphql(
@@ -251,13 +251,13 @@ def test_filtered_runs_query():
     with instance_for_test() as instance:
         repo = get_repo()
         _ = instance.create_run_for_pipeline(
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.STARTED
+            repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.STARTED
         ).run_id
         run_id_2 = instance.create_run_for_pipeline(
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.FAILURE
+            repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.FAILURE
         ).run_id
         _ = instance.create_run_for_pipeline(
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.SUCCESS
+            repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.SUCCESS
         ).run_id
         with define_out_of_process_context(__file__, "get_repo", instance) as context:
             result = execute_dagster_graphql(context, FILTERED_RUNS_QUERY)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -16,7 +16,7 @@ from dagster_graphql.test.utils import (
 from dagster import AssetKey, DagsterEventType
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionKey
 from dagster._core.test_utils import poll_for_finished_run
-from dagster._legacy import PipelineRunStatus
+from dagster._legacy import DagsterRunStatus
 from dagster._utils import Counter, safe_tempfile_path, traced_counter
 
 # from .graphql_context_test_suite import GraphQLContextVariant, make_graphql_context_test_suite
@@ -980,7 +980,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         run_id = _create_run(graphql_context, "foo_job", asset_selection=[{"path": ["bar"]}])
         run = graphql_context.instance.get_run_by_id(run_id)
         assert run.is_finished
-        assert run.status == PipelineRunStatus.SUCCESS
+        assert run.status == DagsterRunStatus.SUCCESS
         assert run.asset_selection == {AssetKey("bar")}
 
     def test_execute_pipeline_subset(self, graphql_context):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_execute_pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_execute_pipeline.py
@@ -15,7 +15,7 @@ from dagster_graphql.test.utils import (
 
 from dagster._core.storage.pipeline_run import RunsFilter
 from dagster._core.test_utils import wait_for_runs_to_finish
-from dagster._legacy import PipelineRunStatus
+from dagster._legacy import DagsterRunStatus
 from dagster._utils import file_relative_path
 from dagster._utils.test import get_temp_file_name
 
@@ -831,7 +831,7 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
 
         wait_for_runs_to_finish(graphql_context.instance)
 
-        assert graphql_context.instance.get_run_by_id(run_id).status == PipelineRunStatus.SUCCESS
+        assert graphql_context.instance.get_run_by_id(run_id).status == DagsterRunStatus.SUCCESS
 
         logs = get_all_logs_for_finished_run_via_subscription(graphql_context, run_id)[
             "pipelineRunLogs"
@@ -856,7 +856,7 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
 
         wait_for_runs_to_finish(graphql_context.instance)
 
-        assert graphql_context.instance.get_run_by_id(run_id).status == PipelineRunStatus.SUCCESS
+        assert graphql_context.instance.get_run_by_id(run_id).status == DagsterRunStatus.SUCCESS
 
         logs = get_all_logs_for_finished_run_via_subscription(graphql_context, run_id)[
             "pipelineRunLogs"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -11,7 +11,7 @@ from dagster_graphql.test.utils import (
 from dagster._core.execution.backfill import BulkActionStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._core.test_utils import create_run_for_test
-from dagster._legacy import PipelineRun, PipelineRunStatus
+from dagster._legacy import DagsterRunStatus, PipelineRun
 from dagster._seven import get_system_temp_directory
 
 from .graphql_context_test_suite import ExecutingGraphQLContextTestMatrix
@@ -91,7 +91,7 @@ GET_PARTITION_BACKFILLS_QUERY = """
 """
 
 
-def _seed_runs(graphql_context, partition_runs: List[Tuple[str, PipelineRunStatus]], backfill_id):
+def _seed_runs(graphql_context, partition_runs: List[Tuple[str, DagsterRunStatus]], backfill_id):
     for status, partition in partition_runs:
         create_run_for_test(
             instance=graphql_context.instance,
@@ -362,14 +362,14 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         _seed_runs(
             graphql_context,
             [
-                (PipelineRunStatus.SUCCESS, "5"),
-                (PipelineRunStatus.STARTED, "2"),
-                (PipelineRunStatus.STARTED, "3"),
-                (PipelineRunStatus.STARTED, "4"),
-                (PipelineRunStatus.STARTED, "5"),
-                (PipelineRunStatus.CANCELED, "2"),
-                (PipelineRunStatus.FAILURE, "3"),
-                (PipelineRunStatus.SUCCESS, "4"),
+                (DagsterRunStatus.SUCCESS, "5"),
+                (DagsterRunStatus.STARTED, "2"),
+                (DagsterRunStatus.STARTED, "3"),
+                (DagsterRunStatus.STARTED, "4"),
+                (DagsterRunStatus.STARTED, "5"),
+                (DagsterRunStatus.CANCELED, "2"),
+                (DagsterRunStatus.FAILURE, "3"),
+                (DagsterRunStatus.SUCCESS, "4"),
             ],
             backfill_id,
         )
@@ -436,10 +436,10 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         _seed_runs(
             graphql_context,
             [
-                (PipelineRunStatus.SUCCESS, "2"),
-                (PipelineRunStatus.SUCCESS, "3"),
-                (PipelineRunStatus.SUCCESS, "4"),
-                (PipelineRunStatus.SUCCESS, "5"),
+                (DagsterRunStatus.SUCCESS, "2"),
+                (DagsterRunStatus.SUCCESS, "3"),
+                (DagsterRunStatus.SUCCESS, "4"),
+                (DagsterRunStatus.SUCCESS, "5"),
             ],
             backfill_id,
         )
@@ -494,10 +494,10 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         _seed_runs(
             graphql_context,
             [
-                (PipelineRunStatus.SUCCESS, "2"),
-                (PipelineRunStatus.SUCCESS, "3"),
-                (PipelineRunStatus.SUCCESS, "4"),
-                (PipelineRunStatus.CANCELED, "5"),
+                (DagsterRunStatus.SUCCESS, "2"),
+                (DagsterRunStatus.SUCCESS, "3"),
+                (DagsterRunStatus.SUCCESS, "4"),
+                (DagsterRunStatus.CANCELED, "5"),
             ],
             backfill_id,
         )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
@@ -14,7 +14,7 @@ from dagster_graphql.test.utils import (
 )
 
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.storage.tags import RESUME_RETRY_TAG
 from dagster._core.test_utils import poll_for_finished_run
 from dagster._core.utils import make_new_run_id
@@ -511,7 +511,7 @@ class TestHardFailures(ExecutingGraphQLContextTestMatrix):
             os.remove(output_file)
 
         run_id = result.data["launchPipelineExecution"]["run"]["runId"]
-        assert graphql_context.instance.get_run_by_id(run_id).status == PipelineRunStatus.FAILURE
+        assert graphql_context.instance.get_run_by_id(run_id).status == DagsterRunStatus.FAILURE
 
         retry = execute_dagster_graphql_and_finish_runs(
             graphql_context,
@@ -523,7 +523,7 @@ class TestHardFailures(ExecutingGraphQLContextTestMatrix):
             "launchPipelineReexecution"
         ]
         run_id = retry.data["launchPipelineReexecution"]["run"]["runId"]
-        assert graphql_context.instance.get_run_by_id(run_id).status == PipelineRunStatus.SUCCESS
+        assert graphql_context.instance.get_run_by_id(run_id).status == DagsterRunStatus.SUCCESS
         logs = get_all_logs_for_finished_run_via_subscription(graphql_context, run_id)[
             "pipelineRunLogs"
         ]["messages"]
@@ -558,7 +558,7 @@ class TestHardFailures(ExecutingGraphQLContextTestMatrix):
 
         parent_run_id = result.data["launchPipelineExecution"]["run"]["runId"]
         parent_run = graphql_context.instance.get_run_by_id(parent_run_id)
-        assert parent_run.status == PipelineRunStatus.FAILURE
+        assert parent_run.status == DagsterRunStatus.FAILURE
 
         # override run config to make it fail
         graphql_context.instance.delete_run(parent_run_id)
@@ -601,7 +601,7 @@ class TestHardFailures(ExecutingGraphQLContextTestMatrix):
             os.remove(output_file)
 
         run_id = result.data["launchPipelineExecution"]["run"]["runId"]
-        assert graphql_context.instance.get_run_by_id(run_id).status == PipelineRunStatus.FAILURE
+        assert graphql_context.instance.get_run_by_id(run_id).status == DagsterRunStatus.FAILURE
 
         retry = execute_dagster_graphql_and_finish_runs(
             graphql_context,
@@ -610,7 +610,7 @@ class TestHardFailures(ExecutingGraphQLContextTestMatrix):
         )
 
         run_id = retry.data["launchPipelineReexecution"]["run"]["runId"]
-        assert graphql_context.instance.get_run_by_id(run_id).status == PipelineRunStatus.SUCCESS
+        assert graphql_context.instance.get_run_by_id(run_id).status == DagsterRunStatus.SUCCESS
         logs = get_all_logs_for_finished_run_via_subscription(graphql_context, run_id)[
             "pipelineRunLogs"
         ]["messages"]
@@ -720,7 +720,7 @@ class TestRetryExecutionAsyncOnlyBehavior(ExecutingGraphQLContextTestMatrix):
 
         # Wait for the original run to finish
         poll_for_finished_run(instance, run_id, timeout=30)
-        assert instance.get_run_by_id(run_id).status == PipelineRunStatus.CANCELED
+        assert instance.get_run_by_id(run_id).status == DagsterRunStatus.CANCELED
 
         # Start retry
         new_run_id = make_new_run_id()

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_cancellation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_cancellation.py
@@ -7,7 +7,7 @@ from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
 from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_selector
 
 from dagster._core.definitions.reconstruct import ReconstructableRepository
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._grpc.types import CancelExecutionRequest
 from dagster._legacy import execute_pipeline
 from dagster._utils import file_relative_path, safe_tempfile_path
@@ -93,7 +93,7 @@ class TestQueuedRunTermination(QueuedRunCoordinatorTestSuite):
             assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
             run_id = result.data["launchPipelineExecution"]["run"]["runId"]
 
-            assert graphql_context.instance.get_run_by_id(run_id).status == PipelineRunStatus.QUEUED
+            assert graphql_context.instance.get_run_by_id(run_id).status == DagsterRunStatus.QUEUED
 
             result = execute_dagster_graphql(
                 graphql_context, RUN_CANCELLATION_QUERY, variables={"runId": run_id}
@@ -124,7 +124,7 @@ class TestQueuedRunTermination(QueuedRunCoordinatorTestSuite):
             assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
             run_id = result.data["launchPipelineExecution"]["run"]["runId"]
 
-            assert graphql_context.instance.get_run_by_id(run_id).status == PipelineRunStatus.QUEUED
+            assert graphql_context.instance.get_run_by_id(run_id).status == DagsterRunStatus.QUEUED
 
             result = execute_dagster_graphql(
                 graphql_context,
@@ -224,7 +224,7 @@ class TestRunVariantTermination(RunTerminationTestSuite):
 
             instance = graphql_context.instance
             run = instance.get_run_by_id(run_id)
-            assert run.status == PipelineRunStatus.CANCELED
+            assert run.status == DagsterRunStatus.CANCELED
 
     def test_run_not_found(self, graphql_context):
         result = execute_dagster_graphql(
@@ -296,7 +296,7 @@ class TestRunVariantTermination(RunTerminationTestSuite):
             repository_location.client.cancel_execution(CancelExecutionRequest(run_id=run_id))
 
             assert (
-                graphql_context.instance.get_run_by_id(run_id).status == PipelineRunStatus.CANCELED
+                graphql_context.instance.get_run_by_id(run_id).status == DagsterRunStatus.CANCELED
             )
 
     def test_run_finished(self, graphql_context):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -14,7 +14,7 @@ from dagster_graphql_tests.graphql.graphql_context_test_suite import (
 from dagster import AssetMaterialization, Output, job, op, repository
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
 from dagster._core.execution.api import execute_run
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.storage.tags import PARENT_RUN_ID_TAG, ROOT_RUN_ID_TAG
 from dagster._core.test_utils import instance_for_test
 from dagster._legacy import execute_pipeline, lambda_solid, pipeline
@@ -661,10 +661,10 @@ def test_filtered_runs_status():
     with instance_for_test() as instance:
         repo = get_repo_at_time_1()
         _ = instance.create_run_for_pipeline(
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.STARTED
+            repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.STARTED
         ).run_id
         run_id_2 = instance.create_run_for_pipeline(
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.FAILURE
+            repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.FAILURE
         ).run_id
         with define_out_of_process_context(__file__, "get_repo_at_time_1", instance) as context:
             result = execute_dagster_graphql(
@@ -682,13 +682,13 @@ def test_filtered_runs_multiple_statuses():
     with instance_for_test() as instance:
         repo = get_repo_at_time_1()
         _ = instance.create_run_for_pipeline(
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.STARTED
+            repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.STARTED
         ).run_id
         run_id_2 = instance.create_run_for_pipeline(
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.FAILURE
+            repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.FAILURE
         ).run_id
         run_id_3 = instance.create_run_for_pipeline(
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.SUCCESS
+            repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.SUCCESS
         ).run_id
         with define_out_of_process_context(__file__, "get_repo_at_time_1", instance) as context:
             result = execute_dagster_graphql(
@@ -709,17 +709,17 @@ def test_filtered_runs_multiple_filters():
 
         started_run_with_tags = instance.create_run_for_pipeline(
             repo.get_pipeline("foo_pipeline"),
-            status=PipelineRunStatus.STARTED,
+            status=DagsterRunStatus.STARTED,
             tags={"foo": "bar"},
         )
         failed_run_with_tags = instance.create_run_for_pipeline(
             repo.get_pipeline("foo_pipeline"),
-            status=PipelineRunStatus.FAILURE,
+            status=DagsterRunStatus.FAILURE,
             tags={"foo": "bar"},
         )
         started_run_without_tags = instance.create_run_for_pipeline(
             repo.get_pipeline("foo_pipeline"),
-            status=PipelineRunStatus.STARTED,
+            status=DagsterRunStatus.STARTED,
             tags={"baz": "boom"},
         )
 
@@ -746,10 +746,10 @@ def test_filtered_runs_count():
     with instance_for_test() as instance:
         repo = get_repo_at_time_1()
         instance.create_run_for_pipeline(  # pylint: disable=expression-not-assigned
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.STARTED
+            repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.STARTED
         ).run_id
         instance.create_run_for_pipeline(  # pylint: disable=expression-not-assigned
-            repo.get_pipeline("foo_pipeline"), status=PipelineRunStatus.FAILURE
+            repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.FAILURE
         ).run_id
         with define_out_of_process_context(__file__, "get_repo_at_time_1", instance) as context:
             result = execute_dagster_graphql(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/test_cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/test_cli.py
@@ -8,7 +8,7 @@ from click.testing import CliRunner
 from dagster_graphql.cli import ui
 
 from dagster import _seven
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import instance_for_test
 from dagster._utils import file_relative_path
 
@@ -315,7 +315,7 @@ def test_logs_in_start_execution_predefined():
             # assert that the watching run storage captured the run correctly from the other process
             run = instance.get_run_by_id(run_id)
 
-            assert run.status == PipelineRunStatus.SUCCESS
+            assert run.status == DagsterRunStatus.SUCCESS
 
 
 def _is_done(instance, run_id):

--- a/python_modules/dagster/dagster/_cli/debug.py
+++ b/python_modules/dagster/dagster/_cli/debug.py
@@ -6,7 +6,7 @@ from tqdm import tqdm
 
 from dagster import DagsterInstance
 from dagster._core.debug import DebugRunPayload
-from dagster._core.storage.pipeline_run import PipelineRunStatus, RunsFilter
+from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
 from dagster._serdes import deserialize_as
 
 
@@ -14,7 +14,7 @@ def _recent_failed_runs_text(instance):
     lines = []
     runs = instance.get_runs(
         limit=5,
-        filters=RunsFilter(statuses=[PipelineRunStatus.FAILURE, PipelineRunStatus.CANCELED]),
+        filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE, DagsterRunStatus.CANCELED]),
     )
     if len(runs) <= 0:
         return ""

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -4,7 +4,7 @@ from typing import Any, Mapping, NamedTuple, Optional, Sequence
 import dagster._check as check
 from dagster._annotations import PublicAttr
 from dagster._core.definitions.events import AssetKey
-from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus, PipelineRun
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._serdes.serdes import register_serdes_enum_fallbacks, whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo
@@ -116,7 +116,7 @@ class PipelineRunReaction(
         [
             ("pipeline_run", Optional[PipelineRun]),
             ("error", Optional[SerializableErrorInfo]),
-            ("run_status", Optional[PipelineRunStatus]),
+            ("run_status", Optional[DagsterRunStatus]),
         ],
     )
 ):
@@ -134,11 +134,11 @@ class PipelineRunReaction(
         cls,
         pipeline_run: Optional[PipelineRun],
         error: Optional[SerializableErrorInfo] = None,
-        run_status: Optional[PipelineRunStatus] = None,
+        run_status: Optional[DagsterRunStatus] = None,
     ):
         return super(PipelineRunReaction, cls).__new__(
             cls,
             pipeline_run=check.opt_inst_param(pipeline_run, "pipeline_run", PipelineRun),
             error=check.opt_inst_param(error, "error", SerializableErrorInfo),
-            run_status=check.opt_inst_param(run_status, "run_status", PipelineRunStatus),
+            run_status=check.opt_inst_param(run_status, "run_status", DagsterRunStatus),
         )

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -47,7 +47,7 @@ from dagster._core.execution.plan.objects import StepFailureData, StepRetryData,
 from dagster._core.execution.plan.outputs import StepOutputData
 from dagster._core.log_manager import DagsterLogManager
 from dagster._core.storage.captured_log_manager import CapturedLogContext
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._serdes import (
     DefaultNamedTupleSerializer,
     WhitelistMap,
@@ -223,13 +223,13 @@ MARKER_EVENTS = {
 
 
 EVENT_TYPE_TO_PIPELINE_RUN_STATUS = {
-    DagsterEventType.RUN_START: PipelineRunStatus.STARTED,
-    DagsterEventType.RUN_SUCCESS: PipelineRunStatus.SUCCESS,
-    DagsterEventType.RUN_FAILURE: PipelineRunStatus.FAILURE,
-    DagsterEventType.RUN_ENQUEUED: PipelineRunStatus.QUEUED,
-    DagsterEventType.RUN_STARTING: PipelineRunStatus.STARTING,
-    DagsterEventType.RUN_CANCELING: PipelineRunStatus.CANCELING,
-    DagsterEventType.RUN_CANCELED: PipelineRunStatus.CANCELED,
+    DagsterEventType.RUN_START: DagsterRunStatus.STARTED,
+    DagsterEventType.RUN_SUCCESS: DagsterRunStatus.SUCCESS,
+    DagsterEventType.RUN_FAILURE: DagsterRunStatus.FAILURE,
+    DagsterEventType.RUN_ENQUEUED: DagsterRunStatus.QUEUED,
+    DagsterEventType.RUN_STARTING: DagsterRunStatus.STARTING,
+    DagsterEventType.RUN_CANCELING: DagsterRunStatus.CANCELING,
+    DagsterEventType.RUN_CANCELED: DagsterRunStatus.CANCELED,
 }
 
 PIPELINE_RUN_STATUS_TO_EVENT_TYPE = {v: k for k, v in EVENT_TYPE_TO_PIPELINE_RUN_STATUS.items()}

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -17,7 +17,7 @@ from dagster._core.host_representation.external_data import (
 )
 from dagster._core.host_representation.origin import ExternalPartitionSetOrigin
 from dagster._core.instance import DagsterInstance
-from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus, RunsFilter
+from dagster._core.storage.pipeline_run import DagsterRunStatus, PipelineRun, RunsFilter
 from dagster._core.storage.tags import (
     PARENT_RUN_ID_TAG,
     PARTITION_NAME_TAG,
@@ -253,7 +253,7 @@ def create_backfill_run(
 
     elif backfill_job.from_failure:
         last_run = _fetch_last_run(instance, external_partition_set, partition_data.name)
-        if not last_run or last_run.status != PipelineRunStatus.FAILURE:
+        if not last_run or last_run.status != DagsterRunStatus.FAILURE:
             return None
         return instance.create_reexecuted_run(
             last_run,
@@ -275,7 +275,7 @@ def create_backfill_run(
                 tags, {PARENT_RUN_ID_TAG: parent_run_id, ROOT_RUN_ID_TAG: root_run_id}
             )
         step_keys_to_execute = backfill_job.reexecution_steps
-        if last_run and last_run.status == PipelineRunStatus.SUCCESS:
+        if last_run and last_run.status == DagsterRunStatus.SUCCESS:
             known_state = KnownExecutionState.build_for_reexecution(
                 instance,
                 last_run,
@@ -309,7 +309,7 @@ def create_backfill_run(
         tags=tags,
         root_run_id=root_run_id,
         parent_run_id=parent_run_id,
-        status=PipelineRunStatus.NOT_STARTED,
+        status=DagsterRunStatus.NOT_STARTED,
         external_pipeline_origin=external_pipeline.get_external_origin(),
         pipeline_code_origin=external_pipeline.get_python_origin(),
         solid_selection=solid_selection,

--- a/python_modules/dagster/dagster/_core/execution/host_mode.py
+++ b/python_modules/dagster/dagster/_core/execution/host_mode.py
@@ -21,7 +21,7 @@ from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.executor.init import InitExecutorContext
 from dagster._core.instance import DagsterInstance
 from dagster._core.log_manager import DagsterLogManager
-from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus, PipelineRun
 from dagster._loggers import default_system_loggers
 from dagster._utils import ensure_single_item
 from dagster._utils.error import serializable_error_info_from_exc_info
@@ -167,7 +167,7 @@ def execute_run_host_mode(
     check.opt_sequence_param(executor_defs, "executor_defs", of_type=ExecutorDefinition)
     executor_defs = executor_defs if executor_defs != None else default_executors
 
-    if pipeline_run.status == PipelineRunStatus.CANCELED:
+    if pipeline_run.status == DagsterRunStatus.CANCELED:
         message = "Not starting execution since the run was canceled before execution could start"
         instance.report_engine_event(
             message,
@@ -176,8 +176,8 @@ def execute_run_host_mode(
         raise DagsterInvariantViolationError(message)
 
     check.invariant(
-        pipeline_run.status == PipelineRunStatus.NOT_STARTED
-        or pipeline_run.status == PipelineRunStatus.STARTING,
+        pipeline_run.status == DagsterRunStatus.NOT_STARTED
+        or pipeline_run.status == DagsterRunStatus.STARTING,
         desc="Pipeline run {} ({}) in state {}, expected NOT_STARTED or STARTING".format(
             pipeline_run.pipeline_name, pipeline_run.run_id, pipeline_run.status
         ),

--- a/python_modules/dagster/dagster/_core/execution/run_cancellation_thread.py
+++ b/python_modules/dagster/dagster/_core/execution/run_cancellation_thread.py
@@ -3,7 +3,7 @@ from typing import Tuple, cast
 
 import dagster._check as check
 from dagster._core.instance import DagsterInstance, InstanceRef
-from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus, PipelineRun
 from dagster._utils import send_interrupt
 
 
@@ -23,8 +23,8 @@ def _kill_on_cancel(instance_ref: InstanceRef, run_id, shutdown_event):
                 ),
             )
             if run.status in [
-                PipelineRunStatus.CANCELING,
-                PipelineRunStatus.CANCELED,
+                DagsterRunStatus.CANCELING,
+                DagsterRunStatus.CANCELED,
             ]:
                 print(  # pylint: disable=print-call
                     f"Detected run status {run.status}, sending interrupt to main thread"

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -52,10 +52,10 @@ from dagster._core.errors import (
 from dagster._core.storage.pipeline_run import (
     IN_PROGRESS_RUN_STATUSES,
     DagsterRun,
+    DagsterRunStatus,
     JobBucket,
     PipelineRun,
     PipelineRunStatsSnapshot,
-    PipelineRunStatus,
     RunPartitionData,
     RunRecord,
     RunsFilter,
@@ -1204,7 +1204,7 @@ class DagsterInstance:
 
         if strategy == ReexecutionStrategy.FROM_FAILURE:
             check.invariant(
-                parent_run.status == PipelineRunStatus.FAILURE,
+                parent_run.status == DagsterRunStatus.FAILURE,
                 "Cannot reexecute from failure a run that is not failed",
             )
 
@@ -1235,7 +1235,7 @@ class DagsterInstance:
             mode=mode,
             solids_to_execute=parent_run.solids_to_execute,
             step_keys_to_execute=step_keys_to_execute,
-            status=PipelineRunStatus.NOT_STARTED,
+            status=DagsterRunStatus.NOT_STARTED,
             tags=tags,
             root_run_id=root_run_id,
             parent_run_id=parent_run_id,
@@ -1284,7 +1284,7 @@ class DagsterInstance:
             solid_selection=solid_selection,
             solids_to_execute=solids_to_execute,
             step_keys_to_execute=step_keys_to_execute,
-            status=PipelineRunStatus.MANAGED,
+            status=DagsterRunStatus.MANAGED,
             tags=tags,
             root_run_id=root_run_id,
             parent_run_id=parent_run_id,

--- a/python_modules/dagster/dagster/_core/run_coordinator/default_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/default_run_coordinator.py
@@ -1,7 +1,7 @@
 import logging
 
 import dagster._check as check
-from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus, PipelineRun
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 
 from .base import RunCoordinator, SubmitRunContext
@@ -30,7 +30,7 @@ class DefaultRunCoordinator(RunCoordinator, ConfigurableClass):
     def submit_run(self, context: SubmitRunContext) -> PipelineRun:
         pipeline_run = context.pipeline_run
 
-        if pipeline_run.status == PipelineRunStatus.NOT_STARTED:
+        if pipeline_run.status == DagsterRunStatus.NOT_STARTED:
             self._instance.launch_run(pipeline_run.run_id, context.workspace)
         else:
             self._logger.warning(

--- a/python_modules/dagster/dagster/_core/run_coordinator/queued_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/queued_run_coordinator.py
@@ -5,7 +5,7 @@ from dagster import DagsterEvent, DagsterEventType, IntSource, String
 from dagster import _check as check
 from dagster._builtins import Bool
 from dagster._config import Array, Field, Noneable, ScalarUnion, Shape
-from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus, PipelineRun
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 
 from .base import RunCoordinator, SubmitRunContext
@@ -123,7 +123,7 @@ class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
     def submit_run(self, context: SubmitRunContext) -> PipelineRun:
         pipeline_run = context.pipeline_run
 
-        if pipeline_run.status == PipelineRunStatus.NOT_STARTED:
+        if pipeline_run.status == DagsterRunStatus.NOT_STARTED:
             enqueued_event = DagsterEvent(
                 event_type_value=DagsterEventType.PIPELINE_ENQUEUED.value,
                 pipeline_name=pipeline_run.pipeline_name,
@@ -147,7 +147,7 @@ class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
             return False
         # NOTE: possible race condition if the dequeuer acts on this run at the same time
         # https://github.com/dagster-io/dagster/issues/3323
-        if run.status == PipelineRunStatus.QUEUED:
+        if run.status == DagsterRunStatus.QUEUED:
             self._instance.report_run_canceling(
                 run,
                 message="Canceling run from the queue.",

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
@@ -10,7 +10,7 @@ from watchdog.observers import Observer
 import dagster._check as check
 from dagster._config import StringSource
 from dagster._core.storage.event_log.base import EventLogCursor
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.storage.sql import (
     check_alembic_revision,
     create_engine,
@@ -169,9 +169,9 @@ class ConsolidatedSqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                     logging.exception("Exception in callback for event watch on run %s.", run_id)
 
                 if (
-                    status == PipelineRunStatus.SUCCESS
-                    or status == PipelineRunStatus.FAILURE
-                    or status == PipelineRunStatus.CANCELED
+                    status == DagsterRunStatus.SUCCESS
+                    or status == DagsterRunStatus.FAILURE
+                    or status == DagsterRunStatus.CANCELED
                 ):
                     self.end_watch(run_id, callback)
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -21,7 +21,7 @@ from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.events import ASSET_EVENTS
 from dagster._core.events.log import EventLogEntry
 from dagster._core.storage.event_log.base import EventLogCursor, EventLogRecord, EventRecordsFilter
-from dagster._core.storage.pipeline_run import PipelineRunStatus, RunsFilter
+from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
 from dagster._core.storage.sql import (
     check_alembic_revision,
     create_engine,
@@ -446,9 +446,9 @@ class SqliteEventLogStorageWatchdog(PatternMatchingEventHandler):
                 logging.exception("Exception in callback for event watch on run %s.", self._run_id)
 
             if (
-                status == PipelineRunStatus.SUCCESS
-                or status == PipelineRunStatus.FAILURE
-                or status == PipelineRunStatus.CANCELED
+                status == DagsterRunStatus.SUCCESS
+                or status == DagsterRunStatus.FAILURE
+                or status == DagsterRunStatus.CANCELED
             ):
                 self._event_log_storage.end_watch(self._run_id, self._cb)
 

--- a/python_modules/dagster/dagster/_core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/_core/storage/pipeline_run.py
@@ -95,31 +95,30 @@ class DagsterRunStatus(Enum):
     CANCELED = "CANCELED"
 
 
-PipelineRunStatus = DagsterRunStatus
 register_serdes_enum_fallbacks({"PipelineRunStatus": DagsterRunStatus})
 
 # These statuses that indicate a run may be using compute resources
 IN_PROGRESS_RUN_STATUSES = [
-    PipelineRunStatus.STARTING,
-    PipelineRunStatus.STARTED,
-    PipelineRunStatus.CANCELING,
+    DagsterRunStatus.STARTING,
+    DagsterRunStatus.STARTED,
+    DagsterRunStatus.CANCELING,
 ]
 
 # This serves as an explicit list of run statuses that indicate that the run is not using compute
 # resources. This and the enum above should cover all run statuses.
 NON_IN_PROGRESS_RUN_STATUSES = [
-    PipelineRunStatus.QUEUED,
-    PipelineRunStatus.NOT_STARTED,
-    PipelineRunStatus.SUCCESS,
-    PipelineRunStatus.FAILURE,
-    PipelineRunStatus.MANAGED,
-    PipelineRunStatus.CANCELED,
+    DagsterRunStatus.QUEUED,
+    DagsterRunStatus.NOT_STARTED,
+    DagsterRunStatus.SUCCESS,
+    DagsterRunStatus.FAILURE,
+    DagsterRunStatus.MANAGED,
+    DagsterRunStatus.CANCELED,
 ]
 
 FINISHED_STATUSES = [
-    PipelineRunStatus.SUCCESS,
-    PipelineRunStatus.FAILURE,
-    PipelineRunStatus.CANCELED,
+    DagsterRunStatus.SUCCESS,
+    DagsterRunStatus.FAILURE,
+    DagsterRunStatus.CANCELED,
 ]
 
 
@@ -325,7 +324,7 @@ class PipelineRun(
             ("solid_selection", Optional[Sequence[str]]),
             ("solids_to_execute", Optional[FrozenSet[str]]),
             ("step_keys_to_execute", Optional[Sequence[str]]),
-            ("status", PipelineRunStatus),
+            ("status", DagsterRunStatus),
             ("tags", Mapping[str, str]),
             ("root_run_id", Optional[str]),
             ("parent_run_id", Optional[str]),
@@ -351,7 +350,7 @@ class PipelineRun(
         solid_selection: Optional[Sequence[str]] = None,
         solids_to_execute: Optional[FrozenSet[str]] = None,
         step_keys_to_execute: Optional[Sequence[str]] = None,
-        status: Optional[PipelineRunStatus] = None,
+        status: Optional[DagsterRunStatus] = None,
         tags: Optional[Mapping[str, str]] = None,
         root_run_id: Optional[str] = None,
         parent_run_id: Optional[str] = None,
@@ -388,7 +387,7 @@ class PipelineRun(
         # https://github.com/dagster-io/dagster/issues/3181
         from dagster._core.host_representation.origin import ExternalPipelineOrigin
 
-        if status == PipelineRunStatus.QUEUED:
+        if status == DagsterRunStatus.QUEUED:
             check.inst_param(
                 external_pipeline_origin,
                 "external_pipeline_origin",
@@ -410,7 +409,7 @@ class PipelineRun(
             solids_to_execute=solids_to_execute,
             step_keys_to_execute=step_keys_to_execute,
             status=check.opt_inst_param(
-                status, "status", PipelineRunStatus, PipelineRunStatus.NOT_STARTED
+                status, "status", DagsterRunStatus, DagsterRunStatus.NOT_STARTED
             ),
             tags=check.opt_mapping_param(tags, "tags", key_type=str, value_type=str),
             root_run_id=check.opt_str_param(root_run_id, "root_run_id"),
@@ -431,7 +430,7 @@ class PipelineRun(
         )
 
     def with_status(self, status):
-        if status == PipelineRunStatus.QUEUED:
+        if status == DagsterRunStatus.QUEUED:
             # Placing this with the other imports causes a cyclic import
             # https://github.com/dagster-io/dagster/issues/3181
             from dagster._core.host_representation.origin import ExternalPipelineOrigin
@@ -484,17 +483,17 @@ class PipelineRun(
     @public  # type: ignore
     @property
     def is_success(self):
-        return self.status == PipelineRunStatus.SUCCESS
+        return self.status == DagsterRunStatus.SUCCESS
 
     @public  # type: ignore
     @property
     def is_failure(self):
-        return self.status == PipelineRunStatus.FAILURE
+        return self.status == DagsterRunStatus.FAILURE
 
     @public  # type: ignore
     @property
     def is_failure_or_canceled(self):
-        return self.status == PipelineRunStatus.FAILURE or self.status == PipelineRunStatus.CANCELED
+        return self.status == DagsterRunStatus.FAILURE or self.status == DagsterRunStatus.CANCELED
 
     @public  # type: ignore
     @property
@@ -647,7 +646,7 @@ class RunsFilter(
             cls,
             run_ids=check.opt_sequence_param(run_ids, "run_ids", of_type=str),
             job_name=check.opt_str_param(job_name, "job_name"),
-            statuses=check.opt_sequence_param(statuses, "statuses", of_type=PipelineRunStatus),
+            statuses=check.opt_sequence_param(statuses, "statuses", of_type=DagsterRunStatus),
             tags=check.opt_mapping_param(tags, "tags", key_type=str),
             snapshot_id=check.opt_str_param(snapshot_id, "snapshot_id"),
             updated_after=check.opt_inst_param(updated_after, "updated_after", datetime),

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -8,7 +8,7 @@ from dagster._serdes import deserialize_as
 
 from ...execution.backfill import PartitionBackfill
 from ...execution.bulk_actions import BulkActionType
-from ..pipeline_run import PipelineRun, PipelineRunStatus
+from ..pipeline_run import DagsterRunStatus, PipelineRun
 from ..runs.base import RunStorage
 from ..runs.schema import BulkActionsTable, RunTagsTable, RunsTable
 from ..tags import PARTITION_NAME_TAG, PARTITION_SET_TAG, REPOSITORY_LABEL_TAG
@@ -32,10 +32,10 @@ OPTIONAL_DATA_MIGRATIONS = {
 CHUNK_SIZE = 100
 
 UNSTARTED_RUN_STATUSES = {
-    PipelineRunStatus.QUEUED,
-    PipelineRunStatus.NOT_STARTED,
-    PipelineRunStatus.MANAGED,
-    PipelineRunStatus.STARTING,
+    DagsterRunStatus.QUEUED,
+    DagsterRunStatus.NOT_STARTED,
+    DagsterRunStatus.MANAGED,
+    DagsterRunStatus.STARTING,
 }
 
 

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -26,7 +26,7 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.launcher import RunLauncher
 from dagster._core.run_coordinator import RunCoordinator, SubmitRunContext
 from dagster._core.secrets import SecretsLoader
-from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus, RunsFilter
+from dagster._core.storage.pipeline_run import DagsterRunStatus, PipelineRun, RunsFilter
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import WorkspaceLoadTarget
 from dagster._daemon.controller import create_daemon_grpc_server_registry
@@ -272,9 +272,9 @@ def poll_for_finished_run(instance, run_id=None, timeout=20, run_tags=None):
         run_ids=[run_id] if run_id else None,
         tags=run_tags,
         statuses=[
-            PipelineRunStatus.SUCCESS,
-            PipelineRunStatus.FAILURE,
-            PipelineRunStatus.CANCELED,
+            DagsterRunStatus.SUCCESS,
+            DagsterRunStatus.FAILURE,
+            DagsterRunStatus.CANCELED,
         ],
     )
 
@@ -375,7 +375,7 @@ class MockedRunLauncher(RunLauncher, ConfigurableClass):
     def launch_run(self, context):
         run = context.pipeline_run
         check.inst_param(run, "run", PipelineRun)
-        check.invariant(run.status == PipelineRunStatus.STARTING)
+        check.invariant(run.status == DagsterRunStatus.STARTING)
 
         if self._bad_run_ids and run.run_id in self._bad_run_ids:
             raise Exception(f"Bad run {run.run_id}")

--- a/python_modules/dagster/dagster/_daemon/monitoring/monitoring_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/monitoring/monitoring_daemon.py
@@ -8,8 +8,8 @@ from dagster._core.events import DagsterEventType
 from dagster._core.launcher import WorkerStatus
 from dagster._core.storage.pipeline_run import (
     IN_PROGRESS_RUN_STATUSES,
+    DagsterRunStatus,
     PipelineRun,
-    PipelineRunStatus,
     RunsFilter,
 )
 from dagster._core.workspace.context import IWorkspace, IWorkspaceProcessContext
@@ -19,7 +19,7 @@ RESUME_RUN_LOG_MESSAGE = "Launching a new run worker to resume run"
 
 
 def monitor_starting_run(instance: DagsterInstance, run, logger):
-    check.invariant(run.status == PipelineRunStatus.STARTING)
+    check.invariant(run.status == DagsterRunStatus.STARTING)
     run_stats = instance.get_run_stats(run.run_id)
 
     launch_time = check.not_none(
@@ -48,7 +48,7 @@ def monitor_started_run(
     run: PipelineRun,
     logger: logging.Logger,
 ):
-    check.invariant(run.status == PipelineRunStatus.STARTED)
+    check.invariant(run.status == DagsterRunStatus.STARTED)
     check_health_result = instance.run_launcher.check_run_worker_health(run)
     if check_health_result.status not in [WorkerStatus.RUNNING, WorkerStatus.SUCCESS]:
         num_prev_attempts = count_resume_run_attempts(instance, run.run_id)
@@ -112,12 +112,12 @@ def execute_monitoring_iteration(
         try:
             logger.info(f"Checking run {run.run_id}")
 
-            if run.status == PipelineRunStatus.STARTING:
+            if run.status == DagsterRunStatus.STARTING:
                 monitor_starting_run(instance, run, logger)
-            elif run.status == PipelineRunStatus.STARTED:
+            elif run.status == DagsterRunStatus.STARTED:
 
                 monitor_started_run(instance, workspace, run, logger)
-            elif run.status == PipelineRunStatus.CANCELING:
+            elif run.status == DagsterRunStatus.CANCELING:
                 # TODO: implement canceling timeouts
                 pass
             else:

--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -8,8 +8,8 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.run_coordinator.queued_run_coordinator import QueuedRunCoordinator
 from dagster._core.storage.pipeline_run import (
     IN_PROGRESS_RUN_STATUSES,
+    DagsterRunStatus,
     PipelineRun,
-    PipelineRunStatus,
     RunsFilter,
 )
 from dagster._core.storage.tags import PRIORITY_TAG
@@ -187,7 +187,7 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
             self._logger.info("Launched %d runs.", num_dequeued_runs)
 
     def _get_queued_runs(self, instance):
-        queued_runs_filter = RunsFilter(statuses=[PipelineRunStatus.QUEUED])
+        queued_runs_filter = RunsFilter(statuses=[DagsterRunStatus.QUEUED])
 
         # Reversed for fifo ordering
         # Note: should add a maximum fetch limit https://github.com/dagster-io/dagster/issues/3339
@@ -218,7 +218,7 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
         # double check that the run is still queued before dequeing
         reloaded_run = check.not_none(instance.get_run_by_id(run.run_id))
 
-        if reloaded_run.status != PipelineRunStatus.QUEUED:
+        if reloaded_run.status != DagsterRunStatus.QUEUED:
             self._logger.info(
                 "Run %s is now %s instead of QUEUED, skipping",
                 reloaded_run.run_id,

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -30,7 +30,7 @@ from dagster._core.scheduler.instigation import (
     TickData,
     TickStatus,
 )
-from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus, RunsFilter
+from dagster._core.storage.pipeline_run import DagsterRunStatus, PipelineRun, RunsFilter
 from dagster._core.storage.tags import RUN_KEY_TAG, SENSOR_NAME_TAG
 from dagster._core.telemetry import SENSOR_RUN_CREATED, hash_name, log_action
 from dagster._core.workspace.context import IWorkspaceProcessContext
@@ -768,7 +768,7 @@ def _get_or_create_sensor_run(
     run = existing_runs_by_key.get(run_request.run_key)
 
     if run:
-        if run.status != PipelineRunStatus.NOT_STARTED:
+        if run.status != DagsterRunStatus.NOT_STARTED:
             # A run already exists and was launched for this run key, but the daemon must have
             # crashed before the tick could be updated
             return SkippedSensorRun(run_key=run_request.run_key, existing_run=run)
@@ -832,7 +832,7 @@ def _create_sensor_run(
         mode=target_data.mode,
         solids_to_execute=external_pipeline.solids_to_execute,
         step_keys_to_execute=None,
-        status=PipelineRunStatus.NOT_STARTED,
+        status=DagsterRunStatus.NOT_STARTED,
         solid_selection=target_data.solid_selection,
         root_run_id=None,
         parent_run_id=None,

--- a/python_modules/dagster/dagster/_legacy/__init__.py
+++ b/python_modules/dagster/dagster/_legacy/__init__.py
@@ -37,7 +37,7 @@ from dagster._core.execution.results import (
     SolidExecutionResult,
 )
 from dagster._core.storage.fs_io_manager import custom_path_fs_io_manager, fs_io_manager
-from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus, PipelineRun
 from dagster._utils.partitions import (
     create_offset_partition_selector,
     date_partition_range,

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -30,7 +30,7 @@ from dagster._core.scheduler.instigation import (
     TickStatus,
 )
 from dagster._core.scheduler.scheduler import DEFAULT_MAX_CATCHUP_RUNS, DagsterSchedulerError
-from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus, RunsFilter
+from dagster._core.storage.pipeline_run import DagsterRunStatus, PipelineRun, RunsFilter
 from dagster._core.storage.tags import RUN_KEY_TAG, SCHEDULED_EXECUTION_TIME_TAG
 from dagster._core.telemetry import SCHEDULED_RUN_CREATED, hash_name, log_action
 from dagster._core.workspace.context import IWorkspaceProcessContext
@@ -599,7 +599,7 @@ def _schedule_runs_at_time(
 
         run = _get_existing_run_for_request(instance, external_schedule, schedule_time, run_request)
         if run:
-            if run.status != PipelineRunStatus.NOT_STARTED:
+            if run.status != DagsterRunStatus.NOT_STARTED:
                 # A run already exists and was launched for this time period,
                 # but the scheduler must have crashed or errored before the tick could be put
                 # into a SUCCESS state
@@ -626,7 +626,7 @@ def _schedule_runs_at_time(
 
         _check_for_debug_crash(debug_crash_flags, "RUN_CREATED")
 
-        if run.status != PipelineRunStatus.FAILURE:
+        if run.status != DagsterRunStatus.FAILURE:
             try:
                 instance.submit_run(run.run_id, workspace_process_context.create_request_context())
                 logger.info(f"Completed scheduled launch of run {run.run_id} for {schedule_name}")
@@ -732,7 +732,7 @@ def _create_scheduler_run(
         solids_to_execute=external_pipeline.solids_to_execute,
         step_keys_to_execute=None,
         solid_selection=external_pipeline.solid_selection,
-        status=PipelineRunStatus.NOT_STARTED,
+        status=DagsterRunStatus.NOT_STARTED,
         root_run_id=None,
         parent_run_id=None,
         tags=tags,

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_launch_run.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_launch_run.py
@@ -1,5 +1,5 @@
 from dagster._core.host_representation.handle import PipelineHandle
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import instance_for_test, poll_for_event, poll_for_finished_run
 from dagster._grpc.server import ExecuteExternalPipelineArgs
 from dagster._serdes import deserialize_json_to_dagster_namedtuple
@@ -63,7 +63,7 @@ def test_launch_run_with_unloadable_pipeline_grpc():
 
             assert finished_pipeline_run
             assert finished_pipeline_run.run_id == run_id
-            assert finished_pipeline_run.status == PipelineRunStatus.FAILURE
+            assert finished_pipeline_run.status == DagsterRunStatus.FAILURE
 
             poll_for_event(
                 instance, run_id, event_type="ENGINE_EVENT", message="Process for run exited"
@@ -123,7 +123,7 @@ def test_launch_run_grpc():
 
             assert finished_pipeline_run
             assert finished_pipeline_run.run_id == run_id
-            assert finished_pipeline_run.status == PipelineRunStatus.SUCCESS
+            assert finished_pipeline_run.status == DagsterRunStatus.SUCCESS
 
             poll_for_event(
                 instance, run_id, event_type="ENGINE_EVENT", message="Process for run exited"

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
@@ -4,7 +4,7 @@ from click.testing import CliRunner
 
 from dagster._cli.job import execute_launch_command, job_launch_command
 from dagster._core.errors import DagsterRunAlreadyExists
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import new_cwd
 from dagster._utils import file_relative_path
 
@@ -161,7 +161,7 @@ def test_launch_queued(gen_pipeline_args):
             run = instance.get_run_by_id(run_id)
             assert run is not None
 
-            assert run.status == PipelineRunStatus.QUEUED
+            assert run.status == DagsterRunStatus.QUEUED
 
 
 @pytest.mark.parametrize(
@@ -193,7 +193,7 @@ def test_job_launch_queued(gen_pipeline_args):
             run = instance.get_run_by_id(run_id)
             assert run is not None
 
-            assert run.status == PipelineRunStatus.QUEUED
+            assert run.status == DagsterRunStatus.QUEUED
 
 
 def test_default_working_directory():

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
@@ -4,7 +4,7 @@ import pytest
 
 from dagster import DagsterInstance, job, op, reconstructable, repository
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.storage.tags import RESUME_RETRY_TAG
 from dagster._core.test_utils import (
     environ,
@@ -110,7 +110,7 @@ def test_create_reexecuted_run_from_failure(
     instance.launch_run(run.run_id, workspace)
     run = poll_for_finished_run(instance, run.run_id)
 
-    assert run.status == PipelineRunStatus.SUCCESS
+    assert run.status == DagsterRunStatus.SUCCESS
     assert step_did_not_run(instance, run, "before_failure")
     assert step_succeeded(instance, run, "conditional_fail")
     assert step_succeeded(instance, run, "after_failure")
@@ -165,7 +165,7 @@ def test_create_reexecuted_run_all_steps(
     instance.launch_run(run.run_id, workspace)
     run = poll_for_finished_run(instance, run.run_id)
 
-    assert run.status == PipelineRunStatus.SUCCESS
+    assert run.status == DagsterRunStatus.SUCCESS
     assert step_succeeded(instance, run, "before_failure")
     assert step_succeeded(instance, run, "conditional_fail")
     assert step_succeeded(instance, run, "after_failure")

--- a/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_default_run_launcher.py
@@ -16,7 +16,7 @@ from dagster import (
     repository,
 )
 from dagster._core.errors import DagsterLaunchFailedError
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.storage.tags import GRPC_INFO_TAG
 from dagster._core.test_utils import (
     environ,
@@ -167,7 +167,7 @@ def test_successful_run(instance, workspace, run_config):  # pylint: disable=red
     )
     run_id = pipeline_run.run_id
 
-    assert instance.get_run_by_id(run_id).status == PipelineRunStatus.NOT_STARTED
+    assert instance.get_run_by_id(run_id).status == DagsterRunStatus.NOT_STARTED
 
     instance.launch_run(run_id=pipeline_run.run_id, workspace=workspace)
 
@@ -176,7 +176,7 @@ def test_successful_run(instance, workspace, run_config):  # pylint: disable=red
     assert pipeline_run.run_id == run_id
 
     pipeline_run = poll_for_finished_run(instance, run_id)
-    assert pipeline_run.status == PipelineRunStatus.SUCCESS
+    assert pipeline_run.status == DagsterRunStatus.SUCCESS
 
 
 def test_successful_run_from_pending(
@@ -228,7 +228,7 @@ def test_successful_run_from_pending(
 
     run_id = created_pipeline_run.run_id
 
-    assert instance.get_run_by_id(run_id).status == PipelineRunStatus.NOT_STARTED
+    assert instance.get_run_by_id(run_id).status == DagsterRunStatus.NOT_STARTED
 
     instance.launch_run(run_id=run_id, workspace=pending_workspace)
 
@@ -244,7 +244,7 @@ def test_successful_run_from_pending(
     )
 
     finished_pipeline_run = poll_for_finished_run(instance, run_id)
-    assert finished_pipeline_run.status == PipelineRunStatus.SUCCESS
+    assert finished_pipeline_run.status == DagsterRunStatus.SUCCESS
 
     call_counts = instance.run_storage.kvs_get(
         {
@@ -314,7 +314,7 @@ def test_invalid_instance_run():
                             instance.launch_run(run_id=pipeline_run.run_id, workspace=workspace)
 
                         failed_run = instance.get_run_by_id(pipeline_run.run_id)
-                        assert failed_run.status == PipelineRunStatus.FAILURE
+                        assert failed_run.status == DagsterRunStatus.FAILURE
 
 
 @pytest.mark.parametrize(
@@ -341,7 +341,7 @@ def test_crashy_run(instance, workspace, run_config):  # pylint: disable=redefin
 
     run_id = pipeline_run.run_id
 
-    assert instance.get_run_by_id(run_id).status == PipelineRunStatus.NOT_STARTED
+    assert instance.get_run_by_id(run_id).status == DagsterRunStatus.NOT_STARTED
 
     instance.launch_run(pipeline_run.run_id, workspace)
 
@@ -351,7 +351,7 @@ def test_crashy_run(instance, workspace, run_config):  # pylint: disable=redefin
     assert failed_pipeline_run.run_id == run_id
 
     failed_pipeline_run = poll_for_finished_run(instance, run_id, timeout=5)
-    assert failed_pipeline_run.status == PipelineRunStatus.FAILURE
+    assert failed_pipeline_run.status == DagsterRunStatus.FAILURE
 
     event_records = instance.all_logs(run_id)
 
@@ -384,7 +384,7 @@ def test_exity_run(run_config, instance, workspace):  # pylint: disable=redefine
 
     run_id = pipeline_run.run_id
 
-    assert instance.get_run_by_id(run_id).status == PipelineRunStatus.NOT_STARTED
+    assert instance.get_run_by_id(run_id).status == DagsterRunStatus.NOT_STARTED
 
     instance.launch_run(pipeline_run.run_id, workspace)
 
@@ -394,7 +394,7 @@ def test_exity_run(run_config, instance, workspace):  # pylint: disable=redefine
     assert failed_pipeline_run.run_id == run_id
 
     failed_pipeline_run = poll_for_finished_run(instance, run_id, timeout=5)
-    assert failed_pipeline_run.status == PipelineRunStatus.FAILURE
+    assert failed_pipeline_run.status == DagsterRunStatus.FAILURE
 
     event_records = instance.all_logs(run_id)
 
@@ -424,7 +424,7 @@ def test_terminated_run(instance, workspace, run_config):  # pylint: disable=red
 
     run_id = pipeline_run.run_id
 
-    assert instance.get_run_by_id(run_id).status == PipelineRunStatus.NOT_STARTED
+    assert instance.get_run_by_id(run_id).status == DagsterRunStatus.NOT_STARTED
 
     instance.launch_run(pipeline_run.run_id, workspace)
 
@@ -435,7 +435,7 @@ def test_terminated_run(instance, workspace, run_config):  # pylint: disable=red
 
     terminated_pipeline_run = poll_for_finished_run(instance, run_id, timeout=30)
     terminated_pipeline_run = instance.get_run_by_id(run_id)
-    assert terminated_pipeline_run.status == PipelineRunStatus.CANCELED
+    assert terminated_pipeline_run.status == DagsterRunStatus.CANCELED
 
     poll_for_event(
         instance,
@@ -535,7 +535,7 @@ def test_cleanup_after_force_terminate(run_config, instance, workspace):
 
         time.sleep(1)
 
-    assert instance.get_run_by_id(run_id).status == PipelineRunStatus.CANCELED
+    assert instance.get_run_by_id(run_id).status == DagsterRunStatus.CANCELED
 
 
 def _get_engine_events(event_records):
@@ -597,7 +597,7 @@ def test_single_solid_selection_execution(
     )
     run_id = pipeline_run.run_id
 
-    assert instance.get_run_by_id(run_id).status == PipelineRunStatus.NOT_STARTED
+    assert instance.get_run_by_id(run_id).status == DagsterRunStatus.NOT_STARTED
 
     instance.launch_run(pipeline_run.run_id, workspace)
     finished_pipeline_run = poll_for_finished_run(instance, run_id)
@@ -606,7 +606,7 @@ def test_single_solid_selection_execution(
 
     assert finished_pipeline_run
     assert finished_pipeline_run.run_id == run_id
-    assert finished_pipeline_run.status == PipelineRunStatus.SUCCESS
+    assert finished_pipeline_run.status == DagsterRunStatus.SUCCESS
 
     assert _get_successful_step_keys(event_records) == {"return_one"}
 
@@ -635,7 +635,7 @@ def test_multi_solid_selection_execution(
     )
     run_id = pipeline_run.run_id
 
-    assert instance.get_run_by_id(run_id).status == PipelineRunStatus.NOT_STARTED
+    assert instance.get_run_by_id(run_id).status == DagsterRunStatus.NOT_STARTED
 
     instance.launch_run(pipeline_run.run_id, workspace)
     finished_pipeline_run = poll_for_finished_run(instance, run_id)
@@ -644,7 +644,7 @@ def test_multi_solid_selection_execution(
 
     assert finished_pipeline_run
     assert finished_pipeline_run.run_id == run_id
-    assert finished_pipeline_run.status == PipelineRunStatus.SUCCESS
+    assert finished_pipeline_run.status == DagsterRunStatus.SUCCESS
 
     assert _get_successful_step_keys(event_records) == {
         "return_one",
@@ -670,14 +670,14 @@ def test_engine_events(instance, workspace, run_config):  # pylint: disable=rede
     )
     run_id = pipeline_run.run_id
 
-    assert instance.get_run_by_id(run_id).status == PipelineRunStatus.NOT_STARTED
+    assert instance.get_run_by_id(run_id).status == DagsterRunStatus.NOT_STARTED
 
     instance.launch_run(pipeline_run.run_id, workspace)
     finished_pipeline_run = poll_for_finished_run(instance, run_id)
 
     assert finished_pipeline_run
     assert finished_pipeline_run.run_id == run_id
-    assert finished_pipeline_run.status == PipelineRunStatus.SUCCESS
+    assert finished_pipeline_run.status == DagsterRunStatus.SUCCESS
 
     poll_for_event(
         instance,

--- a/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_persistent_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_persistent_grpc_run_launcher.py
@@ -10,7 +10,7 @@ from dagster_tests.core_tests.launcher_tests.test_default_run_launcher import (
 
 from dagster import _seven, file_relative_path
 from dagster._core.errors import DagsterLaunchFailedError
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.storage.tags import GRPC_INFO_TAG
 from dagster._core.test_utils import instance_for_test, poll_for_finished_run, poll_for_step_start
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
@@ -58,7 +58,7 @@ def test_run_always_finishes():  # pylint: disable=redefined-outer-name
                 )
                 run_id = pipeline_run.run_id
 
-                assert instance.get_run_by_id(run_id).status == PipelineRunStatus.NOT_STARTED
+                assert instance.get_run_by_id(run_id).status == DagsterRunStatus.NOT_STARTED
 
                 instance.launch_run(run_id=run_id, workspace=workspace)
 
@@ -69,7 +69,7 @@ def test_run_always_finishes():  # pylint: disable=redefined-outer-name
 
         # Server should wait until run finishes, then shutdown
         pipeline_run = poll_for_finished_run(instance, run_id)
-        assert pipeline_run.status == PipelineRunStatus.SUCCESS
+        assert pipeline_run.status == DagsterRunStatus.SUCCESS
 
         start_time = time.time()
         while server_process.server_process.poll() is None:
@@ -151,7 +151,7 @@ def test_run_from_pending_repository():
 
                 run_id = pipeline_run.run_id
 
-                assert instance.get_run_by_id(run_id).status == PipelineRunStatus.NOT_STARTED
+                assert instance.get_run_by_id(run_id).status == DagsterRunStatus.NOT_STARTED
 
                 instance.launch_run(run_id=run_id, workspace=workspace)
 
@@ -162,7 +162,7 @@ def test_run_from_pending_repository():
 
         # Server should wait until run finishes, then shutdown
         pipeline_run = poll_for_finished_run(instance, run_id)
-        assert pipeline_run.status == PipelineRunStatus.SUCCESS
+        assert pipeline_run.status == DagsterRunStatus.SUCCESS
 
         start_time = time.time()
         while server_process.server_process.poll() is None:

--- a/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_default_run_coordinator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_default_run_coordinator.py
@@ -3,7 +3,7 @@ from dagster_tests.api_tests.utils import get_bar_workspace
 
 from dagster._core.run_coordinator import SubmitRunContext
 from dagster._core.run_coordinator.default_run_coordinator import DefaultRunCoordinator
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import create_run_for_test, instance_for_test
 from dagster._utils import merge_dicts
 
@@ -47,11 +47,11 @@ def test_submit_run(instance, coodinator):  # pylint: disable=redefined-outer-na
         run = create_run(instance, external_pipeline, run_id="foo-1")
         returned_run = coodinator.submit_run(SubmitRunContext(run, workspace))
         assert returned_run.run_id == "foo-1"
-        assert returned_run.status == PipelineRunStatus.STARTING
+        assert returned_run.status == DagsterRunStatus.STARTING
 
         assert len(instance.run_launcher.queue()) == 1
         assert instance.run_launcher.queue()[0].run_id == "foo-1"
-        assert instance.run_launcher.queue()[0].status == PipelineRunStatus.STARTING
+        assert instance.run_launcher.queue()[0].status == DagsterRunStatus.STARTING
         assert instance.get_run_by_id("foo-1")
 
 
@@ -64,7 +64,7 @@ def test_submit_run_checks_status(instance, coodinator):  # pylint: disable=rede
         )
 
         run = create_run(
-            instance, external_pipeline, run_id="foo-1", status=PipelineRunStatus.STARTED
+            instance, external_pipeline, run_id="foo-1", status=DagsterRunStatus.STARTED
         )
         coodinator.submit_run(SubmitRunContext(run, workspace))
 

--- a/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_queued_run_coordinator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_queued_run_coordinator.py
@@ -5,7 +5,7 @@ from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.events import DagsterEventType
 from dagster._core.run_coordinator import SubmitRunContext
 from dagster._core.run_coordinator.queued_run_coordinator import QueuedRunCoordinator
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import create_run_for_test, environ, instance_for_test
 from dagster._utils import merge_dicts
 
@@ -137,21 +137,21 @@ class TestQueuedRunCoordinator:
         self, instance, coordinator, workspace, external_pipeline
     ):  # pylint: disable=redefined-outer-name
         run = self.create_run(
-            instance, external_pipeline, run_id="foo-1", status=PipelineRunStatus.NOT_STARTED
+            instance, external_pipeline, run_id="foo-1", status=DagsterRunStatus.NOT_STARTED
         )
         returned_run = coordinator.submit_run(SubmitRunContext(run, workspace))
         assert returned_run.run_id == "foo-1"
-        assert returned_run.status == PipelineRunStatus.QUEUED
+        assert returned_run.status == DagsterRunStatus.QUEUED
 
         assert len(instance.run_launcher.queue()) == 0
         stored_run = instance.get_run_by_id("foo-1")
-        assert stored_run.status == PipelineRunStatus.QUEUED
+        assert stored_run.status == DagsterRunStatus.QUEUED
 
     def test_submit_run_checks_status(
         self, instance, coordinator, workspace, external_pipeline
     ):  # pylint: disable=redefined-outer-name
         run = self.create_run(
-            instance, external_pipeline, run_id="foo-1", status=PipelineRunStatus.QUEUED
+            instance, external_pipeline, run_id="foo-1", status=DagsterRunStatus.QUEUED
         )
         coordinator.submit_run(SubmitRunContext(run, workspace))
 
@@ -169,11 +169,11 @@ class TestQueuedRunCoordinator:
         self, instance, coordinator, workspace, external_pipeline
     ):  # pylint: disable=redefined-outer-name
         run = self.create_run(
-            instance, external_pipeline, run_id="foo-1", status=PipelineRunStatus.NOT_STARTED
+            instance, external_pipeline, run_id="foo-1", status=DagsterRunStatus.NOT_STARTED
         )
 
         coordinator.submit_run(SubmitRunContext(run, workspace))
 
         coordinator.cancel_run(run.run_id)
         stored_run = instance.get_run_by_id("foo-1")
-        assert stored_run.status == PipelineRunStatus.CANCELED
+        assert stored_run.status == DagsterRunStatus.CANCELED

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_job_run.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_job_run.py
@@ -18,8 +18,8 @@ from dagster._core.origin import (
 from dagster._core.storage.pipeline_run import (
     IN_PROGRESS_RUN_STATUSES,
     NON_IN_PROGRESS_RUN_STATUSES,
+    DagsterRunStatus,
     PipelineRun,
-    PipelineRunStatus,
     RunsFilter,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
@@ -52,29 +52,29 @@ def test_queued_pipeline_origin_check():
 
     PipelineRun(
         pipeline_name="foo",
-        status=PipelineRunStatus.QUEUED,
+        status=DagsterRunStatus.QUEUED,
         external_pipeline_origin=fake_pipeline_origin,
         pipeline_code_origin=fake_code_origin,
     )
 
     with pytest.raises(check.CheckError):
-        PipelineRun(pipeline_name="foo", status=PipelineRunStatus.QUEUED)
+        PipelineRun(pipeline_name="foo", status=DagsterRunStatus.QUEUED)
 
     with pytest.raises(check.CheckError):
-        PipelineRun(pipeline_name="foo").with_status(PipelineRunStatus.QUEUED)
+        PipelineRun(pipeline_name="foo").with_status(DagsterRunStatus.QUEUED)
 
 
 def test_in_progress_statuses():
     """
     If this fails, then the dequeuer's statuses are out of sync with all PipelineRunStatuses.
     """
-    for status in PipelineRunStatus:
+    for status in DagsterRunStatus:
         in_progress = status in IN_PROGRESS_RUN_STATUSES
         non_in_progress = status in NON_IN_PROGRESS_RUN_STATUSES
         assert in_progress != non_in_progress  # should be in exactly one of the two
 
     assert len(IN_PROGRESS_RUN_STATUSES) + len(NON_IN_PROGRESS_RUN_STATUSES) == len(
-        PipelineRunStatus
+        DagsterRunStatus
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_local_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_local_instance.py
@@ -17,7 +17,7 @@ from dagster._core.launcher import DefaultRunLauncher
 from dagster._core.run_coordinator import DefaultRunCoordinator
 from dagster._core.storage.event_log import SqliteEventLogStorage
 from dagster._core.storage.local_compute_log_manager import LocalComputeLogManager
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.storage.root import LocalArtifactStorage
 from dagster._core.storage.runs import SqliteRunStorage
 from dagster._core.test_utils import environ
@@ -54,7 +54,7 @@ def test_fs_stores():
             result = simple.execute_in_process(instance=instance)
 
             assert run_store.has_run(result.run_id)
-            assert run_store.get_run_by_id(result.run_id).status == PipelineRunStatus.SUCCESS
+            assert run_store.get_run_by_id(result.run_id).status == DagsterRunStatus.SUCCESS
             assert DagsterEventType.PIPELINE_SUCCESS in [
                 event.dagster_event.event_type
                 for event in event_store.get_logs_for_run(result.run_id)

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_pipeline_run.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_pipeline_run.py
@@ -18,8 +18,8 @@ from dagster._core.origin import (
 from dagster._core.storage.pipeline_run import (
     IN_PROGRESS_RUN_STATUSES,
     NON_IN_PROGRESS_RUN_STATUSES,
+    DagsterRunStatus,
     PipelineRun,
-    PipelineRunStatus,
     RunsFilter,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
@@ -52,29 +52,29 @@ def test_queued_pipeline_origin_check():
 
     PipelineRun(
         pipeline_name="foo",
-        status=PipelineRunStatus.QUEUED,
+        status=DagsterRunStatus.QUEUED,
         external_pipeline_origin=fake_pipeline_origin,
         pipeline_code_origin=fake_code_origin,
     )
 
     with pytest.raises(check.CheckError):
-        PipelineRun(pipeline_name="foo", status=PipelineRunStatus.QUEUED)
+        PipelineRun(pipeline_name="foo", status=DagsterRunStatus.QUEUED)
 
     with pytest.raises(check.CheckError):
-        PipelineRun(pipeline_name="foo").with_status(PipelineRunStatus.QUEUED)
+        PipelineRun(pipeline_name="foo").with_status(DagsterRunStatus.QUEUED)
 
 
 def test_in_progress_statuses():
     """
     If this fails, then the dequeuer's statuses are out of sync with all PipelineRunStatuses.
     """
-    for status in PipelineRunStatus:
+    for status in DagsterRunStatus:
         in_progress = status in IN_PROGRESS_RUN_STATUSES
         non_in_progress = status in NON_IN_PROGRESS_RUN_STATUSES
         assert in_progress != non_in_progress  # should be in exactly one of the two
 
     assert len(IN_PROGRESS_RUN_STATUSES) + len(NON_IN_PROGRESS_RUN_STATUSES) == len(
-        PipelineRunStatus
+        DagsterRunStatus
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
@@ -26,8 +26,8 @@ from dagster._core.storage.event_log import InMemoryEventLogStorage
 from dagster._core.storage.noop_compute_log_manager import NoOpComputeLogManager
 from dagster._core.storage.pipeline_run import (
     DagsterRun,
+    DagsterRunStatus,
     JobBucket,
-    PipelineRunStatus,
     RunsFilter,
     TagBucket,
 )
@@ -106,7 +106,7 @@ class TestRunStorage:
         pipeline_name,
         mode="default",
         tags=None,
-        status=PipelineRunStatus.NOT_STARTED,
+        status=DagsterRunStatus.NOT_STARTED,
         parent_run_id=None,
         root_run_id=None,
         pipeline_snapshot_id=None,
@@ -343,7 +343,7 @@ class TestRunStorage:
                 run_id=one,
                 pipeline_name="some_pipeline",
                 tags={"tag": "hello", "tag2": "world"},
-                status=PipelineRunStatus.SUCCESS,
+                status=DagsterRunStatus.SUCCESS,
             )
         )
         storage.add_run(
@@ -351,13 +351,13 @@ class TestRunStorage:
                 run_id=two,
                 pipeline_name="some_pipeline",
                 tags={"tag": "hello"},
-                status=PipelineRunStatus.FAILURE,
+                status=DagsterRunStatus.FAILURE,
             ),
         )
 
         storage.add_run(
             TestRunStorage.build_run(
-                run_id=three, pipeline_name="other_pipeline", status=PipelineRunStatus.SUCCESS
+                run_id=three, pipeline_name="other_pipeline", status=DagsterRunStatus.SUCCESS
             )
         )
 
@@ -366,7 +366,7 @@ class TestRunStorage:
                 run_id=four,
                 pipeline_name="some_other_pipeline",
                 tags={"tag": "goodbye"},
-                status=PipelineRunStatus.FAILURE,
+                status=DagsterRunStatus.FAILURE,
             ),
         )
 
@@ -385,8 +385,8 @@ class TestRunStorage:
         assert some_runs[0].run_id == two
         assert some_runs[1].run_id == one
 
-        some_runs = storage.get_runs(RunsFilter(statuses=[PipelineRunStatus.SUCCESS]))
-        count = storage.get_runs_count(RunsFilter(statuses=[PipelineRunStatus.SUCCESS]))
+        some_runs = storage.get_runs(RunsFilter(statuses=[DagsterRunStatus.SUCCESS]))
+        count = storage.get_runs_count(RunsFilter(statuses=[DagsterRunStatus.SUCCESS]))
         assert len(some_runs) == 2
         assert count == 2
         assert some_runs[0].run_id == three
@@ -433,14 +433,14 @@ class TestRunStorage:
             RunsFilter(
                 pipeline_name="some_pipeline",
                 tags={"tag": "hello"},
-                statuses=[PipelineRunStatus.SUCCESS],
+                statuses=[DagsterRunStatus.SUCCESS],
             )
         )
         count = storage.get_runs_count(
             RunsFilter(
                 pipeline_name="some_pipeline",
                 tags={"tag": "hello"},
-                statuses=[PipelineRunStatus.SUCCESS],
+                statuses=[DagsterRunStatus.SUCCESS],
             )
         )
         assert len(some_runs) == 1
@@ -453,7 +453,7 @@ class TestRunStorage:
                 run_ids=[one],
                 pipeline_name="some_pipeline",
                 tags={"tag": "hello"},
-                statuses=[PipelineRunStatus.SUCCESS],
+                statuses=[DagsterRunStatus.SUCCESS],
             )
         )
         count = storage.get_runs_count(
@@ -461,7 +461,7 @@ class TestRunStorage:
                 run_ids=[one],
                 pipeline_name="some_pipeline",
                 tags={"tag": "hello"},
-                statuses=[PipelineRunStatus.SUCCESS],
+                statuses=[DagsterRunStatus.SUCCESS],
             )
         )
         assert len(some_runs) == 1
@@ -590,43 +590,43 @@ class TestRunStorage:
         four = make_new_run_id()
         storage.add_run(
             TestRunStorage.build_run(
-                run_id=one, pipeline_name="some_pipeline", status=PipelineRunStatus.NOT_STARTED
+                run_id=one, pipeline_name="some_pipeline", status=DagsterRunStatus.NOT_STARTED
             )
         )
         storage.add_run(
             TestRunStorage.build_run(
-                run_id=two, pipeline_name="some_pipeline", status=PipelineRunStatus.STARTED
+                run_id=two, pipeline_name="some_pipeline", status=DagsterRunStatus.STARTED
             )
         )
         storage.add_run(
             TestRunStorage.build_run(
-                run_id=three, pipeline_name="some_pipeline", status=PipelineRunStatus.STARTED
+                run_id=three, pipeline_name="some_pipeline", status=DagsterRunStatus.STARTED
             )
         )
         storage.add_run(
             TestRunStorage.build_run(
-                run_id=four, pipeline_name="some_pipeline", status=PipelineRunStatus.FAILURE
+                run_id=four, pipeline_name="some_pipeline", status=DagsterRunStatus.FAILURE
             )
         )
 
         assert {
             run.run_id
-            for run in storage.get_runs(RunsFilter(statuses=[PipelineRunStatus.NOT_STARTED]))
+            for run in storage.get_runs(RunsFilter(statuses=[DagsterRunStatus.NOT_STARTED]))
         } == {one}
 
         assert {
-            run.run_id for run in storage.get_runs(RunsFilter(statuses=[PipelineRunStatus.STARTED]))
+            run.run_id for run in storage.get_runs(RunsFilter(statuses=[DagsterRunStatus.STARTED]))
         } == {
             two,
             three,
         }
 
         assert {
-            run.run_id for run in storage.get_runs(RunsFilter(statuses=[PipelineRunStatus.FAILURE]))
+            run.run_id for run in storage.get_runs(RunsFilter(statuses=[DagsterRunStatus.FAILURE]))
         } == {four}
 
         assert {
-            run.run_id for run in storage.get_runs(RunsFilter(statuses=[PipelineRunStatus.SUCCESS]))
+            run.run_id for run in storage.get_runs(RunsFilter(statuses=[DagsterRunStatus.SUCCESS]))
         } == set()
 
     def test_fetch_records_by_update_timestamp(self, storage):
@@ -638,17 +638,17 @@ class TestRunStorage:
         three = make_new_run_id()
         storage.add_run(
             TestRunStorage.build_run(
-                run_id=one, pipeline_name="some_pipeline", status=PipelineRunStatus.STARTED
+                run_id=one, pipeline_name="some_pipeline", status=DagsterRunStatus.STARTED
             )
         )
         storage.add_run(
             TestRunStorage.build_run(
-                run_id=two, pipeline_name="some_pipeline", status=PipelineRunStatus.FAILURE
+                run_id=two, pipeline_name="some_pipeline", status=DagsterRunStatus.FAILURE
             )
         )
         storage.add_run(
             TestRunStorage.build_run(
-                run_id=three, pipeline_name="some_pipeline", status=PipelineRunStatus.STARTED
+                run_id=three, pipeline_name="some_pipeline", status=DagsterRunStatus.STARTED
             )
         )
         storage.handle_run_event(
@@ -686,7 +686,7 @@ class TestRunStorage:
             record.pipeline_run.run_id
             for record in storage.get_run_records(
                 filters=RunsFilter(
-                    statuses=[PipelineRunStatus.FAILURE], updated_after=run_two_update_timestamp
+                    statuses=[DagsterRunStatus.FAILURE], updated_after=run_two_update_timestamp
                 ),
             )
         ] == [one]
@@ -699,44 +699,44 @@ class TestRunStorage:
         four = make_new_run_id()
         storage.add_run(
             TestRunStorage.build_run(
-                run_id=one, pipeline_name="some_pipeline", status=PipelineRunStatus.STARTED
+                run_id=one, pipeline_name="some_pipeline", status=DagsterRunStatus.STARTED
             )
         )
         storage.add_run(
             TestRunStorage.build_run(
-                run_id=two, pipeline_name="some_pipeline", status=PipelineRunStatus.STARTED
+                run_id=two, pipeline_name="some_pipeline", status=DagsterRunStatus.STARTED
             )
         )
         storage.add_run(
             TestRunStorage.build_run(
-                run_id=three, pipeline_name="some_pipeline", status=PipelineRunStatus.NOT_STARTED
+                run_id=three, pipeline_name="some_pipeline", status=DagsterRunStatus.NOT_STARTED
             )
         )
         storage.add_run(
             TestRunStorage.build_run(
-                run_id=four, pipeline_name="some_pipeline", status=PipelineRunStatus.STARTED
+                run_id=four, pipeline_name="some_pipeline", status=DagsterRunStatus.STARTED
             )
         )
 
         cursor_four_runs = storage.get_runs(
-            RunsFilter(statuses=[PipelineRunStatus.STARTED]), cursor=four
+            RunsFilter(statuses=[DagsterRunStatus.STARTED]), cursor=four
         )
         assert len(cursor_four_runs) == 2
         assert {run.run_id for run in cursor_four_runs} == {one, two}
 
         cursor_two_runs = storage.get_runs(
-            RunsFilter(statuses=[PipelineRunStatus.STARTED]), cursor=two
+            RunsFilter(statuses=[DagsterRunStatus.STARTED]), cursor=two
         )
         assert len(cursor_two_runs) == 1
         assert {run.run_id for run in cursor_two_runs} == {one}
 
         cursor_one_runs = storage.get_runs(
-            RunsFilter(statuses=[PipelineRunStatus.STARTED]), cursor=one
+            RunsFilter(statuses=[DagsterRunStatus.STARTED]), cursor=one
         )
         assert not cursor_one_runs
 
         cursor_four_limit_one = storage.get_runs(
-            RunsFilter(statuses=[PipelineRunStatus.STARTED]), cursor=four, limit=1
+            RunsFilter(statuses=[DagsterRunStatus.STARTED]), cursor=four, limit=1
         )
         assert len(cursor_four_limit_one) == 1
         assert cursor_four_limit_one[0].run_id == two
@@ -892,14 +892,14 @@ class TestRunStorage:
             TestRunStorage.build_run(
                 run_id=one,
                 pipeline_name="some_pipeline",
-                status=PipelineRunStatus.SUCCESS,
+                status=DagsterRunStatus.SUCCESS,
             )
         )
         storage.add_run(
             TestRunStorage.build_run(
                 run_id=two,
                 pipeline_name="some_pipeline",
-                status=PipelineRunStatus.SUCCESS,
+                status=DagsterRunStatus.SUCCESS,
             ),
         )
 
@@ -1018,7 +1018,7 @@ class TestRunStorage:
                     run_id=failed_run_id,
                     pipeline_name="foo_pipeline",
                     tags={PARENT_RUN_ID_TAG: root_run.run_id, ROOT_RUN_ID_TAG: root_run.run_id},
-                    status=PipelineRunStatus.FAILURE,
+                    status=DagsterRunStatus.FAILURE,
                 )
             )
             for _ in range(3):
@@ -1034,7 +1034,7 @@ class TestRunStorage:
             storage.add_run(run)
 
         run_groups = storage.get_run_groups(
-            limit=5, filters=RunsFilter(statuses=[PipelineRunStatus.FAILURE])
+            limit=5, filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])
         )
 
         assert len(run_groups) == 3
@@ -1089,7 +1089,7 @@ class TestRunStorage:
         one = TestRunStorage.build_run(
             run_id=make_new_run_id(),
             pipeline_name="foo_pipeline",
-            status=PipelineRunStatus.FAILURE,
+            status=DagsterRunStatus.FAILURE,
             tags={
                 PARTITION_NAME_TAG: "one",
                 PARTITION_SET_TAG: "foo_set",
@@ -1099,7 +1099,7 @@ class TestRunStorage:
         two = TestRunStorage.build_run(
             run_id=make_new_run_id(),
             pipeline_name="foo_pipeline",
-            status=PipelineRunStatus.FAILURE,
+            status=DagsterRunStatus.FAILURE,
             tags={
                 PARTITION_NAME_TAG: "two",
                 PARTITION_SET_TAG: "foo_set",
@@ -1109,7 +1109,7 @@ class TestRunStorage:
         two_retried = TestRunStorage.build_run(
             run_id=make_new_run_id(),
             pipeline_name="foo_pipeline",
-            status=PipelineRunStatus.SUCCESS,
+            status=DagsterRunStatus.SUCCESS,
             tags={
                 PARTITION_NAME_TAG: "two",
                 PARTITION_SET_TAG: "foo_set",
@@ -1119,7 +1119,7 @@ class TestRunStorage:
         three = TestRunStorage.build_run(
             run_id=make_new_run_id(),
             pipeline_name="foo_pipeline",
-            status=PipelineRunStatus.SUCCESS,
+            status=DagsterRunStatus.SUCCESS,
             tags={
                 PARTITION_NAME_TAG: "three",
                 PARTITION_SET_TAG: "foo_set",
@@ -1238,7 +1238,7 @@ class TestRunStorage:
 
         storage.handle_run_event(run_id, dagster_pipeline_start_event)
 
-        assert storage.get_run_by_id(run_id).status == PipelineRunStatus.STARTED
+        assert storage.get_run_by_id(run_id).status == DagsterRunStatus.STARTED
 
         storage.handle_run_event(
             make_new_run_id(),  # diff run
@@ -1253,7 +1253,7 @@ class TestRunStorage:
             ),
         )
 
-        assert storage.get_run_by_id(run_id).status == PipelineRunStatus.STARTED
+        assert storage.get_run_by_id(run_id).status == DagsterRunStatus.STARTED
 
         storage.handle_run_event(
             run_id,  # correct run
@@ -1268,7 +1268,7 @@ class TestRunStorage:
             ),
         )
 
-        assert storage.get_run_by_id(run_id).status == PipelineRunStatus.SUCCESS
+        assert storage.get_run_by_id(run_id).status == DagsterRunStatus.SUCCESS
 
     def test_debug_snapshot_import(self, storage):
         from dagster._core.execution.api import create_execution_plan

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_failure_recovery.py
@@ -6,7 +6,7 @@ import pytest
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.instance import DagsterInstance
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus, TickStatus
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.storage.tags import RUN_KEY_TAG, SENSOR_NAME_TAG
 from dagster._core.test_utils import (
     SingleThreadPoolExecutor,
@@ -165,7 +165,7 @@ def test_failure_after_run_created_before_run_launched(
 
         run = instance.get_runs()[0]
         # Run was created, but hasn't launched yet
-        assert run.status == PipelineRunStatus.NOT_STARTED
+        assert run.status == DagsterRunStatus.NOT_STARTED
         assert run.tags.get(SENSOR_NAME_TAG) == "run_key_sensor"
         assert run.tags.get(RUN_KEY_TAG) == "only_once"
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
@@ -9,7 +9,7 @@ import pytest
 from dagster._core.events import DagsterEvent, DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._core.launcher import CheckRunHealthResult, RunLauncher, WorkerStatus
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import (
     create_run_for_test,
     create_test_daemon_workspace_context,
@@ -126,7 +126,7 @@ def test_monitor_starting(instance, logger):
         instance.get_run_by_id(run.run_id),
         logger,
     )
-    assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.STARTING
+    assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.STARTING
 
     run = create_run_for_test(instance, pipeline_name="foo")
     report_starting_event(instance, run, timestamp=time.time() - 1000)
@@ -136,35 +136,35 @@ def test_monitor_starting(instance, logger):
         instance.get_run_by_id(run.run_id),
         logger,
     )
-    assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.FAILURE
+    assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.FAILURE
 
 
 def test_monitor_started(instance, workspace, logger):
 
-    run = create_run_for_test(instance, pipeline_name="foo", status=PipelineRunStatus.STARTED)
+    run = create_run_for_test(instance, pipeline_name="foo", status=DagsterRunStatus.STARTED)
     with environ({"DAGSTER_TEST_RUN_HEALTH_CHECK_RESULT": "healthy"}):
         monitor_started_run(instance, workspace, run, logger)
-        assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.STARTED
+        assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.STARTED
         assert instance.run_launcher.launch_run_calls == 0
         assert instance.run_launcher.resume_run_calls == 0
 
     monitor_started_run(instance, workspace, run, logger)
-    assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.STARTED
+    assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.STARTED
     assert instance.run_launcher.launch_run_calls == 0
     assert instance.run_launcher.resume_run_calls == 1
 
     monitor_started_run(instance, workspace, run, logger)
-    assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.STARTED
+    assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.STARTED
     assert instance.run_launcher.launch_run_calls == 0
     assert instance.run_launcher.resume_run_calls == 2
 
     monitor_started_run(instance, workspace, run, logger)
-    assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.STARTED
+    assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.STARTED
     assert instance.run_launcher.launch_run_calls == 0
     assert instance.run_launcher.resume_run_calls == 3
 
     # exausted the 3 attempts
     monitor_started_run(instance, workspace, run, logger)
-    assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.FAILURE
+    assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.FAILURE
     assert instance.run_launcher.launch_run_calls == 0
     assert instance.run_launcher.resume_run_calls == 3

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -6,7 +6,7 @@ import pytest
 from dagster_tests.api_tests.utils import get_foo_pipeline_handle
 
 from dagster._core.host_representation.repository_location import GrpcServerRepositoryLocation
-from dagster._core.storage.pipeline_run import IN_PROGRESS_RUN_STATUSES, PipelineRunStatus
+from dagster._core.storage.pipeline_run import IN_PROGRESS_RUN_STATUSES, DagsterRunStatus
 from dagster._core.storage.tags import PRIORITY_TAG
 from dagster._core.test_utils import (
     create_run_for_test,
@@ -86,13 +86,13 @@ def test_attempt_to_launch_runs_filter(instance, workspace_context, daemon, pipe
         instance,
         pipeline_handle,
         run_id="queued-run",
-        status=PipelineRunStatus.QUEUED,
+        status=DagsterRunStatus.QUEUED,
     )
     create_run(
         instance,
         pipeline_handle,
         run_id="non-queued-run",
-        status=PipelineRunStatus.NOT_STARTED,
+        status=DagsterRunStatus.NOT_STARTED,
     )
 
     list(daemon.run_iteration(workspace_context))
@@ -105,13 +105,13 @@ def test_attempt_to_launch_runs_no_queued(instance, pipeline_handle, workspace_c
         instance,
         pipeline_handle,
         run_id="queued-run",
-        status=PipelineRunStatus.STARTED,
+        status=DagsterRunStatus.STARTED,
     )
     create_run(
         instance,
         pipeline_handle,
         run_id="non-queued-run",
-        status=PipelineRunStatus.NOT_STARTED,
+        status=DagsterRunStatus.NOT_STARTED,
     )
 
     list(daemon.run_iteration(workspace_context))
@@ -146,7 +146,7 @@ def test_get_queued_runs_max_runs(num_in_progress_runs, pipeline_handle, workspa
                 instance,
                 pipeline_handle,
                 run_id=run_id,
-                status=PipelineRunStatus.QUEUED,
+                status=DagsterRunStatus.QUEUED,
             )
 
         list(daemon.run_iteration(bounded_ctx))
@@ -177,7 +177,7 @@ def test_disable_max_concurrent_runs_limit(workspace_context, pipeline_handle, d
                 instance,
                 pipeline_handle,
                 run_id=run_id,
-                status=PipelineRunStatus.QUEUED,
+                status=DagsterRunStatus.QUEUED,
             )
 
         list(daemon.run_iteration(bounded_ctx))
@@ -186,19 +186,19 @@ def test_disable_max_concurrent_runs_limit(workspace_context, pipeline_handle, d
 
 
 def test_priority(instance, workspace_context, pipeline_handle, daemon):
-    create_run(instance, pipeline_handle, run_id="default-pri-run", status=PipelineRunStatus.QUEUED)
+    create_run(instance, pipeline_handle, run_id="default-pri-run", status=DagsterRunStatus.QUEUED)
     create_run(
         instance,
         pipeline_handle,
         run_id="low-pri-run",
-        status=PipelineRunStatus.QUEUED,
+        status=DagsterRunStatus.QUEUED,
         tags={PRIORITY_TAG: "-1"},
     )
     create_run(
         instance,
         pipeline_handle,
         run_id="hi-pri-run",
-        status=PipelineRunStatus.QUEUED,
+        status=DagsterRunStatus.QUEUED,
         tags={PRIORITY_TAG: "3"},
     )
 
@@ -216,7 +216,7 @@ def test_priority_on_malformed_tag(instance, workspace_context, pipeline_handle,
         instance,
         pipeline_handle,
         run_id="bad-pri-run",
-        status=PipelineRunStatus.QUEUED,
+        status=DagsterRunStatus.QUEUED,
         tags={PRIORITY_TAG: "foobar"},
     )
 
@@ -236,21 +236,21 @@ def test_tag_limits(workspace_context, pipeline_handle, daemon):
             instance,
             pipeline_handle,
             run_id="tiny-1",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"database": "tiny"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="tiny-2",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"database": "tiny"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="large-1",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"database": "large"},
         )
 
@@ -272,21 +272,21 @@ def test_tag_limits_just_key(workspace_context, pipeline_handle, daemon):
             instance,
             pipeline_handle,
             run_id="tiny-1",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"database": "tiny"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="tiny-2",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"database": "tiny"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="large-1",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"database": "large"},
         )
 
@@ -313,28 +313,28 @@ def test_multiple_tag_limits(
             instance,
             pipeline_handle,
             run_id="run-1",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"database": "tiny", "user": "johann"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="run-2",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"database": "tiny"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="run-3",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"user": "johann"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="run-4",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"user": "johann"},
         )
 
@@ -357,28 +357,28 @@ def test_overlapping_tag_limits(workspace_context, daemon, pipeline_handle):
             instance,
             pipeline_handle,
             run_id="run-1",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "bar"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="run-2",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "bar"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="run-3",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "other"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="run-4",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "other"},
         )
 
@@ -400,14 +400,14 @@ def test_limits_per_unique_value(workspace_context, pipeline_handle, daemon):
             instance,
             pipeline_handle,
             run_id="run-1",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "bar"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="run-2",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "bar"},
         )
         list(daemon.run_iteration(bounded_ctx))
@@ -416,14 +416,14 @@ def test_limits_per_unique_value(workspace_context, pipeline_handle, daemon):
             instance,
             pipeline_handle,
             run_id="run-3",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "other"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="run-4",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "other"},
         )
 
@@ -446,28 +446,28 @@ def test_limits_per_unique_value_overlapping_limits(workspace_context, daemon, p
             instance,
             pipeline_handle,
             run_id="run-1",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "bar"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="run-2",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "bar"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="run-3",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "other"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="run-4",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "other-2"},
         )
 
@@ -488,35 +488,35 @@ def test_limits_per_unique_value_overlapping_limits(workspace_context, daemon, p
             instance,
             pipeline_handle,
             run_id="run-1",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "bar"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="run-2",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "baz"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="run-3",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "bar"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="run-4",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "baz"},
         )
         create_run(
             instance,
             pipeline_handle,
             run_id="run-5",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"foo": "baz"},
         )
 
@@ -534,14 +534,14 @@ def test_locations_not_created(instance, monkeypatch, workspace_context, daemon,
         instance,
         pipeline_handle,
         run_id="queued-run",
-        status=PipelineRunStatus.QUEUED,
+        status=DagsterRunStatus.QUEUED,
     )
 
     create_run(
         instance,
         pipeline_handle,
         run_id="queued-run-2",
-        status=PipelineRunStatus.QUEUED,
+        status=DagsterRunStatus.QUEUED,
     )
 
     original_method = GrpcServerRepositoryLocation.__init__
@@ -589,14 +589,14 @@ def test_skip_error_runs(instance, pipeline_handle, workspace_context, daemon):
         instance,
         pipeline_handle,
         run_id="bad-run",
-        status=PipelineRunStatus.QUEUED,
+        status=DagsterRunStatus.QUEUED,
     )
 
     create_run(
         instance,
         pipeline_handle,
         run_id="good-run",
-        status=PipelineRunStatus.QUEUED,
+        status=DagsterRunStatus.QUEUED,
     )
 
     errors = [error for error in list(daemon.run_iteration(workspace_context)) if error]
@@ -605,7 +605,7 @@ def test_skip_error_runs(instance, pipeline_handle, workspace_context, daemon):
     assert "Bad run bad-run" in errors[0].message
 
     assert get_run_ids(instance.run_launcher.queue()) == ["good-run"]
-    assert instance.get_run_by_id("bad-run").status == PipelineRunStatus.FAILURE
+    assert instance.get_run_by_id("bad-run").status == DagsterRunStatus.FAILURE
 
 
 def test_key_limit_with_extra_tags(workspace_context, daemon, pipeline_handle):
@@ -621,7 +621,7 @@ def test_key_limit_with_extra_tags(workspace_context, daemon, pipeline_handle):
             instance,
             pipeline_handle,
             run_id="run-1",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"other-tag": "value", "test": "value"},
         )
 
@@ -629,7 +629,7 @@ def test_key_limit_with_extra_tags(workspace_context, daemon, pipeline_handle):
             instance,
             pipeline_handle,
             run_id="run-2",
-            status=PipelineRunStatus.QUEUED,
+            status=DagsterRunStatus.QUEUED,
             tags={"other-tag": "value", "test": "value"},
         )
 

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_host_run_worker.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_host_run_worker.py
@@ -6,7 +6,7 @@ from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.host_mode import execute_run_host_mode
 from dagster._core.execution.retries import RetryMode
 from dagster._core.executor.multiprocess import MultiprocessExecutor
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import instance_for_test
 from dagster._legacy import ModeDefinition, pipeline, solid
 
@@ -104,7 +104,7 @@ def test_host_run_worker():
             raise_on_error=True,
         )
 
-        assert instance.get_run_by_id(pipeline_run.run_id).status == PipelineRunStatus.SUCCESS
+        assert instance.get_run_by_id(pipeline_run.run_id).status == DagsterRunStatus.SUCCESS
 
         logs = instance.all_logs(pipeline_run.run_id)
         assert any(
@@ -152,7 +152,7 @@ def test_custom_executor_fn():
             raise_on_error=True,
         )
 
-        assert instance.get_run_by_id(pipeline_run.run_id).status == PipelineRunStatus.SUCCESS
+        assert instance.get_run_by_id(pipeline_run.run_id).status == DagsterRunStatus.SUCCESS
 
         logs = instance.all_logs(pipeline_run.run_id)
         assert any(

--- a/python_modules/dagster/dagster_tests/execution_tests/test_api_iterators.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_api_iterators.py
@@ -12,7 +12,7 @@ from dagster._core.execution.api import (
     execute_run,
     execute_run_iterator,
 )
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import instance_for_test
 from dagster._legacy import ModeDefinition, PipelineDefinition, solid
 
@@ -121,7 +121,7 @@ def test_execute_run_iterator():
             pipeline_def=pipeline_def,
             run_config={"loggers": {"callback": {}}},
             mode="default",
-        ).with_status(PipelineRunStatus.SUCCESS)
+        ).with_status(DagsterRunStatus.SUCCESS)
 
         events = list(
             execute_run_iterator(InMemoryPipeline(pipeline_def), pipeline_run, instance=instance)
@@ -171,7 +171,7 @@ def test_execute_run_iterator():
             pipeline_def=pipeline_def,
             run_config={"loggers": {"callback": {}}},
             mode="default",
-        ).with_status(PipelineRunStatus.CANCELED)
+        ).with_status(DagsterRunStatus.CANCELED)
 
         events = list(
             execute_run_iterator(InMemoryPipeline(pipeline_def), pipeline_run, instance=instance)
@@ -203,7 +203,7 @@ def test_restart_running_run_worker():
             pipeline_def=pipeline_def,
             run_config={"loggers": {"callback": {}}},
             mode="default",
-        ).with_status(PipelineRunStatus.STARTED)
+        ).with_status(DagsterRunStatus.STARTED)
 
         events = list(
             execute_run_iterator(InMemoryPipeline(pipeline_def), pipeline_run, instance=instance)
@@ -217,7 +217,7 @@ def test_restart_running_run_worker():
             ]
         )
 
-        assert instance.get_run_by_id(pipeline_run.run_id).status == PipelineRunStatus.FAILURE
+        assert instance.get_run_by_id(pipeline_run.run_id).status == DagsterRunStatus.FAILURE
 
 
 def test_start_run_worker_after_run_failure():
@@ -239,7 +239,7 @@ def test_start_run_worker_after_run_failure():
             pipeline_def=pipeline_def,
             run_config={"loggers": {"callback": {}}},
             mode="default",
-        ).with_status(PipelineRunStatus.FAILURE)
+        ).with_status(DagsterRunStatus.FAILURE)
 
         event = next(
             execute_run_iterator(InMemoryPipeline(pipeline_def), pipeline_run, instance=instance)
@@ -269,7 +269,7 @@ def test_execute_canceled_state():
             pipeline_def=pipeline_def,
             run_config={"loggers": {"callback": {}}},
             mode="default",
-        ).with_status(PipelineRunStatus.CANCELED)
+        ).with_status(DagsterRunStatus.CANCELED)
 
         with pytest.raises(DagsterInvariantViolationError):
             execute_run(
@@ -290,7 +290,7 @@ def test_execute_canceled_state():
             pipeline_def=pipeline_def,
             run_config={"loggers": {"callback": {}}},
             mode="default",
-        ).with_status(PipelineRunStatus.CANCELED)
+        ).with_status(DagsterRunStatus.CANCELED)
 
         iter_events = list(
             execute_run_iterator(InMemoryPipeline(pipeline_def), iter_run, instance=instance)
@@ -325,7 +325,7 @@ def test_execute_run_bad_state():
             pipeline_def=pipeline_def,
             run_config={"loggers": {"callback": {}}},
             mode="default",
-        ).with_status(PipelineRunStatus.SUCCESS)
+        ).with_status(DagsterRunStatus.SUCCESS)
 
         with pytest.raises(
             check.CheckError,

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_execution_plan_snapshot.py
@@ -17,7 +17,7 @@ from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance.ref import InstanceRef
 from dagster._core.snap.execution_plan_snapshot import snapshot_from_execution_plan
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.storage.root_input_manager import root_input_manager
 from dagster._legacy import (
     DynamicOutputDefinition,
@@ -193,7 +193,7 @@ def test_execution_plan_snapshot_backcompat():
                 assert len(runs) == 1
 
                 run = runs[0]
-                assert run.status == PipelineRunStatus.NOT_STARTED
+                assert run.status == DagsterRunStatus.NOT_STARTED
 
                 the_pipeline = InMemoryPipeline(dynamic_pipeline)
 

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -16,7 +16,7 @@ from dagster._core.host_representation.origin import (
     GrpcServerRepositoryLocationOrigin,
     RegisteredRepositoryLocationOrigin,
 )
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import (
     create_run_for_test,
     environ,
@@ -641,7 +641,7 @@ def test_load_with_secrets_loader_instance_ref():
 
                 assert finished_pipeline_run
                 assert finished_pipeline_run.run_id == run_id
-                assert finished_pipeline_run.status == PipelineRunStatus.SUCCESS
+                assert finished_pipeline_run.status == DagsterRunStatus.SUCCESS
 
             finally:
                 client.shutdown_server()

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
@@ -5,7 +5,7 @@ import pytest
 
 from dagster._core.instance import DagsterInstance
 from dagster._core.scheduler.instigation import TickStatus
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG, SCHEDULED_EXECUTION_TIME_TAG
 from dagster._core.test_utils import (
     SingleThreadPoolExecutor,
@@ -174,7 +174,7 @@ def test_failure_recovery_after_run_created(
             # Run was created, but hasn't launched yet
             assert run.tags[SCHEDULED_EXECUTION_TIME_TAG] == frozen_datetime.isoformat()
             assert run.tags[PARTITION_NAME_TAG] == "2019-02-26"
-            assert run.status == PipelineRunStatus.NOT_STARTED
+            assert run.status == DagsterRunStatus.NOT_STARTED
         else:
             # The run was created and launched - running again should do nothing other than
             # moving the tick to success state.

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -37,7 +37,7 @@ from dagster._core.scheduler.instigation import (
     TickStatus,
 )
 from dagster._core.scheduler.scheduler import DEFAULT_MAX_CATCHUP_RUNS
-from dagster._core.storage.pipeline_run import PipelineRunStatus, RunsFilter
+from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import PARTITION_NAME_TAG, SCHEDULED_EXECUTION_TIME_TAG
 from dagster._core.test_utils import (
     SingleThreadPoolExecutor,
@@ -584,7 +584,7 @@ def validate_run_started(
         if partition_time:
             assert run.run_config == _solid_config(partition_time)
     else:
-        assert run.status == PipelineRunStatus.FAILURE
+        assert run.status == DagsterRunStatus.FAILURE
 
 
 def wait_for_all_runs_to_start(instance, timeout=10):
@@ -595,7 +595,7 @@ def wait_for_all_runs_to_start(instance, timeout=10):
         time.sleep(0.5)
 
         not_started_runs = [
-            run for run in instance.get_runs() if run.status == PipelineRunStatus.NOT_STARTED
+            run for run in instance.get_runs() if run.status == DagsterRunStatus.NOT_STARTED
         ]
 
         if len(not_started_runs) == 0:

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/hooks/dagster_hook.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/hooks/dagster_hook.py
@@ -9,7 +9,7 @@ from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
 from airflow.models import Connection
 
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 
 
 class DagsterHook(BaseHook):
@@ -213,9 +213,9 @@ fragment PythonErrorFragment on PythonError {
         headers = {"Dagster-Cloud-Api-Token": self.user_token if self.user_token else ""}
         status = ""
         while status not in [
-            PipelineRunStatus.SUCCESS.value,
-            PipelineRunStatus.FAILURE.value,
-            PipelineRunStatus.CANCELED.value,
+            DagsterRunStatus.SUCCESS.value,
+            DagsterRunStatus.FAILURE.value,
+            DagsterRunStatus.CANCELED.value,
         ]:
             response = requests.post(
                 url=self.url, json={"query": query, "variables": variables}, headers=headers
@@ -230,11 +230,11 @@ fragment PythonErrorFragment on PythonError {
                     f'Error fetching run status: {response_json["data"]["runOrError"]["message"]}'
                 )
 
-            if status == PipelineRunStatus.SUCCESS.value:
+            if status == DagsterRunStatus.SUCCESS.value:
                 logging.info(f"Run {run_id} completed successfully")
-            elif status == PipelineRunStatus.FAILURE.value:
+            elif status == DagsterRunStatus.FAILURE.value:
                 raise AirflowException(f"Run {run_id} failed")
-            elif status == PipelineRunStatus.CANCELED.value:
+            elif status == DagsterRunStatus.CANCELED.value:
                 raise AirflowException(f"Run {run_id} was cancelled")
             time.sleep(5)
 

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -37,7 +37,7 @@ from dagster._core.events.log import EventLogEntry
 from dagster._core.events.utils import filter_dagster_events_from_cli_logs
 from dagster._core.execution.plan.objects import StepFailureData, UserFailureData
 from dagster._core.execution.retries import RetryMode
-from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus, PipelineRun
 from dagster._serdes import pack_value, serialize_dagster_namedtuple, unpack_value
 from dagster._utils.error import serializable_error_info_from_exc_info
 
@@ -332,7 +332,7 @@ def create_k8s_job_task(celery_app, **task_kwargs):
             step_key=step_key,
         )
 
-        if pipeline_run.status != PipelineRunStatus.STARTED:
+        if pipeline_run.status != DagsterRunStatus.STARTED:
             instance.report_engine_event(
                 "Not scheduling step because dagster run status is not STARTED",
                 pipeline_run,

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -18,7 +18,7 @@ from dagster._core.execution.retries import RetryMode
 from dagster._core.launcher import LaunchRunContext, RunLauncher
 from dagster._core.launcher.base import CheckRunHealthResult, WorkerStatus
 from dagster._core.origin import PipelinePythonOrigin
-from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus, PipelineRun
 from dagster._core.storage.tags import DOCKER_IMAGE_TAG
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 from dagster._utils import frozentags, merge_dicts
@@ -272,7 +272,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
         if not pipeline_run:
             return False
 
-        if pipeline_run.status != PipelineRunStatus.STARTED:
+        if pipeline_run.status != DagsterRunStatus.STARTED:
             return False
 
         return True

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
@@ -18,7 +18,7 @@ from dagster_test.test_project import (
     get_test_project_workspace_and_external_pipeline,
 )
 
-from dagster._core.storage.pipeline_run import PipelineRunStatus, RunsFilter
+from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
 from dagster._core.test_utils import environ, poll_for_finished_run, poll_for_step_start
 from dagster._utils.yaml_utils import merge_yamls
 
@@ -79,7 +79,7 @@ def test_launch_docker_no_network(aws_env):
 
             run = instance.get_run_by_id(run.run_id)
 
-            assert run.status == PipelineRunStatus.STARTING
+            assert run.status == DagsterRunStatus.STARTING
             assert run.tags[DOCKER_IMAGE_TAG] == docker_image
             client = docker.client.from_env()
 
@@ -158,7 +158,7 @@ def test_launch_docker_image_on_pipeline_config(aws_env):
 
                 run = instance.get_run_by_id(run.run_id)
 
-                assert run.status == PipelineRunStatus.SUCCESS
+                assert run.status == DagsterRunStatus.SUCCESS
 
                 assert run.tags[DOCKER_IMAGE_TAG] == docker_image
 
@@ -228,7 +228,7 @@ def test_terminate_launched_docker_run(aws_env):
 
             terminated_pipeline_run = poll_for_finished_run(instance, run_id, timeout=30)
             terminated_pipeline_run = instance.get_run_by_id(run_id)
-            assert terminated_pipeline_run.status == PipelineRunStatus.CANCELED
+            assert terminated_pipeline_run.status == DagsterRunStatus.CANCELED
 
             run_logs = instance.all_logs(run_id)
 
@@ -417,14 +417,14 @@ def _test_launch(
             if not terminate:
                 poll_for_finished_run(instance, run.run_id, timeout=60)
 
-                assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.SUCCESS
+                assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.SUCCESS
             else:
                 start_time = time.time()
 
                 filters = RunsFilter(
                     run_ids=[run.run_id],
                     statuses=[
-                        PipelineRunStatus.STARTED,
+                        DagsterRunStatus.STARTED,
                     ],
                 )
 
@@ -441,4 +441,4 @@ def _test_launch(
                 assert launcher.terminate(run.run_id)
 
                 poll_for_finished_run(instance, run.run_id, timeout=60)
-                assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.CANCELED
+                assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.CANCELED

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
@@ -12,7 +12,7 @@ from dagster_test.test_project import (
     get_test_project_workspace_and_external_pipeline,
 )
 
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import poll_for_finished_run
 from dagster._utils.merger import merge_dicts
 from dagster._utils.yaml_utils import load_yaml_from_path, merge_yamls
@@ -98,7 +98,7 @@ def test_image_on_pipeline(aws_env, from_pending_repository):
             for log in instance.all_logs(run.run_id):
                 print(log)  # pylint: disable=print-call
 
-            assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.SUCCESS
+            assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.SUCCESS
 
 
 def test_container_context_on_pipeline(aws_env):
@@ -172,7 +172,7 @@ def test_container_context_on_pipeline(aws_env):
             for log in instance.all_logs(run.run_id):
                 print(log)  # pylint: disable=print-call
 
-            assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.SUCCESS
+            assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.SUCCESS
 
 
 def test_recovery(aws_env):
@@ -238,9 +238,9 @@ def test_recovery(aws_env):
             start_time = time.time()
             while time.time() - start_time < 60:
                 run = instance.get_run_by_id(run.run_id)
-                if run.status == PipelineRunStatus.STARTED:
+                if run.status == DagsterRunStatus.STARTED:
                     break
-                assert run.status == PipelineRunStatus.STARTING
+                assert run.status == DagsterRunStatus.STARTING
                 time.sleep(1)
 
             time.sleep(3)
@@ -253,4 +253,4 @@ def test_recovery(aws_env):
 
             for log in instance.all_logs(run.run_id):
                 print(str(log) + "\n")  # pylint: disable=print-call
-            assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.SUCCESS
+            assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.SUCCESS

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -8,7 +8,7 @@ import kubernetes
 
 from dagster import DagsterInstance
 from dagster import _check as check
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 
 DEFAULT_WAIT_TIMEOUT = 86400.0  # 1 day
 DEFAULT_WAIT_BETWEEN_ATTEMPTS = 10.0  # 10 seconds
@@ -344,7 +344,7 @@ class DagsterKubernetesClient:
                     raise DagsterK8sPipelineStatusException()
 
                 pipeline_run_status = pipeline_run.status
-                if pipeline_run_status != PipelineRunStatus.STARTED:
+                if pipeline_run_status != DagsterRunStatus.STARTED:
                     raise DagsterK8sPipelineStatusException()
 
             self.sleeper(wait_time_between_attempts)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -9,7 +9,7 @@ from dagster._cli.api import ExecuteRunArgs
 from dagster._core.events import EngineEventData
 from dagster._core.launcher import LaunchRunContext, ResumeRunContext, RunLauncher
 from dagster._core.launcher.base import CheckRunHealthResult, WorkerStatus
-from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus, PipelineRun
 from dagster._core.storage.tags import DOCKER_IMAGE_TAG
 from dagster._grpc.types import ResumeRunArgs
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
@@ -289,7 +289,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         pipeline_run = self._instance.get_run_by_id(run_id)
         if not pipeline_run:
             return False
-        if pipeline_run.status != PipelineRunStatus.STARTED:
+        if pipeline_run.status != DagsterRunStatus.STARTED:
             return False
         return True
 

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_terminate.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_terminate.py
@@ -5,7 +5,7 @@ import psutil
 from dagster_shell.utils import execute
 
 from dagster import repository
-from dagster._core.storage.pipeline_run import PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import instance_for_test, poll_for_finished_run, poll_for_step_start
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import PythonFileTarget
@@ -78,7 +78,7 @@ def test_terminate_kills_subproc():
 
             run_id = pipeline_run.run_id
 
-            assert instance.get_run_by_id(run_id).status == PipelineRunStatus.NOT_STARTED
+            assert instance.get_run_by_id(run_id).status == DagsterRunStatus.NOT_STARTED
 
             instance.launch_run(pipeline_run.run_id, workspace)
 
@@ -96,7 +96,7 @@ def test_terminate_kills_subproc():
 
             terminated_pipeline_run = poll_for_finished_run(instance, run_id, timeout=30)
             terminated_pipeline_run = instance.get_run_by_id(run_id)
-            assert terminated_pipeline_run.status == PipelineRunStatus.CANCELED
+            assert terminated_pipeline_run.status == DagsterRunStatus.CANCELED
 
             # make sure the subprocess is killed after a short delay
             time.sleep(0.5)

--- a/python_modules/libraries/dagstermill/dagstermill/manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill/manager.py
@@ -29,7 +29,7 @@ from dagster._core.execution.resources_init import (
     resource_initialization_event_generator,
 )
 from dagster._core.instance import DagsterInstance
-from dagster._core.storage.pipeline_run import DagsterRun, PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.utils import make_new_run_id
 from dagster._legacy import Materialization, ModeDefinition, PipelineDefinition
@@ -273,7 +273,7 @@ class Manager:
             run_config=run_config,
             mode=mode_def.name,
             step_keys_to_execute=None,
-            status=PipelineRunStatus.NOT_STARTED,
+            status=DagsterRunStatus.NOT_STARTED,
             tags=None,
         )
 

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_manager.py
@@ -14,7 +14,7 @@ from dagster import AssetMaterialization, ResourceDefinition
 from dagster import _check as check
 from dagster._core.definitions.dependency import NodeHandle
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
-from dagster._core.storage.pipeline_run import PipelineRun, PipelineRunStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus, PipelineRun
 from dagster._core.test_utils import instance_for_test
 from dagster._core.utils import make_new_run_id
 from dagster._legacy import ModeDefinition
@@ -49,7 +49,7 @@ def in_job_manager(
                 mode=mode or "default",
                 run_config=None,
                 step_keys_to_execute=None,
-                status=PipelineRunStatus.NOT_STARTED,
+                status=DagsterRunStatus.NOT_STARTED,
             )
         )
 


### PR DESCRIPTION
### Summary & Motivation

This is a simple repo-wide conversion of all instances of `PipelineRunStatus` -> `DagsterRunStatus`. They were already aliases of one another.

### How I Tested These Changes

Existing BK tests.
