### PR TITLE
[dagit] Fix possible null state when asset job partitions page is loading

### DIFF
--- a/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
@@ -71,7 +71,7 @@ export const AssetJobPartitionsView: React.FC<{
     dimensionIdx = 0; // may as well show something
   }
 
-  const dimension = merged.dimensions[dimensionIdx];
+  const dimension = merged.dimensions[dimensionIdx] ? merged.dimensions[dimensionIdx] : null;
   const dimensionKeys = dimension?.partitionKeys || [];
 
   const selectedDimensionKeys = dimensionKeys.slice(
@@ -108,7 +108,7 @@ export const AssetJobPartitionsView: React.FC<{
         <div {...containerProps}>
           <PartitionStatus
             partitionNames={dimensionKeys}
-            splitPartitions={!isTimeseriesDimension(dimension)}
+            splitPartitions={dimension ? !isTimeseriesDimension(dimension) : false}
             partitionStateForKey={(key) => merged.stateForSingleDimension(dimensionIdx, key)}
             selected={selectedDimensionKeys}
             selectionWindowSize={pageSize}
@@ -143,7 +143,7 @@ export const AssetJobPartitionsView: React.FC<{
         pipelineName={pipelineName}
         partitionSetName={partitionSetName}
         multidimensional={(merged?.dimensions.length || 0) > 1}
-        dimensionName={dimension?.name}
+        dimensionName={dimension ? dimension.name : null}
         dimensionKeys={dimensionKeys}
         selected={selectedDimensionKeys}
         offset={offset}
@@ -172,7 +172,7 @@ export const AssetJobPartitionGraphs: React.FC<{
   pipelineName: string;
   partitionSetName: string;
   multidimensional: boolean;
-  dimensionName: string;
+  dimensionName: string | null;
   dimensionKeys: string[];
   selected: string[];
   pageSize: number;


### PR DESCRIPTION
### Summary & Motivation

This addresses the crash spotted on Slack and in the stack trace here: https://app.datadoghq.com/rum/explorer?query=%40issue.id%3A1ffe4138-71cb-11ed-b398-da7ad0900002%20%40type%3Aerror&cols=&index=&issueId=1ffe4138-71cb-11ed-b398-da7ad0900002&viz=stream_issues&from_ts=1669935332000&to_ts=1669935392000&live=false.

### How I Tested These Changes

This error happened because TypeScript doesn't see that `array[index]` could possibly be undefined, and fails to typecheck use of the returned object downstream. I changed the array retrieval so that the "null" state is explicit and fixed the type errors. I think this is a pretty reliable way to fix this.
