### PR TITLE
Remove dagster pin from automation

### DIFF
--- a/python_modules/automation/setup.py
+++ b/python_modules/automation/setup.py
@@ -18,7 +18,6 @@ setup(
     ],
     packages=find_packages(exclude=["automation_tests*"]),
     install_requires=[
-        "dagster==0+dev",
         "autoflake",
         "boto3",
         "packaging>=20.9",


### PR DESCRIPTION
Summary:
this package doesn't depend on dagster, and certainly not a specfic version of dagster, so remove the dependency.

### Summary & Motivation

### How I Tested These Changes
