### PR TITLE
Install dagster in an extra

### DIFF
--- a/python_modules/automation/setup.py
+++ b/python_modules/automation/setup.py
@@ -18,7 +18,6 @@ setup(
     ],
     packages=find_packages(exclude=["automation_tests*"]),
     install_requires=[
-        "dagster==0+dev",
         "autoflake",
         "boto3",
         "packaging>=20.9",
@@ -30,6 +29,11 @@ setup(
         "wheel==0.33.6",
         "urllib3",
     ],
+    extras_require={
+        "buildkite": [
+            "dagster==0+dev",  # Support buildkite conditional running of tests
+        ]
+    },
     entry_points={
         "console_scripts": [
             "dagster-image = automation.docker.cli:main",


### PR DESCRIPTION
We need this to conditionally run/skip tests correctly.

But we don't want this actual pin because it breaks our releases.

### Summary & Motivation

### How I Tested These Changes
