### PR TITLE
make Node an abstract class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -34,6 +34,7 @@ from dagster._core.types.dagster_type import (
 
 from .dependency import (
     DependencyStructure,
+    GraphNode,
     IDependencyDefinition,
     Node,
     NodeHandle,
@@ -343,7 +344,7 @@ class GraphDefinition(NodeDefinition):
     ) -> Iterator[NodeHandle]:
         for node in self.node_dict.values():
             cur_node_handle = NodeHandle(node.name, parent_node_handle)
-            if node.is_graph:
+            if isinstance(node, GraphNode):
                 graph_def = node.definition.ensure_graph_def()
                 yield from graph_def.iterate_node_handles(cur_node_handle)
             yield cur_node_handle

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -55,7 +55,7 @@ from dagster._utils import merge_dicts
 
 from .asset_layer import AssetLayer, build_asset_selection_job
 from .config import ConfigMapping
-from .dependency import DependencyDefinition
+from .dependency import DependencyDefinition, GraphNode
 from .executor_definition import ExecutorDefinition, multi_or_in_process_executor
 from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .hook_definition import HookDefinition
@@ -753,9 +753,12 @@ def get_subselected_graph_definition(
 
         # rebuild graph if any nodes inside the graph are selected
         definition: Union[SubselectedGraphDefinition, NodeDefinition]
-        if node.is_graph and resolved_op_selection_dict[node.name] is not LeafNodeSelection:
+        if (
+            isinstance(node, GraphNode)
+            and resolved_op_selection_dict[node.name] is not LeafNodeSelection
+        ):
             definition = get_subselected_graph_definition(
-                cast(GraphDefinition, node.definition),  # guaranteed by node.is_graph
+                node.definition,
                 resolved_op_selection_dict[node.name],
                 parent_handle=node_handle,
             )

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -32,6 +32,7 @@ from .dependency import (
     DependencyDefinition,
     DependencyStructure,
     DynamicCollectDependencyDefinition,
+    GraphNode,
     IDependencyDefinition,
     MultiDependencyDefinition,
     Node,
@@ -768,7 +769,7 @@ def _get_pipeline_subset_def(
 def _iterate_all_nodes(root_node_dict: Mapping[str, Node]) -> Iterator[Node]:
     for node in root_node_dict.values():
         yield node
-        if node.is_graph:
+        if isinstance(node, GraphNode):
             yield from _iterate_all_nodes(node.definition.ensure_graph_def().node_dict)
 
 

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -25,7 +25,7 @@ from dagster._utils import check
 
 from .configurable import ConfigurableDefinition
 from .definition_config_schema import IDefinitionConfigSchema
-from .dependency import DependencyStructure, Node, NodeHandle, NodeInput
+from .dependency import DependencyStructure, GraphNode, Node, NodeHandle, NodeInput
 from .graph_definition import GraphDefinition
 from .logger_definition import LoggerDefinition
 from .mode import ModeDefinition
@@ -137,7 +137,7 @@ def define_run_config_schema_type(creation_data: RunConfigSchemaCreationData) ->
         )
     )
 
-    top_level_node = Node(
+    top_level_node = GraphNode(
         name=creation_data.graph_def.name,
         definition=creation_data.graph_def,
         graph_definition=creation_data.graph_def,

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -17,9 +17,9 @@ from dagster import (
 )
 from dagster import _check as check
 from dagster import reconstructable
-from dagster._core.definitions import Node
-from dagster._core.definitions.dependency import DependencyStructure
-from dagster._core.definitions.graph_definition import _create_adjacency_lists
+from dagster._core.definitions.dependency import DependencyStructure, OpNode
+from dagster._core.definitions.graph_definition import GraphDefinition, _create_adjacency_lists
+from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.errors import DagsterExecutionStepNotFoundError, DagsterInvariantViolationError
 from dagster._core.execution.results import OpExecutionResult
 from dagster._core.instance import DagsterInstance
@@ -80,13 +80,13 @@ def make_compute_fn():
     return compute
 
 
-def _do_construct(solids, dependencies):
-    pipeline_def = PipelineDefinition(name="test", solid_defs=solids, dependencies=dependencies)
-    solids = {
-        s.name: Node(name=s.name, definition=s, graph_definition=pipeline_def.graph) for s in solids
-    }
-    dependency_structure = DependencyStructure.from_definitions(solids, dependencies)
-    return _create_adjacency_lists(list(solids.values()), dependency_structure)
+def _do_construct(ops, dependencies):
+    job_def = JobDefinition(
+        graph_def=GraphDefinition(name="test", node_defs=ops, dependencies=dependencies)
+    )
+    ops = {s.name: OpNode(name=s.name, definition=s, graph_definition=job_def.graph) for s in ops}
+    dependency_structure = DependencyStructure.from_definitions(ops, dependencies)
+    return _create_adjacency_lists(list(ops.values()), dependency_structure)
 
 
 def test_empty_adjaceny_lists():


### PR DESCRIPTION
### Summary & Motivation

Make `Node` an abstract class and create subclasses `OpNode` and `GraphNode`. This eliminates static-analysis-unfriendly `node.is_graph` checks in favor of `isinstance(node, GraphNode)`.

### How I Tested These Changes

Existing BK tests.
