### PR TITLE
enforce multiasset topological order

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -586,6 +586,9 @@ class AssetLayer:
         )
         return self._asset_deps[asset_key]
 
+    def downstream_assets_for_asset(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
+        return {k for k, v in self._asset_deps.items() if asset_key in v}
+
     @property
     def dependency_node_handles_by_asset_key(self) -> Mapping[AssetKey, AbstractSet[NodeHandle]]:
         return self._dependency_node_handles_by_asset_key
@@ -605,6 +608,9 @@ class AssetLayer:
     @property
     def has_assets_defs(self) -> bool:
         return len(self.assets_defs_by_key) > 0
+
+    def has_assets_def_for_asset(self, asset_key: AssetKey) -> bool:
+        return asset_key in self.assets_defs_by_key
 
     def assets_def_for_asset(self, asset_key: AssetKey) -> "AssetsDefinition":
         return self._assets_defs_by_key[asset_key]

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -2199,7 +2199,8 @@ def _get_assets_defs(use_multi: bool = False, allow_subset: bool = False):
         b = 1
         c = b + 1
         out_values = {"a": a, "b": b, "c": c}
-        outputs_to_return = context.selected_output_names if allow_subset else "abc"
+        # Alphabetical order matches topological order here
+        outputs_to_return = sorted(context.selected_output_names) if allow_subset else "abc"
         for output_name in outputs_to_return:
             yield Output(out_values[output_name], output_name)
 
@@ -2233,7 +2234,8 @@ def _get_assets_defs(use_multi: bool = False, allow_subset: bool = False):
         e = (c + 1) if c else None
         f = (d + e) if d and e else None
         out_values = {"d": d, "e": e, "f": f}
-        outputs_to_return = context.selected_output_names if allow_subset else "def"
+        # Alphabetical order matches topological order here
+        outputs_to_return = sorted(context.selected_output_names) if allow_subset else "def"
         for output_name in outputs_to_return:
             yield Output(out_values[output_name], output_name)
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize.py
@@ -255,8 +255,8 @@ def test_materialize_multi_asset():
         },
     )
     def multi_asset_with_internal_deps(thing):
-        yield Output(1, "my_out_name")
         yield Output(2, "my_other_out_name")
+        yield Output(1, "my_out_name")
 
     with instance_for_test() as instance:
         result = materialize([thing_asset, multi_asset_with_internal_deps], instance=instance)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize_to_memory.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize_to_memory.py
@@ -232,8 +232,8 @@ def test_materialize_multi_asset():
         },
     )
     def multi_asset_with_internal_deps(thing):
-        yield Output(1, "my_out_name")
         yield Output(2, "my_other_out_name")
+        yield Output(1, "my_out_name")
 
     result = materialize_to_memory([thing_asset, multi_asset_with_internal_deps])
     assert result.success

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -126,7 +126,7 @@ def _get_assets_defs(use_multi: bool = False, allow_subset: bool = False):
         b = 1
         c = b + 1
         out_values = {"a": a, "b": b, "c": c}
-        outputs_to_return = context.selected_output_names if allow_subset else "abc"
+        outputs_to_return = sorted(context.selected_output_names) if allow_subset else "abc"
         for output_name in outputs_to_return:
             yield Output(out_values[output_name], output_name)
 
@@ -160,7 +160,7 @@ def _get_assets_defs(use_multi: bool = False, allow_subset: bool = False):
         e = (c + 1) if c else None
         f = (d + e) if d and e else None
         out_values = {"d": d, "e": e, "f": f}
-        outputs_to_return = context.selected_output_names if allow_subset else "def"
+        outputs_to_return = sorted(context.selected_output_names) if allow_subset else "def"
         for output_name in outputs_to_return:
             yield Output(out_values[output_name], output_name)
 


### PR DESCRIPTION
### Summary & Motivation

This adds a check during step execution to ensure multiassets yield their constituent assets in topological order.

Without this check, the data version calculation is unreliable.

### How I Tested These Changes

New unit tests.
