### PR TITLE
use logical version machinery when calculating data time

### DIFF
--- a/python_modules/dagster/dagster/_core/event_api.py
+++ b/python_modules/dagster/dagster/_core/event_api.py
@@ -3,7 +3,7 @@ from typing import Mapping, NamedTuple, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._annotations import PublicAttr
-from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.events import AssetKey, AssetMaterialization
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.events import DagsterEventType
 from dagster._core.events.log import EventLogEntry
@@ -51,6 +51,19 @@ class EventLogRecord(NamedTuple):
         dagster_event = self.event_log_entry.dagster_event
         if dagster_event:
             return dagster_event.partition
+
+        return None
+
+    @property
+    def asset_materialization(self) -> Optional[AssetMaterialization]:
+        dagster_event = self.event_log_entry.dagster_event
+        if (
+            dagster_event
+            and dagster_event.event_type_value == DagsterEventType.ASSET_MATERIALIZATION
+        ):
+            materialization = dagster_event.step_materialization_data.materialization
+            if isinstance(materialization, AssetMaterialization):
+                return materialization
 
         return None
 

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -5,7 +5,10 @@ from typing import TYPE_CHECKING, AbstractSet, Dict, Iterable, Mapping, Optional
 import dagster._check as check
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.logical_version import get_input_event_pointer_tag_key
 from dagster._core.errors import DagsterInvariantViolationError
+from dagster._core.event_api import EventRecordsFilter
+from dagster._core.events import DagsterEventType
 from dagster._core.storage.event_log import EventLogRecord, SqlEventLogStorage
 from dagster._core.storage.event_log.sql_event_log import AssetEventTagsTable
 from dagster._core.storage.pipeline_run import (
@@ -15,6 +18,7 @@ from dagster._core.storage.pipeline_run import (
     RunsFilter,
 )
 from dagster._core.storage.tags import PARTITION_NAME_TAG
+from dagster._core.utils import frozendict
 from dagster._utils.cached_method import cached_method
 from dagster._utils.merger import merge_dicts
 
@@ -87,8 +91,6 @@ class CachingInstanceQueryer:
 
     @cached_method
     def _get_planned_materializations_for_run(self, run_id: str) -> AbstractSet[AssetKey]:
-        from dagster._core.events import DagsterEventType
-
         materializations_planned = self._instance.get_records_for_run(
             run_id=run_id,
             of_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
@@ -102,8 +104,6 @@ class CachingInstanceQueryer:
         after_cursor: Optional[int] = None,
         before_cursor: Optional[int] = None,
     ) -> Optional[EventLogRecord]:
-        from dagster import DagsterEventType, EventRecordsFilter
-
         records = self._instance.get_event_records(
             EventRecordsFilter(
                 event_type=DagsterEventType.ASSET_MATERIALIZATION,
@@ -271,6 +271,7 @@ class CachingInstanceQueryer:
         asset_key: AssetKey,
         record_id: Optional[int],
         record_timestamp: Optional[float],
+        record_tags: Mapping[str, str],
         required_keys: AbstractSet[AssetKey],
     ) -> Dict[AssetKey, Tuple[Optional[int], Optional[float]]]:
 
@@ -299,20 +300,31 @@ class CachingInstanceQueryer:
                     if upstream_key in unknown_required_keys:
                         upstream_required_keys.add(upstream_key)
 
-                # get the most recent asset materialization for this parent which happened before
-                # the current record
-                latest_parent_record = self.get_latest_materialization_record(
-                    parent_key, before_cursor=record_id
-                )
+                input_event_pointer_tag = get_input_event_pointer_tag_key(parent_key)
+                if input_event_pointer_tag in record_tags:
+                    # get the asset materialization record that was calculated using the logical
+                    # version machinery
+                    input_record_id = int(record_tags[input_event_pointer_tag])
+                    parent_record = self.get_latest_materialization_record(
+                        parent_key, before_cursor=input_record_id + 1
+                    )
+                else:
+                    # if logical version information was not recorded for this record, get the most
+                    # recent asset materialization for this parent which happened before the
+                    # current record
+                    parent_record = self.get_latest_materialization_record(
+                        parent_key, before_cursor=record_id
+                    )
 
                 # recurse to find the data times of this parent
                 for key, tup in self.calculate_used_data(
                     asset_graph=asset_graph,
                     asset_key=parent_key,
-                    record_id=latest_parent_record.storage_id if latest_parent_record else None,
-                    record_timestamp=latest_parent_record.event_log_entry.timestamp
-                    if latest_parent_record
+                    record_id=parent_record.storage_id if parent_record else None,
+                    record_timestamp=parent_record.event_log_entry.timestamp
+                    if parent_record
                     else None,
+                    record_tags=_extract_tags(parent_record),
                     required_keys=frozenset(upstream_required_keys),
                 ).items():
                     # if root data is missing, this overrides other values
@@ -349,6 +361,7 @@ class CachingInstanceQueryer:
             asset_key=record.asset_key,
             record_id=record.storage_id,
             record_timestamp=record.event_log_entry.timestamp,
+            record_tags=_extract_tags(record),
             required_keys=frozenset(upstream_keys),
         )
         self.set_known_used_data(record, new_known_data=data)
@@ -383,3 +396,19 @@ class CachingInstanceQueryer:
             used_data_times=used_data_times,
             available_data_times={key: evaluation_time for key in used_data_times},
         )
+
+
+def _extract_tags(record: Optional[EventLogRecord]) -> Mapping[str, str]:
+    if record is None:
+        return frozendict()
+    dagster_event = record.event_log_entry.dagster_event
+    if dagster_event is None:
+        raise DagsterInvariantViolationError(
+            "Attempted to extract tags from record with no dagster event."
+        )
+    if dagster_event.event_type_value != DagsterEventType.ASSET_MATERIALIZATION:
+        raise DagsterInvariantViolationError(
+            "Attempted to extract tags from record with dagster event of type "
+            f"{dagster_event.event_type_value}."
+        )
+    return frozendict(dagster_event.step_materialization_data.materialization.tags or {})

--- a/python_modules/dagster/dagster_tests/utils_tests/test_calculate_materialization_times.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_calculate_materialization_times.py
@@ -1,6 +1,7 @@
 import datetime
 from collections import defaultdict
 
+import mock
 import pytest
 
 from dagster import (
@@ -8,6 +9,7 @@ from dagster import (
     AssetOut,
     AssetSelection,
     DagsterEventType,
+    DagsterInstance,
     Output,
     asset,
     multi_asset,
@@ -15,10 +17,10 @@ from dagster import (
 )
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_layer import build_asset_selection_job
-from dagster._core.test_utils import instance_for_test
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 
+@pytest.mark.parametrize("ignore_asset_tags", [True, False])
 @pytest.mark.parametrize(
     ["relative_to", "runs_to_expected_data_times_index"],
     [
@@ -92,7 +94,9 @@ from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
         ),
     ],
 )
-def test_caching_instance_queryer(relative_to, runs_to_expected_data_times_index):
+def test_caching_instance_queryer(
+    ignore_asset_tags, relative_to, runs_to_expected_data_times_index
+):
     """
     A = B = D = F
      \\  //
@@ -144,7 +148,7 @@ def test_caching_instance_queryer(relative_to, runs_to_expected_data_times_index
             return {key}
         return set().union(*(_get_root_keys(upstream_key) for upstream_key in upstream_keys))
 
-    with instance_for_test() as instance:
+    with DagsterInstance.ephemeral() as instance:
 
         # mapping from asset key to a mapping of materialization timestamp to run index
         materialization_times_index = defaultdict(dict)
@@ -187,11 +191,23 @@ def test_caching_instance_queryer(relative_to, runs_to_expected_data_times_index
                         relevant_upstream_keys = {AssetKey(ak)}
                     else:
                         relevant_upstream_keys = {AssetKey(u) for u in relative_to}
-                    upstream_data_times = data_time_queryer.get_used_data_times_for_record(
-                        asset_graph=asset_graph,
-                        record=latest_asset_record,
-                        upstream_keys=relevant_upstream_keys,
-                    )
+                    if ignore_asset_tags:
+                        # simulate an environment where materialization tags were not populated
+                        with mock.patch(
+                            "dagster.AssetMaterialization.tags", new_callable=mock.PropertyMock
+                        ) as tags_property:
+                            tags_property.return_value = None
+                            upstream_data_times = data_time_queryer.get_used_data_times_for_record(
+                                asset_graph=asset_graph,
+                                record=latest_asset_record,
+                                upstream_keys=relevant_upstream_keys,
+                            )
+                    else:
+                        upstream_data_times = data_time_queryer.get_used_data_times_for_record(
+                            asset_graph=asset_graph,
+                            record=latest_asset_record,
+                            upstream_keys=relevant_upstream_keys,
+                        )
                     assert upstream_data_times == {
                         AssetKey(k): materialization_times_index[AssetKey(k)][v]
                         for k, v in expected_data_times.items()


### PR DESCRIPTION
### Summary & Motivation

We have a more accurate way of calculating the upstream materialization for a given materialization, so let's use it!

If the data does not exist in the tags, defaults to old behavior. In theory, this should only happen when you're reading a record that was created pre-1.1.0.

The _extract_tags function is basically just there to make mypy happy, but helps to have a bit more invariant checking I suppose.

### How I Tested These Changes
