### PR TITLE
[dagit] Clean up leftover escaping in plaintext from markdown

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/markdownToPlaintext.test.ts
+++ b/js_modules/dagit/packages/core/src/ui/markdownToPlaintext.test.ts
@@ -1,0 +1,26 @@
+import {markdownToPlaintext} from './markdownToPlaintext';
+
+describe('markdownToPlaintext', () => {
+  it('correctly converts markdown to plaintext', () => {
+    expect(markdownToPlaintext('lorem ipsum')).toBe('lorem ipsum');
+    expect(markdownToPlaintext('## lorem ipsum')).toBe('lorem ipsum');
+    expect(markdownToPlaintext('- lorem ipsum')).toBe('lorem ipsum');
+    expect(
+      markdownToPlaintext(
+        `# Hello World
+- a list of things
+  - with indentation`,
+      ),
+    ).toBe(
+      `Hello World
+a list of things
+with indentation`,
+    );
+  });
+
+  it('does not leave any escaping charaters lying around', () => {
+    expect(markdownToPlaintext('The S&P 500')).toBe('The S&P 500');
+    expect(markdownToPlaintext('"Don\'t quote me on that"')).toBe('"Don\'t quote me on that"');
+    expect(markdownToPlaintext('underscore _ and _ stuff')).toBe('underscore _ and _ stuff');
+  });
+});

--- a/js_modules/dagit/packages/core/src/ui/markdownToPlaintext.ts
+++ b/js_modules/dagit/packages/core/src/ui/markdownToPlaintext.ts
@@ -13,7 +13,10 @@ export const markdownToPlaintext = (md: string) => {
   if (cached) {
     return cached;
   }
-  const str = Remark.processSync(md).toString();
+
+  // Clean up escaping left behind.
+  const str = Remark.processSync(md).toString().replaceAll(/\\/g, '').trim();
   markdownCache.set(md, str);
+
   return str;
 };


### PR DESCRIPTION
### Summary & Motivation

Resolves #10331.

The remark plugin that converts markdown to plaintext leaves some escpaing backslashes behind. We don't need them for the plain string, so remove them.

### How I Tested These Changes

Modify an asset description to have `_ &asdf` as part of its text, load asset graph. Verify that the undescore and ampersand are not escaped in the rendered string.

Wrote a test for this as well.
