### PR TITLE
[dagit] Min width on asset key column in catalog table

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -134,7 +134,9 @@ export const AssetTable = ({
                 }}
               />
             </th>
-            <th>{view === 'directory' ? 'Asset Key Prefix' : 'Asset Key'}</th>
+            <th style={{minWidth: 300}}>
+              {view === 'directory' ? 'Asset key prefix' : 'Asset key'}
+            </th>
             <th style={{width: 340}}>Defined in</th>
             <th style={{width: 265}}>Materialized</th>
             <th style={{width: 215}}>Latest run</th>


### PR DESCRIPTION
### Summary & Motivation

Resolves #9986.

Apply a min width on the asset key column in the asset catalog table.

### How I Tested These Changes

View asset catalog, modify viewport to see table shrink/expand, verify that the asset key column behaves correctly.
