### PR TITLE
Added instructions to open a new file in graph assets tutorial

### DIFF
--- a/docs/content/tutorial/assets/asset-graph.mdx
+++ b/docs/content/tutorial/assets/asset-graph.mdx
@@ -18,6 +18,8 @@ Why split up code into multiple assets? There are a few reasons:
 
 Having defined a dataset of cereals, we'll define a downstream asset that contains only the cereals that are manufactured by Nabisco.
 
+Let's save it as `serial_asset_graph.py`.
+
 ```python file=/guides/dagster/asset_tutorial/serial_asset_graph.py
 import csv
 


### PR DESCRIPTION
### Summary & Motivation
Adding a bit more clarity into the asset-graph part of the tutorial in terms of the location on the code.
Adding "Let's save it as `serial_asset_graph.py`." to tell the user where to store the 
Run make mdx-format as well
### How I Tested These Changes
Ran next-dev-install
Ran make next-watch-build

<img width="867" alt="Screenshot 2022-12-02 at 3 32 19 PM" src="https://user-images.githubusercontent.com/118383272/205380869-f48c224b-464a-4345-bc7a-a4203fba6e24.png">

