### PR TITLE
Remove unneeded pin

### DIFF
--- a/python_modules/automation/setup.py
+++ b/python_modules/automation/setup.py
@@ -31,7 +31,7 @@ setup(
     ],
     extras_require={
         "buildkite": [
-            "dagster==0+dev",  # Support buildkite conditional running of tests
+            "dagster",  # Support buildkite conditional running of tests
         ]
     },
     entry_points={


### PR DESCRIPTION
In our haste to fix the release 1.1.5, I didn't remove the unnecessary pin in:

https://github.com/dagster-io/dagster/pull/10855
