### PR TITLE
Pin apache-airlfow < 2.5.0

### DIFF
--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -45,7 +45,7 @@ setup(
     extras_require={
         "kubernetes": ["kubernetes>=3.0.0", "cryptography>=2.0.0"],
         "test_airflow_2": [
-            "apache-airflow>=2.0.0,<3.0.0",
+            "apache-airflow>=2.0.0,<2.5.0",
             "boto3>=1.26.7",
             "kubernetes>=10.0.1",
             "apache-airflow-providers-docker>=3.2.0,<4",


### PR DESCRIPTION
Our dagster-airflow tests have been breaking since Airflow 2.5.0 was released this afternoon.

This temporarily pins the package to get our builds passing again - and we'll remove the pin (ideally before our next release).
