### PR TITLE
Check scheduler ticks right after each minute boundary instead of once every 5 seconds

### DIFF
--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -254,6 +254,10 @@ def execute_sensor_iteration_loop(
                 sensor_state_lock=sensor_state_lock,
                 log_verbose_checks=verbose_logs_iteration,
             )
+            # Yield to check for heartbeats in case there were no yields within
+            # execute_sensor_iteration
+            yield None
+
             end_time = pendulum.now("UTC").timestamp()
 
             if verbose_logs_iteration:
@@ -262,7 +266,6 @@ def execute_sensor_iteration_loop(
             loop_duration = end_time - start_time
             sleep_time = max(0, MIN_INTERVAL_LOOP_TIME - loop_duration)
             time.sleep(sleep_time)
-            yield None
 
 
 def execute_sensor_iteration(

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_utils.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_utils.py
@@ -1,0 +1,15 @@
+MINUTE_BOUNDARY = 1670596320
+
+from dagster._scheduler.scheduler import _get_next_scheduler_iteration_time
+
+
+def test_next_iteration_time():
+
+    assert MINUTE_BOUNDARY % 60 == 0
+
+    assert _get_next_scheduler_iteration_time(MINUTE_BOUNDARY) == MINUTE_BOUNDARY + 60
+    assert _get_next_scheduler_iteration_time(MINUTE_BOUNDARY + 0.01) == MINUTE_BOUNDARY + 60
+    assert _get_next_scheduler_iteration_time(MINUTE_BOUNDARY + 30) == MINUTE_BOUNDARY + 60
+    assert _get_next_scheduler_iteration_time(MINUTE_BOUNDARY + 59.99) == MINUTE_BOUNDARY + 60
+
+    assert _get_next_scheduler_iteration_time(MINUTE_BOUNDARY + 60) == MINUTE_BOUNDARY + 120


### PR DESCRIPTION
Summary:
A user reported that they were seeing between 1 and 6 seconds of latency when running the scheduler even when running a single simple schedule - this probably stems from our 5 second sleep interval. We have a simple tweak that we can do to try to maximize the chance that a tick will happen right after a 5-second boundary window.

The other change here is to include work that happens outside of the iterator in the timer (e.g. writing the heartbeat), which I did for sensors as well.

Test Plan:
Existing scheduler/sensor suite
Locally, run scheduler with a time.sleep(1) inside the heartbeat write function - see that ticks still happen every 5 seconds instead of every 6 seconds

### Summary & Motivation

### How I Tested These Changes
