### PR TITLE
[Definitions] Enable providing UnresolvedAssetJobDefinitions to Definitions object

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -16,6 +16,7 @@ from .repository_definition import (
 from .resource_definition import ResourceDefinition
 from .schedule_definition import ScheduleDefinition
 from .sensor_definition import SensorDefinition
+from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 
 
 @experimental
@@ -27,7 +28,7 @@ class Definitions:
         ] = None,
         schedules: Optional[Iterable[ScheduleDefinition]] = None,
         sensors: Optional[Iterable[SensorDefinition]] = None,
-        jobs: Optional[Iterable[JobDefinition]] = None,
+        jobs: Optional[Iterable[Union[JobDefinition, UnresolvedAssetJobDefinition]]] = None,
         resources: Optional[Mapping[str, Any]] = None,
     ):
         """
@@ -77,7 +78,7 @@ class Definitions:
             check.iterable_param(sensors, "sensors", SensorDefinition)
 
         if jobs:
-            check.iterable_param(jobs, "jobs", JobDefinition)
+            check.iterable_param(jobs, "jobs", (JobDefinition, UnresolvedAssetJobDefinition))
 
         if resources:
             check.mapping_param(resources, "resources", key_type=str)

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions_class.py
@@ -50,6 +50,16 @@ def test_basic_asset():
     assert all_assets[0].key.to_user_string() == "an_asset"
 
 
+def test_basic_job_definition():
+    @asset
+    def an_asset():
+        pass
+
+    defs = Definitions(assets=[an_asset], jobs=[define_asset_job(name="an_asset_job")])
+
+    assert resolve_pending_repo_if_required(defs).get_job("an_asset_job")
+
+
 def test_basic_schedule_definition():
     @asset
     def an_asset():


### PR DESCRIPTION
## Summary

Allows the `jobs` param for the `Definitions` constructor to also accept `UnresolvedAssetJobDefinition`, since these can be passed along to the underlying `_Repository`.

## Test Plan

New unit test.