### PR TITLE
[dagit] Handle dunder repo name throughout Dagit

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGroupNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGroupNode.tsx
@@ -4,7 +4,7 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {withMiddleTruncation} from '../app/Util';
-import {buildRepoPath} from '../workspace/buildRepoAddress';
+import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 import {workspacePath} from '../workspace/workspacePath';
 
 import {MINIMAL_SCALE, GROUPS_ONLY_SCALE} from './AssetGraphExplorer';
@@ -50,9 +50,12 @@ export const AssetGroupNode: React.FC<{group: GroupLayout; scale: number}> = ({g
               </Link>
               {repositoryDisambiguationRequired && (
                 <GroupRepoName style={{marginBottom: '0.5em'}}>
-                  {withMiddleTruncation(buildRepoPath(repositoryName, repositoryLocationName), {
-                    maxLength: 45,
-                  })}
+                  {withMiddleTruncation(
+                    buildRepoPathForHuman(repositoryName, repositoryLocationName),
+                    {
+                      maxLength: 45,
+                    },
+                  )}
                 </GroupRepoName>
               )}
             </Box>
@@ -82,9 +85,12 @@ export const AssetGroupNode: React.FC<{group: GroupLayout; scale: number}> = ({g
             {groupName}
             {repositoryDisambiguationRequired && (
               <GroupRepoName>
-                {withMiddleTruncation(buildRepoPath(repositoryName, repositoryLocationName), {
-                  maxLength: 45,
-                })}
+                {withMiddleTruncation(
+                  buildRepoPathForHuman(repositoryName, repositoryLocationName),
+                  {
+                    maxLength: 45,
+                  },
+                )}
               </GroupRepoName>
             )}
           </Box>

--- a/js_modules/dagit/packages/core/src/assets/AssetDefinedInMultipleReposNotice.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetDefinedInMultipleReposNotice.tsx
@@ -4,8 +4,8 @@ import React from 'react';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
-import {buildRepoPath} from '../workspace/buildRepoAddress';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {AssetKey} from './types';
@@ -32,7 +32,7 @@ export const AssetDefinedInMultipleReposNotice: React.FC<{
   }
 
   const allReposWithAsset = collision.repositories.map((r) =>
-    repoAddressAsString({name: r.name, location: r.location.name}),
+    repoAddressAsHumanString({name: r.name, location: r.location.name}),
   );
 
   return (
@@ -45,8 +45,9 @@ export const AssetDefinedInMultipleReposNotice: React.FC<{
         title={MULTIPLE_DEFINITIONS_WARNING}
         description={
           <>
-            This asset was loaded from {buildRepoPath(loadedFromRepo.name, loadedFromRepo.location)}
-            , but duplicate definitions were found in{' '}
+            This asset was loaded from{' '}
+            {buildRepoPathForHuman(loadedFromRepo.name, loadedFromRepo.location)}, but duplicate
+            definitions were found in{' '}
             <ButtonLink
               underline="always"
               color={Colors.Yellow700}

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
@@ -23,7 +23,7 @@ import {AssetGroupSelector} from '../types/globalTypes';
 import {ClearButton} from '../ui/ClearButton';
 import {LoadingSpinner} from '../ui/Loading';
 import {StickyTableContainer} from '../ui/StickyTableContainer';
-import {buildRepoPath} from '../workspace/buildRepoAddress';
+import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 
 import {AssetTable, ASSET_TABLE_DEFINITION_FRAGMENT, ASSET_TABLE_FRAGMENT} from './AssetTable';
 import {AssetsEmptyState} from './AssetsEmptyState';
@@ -271,7 +271,10 @@ const AssetGroupSuggest: React.FC<{
               {assetGroup.groupName}
               {repoContextNeeded[assetGroup.groupName] ? (
                 <span style={{opacity: 0.5, paddingLeft: 4}}>
-                  {buildRepoPath(assetGroup.repositoryName, assetGroup.repositoryLocationName)}
+                  {buildRepoPathForHuman(
+                    assetGroup.repositoryName,
+                    assetGroup.repositoryLocationName,
+                  )}
                 </span>
               ) : undefined}
             </>

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -15,7 +15,7 @@ import {DagsterTag} from '../runs/RunTag';
 import {LaunchPipelineExecutionVariables} from '../runs/types/LaunchPipelineExecution';
 import {CONFIG_TYPE_SCHEMA_FRAGMENT} from '../typeexplorer/ConfigTypeSchema';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {ASSET_NODE_CONFIG_FRAGMENT} from './AssetConfig';
@@ -320,7 +320,7 @@ async function stateForLaunchingAssets(
     assets[0]?.repository.name || '',
     assets[0]?.repository.location.name || '',
   );
-  const repoName = repoAddressAsString(repoAddress);
+  const repoName = repoAddressAsHumanString(repoAddress);
 
   if (
     !assets.every(
@@ -502,7 +502,7 @@ export function buildAssetCollisionsAlert(data: LaunchAssetLoaderQuery) {
               <ul>
                 {collision.repositories.map((r, ridx) => (
                   <li key={ridx}>
-                    {repoAddressAsString({name: r.name, location: r.location.name})}
+                    {repoAddressAsHumanString({name: r.name, location: r.location.name})}
                   </li>
                 ))}
               </ul>

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetObservationButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetObservationButton.tsx
@@ -7,7 +7,7 @@ import {usePermissions} from '../app/Permissions';
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
 import {LaunchPipelineExecutionVariables} from '../runs/types/LaunchPipelineExecution';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 
 import {
   buildAssetCollisionsAlert,
@@ -135,7 +135,7 @@ async function stateForObservingAssets(
     assets[0]?.repository.name || '',
     assets[0]?.repository.location.name || '',
   );
-  const repoName = repoAddressAsString(repoAddress);
+  const repoName = repoAddressAsHumanString(repoAddress);
 
   if (
     !assets.every(

--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
@@ -34,7 +34,7 @@ import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {BulkActionStatus, RunStatus} from '../types/globalTypes';
 import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {workspacePathFromAddress, workspacePipelinePath} from '../workspace/workspacePath';
 
 import {BackfillPartitionsRequestedDialog} from './BackfillPartitionsRequestedDialog';
@@ -392,7 +392,9 @@ const BackfillTarget: React.FC<{
   const repoLink = (
     <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}} style={{fontSize: '12px'}}>
       <Icon name="repo" color={Colors.Gray400} />
-      <Link to={workspacePathFromAddress(repoAddress)}>{repoAddressAsString(repoAddress)}</Link>
+      <Link to={workspacePathFromAddress(repoAddress)}>
+        {repoAddressAsHumanString(repoAddress)}
+      </Link>
     </Box>
   );
 

--- a/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -25,7 +25,7 @@ import {ShortcutHandler} from '../app/ShortcutHandler';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment';
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {RepositorySelector} from '../types/globalTypes';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
@@ -162,7 +162,7 @@ const ConfigEditorPartitionPicker: React.FC<ConfigEditorPartitionPickerProps> = 
       },
     );
 
-    const sortOrderKey = `${SORT_ORDER_KEY_BASE}-${basePath}-${repoAddressAsString(
+    const sortOrderKey = `${SORT_ORDER_KEY_BASE}-${basePath}-${repoAddressAsHumanString(
       repoAddress,
     )}-${partitionSetName}`;
 

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -36,7 +36,7 @@ import {
 } from '../configeditor/ConfigEditorUtils';
 import {DagsterTag} from '../runs/RunTag';
 import {PipelineSelector, RepositorySelector} from '../types/globalTypes';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
@@ -658,7 +658,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
                 <Group direction="row" spacing={8} alignItems="center">
                   <Icon name="warning" color={Colors.Yellow500} />
                   <div>
-                    {repoAddressAsString(repoAddress)} has been manually refreshed, and this
+                    {repoAddressAsHumanString(repoAddress)} has been manually refreshed, and this
                     configuration may now be out of date.
                   </div>
                   <Button

--- a/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
@@ -9,7 +9,7 @@ import {DagsterTag} from '../runs/RunTag';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
 import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {LatestRunTag} from './LatestRunTag';
@@ -37,7 +37,7 @@ export function useJobNavMetadata(repoAddress: RepoAddress, pipelineName: string
         tags: [
           {
             key: DagsterTag.RepositoryLabelTag,
-            value: repoAddressAsString(repoAddress),
+            value: repoAddressAsHumanString(repoAddress),
           },
         ],
       },

--- a/js_modules/dagit/packages/core/src/nav/LatestRunTag.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LatestRunTag.tsx
@@ -10,7 +10,7 @@ import {DagsterTag} from '../runs/RunTag';
 import {RunTime, RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {RunStatus} from '../types/globalTypes';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {LatestRunTagQuery, LatestRunTagQueryVariables} from './types/LatestRunTagQuery';
@@ -30,7 +30,7 @@ export const LatestRunTag: React.FC<{pipelineName: string; repoAddress: RepoAddr
           tags: [
             {
               key: DagsterTag.RepositoryLabelTag,
-              value: repoAddressAsString(repoAddress),
+              value: repoAddressAsHumanString(repoAddress),
             },
           ],
         },

--- a/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.test.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import {TestProvider} from '../testing/TestProvider';
 import {LocationStateChangeEventType} from '../types/globalTypes';
 import {HIDDEN_REPO_KEYS} from '../workspace/WorkspaceContext';
+import {DUNDER_REPO_NAME} from '../workspace/buildRepoAddress';
 
 import {LeftNavRepositorySection} from './LeftNavRepositorySection';
 
@@ -29,6 +30,8 @@ describe('Repository options', () => {
   const repoOne = 'lorem';
   const locationTwo = 'bar';
   const repoTwo = 'foo';
+  const locationThree = 'abc_location';
+  const repoThree = DUNDER_REPO_NAME;
 
   afterEach(() => {
     window.localStorage.clear();
@@ -87,7 +90,7 @@ describe('Repository options', () => {
       }),
     };
 
-    const mocksWithTwo = {
+    const mocksWithThree = {
       Workspace: () => ({
         locationEntries: () => [
           {
@@ -102,6 +105,13 @@ describe('Repository options', () => {
               __typename: 'RepositoryLocation',
               name: locationTwo,
               repositories: [{name: repoTwo, pipelines: [...new Array(4)], assetGroups: []}],
+            },
+          },
+          {
+            locationOrLoadError: {
+              __typename: 'RepositoryLocation',
+              name: locationThree,
+              repositories: [{name: repoThree, pipelines: [...new Array(6)], assetGroups: []}],
             },
           },
         ],
@@ -155,7 +165,7 @@ describe('Repository options', () => {
       await act(async () => {
         render(
           <TestProvider
-            apolloProps={{mocks: [defaultMocks, mocksWithTwo]}}
+            apolloProps={{mocks: [defaultMocks, mocksWithThree]}}
             routerProps={{initialEntries: ['/runs']}}
           >
             <LeftNavRepositorySection />
@@ -167,22 +177,28 @@ describe('Repository options', () => {
       expect(loremHeader).toBeVisible();
       const fooHeader = screen.getByRole('button', {name: /foo/i});
       expect(fooHeader).toBeVisible();
+      const dunderHeader = screen.getByRole('button', {name: /abc_location/i});
+      expect(dunderHeader).toBeVisible();
 
       userEvent.click(loremHeader);
       userEvent.click(fooHeader);
+      userEvent.click(dunderHeader);
 
       await waitFor(() => {
-        // Six jobs total. No repo name link since multiple repos are visible.
-        expect(screen.queryAllByRole('link')).toHaveLength(6);
+        // Twelve jobs total. No repo name link since multiple repos are visible.
+        expect(screen.queryAllByRole('link')).toHaveLength(12);
       });
     });
 
     it('initializes with correct repo option, if `HIDDEN_REPO_KEYS` localStorage', async () => {
-      window.localStorage.setItem(HIDDEN_REPO_KEYS, '["lorem:ipsum"]');
+      window.localStorage.setItem(
+        HIDDEN_REPO_KEYS,
+        `["lorem:ipsum","${DUNDER_REPO_NAME}:abc_location"]`,
+      );
       await act(async () => {
         render(
           <TestProvider
-            apolloProps={{mocks: [defaultMocks, mocksWithTwo]}}
+            apolloProps={{mocks: [defaultMocks, mocksWithThree]}}
             routerProps={{initialEntries: ['/runs']}}
           >
             <LeftNavRepositorySection />
@@ -204,7 +220,7 @@ describe('Repository options', () => {
       await act(async () => {
         render(
           <TestProvider
-            apolloProps={{mocks: [defaultMocks, mocksWithTwo]}}
+            apolloProps={{mocks: [defaultMocks, mocksWithThree]}}
             routerProps={{initialEntries: ['/runs']}}
           >
             <LeftNavRepositorySection />
@@ -216,22 +232,28 @@ describe('Repository options', () => {
       expect(loremHeader).toBeVisible();
       const fooHeader = screen.getByRole('button', {name: /foo/i});
       expect(fooHeader).toBeVisible();
+      const dunderHeader = screen.getByRole('button', {name: /abc_location/i});
+      expect(dunderHeader).toBeVisible();
 
       userEvent.click(loremHeader);
       userEvent.click(fooHeader);
+      userEvent.click(dunderHeader);
 
       await waitFor(() => {
-        // Six jobs total. No repo name link since multiple repos are visible.
-        expect(screen.queryAllByRole('link')).toHaveLength(6);
+        // Twelve jobs total. No repo name link since multiple repos are visible.
+        expect(screen.queryAllByRole('link')).toHaveLength(12);
       });
     });
 
     it('initializes empty, if all items in `HIDDEN_REPO_KEYS` localStorage', async () => {
-      window.localStorage.setItem(HIDDEN_REPO_KEYS, '["lorem:ipsum", "foo:bar"]');
+      window.localStorage.setItem(
+        HIDDEN_REPO_KEYS,
+        `["lorem:ipsum", "foo:bar", "${DUNDER_REPO_NAME}:abc_location"]`,
+      );
       await act(async () => {
         render(
           <TestProvider
-            apolloProps={{mocks: [defaultMocks, mocksWithTwo]}}
+            apolloProps={{mocks: [defaultMocks, mocksWithThree]}}
             routerProps={{initialEntries: ['/runs']}}
           >
             <LeftNavRepositorySection />
@@ -243,6 +265,8 @@ describe('Repository options', () => {
       expect(loremHeader).toBeNull();
       const fooHeader = screen.queryByRole('button', {name: /foo/i});
       expect(fooHeader).toBeNull();
+      const dunderHeader = screen.queryByRole('button', {name: /abc_location/i});
+      expect(dunderHeader).toBeNull();
 
       // No linked jobs or repos. Everything is hidden.
       expect(screen.queryAllByRole('link')).toHaveLength(0);
@@ -275,7 +299,7 @@ describe('Repository options', () => {
       await act(async () => {
         rerender(
           <TestProvider
-            apolloProps={{mocks: [defaultMocks, mocksWithTwo]}}
+            apolloProps={{mocks: [defaultMocks, mocksWithThree]}}
             routerProps={{initialEntries: ['/runs']}}
           >
             <LeftNavRepositorySection />
@@ -287,13 +311,16 @@ describe('Repository options', () => {
       expect(loremHeader).toBeVisible();
       const fooHeader = screen.getByRole('button', {name: /foo/i});
       expect(fooHeader).toBeVisible();
+      const dunderHeader = screen.getByRole('button', {name: /abc_location/i});
+      expect(dunderHeader).toBeVisible();
 
       userEvent.click(loremHeader);
       userEvent.click(fooHeader);
+      userEvent.click(dunderHeader);
 
       // After repositories are added and expanded, all become visible.
       await waitFor(() => {
-        expect(screen.getAllByRole('link')).toHaveLength(6);
+        expect(screen.getAllByRole('link')).toHaveLength(12);
       });
     });
 

--- a/js_modules/dagit/packages/core/src/nav/RepoNavItem.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepoNavItem.tsx
@@ -17,8 +17,8 @@ import styled from 'styled-components/macro';
 
 import {usePermissions} from '../app/Permissions';
 import {ShortcutHandler} from '../app/ShortcutHandler';
-import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {buildRepoAddress, DUNDER_REPO_NAME} from '../workspace/buildRepoAddress';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
@@ -99,15 +99,16 @@ const SingleRepoSummary: React.FC<{repo: RepoSelectorOption; onlyRepo: boolean}>
   onlyRepo,
 }) => {
   const repoAddress = buildRepoAddress(repo.repository.name, repo.repositoryLocation.name);
+  const isDunder = repoAddress.name === DUNDER_REPO_NAME;
   const {canReloadRepositoryLocation} = usePermissions();
   return (
     <Group direction="row" spacing={4} alignItems="center">
       <SingleRepoNameLink
         to={workspacePathFromAddress(repoAddress)}
-        title={repoAddressAsString(repoAddress)}
+        title={repoAddressAsHumanString(repoAddress)}
         $onlyRepo={onlyRepo}
       >
-        {repoAddress.name}
+        {isDunder ? repoAddress.location : repoAddress.name}
       </SingleRepoNameLink>
       {canReloadRepositoryLocation.enabled ? (
         <ReloadRepositoryLocationButton location={repoAddress.location}>

--- a/js_modules/dagit/packages/core/src/nav/RepoSelector.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepoSelector.tsx
@@ -17,7 +17,7 @@ import styled from 'styled-components/macro';
 
 import {usePermissions} from '../app/Permissions';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
@@ -74,7 +74,7 @@ export const RepoSelector: React.FC<Props> = (props) => {
               location: option.repositoryLocation.name,
               name: option.repository.name,
             };
-            const addressString = repoAddressAsString(repoAddress);
+            const addressString = repoAddressAsHumanString(repoAddress);
             return (
               <tr key={addressString}>
                 <td>
@@ -92,8 +92,8 @@ export const RepoSelector: React.FC<Props> = (props) => {
                   <RepoLabel htmlFor={`switch-${addressString}`}>
                     <Group direction="column" spacing={4}>
                       <Box flex={{direction: 'row'}} title={addressString}>
+                        <RepoLocation>{repoAddress.location}</RepoLocation>
                         <RepoName>{repoAddress.name}</RepoName>
-                        <RepoLocation>{`@${repoAddress.location}`}</RepoLocation>
                       </Box>
                       <Group direction="column" spacing={2}>
                         {option.repository.displayMetadata.map(({key, value}) => (

--- a/js_modules/dagit/packages/core/src/nav/RepositoryLink.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepositoryLink.tsx
@@ -4,7 +4,7 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {usePermissions} from '../app/Permissions';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
@@ -17,7 +17,7 @@ export const RepositoryLink: React.FC<{
 }> = ({repoAddress, showIcon = false, showRefresh = true}) => {
   const {location} = repoAddress;
   const {canReloadRepositoryLocation} = usePermissions();
-  const repoString = repoAddressAsString(repoAddress);
+  const repoString = repoAddressAsHumanString(repoAddress);
 
   return (
     <Box flex={{display: 'inline-flex', direction: 'row', alignItems: 'center'}} title={repoString}>

--- a/js_modules/dagit/packages/core/src/overview/OverviewJobsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewJobsRoot.tsx
@@ -9,7 +9,7 @@ import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {RepoFilterButton} from '../instance/RepoFilterButton';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {OverviewJobsTable} from './OverviewJobsTable';
@@ -38,7 +38,7 @@ export const OverviewJobsRoot = () => {
   const repoBuckets = React.useMemo(() => {
     const visibleKeys = visibleRepoKeys(visibleRepos);
     return buildBuckets(data).filter(({repoAddress}) =>
-      visibleKeys.has(repoAddressAsString(repoAddress)),
+      visibleKeys.has(repoAddressAsHumanString(repoAddress)),
     );
   }, [data, visibleRepos]);
 

--- a/js_modules/dagit/packages/core/src/overview/OverviewJobsTable.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewJobsTable.tsx
@@ -7,7 +7,7 @@ import {findDuplicateRepoNames} from '../ui/findDuplicateRepoNames';
 import {useRepoExpansionState} from '../ui/useRepoExpansionState';
 import {VirtualizedJobHeader, VirtualizedJobRow} from '../workspace/VirtualizedJobRow';
 import {RepoRow} from '../workspace/VirtualizedWorkspaceTable';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {OVERVIEW_COLLAPSED_KEY} from './OverviewExpansionKey';
@@ -31,7 +31,7 @@ type RowType =
 export const OverviewJobsTable: React.FC<Props> = ({repos}) => {
   const parentRef = React.useRef<HTMLDivElement | null>(null);
   const allKeys = React.useMemo(
-    () => repos.map(({repoAddress}) => repoAddressAsString(repoAddress)),
+    () => repos.map(({repoAddress}) => repoAddressAsHumanString(repoAddress)),
     [repos],
   );
 
@@ -44,7 +44,7 @@ export const OverviewJobsTable: React.FC<Props> = ({repos}) => {
     const flat: RowType[] = [];
     repos.forEach(({repoAddress, jobs}) => {
       flat.push({type: 'header', repoAddress, jobCount: jobs.length});
-      const repoKey = repoAddressAsString(repoAddress);
+      const repoKey = repoAddressAsHumanString(repoAddress);
       if (expandedKeys.includes(repoKey)) {
         jobs.forEach(({isJob, name}) => {
           flat.push({type: 'job', repoAddress, isJob, name});
@@ -86,7 +86,7 @@ export const OverviewJobsTable: React.FC<Props> = ({repos}) => {
                   start={start}
                   onToggle={onToggle}
                   onToggleAll={onToggleAll}
-                  expanded={expandedKeys.includes(repoAddressAsString(row.repoAddress))}
+                  expanded={expandedKeys.includes(repoAddressAsHumanString(row.repoAddress))}
                   showLocation={duplicateRepoNames.has(row.repoAddress.name)}
                   rightElement={
                     <Tooltip

--- a/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
@@ -24,7 +24,7 @@ import {UnloadableSchedules} from '../instigation/Unloadable';
 import {SchedulerInfo} from '../schedules/SchedulerInfo';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {OverviewScheduleTable} from './OverviewSchedulesTable';
@@ -52,7 +52,7 @@ export const OverviewSchedulesRoot = () => {
   const repoBuckets = React.useMemo(() => {
     const visibleKeys = visibleRepoKeys(visibleRepos);
     return buildBuckets(data).filter(({repoAddress}) =>
-      visibleKeys.has(repoAddressAsString(repoAddress)),
+      visibleKeys.has(repoAddressAsHumanString(repoAddress)),
     );
   }, [data, visibleRepos]);
 

--- a/js_modules/dagit/packages/core/src/overview/OverviewSchedulesTable.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSchedulesTable.tsx
@@ -10,7 +10,7 @@ import {
   VirtualizedScheduleRow,
 } from '../workspace/VirtualizedScheduleRow';
 import {RepoRow} from '../workspace/VirtualizedWorkspaceTable';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {OVERVIEW_COLLAPSED_KEY} from './OverviewExpansionKey';
@@ -31,7 +31,7 @@ type RowType =
 export const OverviewScheduleTable: React.FC<Props> = ({repos}) => {
   const parentRef = React.useRef<HTMLDivElement | null>(null);
   const allKeys = React.useMemo(
-    () => repos.map(({repoAddress}) => repoAddressAsString(repoAddress)),
+    () => repos.map(({repoAddress}) => repoAddressAsHumanString(repoAddress)),
     [repos],
   );
   const {expandedKeys, onToggle, onToggleAll} = useRepoExpansionState(
@@ -43,7 +43,7 @@ export const OverviewScheduleTable: React.FC<Props> = ({repos}) => {
     const flat: RowType[] = [];
     repos.forEach(({repoAddress, schedules}) => {
       flat.push({type: 'header', repoAddress, scheduleCount: schedules.length});
-      const repoKey = repoAddressAsString(repoAddress);
+      const repoKey = repoAddressAsHumanString(repoAddress);
       if (expandedKeys.includes(repoKey)) {
         schedules.forEach((name) => {
           flat.push({type: 'schedule', repoAddress, name});
@@ -85,7 +85,7 @@ export const OverviewScheduleTable: React.FC<Props> = ({repos}) => {
                   start={start}
                   onToggle={onToggle}
                   onToggleAll={onToggleAll}
-                  expanded={expandedKeys.includes(repoAddressAsString(row.repoAddress))}
+                  expanded={expandedKeys.includes(repoAddressAsHumanString(row.repoAddress))}
                   showLocation={duplicateRepoNames.has(row.repoAddress.name)}
                   rightElement={
                     <Tooltip

--- a/js_modules/dagit/packages/core/src/overview/OverviewSensorsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSensorsRoot.tsx
@@ -24,7 +24,7 @@ import {UnloadableSensors} from '../instigation/Unloadable';
 import {SensorInfo} from '../sensors/SensorInfo';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {OverviewSensorTable} from './OverviewSensorsTable';
@@ -52,7 +52,7 @@ export const OverviewSensorsRoot = () => {
   const repoBuckets = React.useMemo(() => {
     const visibleKeys = visibleRepoKeys(visibleRepos);
     return buildBuckets(data).filter(({repoAddress}) =>
-      visibleKeys.has(repoAddressAsString(repoAddress)),
+      visibleKeys.has(repoAddressAsHumanString(repoAddress)),
     );
   }, [data, visibleRepos]);
 

--- a/js_modules/dagit/packages/core/src/overview/OverviewSensorsTable.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSensorsTable.tsx
@@ -7,7 +7,7 @@ import {findDuplicateRepoNames} from '../ui/findDuplicateRepoNames';
 import {useRepoExpansionState} from '../ui/useRepoExpansionState';
 import {VirtualizedSensorHeader, VirtualizedSensorRow} from '../workspace/VirtualizedSensorRow';
 import {RepoRow} from '../workspace/VirtualizedWorkspaceTable';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {OVERVIEW_COLLAPSED_KEY} from './OverviewExpansionKey';
@@ -28,7 +28,7 @@ type RowType =
 export const OverviewSensorTable: React.FC<Props> = ({repos}) => {
   const parentRef = React.useRef<HTMLDivElement | null>(null);
   const allKeys = React.useMemo(
-    () => repos.map(({repoAddress}) => repoAddressAsString(repoAddress)),
+    () => repos.map(({repoAddress}) => repoAddressAsHumanString(repoAddress)),
     [repos],
   );
   const {expandedKeys, onToggle, onToggleAll} = useRepoExpansionState(
@@ -40,7 +40,7 @@ export const OverviewSensorTable: React.FC<Props> = ({repos}) => {
     const flat: RowType[] = [];
     repos.forEach(({repoAddress, sensors}) => {
       flat.push({type: 'header', repoAddress, sensorCount: sensors.length});
-      const repoKey = repoAddressAsString(repoAddress);
+      const repoKey = repoAddressAsHumanString(repoAddress);
       if (expandedKeys.includes(repoKey)) {
         sensors.forEach((name) => {
           flat.push({type: 'sensor', repoAddress, name});
@@ -82,7 +82,7 @@ export const OverviewSensorTable: React.FC<Props> = ({repos}) => {
                   start={start}
                   onToggle={onToggle}
                   onToggleAll={onToggleAll}
-                  expanded={expandedKeys.includes(repoAddressAsString(row.repoAddress))}
+                  expanded={expandedKeys.includes(repoAddressAsHumanString(row.repoAddress))}
                   showLocation={duplicateRepoNames.has(row.repoAddress.name)}
                   rightElement={
                     <Tooltip

--- a/js_modules/dagit/packages/core/src/overview/sortRepoBuckets.test.tsx
+++ b/js_modules/dagit/packages/core/src/overview/sortRepoBuckets.test.tsx
@@ -1,5 +1,5 @@
-import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {buildRepoAddress, DUNDER_REPO_NAME} from '../workspace/buildRepoAddress';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 
 import {sortRepoBuckets} from './sortRepoBuckets';
 
@@ -31,6 +31,19 @@ describe('sortRepoBuckets', () => {
     expect(sorted).toEqual([boston, chicago, newyork]);
   });
 
+  it('sorts by repo location when dunder repo names are used', () => {
+    const newyork = {repoAddress: buildRepoAddress(DUNDER_REPO_NAME, 'newyork')};
+    const chicago = {repoAddress: buildRepoAddress(DUNDER_REPO_NAME, 'chicago')};
+    const boston = {repoAddress: buildRepoAddress('lorem', 'boston')};
+    const list = [newyork, chicago, boston];
+
+    const sorted = sortRepoBuckets(list);
+
+    // Same repo bucket objects. Repo locations are used for sort order when dunder repo
+    // names are used, which puts `chicago` ahead of `lorem@boston`.
+    expect(sorted).toEqual([chicago, boston, newyork]);
+  });
+
   it('sorts correctly with regard to capitalization and diacritics', () => {
     // Would be sorted after "lorem" because of `ä`, in spite of `a` being after `o`.
     const umlaut = {repoAddress: buildRepoAddress('lärem', 'ipsum')};
@@ -45,7 +58,7 @@ describe('sortRepoBuckets', () => {
     const list = [umlaut, capitalizedWithU, capitalizedWithO, normal];
 
     // Sanity check default sorting, which does not give us the ideal result.
-    expect(list.map(({repoAddress}) => repoAddressAsString(repoAddress)).sort()).toEqual([
+    expect(list.map(({repoAddress}) => repoAddressAsHumanString(repoAddress)).sort()).toEqual([
       'Lorem@upsum',
       'Lurem@ipsum',
       'lorem@ipsum',

--- a/js_modules/dagit/packages/core/src/overview/sortRepoBuckets.tsx
+++ b/js_modules/dagit/packages/core/src/overview/sortRepoBuckets.tsx
@@ -1,4 +1,4 @@
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 interface Bucket {
@@ -7,8 +7,8 @@ interface Bucket {
 
 export const sortRepoBuckets = <B extends Bucket>(buckets: B[]) => {
   return [...buckets].sort((a, b) => {
-    const aString = repoAddressAsString(a.repoAddress);
-    const bString = repoAddressAsString(b.repoAddress);
+    const aString = repoAddressAsHumanString(a.repoAddress);
+    const bString = repoAddressAsHumanString(b.repoAddress);
     return aString.localeCompare(bString);
   });
 };

--- a/js_modules/dagit/packages/core/src/overview/visibleRepoKeys.tsx
+++ b/js_modules/dagit/packages/core/src/overview/visibleRepoKeys.tsx
@@ -1,11 +1,13 @@
 import {DagsterRepoOption} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 
 export const visibleRepoKeys = (visibleRepos: DagsterRepoOption[]) => {
   return new Set(
     visibleRepos.map((option) =>
-      repoAddressAsString(buildRepoAddress(option.repository.name, option.repositoryLocation.name)),
+      repoAddressAsHumanString(
+        buildRepoAddress(option.repository.name, option.repositoryLocation.name),
+      ),
     ),
   );
 };

--- a/js_modules/dagit/packages/core/src/pipelines/NonIdealPipelineQueryResult.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/NonIdealPipelineQueryResult.tsx
@@ -1,7 +1,7 @@
 import {NonIdealState} from '@dagster-io/ui';
 import React from 'react';
 
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 interface Props {
@@ -49,7 +49,7 @@ export const NonIdealPipelineQueryResult: React.FC<Props> = ({isGraph, repoAddre
     return (
       <NonIdealState
         icon="error"
-        title={`${repoAddress ? repoAddressAsString(repoAddress) : 'Definitions'} not found`}
+        title={`${repoAddress ? repoAddressAsHumanString(repoAddress) : 'Definitions'} not found`}
         description={result.message}
       />
     );

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineRoot.test.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineRoot.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import {TestProvider} from '../testing/TestProvider';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsURLString} from '../workspace/repoAddressAsString';
 
 import {PipelineRoot} from './PipelineRoot';
 
@@ -57,7 +57,9 @@ describe('PipelineRoot', () => {
 
   const repoAddress = buildRepoAddress(REPO_NAME, REPO_LOCATION);
   const pipelineName = 'pipez';
-  const path = `/locations/${repoAddressAsString(repoAddress)}/pipelines/${pipelineName}:default`;
+  const path = `/locations/${repoAddressAsURLString(
+    repoAddress,
+  )}/pipelines/${pipelineName}:default`;
 
   it('renders overview by default', async () => {
     const routerProps = {

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineTable.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineTable.tsx
@@ -5,7 +5,7 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {RunStatusWithStats} from '../runs/RunStatusDots';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
@@ -41,7 +41,7 @@ export const PipelineTable: React.FC<Props> = (props) => {
       </thead>
       <tbody>
         {pipelinesOrJobs.map(({pipelineOrJob, repoAddress}) => (
-          <tr key={`${pipelineOrJob.name}-${repoAddressAsString(repoAddress)}`}>
+          <tr key={`${pipelineOrJob.name}-${repoAddressAsHumanString(repoAddress)}`}>
             <td>
               <Group direction="column" spacing={4}>
                 <PipelineReference
@@ -50,7 +50,7 @@ export const PipelineTable: React.FC<Props> = (props) => {
                   pipelineHrefContext={repoAddress}
                   truncationThreshold={80}
                 />
-                {showRepo ? <Caption>{repoAddressAsString(repoAddress)}</Caption> : null}
+                {showRepo ? <Caption>{repoAddressAsHumanString(repoAddress)}</Caption> : null}
                 <Description>{pipelineOrJob.description}</Description>
               </Group>
             </td>

--- a/js_modules/dagit/packages/core/src/runs/RepoSectionHeader.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RepoSectionHeader.tsx
@@ -2,6 +2,8 @@ import {Box, Colors, Icon, IconWrapper} from '@dagster-io/ui';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
+import {DUNDER_REPO_NAME} from '../workspace/buildRepoAddress';
+
 export const SECTION_HEADER_HEIGHT = 32;
 
 interface Props {
@@ -15,6 +17,7 @@ interface Props {
 
 export const RepoSectionHeader = (props: Props) => {
   const {expanded, onClick, repoName, repoLocation, showLocation, rightElement} = props;
+  const isDunderRepoName = repoName === DUNDER_REPO_NAME;
   return (
     <SectionHeaderButton $open={expanded} onClick={onClick}>
       <Box
@@ -24,8 +27,10 @@ export const RepoSectionHeader = (props: Props) => {
         <Box flex={{alignItems: 'center', gap: 8}}>
           <Icon name="folder" color={Colors.Dark} />
           <div>
-            <RepoName>{repoName}</RepoName>
-            {showLocation ? <RepoLocation>{`@${repoLocation}`}</RepoLocation> : null}
+            <RepoName>{isDunderRepoName ? repoLocation : repoName}</RepoName>
+            {showLocation && !isDunderRepoName ? (
+              <RepoLocation>{`@${repoLocation}`}</RepoLocation>
+            ) : null}
           </div>
         </Box>
         <Box flex={{alignItems: 'center', gap: 8}}>

--- a/js_modules/dagit/packages/core/src/runs/RunActionButtons.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionButtons.tsx
@@ -5,8 +5,8 @@ import {SharedToaster} from '../app/DomUtils';
 import {filterByQuery, GraphQueryItem} from '../app/GraphQueryImpl';
 import {usePermissions} from '../app/Permissions';
 import {LaunchButtonConfiguration, LaunchButtonDropdown} from '../launchpad/LaunchButton';
-import {buildRepoAddress, buildRepoPath} from '../workspace/buildRepoAddress';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {buildRepoAddress, buildRepoPathForHuman} from '../workspace/buildRepoAddress';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {useRepositoryForRun} from '../workspace/useRepositoryForRun';
 
 import {IRunMetadataDict, IStepState} from './RunMetadataProvider';
@@ -292,7 +292,7 @@ function usePipelineAvailabilityErrorForRun(
     if (matchType === 'snapshot-only') {
       // Only the snapshot ID matched, but not the repo.
       const originRepoName = run.repositoryOrigin
-        ? repoAddressAsString(
+        ? repoAddressAsHumanString(
             buildRepoAddress(
               run.repositoryOrigin.repositoryName,
               run.repositoryOrigin.repositoryLocationName,
@@ -335,7 +335,7 @@ function usePipelineAvailabilityErrorForRun(
     <Group direction="column" spacing={8}>
       <div>{`"${run.pipelineName}" is not available in the your definitions.`}</div>
       {repoForRun && repoLocationForRun ? (
-        <div>{`Load definitions for ${buildRepoPath(
+        <div>{`Load definitions for ${buildRepoPathForHuman(
           repoForRun,
           repoLocationForRun,
         )} and try again.`}</div>

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -23,7 +23,7 @@ import {RunStatus} from '../types/globalTypes';
 import {AnchorButton} from '../ui/AnchorButton';
 import {findDuplicateRepoNames} from '../ui/findDuplicateRepoNames';
 import {useRepoExpansionState} from '../ui/useRepoExpansionState';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsURLString} from '../workspace/repoAddressAsString';
 import {repoAddressFromPath} from '../workspace/repoAddressFromPath';
 import {RepoAddress} from '../workspace/types';
 
@@ -76,7 +76,7 @@ export const RunTimeline = (props: Props) => {
 
   const buckets = jobs.reduce((accum, job) => {
     const {repoAddress} = job;
-    const repoKey = repoAddressAsString(repoAddress);
+    const repoKey = repoAddressAsURLString(repoAddress);
     const jobsForRepo = accum[repoKey] || [];
     return {...accum, [repoKey]: [...jobsForRepo, job]};
   }, {});

--- a/js_modules/dagit/packages/core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/useRunsForTimeline.tsx
@@ -5,7 +5,7 @@ import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {SCHEDULE_FUTURE_TICKS_FRAGMENT} from '../instance/NextTick';
 import {InstigationStatus, RunsFilter, RunStatus} from '../types/globalTypes';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePipelinePath} from '../workspace/workspacePath';
 
@@ -182,7 +182,7 @@ export const useRunsForTimeline = (range: [number, number], runsFilter: RunsFilt
 };
 
 export const makeJobKey = (repoAddress: RepoAddress, jobName: string) =>
-  `${jobName}-${repoAddressAsString(repoAddress)}`;
+  `${jobName}-${repoAddressAsHumanString(repoAddress)}`;
 
 const RUN_TIMELINE_QUERY = gql`
   query RunTimelineQuery(

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesRoot.tsx
@@ -9,7 +9,7 @@ import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {UnloadableSchedules} from '../instigation/Unloadable';
 import {InstigationType} from '../types/globalTypes';
 import {Loading} from '../ui/Loading';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
@@ -45,7 +45,7 @@ export const SchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
       {(result) => {
         const {repositoryOrError, unloadableInstigationStatesOrError, instance} = result;
         let schedulesSection = null;
-        const repoName = repoAddressAsString(repoAddress);
+        const repoName = repoAddressAsHumanString(repoAddress);
 
         if (repositoryOrError.__typename === 'PythonError') {
           schedulesSection = <PythonErrorInfo error={repositoryOrError} />;

--- a/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
+++ b/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
-import {buildRepoPath} from '../workspace/buildRepoAddress';
+import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 import {workspacePath} from '../workspace/workspacePath';
 
 import {SearchResult, SearchResultType} from './types';
@@ -42,7 +42,7 @@ const bootstrapDataToSearchResults = (data?: SearchBootstrapQuery) => {
       ...repos.reduce((inner, repo) => {
         const {name: repoName, partitionSets, pipelines, schedules, sensors} = repo;
         const {name: locationName} = repoLocation;
-        const repoPath = buildRepoPath(repoName, locationName);
+        const repoPath = buildRepoPathForHuman(repoName, locationName);
 
         const allPipelinesAndJobs = pipelines
           .filter((item) => !isHiddenAssetGroupJob(item.name))

--- a/js_modules/dagit/packages/core/src/sensors/SensorsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorsRoot.tsx
@@ -11,7 +11,7 @@ import {INSTIGATION_STATE_FRAGMENT} from '../instigation/InstigationUtils';
 import {UnloadableSensors} from '../instigation/Unloadable';
 import {InstigationType} from '../types/globalTypes';
 import {Loading} from '../ui/Loading';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
@@ -30,7 +30,7 @@ export const SensorsRoot = (props: Props) => {
 
   const {repoAddress} = props;
   const repositorySelector = repoAddressToSelector(repoAddress);
-  const repoName = repoAddressAsString(repoAddress);
+  const repoName = repoAddressAsHumanString(repoAddress);
 
   const queryResult = useQuery<SensorsRootQuery, SensorsRootQueryVariables>(SENSORS_ROOT_QUERY, {
     variables: {

--- a/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
@@ -11,8 +11,8 @@ import {LeftNavItemType} from '../nav/LeftNavItemType';
 import {getAssetGroupItemsForOption, getJobItemsForOption} from '../nav/getLeftNavItemsForOption';
 import {explorerPathFromString} from '../pipelines/PipelinePathUtils';
 import {DagsterRepoOption, WorkspaceContext} from '../workspace/WorkspaceContext';
-import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {buildRepoAddress, DUNDER_REPO_NAME} from '../workspace/buildRepoAddress';
+import {repoAddressAsHumanString, repoAddressAsURLString} from '../workspace/repoAddressAsString';
 import {repoAddressFromPath} from '../workspace/repoAddressFromPath';
 import {RepoAddress} from '../workspace/types';
 
@@ -32,7 +32,7 @@ export const SectionedLeftNav = () => {
 
   const onToggle = React.useCallback(
     (repoAddress: RepoAddress) => {
-      const key = repoAddressAsString(repoAddress);
+      const key = repoAddressAsURLString(repoAddress);
       setExpandedKeys((current) => {
         let nextExpandedKeys = [...(current || [])];
         if (nextExpandedKeys.includes(key)) {
@@ -45,6 +45,17 @@ export const SectionedLeftNav = () => {
     },
     [setExpandedKeys],
   );
+
+  const visibleReposAndKeys = React.useMemo(() => {
+    return visibleRepos.map((repo) => {
+      const repoAddress = buildRepoAddress(repo.repository.name, repo.repositoryLocation.name);
+      return {
+        repo,
+        repoAddress,
+        key: repoAddressAsHumanString(repoAddress),
+      };
+    });
+  }, [visibleRepos]);
 
   const duplicateRepoNames = React.useMemo(() => {
     const uniques = new Set<string>();
@@ -62,21 +73,21 @@ export const SectionedLeftNav = () => {
 
   // Sort repositories alphabetically, then move empty repos to the bottom.
   const sortedRepos = React.useMemo(() => {
-    const alphaSorted = [...visibleRepos].sort((a, b) =>
-      a.repository.name.toLocaleLowerCase().localeCompare(b.repository.name.toLocaleLowerCase()),
+    const alphaSorted = [...visibleReposAndKeys].sort((a, b) =>
+      a.key.toLocaleLowerCase().localeCompare(b.key.toLocaleLowerCase()),
     );
     const reposWithJobs = [];
     const reposWithoutJobs = [];
-    for (const repo of alphaSorted) {
-      const jobs = repo.repository.pipelines;
+    for (const repoWithKey of alphaSorted) {
+      const jobs = repoWithKey.repo.repository.pipelines;
       if (jobs.length > 0 && jobs.some((job) => !isHiddenAssetGroupJob(job.name))) {
-        reposWithJobs.push(repo);
+        reposWithJobs.push(repoWithKey);
       } else {
-        reposWithoutJobs.push(repo);
+        reposWithoutJobs.push(repoWithKey);
       }
     }
     return [...reposWithJobs, ...reposWithoutJobs];
-  }, [visibleRepos]);
+  }, [visibleReposAndKeys]);
 
   if (loading) {
     return <div style={{flex: 1}} />;
@@ -84,19 +95,18 @@ export const SectionedLeftNav = () => {
 
   return (
     <Container>
-      {sortedRepos.map((repo) => {
-        const repoName = repo.repository.name;
-        const repoAddress = buildRepoAddress(repoName, repo.repositoryLocation.name);
-        const addressAsString = repoAddressAsString(repoAddress);
+      {sortedRepos.map(({repo, repoAddress, key}) => {
+        const {name} = repoAddress;
+        const addressAsString = repoAddressAsURLString(repoAddress);
         return (
           <Section
-            key={addressAsString}
+            key={key}
             onToggle={onToggle}
             option={repo}
             repoAddress={repoAddress}
             expanded={sortedRepos.length === 1 || expandedKeys.includes(addressAsString)}
             collapsible={sortedRepos.length > 1}
-            showRepoLocation={duplicateRepoNames.has(repoName)}
+            showRepoLocation={duplicateRepoNames.has(name) && name !== DUNDER_REPO_NAME}
             match={match?.repoAddress === repoAddress ? match : null}
           />
         );
@@ -164,6 +174,9 @@ export const Section: React.FC<SectionProps> = React.memo((props) => {
     );
   };
 
+  const {name: repoName, location: repoLocation} = repoAddress;
+  const isDunderName = repoName === DUNDER_REPO_NAME;
+
   return (
     <Box background={Colors.Gray100} border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
       <SectionHeader
@@ -183,9 +196,9 @@ export const Section: React.FC<SectionProps> = React.memo((props) => {
           <RepoNameContainer>
             <Box flex={{direction: 'column'}} style={{flex: 1, minWidth: 0}}>
               <RepoName style={{fontWeight: 500}} data-tooltip={option.repository.name}>
-                {option.repository.name}
+                {isDunderName ? repoLocation : repoName}
               </RepoName>
-              {showRepoLocation ? (
+              {showRepoLocation && !isDunderName ? (
                 <RepoLocation data-tooltip={`@${option.repositoryLocation.name}`} $disabled={empty}>
                   @{option.repositoryLocation.name}
                 </RepoLocation>

--- a/js_modules/dagit/packages/core/src/ui/useRepoExpansionState.test.tsx
+++ b/js_modules/dagit/packages/core/src/ui/useRepoExpansionState.test.tsx
@@ -8,7 +8,7 @@ import {repoAddressFromPath} from '../workspace/repoAddressFromPath';
 import {buildStorageKey, useRepoExpansionState} from './useRepoExpansionState';
 
 const COLLAPSED_STORAGE_KEY = 'collapsed-key';
-const ALL_REPO_KEYS = ['lorem@ipsum', 'dolorsit@amet', 'consectetur@adipiscing'];
+const ALL_REPO_KEYS = ['ipsum:lorem', 'amet:dolorsit', 'adipiscing:consectetur'];
 
 describe('useRepoExpansionState', () => {
   const Test = () => {
@@ -53,39 +53,39 @@ describe('useRepoExpansionState', () => {
     });
 
     // Expect all keys to be expanded
-    expect(screen.getByText('lorem@ipsum expanded')).toBeVisible();
-    expect(screen.getByText('dolorsit@amet expanded')).toBeVisible();
-    expect(screen.getByText('consectetur@adipiscing expanded')).toBeVisible();
+    expect(screen.getByText('ipsum:lorem expanded')).toBeVisible();
+    expect(screen.getByText('amet:dolorsit expanded')).toBeVisible();
+    expect(screen.getByText('adipiscing:consectetur expanded')).toBeVisible();
   });
 
   it('tracks collapsed keys', async () => {
     window.localStorage.setItem(
       buildStorageKey('', COLLAPSED_STORAGE_KEY),
-      JSON.stringify(['lorem@ipsum']),
+      JSON.stringify(['ipsum:lorem']),
     );
     await act(async () => {
       render(<Test />);
     });
 
     // Expect keys to have appropriate state. One collapsed!
-    expect(screen.getByText('lorem@ipsum collapsed')).toBeVisible();
-    expect(screen.getByText('dolorsit@amet expanded')).toBeVisible();
-    expect(screen.getByText('consectetur@adipiscing expanded')).toBeVisible();
+    expect(screen.getByText('ipsum:lorem collapsed')).toBeVisible();
+    expect(screen.getByText('amet:dolorsit expanded')).toBeVisible();
+    expect(screen.getByText('adipiscing:consectetur expanded')).toBeVisible();
   });
 
   it('toggles a key to expanded', async () => {
     const fullCollapsedKey = buildStorageKey('', COLLAPSED_STORAGE_KEY);
-    window.localStorage.setItem(fullCollapsedKey, JSON.stringify(['lorem@ipsum']));
+    window.localStorage.setItem(fullCollapsedKey, JSON.stringify(['ipsum:lorem']));
     await act(async () => {
       render(<Test />);
     });
 
-    const button = screen.getByRole('button', {name: 'toggle lorem@ipsum'});
+    const button = screen.getByRole('button', {name: 'toggle ipsum:lorem'});
     await act(async () => {
       userEvent.click(button);
     });
 
-    expect(screen.getByText('lorem@ipsum expanded')).toBeVisible();
+    expect(screen.getByText('ipsum:lorem expanded')).toBeVisible();
     expect(window.localStorage.getItem(fullCollapsedKey)).toEqual('[]');
   });
 
@@ -96,18 +96,18 @@ describe('useRepoExpansionState', () => {
       render(<Test />);
     });
 
-    const button = screen.getByRole('button', {name: 'toggle lorem@ipsum'});
+    const button = screen.getByRole('button', {name: 'toggle ipsum:lorem'});
     await act(async () => {
       userEvent.click(button);
     });
 
-    expect(screen.getByText('lorem@ipsum collapsed')).toBeVisible();
-    expect(window.localStorage.getItem(fullCollapsedKey)).toEqual(JSON.stringify(['lorem@ipsum']));
+    expect(screen.getByText('ipsum:lorem collapsed')).toBeVisible();
+    expect(window.localStorage.getItem(fullCollapsedKey)).toEqual(JSON.stringify(['ipsum:lorem']));
   });
 
   it('toggles all to expanded', async () => {
     const fullCollapsedKey = buildStorageKey('', COLLAPSED_STORAGE_KEY);
-    window.localStorage.setItem(fullCollapsedKey, JSON.stringify(['lorem@ipsum', 'dolorsit@amet']));
+    window.localStorage.setItem(fullCollapsedKey, JSON.stringify(['ipsum:lorem', 'amet:dolorsit']));
     await act(async () => {
       render(<Test />);
     });
@@ -118,14 +118,14 @@ describe('useRepoExpansionState', () => {
     });
 
     // Everything expanded!
-    expect(screen.getByText('lorem@ipsum expanded')).toBeVisible();
-    expect(screen.getByText('dolorsit@amet expanded')).toBeVisible();
-    expect(screen.getByText('consectetur@adipiscing expanded')).toBeVisible();
+    expect(screen.getByText('ipsum:lorem expanded')).toBeVisible();
+    expect(screen.getByText('amet:dolorsit expanded')).toBeVisible();
+    expect(screen.getByText('adipiscing:consectetur expanded')).toBeVisible();
   });
 
   it('toggles all to collapsed', async () => {
     const fullCollapsedKey = buildStorageKey('', COLLAPSED_STORAGE_KEY);
-    window.localStorage.setItem(fullCollapsedKey, JSON.stringify(['lorem@ipsum']));
+    window.localStorage.setItem(fullCollapsedKey, JSON.stringify(['ipsum:lorem']));
     await act(async () => {
       render(<Test />);
     });
@@ -136,8 +136,8 @@ describe('useRepoExpansionState', () => {
     });
 
     // Everything collapsed!
-    expect(screen.getByText('lorem@ipsum collapsed')).toBeVisible();
-    expect(screen.getByText('dolorsit@amet collapsed')).toBeVisible();
-    expect(screen.getByText('consectetur@adipiscing collapsed')).toBeVisible();
+    expect(screen.getByText('ipsum:lorem collapsed')).toBeVisible();
+    expect(screen.getByText('amet:dolorsit collapsed')).toBeVisible();
+    expect(screen.getByText('adipiscing:consectetur collapsed')).toBeVisible();
   });
 });

--- a/js_modules/dagit/packages/core/src/ui/useRepoExpansionState.tsx
+++ b/js_modules/dagit/packages/core/src/ui/useRepoExpansionState.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {AppContext} from '../app/AppContext';
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
-import {repoAddressAsString} from '../workspace/repoAddressAsString';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 const validateExpandedKeys = (parsed: unknown) => (Array.isArray(parsed) ? parsed : []);
@@ -23,7 +23,7 @@ export const useRepoExpansionState = (collapsedKey: string, allKeys: string[]) =
 
   const onToggle = React.useCallback(
     (repoAddress: RepoAddress) => {
-      const key = repoAddressAsString(repoAddress);
+      const key = repoAddressAsHumanString(repoAddress);
       setCollapsedKeys((current) => {
         const nextCollapsedKeys = new Set(current || []);
         if (nextCollapsedKeys.has(key)) {

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
@@ -9,7 +9,7 @@ import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {RepositoryLink} from '../nav/RepositoryLink';
 
-import {repoAddressAsString} from './repoAddressAsString';
+import {repoAddressAsHumanString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
 import {
@@ -78,13 +78,15 @@ export const RepositoryAssetsList: React.FC<Props> = (props) => {
     return null;
   }
 
+  const repoName = repoAddressAsHumanString(repoAddress);
+
   if (error || !assetsForTable) {
     return (
       <Box padding={{vertical: 64}}>
         <NonIdealState
           icon="error"
           title="Unable to load graphs"
-          description={`Could not load graphs for ${repoAddressAsString(repoAddress)}`}
+          description={`Could not load graphs for ${repoName}`}
         />
       </Box>
     );
@@ -96,7 +98,7 @@ export const RepositoryAssetsList: React.FC<Props> = (props) => {
         <NonIdealState
           icon="error"
           title="No assets found"
-          description={`No @asset definitions for ${repoAddressAsString(repoAddress)}`}
+          description={`No @asset definitions for ${repoName}`}
         />
       </Box>
     );

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryGraphsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryGraphsList.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components/macro';
 import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 
-import {repoAddressAsString} from './repoAddressAsString';
+import {repoAddressAsHumanString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
 import {
@@ -116,7 +116,7 @@ export const RepositoryGraphsList: React.FC<Props> = (props) => {
     return null;
   }
 
-  const repoName = repoAddressAsString(repoAddress);
+  const repoName = repoAddressAsHumanString(repoAddress);
 
   if (error || !graphsForTable) {
     return (
@@ -151,7 +151,7 @@ export const RepositoryGraphsList: React.FC<Props> = (props) => {
       </thead>
       <tbody>
         {graphsForTable.map(({name, description, path, repoAddress}) => (
-          <tr key={`${name}-${repoAddressAsString(repoAddress)}`}>
+          <tr key={`${name}-${repoAddressAsHumanString(repoAddress)}`}>
             <td>
               <Group direction="column" spacing={4}>
                 <Link to={workspacePath(repoAddress.name, repoAddress.location, path)}>{name}</Link>

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryPipelinesList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryPipelinesList.tsx
@@ -6,7 +6,7 @@ import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {PipelineTable, PIPELINE_TABLE_FRAGMENT} from '../pipelines/PipelineTable';
 
-import {repoAddressAsString} from './repoAddressAsString';
+import {repoAddressAsHumanString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
 import {
@@ -72,7 +72,7 @@ export const RepositoryPipelinesList: React.FC<Props> = (props) => {
     return null;
   }
 
-  const repoName = repoAddressAsString(repoAddress);
+  const repoName = repoAddressAsHumanString(repoAddress);
 
   if (error || !pipelinesForTable) {
     return (

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
@@ -20,7 +20,7 @@ import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {Container, HeaderCell, Inner, Row, RowCell} from '../ui/VirtualizedTable';
 
 import {LoadingOrNone, useDelayedRowQuery} from './VirtualizedWorkspaceTable';
-import {repoAddressAsString} from './repoAddressAsString';
+import {repoAddressAsHumanString} from './repoAddressAsString';
 import {RepoAddress} from './types';
 import {SingleAssetQuery, SingleAssetQueryVariables} from './types/SingleAssetQuery';
 import {workspacePathFromAddress} from './workspacePath';
@@ -41,7 +41,7 @@ const ASSET_GROUPS_EXPANSION_STATE_STORAGE_KEY = 'assets-virtualized-expansion-s
 
 export const VirtualizedAssetTable: React.FC<Props> = ({repoAddress, assets}) => {
   const parentRef = React.useRef<HTMLDivElement | null>(null);
-  const repoKey = repoAddressAsString(repoAddress);
+  const repoKey = repoAddressAsHumanString(repoAddress);
   const {expandedKeys, onToggle} = useAssetGroupExpansionState(
     `${repoKey}-${ASSET_GROUPS_EXPANSION_STATE_STORAGE_KEY}`,
   );

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceAssetsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceAssetsRoot.tsx
@@ -9,7 +9,7 @@ import {useAssetNodeSearch} from '../assets/useAssetSearch';
 
 import {VirtualizedAssetTable} from './VirtualizedAssetTable';
 import {WorkspaceHeader} from './WorkspaceHeader';
-import {repoAddressAsString} from './repoAddressAsString';
+import {repoAddressAsHumanString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
 import {WorkspaceAssetsQuery, WorkspaceAssetsQueryVariables} from './types/WorkspaceAssetsQuery';
@@ -55,7 +55,7 @@ export const WorkspaceAssetsRoot = ({repoAddress}: {repoAddress: RepoAddress}) =
       );
     }
 
-    const repoName = repoAddressAsString(repoAddress);
+    const repoName = repoAddressAsHumanString(repoAddress);
 
     if (!filteredBySearch.length) {
       if (anySearch) {

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceGraphsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceGraphsRoot.tsx
@@ -9,7 +9,7 @@ import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 
 import {Graph, VirtualizedGraphTable} from './VirtualizedGraphTable';
 import {WorkspaceHeader} from './WorkspaceHeader';
-import {repoAddressAsString} from './repoAddressAsString';
+import {repoAddressAsHumanString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
 import {WorkspaceGraphsQuery, WorkspaceGraphsQueryVariables} from './types/WorkspaceGraphsQuery';
@@ -82,7 +82,7 @@ export const WorkspaceGraphsRoot = ({repoAddress}: {repoAddress: RepoAddress}) =
       );
     }
 
-    const repoName = repoAddressAsString(repoAddress);
+    const repoName = repoAddressAsHumanString(repoAddress);
 
     if (!filteredBySearch.length) {
       if (anySearch) {

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceHeader.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceHeader.tsx
@@ -7,7 +7,7 @@ import {QueryRefreshState} from '../app/QueryRefresh';
 import {ReloadRepositoryLocationButton} from '../nav/ReloadRepositoryLocationButton';
 
 import {WorkspaceTabs} from './WorkspaceTabs';
-import {repoAddressAsString} from './repoAddressAsString';
+import {repoAddressAsHumanString} from './repoAddressAsString';
 import {RepoAddress} from './types';
 
 interface Props<TData> {
@@ -30,7 +30,7 @@ export const WorkspaceHeader = <TData extends Record<string, any>>(props: Props<
             </Link>
           </Heading>
           <Heading>/</Heading>
-          <Heading style={{color: Colors.Gray600}}>{repoAddressAsString(repoAddress)}</Heading>
+          <Heading style={{color: Colors.Gray600}}>{repoAddressAsHumanString(repoAddress)}</Heading>
         </Box>
       }
       tabs={

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceJobsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceJobsRoot.tsx
@@ -9,7 +9,7 @@ import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 
 import {VirtualizedJobTable} from './VirtualizedJobTable';
 import {WorkspaceHeader} from './WorkspaceHeader';
-import {repoAddressAsString} from './repoAddressAsString';
+import {repoAddressAsHumanString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
 import {WorkspaceJobsQuery, WorkspaceJobsQueryVariables} from './types/WorkspaceJobsQuery';
@@ -61,7 +61,7 @@ export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => 
       );
     }
 
-    const repoName = repoAddressAsString(repoAddress);
+    const repoName = repoAddressAsHumanString(repoAddress);
 
     if (!filteredBySearch.length) {
       if (anySearch) {

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewWithGrid.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewWithGrid.tsx
@@ -17,14 +17,14 @@ import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {InstanceTabs} from '../instance/InstanceTabs';
 
 import {DagsterRepoOption, useRepositoryOptions} from './WorkspaceContext';
-import {buildRepoAddress} from './buildRepoAddress';
-import {repoAddressAsString} from './repoAddressAsString';
+import {buildRepoAddress, DUNDER_REPO_NAME} from './buildRepoAddress';
+import {repoAddressAsHumanString} from './repoAddressAsString';
 import {workspacePath} from './workspacePath';
 
 export const WorkspaceOverviewWithGrid = () => {
   return (
     <Page>
-      <PageHeader title={<Heading>Deployment</Heading>} tabs={<InstanceTabs tab="workspace" />} />
+      <PageHeader title={<Heading>Deployment</Heading>} tabs={<InstanceTabs tab="definitions" />} />
       <WorkspaceOverviewGrid />
     </Page>
   );
@@ -75,7 +75,7 @@ export const WorkspaceOverviewGrid = () => {
           option.repository.name,
           option.repositoryLocation.name,
         );
-        return <RepositoryGridItem key={repoAddressAsString(repoAddress)} repo={option} />;
+        return <RepositoryGridItem key={repoAddressAsHumanString(repoAddress)} repo={option} />;
       })}
     </CardGrid>
   );
@@ -100,9 +100,9 @@ const RepositoryGridItem: React.FC<{repo: DagsterRepoOption}> = React.memo(({rep
         >
           <Box flex={{direction: 'row', alignItems: 'flex-start', gap: 8}}>
             <Icon name="folder" style={{marginTop: 1}} />
-            <RepoName>{repoName}</RepoName>
+            <RepoName>{repoName === DUNDER_REPO_NAME ? repoLocation : repoName}</RepoName>
           </Box>
-          <RepoLocation>{`@${repoLocation}`}</RepoLocation>
+          {repoName === DUNDER_REPO_NAME ? null : <RepoLocation>{`@${repoLocation}`}</RepoLocation>}
         </Box>
         <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}} padding={{top: 12}}>
           <Tag icon="asset">{assetCount}</Tag>

--- a/js_modules/dagit/packages/core/src/workspace/WorkspacePipelineRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspacePipelineRoot.tsx
@@ -7,7 +7,7 @@ import {explorerPathFromString} from '../pipelines/PipelinePathUtils';
 import {LoadingSpinner} from '../ui/Loading';
 
 import {isThisThingAJob, optionToRepoAddress, useRepositoryOptions} from './WorkspaceContext';
-import {buildRepoPath} from './buildRepoAddress';
+import {buildRepoPathForHuman} from './buildRepoAddress';
 import {findRepoContainingPipeline} from './findRepoContainingPipeline';
 import {workspacePath, workspacePathFromAddress} from './workspacePath';
 
@@ -106,7 +106,7 @@ export const WorkspacePipelineRoot = () => {
               repository: {name},
               repositoryLocation: {name: location},
             } = repository;
-            const repoString = buildRepoPath(name, location);
+            const repoString = buildRepoPathForHuman(name, location);
             return (
               <tr key={repoString}>
                 <td style={{width: '40%'}}>{repoString}</td>

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceRepoRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceRepoRoot.tsx
@@ -12,7 +12,7 @@ import {RepositoryAssetsList} from './RepositoryAssetsList';
 import {RepositoryGraphsList} from './RepositoryGraphsList';
 import {RepositoryPipelinesList} from './RepositoryPipelinesList';
 import {useRepository} from './WorkspaceContext';
-import {repoAddressAsString} from './repoAddressAsString';
+import {repoAddressAsHumanString} from './repoAddressAsString';
 import {RepoAddress} from './types';
 import {workspacePathFromAddress} from './workspacePath';
 
@@ -24,7 +24,7 @@ export const WorkspaceRepoRoot: React.FC<Props> = (props) => {
   const {repoAddress} = props;
   const {tab} = useParams<{tab?: string}>();
 
-  const path = repoAddressAsString(repoAddress);
+  const path = repoAddressAsHumanString(repoAddress);
   const repo = useRepository(repoAddress);
 
   const anyPipelines = React.useMemo(() => {

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
@@ -17,6 +17,7 @@ import {WorkspacePipelineRoot} from './WorkspacePipelineRoot';
 import {WorkspaceRepoRoot} from './WorkspaceRepoRoot';
 import {WorkspaceSchedulesRoot} from './WorkspaceSchedulesRoot';
 import {WorkspaceSensorsRoot} from './WorkspaceSensorsRoot';
+import {repoAddressAsHumanString} from './repoAddressAsString';
 import {repoAddressFromPath} from './repoAddressFromPath';
 
 const RepoRouteContainer = () => {
@@ -67,7 +68,7 @@ const RepoRouteContainer = () => {
           description={
             <div>
               <div>
-                <strong>{repoPath}</strong>
+                <strong>{repoAddressAsHumanString(addressForPath)}</strong>
               </div>
               {'  is not loaded in the current workspace.'}
             </div>

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceSchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceSchedulesRoot.tsx
@@ -8,7 +8,7 @@ import {useTrackPageView} from '../app/analytics';
 
 import {VirtualizedScheduleTable} from './VirtualizedScheduleTable';
 import {WorkspaceHeader} from './WorkspaceHeader';
-import {repoAddressAsString} from './repoAddressAsString';
+import {repoAddressAsHumanString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
 import {
@@ -60,7 +60,7 @@ export const WorkspaceSchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}
       );
     }
 
-    const repoName = repoAddressAsString(repoAddress);
+    const repoName = repoAddressAsHumanString(repoAddress);
 
     if (!filteredBySearch.length) {
       if (anySearch) {

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceSensorsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceSensorsRoot.tsx
@@ -8,7 +8,7 @@ import {useTrackPageView} from '../app/analytics';
 
 import {VirtualizedSensorTable} from './VirtualizedSensorTable';
 import {WorkspaceHeader} from './WorkspaceHeader';
-import {repoAddressAsString} from './repoAddressAsString';
+import {repoAddressAsHumanString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
 import {WorkspaceSensorsQuery, WorkspaceSensorsQueryVariables} from './types/WorkspaceSensorsQuery';
@@ -57,7 +57,7 @@ export const WorkspaceSensorsRoot = ({repoAddress}: {repoAddress: RepoAddress}) 
       );
     }
 
-    const repoName = repoAddressAsString(repoAddress);
+    const repoName = repoAddressAsHumanString(repoAddress);
 
     if (!filteredBySearch.length) {
       if (anySearch) {

--- a/js_modules/dagit/packages/core/src/workspace/buildRepoAddress.test.ts
+++ b/js_modules/dagit/packages/core/src/workspace/buildRepoAddress.test.ts
@@ -1,0 +1,54 @@
+import {
+  buildRepoAddress,
+  buildRepoPathForHuman,
+  buildRepoPathForURL,
+  DUNDER_REPO_NAME,
+} from './buildRepoAddress';
+
+describe('Repo address utilities', () => {
+  describe('buildRepoAddress', () => {
+    it('creates a RepoAddress object', () => {
+      expect(buildRepoAddress('foo', 'bar')).toEqual({
+        name: 'foo',
+        location: 'bar',
+      });
+    });
+
+    it('memoizes based on the name/location', () => {
+      const repoAddress = buildRepoAddress('foo', 'bar');
+      expect(buildRepoAddress('foo', 'bar')).toBe(repoAddress);
+    });
+  });
+
+  describe('buildRepoPathForHuman', () => {
+    it('renders a legible repo path', () => {
+      expect(buildRepoPathForHuman('foo', 'bar')).toBe('foo@bar');
+      expect(buildRepoPathForHuman('foo_repo', 'bar_location')).toBe('foo_repo@bar_location');
+      expect(buildRepoPathForHuman('foo', 'location:with:colons')).toBe('foo@location:with:colons');
+    });
+
+    it('omits the dunder repo name', () => {
+      expect(buildRepoPathForHuman(DUNDER_REPO_NAME, 'bar')).toBe('bar');
+    });
+  });
+
+  describe('buildRepoPathForURL', () => {
+    it('renders a repo path for URLs', () => {
+      expect(buildRepoPathForURL('foo', 'bar')).toBe('foo@bar');
+      expect(buildRepoPathForURL('foo_repo', 'bar_location')).toBe('foo_repo@bar_location');
+    });
+
+    it('URI-encodes characters in location name', () => {
+      expect(buildRepoPathForURL('foo', 'location:with:colons')).toBe(
+        'foo@location%3Awith%3Acolons',
+      );
+      expect(buildRepoPathForURL('foo', 'location/with/slashes')).toBe(
+        'foo@location%2Fwith%2Fslashes',
+      );
+    });
+
+    it('omits the dunder repo name', () => {
+      expect(buildRepoPathForURL(DUNDER_REPO_NAME, 'bar')).toBe('bar');
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/workspace/buildRepoAddress.ts
+++ b/js_modules/dagit/packages/core/src/workspace/buildRepoAddress.ts
@@ -2,10 +2,25 @@ import memoize from 'lodash/memoize';
 
 import {RepoAddress} from './types';
 
+export const DUNDER_REPO_NAME = '__repository__';
+
 const memo = memoize(
   (repoAddress: RepoAddress) => repoAddress,
-  (repoAddress: RepoAddress) => buildRepoPath(repoAddress.name, repoAddress.location),
+  (repoAddress: RepoAddress) => buildRepoPathForURL(repoAddress.name, repoAddress.location),
 );
 
 export const buildRepoAddress = (name: string, location: string) => memo({name, location});
-export const buildRepoPath = (name: string, location: string) => `${name}@${location}`;
+
+export const buildRepoPathForHuman = (name: string, location: string) => {
+  return name === DUNDER_REPO_NAME ? location : `${name}@${location}`;
+};
+
+export const buildRepoPathForURL = (name: string, location: string) => {
+  const encodedLocation = encodeURIComponent(location);
+  return name === DUNDER_REPO_NAME ? encodedLocation : `${name}@${encodedLocation}`;
+};
+
+// todo dish: Temporary for cloud compatibility. Delete after cloud is updated.
+export const buildRepoPath = (name: string, location: string) => {
+  return buildRepoPathForHuman(name, location);
+};

--- a/js_modules/dagit/packages/core/src/workspace/repoAddressAsString.ts
+++ b/js_modules/dagit/packages/core/src/workspace/repoAddressAsString.ts
@@ -1,8 +1,12 @@
 import memoize from 'lodash/memoize';
 
-import {buildRepoPath} from './buildRepoAddress';
+import {buildRepoPathForHuman, buildRepoPathForURL} from './buildRepoAddress';
 import {RepoAddress} from './types';
 
-export const repoAddressAsString = memoize((repoAddress: RepoAddress) =>
-  buildRepoPath(repoAddress.name, repoAddress.location),
-);
+export const repoAddressAsHumanString = memoize((repoAddress: RepoAddress) => {
+  return buildRepoPathForHuman(repoAddress.name, repoAddress.location);
+});
+
+export const repoAddressAsURLString = memoize((repoAddress: RepoAddress) => {
+  return buildRepoPathForURL(repoAddress.name, repoAddress.location);
+});

--- a/js_modules/dagit/packages/core/src/workspace/repoAddressFromPath.test.ts
+++ b/js_modules/dagit/packages/core/src/workspace/repoAddressFromPath.test.ts
@@ -1,0 +1,37 @@
+import {DUNDER_REPO_NAME} from './buildRepoAddress';
+import {repoAddressFromPath} from './repoAddressFromPath';
+
+describe('repoAddressFromPath', () => {
+  it('returns null if empty string', () => {
+    expect(repoAddressFromPath('')).toEqual(null);
+  });
+
+  it('builds a RepoAddress from a valid repo@location', () => {
+    expect(repoAddressFromPath('foo@bar')).toEqual({
+      name: 'foo',
+      location: 'bar',
+    });
+  });
+
+  it('builds a RepoAddress from a valid repo@location with encoded location', () => {
+    expect(repoAddressFromPath('foo@bar%3Abaz')).toEqual({
+      name: 'foo',
+      location: 'bar:baz',
+    });
+    expect(repoAddressFromPath('foo@bar%2Fbaz')).toEqual({
+      name: 'foo',
+      location: 'bar/baz',
+    });
+  });
+
+  it('builds a RepoAddress from a code location with a dunder repo name', () => {
+    expect(repoAddressFromPath('bar')).toEqual({
+      name: DUNDER_REPO_NAME,
+      location: 'bar',
+    });
+    expect(repoAddressFromPath('bar%2Fbaz')).toEqual({
+      name: DUNDER_REPO_NAME,
+      location: 'bar/baz',
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/workspace/repoAddressFromPath.ts
+++ b/js_modules/dagit/packages/core/src/workspace/repoAddressFromPath.ts
@@ -1,11 +1,25 @@
-import {buildRepoAddress} from './buildRepoAddress';
+import {buildRepoAddress, DUNDER_REPO_NAME} from './buildRepoAddress';
 import {RepoAddress} from './types';
 
 export const repoAddressFromPath = (path: string): RepoAddress | null => {
-  const postSplit = path.split('@');
-  if (postSplit.length === 2) {
-    const [name, location] = postSplit;
-    return buildRepoAddress(name, location);
+  // Split on `@`. If there are any elements beyond the first two, we're going to ignore
+  // them because they shouldn't be there -- the location name should be URI-encoded.
+  const [beforeAt, afterAt] = path.split('@');
+
+  // This is an empty string with no value to us here.
+  if (!beforeAt) {
+    return null;
   }
-  return null;
+
+  // If there are no elements after `@`, this is a code location with a dunder repo name.
+  if (!afterAt) {
+    return buildRepoAddress(DUNDER_REPO_NAME, decodeURIComponent(beforeAt));
+  }
+
+  // It should not be necessary to decode repo name since we restrict repo names to characters
+  // that do not need encoding.
+  const repoName = beforeAt;
+  const locationName = decodeURIComponent(afterAt);
+
+  return buildRepoAddress(repoName, locationName);
 };

--- a/js_modules/dagit/packages/core/src/workspace/workspacePath.ts
+++ b/js_modules/dagit/packages/core/src/workspace/workspacePath.ts
@@ -1,9 +1,9 @@
-import {buildRepoPath} from './buildRepoAddress';
+import {buildRepoPathForURL} from './buildRepoAddress';
 import {RepoAddress} from './types';
 
 export const workspacePath = (repoName: string, repoLocation: string, path = '') => {
   const finalPath = path.startsWith('/') ? path : `/${path}`;
-  return `/locations/${buildRepoPath(repoName, repoLocation)}${finalPath}`;
+  return `/locations/${buildRepoPathForURL(repoName, repoLocation)}${finalPath}`;
 };
 
 type PathConfig = {
@@ -22,7 +22,7 @@ export const workspacePipelinePath = ({
   path = '',
 }: PathConfig) => {
   const finalPath = path.startsWith('/') ? path : `/${path}`;
-  return `/locations/${buildRepoPath(repoName, repoLocation)}/${
+  return `/locations/${buildRepoPathForURL(repoName, repoLocation)}/${
     isJob ? 'jobs' : 'pipelines'
   }/${pipelineName}${finalPath}`;
 };


### PR DESCRIPTION
### Summary & Motivation

Handle the dunder repository name `__repository__` as a special case throughout Dagit, where instead of showing `repo@location`, we simply show `location`. This applies to URLs, repository links, repository headers, the left nav, etc. -- anywhere that we would currently show both the repo name and the location name.

Under the hood, the `__repository__` repo name is still used for querying GraphQL.

Additionally:

- **URI-encode location names.** Since we have no character restrictions in place for location names, use URI encoding for `repo@location` values that would show up as part of the URL path. This will allow us to support dunder repo cases where the location name is human-readable as `location@here`, which would otherwise be parsed as repo name `location`, location `here`. This value will instead be encoded as `location%40home` in the URL, and can be parsed as being a location name for a dunder repo.
- **Split RepoAddress utility functions.**
  - `buildRepoPath` is now split into `buildRepoPathForHuman` (to be rendered in the UI) and `buildRepoPathForURI` (encoded for use in a URL path element).
  - `repoAddressAsString` is similarly split.

Screenshots of dunder repo behavior in Dagit:

Definitions grid and left nav:

<img width="859" alt="Screenshot 2022-12-05 at 1 52 55 PM" src="https://user-images.githubusercontent.com/2823852/205735092-5e8e76a2-45a4-4572-9039-d3f468ee7234.png">

Job permalink with location name:

<img width="399" alt="Screenshot 2022-12-05 at 1 53 01 PM" src="https://user-images.githubusercontent.com/2823852/205735095-8e7a5d7d-3b42-4213-9cf3-afb2b52549ce.png">

Timeline bucketing:

<img width="890" alt="Screenshot 2022-12-05 at 1 56 17 PM" src="https://user-images.githubusercontent.com/2823852/205735096-58b6cd1c-3298-431e-b7f3-c4450d81ac9e.png">

### How I Tested These Changes

Wrote a handful of tests for the parsing and stringifying behavior.

Load the default workspace, which contains a single code location with many repositories. Verify that everything is unchanged: we still show the repo name in the left nav, still show `@location` in the definitions grid, still show `repo@location` in tags and tables everywhere.

Load Dagit pointing at a single file with a dunder repo name. (Noted inline -- this change will not be merged.) Verify that the left nav, URL, definitions grid, and overview tables show only the filename (code location) and not the dunder repo. Navigate to job, verify that it loads correctly.
