### PR TITLE
[loosen-defs-requirement] Allow Definitions to be set to any name

### DIFF
--- a/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
+++ b/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
@@ -62,13 +62,6 @@ def loadable_targets_from_loaded_module(module: ModuleType) -> Sequence[Loadable
                 "Cannot have more than one Definitions object defined at module scope"
             )
 
-        # currently this is super strict and requires that it be named defs
-        symbol = loadable_defs[0].attribute
-        if symbol != "defs":
-            raise DagsterInvariantViolationError(
-                f"Found Definitions object at {symbol}. This object must be at a top-level variable named 'defs'."
-            )
-
         return loadable_defs
 
     loadable_repos = _loadable_targets_of_type(

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/single_defs_any_name.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/single_defs_any_name.py
@@ -5,4 +5,4 @@ def _make_defs():
     return Definitions()
 
 
-wrong_name = _make_defs()
+not_defs = _make_defs()

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
@@ -5,7 +5,6 @@ import pytest
 
 from dagster import DagsterInvariantViolationError, RepositoryDefinition
 from dagster._core.code_pointer import CodePointer
-from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.reconstruct import repository_def_from_pointer
 from dagster._core.definitions.repository_definition import PendingRepositoryDefinition
 from dagster._core.errors import DagsterImportError
@@ -216,13 +215,13 @@ def test_single_defs_in_file():
     assert isinstance(repo_def, RepositoryDefinition)
 
 
-def test_single_def_wrong_variable():
-    dagster_defs_path = file_relative_path(__file__, "single_defs_wrong_name.py")
-    with pytest.raises(
-        DagsterInvariantViolationError,
-        match="Found Definitions object at wrong_name. This object must be at a top-level variable named 'defs'.",
-    ):
-        loadable_targets_from_python_file(dagster_defs_path)
+def test_single_def_any_name():
+    dagster_defs_path = file_relative_path(__file__, "single_defs_any_name.py")
+    loadable_targets = loadable_targets_from_python_file(dagster_defs_path)
+
+    assert len(loadable_targets) == 1
+    symbol = loadable_targets[0].attribute
+    assert symbol == "not_defs"
 
 
 def test_double_defs_in_file():


### PR DESCRIPTION
Summary & Motivation: In meeting today, we decided that an arbitrary constraint like this is too annoying, and that `defs` should just be a convention rather than a dagster-enforced keyword.

Test Plan: BK
