### PR TITLE
[dagster-airbyte] Fix normalization table generation, materializations for non-object Streams

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -421,15 +421,16 @@ class AirbyteConnectionMetadata(
                 else stream["stream"]["jsonSchema"]
             )
             normalization_tables: Dict[str, AirbyteTableMetadata] = {}
+            schema_props = schema.get("properties", schema.get("items", {}).get("properties", {}))
             if self.has_basic_normalization and return_normalization_tables:
-                for k, v in schema["properties"].items():
+                for k, v in schema_props.items():
                     for normalization_table_name, meta in _get_normalization_tables_for_schema(
                         k, v, f"{name}_"
                     ).items():
                         prefixed_norm_table_name = f"{self.stream_prefix}{normalization_table_name}"
                         normalization_tables[prefixed_norm_table_name] = meta
             tables[prefixed_name] = AirbyteTableMetadata(
-                schema=generate_table_schema(schema["properties"]),
+                schema=generate_table_schema(schema_props),
                 normalization_tables=normalization_tables,
             )
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_airbyte_project/connections/github_snowflake_ben/configuration.yaml
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_airbyte_project/connections/github_snowflake_ben/configuration.yaml
@@ -4593,12 +4593,89 @@ configuration:
         - - id
         alias_name: pull_requests
         selected: false
+    - config:
+        aliasName: array_test
+        cursorField:
+        - created_at
+        destinationSyncMode: append_dedup
+        primaryKey:
+        - - id
+        selected: true
+        syncMode: incremental
+      stream:
+        defaultCursorField:
+        - created_at
+        jsonSchema:
+          $schema: http://json-schema.org/draft-07/schema#
+          items:
+            properties:
+              author:
+                properties:
+                  id:
+                    type:
+                    - 'null'
+                    - integer
+                type:
+                - 'null'
+                - object
+              name:
+                type: string
+              version:
+                type: string
+            required:
+            - name
+            - version
+            type: object
+          type: array
+        name: array_test
+        sourceDefinedCursor: true
+        sourceDefinedPrimaryKey:
+        - - id
+        supportedSyncModes:
+        - full_refresh
+        - overwrite
+    - config:
+        aliasName: unknown_test
+        cursorField:
+        - created_at
+        destinationSyncMode: append_dedup
+        primaryKey:
+        - - id
+        selected: true
+        syncMode: incremental
+      stream:
+        defaultCursorField:
+        - created_at
+        jsonSchema:
+          $schema: http://json-schema.org/draft-07/schema#
+          type: unknown
+        name: unknown_test
+        sourceDefinedCursor: true
+        sourceDefinedPrimaryKey:
+        - - id
+        supportedSyncModes:
+        - full_refresh
+        - overwrite
     - stream:
         name: releases
         json_schema:
           type: object
           $schema: http://json-schema.org/draft-07/schema#
           properties:
+            foo:
+              oneOf:
+              - properties:
+                  bar:
+                    type: string
+                type:
+                - 'null'
+                - object
+              - properties:
+                  baz:
+                    type: string
+                type:
+                - 'null'
+                - object
             id:
               type:
               - 'null'

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -116,12 +116,19 @@ def test_load_from_instance(
         assert len(ab_assets) == 0
         return
 
-    tables = {"dagster_releases", "dagster_tags", "dagster_teams"} | (
+    tables = {
+        "dagster_releases",
+        "dagster_tags",
+        "dagster_teams",
+        "dagster_array_test",
+        "dagster_unknown_test",
+    } | (
         {
             "dagster_releases_assets",
             "dagster_releases_author",
             "dagster_tags_commit",
             "dagster_releases_foo",
+            "dagster_array_test_author",
         }
         if use_normalization_tables
         else set()

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_project.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_project.py
@@ -56,8 +56,20 @@ def test_load_from_project(
         assert len(ab_assets) == 0
         return
 
-    tables = {"dagster_releases", "dagster_tags", "dagster_teams"} | (
-        {"dagster_releases_assets", "dagster_releases_author", "dagster_tags_commit"}
+    tables = {
+        "dagster_releases",
+        "dagster_tags",
+        "dagster_teams",
+        "dagster_array_test",
+        "dagster_unknown_test",
+    } | (
+        {
+            "dagster_releases_assets",
+            "dagster_releases_author",
+            "dagster_tags_commit",
+            "dagster_releases_foo",
+            "dagster_array_test_author",
+        }
         if use_normalization_tables
         else set()
     )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
@@ -235,6 +235,62 @@ def get_project_connection_json(**kwargs):
                     },
                     {
                         "stream": {
+                            "name": "unknown_test",
+                            "jsonSchema": {
+                                "type": "unknown",
+                                "$schema": "http://json-schema.org/draft-07/schema#",
+                            },
+                            "supportedSyncModes": ["full_refresh", "overwrite"],
+                            "sourceDefinedCursor": True,
+                            "defaultCursorField": ["created_at"],
+                            "sourceDefinedPrimaryKey": [["id"]],
+                        },
+                        "config": {
+                            "syncMode": "incremental",
+                            "cursorField": ["created_at"],
+                            "destinationSyncMode": "append_dedup",
+                            "primaryKey": [["id"]],
+                            "aliasName": "unknown_test",
+                            "selected": True,
+                        },
+                    },
+                    {
+                        "stream": {
+                            "name": "array_test",
+                            "jsonSchema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "required": ["name", "version"],
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "version": {"type": "string"},
+                                        "author": {
+                                            "type": ["null", "object"],
+                                            "properties": {
+                                                "id": {"type": ["null", "integer"]},
+                                            },
+                                        },
+                                    },
+                                },
+                                "$schema": "http://json-schema.org/draft-07/schema#",
+                            },
+                            "supportedSyncModes": ["full_refresh", "overwrite"],
+                            "sourceDefinedCursor": True,
+                            "defaultCursorField": ["created_at"],
+                            "sourceDefinedPrimaryKey": [["id"]],
+                        },
+                        "config": {
+                            "syncMode": "incremental",
+                            "cursorField": ["created_at"],
+                            "destinationSyncMode": "append_dedup",
+                            "primaryKey": [["id"]],
+                            "aliasName": "array_test",
+                            "selected": True,
+                        },
+                    },
+                    {
+                        "stream": {
                             "name": "tags",
                             "jsonSchema": {
                                 "type": "object",
@@ -339,6 +395,14 @@ def get_project_job_json():
                         },
                         {
                             "streamName": "dagster_releases",
+                            "stats": {
+                                "recordsEmitted": 119,
+                                "bytesEmitted": 620910,
+                                "recordsCommitted": 119,
+                            },
+                        },
+                        {
+                            "streamName": "dagster_array_test",
                             "stats": {
                                 "recordsEmitted": 119,
                                 "bytesEmitted": 620910,
@@ -481,6 +545,62 @@ def get_instance_connections_json():
                                 "destinationSyncMode": "append_dedup",
                                 "primaryKey": [["id"]],
                                 "aliasName": "releases",
+                                "selected": True,
+                            },
+                        },
+                        {
+                            "stream": {
+                                "name": "unknown_test",
+                                "jsonSchema": {
+                                    "type": "unknown",
+                                    "$schema": "http://json-schema.org/draft-07/schema#",
+                                },
+                                "supportedSyncModes": ["full_refresh", "overwrite"],
+                                "sourceDefinedCursor": True,
+                                "defaultCursorField": ["created_at"],
+                                "sourceDefinedPrimaryKey": [["id"]],
+                            },
+                            "config": {
+                                "syncMode": "incremental",
+                                "cursorField": ["created_at"],
+                                "destinationSyncMode": "append_dedup",
+                                "primaryKey": [["id"]],
+                                "aliasName": "unknown_test",
+                                "selected": True,
+                            },
+                        },
+                        {
+                            "stream": {
+                                "name": "array_test",
+                                "jsonSchema": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "required": ["name", "version"],
+                                        "properties": {
+                                            "name": {"type": "string"},
+                                            "version": {"type": "string"},
+                                            "author": {
+                                                "type": ["null", "object"],
+                                                "properties": {
+                                                    "id": {"type": ["null", "integer"]},
+                                                },
+                                            },
+                                        },
+                                    },
+                                    "$schema": "http://json-schema.org/draft-07/schema#",
+                                },
+                                "supportedSyncModes": ["full_refresh", "overwrite"],
+                                "sourceDefinedCursor": True,
+                                "defaultCursorField": ["created_at"],
+                                "sourceDefinedPrimaryKey": [["id"]],
+                            },
+                            "config": {
+                                "syncMode": "incremental",
+                                "cursorField": ["created_at"],
+                                "destinationSyncMode": "append_dedup",
+                                "primaryKey": [["id"]],
+                                "aliasName": "array_test",
                                 "selected": True,
                             },
                         },


### PR DESCRIPTION
## Summary

Some Airbyte sources have streams whose root data type is an array rather than an object. Updates our normalization-table-generating and materialization-generating code to properly handle this, and to safely handle an unknown root data type.

## Test Plan

New unit test case.