### PR TITLE
[docs] Rename Function Referenced in Dynamic Graphs Docs

### DIFF
--- a/docs/content/concepts/ops-jobs-graphs/dynamic-graphs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/dynamic-graphs.mdx
@@ -39,7 +39,7 @@ def naive():
     data_processing()
 ```
 
-While, the implementation of `expensive_computation` can internally do something to parallelize the compute, if anything goes wrong with any part we have to restart the whole computation.
+While, the implementation of `expensive_processing` can internally do something to parallelize the compute, if anything goes wrong with any part we have to restart the whole computation.
 
 ### A Dynamic Job
 


### PR DESCRIPTION
### Summary & Motivation
- The Dynamic Graphs [docs](https://docs.dagster.io/concepts/ops-jobs-graphs/dynamic-graphs#using-dynamic-outputs) mention a function `expensive_computation` that doesn't exist in the code snippet
- The snippet mentions `expensive_processing` which should probably be renamed to `expensive_computation`

Example below:
<img width="666" alt="image" src="https://user-images.githubusercontent.com/29241719/205751427-b0b093bc-34ad-4413-8bb1-ce9f418fc952.png">

### How I Tested These Changes
```
cd docs
make next-watch-build
```

Docs are as expected when navigating to `http://localhost:3001/concepts/ops-jobs-graphs/dynamic-graphs#using-dynamic-outputs`
<img width="769" alt="image" src="https://user-images.githubusercontent.com/29241719/205750952-ea16a5cc-f568-408a-96e9-942af58b433f.png">
