### PR TITLE
[docs] Add missing `make` command to Contributing docs

### DIFF
--- a/docs/content/community/contributing.mdx
+++ b/docs/content/community/contributing.mdx
@@ -147,7 +147,7 @@ To run the Dagster documentation website locally, run the following commands:
 
 ```bash
 cd docs
-next-watch-build   # Serves the docs website on http://localhost:3001
+make next-watch-build   # Serves the docs website on http://localhost:3001
 ```
 
 Troubleshooting tip: You may need to run `make next-dev-install` first to install dependencies. Also make sure that your Node version is >=12.13.0.


### PR DESCRIPTION
### Summary & Motivation
- Within the `Developing Docs` [documentation](https://docs.dagster.io/community/contributing#developing-docs), the code snippet mentions the `next-watch-build` command
- This command is actually a Make command ([code pointer](https://github.com/dagster-io/dagster/blob/master/docs/Makefile#L14)), but the `make` keyword was missing

Example below: 
<img width="699" alt="image" src="https://user-images.githubusercontent.com/29241719/205758605-26917d87-a372-4805-9ef6-a4d61aa62472.png">

### How I Tested These Changes
```
cd docs
make next-watch-build
```
`make` command is added when navigating to `http://localhost:3001/community/contributing#developing-docs`
<img width="763" alt="image" src="https://user-images.githubusercontent.com/29241719/205758860-4155f6e7-75da-4ba4-8ebf-fff7ef8c056c.png">

