### PR TITLE
[dagit] Move op graphs behind “Show per-asset status”

### DIFF
--- a/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
@@ -139,16 +139,18 @@ export const AssetJobPartitionsView: React.FC<{
           </Box>
         )}
       </Box>
-      <AssetJobPartitionGraphs
-        pipelineName={pipelineName}
-        partitionSetName={partitionSetName}
-        multidimensional={(merged?.dimensions.length || 0) > 1}
-        dimensionName={dimension ? dimension.name : null}
-        dimensionKeys={dimensionKeys}
-        selected={selectedDimensionKeys}
-        offset={offset}
-        pageSize={pageSize}
-      />
+      {showAssets && (
+        <AssetJobPartitionGraphs
+          pipelineName={pipelineName}
+          partitionSetName={partitionSetName}
+          multidimensional={(merged?.dimensions.length || 0) > 1}
+          dimensionName={dimension ? dimension.name : null}
+          dimensionKeys={dimensionKeys}
+          selected={selectedDimensionKeys}
+          offset={offset}
+          pageSize={pageSize}
+        />
+      )}
       <Box
         padding={{horizontal: 24, vertical: 16}}
         border={{side: 'horizontal', color: Colors.KeylineGray, width: 1}}


### PR DESCRIPTION
### Summary & Motivation

This is a small PR that moves the "Run Duration" and "Step Duration" graphs on the Asset Partitions page behind the "Show per-asset status" button.

The rationale for this is that these graphs make expensive queries and slow down the overall page. On the corresponding op job page, only step duration is hidden until you "Show per-op status". The slight difference in behavior is due to the fact that the asset run data isn't loaded at all for the health bar.

Note: I'm not wild about the "Show per-asset status" button overall. When we get through the backlog the plan is to more broadly redesign this page!

### How I Tested These Changes
