### PR TITLE
Replace partition ranges with subsets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -10,6 +10,7 @@ from typing import (
     Sequence,
     Set,
     Union,
+    cast,
 )
 
 import toposort
@@ -22,7 +23,6 @@ from .assets import AssetsDefinition
 from .events import AssetKey, AssetKeyPartitionKey
 from .freshness_policy import FreshnessPolicy
 from .partition import PartitionsDefinition
-from .partition_key_range import PartitionKeyRange
 from .partition_mapping import PartitionMapping, infer_partition_mapping
 from .source_asset import SourceAsset
 
@@ -222,15 +222,12 @@ class AssetGraph(
             )
 
         partition_mapping = self.get_partition_mapping(child_asset_key, parent_asset_key)
-        downstream_partition_key_range = (
-            partition_mapping.get_downstream_partitions_for_partition_range(
-                PartitionKeyRange(parent_partition_key, parent_partition_key),
-                downstream_partitions_def=child_partitions_def,
-                upstream_partitions_def=parent_partitions_def,
-            )
+        child_partitions_subset = partition_mapping.get_downstream_partitions_for_partitions(
+            parent_partitions_def.empty_subset().with_partition_keys([parent_partition_key]),
+            downstream_partitions_def=child_partitions_def,
         )
 
-        return child_partitions_def.get_partition_keys_in_range(downstream_partition_key_range)
+        return list(child_partitions_subset.get_partition_keys())
 
     def get_parents_partitions(
         self, asset_key: AssetKey, partition_key: Optional[str] = None
@@ -278,15 +275,15 @@ class AssetGraph(
             )
 
         partition_mapping = self.get_partition_mapping(child_asset_key, parent_asset_key)
-        upstream_partition_key_range = (
-            partition_mapping.get_upstream_partitions_for_partition_range(
-                PartitionKeyRange(partition_key, partition_key) if partition_key else None,
-                downstream_partitions_def=child_partitions_def,
-                upstream_partitions_def=parent_partitions_def,
-            )
+        parent_partition_key_subset = partition_mapping.get_upstream_partitions_for_partitions(
+            cast(PartitionsDefinition, child_partitions_def)
+            .empty_subset()
+            .with_partition_keys([partition_key])
+            if partition_key
+            else None,
+            upstream_partitions_def=parent_partitions_def,
         )
-
-        return parent_partitions_def.get_partition_keys_in_range(upstream_partition_key_range)
+        return list(parent_partition_key_subset.get_partition_keys())
 
     def has_non_source_parents(self, asset_key: AssetKey) -> bool:
         """Determines if an asset has any parents which are not source assets"""

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -3,7 +3,7 @@ from typing import NamedTuple, Optional
 
 import dagster._check as check
 from dagster._annotations import public
-from dagster._core.definitions.partition import PartitionsDefinition
+from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._serdes import whitelist_for_serdes
 
@@ -45,7 +45,7 @@ class PartitionMapping(ABC):
         upstream_partitions_def: PartitionsDefinition,
     ) -> PartitionKeyRange:
         """Returns the range of partition keys in the downstream asset that use the data in the given
-        partition key range of the downstream asset.
+        partition key range of the upstream asset.
 
         Args:
             upstream_partition_key_range (PartitionKeyRange): The range of partition keys in the
@@ -55,6 +55,77 @@ class PartitionMapping(ABC):
             upstream_partitions_def (PartitionsDefinition): The partitions definition for the
                 upstream asset.
         """
+
+    @public
+    def get_upstream_partitions_for_partitions(
+        self,
+        downstream_partitions_subset: Optional[PartitionsSubset],
+        upstream_partitions_def: PartitionsDefinition,
+    ) -> PartitionsSubset:
+        """
+        Returns the subset of partition keys in the upstream asset that include data necessary
+        to compute the contents of the given partition key subset in the downstream asset.
+
+        Args:
+            downstream_partitions_subset (Optional[PartitionsSubset]):
+                The subset of partition keys in the downstream asset.
+            upstream_partitions_def (PartitionsDefinition): The partitions definition for the
+                upstream asset.
+        """
+        upstream_key_ranges = []
+        if downstream_partitions_subset is None:
+            upstream_key_ranges.append(
+                self.get_upstream_partitions_for_partition_range(
+                    None, None, upstream_partitions_def
+                )
+            )
+        else:
+            for key_range in downstream_partitions_subset.get_partition_key_ranges():
+                upstream_key_ranges.append(
+                    self.get_upstream_partitions_for_partition_range(
+                        key_range,
+                        downstream_partitions_subset.partitions_def,
+                        upstream_partitions_def,
+                    )
+                )
+
+        return upstream_partitions_def.empty_subset().with_partition_keys(
+            pk
+            for upstream_key_range in upstream_key_ranges
+            for pk in upstream_partitions_def.get_partition_keys_in_range(upstream_key_range)
+        )
+
+    @public
+    def get_downstream_partitions_for_partitions(
+        self,
+        upstream_partitions_subset: PartitionsSubset,
+        downstream_partitions_def: PartitionsDefinition,
+    ) -> PartitionsSubset:
+        """
+        Returns the subset of partition keys in the downstream asset that use the data in the given
+        partition key subset of the upstream asset.
+
+        Args:
+            upstream_partitions_subset (Union[PartitionKeyRange, PartitionsSubset]): The
+                subset of partition keys in the upstream asset.
+            downstream_partitions_def (PartitionsDefinition): The partitions definition for the
+                downstream asset.
+        """
+        downstream_key_ranges = []
+        for key_range in upstream_partitions_subset.get_partition_key_ranges():
+            downstream_key_ranges.append(
+                self.get_downstream_partitions_for_partition_range(
+                    key_range,
+                    downstream_partitions_def,
+                    upstream_partitions_subset.partitions_def,
+                )
+            )
+
+        return downstream_partitions_def.empty_subset().with_partition_keys(
+            pk
+            for upstream_key_range in downstream_key_ranges
+            for pk in downstream_partitions_def.get_partition_keys_in_range(upstream_key_range)
+        )
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -217,6 +217,15 @@ class TimeWindowPartitionsDefinition(
         else:
             return next_window
 
+    def get_prev_partition_window(self, start_dt: datetime) -> Optional[TimeWindow]:
+        windows_iter = iter(self._reverse_iterate_time_windows(start_dt))
+        prev_window = next(windows_iter)
+        first_partition_window = self.get_first_partition_window()
+        if first_partition_window is None or prev_window.start < first_partition_window.start:
+            return None
+        else:
+            return prev_window
+
     def get_first_partition_window(
         self, current_time: Optional[datetime] = None
     ) -> Optional[TimeWindow]:
@@ -258,19 +267,28 @@ class TimeWindowPartitionsDefinition(
 
         return TimeWindowPartitionMapping()
 
-    def get_partition_keys_in_range(self, partition_key_range: PartitionKeyRange) -> Sequence[str]:
-        start_time = self.start_time_for_partition_key(partition_key_range.start)
-        end_time = self.start_time_for_partition_key(partition_key_range.end)
-
+    def get_partition_keys_in_time_window(self, time_window: TimeWindow) -> Sequence[str]:
         result: List[str] = []
-        for time_window in self._iterate_time_windows(start_time):
-            if time_window.start <= end_time:
-                result.append(time_window.start.strftime(self.fmt))
+        for partition_time_window in self._iterate_time_windows(time_window.start):
+            if partition_time_window.start < time_window.end:
+                result.append(partition_time_window.start.strftime(self.fmt))
             else:
                 break
+        return result
 
-        current_partitions = [partition.name for partition in self.get_partitions()]
-        return [partition for partition in result if partition in current_partitions]
+    def get_partition_key_range_for_time_window(self, time_window: TimeWindow) -> PartitionKeyRange:
+        start_partition_key = self.get_partition_key_for_timestamp(time_window.start.timestamp())
+        end_partition_key = self.get_partition_key_for_timestamp(
+            cast(TimeWindow, self.get_prev_partition_window(time_window.end)).start.timestamp()
+        )
+
+        return PartitionKeyRange(start_partition_key, end_partition_key)
+
+    def get_partition_keys_in_range(self, partition_key_range: PartitionKeyRange) -> Sequence[str]:
+        start_time = self.start_time_for_partition_key(partition_key_range.start)
+        end_time = self.end_time_for_partition_key(partition_key_range.end)
+
+        return self.get_partition_keys_in_time_window(TimeWindow(start_time, end_time))
 
     @public  # type: ignore
     @property
@@ -1004,6 +1022,21 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
 
         return result
 
+    def get_partition_keys(self, current_time: Optional[datetime] = None) -> Iterable[str]:
+        return [
+            pk
+            for time_window in self._included_time_windows
+            for pk in self._partitions_def.get_partition_keys_in_time_window(time_window)
+        ]
+
+    def get_partition_key_ranges(
+        self, current_time: Optional[datetime] = None
+    ) -> Sequence[PartitionKeyRange]:
+        return [
+            self._partitions_def.get_partition_key_range_for_time_window(window)
+            for window in self._included_time_windows
+        ]
+
     @property
     def included_time_windows(self) -> Sequence[TimeWindow]:
         return self._included_time_windows
@@ -1071,4 +1104,15 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
                 (window.start.timestamp(), window.end.timestamp())
                 for window in self._included_time_windows
             ]
+        )
+
+    @property
+    def partitions_def(self) -> PartitionsDefinition:
+        return self._partitions_def
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, TimeWindowPartitionsSubset)
+            and self._partitions_def == other._partitions_def
+            and self._included_time_windows == other._included_time_windows
         )

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_partition_mappings.py
@@ -92,7 +92,7 @@ def test_filter_mapping_partitions_dep():
 
     assert get_upstream_partitions_for_partition_range(
         downstream_asset,
-        upstream_asset,
+        upstream_asset.partitions_def,
         AssetKey("upstream_asset"),
         PartitionKeyRange("ringo", "paul"),
     ) == PartitionKeyRange("southern|ringo", "southern|paul")

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
@@ -64,7 +64,7 @@ def test_assets_with_same_partitioning():
 
     assert get_upstream_partitions_for_partition_range(
         downstream_asset,
-        upstream_asset,
+        upstream_asset.partitions_def,
         AssetKey("upstream_asset"),
         PartitionKeyRange("a", "c"),
     ) == PartitionKeyRange("a", "c")
@@ -354,14 +354,14 @@ def test_multi_assets_with_same_partitioning():
 
     assert get_upstream_partitions_for_partition_range(
         downstream_asset_1,
-        upstream_asset,
+        upstream_asset.partitions_def,
         AssetKey("upstream_asset_1"),
         PartitionKeyRange("a", "c"),
     ) == PartitionKeyRange("a", "c")
 
     assert get_upstream_partitions_for_partition_range(
         downstream_asset_2,
-        upstream_asset,
+        upstream_asset.partitions_def,
         AssetKey("upstream_asset_2"),
         PartitionKeyRange("a", "c"),
     ) == PartitionKeyRange("a", "c")

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_time_window_partition_mapping.py
@@ -11,85 +11,96 @@ from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
 
 
+def subset_with_key(partitions_def: TimeWindowPartitionsDefinition, key: str):
+    return partitions_def.empty_subset().with_partition_keys([key])
+
+
+def subset_with_key_range(partitions_def: TimeWindowPartitionsDefinition, start: str, end: str):
+    return partitions_def.empty_subset().with_partition_keys(
+        partitions_def.get_partition_keys_in_range(PartitionKeyRange(start, end))
+    )
+
+
 def test_get_upstream_partitions_for_partition_range_same_partitioning():
     downstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
     upstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
     # single partition key
-    partition_key_range = PartitionKeyRange("2021-05-07", "2021-05-07")
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partition_range(
-        partition_key_range,
-        downstream_partitions_def,
+    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+        subset_with_key(downstream_partitions_def, "2021-05-07"),
         upstream_partitions_def,
     )
-    assert partition_key_range == result
+    assert result == upstream_partitions_def.empty_subset().with_partition_keys(["2021-05-07"])
 
     # range of partition keys
-    partition_key_range = PartitionKeyRange("2021-05-07", "2021-05-09")
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partition_range(
-        partition_key_range,
-        downstream_partitions_def,
+    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+        subset_with_key_range(downstream_partitions_def, "2021-05-07", "2021-05-09"),
         upstream_partitions_def,
     )
-    assert partition_key_range == result
+    assert result == subset_with_key_range(upstream_partitions_def, "2021-05-07", "2021-05-09")
 
 
 def test_get_upstream_partitions_for_partition_range_same_partitioning_different_formats():
     downstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
     upstream_partitions_def = DailyPartitionsDefinition(start_date="2021/05/05", fmt="%Y/%m/%d")
 
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partition_range(
-        PartitionKeyRange("2021-05-07", "2021-05-09"),
-        downstream_partitions_def,
+    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+        subset_with_key_range(downstream_partitions_def, "2021-05-07", "2021-05-09"),
         upstream_partitions_def,
     )
-    assert result == PartitionKeyRange("2021/05/07", "2021/05/09")
+    assert result == subset_with_key_range(upstream_partitions_def, "2021/05/07", "2021/05/09")
+    assert result.get_partition_keys() == upstream_partitions_def.get_partition_keys_in_range(
+        PartitionKeyRange("2021/05/07", "2021/05/09")
+    )
 
 
 def test_get_upstream_partitions_for_partition_range_hourly_downstream_daily_upstream():
     downstream_partitions_def = HourlyPartitionsDefinition(start_date="2021-05-05-00:00")
     upstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partition_range(
-        PartitionKeyRange("2021-05-07-05:00", "2021-05-07-05:00"),
-        downstream_partitions_def,
+    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+        subset_with_key(downstream_partitions_def, "2021-05-07-05:00"),
         upstream_partitions_def,
     )
-    assert result == PartitionKeyRange("2021-05-07", "2021-05-07")
+    assert result == upstream_partitions_def.empty_subset().with_partition_keys(["2021-05-07"])
 
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partition_range(
-        PartitionKeyRange("2021-05-07-05:00", "2021-05-09-09:00"),
-        downstream_partitions_def,
+    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+        subset_with_key_range(downstream_partitions_def, "2021-05-07-05:00", "2021-05-09-09:00"),
         upstream_partitions_def,
     )
-    assert result == PartitionKeyRange("2021-05-07", "2021-05-09")
+    assert result.get_partition_keys() == upstream_partitions_def.get_partition_keys_in_range(
+        PartitionKeyRange("2021-05-07", "2021-05-09")
+    )
 
 
 def test_get_upstream_partitions_for_partition_range_daily_downstream_hourly_upstream():
     downstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
     upstream_partitions_def = HourlyPartitionsDefinition(start_date="2021-05-05-00:00")
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partition_range(
-        PartitionKeyRange("2021-05-07", "2021-05-07"),
-        downstream_partitions_def,
+    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+        subset_with_key(downstream_partitions_def, "2021-05-07"),
         upstream_partitions_def,
     )
-    assert result == PartitionKeyRange("2021-05-07-00:00", "2021-05-07-23:00")
+    assert result.get_partition_keys() == upstream_partitions_def.get_partition_keys_in_range(
+        PartitionKeyRange("2021-05-07-00:00", "2021-05-07-23:00")
+    )
 
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partition_range(
-        PartitionKeyRange("2021-05-07", "2021-05-09"),
-        downstream_partitions_def,
+    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+        subset_with_key_range(downstream_partitions_def, "2021-05-07", "2021-05-09"),
         upstream_partitions_def,
     )
-    assert result == PartitionKeyRange("2021-05-07-00:00", "2021-05-09-23:00")
+    assert result.get_partition_keys() == upstream_partitions_def.get_partition_keys_in_range(
+        PartitionKeyRange("2021-05-07-00:00", "2021-05-09-23:00")
+    )
 
 
 def test_get_upstream_partitions_for_partition_range_monthly_downstream_daily_upstream():
     downstream_partitions_def = MonthlyPartitionsDefinition(start_date="2021-05-01")
     upstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-01")
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partition_range(
-        PartitionKeyRange("2021-05-01", "2021-07-01"),
-        downstream_partitions_def,
+    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+        subset_with_key_range(downstream_partitions_def, "2021-05-01", "2021-07-01"),
         upstream_partitions_def,
     )
-    assert result == PartitionKeyRange("2021-05-01", "2021-07-31")
+    assert result.get_partition_keys() == upstream_partitions_def.get_partition_keys_in_range(
+        PartitionKeyRange("2021-05-01", "2021-07-31")
+    )
 
 
 def test_get_upstream_partitions_for_partition_range_twice_daily_downstream_daily_upstream():
@@ -100,12 +111,13 @@ def test_get_upstream_partitions_for_partition_range_twice_daily_downstream_dail
     upstream_partitions_def = TimeWindowPartitionsDefinition(
         cron_schedule="0 0,11 * * *", start=start, fmt="%Y-%m-%d %H:%M"
     )
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partition_range(
-        PartitionKeyRange("2021-05-01", "2021-05-03"),
-        downstream_partitions_def,
+    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+        subset_with_key_range(downstream_partitions_def, "2021-05-01", "2021-05-03"),
         upstream_partitions_def,
     )
-    assert result == PartitionKeyRange("2021-05-01 00:00", "2021-05-03 11:00")
+    assert result.get_partition_keys() == upstream_partitions_def.get_partition_keys_in_range(
+        PartitionKeyRange("2021-05-01 00:00", "2021-05-03 11:00")
+    )
 
 
 def test_get_upstream_partitions_for_partition_range_daily_downstream_twice_daily_upstream():
@@ -116,12 +128,13 @@ def test_get_upstream_partitions_for_partition_range_daily_downstream_twice_dail
     upstream_partitions_def = TimeWindowPartitionsDefinition(
         cron_schedule="0 0 * * *", start=start, fmt="%Y-%m-%d"
     )
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partition_range(
-        PartitionKeyRange("2021-05-01 00:00", "2021-05-03 00:00"),
-        downstream_partitions_def,
+    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+        subset_with_key_range(downstream_partitions_def, "2021-05-01 00:00", "2021-05-03 00:00"),
         upstream_partitions_def,
     )
-    assert result == PartitionKeyRange("2021-05-01", "2021-05-03")
+    assert result.get_partition_keys() == upstream_partitions_def.get_partition_keys_in_range(
+        PartitionKeyRange("2021-05-01", "2021-05-03")
+    )
 
 
 def test_get_upstream_partitions_for_partition_range_daily_non_aligned():
@@ -132,12 +145,13 @@ def test_get_upstream_partitions_for_partition_range_daily_non_aligned():
     upstream_partitions_def = TimeWindowPartitionsDefinition(
         cron_schedule="0 11 * * *", start=start, fmt="%Y-%m-%d"
     )
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partition_range(
-        PartitionKeyRange("2021-05-02", "2021-05-04"),
-        downstream_partitions_def,
+    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+        subset_with_key_range(downstream_partitions_def, "2021-05-02", "2021-05-04"),
         upstream_partitions_def,
     )
-    assert result == PartitionKeyRange("2021-05-01", "2021-05-04")
+    assert result.get_partition_keys() == upstream_partitions_def.get_partition_keys_in_range(
+        PartitionKeyRange("2021-05-01", "2021-05-04")
+    )
 
 
 def test_get_upstream_partitions_for_partition_range_weekly_with_offset():
@@ -145,9 +159,10 @@ def test_get_upstream_partitions_for_partition_range_weekly_with_offset():
         start_date="2022-09-04", day_offset=0, hour_offset=10
     )
 
-    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partition_range(
-        PartitionKeyRange("2022-09-11", "2022-09-11"),
-        partitions_def,
+    result = TimeWindowPartitionMapping().get_upstream_partitions_for_partitions(
+        subset_with_key_range(partitions_def, "2022-09-11", "2022-09-11"),
         partitions_def,
     )
-    assert result == PartitionKeyRange("2022-09-11", "2022-09-11")
+    assert result.get_partition_keys() == (
+        partitions_def.get_partition_keys_in_range(PartitionKeyRange("2022-09-11", "2022-09-11"))
+    )

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
@@ -507,33 +507,6 @@ def my_repo():
     return [july_asset, july_asset_2, august_asset]
 
 
-def test_invalid_partition_mapping():
-    @multi_asset_sensor(asset_keys=[july_asset.key])
-    def asset_sensor(context):
-        partition = next(
-            iter(context.latest_materialization_records_by_partition(july_asset.key).keys())
-        )
-
-        # Line errors because we're trying to map to a partition that doesn't exist
-        context.get_downstream_partition_keys(
-            partition,
-            to_asset_key=august_asset.key,
-            from_asset_key=july_asset.key,
-        )
-
-    with instance_for_test() as instance:
-        materialize(
-            [july_asset],
-            partition_key="2022-07-01",
-            instance=instance,
-        )
-        ctx = build_multi_asset_sensor_context(
-            asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
-        )
-        with pytest.warns(UserWarning):
-            asset_sensor(ctx)
-
-
 def test_multi_asset_sensor_after_cursor_partition_flag():
     @multi_asset_sensor(asset_keys=[july_asset.key])
     def after_cursor_partitions_asset_sensor(context):

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_time_window_partitions.py
@@ -508,3 +508,11 @@ def test_partition_subset_with_partition_keys(initial: str, added: str):
         1 if updated_subset_str[0] == "+" else 0
     )
     assert len(updated_subset.included_time_windows) == expected_range_count, updated_subset_str
+
+
+def test_time_window_partitions_subset():
+    weekly_partitions_def = WeeklyPartitionsDefinition(start_date="2022-01-01")
+
+    with_keys = ["2022-01-02", "2022-01-09", "2022-01-23", "2022-02-06"]
+    subset = weekly_partitions_def.empty_subset().with_partition_keys(with_keys)
+    assert set(subset.get_partition_keys()) == set(with_keys)


### PR DESCRIPTION
After multidimensional partition definitions were introduced, partition ranges are insufficient in many cases. For example:
```
MultiPartitionsDefinition(
    {"ab": StaticPartitionsDefinition(["a", "b"]), "12": StaticPartitionsDefinition(["1", "2"])}
)
```
has partition keys: ['1|a', '1|b', '2|a', '2|b']

If this asset had an upstream asset with partitions definition StaticPartitionsDefinition(["a", "b"]), the downstream partition keys should be ['1|a', '2|a'] but this can't exist as a range of the partition key list.

This PR amends the existing methods that fetch upstream/downstream partitions ranges to instead work with subsets. This means that PartitionMappings should return subsets instead of ranges. In order to not break users, this PR introduces the following methods:
- get_upstream_partitions_for_partition_subset, which reads from get_upstream_partitions_for_partition_range
- get_downstream_partitions_for_partition_subset which reads from get_downstream_partitions_for_partition_range

In the future, at the next major release, I think we should deprecate the range methods on PartitionMappings and replace these all with subset methods. This will enable future use cases like MultiPartition assets that depend on differently MultiPartitioned assets.