### PR TITLE
solid -> node method renames

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_type_guide.py
+++ b/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_type_guide.py
@@ -217,7 +217,7 @@ def test_nothing_type():
 
     result = execute_pipeline(nothing_pipeline)
     assert result.success
-    assert result.output_for_solid("after_cleanup") == "worked"
+    assert result.output_for_node("after_cleanup") == "worked"
 
 
 def test_nothing_fanin_actually_test():

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -1,3 +1,5 @@
+# pyright: strict
+
 from collections import OrderedDict, defaultdict
 from typing import (
     TYPE_CHECKING,
@@ -6,6 +8,7 @@ from typing import (
     Dict,
     Iterable,
     Iterator,
+    List,
     Mapping,
     Optional,
     Sequence,
@@ -52,7 +55,6 @@ from .solid_container import create_execution_structure, validate_dependency_dic
 from .version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
-    from dagster._core.execution.context.init import InitResourceContext
     from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
     from dagster._core.instance import DagsterInstance
 
@@ -71,7 +73,7 @@ def _check_node_defs_arg(
 
     _node_defs = check.opt_sequence_param(node_defs, "node_defs")
     for node_def in _node_defs:
-        if isinstance(node_def, NodeDefinition):
+        if isinstance(node_def, NodeDefinition):  # type: ignore
             continue
         elif callable(node_def):
             raise DagsterInvalidDefinitionError(
@@ -315,7 +317,7 @@ class GraphDefinition(NodeDefinition):
     def get_solid(self, handle: NodeHandle) -> Node:
         check.inst_param(handle, "handle", NodeHandle)
         current = handle
-        lineage = []
+        lineage: List[str] = []
         while current:
             lineage.append(current.name)
             current = current.parent
@@ -907,9 +909,9 @@ def _validate_out_mappings(
     name: str,
     class_name: str,
 ) -> Tuple[Sequence[OutputMapping], Sequence[OutputDefinition]]:
-    output_defs = []
+    output_defs: List[OutputDefinition] = []
     for mapping in output_mappings:
-        if isinstance(mapping, OutputMapping):
+        if isinstance(mapping, OutputMapping):  # type: ignore
 
             target_solid = solid_dict.get(mapping.maps_from.solid_name)
             if target_solid is None:

--- a/python_modules/dagster/dagster/_core/execution/execution_result.py
+++ b/python_modules/dagster/dagster/_core/execution/execution_result.py
@@ -1,5 +1,7 @@
+# pyright: strict
+
 from abc import ABC, abstractmethod
-from typing import AbstractSet, Any, Callable, List, Sequence, Union, cast
+from typing import AbstractSet, Callable, List, Sequence, Set, Union, cast
 
 import dagster._check as check
 from dagster._core.definitions import JobDefinition, NodeHandle
@@ -54,7 +56,7 @@ class ExecutionResult(ABC):
         return step_events
 
     @abstractmethod
-    def _get_output_for_handle(self, handle: NodeHandle, output_name: str) -> Any:
+    def _get_output_for_handle(self, handle: NodeHandle, output_name: str) -> object:
         raise NotImplementedError()
 
     def _filter_events_by_handle(self, handle: NodeHandle) -> Sequence[DagsterEvent]:
@@ -66,7 +68,7 @@ class ExecutionResult(ABC):
 
         return self.filter_events(_is_event_from_node)
 
-    def output_value(self, output_name: str = DEFAULT_OUTPUT) -> Any:
+    def output_value(self, output_name: str = DEFAULT_OUTPUT) -> object:
 
         check.str_param(output_name, "output_name")
 
@@ -90,7 +92,7 @@ class ExecutionResult(ABC):
         # Get output from origin node
         return self._get_output_for_handle(check.not_none(origin_handle), origin_output_def.name)
 
-    def output_for_node(self, node_str: str, output_name: str = DEFAULT_OUTPUT) -> Any:
+    def output_for_node(self, node_str: str, output_name: str = DEFAULT_OUTPUT) -> object:
 
         # resolve handle of node that node_str is referring to
         target_handle = NodeHandle.from_string(node_str)
@@ -118,7 +120,7 @@ class ExecutionResult(ABC):
 
         return self._filter_events_by_handle(NodeHandle.from_string(node_name))
 
-    def get_job_failure_event(self):
+    def get_job_failure_event(self) -> DagsterEvent:
         """Returns a DagsterEvent with type DagsterEventType.PIPELINE_FAILURE if it ocurred during
         execution
         """
@@ -131,7 +133,7 @@ class ExecutionResult(ABC):
 
         return events[0]
 
-    def get_job_success_event(self):
+    def get_job_success_event(self) -> DagsterEvent:
         """Returns a DagsterEvent with type DagsterEventType.PIPELINE_SUCCESS if it ocurred during
         execution
         """
@@ -145,7 +147,7 @@ class ExecutionResult(ABC):
         return events[0]
 
     def asset_materializations_for_node(
-        self, node_name
+        self, node_name: str
     ) -> Sequence[Union[Materialization, AssetMaterialization]]:
         return [
             cast(StepMaterializationData, event.event_specific_data).materialization
@@ -153,7 +155,7 @@ class ExecutionResult(ABC):
             if event.event_type_value == DagsterEventType.ASSET_MATERIALIZATION.value
         ]
 
-    def asset_observations_for_node(self, node_name) -> Sequence[AssetObservation]:
+    def asset_observations_for_node(self, node_name: str) -> Sequence[AssetObservation]:
         return [
             cast(AssetObservationData, event.event_specific_data).asset_observation
             for event in self.events_for_node(node_name)
@@ -167,7 +169,7 @@ class ExecutionResult(ABC):
         failure_events = self.filter_events(
             lambda event: event.is_step_failure or event.is_resource_init_failure
         )
-        keys = set()
+        keys: Set[str] = set()
         for event in failure_events:
             if event.step_key:
                 keys.add(event.step_key)

--- a/python_modules/dagster/dagster/_utils/test/__init__.py
+++ b/python_modules/dagster/dagster/_utils/test/__init__.py
@@ -213,7 +213,7 @@ def execute_solids_within_pipeline(
         instance=instance,
     )
 
-    return {sr.node.name: sr for sr in result.solid_result_list}
+    return {sr.node.name: sr for sr in result.node_result_list}
 
 
 def wrap_op_in_graph(

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_composite_descent.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_composite_descent.py
@@ -29,7 +29,7 @@ def test_single_level_pipeline():
     result = execute_pipeline(return_int_pipeline, {"solids": {"return_int": {"config": 2}}})
 
     assert result.success
-    assert result.result_for_solid("return_int").output_value() == 2
+    assert result.result_for_node("return_int").output_value() == 2
 
 
 def test_single_solid_pipeline_composite_descent():
@@ -52,7 +52,7 @@ def test_single_solid_pipeline_composite_descent():
     result = execute_pipeline(return_int_pipeline, {"solids": {"return_int": {"config": 3}}})
 
     assert result.success
-    assert result.result_for_solid("return_int").output_value() == 3
+    assert result.result_for_node("return_int").output_value() == 3
 
 
 def test_single_layer_pipeline_composite_descent():
@@ -371,7 +371,7 @@ def test_provide_one_of_two_inputs_via_config():
 
     assert result.success
     assert (
-        result.result_for_solid("wrap_all_config_one_input").output_value()
+        result.result_for_node("wrap_all_config_one_input").output_value()
         == "override_a.override_b.set_input_a.set_input_b"
     )
 
@@ -530,7 +530,7 @@ def test_config_mapped_enum():
         execute_pipeline(
             wrapping_return_enum_pipeline,
             {"solids": {"wrapping_return_enum": {"config": {"num": 1}}}},
-        ).output_for_solid("wrapping_return_enum")
+        ).output_for_node("wrapping_return_enum")
         == TestPythonEnum.VALUE_ONE
     )
 
@@ -538,7 +538,7 @@ def test_config_mapped_enum():
         execute_pipeline(
             wrapping_return_enum_pipeline,
             {"solids": {"wrapping_return_enum": {"config": {"num": -11}}}},
-        ).output_for_solid("wrapping_return_enum")
+        ).output_for_node("wrapping_return_enum")
         == TestPythonEnum.OTHER
     )
 
@@ -567,7 +567,7 @@ def test_config_mapped_enum():
         execute_pipeline(
             wrap_return_int_pipeline,
             {"solids": {"wrap_return_int": {"config": {"enum": "VALUE_ONE"}}}},
-        ).output_for_solid("wrap_return_int")
+        ).output_for_node("wrap_return_int")
         == 1
     )
 
@@ -575,7 +575,7 @@ def test_config_mapped_enum():
         execute_pipeline(
             wrap_return_int_pipeline,
             {"solids": {"wrap_return_int": {"config": {"enum": "OTHER"}}}},
-        ).output_for_solid("wrap_return_int")
+        ).output_for_node("wrap_return_int")
         == 2
     )
 
@@ -594,7 +594,7 @@ def test_single_level_pipeline_with_configured_solid():
     result = execute_pipeline(return_int_pipeline)
 
     assert result.success
-    assert result.result_for_solid("return_int_5").output_value() == 5
+    assert result.result_for_node("return_int_5").output_value() == 5
 
 
 def test_configured_solid_with_inputs():
@@ -614,7 +614,7 @@ def test_configured_solid_with_inputs():
     )
 
     assert result.success
-    assert result.result_for_solid("return_int_configured").output_value() == 6
+    assert result.result_for_node("return_int_configured").output_value() == 6
 
 
 def test_single_level_pipeline_with_complex_configured_solid_within_composite():
@@ -647,7 +647,7 @@ def test_single_level_pipeline_with_complex_configured_solid_within_composite():
     )
 
     assert result.success
-    assert result.result_for_solid("introduce_wrapper").output_value() == "AJ is 20 years old"
+    assert result.result_for_node("introduce_wrapper").output_value() == "AJ is 20 years old"
 
 
 def test_single_level_pipeline_with_complex_configured_solid():
@@ -664,7 +664,7 @@ def test_single_level_pipeline_with_complex_configured_solid():
     result = execute_pipeline(introduce_pipeline)
 
     assert result.success
-    assert result.result_for_solid("introduce_aj").output_value() == "AJ is 20 years old"
+    assert result.result_for_node("introduce_aj").output_value() == "AJ is 20 years old"
 
 
 def test_single_level_pipeline_with_complex_configured_solid_nested():
@@ -685,7 +685,7 @@ def test_single_level_pipeline_with_complex_configured_solid_nested():
     result = execute_pipeline(introduce_pipeline)
 
     assert result.success
-    assert result.result_for_solid("introduce_aj_20").output_value() == "AJ is 20 years old"
+    assert result.result_for_node("introduce_aj_20").output_value() == "AJ is 20 years old"
 
 
 def test_single_level_pipeline_with_configured_graph():
@@ -720,7 +720,7 @@ def test_single_level_pipeline_with_configured_graph():
     result = execute_pipeline(test_pipeline)
 
     assert result.success
-    assert result.result_for_solid("multiply_three_by_four").output_value() == 12
+    assert result.result_for_node("multiply_three_by_four").output_value() == 12
 
 
 def test_single_level_pipeline_with_configured_decorated_graph():
@@ -759,7 +759,7 @@ def test_single_level_pipeline_with_configured_decorated_graph():
     result = execute_pipeline(test_pipeline)
 
     assert result.success
-    assert result.result_for_solid("multiply_three_by_four").output_value() == 12
+    assert result.result_for_node("multiply_three_by_four").output_value() == 12
 
 
 def test_configured_graph_with_inputs():
@@ -799,7 +799,7 @@ def test_configured_graph_with_inputs():
     )
 
     assert result.success
-    assert result.result_for_solid("return_int_composite").output_value() == 10
+    assert result.result_for_node("return_int_composite").output_value() == 10
 
 
 def test_configured_graph_cannot_stub_inner_solids_config():

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_config_mappings.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_config_mappings.py
@@ -269,7 +269,7 @@ def test_composite_config_field():
 
     res = execute_pipeline(test_pipeline, {"solids": {"test": {"config": {"override": 5}}}})
     assert res.result_for_handle("test.inner_solid").output_value() == "5"
-    assert res.result_for_solid("test").output_value() == "5"
+    assert res.result_for_node("test").output_value() == "5"
 
 
 def test_nested_composite_config_field():
@@ -303,7 +303,7 @@ def test_nested_composite_config_field():
     assert res.success
     assert res.result_for_handle("test.outer.inner_solid").output_value() == "5"
     assert res.result_for_handle("test.outer").output_value() == "5"
-    assert res.result_for_solid("test").output_value() == "5"
+    assert res.result_for_node("test").output_value() == "5"
 
 
 def test_nested_with_inputs():
@@ -350,7 +350,7 @@ def test_nested_with_inputs():
     )
 
     assert result.success
-    assert result.result_for_solid("pipe").output_value() == "override.foo - foobar"
+    assert result.result_for_node("pipe").output_value() == "override.foo - foobar"
 
 
 def test_wrap_none_config_and_inputs():
@@ -407,7 +407,7 @@ def test_wrap_none_config_and_inputs():
     )
     assert result.success
     assert (
-        result.result_for_solid("pipe").output_value()
+        result.result_for_node("pipe").output_value()
         == "set_config_a.set_config_b.set_input_a.set_input_b"
     )
 
@@ -538,7 +538,7 @@ def test_wrap_all_config_no_inputs():
     )
     assert result.success
     assert (
-        result.result_for_solid("pipe").output_value()
+        result.result_for_node("pipe").output_value()
         == "override_a.override_b.set_input_a.set_input_b"
     )
 
@@ -654,7 +654,7 @@ def test_wrap_all_config_one_input():
     )
     assert result.success
     assert (
-        result.result_for_solid("pipe").output_value()
+        result.result_for_node("pipe").output_value()
         == "override_a.override_b.set_input_a.set_input_b"
     )
 
@@ -766,7 +766,7 @@ def test_wrap_all_config_and_inputs():
 
     assert result.success
     assert (
-        result.result_for_solid("pipe").output_value()
+        result.result_for_node("pipe").output_value()
         == "override_a.override_b.override_input_a.override_input_b"
     )
 
@@ -815,10 +815,10 @@ def test_empty_config():
         wrap_solid()
 
     res = execute_pipeline(wrap_pipeline, run_config={"solids": {}})
-    assert res.result_for_solid("wrap_solid").output_values == {"result": "an input"}
+    assert res.result_for_node("wrap_solid").output_values == {"result": "an input"}
 
     res = execute_pipeline(wrap_pipeline)
-    assert res.result_for_solid("wrap_solid").output_values == {"result": "an input"}
+    assert res.result_for_node("wrap_solid").output_values == {"result": "an input"}
 
 
 def test_nested_empty_config():
@@ -840,10 +840,10 @@ def test_nested_empty_config():
         double_wrap()
 
     res = execute_pipeline(wrap_pipeline, run_config={"solids": {}})
-    assert res.result_for_solid("double_wrap").output_values == {"result": "an input"}
+    assert res.result_for_node("double_wrap").output_values == {"result": "an input"}
 
     res = execute_pipeline(wrap_pipeline)
-    assert res.result_for_solid("double_wrap").output_values == {"result": "an input"}
+    assert res.result_for_node("double_wrap").output_values == {"result": "an input"}
 
 
 def test_nested_empty_config_input():
@@ -874,7 +874,7 @@ def test_nested_empty_config_input():
         run_config={"solids": {"double_wrap": {"inputs": {"num": {"value": 2}}}}},
     )
     assert res.result_for_handle("double_wrap.number").output_value() == 2
-    assert res.result_for_solid("double_wrap").output_values == {"result": 4}
+    assert res.result_for_node("double_wrap").output_values == {"result": 4}
 
 
 def test_default_config_schema():

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
@@ -129,7 +129,7 @@ def test_one_layer_off_dependencies():
 def test_malformed_dependencies():
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='Expected IDependencyDefinition for solid "B" input "b_input"',
+        match='Expected IDependencyDefinition for node "B" input "b_input"',
     ):
         GraphDefinition(
             node_defs=solid_a_b_list(),

--- a/python_modules/dagster/dagster_tests/core_tests/test_compute_only_pipeline.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_compute_only_pipeline.py
@@ -25,7 +25,7 @@ def test_execute_solid_with_dep_only_inputs_no_api():
 
     assert pipeline_result.success
 
-    for result in pipeline_result.solid_result_list:
+    for result in pipeline_result.node_result_list:
         assert result.success
 
     assert did_run_dict["step_one"] is True
@@ -49,7 +49,7 @@ def test_execute_solid_with_dep_only_inputs_with_api():
 
     pipeline_result = execute_pipeline(pipe)
 
-    for result in pipeline_result.solid_result_list:
+    for result in pipeline_result.node_result_list:
         assert result.success
 
     assert did_run_dict["step_one"] is True

--- a/python_modules/dagster/dagster_tests/core_tests/test_mode_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_mode_definitions.py
@@ -59,18 +59,18 @@ def test_mode_from_resources():
     def pipeline_def():
         ret_three()
 
-    assert execute_pipeline(pipeline_def).result_for_solid("ret_three").output_value() == 3
+    assert execute_pipeline(pipeline_def).result_for_node("ret_three").output_value() == 3
 
 
 def test_execute_single_mode():
     single_mode_pipeline = define_single_mode_pipeline()
     assert single_mode_pipeline.is_single_mode is True
 
-    assert execute_pipeline(single_mode_pipeline).result_for_solid("return_two").output_value() == 2
+    assert execute_pipeline(single_mode_pipeline).result_for_node("return_two").output_value() == 2
 
     assert (
         execute_pipeline(single_mode_pipeline, mode="the_mode")
-        .result_for_solid("return_two")
+        .result_for_node("return_two")
         .output_value()
         == 2
     )
@@ -80,7 +80,7 @@ def test_wrong_single_mode():
     with pytest.raises(DagsterInvariantViolationError):
         assert (
             execute_pipeline(pipeline=define_single_mode_pipeline(), mode="wrong_mode")
-            .result_for_solid("return_two")
+            .result_for_node("return_two")
             .output_value()
             == 2
         )
@@ -119,14 +119,14 @@ def test_execute_multi_mode():
 
     assert (
         execute_pipeline(pipeline=multi_mode_pipeline, mode="mode_one")
-        .result_for_solid("return_three")
+        .result_for_node("return_three")
         .output_value()
         == 3
     )
 
     assert (
         execute_pipeline(pipeline=multi_mode_pipeline, mode="mode_two")
-        .result_for_solid("return_three")
+        .result_for_node("return_three")
         .output_value()
         == 3
     )
@@ -151,7 +151,7 @@ def test_execute_multi_mode_with_resources():
         run_config={"resources": {"op": {"config": 2}}},
     )
 
-    assert add_mode_result.result_for_solid("apply_to_three").output_value() == 5
+    assert add_mode_result.result_for_node("apply_to_three").output_value() == 5
 
     mult_mode_result = execute_pipeline(
         pipeline=pipeline_def,
@@ -159,7 +159,7 @@ def test_execute_multi_mode_with_resources():
         run_config={"resources": {"op": {"config": 3}}},
     )
 
-    assert mult_mode_result.result_for_solid("apply_to_three").output_value() == 9
+    assert mult_mode_result.result_for_node("apply_to_three").output_value() == 9
 
 
 def test_mode_with_resource_deps():

--- a/python_modules/dagster/dagster_tests/core_tests/test_multi_dependency.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_multi_dependency.py
@@ -60,7 +60,7 @@ def test_simple_values():
         )
     )
     assert result.success
-    assert result.result_for_solid("sum_num").output_value() == 6
+    assert result.result_for_node("sum_num").output_value() == 6
 
 
 @solid(input_defs=[InputDefinition("stuff", List[Any])])

--- a/python_modules/dagster/dagster_tests/core_tests/test_multiple_outputs.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_multiple_outputs.py
@@ -38,7 +38,7 @@ def test_multiple_outputs():
         multiple_outputs()
 
     result = execute_pipeline(multiple_outputs_pipeline)
-    solid_result = result.solid_result_list[0]
+    solid_result = result.node_result_list[0]
 
     assert solid_result.node.name == "multiple_outputs"
     assert solid_result.output_value("output_one") == "foo"
@@ -126,7 +126,7 @@ def test_multiple_outputs_only_emit_one():
     result = execute_pipeline(define_multi_out())
     assert result.success
 
-    solid_result = result.result_for_solid("multiple_outputs")
+    solid_result = result.result_for_node("multiple_outputs")
     assert set(solid_result.output_values.keys()) == set(["output_one"])
 
     with pytest.raises(
@@ -145,9 +145,9 @@ def test_multiple_outputs_only_emit_one():
             "'multiple_outputs_only_emit_one_pipeline'. No such top level solid."
         ),
     ):
-        result.result_for_solid("not_present")
+        result.result_for_node("not_present")
 
-    assert result.result_for_solid("downstream_two").skipped
+    assert result.result_for_node("downstream_two").skipped
 
 
 def test_multiple_outputs_only_emit_one_multiproc():
@@ -161,7 +161,7 @@ def test_multiple_outputs_only_emit_one_multiproc():
         )
         assert result.success
 
-        solid_result = result.result_for_solid("multiple_outputs")
+        solid_result = result.result_for_node("multiple_outputs")
         assert set(solid_result.output_values.keys()) == set(["output_one"])
 
         with pytest.raises(
@@ -180,9 +180,9 @@ def test_multiple_outputs_only_emit_one_multiproc():
                 "'multiple_outputs_only_emit_one_pipeline'. No such top level solid."
             ),
         ):
-            result.result_for_solid("not_present")
+            result.result_for_node("not_present")
 
-        assert result.result_for_solid("downstream_two").skipped
+        assert result.result_for_node("downstream_two").skipped
 
 
 def test_missing_non_optional_output_fails():

--- a/python_modules/dagster/dagster_tests/core_tests/test_naming_collisions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_naming_collisions.py
@@ -34,7 +34,7 @@ def test_execute_solid_with_input_same_name():
         pipe, run_config={"solids": {"pass_value": {"config": {"value": "foo"}}}}
     )
 
-    assert result.result_for_solid("a_thing").output_value() == "foofoo"
+    assert result.result_for_node("a_thing").output_value() == "foofoo"
 
 
 def test_execute_two_solids_with_same_input_name():
@@ -62,8 +62,8 @@ def test_execute_two_solids_with_same_input_name():
     )
 
     assert result.success
-    assert result.result_for_solid("solid_one").output_value() == "foofoo"
-    assert result.result_for_solid("solid_two").output_value() == "barbar"
+    assert result.result_for_node("solid_one").output_value() == "foofoo"
+    assert result.result_for_node("solid_two").output_value() == "barbar"
 
 
 def test_execute_dep_solid_different_input_name():
@@ -86,7 +86,7 @@ def test_execute_dep_solid_different_input_name():
     )
 
     assert result.success
-    assert len(result.solid_result_list) == 3
-    assert result.result_for_solid("pass_to_first").output_value() == "bar"
-    assert result.result_for_solid("first_solid").output_value() == "barbar"
-    assert result.result_for_solid("second_solid").output_value() == "barbarbarbar"
+    assert len(result.node_result_list) == 3
+    assert result.result_for_node("pass_to_first").output_value() == "bar"
+    assert result.result_for_node("first_solid").output_value() == "barbar"
+    assert result.result_for_node("second_solid").output_value() == "barbarbarbar"

--- a/python_modules/dagster/dagster_tests/core_tests/test_output_materialization.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_output_materialization.py
@@ -185,7 +185,7 @@ def test_basic_materialization_event():
         )
 
         assert result.success
-        solid_result = result.result_for_solid("return_one")
+        solid_result = result.result_for_node("return_one")
         step_events = solid_result.step_events_by_kind[StepKind.COMPUTE]
         mat_event = list(
             filter(

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
@@ -50,7 +50,7 @@ def test_compute_failure_pipeline():
 
     assert not pipeline_result.success
 
-    result_list = pipeline_result.solid_result_list
+    result_list = pipeline_result.node_result_list
 
     assert len(result_list) == 1
     assert not result_list[0].success
@@ -84,19 +84,18 @@ def test_failure_midstream():
 
     pipeline_result = execute_pipeline(pipeline_def, raise_on_error=False)
 
-    assert pipeline_result.result_for_solid("solid_a").success
-    assert pipeline_result.result_for_solid("solid_b").success
-    assert not pipeline_result.result_for_solid("solid_c").success
+    assert pipeline_result.result_for_node("solid_a").success
+    assert pipeline_result.result_for_node("solid_b").success
+    assert not pipeline_result.result_for_node("solid_c").success
     assert (
-        pipeline_result.result_for_solid("solid_c").failure_data.error.cls_name
+        pipeline_result.result_for_node("solid_c").failure_data.error.cls_name
         == "DagsterExecutionStepExecutionError"
     )
     assert (
-        pipeline_result.result_for_solid("solid_c").failure_data.error.cause.cls_name
-        == "CheckError"
+        pipeline_result.result_for_node("solid_c").failure_data.error.cause.cls_name == "CheckError"
     )
-    assert not pipeline_result.result_for_solid("solid_d").success
-    assert pipeline_result.result_for_solid("solid_d").skipped
+    assert not pipeline_result.result_for_node("solid_d").success
+    assert pipeline_result.result_for_node("solid_d").skipped
 
 
 def test_failure_propagation():
@@ -137,18 +136,17 @@ def test_failure_propagation():
 
     pipeline_result = execute_pipeline(pipeline_def, raise_on_error=False)
 
-    assert pipeline_result.result_for_solid("solid_a").success
-    assert pipeline_result.result_for_solid("solid_b").success
-    assert pipeline_result.result_for_solid("solid_c").success
-    assert not pipeline_result.result_for_solid("solid_d").success
+    assert pipeline_result.result_for_node("solid_a").success
+    assert pipeline_result.result_for_node("solid_b").success
+    assert pipeline_result.result_for_node("solid_c").success
+    assert not pipeline_result.result_for_node("solid_d").success
     assert (
-        pipeline_result.result_for_solid("solid_d").failure_data.error.cause.cls_name
-        == "CheckError"
+        pipeline_result.result_for_node("solid_d").failure_data.error.cause.cls_name == "CheckError"
     )
-    assert not pipeline_result.result_for_solid("solid_e").success
-    assert pipeline_result.result_for_solid("solid_e").skipped
-    assert not pipeline_result.result_for_solid("solid_f").success
-    assert pipeline_result.result_for_solid("solid_f").skipped
+    assert not pipeline_result.result_for_node("solid_e").success
+    assert pipeline_result.result_for_node("solid_e").skipped
+    assert not pipeline_result.result_for_node("solid_f").success
+    assert pipeline_result.result_for_node("solid_f").skipped
 
 
 def test_do_not_yield_result():

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -89,7 +89,7 @@ def _do_construct(ops, dependencies):
     return _create_adjacency_lists(list(ops.values()), dependency_structure)
 
 
-def test_empty_adjaceny_lists():
+def test_empty_adjacency_lists():
     solids = [create_root_solid("a_node")]
     forward_edges, backwards_edges = _do_construct(solids, {})
     assert forward_edges == {"a_node": set()}
@@ -308,30 +308,30 @@ def test_two_root_solid_pipeline_with_partial_dependency_definition():
 def _do_test(pipe):
     result = execute_pipeline(pipe)
 
-    assert result.result_for_solid("A").output_value() == [
+    assert result.result_for_node("A").output_value() == [
         input_set("A_input"),
         compute_called("A"),
     ]
 
-    assert result.result_for_solid("B").output_value() == [
+    assert result.result_for_node("B").output_value() == [
         input_set("A_input"),
         compute_called("A"),
         compute_called("B"),
     ]
 
-    assert result.result_for_solid("C").output_value() == [
+    assert result.result_for_node("C").output_value() == [
         input_set("A_input"),
         compute_called("A"),
         compute_called("C"),
     ]
 
-    assert result.result_for_solid("D").output_value() == [
+    assert result.result_for_node("D").output_value() == [
         input_set("A_input"),
         compute_called("A"),
         compute_called("C"),
         compute_called("B"),
         compute_called("D"),
-    ] or result.result_for_solid("D").output_value() == [
+    ] or result.result_for_node("D").output_value() == [
         input_set("A_input"),
         compute_called("A"),
         compute_called("B"),
@@ -375,7 +375,7 @@ def test_pipeline_subset():
 
     pipeline_result = execute_pipeline(pipeline_def)
     assert pipeline_result.success
-    assert pipeline_result.result_for_solid("add_one").output_value() == 2
+    assert pipeline_result.result_for_node("add_one").output_value() == 2
 
     env_config = {"solids": {"add_one": {"inputs": {"num": {"value": 3}}}}}
 
@@ -384,8 +384,8 @@ def test_pipeline_subset():
     )
 
     assert subset_result.success
-    assert len(subset_result.solid_result_list) == 1
-    assert subset_result.result_for_solid("add_one").output_value() == 4
+    assert len(subset_result.node_result_list) == 1
+    assert subset_result.result_for_node("add_one").output_value() == 4
 
 
 def test_pipeline_explicit_subset():
@@ -405,7 +405,7 @@ def test_pipeline_explicit_subset():
 
     pipeline_result = execute_pipeline(pipeline_def)
     assert pipeline_result.success
-    assert pipeline_result.result_for_solid("add_one").output_value() == 2
+    assert pipeline_result.result_for_node("add_one").output_value() == 2
 
     env_config = {"solids": {"add_one": {"inputs": {"num": {"value": 3}}}}}
 
@@ -414,8 +414,8 @@ def test_pipeline_explicit_subset():
     )
 
     assert subset_result.success
-    assert len(subset_result.solid_result_list) == 1
-    assert subset_result.result_for_solid("add_one").output_value() == 4
+    assert len(subset_result.node_result_list) == 1
+    assert subset_result.result_for_node("add_one").output_value() == 4
 
 
 def test_pipeline_subset_of_subset():
@@ -434,14 +434,14 @@ def test_pipeline_subset_of_subset():
 
     pipeline_result = execute_pipeline(pipeline_def)
     assert pipeline_result.success
-    assert len(pipeline_result.solid_result_list) == 4
-    assert pipeline_result.result_for_solid("add_one_a").output_value() == 2
+    assert len(pipeline_result.node_result_list) == 4
+    assert pipeline_result.result_for_node("add_one_a").output_value() == 2
 
     subset_pipeline = pipeline_def.get_pipeline_subset_def({"add_one_a", "return_one_a"})
     subset_result = execute_pipeline(subset_pipeline)
     assert subset_result.success
-    assert len(subset_result.solid_result_list) == 2
-    assert subset_result.result_for_solid("add_one_a").output_value() == 2
+    assert len(subset_result.node_result_list) == 2
+    assert subset_result.result_for_node("add_one_a").output_value() == 2
 
     with pytest.raises(
         DagsterInvariantViolationError,
@@ -486,21 +486,21 @@ def test_pipeline_subset_with_multi_dependency():
 
     pipeline_result = execute_pipeline(pipeline_def)
     assert pipeline_result.success
-    assert pipeline_result.result_for_solid("noop").output_value() == 3
+    assert pipeline_result.result_for_node("noop").output_value() == 3
 
     subset_result = execute_pipeline(pipeline_def.get_pipeline_subset_def({"noop"}))
 
     assert subset_result.success
-    assert len(subset_result.solid_result_list) == 1
-    assert pipeline_result.result_for_solid("noop").output_value() == 3
+    assert len(subset_result.node_result_list) == 1
+    assert pipeline_result.result_for_node("noop").output_value() == 3
 
     subset_result = execute_pipeline(
         pipeline_def.get_pipeline_subset_def({"return_one", "return_two", "noop"})
     )
 
     assert subset_result.success
-    assert len(subset_result.solid_result_list) == 3
-    assert pipeline_result.result_for_solid("noop").output_value() == 3
+    assert len(subset_result.node_result_list) == 3
+    assert pipeline_result.result_for_node("noop").output_value() == 3
 
 
 def test_pipeline_explicit_subset_with_multi_dependency():
@@ -533,21 +533,21 @@ def test_pipeline_explicit_subset_with_multi_dependency():
 
     pipeline_result = execute_pipeline(pipeline_def)
     assert pipeline_result.success
-    assert pipeline_result.result_for_solid("noop").output_value() == 3
+    assert pipeline_result.result_for_node("noop").output_value() == 3
 
     subset_result = execute_pipeline(pipeline_def, solid_selection=["noop"])
 
     assert subset_result.success
-    assert len(subset_result.solid_result_list) == 1
-    assert pipeline_result.result_for_solid("noop").output_value() == 3
+    assert len(subset_result.node_result_list) == 1
+    assert pipeline_result.result_for_node("noop").output_value() == 3
 
     subset_result = execute_pipeline(
         pipeline_def, solid_selection=["return_one", "return_two", "noop"]
     )
 
     assert subset_result.success
-    assert len(subset_result.solid_result_list) == 3
-    assert pipeline_result.result_for_solid("noop").output_value() == 3
+    assert len(subset_result.node_result_list) == 3
+    assert pipeline_result.result_for_node("noop").output_value() == 3
 
 
 def define_three_part_pipeline():
@@ -593,9 +593,9 @@ def test_pipeline_execution_explicit_disjoint_subset():
     )
 
     assert result.success
-    assert len(result.solid_result_list) == 2
-    assert result.result_for_solid("add_one").output_value() == 3
-    assert result.result_for_solid("add_three").output_value() == 8
+    assert len(result.node_result_list) == 2
+    assert result.result_for_node("add_one").output_value() == 3
+    assert result.result_for_node("add_three").output_value() == 8
 
 
 def test_pipeline_wrapping_types():
@@ -763,7 +763,7 @@ def test_reexecution_fs_storage():
     instance = DagsterInstance.ephemeral()
     pipeline_result = execute_pipeline(pipeline_def, instance=instance)
     assert pipeline_result.success
-    assert pipeline_result.result_for_solid("add_one").output_value() == 2
+    assert pipeline_result.result_for_node("add_one").output_value() == 2
 
     reexecution_result = reexecute_pipeline(
         pipeline_def,
@@ -772,9 +772,9 @@ def test_reexecution_fs_storage():
     )
 
     assert reexecution_result.success
-    assert len(reexecution_result.solid_result_list) == 2
-    assert reexecution_result.result_for_solid("return_one").output_value() == 1
-    assert reexecution_result.result_for_solid("add_one").output_value() == 2
+    assert len(reexecution_result.node_result_list) == 2
+    assert reexecution_result.result_for_node("return_one").output_value() == 1
+    assert reexecution_result.result_for_node("add_one").output_value() == 2
     reexecution_run = instance.get_run_by_id(reexecution_result.run_id)
     assert reexecution_run.parent_run_id == pipeline_result.run_id
     assert reexecution_run.root_run_id == pipeline_result.run_id
@@ -786,9 +786,9 @@ def test_reexecution_fs_storage():
     )
 
     assert grandchild_result.success
-    assert len(grandchild_result.solid_result_list) == 2
-    assert grandchild_result.result_for_solid("return_one").output_value() == 1
-    assert grandchild_result.result_for_solid("add_one").output_value() == 2
+    assert len(grandchild_result.node_result_list) == 2
+    assert grandchild_result.result_for_node("return_one").output_value() == 1
+    assert grandchild_result.result_for_node("add_one").output_value() == 2
     grandchild_run = instance.get_run_by_id(grandchild_result.run_id)
     assert grandchild_run.parent_run_id == reexecution_result.run_id
     assert grandchild_run.root_run_id == pipeline_result.run_id
@@ -839,9 +839,9 @@ def test_multiproc_reexecution_fs_storage_after_fail():
         )
 
         assert reexecution_result.success
-        assert len(reexecution_result.solid_result_list) == 2
-        assert reexecution_result.result_for_solid("return_one").output_value() == 1
-        assert reexecution_result.result_for_solid("add_one").output_value() == 2
+        assert len(reexecution_result.node_result_list) == 2
+        assert reexecution_result.result_for_node("return_one").output_value() == 1
+        assert reexecution_result.result_for_node("add_one").output_value() == 2
         reexecution_run = instance.get_run_by_id(reexecution_result.run_id)
         assert reexecution_run.parent_run_id == pipeline_result.run_id
         assert reexecution_run.root_run_id == pipeline_result.run_id
@@ -854,9 +854,9 @@ def test_multiproc_reexecution_fs_storage_after_fail():
         )
 
         assert grandchild_result.success
-        assert len(grandchild_result.solid_result_list) == 2
-        assert grandchild_result.result_for_solid("return_one").output_value() == 1
-        assert grandchild_result.result_for_solid("add_one").output_value() == 2
+        assert len(grandchild_result.node_result_list) == 2
+        assert grandchild_result.result_for_node("return_one").output_value() == 1
+        assert grandchild_result.result_for_node("add_one").output_value() == 2
         grandchild_run = instance.get_run_by_id(grandchild_result.run_id)
         assert grandchild_run.parent_run_id == reexecution_result.run_id
         assert grandchild_run.root_run_id == pipeline_result.run_id
@@ -881,7 +881,7 @@ def test_reexecution_fs_storage_with_solid_selection():
     # Case 1: re-execute a part of a pipeline when the original pipeline doesn't have solid selection
     pipeline_result = execute_pipeline(pipeline_def, instance=instance)
     assert pipeline_result.success
-    assert pipeline_result.result_for_solid("add_one").output_value() == 2
+    assert pipeline_result.result_for_node("add_one").output_value() == 2
 
     # This is how this is actually done in dagster_graphql.implementation.pipeline_execution_manager
     reexecution_result_no_solid_selection = reexecute_pipeline(
@@ -891,9 +891,9 @@ def test_reexecution_fs_storage_with_solid_selection():
         instance=instance,
     )
     assert reexecution_result_no_solid_selection.success
-    assert len(reexecution_result_no_solid_selection.solid_result_list) == 2
-    assert reexecution_result_no_solid_selection.result_for_solid("add_one").skipped
-    assert reexecution_result_no_solid_selection.result_for_solid("return_one").output_value() == 1
+    assert len(reexecution_result_no_solid_selection.node_result_list) == 2
+    assert reexecution_result_no_solid_selection.result_for_node("add_one").skipped
+    assert reexecution_result_no_solid_selection.result_for_node("return_one").output_value() == 1
 
     # Case 2: re-execute a pipeline when the original pipeline has solid selection
     pipeline_result_solid_selection = execute_pipeline(
@@ -902,10 +902,10 @@ def test_reexecution_fs_storage_with_solid_selection():
         solid_selection=["return_one"],
     )
     assert pipeline_result_solid_selection.success
-    assert len(pipeline_result_solid_selection.solid_result_list) == 1
+    assert len(pipeline_result_solid_selection.node_result_list) == 1
     with pytest.raises(DagsterInvariantViolationError):
-        pipeline_result_solid_selection.result_for_solid("add_one")
-    assert pipeline_result_solid_selection.result_for_solid("return_one").output_value() == 1
+        pipeline_result_solid_selection.result_for_node("add_one")
+    assert pipeline_result_solid_selection.result_for_node("return_one").output_value() == 1
 
     reexecution_result_solid_selection = reexecute_pipeline(
         pipeline_def,
@@ -914,10 +914,10 @@ def test_reexecution_fs_storage_with_solid_selection():
     )
 
     assert reexecution_result_solid_selection.success
-    assert len(reexecution_result_solid_selection.solid_result_list) == 1
+    assert len(reexecution_result_solid_selection.node_result_list) == 1
     with pytest.raises(DagsterInvariantViolationError):
-        pipeline_result_solid_selection.result_for_solid("add_one")
-    assert reexecution_result_solid_selection.result_for_solid("return_one").output_value() == 1
+        pipeline_result_solid_selection.result_for_node("add_one")
+    assert reexecution_result_solid_selection.result_for_node("return_one").output_value() == 1
 
     # Case 3: re-execute a pipeline partially when the original pipeline has solid selection and
     #   re-exeucte a step which hasn't been included in the original pipeline
@@ -942,8 +942,8 @@ def test_reexecution_fs_storage_with_solid_selection():
     )
 
     assert re_reexecution_result.success
-    assert len(re_reexecution_result.solid_result_list) == 1
-    assert re_reexecution_result.result_for_solid("return_one").output_value() == 1
+    assert len(re_reexecution_result.node_result_list) == 1
+    assert re_reexecution_result.result_for_node("return_one").output_value() == 1
 
 
 def test_single_step_reexecution():
@@ -964,7 +964,7 @@ def test_single_step_reexecution():
     instance = DagsterInstance.ephemeral()
     pipeline_result = execute_pipeline(pipeline_def, instance=instance)
     assert pipeline_result.success
-    assert pipeline_result.result_for_solid("add_one").output_value() == 2
+    assert pipeline_result.result_for_node("add_one").output_value() == 2
 
     # This is how this is actually done in dagster_graphql.implementation.pipeline_execution_manager
     reexecution_result = reexecute_pipeline(
@@ -975,8 +975,8 @@ def test_single_step_reexecution():
     )
 
     assert reexecution_result.success
-    assert reexecution_result.result_for_solid("return_one").output_value() is None
-    assert reexecution_result.result_for_solid("add_one").output_value() == 2
+    assert reexecution_result.result_for_node("return_one").output_value() is None
+    assert reexecution_result.result_for_node("add_one").output_value() == 2
 
 
 def test_two_step_reexecution():
@@ -996,7 +996,7 @@ def test_two_step_reexecution():
 
     pipeline_result = execute_pipeline(two_step_reexec, instance=instance)
     assert pipeline_result.success
-    assert pipeline_result.result_for_solid("add_one_2").output_value() == 3
+    assert pipeline_result.result_for_node("add_one_2").output_value() == 3
 
     reexecution_result = reexecute_pipeline(
         two_step_reexec,
@@ -1005,8 +1005,8 @@ def test_two_step_reexecution():
         step_selection=["add_one", "add_one_2"],
     )
     assert reexecution_result.success
-    assert reexecution_result.result_for_solid("return_one").output_value() is None
-    assert reexecution_result.result_for_solid("add_one_2").output_value() == 3
+    assert reexecution_result.result_for_node("return_one").output_value() is None
+    assert reexecution_result.result_for_node("add_one_2").output_value() == 3
 
 
 def test_optional():
@@ -1032,10 +1032,10 @@ def test_optional():
     pipeline_result = execute_pipeline(opt_pipeline)
     assert pipeline_result.success
 
-    result_required = pipeline_result.result_for_solid("echo_x")
+    result_required = pipeline_result.result_for_node("echo_x")
     assert result_required.success
 
-    result_optional = pipeline_result.result_for_solid("echo_y")
+    result_optional = pipeline_result.result_for_node("echo_y")
     assert not result_optional.success
     assert result_optional.skipped
 
@@ -1147,7 +1147,7 @@ def test_multi_dep_optional():
 
     result = execute_pipeline(test_remaining)
     assert result.success
-    assert result.result_for_solid("collect").output_value() == [1]
+    assert result.result_for_node("collect").output_value() == [1]
 
     @pipeline
     def test_all_skip():
@@ -1155,7 +1155,7 @@ def test_multi_dep_optional():
 
     result = execute_pipeline(test_all_skip)
     assert result.success
-    assert result.result_for_solid("collect").skipped
+    assert result.result_for_node("collect").skipped
 
     @pipeline
     def test_skipped_upstream():
@@ -1163,7 +1163,7 @@ def test_multi_dep_optional():
 
     result = execute_pipeline(test_skipped_upstream)
     assert result.success
-    assert result.result_for_solid("collect").output_value() == [1]
+    assert result.result_for_node("collect").output_value() == [1]
 
     @pipeline
     def test_all_upstream_skip():
@@ -1171,7 +1171,7 @@ def test_multi_dep_optional():
 
     result = execute_pipeline(test_all_upstream_skip)
     assert result.success
-    assert result.result_for_solid("collect").skipped
+    assert result.result_for_node("collect").skipped
 
     @pipeline
     def test_all_upstream_skip_with_other():
@@ -1179,7 +1179,7 @@ def test_multi_dep_optional():
 
     result = execute_pipeline(test_all_upstream_skip_with_other)
     assert result.success
-    assert result.result_for_solid("collect_and").skipped
+    assert result.result_for_node("collect_and").skipped
 
     @pipeline
     def test_all_skip_with_other():
@@ -1187,7 +1187,7 @@ def test_multi_dep_optional():
 
     result = execute_pipeline(test_all_skip_with_other)
     assert result.success
-    assert result.result_for_solid("collect_and").skipped
+    assert result.result_for_node("collect_and").skipped
 
     @pipeline
     def test_other_skip():
@@ -1195,7 +1195,7 @@ def test_multi_dep_optional():
 
     result = execute_pipeline(test_other_skip)
     assert result.success
-    assert result.result_for_solid("collect_and").skipped
+    assert result.result_for_node("collect_and").skipped
 
     @pipeline
     def test_other_skip_upstream():
@@ -1203,4 +1203,4 @@ def test_multi_dep_optional():
 
     result = execute_pipeline(test_other_skip_upstream)
     assert result.success
-    assert result.result_for_solid("collect_and").skipped
+    assert result.result_for_node("collect_and").skipped

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_aliases.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_aliases.py
@@ -33,7 +33,7 @@ def test_aliased_solids():
 
     result = execute_pipeline(pipeline)
     assert result.success
-    solid_result = result.result_for_solid("third")
+    solid_result = result.result_for_node("third")
     assert solid_result.output_value() == [
         "first",
         "not_first",
@@ -64,7 +64,7 @@ def test_only_aliased_solids():
 
     result = execute_pipeline(pipeline)
     assert result.success
-    solid_result = result.result_for_solid("the_consequence")
+    solid_result = result.result_for_node("the_consequence")
     assert solid_result.output_value() == ["first", "not_first"]
 
 
@@ -87,8 +87,8 @@ def test_aliased_configs():
     )
 
     assert result.success
-    assert result.result_for_solid("load_a").output_value() == 2
-    assert result.result_for_solid("load_b").output_value() == 3
+    assert result.result_for_node("load_a").output_value() == 2
+    assert result.result_for_node("load_b").output_value() == 3
 
 
 def test_aliased_solids_context():

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
@@ -16,7 +16,8 @@ from dagster import (
     reconstructable,
 )
 from dagster._core.errors import DagsterUnmetExecutorRequirementsError
-from dagster._core.events import DagsterEventType
+from dagster._core.events import DagsterEvent, DagsterEventType
+from dagster._core.execution.results import OpExecutionResult, PipelineExecutionResult
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.captured_log_manager import CapturedLogManager
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
@@ -41,11 +42,13 @@ from .retry_jobs import (
 def test_diamond_simple_execution():
     result = execute_pipeline(define_diamond_pipeline())
     assert result.success
-    assert result.result_for_solid("adder").output_value() == 11
+    assert result.result_for_node("adder").output_value() == 11
 
 
-def compute_event(result, solid_name):
-    return result.result_for_solid(solid_name).compute_step_events[0]
+def compute_event(result: PipelineExecutionResult, solid_name: str) -> DagsterEvent:
+    node_result = result.result_for_node(solid_name)
+    assert isinstance(node_result, OpExecutionResult)
+    return node_result.compute_step_events[0]
 
 
 def test_diamond_multi_execution():
@@ -60,7 +63,7 @@ def test_diamond_multi_execution():
         )
         assert result.success
 
-        assert result.result_for_solid("adder").output_value() == 11
+        assert result.result_for_node("adder").output_value() == 11
 
 
 def test_explicit_spawn():
@@ -75,7 +78,7 @@ def test_explicit_spawn():
         )
         assert result.success
 
-        assert result.result_for_solid("adder").output_value() == 11
+        assert result.result_for_node("adder").output_value() == 11
 
 
 @pytest.mark.skipif(os.name == "nt", reason="No forkserver on windows")
@@ -91,7 +94,7 @@ def test_forkserver_execution():
         )
         assert result.success
 
-        assert result.result_for_solid("adder").output_value() == 11
+        assert result.result_for_node("adder").output_value() == 11
 
 
 @pytest.mark.skipif(os.name == "nt", reason="No forkserver on windows")
@@ -111,7 +114,7 @@ def test_forkserver_preload():
         )
         assert result.success
 
-        assert result.result_for_solid("adder").output_value() == 11
+        assert result.result_for_node("adder").output_value() == 11
 
 
 def define_diamond_pipeline():
@@ -257,7 +260,7 @@ def test_solid_selection():
 
         assert result.success
 
-        assert result.result_for_solid("adder").output_value() == 2
+        assert result.result_for_node("adder").output_value() == 2
 
 
 def define_subdag_pipeline():
@@ -345,7 +348,7 @@ def test_ephemeral_event_log():
         )
         assert result.success
 
-        assert result.result_for_solid("adder").output_value() == 11
+        assert result.result_for_node("adder").output_value() == 11
 
 
 @solid(
@@ -413,7 +416,7 @@ def test_failure_multiprocessing():
             raise_on_error=False,
         )
         assert not result.success
-        failure_data = result.result_for_solid("throw").failure_data
+        failure_data = result.result_for_node("throw").failure_data
         assert failure_data
         assert failure_data.error.cls_name == "Failure"
 
@@ -450,7 +453,7 @@ def test_crash_multiprocessing():
             raise_on_error=False,
         )
         assert not result.success
-        failure_data = result.result_for_solid("sys_exit").failure_data
+        failure_data = result.result_for_node("sys_exit").failure_data
         assert failure_data
         assert failure_data.error.cls_name == "ChildProcessCrashException"
 
@@ -504,7 +507,7 @@ def test_crash_hard_multiprocessing():
             raise_on_error=False,
         )
         assert not result.success
-        failure_data = result.result_for_solid("segfault_solid").failure_data
+        failure_data = result.result_for_node("segfault_solid").failure_data
         assert failure_data
         assert failure_data.error.cls_name == "ChildProcessCrashException"
 

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
@@ -373,8 +373,8 @@ def test_pipeline(mode):
             mode=mode,
             run_config=make_run_config(tmpdir, mode),
         )
-        assert result.result_for_solid("return_two").output_value() == 2
-        assert result.result_for_solid("add_one").output_value() == 3
+        assert result.result_for_node("return_two").output_value() == 2
+        assert result.result_for_node("add_one").output_value() == 3
 
 
 @pytest.mark.parametrize(
@@ -403,7 +403,7 @@ def test_dynamic_job(job_fn):
                 },
                 instance=instance,
             )
-            assert result.output_for_solid("total") == 6
+            assert result.output_for_node("total") == 6
 
 
 @pytest.mark.parametrize(
@@ -434,7 +434,7 @@ def test_reexecution(job_fn):
                 instance=instance,
             )
             assert run1.success
-            assert run1.result_for_solid("combine").output_value() == 3
+            assert run1.result_for_node("combine").output_value() == 3
             run2 = reexecute_pipeline(
                 pipeline=reconstructable(job_fn),
                 parent_run_id=run1.run_id,
@@ -443,7 +443,7 @@ def test_reexecution(job_fn):
                 step_selection=["combine"],
             )
             assert run2.success
-            assert run2.result_for_solid("combine").output_value() == 3
+            assert run2.result_for_node("combine").output_value() == 3
 
 
 def test_retry_policy():
@@ -461,7 +461,7 @@ def test_retry_policy():
                 instance=instance,
             )
             assert run.success
-            assert run.result_for_solid("retry_op").output_value() == 3
+            assert run.result_for_node("retry_op").output_value() == 3
             step_retry_events = [
                 e for e in run.event_list if e.event_type_value == "STEP_RESTARTED"
             ]
@@ -483,7 +483,7 @@ def test_explicit_failure():
                 instance=instance,
                 raise_on_error=False,
             )
-            fd = run.result_for_solid("retry_op").failure_data
+            fd = run.result_for_node("retry_op").failure_data
             assert fd.user_failure_data.description == "some failure description"
             assert fd.user_failure_data.metadata_entries == [
                 MetadataEntry.float(label="foo", value=1.23)
@@ -507,7 +507,7 @@ def test_arbitrary_error():
             )
             failure_events = [e for e in run.event_list if e.event_type_value == "STEP_FAILURE"]
             assert len(failure_events) == 1
-            fd = run.result_for_solid("retry_op").failure_data
+            fd = run.result_for_node("retry_op").failure_data
             assert fd.error.cause.cls_name == "TypeError"
 
 
@@ -520,8 +520,8 @@ def test_launcher_requests_retry():
             run_config=make_run_config(tmpdir, mode),
         )
         assert result.success
-        assert result.result_for_solid("return_two").output_value() == 2
-        assert result.result_for_solid("add_one").output_value() == 3
+        assert result.result_for_node("return_two").output_value() == 2
+        assert result.result_for_node("add_one").output_value() == 3
         for step_key, events in result.events_by_step_key.items():
             if step_key:
                 event_types = [event.event_type for event in events]
@@ -580,8 +580,8 @@ def test_multiproc_launcher_requests_retry():
             run_config=run_config,
         )
         assert result.success
-        assert result.result_for_solid("return_two").output_value() == 2
-        assert result.result_for_solid("add_one").output_value() == 3
+        assert result.result_for_node("return_two").output_value() == 2
+        assert result.result_for_node("add_one").output_value() == 3
         for step_key, events in result.events_by_step_key.items():
             if step_key:
                 event_types = [event.event_type for event in events]

--- a/python_modules/dagster/dagster_tests/execution_tests/test_expectations.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_expectations.py
@@ -1,11 +1,18 @@
+from typing import Sequence
+
 import pytest
 
 from dagster import DagsterEventType, DagsterInvariantViolationError, ExpectationResult
+from dagster._core.events import DagsterEvent
+from dagster._core.execution.results import OpExecutionResult, PipelineExecutionResult
 from dagster._legacy import PipelineDefinition, execute_pipeline, solid
 
 
-def expt_results_for_compute_step(result, solid_name):
-    solid_result = result.result_for_solid(solid_name)
+def expt_results_for_compute_step(
+    result: PipelineExecutionResult, solid_name: str
+) -> Sequence[DagsterEvent]:
+    solid_result = result.result_for_node(solid_name)
+    assert isinstance(solid_result, OpExecutionResult)
     return [
         compute_step_event
         for compute_step_event in solid_result.compute_step_events

--- a/python_modules/dagster/dagster_tests/execution_tests/test_failure.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_failure.py
@@ -16,7 +16,7 @@ def test_failure():
 
     result = execute_pipeline(failure, raise_on_error=False)
     assert not result.success
-    failure_data = result.result_for_solid("throw").failure_data
+    failure_data = result.result_for_node("throw").failure_data
     assert failure_data
     assert failure_data.error.cls_name == "Failure"
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_input_values_from_intermediates.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_input_values_from_intermediates.py
@@ -24,13 +24,13 @@ def test_from_intermediates_from_multiple_outputs():
     assert result
     assert result.success
     assert (
-        result.result_for_solid("gather")
+        result.result_for_node("gather")
         .compute_input_event_dict["stuff"]
         .event_specific_data[1]
         .label
         == "stuff"
     )
-    assert result.result_for_solid("gather").output_value() == "x and y"
+    assert result.result_for_node("gather").output_value() == "x and y"
 
 
 def test_from_intermediates_from_config():
@@ -49,10 +49,10 @@ def test_from_intermediates_from_config():
     assert result
     assert result.success
     assert (
-        result.result_for_solid("x")
+        result.result_for_node("x")
         .compute_input_event_dict["string_input"]
         .event_specific_data[1]
         .label
         == "string_input"
     )
-    assert result.result_for_solid("x").output_value() == "Dagster is great!"
+    assert result.result_for_node("x").output_value() == "Dagster is great!"

--- a/python_modules/dagster/dagster_tests/execution_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_job.py
@@ -49,7 +49,7 @@ def test_job_execution_multiprocess_config():
         )
 
         assert result.success
-        assert result.output_for_solid("my_op") == 5
+        assert result.output_for_node("my_op") == 5
 
 
 results_lst = []

--- a/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
@@ -28,12 +28,16 @@ from dagster._core.definitions.metadata.table import (
     TableRecord,
     TableSchema,
 )
+from dagster._core.execution.results import OpExecutionResult, PipelineExecutionResult
 from dagster._legacy import execute_pipeline, pipeline, solid
 from dagster._utils import frozendict
 
 
-def solid_events_for_type(result, solid_name, event_type):
-    solid_result = result.result_for_solid(solid_name)
+def solid_events_for_type(
+    result: PipelineExecutionResult, solid_name: str, event_type: DagsterEventType
+):
+    solid_result = result.result_for_node(solid_name)
+    assert isinstance(solid_result, OpExecutionResult)
     return [
         compute_step_event
         for compute_step_event in solid_result.compute_step_events

--- a/python_modules/dagster/dagster_tests/execution_tests/test_modes.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_modes.py
@@ -44,7 +44,7 @@ def test_execute_pipeline_with_mode():
         mode="add_one",
     )
     assert pipeline_result.success
-    assert pipeline_result.result_for_solid("solid_that_uses_adder_resource").output_value() == 5
+    assert pipeline_result.result_for_node("solid_that_uses_adder_resource").output_value() == 5
 
     pipeline_result = execute_pipeline(
         pipeline_with_mode,
@@ -54,7 +54,7 @@ def test_execute_pipeline_with_mode():
         mode="add_two",
     )
     assert pipeline_result.success
-    assert pipeline_result.result_for_solid("solid_that_uses_adder_resource").output_value() == 6
+    assert pipeline_result.result_for_node("solid_that_uses_adder_resource").output_value() == 6
 
 
 def test_execute_pipeline_with_non_existant_mode():
@@ -86,7 +86,7 @@ def pipeline_with_one_mode_and_tags():
 def test_execute_pipeline_with_mode_and_tags():
     pipeline_result = execute_pipeline(pipeline_with_one_mode_and_tags)
     assert pipeline_result.success
-    assert pipeline_result.result_for_solid("solid_that_gets_tags").output_value() == {
+    assert pipeline_result.result_for_node("solid_that_gets_tags").output_value() == {
         "tag_key": "tag_value"
     }
 
@@ -106,7 +106,7 @@ def pipeline_with_multi_mode_and_tags():
 def test_execute_pipeline_with_multi_mode_and_pipeline_def_tags():
     pipeline_result = execute_pipeline(pipeline_with_multi_mode_and_tags, mode="tags_1")
     assert pipeline_result.success
-    assert pipeline_result.result_for_solid("solid_that_gets_tags").output_value() == {
+    assert pipeline_result.result_for_node("solid_that_gets_tags").output_value() == {
         "pipeline_tag_key": "pipeline_tag_value"
     }
 
@@ -118,7 +118,7 @@ def test_execute_pipeline_with_multi_mode_and_pipeline_def_tags_and_execute_tags
         tags={"run_tag_key": "run_tag_value"},
     )
     assert pipeline_result.success
-    assert pipeline_result.result_for_solid("solid_that_gets_tags").output_value() == {
+    assert pipeline_result.result_for_node("solid_that_gets_tags").output_value() == {
         "pipeline_tag_key": "pipeline_tag_value",
         "run_tag_key": "run_tag_value",
     }

--- a/python_modules/dagster/dagster_tests/execution_tests/test_retries.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_retries.py
@@ -109,7 +109,7 @@ def test_retries(environment):
             instance=instance,
         )
         assert second_result.success
-        downstream_of_failed = second_result.result_for_solid("downstream_of_failed").output_value()
+        downstream_of_failed = second_result.result_for_node("downstream_of_failed").output_value()
         assert downstream_of_failed == "okay perfect"
 
         will_be_skipped = [
@@ -286,7 +286,7 @@ def test_basic_retry_policy():
 
     result = execute_pipeline(policy_test, raise_on_error=False)
     assert not result.success
-    assert result.result_for_solid("throws").retry_attempts == 1
+    assert result.result_for_node("throws").retry_attempts == 1
 
 
 def test_retry_policy_rules():
@@ -315,12 +315,12 @@ def test_retry_policy_rules():
 
     result = execute_pipeline(policy_test, raise_on_error=False)
     assert not result.success
-    assert result.result_for_solid("throw_no_policy").retry_attempts == 3
-    assert result.result_for_solid("throw_with_policy").retry_attempts == 2
-    assert result.result_for_solid("override_no").retry_attempts == 1
-    assert result.result_for_solid("override_with").retry_attempts == 1
-    assert result.result_for_solid("config_override_no").retry_attempts == 1
-    assert result.result_for_solid("override_fail").retry_attempts == 1
+    assert result.result_for_node("throw_no_policy").retry_attempts == 3
+    assert result.result_for_node("throw_with_policy").retry_attempts == 2
+    assert result.result_for_node("override_no").retry_attempts == 1
+    assert result.result_for_node("override_with").retry_attempts == 1
+    assert result.result_for_node("config_override_no").retry_attempts == 1
+    assert result.result_for_node("override_fail").retry_attempts == 1
 
 
 def test_delay():
@@ -339,7 +339,7 @@ def test_delay():
     elapsed_time = time.time() - start
     assert not result.success
     assert elapsed_time > delay
-    assert result.result_for_solid("throws").retry_attempts == 1
+    assert result.result_for_node("throws").retry_attempts == 1
 
 
 def test_policy_delay_calc():

--- a/python_modules/dagster/dagster_tests/execution_tests/test_timing.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_timing.py
@@ -18,7 +18,7 @@ def test_event_timing_before_yield():
 
     pipeline_def = PipelineDefinition(solid_defs=[before_yield_solid], name="test")
     pipeline_result = execute_pipeline(pipeline_def)
-    success_event = pipeline_result.result_for_solid("before_yield_solid").get_step_success_event()
+    success_event = pipeline_result.result_for_node("before_yield_solid").get_step_success_event()
     assert success_event.event_specific_data.duration_ms >= 10.0
 
 
@@ -33,7 +33,7 @@ def test_event_timing_after_yield():
 
     pipeline_def = PipelineDefinition(solid_defs=[after_yield_solid], name="test")
     pipeline_result = execute_pipeline(pipeline_def)
-    success_event = pipeline_result.result_for_solid("after_yield_solid").get_step_success_event()
+    success_event = pipeline_result.result_for_node("after_yield_solid").get_step_success_event()
     assert success_event.event_specific_data.duration_ms >= 10.0
 
 
@@ -48,5 +48,5 @@ def test_event_timing_direct_return():
 
     pipeline_def = PipelineDefinition(solid_defs=[direct_return_solid], name="test")
     pipeline_result = execute_pipeline(pipeline_def)
-    success_event = pipeline_result.result_for_solid("direct_return_solid").get_step_success_event()
+    success_event = pipeline_result.result_for_node("direct_return_solid").get_step_success_event()
     assert success_event.event_specific_data.duration_ms >= 10.0

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_solid_isolation.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_solid_isolation.py
@@ -156,10 +156,10 @@ def test_graphs():
     assert result.output_values_for_solid("hello") == {"result": "hello"}
     assert result.output_value_for_handle("hello") == "hello"
 
-    nested_result = result.result_for_solid("hello")
+    nested_result = result.result_for_node("hello")
     assert nested_result.success
     assert nested_result.output_value() == "hello"
-    assert len(result.solid_result_list) == 1
+    assert len(result.node_result_list) == 1
     assert nested_result.output_values == {"result": "hello"}
 
     with pytest.raises(
@@ -168,7 +168,7 @@ def test_graphs():
             "Tried to get result for solid 'goodbye' in 'hello_graph'. No such top level " "solid"
         ),
     ):
-        _ = result.result_for_solid("goodbye")
+        _ = result.result_for_node("goodbye")
 
 
 def test_graph_with_no_output_mappings():
@@ -199,7 +199,7 @@ def test_graph_with_no_output_mappings():
     ):
         _ = res.output_value()
 
-    assert len(res.solid_result_list) == 5
+    assert len(res.node_result_list) == 5
 
 
 def test_execute_nested_graphs():
@@ -223,7 +223,7 @@ def test_execute_nested_graphs():
     ):
         _ = res.output_value()
 
-    assert len(res.solid_result_list) == 2
+    assert len(res.node_result_list) == 2
 
 
 def test_single_solid_with_bad_inputs():

--- a/python_modules/libraries/dagster-celery-docker/dagster_celery_docker_tests/test_execute_docker.py
+++ b/python_modules/libraries/dagster-celery-docker/dagster_celery_docker_tests/test_execute_docker.py
@@ -76,7 +76,7 @@ def test_execute_celery_docker_image_on_executor_config(aws_creds):
             instance=instance,
         )
         assert result.success
-        assert result.result_for_solid("get_environment_solid").output_value("result") == "here!"
+        assert result.result_for_node("get_environment_solid").output_value("result") == "here!"
 
 
 def test_execute_celery_docker_image_on_pipeline_config(aws_creds):
@@ -126,4 +126,4 @@ def test_execute_celery_docker_image_on_pipeline_config(aws_creds):
             instance=instance,
         )
         assert result.success
-        assert result.result_for_solid("get_environment_solid").output_value("result") == "here!"
+        assert result.result_for_node("get_environment_solid").output_value("result") == "here!"

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_execute.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_execute.py
@@ -66,7 +66,7 @@ def test_execute_on_dask_local():
                 instance=instance,
                 mode="filesystem",
             )
-            assert result.result_for_solid("simple").output_value() == 1
+            assert result.result_for_node("simple").output_value() == 1
 
 
 def dask_composite_pipeline():
@@ -185,7 +185,7 @@ def test_execute_on_dask_local_without_io_manager():
                 instance=instance,
                 mode="default",
             )
-            assert result.result_for_solid("simple").output_value() == 1
+            assert result.result_for_node("simple").output_value() == 1
 
 
 @solid(input_defs=[InputDefinition("df", DataFrame)])
@@ -271,7 +271,7 @@ def test_existing_scheduler():
                         None, _execute, scheduler.address, instance
                     )
                     assert result.success
-                    assert result.result_for_solid("simple").output_value() == 1
+                    assert result.result_for_node("simple").output_value() == 1
 
     asyncio.get_event_loop().run_until_complete(_run_test())
 
@@ -307,7 +307,7 @@ def test_dask_executor_memoization():
             run_config={"execution": {"dask": {"config": {"cluster": {"local": {"timeout": 30}}}}}},
         )
         assert result.success
-        assert result.output_for_solid("foo_solid") == "foo"
+        assert result.output_for_node("foo_solid") == "foo"
 
         result = execute_pipeline(
             reconstructable(foo_pipeline),
@@ -336,4 +336,4 @@ def test_dask_executor_job():
             run_config={"execution": {"config": {"cluster": {"local": {"timeout": 30}}}}},
         )
         assert result.success
-        assert result.output_for_solid("the_op") == 5
+        assert result.output_for_node("the_op") == 5

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/pandas_hello_world/test_pandas_hello_world.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/pandas_hello_world/test_pandas_hello_world.py
@@ -23,13 +23,13 @@ def test_execute_pipeline():
 
     assert result.success
 
-    assert result.result_for_solid("sum_op").output_value().to_dict("list") == {
+    assert result.result_for_node("sum_op").output_value().to_dict("list") == {
         "num1": [1, 3],
         "num2": [2, 4],
         "sum": [3, 7],
     }
 
-    assert result.result_for_solid("sum_sq_op").output_value().to_dict("list") == {
+    assert result.result_for_node("sum_sq_op").output_value().to_dict("list") == {
         "num1": [1, 3],
         "num2": [2, 4],
         "sum": [3, 7],

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_dagstermill_pandas_solids.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_dagstermill_pandas_solids.py
@@ -36,6 +36,6 @@ def test_papermill_pandas_hello_world_pipeline():
                 instance=instance,
             )
             assert pipeline_result.success
-            solid_result = pipeline_result.result_for_solid("papermill_pandas_hello_world")
+            solid_result = pipeline_result.result_for_node("papermill_pandas_hello_world")
             expected = pd.read_csv(file_relative_path(__file__, "num_prod.csv")) + 1
             assert solid_result.output_value().equals(expected)

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_io.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_io.py
@@ -28,8 +28,8 @@ def test_no_output_notebook_yes_file_manager():
         ]
         assert len(materializations) == 0
 
-        assert result.result_for_solid("hello_world_no_output_notebook").success
-        assert not result.result_for_solid("hello_world_no_output_notebook").output_values
+        assert result.result_for_node("hello_world_no_output_notebook").success
+        assert not result.result_for_node("hello_world_no_output_notebook").output_values
 
 
 @pytest.mark.notebook_test
@@ -43,8 +43,8 @@ def test_no_output_notebook_no_file_manager():
         ]
         assert len(materializations) == 0
 
-        assert result.result_for_solid("hello_world_no_output_notebook").success
-        assert not result.result_for_solid("hello_world_no_output_notebook").output_values
+        assert result.result_for_node("hello_world_no_output_notebook").success
+        assert not result.result_for_node("hello_world_no_output_notebook").output_values
 
 
 @pytest.mark.notebook_test
@@ -60,8 +60,8 @@ def test_yes_output_notebook_yes_io_manager():
         ]
         assert len(materializations) == 1
 
-        assert result.result_for_solid("hello_world").success
-        assert "notebook" in result.result_for_solid("hello_world").output_values
+        assert result.result_for_node("hello_world").success
+        assert "notebook" in result.result_for_node("hello_world").output_values
 
         output_path = (
             materializations[0]
@@ -70,6 +70,6 @@ def test_yes_output_notebook_yes_io_manager():
         )
         assert os.path.exists(output_path)
 
-        assert result.result_for_solid("load_notebook").success
+        assert result.result_for_node("load_notebook").success
         with open(output_path, "rb") as f:
-            assert f.read() == result.result_for_solid("load_notebook").output_value()
+            assert f.read() == result.result_for_node("load_notebook").output_value()

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_ops.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_ops.py
@@ -82,7 +82,7 @@ def test_hello_world_job():
 def test_hello_world_with_config():
     with exec_for_test("hello_world_config_job") as result:
         assert result.success
-        assert result.output_for_solid("hello_world_config") == "hello"
+        assert result.output_for_node("hello_world_config") == "hello"
 
 
 @pytest.mark.notebook_test
@@ -92,35 +92,35 @@ def test_hello_world_with_config_escape():
         env={"ops": {"hello_world_config": {"config": {"greeting": "'"}}}},
     ) as result:
         assert result.success
-        assert result.output_for_solid("hello_world_config") == "'"
+        assert result.output_for_node("hello_world_config") == "'"
 
     with exec_for_test(
         "hello_world_config_job",
         env={"ops": {"hello_world_config": {"config": {"greeting": '"'}}}},
     ) as result:
         assert result.success
-        assert result.output_for_solid("hello_world_config") == '"'
+        assert result.output_for_node("hello_world_config") == '"'
 
     with exec_for_test(
         "hello_world_config_job",
         env={"ops": {"hello_world_config": {"config": {"greeting": "\\"}}}},
     ) as result:
         assert result.success
-        assert result.output_for_solid("hello_world_config") == "\\"
+        assert result.output_for_node("hello_world_config") == "\\"
 
     with exec_for_test(
         "hello_world_config_job",
         env={"ops": {"hello_world_config": {"config": {"greeting": "}"}}}},
     ) as result:
         assert result.success
-        assert result.output_for_solid("hello_world_config") == "}"
+        assert result.output_for_node("hello_world_config") == "}"
 
     with exec_for_test(
         "hello_world_config_job",
         env={"ops": {"hello_world_config": {"config": {"greeting": "\n"}}}},
     ) as result:
         assert result.success
-        assert result.output_for_solid("hello_world_config") == "\n"
+        assert result.output_for_node("hello_world_config") == "\n"
 
 
 @pytest.mark.notebook_test
@@ -130,7 +130,7 @@ def test_alias_with_config():
         env={"ops": {"aliased_greeting": {"config": {"greeting": "boo"}}}},
     ) as result:
         assert result.success
-        assert result.output_for_solid("aliased_greeting") == "boo"
+        assert result.output_for_node("aliased_greeting") == "boo"
 
 
 @pytest.mark.notebook_test
@@ -172,7 +172,7 @@ def test_reexecute_result_notebook():
 def test_hello_world_with_output():
     with exec_for_test("hello_world_output_job") as result:
         assert result.success
-        assert result.result_for_solid("hello_world_output").output_value() == "hello, world"
+        assert result.result_for_node("hello_world_output").output_value() == "hello, world"
 
 
 @pytest.mark.notebook_test
@@ -191,7 +191,7 @@ def test_add_job():
         "add_job", {"loggers": {"console": {"config": {"log_level": "ERROR"}}}}
     ) as result:
         assert result.success
-        assert result.result_for_solid("add_two_numbers").output_value() == 3
+        assert result.result_for_node("add_two_numbers").output_value() == 3
 
 
 @pytest.mark.notebook_test
@@ -201,8 +201,8 @@ def test_double_add_job():
         {"loggers": {"console": {"config": {"log_level": "ERROR"}}}},
     ) as result:
         assert result.success
-        assert result.result_for_solid("add_two_numbers_1").output_value() == 3
-        assert result.result_for_solid("add_two_numbers_2").output_value() == 7
+        assert result.result_for_node("add_two_numbers_1").output_value() == 3
+        assert result.result_for_node("add_two_numbers_2").output_value() == 7
 
 
 @pytest.mark.notebook_test
@@ -218,9 +218,9 @@ def test_fan_in_notebook_job():
         },
     ) as result:
         assert result.success
-        assert result.result_for_solid("op_1").output_value() == "hello"
-        assert result.result_for_solid("op_2").output_value() == "world"
-        assert result.result_for_solid("fan_in").output_value() == "hello world"
+        assert result.result_for_node("op_1").output_value() == "hello"
+        assert result.result_for_node("op_2").output_value() == "world"
+        assert result.result_for_node("fan_in").output_value() == "hello world"
 
 
 @pytest.mark.notebook_test
@@ -234,7 +234,7 @@ def test_graph_job():
     ) as result:
         assert result.success
         assert (
-            result.result_for_solid("outer").result_for_solid("yield_something").output_value()
+            result.result_for_node("outer").result_for_node("yield_something").output_value()
             == "hello"
         )
 
@@ -263,8 +263,8 @@ def test_notebook_dag():
         {"ops": {"load_a": {"config": 1}, "load_b": {"config": 2}}},
     ) as result:
         assert result.success
-        assert result.result_for_solid("add_two_numbers").output_value() == 3
-        assert result.result_for_solid("mult_two_numbers").output_value() == 6
+        assert result.result_for_node("add_two_numbers").output_value() == 3
+        assert result.result_for_node("mult_two_numbers").output_value() == 6
 
 
 @pytest.mark.notebook_test
@@ -448,21 +448,21 @@ def test_hello_logging():
 def test_reimport():
     with exec_for_test("reimport_job") as result:
         assert result.success
-        assert result.result_for_solid("reimport").output_value() == 6
+        assert result.result_for_node("reimport").output_value() == 6
 
 
 @pytest.mark.notebook_test
 def test_yield_3_job():
     with exec_for_test("yield_3_job") as result:
         assert result.success
-        assert result.result_for_solid("yield_3").output_value() == 3
+        assert result.result_for_node("yield_3").output_value() == 3
 
 
 @pytest.mark.notebook_test
 def test_yield_obj_job():
     with exec_for_test("yield_obj_job") as result:
         assert result.success
-        assert result.result_for_solid("yield_obj").output_value().x == 3
+        assert result.result_for_node("yield_obj").output_value().x == 3
 
 
 @pytest.mark.notebook_test
@@ -534,7 +534,7 @@ def test_retries(capsys):
         "retries_job", {"execution": {"config": {"in_process": {}}}}, raise_on_error=False
     ) as result:
 
-        assert result.result_for_solid("yield_retry").retry_attempts == 1
+        assert result.result_for_node("yield_retry").retry_attempts == 1
 
         # the raise_retry op should trigger a warning to use yield_event
         warn_found = False
@@ -552,7 +552,7 @@ def test_failure(capsys):
         "failure_job", {"execution": {"config": {"in_process": {}}}}, raise_on_error=False
     ) as result:
         assert (
-            result.result_for_solid("yield_failure").failure_data.user_failure_data.description
+            result.result_for_node("yield_failure").failure_data.user_failure_data.description
             == "bad bad notebook"
         )
 


### PR DESCRIPTION
### Summary & Motivation

Rename several methods on `ExecutionResult` classes to use `node` instead of `solid`:

- result_for_solid -> result_for_node
- output_for_solid -> output_for_node
- solid_result_list -> node_result_list

Also a few similar local variable and argument renames, and a small number of added type annotations.

### How I Tested These Changes

BK