### PR TITLE
dagster-graphql: external: gen_location_state_changes: state subscriber  bugfix

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -15,6 +15,7 @@ from dagster._core.host_representation import (
     ManagedGrpcPythonEnvRepositoryLocationOrigin,
     RepositoryLocation,
 )
+from dagster._core.host_representation.grpc_server_state_subscriber import LocationStateSubscriber
 from dagster._core.workspace.context import WorkspaceLocationEntry, WorkspaceLocationLoadStatus
 
 from .asset_graph import GrapheneAssetGroup, GrapheneAssetNode
@@ -356,10 +357,10 @@ async def gen_location_state_changes(graphene_info):
     queue = asyncio.Queue()
     loop = asyncio.get_event_loop()
 
-    def _enqueue(event, cursor):
-        loop.call_soon_threadsafe(queue.put_nowait, (event, cursor))
+    def _enqueue(event):
+        loop.call_soon_threadsafe(queue.put_nowait, event)
 
-    token = context.add_state_subscriber(_enqueue)
+    token = context.add_state_subscriber(LocationStateSubscriber(_enqueue))
     try:
         while True:
             event = await queue.get()


### PR DESCRIPTION
### Summary & Motivation
During the migration to Graphene 3, the `gen_location_state_changes` function introduced a `_enqueue` function which was added to the context's state subscribers. Mismatching the source of the subscribers' dictionary, a function was added instead of a `LocationStateSubscriber` with the function as a callback.

Detected the issue on our Dagster deployment as `AttributeError: 'function' object has no attribute 'handle_event'` on `dagster/_core/workspace/context.py:492` (`subscriber.handle_event(event)`).

### How I Tested These Changes
- Deploying a patched version for testing on our K8s cluster, with external repositories - the patch has resolved the issue.
- Running `dagster_graphql` tests locally - had two tests failing before and after the change. Probably due to a bad setup on my side (specifically on `dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py`).
