### PR TITLE
Pin duckdb <= 6.0.0

### DIFF
--- a/examples/project_fully_featured/setup.py
+++ b/examples/project_fully_featured/setup.py
@@ -26,7 +26,7 @@ setup(
         "dbt-core",
         "dbt-duckdb",
         "dbt-snowflake",
-        "duckdb!=0.3.3",  # missing wheels
+        "duckdb!=0.3.3, <= 6.0.0",  # missing wheels
         "mock",
         # DataFrames were not written to Snowflake, causing errors
         "pandas<1.4.0",


### PR DESCRIPTION
6.0.1 fails with:

```
      unable to execute 'gcc': No such file or directory
      unable to execute 'gcc': No such file or directory
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: legacy-install-failure

× Encountered error while trying to install package.
╰─> duckdb
```
