### PR TITLE
[dagit] Fix the “Assets” label on large asset runs

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/AssetKeyTagCollection.tsx
+++ b/js_modules/dagit/packages/core/src/runs/AssetKeyTagCollection.tsx
@@ -99,8 +99,13 @@ export const AssetKeyTagCollection: React.FC<{
   return (
     <Box flex={{direction: 'row', gap: 8, wrap: 'wrap', alignItems: 'center'}}>
       <Icon color={Colors.Gray400} name="asset" size={16} />
-      {`${displayed.map(displayNameForAssetKey).join(', ')}${
-        hidden > 0 ? ` + ${hidden} more` : ''
+      {`${displayed.map(displayNameForAssetKey).join(', ')}
+      ${
+        hidden > 0 && displayed.length > 0
+          ? ` + ${hidden} more`
+          : hidden > 0
+          ? `${hidden} assets`
+          : ''
       }`}
     </Box>
   );


### PR DESCRIPTION
### Summary & Motivation

I think this was a small oversight in the "non-clickable" version of `AssetKeyTagCollection`

![image](https://user-images.githubusercontent.com/1037212/206020033-2faff60e-b53b-47cd-8c48-1a3bac8f86ac.png)

![image](https://user-images.githubusercontent.com/1037212/206020085-b19a2a1d-2f9d-41be-b1a8-ec13643f3ac0.png)

### How I Tested These Changes

Verify that the run history looks correct with asset jobs >3 assets and less than 3 assets
