### PR TITLE
[dagit] Use code location name instead of ID for toast

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/types/CodeLocationStatusQuery.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/CodeLocationStatusQuery.ts
@@ -16,6 +16,7 @@ export interface CodeLocationStatusQuery_locationStatusesOrError_PythonError {
 export interface CodeLocationStatusQuery_locationStatusesOrError_WorkspaceLocationStatusEntries_entries {
   __typename: "WorkspaceLocationStatusEntry";
   id: string;
+  name: string;
   loadStatus: RepositoryLocationLoadStatus;
   updateTimestamp: number;
 }

--- a/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
@@ -190,7 +190,7 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
           <Box flex={{direction: 'row', justifyContent: 'space-between', gap: 24, grow: 1}}>
             {currentlyLoading.length === 1 ? (
               <span>
-                Updating <strong>{currentlyLoading[0].id}</strong>
+                Updating <strong>{currentlyLoading[0].name}</strong>
               </span>
             ) : (
               <span>Updating {currentlyLoading.length} code locations</span>
@@ -258,6 +258,7 @@ const CODE_LOCATION_STATUS_QUERY = gql`
       ... on WorkspaceLocationStatusEntries {
         entries {
           id
+          name
           loadStatus
           updateTimestamp
         }


### PR DESCRIPTION
### Summary & Motivation

The `id` field on code location entry status is prepended with `location_status`, which appears in the toast in Dagit when a code location is added.

Instead, use `name`, which is the appropriate display name of the code location. 

### How I Tested These Changes

Load dagit-cloud, add a code location. Verify that the toast has the `name` string.
