### PR TITLE
[dagit] Fix “Job In” label regression in Chrome v109

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/MiddleTruncate.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/MiddleTruncate.stories.tsx
@@ -2,11 +2,13 @@ import {Meta} from '@storybook/react/types-6-0';
 import faker from 'faker';
 import * as React from 'react';
 
+import {BaseTag} from './BaseTag';
 import {Box} from './Box';
 import {Colors} from './Colors';
 import {Icon} from './Icon';
 import {MiddleTruncate} from './MiddleTruncate';
 import {Slider} from './Slider';
+import {Tag} from './Tag';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -41,6 +43,22 @@ export const Simple = () => {
         <MiddleTruncate text="Hello world" />
       </div>
     </>
+  );
+};
+
+export const TagUsage = () => {
+  return (
+    <Tag icon="job">
+      <span>
+        Job in{' '}
+        <Box
+          flex={{display: 'inline-flex', direction: 'row', alignItems: 'center'}}
+          style={{maxWidth: 100}}
+        >
+          <MiddleTruncate text="repo@longrepolocation.py" />
+        </Box>
+      </span>
+    </Tag>
   );
 };
 

--- a/js_modules/dagit/packages/ui/src/components/MiddleTruncate.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/MiddleTruncate.stories.tsx
@@ -2,7 +2,6 @@ import {Meta} from '@storybook/react/types-6-0';
 import faker from 'faker';
 import * as React from 'react';
 
-import {BaseTag} from './BaseTag';
 import {Box} from './Box';
 import {Colors} from './Colors';
 import {Icon} from './Icon';

--- a/js_modules/dagit/packages/ui/src/components/MiddleTruncate.tsx
+++ b/js_modules/dagit/packages/ui/src/components/MiddleTruncate.tsx
@@ -54,8 +54,8 @@ export const MiddleTruncate: React.FC<{text: string}> = React.memo(({text}) => {
 
   return (
     <Container onCopy={handleCopy} title={text}>
-      <MeasureWidth ref={measure}>{text}</MeasureWidth>
       <span>{truncatedText}</span>
+      <MeasureWidth ref={measure}>{text}</MeasureWidth>
     </Container>
   );
 });


### PR DESCRIPTION
### Summary & Motivation

This PR is a small patch to resolve an issue reported in Slack here:
https://elementl-workspace.slack.com/archives/C03CCE471E0/p1670355704131579

This rendering issue only appears in Chrome 109 and only impacts the "Job in repo", "Asset in repo" tags.  I added a test case to our MiddleTruncation storybook to verify the fix and make it easier to spot this in the future.

I believe the reason this was happening was because MiddleTruncation renders its text twice, and the default flex "align-items" value is "baseline", which aligns the children based on the location of the first text baseline inside each of them. Putting the measurement div below the rendered div fixes the issue for me.



### How I Tested These Changes

Before:
<img width="492" alt="image" src="https://user-images.githubusercontent.com/1037212/206021818-0ee6f0c8-2192-4803-bf7c-57552d38aa4c.png">

After: 
<img width="485" alt="image" src="https://user-images.githubusercontent.com/1037212/206028226-8289ab45-3cfc-4769-af13-46482cfa24ee.png">

