### PR TITLE
feat(dbt-cloud): raise error on jobs that do not create assets

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -197,6 +197,16 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
             result["unique_id"] for result in run_results_json["results"]
         )
 
+        # If there are no executed nodes, then there are no assets to generate.
+        # Inform the user to inspect their dbt Cloud job's command.
+        if not executed_node_ids:
+            raise DagsterDbtCloudJobInvariantViolationError(
+                f"The dbt Cloud job '{job['name']}' ({job['id']}) does not generate any "
+                "software-defined assets. Ensure that your dbt project has nodes to execute, "
+                "and that your dbt Cloud job's commands have the proper filter options applied. "
+                f"Received commands: {commands}."
+            )
+
         # Generate the dependency structure for the executed nodes.
         dbt_dependencies = _get_deps(
             dbt_nodes=dbt_nodes,


### PR DESCRIPTION
### Summary & Motivation
A user encountered an error in which their dbt Cloud job was not producing any software-defined assets. Their UI was empty.

Now, explicitly redirect them to inspect their dbt Cloud job's commands and also their dbt project to see if anything is amiss. For example, if their selection string was incorrect, if their dbt project doesn't actually contain any executable nodes, etc.

### How I Tested These Changes
pytest
