### PR TITLE
[dagit] Pass repository tag when loading runs for Partitions page

### DIFF
--- a/js_modules/dagit/packages/core/src/gantt/GanttChart.stories.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChart.stories.tsx
@@ -194,6 +194,22 @@ const LOGS: RunMetadataProviderMessageFragment[] = [
     __typename: 'ExecutionStepSuccessEvent',
   },
   {
+    message: 'Starting initialization of resources [io_manager].',
+    timestamp: '0',
+    markerStart: `c-resource-1`,
+    markerEnd: null,
+    stepKey: 'C',
+    __typename: 'ResourceInitStartedEvent',
+  },
+  {
+    message: 'Finished initialization of resources [io_manager].',
+    timestamp: '0',
+    markerStart: null,
+    markerEnd: `c-resource-1`,
+    stepKey: 'C',
+    __typename: 'ResourceInitSuccessEvent',
+  },
+  {
     message: 'Started execution of step "C".',
     timestamp: '0',
     stepKey: 'C',

--- a/js_modules/dagit/packages/core/src/instance/BackfillStepStatusDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillStepStatusDialog.tsx
@@ -6,6 +6,7 @@ import {usePartitionStepQuery} from '../partitions/usePartitionStepQuery';
 import {DagsterTag} from '../runs/RunTag';
 import {RunFilterToken} from '../runs/RunsFilterInput';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
+import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
 import {
@@ -68,21 +69,23 @@ export const BackfillStepStatusDialogContent = ({
 }: ContentProps) => {
   const [pageSize, setPageSize] = React.useState(60);
   const [offset, setOffset] = React.useState<number>(0);
+
   const runsFilter = React.useMemo(() => {
     const token: RunFilterToken = {token: 'tag', value: `dagster/backfill=${backfill.backfillId}`};
     return [token];
   }, [backfill.backfillId]);
 
-  const partitions = usePartitionStepQuery(
-    partitionSet.name,
-    DagsterTag.Partition,
-    backfill.partitionNames,
+  const partitions = usePartitionStepQuery({
+    partitionSetName: partitionSet.name,
+    partitionTagName: DagsterTag.Partition,
+    partitionNames: backfill.partitionNames,
     pageSize,
     runsFilter,
-    partitionSet.pipelineName,
+    repositorySelector: repoAddressToSelector(repoAddress),
+    jobName: partitionSet.pipelineName,
     offset,
-    !backfill,
-  );
+    skipQuery: !backfill,
+  });
 
   return (
     <PartitionPerOpStatus

--- a/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
@@ -11,6 +11,7 @@ import {
 import {usePartitionHealthData} from '../assets/usePartitionHealthData';
 import {useViewport} from '../gantt/useViewport';
 import {DagsterTag} from '../runs/RunTag';
+import {RepositorySelector} from '../types/globalTypes';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
@@ -141,6 +142,7 @@ export const AssetJobPartitionsView: React.FC<{
       </Box>
       {showAssets && (
         <AssetJobPartitionGraphs
+          repositorySelector={repositorySelector}
           pipelineName={pipelineName}
           partitionSetName={partitionSetName}
           multidimensional={(merged?.dimensions.length || 0) > 1}
@@ -171,6 +173,7 @@ export const AssetJobPartitionsView: React.FC<{
 };
 
 export const AssetJobPartitionGraphs: React.FC<{
+  repositorySelector: RepositorySelector;
   pipelineName: string;
   partitionSetName: string;
   multidimensional: boolean;
@@ -180,6 +183,7 @@ export const AssetJobPartitionGraphs: React.FC<{
   pageSize: number;
   offset: number;
 }> = ({
+  repositorySelector,
   dimensionKeys,
   dimensionName,
   selected,
@@ -189,16 +193,19 @@ export const AssetJobPartitionGraphs: React.FC<{
   pipelineName,
   offset,
 }) => {
-  const partitions = usePartitionStepQuery(
+  const partitions = usePartitionStepQuery({
     partitionSetName,
-    multidimensional ? `${DagsterTag.Partition}/${dimensionName}` : DagsterTag.Partition,
-    dimensionKeys,
+    partitionTagName: multidimensional
+      ? `${DagsterTag.Partition}/${dimensionName}`
+      : DagsterTag.Partition,
+    partitionNames: dimensionKeys,
+    repositorySelector,
     pageSize,
-    [],
-    pipelineName,
+    runsFilter: [],
+    jobName: pipelineName,
     offset,
-    !dimensionName,
-  );
+    skipQuery: !dimensionName,
+  });
 
   const {stepDurationData, runDurationData} = usePartitionDurations(partitions);
 

--- a/js_modules/dagit/packages/core/src/partitions/OpJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/OpJobPartitionsView.tsx
@@ -103,16 +103,17 @@ const OpJobPartitionsViewContent: React.FC<{
   const repositorySelector = repoAddressToSelector(repoAddress);
   const [backfillRefetchCounter, setBackfillRefetchCounter] = React.useState(0);
 
-  const partitions = usePartitionStepQuery(
-    partitionSet.name,
-    DagsterTag.Partition,
+  const partitions = usePartitionStepQuery({
+    partitionSetName: partitionSet.name,
+    partitionTagName: DagsterTag.Partition,
     partitionNames,
     pageSize,
-    [],
-    partitionSet.pipelineName,
+    runsFilter: [],
+    repositorySelector,
+    jobName: partitionSet.pipelineName,
     offset,
-    !showSteps,
-  );
+    skipQuery: !showSteps,
+  });
 
   React.useEffect(() => {
     if (viewport.width && !showSteps) {


### PR DESCRIPTION
### Summary & Motivation

This PR resolves the issue described in https://github.com/dagster-io/dagster/issues/10276

I was able to reproduce this locally by creating two `repo.py` files with a single op + job and loading them both into Dagit. Running one job but not the other shows the correct status everywhere except the partitions page, where the per-step dot matrix shows green dots for the never-executed run.

This was caused by the `usePartitionStepQuery` hook not passing a run filter for the repository. I added it and also refactored the hook to use an options object instead of a long list of comma-separated arguments. 

### How I Tested These Changes

I verified that the runsFilter is passed as expected and that the partitions page now renders accurately for both the run and never-run job.