### PR TITLE
[dagit] Use regular name@location for repo tag on runs

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
@@ -9,7 +9,7 @@ import {DagsterTag} from '../runs/RunTag';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
 import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
-import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
+import {repoAddressAsTag} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {LatestRunTag} from './LatestRunTag';
@@ -37,7 +37,7 @@ export function useJobNavMetadata(repoAddress: RepoAddress, pipelineName: string
         tags: [
           {
             key: DagsterTag.RepositoryLabelTag,
-            value: repoAddressAsHumanString(repoAddress),
+            value: repoAddressAsTag(repoAddress),
           },
         ],
       },

--- a/js_modules/dagit/packages/core/src/nav/LatestRunTag.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LatestRunTag.tsx
@@ -10,7 +10,7 @@ import {DagsterTag} from '../runs/RunTag';
 import {RunTime, RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {RunStatus} from '../types/globalTypes';
-import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
+import {repoAddressAsTag} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {LatestRunTagQuery, LatestRunTagQueryVariables} from './types/LatestRunTagQuery';
@@ -30,7 +30,7 @@ export const LatestRunTag: React.FC<{pipelineName: string; repoAddress: RepoAddr
           tags: [
             {
               key: DagsterTag.RepositoryLabelTag,
-              value: repoAddressAsHumanString(repoAddress),
+              value: repoAddressAsTag(repoAddress),
             },
           ],
         },

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineRunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineRunsRoot.tsx
@@ -32,6 +32,7 @@ import {useCursorPaginatedQuery} from '../runs/useCursorPaginatedQuery';
 import {Loading} from '../ui/Loading';
 import {StickyTableContainer} from '../ui/StickyTableContainer';
 import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
+import {repoAddressAsTag} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {explorerPathFromString} from './PipelinePathUtils';
@@ -70,7 +71,7 @@ export const PipelineRunsRoot: React.FC<Props> = (props) => {
   if (repoAddress) {
     const repoToken = {
       token: 'tag',
-      value: `${DagsterTag.RepositoryLabelTag}=${repoAddress.name}@${repoAddress.location}`,
+      value: `${DagsterTag.RepositoryLabelTag}=${repoAddressAsTag(repoAddress)}`,
     };
     allTokens.push(repoToken);
   }

--- a/js_modules/dagit/packages/core/src/workspace/repoAddressAsString.ts
+++ b/js_modules/dagit/packages/core/src/workspace/repoAddressAsString.ts
@@ -10,3 +10,8 @@ export const repoAddressAsHumanString = memoize((repoAddress: RepoAddress) => {
 export const repoAddressAsURLString = memoize((repoAddress: RepoAddress) => {
   return buildRepoPathForURL(repoAddress.name, repoAddress.location);
 });
+
+// Unencoded, dunder repo visible.
+export const repoAddressAsTag = memoize((repoAddress: RepoAddress) => {
+  return `${repoAddress.name}@${repoAddress.location}`;
+});


### PR DESCRIPTION
### Summary & Motivation

In cases where we are using the RepoAddress values to query for a run tag, we should continue using `repo@location`. This is not expected to be URI-encoded.

This should fix an issue where launching a run does not include the dunder repo in the created tag.

### How I Tested These Changes

Run dagit with `-f` for a file that will use a dunder repo name. Launch a run. Verify that I see the (failed) run in the "Runs" tab on that job within Dagit, indicating that it can be queried successfully by tag.
