### PR TITLE
feat(dbt-cloud): support multiple commands in jobs

### DIFF
--- a/docs/content/integrations/dbt-cloud.mdx
+++ b/docs/content/integrations/dbt-cloud.mdx
@@ -78,7 +78,8 @@ dbt_cloud_assets = load_assets_from_dbt_cloud_job(
 ```
 
 <Note>
-  We currently require that your dbt Cloud job only has one command: one of
+  We support dbt Cloud jobs with multiple commands, but we require one of the
+  commands be a materialization command. A materialization command is one of
   either `dbt run` or `dbt build`, along with any optional command line
   arguments.
 </Note>

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -58,8 +58,8 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
         self._job_id = job_id
         self._project_id: int
         self._has_generate_docs: bool
-        self._dbt_cloud_job_command: str
-        self._job_command_step: int
+        self._job_commands: List[str]
+        self._job_materialization_command_step: int
         self._node_info_to_asset_key = node_info_to_asset_key
         self._node_info_to_group_fn = node_info_to_group_fn
         self._partitions_def = partitions_def
@@ -94,12 +94,10 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
         self._project_id = job["project_id"]
         self._has_generate_docs = job["generate_docs"]
 
-        # Initially, we'll constraint the kinds of dbt Cloud jobs that we support running.
-        # A simple constraint to is that we only support jobs that run a single command,
-        # as defined in the dbt Cloud job's execution settings.
+        # We constraint the kinds of dbt Cloud jobs that we support running.
         #
-        # TODO: For the moment, we'll support either `dbt run` or `dbt build`.
-        # In the future, we can adjust this to support multiple commands.
+        # A simple constraint is that we only support jobs that run multiple steps,
+        # but it must contain one of either `dbt run` or `dbt build`.
         #
         # As a reminder, `dbt deps` is automatically run before the job's configured commands.
         # And if the settings are enabled, `dbt docs generate` and `dbt source freshness` can
@@ -107,19 +105,23 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
         #
         # These commands that execute before and after the job's configured commands do not count
         # towards the single command constraint.
-        commands = job["execute_steps"]
-        if len(commands) != 1 or not commands[0].lower().startswith(("dbt run", "dbt build")):
+        self._job_commands = job["execute_steps"]
+        materialization_command_filter = [
+            command.lower().startswith(("dbt run", "dbt build")) for command in self._job_commands
+        ]
+        if sum(materialization_command_filter) != 1:
             raise DagsterDbtCloudJobInvariantViolationError(
-                f"The dbt Cloud job '{job['name']}' ({job['id']}) must have a single command. "
-                "It must one of `dbt run` or `dbt build`. Received commands: {commands}."
+                f"The dbt Cloud job '{job['name']}' ({job['id']}) must have a single `dbt run` "
+                f"or `dbt build` in its commands. Received commands: {self._job_commands}."
             )
 
-        self._dbt_cloud_job_command = commands[0].strip()
+        self._job_materialization_command_step = materialization_command_filter.index(True)
 
-        # Retrieve the filters options from the dbt Cloud job's command.
+        # Retrieve the filters options from the dbt Cloud job's materialization command.
         #
         # There are three filters: `--select`, `--exclude`, and `--selector`.
-        parsed_args = dbt_parse_args(args=shlex.split(self._dbt_cloud_job_command)[1:])
+        materialization_command = self._job_commands[self._job_materialization_command_step]
+        parsed_args = dbt_parse_args(args=shlex.split(materialization_command)[1:])
         dbt_compile_options: List[str] = []
 
         selected_models = parsed_args.select or []
@@ -145,8 +147,8 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
         if dbt_vars:
             raise DagsterDbtCloudJobInvariantViolationError(
                 f"The dbt Cloud job '{job['name']}' ({job['id']}) must not have variables defined "
-                "from `--vars`. Instead, declare the variable in the `dbt_project.yml` file. "
-                f"Received commands: {commands}."
+                "from `--vars` in its `dbt run` or `dbt build` command. Instead, declare the "
+                f"variables in the `dbt_project.yml` file. Received commands: {self._job_commands}."
             )
 
         if self._partitions_def and self._partition_key_to_vars_fn:
@@ -173,18 +175,20 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
         # that the last step is the correct target.
         #
         # Here, we ignore the `dbt docs generate` step.
-        self._job_command_step = len(compile_run_dbt_output.run_details.get("run_steps", []))
-        if self._job_command_step > 0 and self._has_generate_docs:
-            self._job_command_step -= 1
+        compile_job_materialization_command_step = len(
+            compile_run_dbt_output.run_details.get("run_steps", [])
+        )
+        if self._has_generate_docs:
+            compile_job_materialization_command_step -= 1
 
         # Fetch the compilation run's manifest and run results.
         compile_run_id = compile_run_dbt_output.run_id
 
         manifest_json = self._dbt_cloud.get_manifest(
-            run_id=compile_run_id, step=self._job_command_step
+            run_id=compile_run_id, step=compile_job_materialization_command_step
         )
         run_results_json = self._dbt_cloud.get_run_results(
-            run_id=compile_run_id, step=self._job_command_step
+            run_id=compile_run_id, step=compile_job_materialization_command_step
         )
 
         # Filter the manifest to only include the nodes that were executed.
@@ -203,8 +207,8 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
             raise DagsterDbtCloudJobInvariantViolationError(
                 f"The dbt Cloud job '{job['name']}' ({job['id']}) does not generate any "
                 "software-defined assets. Ensure that your dbt project has nodes to execute, "
-                "and that your dbt Cloud job's commands have the proper filter options applied. "
-                f"Received commands: {commands}."
+                "and that your dbt Cloud job's materialization command has the proper filter "
+                f"options applied. Received commands: {self._job_commands}."
             )
 
         # Generate the dependency structure for the executed nodes.
@@ -266,8 +270,8 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
             can_subset=True,
             extra_metadata={
                 "job_id": self._job_id,
-                "job_command": self._dbt_cloud_job_command,
-                "job_command_step": self._job_command_step,
+                "job_commands": self._job_commands,
+                "job_materialization_command_step": self._job_materialization_command_step,
                 "group_names_by_output_name": {
                     asset_outs[asset_key][0]: group_name
                     for asset_key, group_name in group_names_by_key.items()
@@ -302,8 +306,8 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
     ) -> AssetsDefinition:
         metadata = cast(Mapping[str, Any], assets_definition_cacheable_data.extra_metadata)
         job_id = cast(int, metadata["job_id"])
-        job_command = cast(str, metadata["job_command"])
-        job_command_step = cast(int, metadata["job_command_step"])
+        job_commands = cast(List[str], list(metadata["job_commands"]))
+        job_materialization_command_step = cast(int, metadata["job_materialization_command_step"])
         group_names_by_output_name = cast(Mapping[str, str], metadata["group_names_by_output_name"])
         fqns_by_output_name = cast(Mapping[str, List[str]], metadata["fqns_by_output_name"])
 
@@ -364,19 +368,35 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
 
                 dbt_options.append(f"--select {' '.join(sorted(selected_models))}")
 
+            # Override the materialization step with the selection filter
+            materialization_command = job_commands[job_materialization_command_step]
+            job_commands[
+                job_materialization_command_step
+            ] = f"{materialization_command} {' '.join(dbt_options)}".strip()
+
             # Run the dbt Cloud job to rematerialize the assets.
             dbt_cloud_output = dbt_cloud.run_job_and_poll(
                 job_id=job_id,
-                steps_override=[f"{job_command} {' '.join(dbt_options)}"],
+                steps_override=job_commands,
             )
+
+            # Target the materialization step when retrieving run artifacts, rather than assuming
+            # that the last step is the correct target.
+            #
+            # We ignore the commands in front of the materialization command. And again, we ignore
+            # the `dbt docs generate` step.
+            materialization_command_step = len(dbt_cloud_output.run_details.get("run_steps", []))
+            materialization_command_step -= len(job_commands) - job_materialization_command_step - 1
+            if dbt_cloud_output.run_details.get("job", {}).get("generate_docs"):
+                materialization_command_step -= 1
 
             # TODO: Assume the run completely fails or completely succeeds.
             # In the future, we can relax this assumption.
             manifest_json = dbt_cloud.get_manifest(
-                run_id=dbt_cloud_output.run_id, step=job_command_step
+                run_id=dbt_cloud_output.run_id, step=materialization_command_step
             )
             run_results_json = self._dbt_cloud.get_run_results(
-                run_id=dbt_cloud_output.run_id, step=job_command_step
+                run_id=dbt_cloud_output.run_id, step=materialization_command_step
             )
 
             for result in run_results_json.get("results", []):

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
@@ -117,9 +117,11 @@ def _add_dbt_cloud_job_responses(
 
 
 @responses.activate
-@pytest.mark.parametrize("dbt_command", ["dbt run", "dbt build"])
+@pytest.mark.parametrize("before_dbt_materialization_command", [[], ["dbt test"]])
+@pytest.mark.parametrize("dbt_materialization_command", ["dbt run", "dbt build"])
+@pytest.mark.parametrize("after_dbt_materialization_command", [[], ["dbt test"]])
 @pytest.mark.parametrize(
-    ["dbt_command_options", "expected_dbt_command_options"],
+    ["dbt_materialization_command_options", "expected_dbt_materialization_command_options"],
     [
         ("-s a:b c:d *x", "--select a:b c:d *x"),
         ("--exclude e:f g:h", "--exclude e:f g:h"),
@@ -132,15 +134,22 @@ def _add_dbt_cloud_job_responses(
 )
 def test_load_assets_from_dbt_cloud_job(
     mocker,
-    dbt_command,
-    dbt_command_options,
-    expected_dbt_command_options,
+    before_dbt_materialization_command,
+    dbt_materialization_command,
+    after_dbt_materialization_command,
+    dbt_materialization_command_options,
+    expected_dbt_materialization_command_options,
     dbt_cloud,
     dbt_cloud_service,
 ):
+    dbt_commands = (
+        before_dbt_materialization_command
+        + [f"{dbt_materialization_command} {dbt_materialization_command_options}"]
+        + after_dbt_materialization_command
+    )
     _add_dbt_cloud_job_responses(
         dbt_cloud_api_base_url=dbt_cloud_service.api_base_url,
-        dbt_commands=[f"{dbt_command} {dbt_command_options}"],
+        dbt_commands=dbt_commands,
     )
 
     dbt_cloud_cacheable_assets = load_assets_from_dbt_cloud_job(
@@ -160,10 +169,12 @@ def test_load_assets_from_dbt_cloud_job(
     mock_run_job_and_poll.assert_called_once_with(
         job_id=DBT_CLOUD_JOB_ID,
         cause="Generating software-defined assets for Dagster.",
-        steps_override=[f"dbt compile {expected_dbt_command_options}"],
+        steps_override=[f"dbt compile {expected_dbt_materialization_command_options}"],
     )
 
     assert_assets_match_project(dbt_cloud_assets, has_non_argument_deps=True)
+
+    mock_run_job_and_poll.reset_mock()
 
     # Assert that the outputs have the correct metadata
     for output in dbt_cloud_assets[0].op.output_dict.values():
@@ -182,6 +193,11 @@ def test_load_assets_from_dbt_cloud_job(
     with instance_for_test() as instance:
         assert materialize_cereal_assets.execute_in_process(instance=instance).success
 
+    mock_run_job_and_poll.assert_called_once_with(
+        job_id=DBT_CLOUD_JOB_ID,
+        steps_override=dbt_commands,
+    )
+
 
 @responses.activate
 @pytest.mark.parametrize(
@@ -189,10 +205,15 @@ def test_load_assets_from_dbt_cloud_job(
     [
         [],
         ["dbt deps"],
-        ["dbt deps", "dbt build"],
+        ["dbt deps", "dbt test"],
         [f"dbt build --vars '{json.dumps({'static_variable': 'bad'})}'"],
     ],
-    ids=["empty commands", "no run/build step", "multiple commands", "has static variables"],
+    ids=[
+        "empty commands",
+        "no run/build step",
+        "multiple commands, no run/build step",
+        "has static variables",
+    ],
 )
 def test_invalid_dbt_cloud_job_commands(dbt_cloud, dbt_cloud_service, invalid_dbt_commands):
     dbt_cloud_cacheable_assets = load_assets_from_dbt_cloud_job(
@@ -402,5 +423,5 @@ def test_subsetting(
     )
     mock_run_job_and_poll.assert_called_once_with(
         job_id=DBT_CLOUD_JOB_ID,
-        steps_override=[f"dbt build {dbt_filter_option}"],
+        steps_override=[f"dbt build {dbt_filter_option}".strip()],
     )


### PR DESCRIPTION
### Summary & Motivation
Allow dbt Cloud jobs managed by Dagster to have multiple commands. 

Previously, the constraint was that the list of commands must be length 1, and that the command had to be either `dbt run` or `dbt build`. Now, we relax that constraint a bit: dbt Cloud jobs can have multiple commands, but one of the commands still must be either `dbt run` or `dbt build`.

### How I Tested These Changes
- pytest
- locally, with a dbt Cloud job with commands: `["dbt test", "dbt run"]`.
