### PR TITLE
Fix error message related to pyproject.toml

### DIFF
--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -107,7 +107,7 @@ def get_workspace_load_target(kwargs: Mapping[str, str]):
         if os.path.exists("workspace.yaml"):
             return WorkspaceFileTarget(paths=["workspace.yaml"])
         raise click.UsageError(
-            "No arguments given and no [tools.dagster] block in pyproject.toml found."
+            "No arguments given and no [tool.dagster] block in pyproject.toml found."
         )
 
     if kwargs.get("workspace"):


### PR DESCRIPTION
Summary & Motivation: It is [tool.dagster] not [tools.dagster]

Resolves https://github.com/dagster-io/dagster/issues/10958

Test Plan: Read
