### PR TITLE
Fix bug with re-execution snapshot ids

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1219,6 +1219,7 @@ type Run implements PipelineRun {
   canTerminate: Boolean!
   assets: [Asset!]!
   eventConnection(afterCursor: String): EventConnection!
+  parentPipelineSnapshotId: String
   assetSelection: [AssetKey!]
   resolvedOpSelection: [String!]
   assetMaterializations: [MaterializationEvent!]!

--- a/js_modules/dagit/packages/core/src/instance/types/RunReExecutionQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/RunReExecutionQuery.ts
@@ -104,6 +104,7 @@ export interface RunReExecutionQuery_pipelineRunOrError_Run {
   solidSelection: string[] | null;
   assetSelection: RunReExecutionQuery_pipelineRunOrError_Run_assetSelection[] | null;
   pipelineSnapshotId: string | null;
+  parentPipelineSnapshotId: string | null;
   executionPlan: RunReExecutionQuery_pipelineRunOrError_Run_executionPlan | null;
   stepKeysToExecute: string[] | null;
   repositoryOrigin: RunReExecutionQuery_pipelineRunOrError_Run_repositoryOrigin | null;

--- a/js_modules/dagit/packages/core/src/instigation/types/LaunchedRunListQuery.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/LaunchedRunListQuery.ts
@@ -38,6 +38,7 @@ export interface LaunchedRunListQuery_pipelineRunsOrError_Runs_results {
   rootRunId: string | null;
   parentRunId: string | null;
   pipelineSnapshotId: string | null;
+  parentPipelineSnapshotId: string | null;
   pipelineName: string;
   repositoryOrigin: LaunchedRunListQuery_pipelineRunsOrError_Runs_results_repositoryOrigin | null;
   solidSelection: string[] | null;

--- a/js_modules/dagit/packages/core/src/partitions/types/PartitionRunListQuery.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/PartitionRunListQuery.ts
@@ -38,6 +38,7 @@ export interface PartitionRunListQuery_pipelineRunsOrError_Runs_results {
   rootRunId: string | null;
   parentRunId: string | null;
   pipelineSnapshotId: string | null;
+  parentPipelineSnapshotId: string | null;
   pipelineName: string;
   repositoryOrigin: PartitionRunListQuery_pipelineRunsOrError_Runs_results_repositoryOrigin | null;
   solidSelection: string[] | null;

--- a/js_modules/dagit/packages/core/src/pipelines/types/PipelineRunsRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/PipelineRunsRootQuery.ts
@@ -38,6 +38,7 @@ export interface PipelineRunsRootQuery_pipelineRunsOrError_Runs_results {
   rootRunId: string | null;
   parentRunId: string | null;
   pipelineSnapshotId: string | null;
+  parentPipelineSnapshotId: string | null;
   pipelineName: string;
   repositoryOrigin: PipelineRunsRootQuery_pipelineRunsOrError_Runs_results_repositoryOrigin | null;
   solidSelection: string[] | null;

--- a/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
@@ -12,6 +12,7 @@ export const RUN_FRAGMENT_FOR_REPOSITORY_MATCH = gql`
     id
     pipelineName
     pipelineSnapshotId
+    parentPipelineSnapshotId
     repositoryOrigin {
       id
       repositoryName
@@ -49,6 +50,7 @@ export const RunFragments = {
         }
       }
       pipelineSnapshotId
+      parentPipelineSnapshotId
       executionPlan {
         artifactsPersisted
         ...ExecutionPlanToGraphFragment

--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -164,6 +164,7 @@ export const RUN_TABLE_RUN_FRAGMENT = gql`
     rootRunId
     parentRunId
     pipelineSnapshotId
+    parentPipelineSnapshotId
     pipelineName
     repositoryOrigin {
       id

--- a/js_modules/dagit/packages/core/src/runs/types/PipelineEnvironmentYamlQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/PipelineEnvironmentYamlQuery.ts
@@ -24,6 +24,7 @@ export interface PipelineEnvironmentYamlQuery_pipelineRunOrError_Run {
   pipelineName: string;
   pipelineSnapshotId: string | null;
   runConfigYaml: string;
+  parentPipelineSnapshotId: string | null;
   repositoryOrigin: PipelineEnvironmentYamlQuery_pipelineRunOrError_Run_repositoryOrigin | null;
 }
 

--- a/js_modules/dagit/packages/core/src/runs/types/RunActionButtonsTestQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunActionButtonsTestQuery.ts
@@ -104,6 +104,7 @@ export interface RunActionButtonsTestQuery_pipelineRunOrError_Run {
   solidSelection: string[] | null;
   assetSelection: RunActionButtonsTestQuery_pipelineRunOrError_Run_assetSelection[] | null;
   pipelineSnapshotId: string | null;
+  parentPipelineSnapshotId: string | null;
   executionPlan: RunActionButtonsTestQuery_pipelineRunOrError_Run_executionPlan | null;
   stepKeysToExecute: string[] | null;
   repositoryOrigin: RunActionButtonsTestQuery_pipelineRunOrError_Run_repositoryOrigin | null;

--- a/js_modules/dagit/packages/core/src/runs/types/RunFragment.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunFragment.ts
@@ -100,6 +100,7 @@ export interface RunFragment {
   solidSelection: string[] | null;
   assetSelection: RunFragment_assetSelection[] | null;
   pipelineSnapshotId: string | null;
+  parentPipelineSnapshotId: string | null;
   executionPlan: RunFragment_executionPlan | null;
   stepKeysToExecute: string[] | null;
   repositoryOrigin: RunFragment_repositoryOrigin | null;

--- a/js_modules/dagit/packages/core/src/runs/types/RunFragmentForRepositoryMatch.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunFragmentForRepositoryMatch.ts
@@ -19,5 +19,6 @@ export interface RunFragmentForRepositoryMatch {
   id: string;
   pipelineName: string;
   pipelineSnapshotId: string | null;
+  parentPipelineSnapshotId: string | null;
   repositoryOrigin: RunFragmentForRepositoryMatch_repositoryOrigin | null;
 }

--- a/js_modules/dagit/packages/core/src/runs/types/RunRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunRootQuery.ts
@@ -104,6 +104,7 @@ export interface RunRootQuery_pipelineRunOrError_Run {
   solidSelection: string[] | null;
   assetSelection: RunRootQuery_pipelineRunOrError_Run_assetSelection[] | null;
   pipelineSnapshotId: string | null;
+  parentPipelineSnapshotId: string | null;
   executionPlan: RunRootQuery_pipelineRunOrError_Run_executionPlan | null;
   stepKeysToExecute: string[] | null;
   repositoryOrigin: RunRootQuery_pipelineRunOrError_Run_repositoryOrigin | null;

--- a/js_modules/dagit/packages/core/src/runs/types/RunTableRunFragment.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunTableRunFragment.ts
@@ -38,6 +38,7 @@ export interface RunTableRunFragment {
   rootRunId: string | null;
   parentRunId: string | null;
   pipelineSnapshotId: string | null;
+  parentPipelineSnapshotId: string | null;
   pipelineName: string;
   repositoryOrigin: RunTableRunFragment_repositoryOrigin | null;
   solidSelection: string[] | null;

--- a/js_modules/dagit/packages/core/src/runs/types/RunsRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunsRootQuery.ts
@@ -38,6 +38,7 @@ export interface RunsRootQuery_pipelineRunsOrError_Runs_results {
   rootRunId: string | null;
   parentRunId: string | null;
   pipelineSnapshotId: string | null;
+  parentPipelineSnapshotId: string | null;
   pipelineName: string;
   repositoryOrigin: RunsRootQuery_pipelineRunsOrError_Runs_results_repositoryOrigin | null;
   solidSelection: string[] | null;

--- a/js_modules/dagit/packages/core/src/schedules/types/PreviousRunsForScheduleQuery.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/PreviousRunsForScheduleQuery.ts
@@ -38,6 +38,7 @@ export interface PreviousRunsForScheduleQuery_pipelineRunsOrError_Runs_results {
   rootRunId: string | null;
   parentRunId: string | null;
   pipelineSnapshotId: string | null;
+  parentPipelineSnapshotId: string | null;
   pipelineName: string;
   repositoryOrigin: PreviousRunsForScheduleQuery_pipelineRunsOrError_Runs_results_repositoryOrigin | null;
   solidSelection: string[] | null;

--- a/js_modules/dagit/packages/core/src/sensors/types/PreviousRunsForSensorQuery.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/PreviousRunsForSensorQuery.ts
@@ -42,6 +42,7 @@ export interface PreviousRunsForSensorQuery_pipelineRunsOrError_Runs_results {
   rootRunId: string | null;
   parentRunId: string | null;
   pipelineSnapshotId: string | null;
+  parentPipelineSnapshotId: string | null;
   pipelineName: string;
   repositoryOrigin: PreviousRunsForSensorQuery_pipelineRunsOrError_Runs_results_repositoryOrigin | null;
   solidSelection: string[] | null;

--- a/js_modules/dagit/packages/core/src/workspace/useRepositoryForRun.ts
+++ b/js_modules/dagit/packages/core/src/workspace/useRepositoryForRun.ts
@@ -48,6 +48,9 @@ export const useRepositoryForRun = (
     }
 
     const pipelineName = run.pipelineName;
+    // When jobs are subsetted (with an opSelection or assetSelection), only their
+    // parentPipelineSnapshotId (the id of the pipelineSnapshot that they were subsetted from) will
+    // be found in the repository, so look for that instead.
     const snapshotId = run.parentPipelineSnapshotId ?? run.pipelineSnapshotId;
 
     // Find the repository that contains the specified pipeline name and snapshot ID, if any.

--- a/js_modules/dagit/packages/core/src/workspace/useRepositoryForRun.ts
+++ b/js_modules/dagit/packages/core/src/workspace/useRepositoryForRun.ts
@@ -48,7 +48,7 @@ export const useRepositoryForRun = (
     }
 
     const pipelineName = run.pipelineName;
-    const snapshotId = run.pipelineSnapshotId;
+    const snapshotId = run.parentPipelineSnapshotId ?? run.pipelineSnapshotId;
 
     // Find the repository that contains the specified pipeline name and snapshot ID, if any.
     if (pipelineName && snapshotId) {

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -348,6 +348,9 @@ class GrapheneRun(graphene.ObjectType):
     def resolve_pipelineSnapshotId(self, _graphene_info):
         return self._pipeline_run.pipeline_snapshot_id
 
+    def resolve_parentPipelineSnapshotId(self, graphene_info):
+        return self._pipeline_run.pipeline_snapshot_id
+
     def resolve_stats(self, graphene_info):
         return get_stats(graphene_info, self.run_id)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -263,6 +263,7 @@ class GrapheneRun(graphene.ObjectType):
     runId = graphene.NonNull(graphene.String)
     # Nullable because of historical runs
     pipelineSnapshotId = graphene.String()
+    parentPipelineSnapshotId = graphene.String()
     repositoryOrigin = graphene.Field(GrapheneRepositoryOrigin)
     status = graphene.NonNull(GrapheneRunStatus)
     pipeline = graphene.NonNull(GraphenePipelineReference)
@@ -349,7 +350,11 @@ class GrapheneRun(graphene.ObjectType):
         return self._pipeline_run.pipeline_snapshot_id
 
     def resolve_parentPipelineSnapshotId(self, graphene_info):
-        return self._pipeline_run.pipeline_snapshot_id
+        if graphene_context.instance.has_pipeline_snapshot(self.pipelineSnapshotId):
+            snapshot = graphene_context.instance.get_pipeline_snapshot(self.pipelineSnapshotId)
+            if snapshot.lineage_snapshot is not None:
+                return snapshot.lineage_snapshot.parent_snapshot_id
+        return None
 
     def resolve_stats(self, graphene_info):
         return get_stats(graphene_info, self.run_id)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -350,8 +350,12 @@ class GrapheneRun(graphene.ObjectType):
         return self._pipeline_run.pipeline_snapshot_id
 
     def resolve_parentPipelineSnapshotId(self, graphene_info):
-        if graphene_context.instance.has_pipeline_snapshot(self.pipelineSnapshotId):
-            snapshot = graphene_context.instance.get_pipeline_snapshot(self.pipelineSnapshotId)
+        pipeline_snapshot_id = self._pipeline_run.pipeline_snapshot_id
+        if (
+            pipeline_snapshot_id is not None
+            and graphene_info.context.instance.has_pipeline_snapshot(pipeline_snapshot_id)
+        ):
+            snapshot = graphene_info.context.instance.get_pipeline_snapshot(pipeline_snapshot_id)
             if snapshot.lineage_snapshot is not None:
                 return snapshot.lineage_snapshot.parent_snapshot_id
         return None

--- a/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
@@ -161,7 +161,7 @@ class PipelineSnapshot(
         graph_def_name: str,
         metadata: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]],
     ):
-        return super(PipelineSnapshot, cls).__new__(
+        x = super(PipelineSnapshot, cls).__new__(
             cls,
             name=check.str_param(name, "name"),
             description=check.opt_str_param(description, "description"),
@@ -189,6 +189,12 @@ class PipelineSnapshot(
             graph_def_name=check.str_param(graph_def_name, "graph_def_name"),
             metadata=check.opt_sequence_param(metadata, "metadata"),
         )
+        print("=" * 100)
+        print("\n")
+        print(x)
+        print("\n")
+        print("=" * 100)
+        return x
 
     @classmethod
     def from_pipeline_def(cls, pipeline_def: PipelineDefinition) -> "PipelineSnapshot":

--- a/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
@@ -161,7 +161,7 @@ class PipelineSnapshot(
         graph_def_name: str,
         metadata: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]],
     ):
-        x = super(PipelineSnapshot, cls).__new__(
+        return super(PipelineSnapshot, cls).__new__(
             cls,
             name=check.str_param(name, "name"),
             description=check.opt_str_param(description, "description"),
@@ -189,12 +189,6 @@ class PipelineSnapshot(
             graph_def_name=check.str_param(graph_def_name, "graph_def_name"),
             metadata=check.opt_sequence_param(metadata, "metadata"),
         )
-        print("=" * 100)
-        print("\n")
-        print(x)
-        print("\n")
-        print("=" * 100)
-        return x
 
     @classmethod
     def from_pipeline_def(cls, pipeline_def: PipelineDefinition) -> "PipelineSnapshot":


### PR DESCRIPTION
### Summary & Motivation

When you subset an asset job (i.e. most of the time), a new snapshot id is generated which will not match the snapshot id of the job found in the repository, which is what we check against when deciding if we'll show the warning message or not.

### How I Tested These Changes

```
from dagster import asset


@asset
def a():
    return 1


@asset
def b(a):
    return a

```

Before these changes, the exclamation point would show up on the page for the run next to the Re-execute button, now it doesn't.

I have no idea of any better way of doing this.