### PR TITLE
cap packaging requirement at 22.0

### DIFF
--- a/python_modules/automation/setup.py
+++ b/python_modules/automation/setup.py
@@ -20,7 +20,9 @@ setup(
     install_requires=[
         "autoflake",
         "boto3",
-        "packaging>=20.9",
+        # packaging v22 has build compatibility issues with dbt as of 2022-12-07
+        # upper bound can be removed as soon as BK passes with packaging >=22
+        "packaging>=20.9,<22",
         "pandas",
         "pytablereader",
         "requests",

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -80,9 +80,6 @@ def library_version_from_core_version(core_version: str) -> str:
 
 def parse_package_version(version_str: str) -> packaging.version.Version:
     parsed_version = packaging.version.parse(version_str)
-    assert isinstance(
-        parsed_version, packaging.version.Version
-    ), f"Found LegacyVersion: {version_str}"
     return parsed_version
 
 

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -80,6 +80,7 @@ def library_version_from_core_version(core_version: str) -> str:
 
 def parse_package_version(version_str: str) -> packaging.version.Version:
     parsed_version = packaging.version.parse(version_str)
+    assert isinstance(parsed_version, packaging.version.Version)
     return parsed_version
 
 

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -77,7 +77,7 @@ setup(
         # ensure version we require is >= that with which we generated the grpc code (set in dev-requirements)
         "grpcio>=1.32.0,<1.48.1",
         "grpcio-health-checking>=1.32.0,<1.44.0",
-        "packaging>=20.9",
+        "packaging>=22.0",
         "pendulum",
         "protobuf>=3.13.0,<4",  # ensure version we require is >= that with which we generated the proto code (set in dev-requirements)
         "python-dateutil",

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -77,7 +77,9 @@ setup(
         # ensure version we require is >= that with which we generated the grpc code (set in dev-requirements)
         "grpcio>=1.32.0,<1.48.1",
         "grpcio-health-checking>=1.32.0,<1.44.0",
-        "packaging>=22.0",
+        # packaging v22 has build compatibility issues with dbt as of 2022-12-07
+        # upper bound can be removed as soon as BK passes with packaging >=22
+        "packaging>=20.9,<22",
         "pendulum",
         "protobuf>=3.13.0,<4",  # ensure version we require is >= that with which we generated the proto code (set in dev-requirements)
         "python-dateutil",

--- a/python_modules/libraries/dagstermill/dagstermill/compat.py
+++ b/python_modules/libraries/dagstermill/dagstermill/compat.py
@@ -1,12 +1,10 @@
 import papermill
-from packaging.version import LegacyVersion, parse
+from packaging.version import parse
 from papermill.exceptions import PapermillExecutionError
 
 
 def is_papermill_2():
     version = parse(papermill.__version__)
-    if isinstance(version, LegacyVersion):
-        return False
     return version.major == 2
 
 

--- a/python_modules/libraries/dagstermill/dagstermill/compat.py
+++ b/python_modules/libraries/dagstermill/dagstermill/compat.py
@@ -1,10 +1,12 @@
 import papermill
-from packaging.version import parse
+from packaging.version import Version, parse
 from papermill.exceptions import PapermillExecutionError
 
 
 def is_papermill_2():
     version = parse(papermill.__version__)
+    # satisfies typechecker that might think version is a LegacyVersion
+    assert isinstance(version, Version)
     return version.major == 2
 
 

--- a/python_modules/libraries/dagstermill/setup.py
+++ b/python_modules/libraries/dagstermill/setup.py
@@ -44,7 +44,7 @@ setup(
         # incidentally brought ipython_genutils, but in v5.1 it was dropped, so as
         # a workaround we need to manually specify it here
         "ipython_genutils>=0.2.0",
-        "packaging>=20.5",
+        "packaging>=22",
         "papermill>=1.0.0",
         "scrapbook>=0.5.0",
         "nbconvert",

--- a/python_modules/libraries/dagstermill/setup.py
+++ b/python_modules/libraries/dagstermill/setup.py
@@ -44,7 +44,9 @@ setup(
         # incidentally brought ipython_genutils, but in v5.1 it was dropped, so as
         # a workaround we need to manually specify it here
         "ipython_genutils>=0.2.0",
-        "packaging>=22",
+        # packaging v22 has build compatibility issues with dbt as of 2022-12-07
+        # upper bound can be removed as soon as BK passes with packaging >=22
+        "packaging>=20.9,<22",
         "papermill>=1.0.0",
         "scrapbook>=0.5.0",
         "nbconvert",


### PR DESCRIPTION
### Summary & Motivation

`packaging` v22 was released today and removes the ancient `LegacyVersion`, which some of our code references.

This removes references to `LegacyVersion` and bumps packaging
requirement to 22.0.

### How I Tested These Changes

BK
