### PR TITLE
RFC - modify partitions definition to better support db io managers

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -256,7 +256,12 @@ class PartitionsDefinition(ABC, Generic[T]):
 class StaticPartitionsDefinition(
     PartitionsDefinition[str],
 ):  # pylint: disable=unsubscriptable-object
-    def __init__(self, partition_keys: Sequence[str]):
+    def __init__(
+        self,
+        partition_keys: Sequence[str],
+        partition_column: Optional[str] = None,
+        partition_key_conversion: Optional[Callable] = None,
+    ):
         check.sequence_param(partition_keys, "partition_keys", of_type=str)
 
         # Dagit selects partition ranges following the format '2022-01-13...2022-01-14'
@@ -265,6 +270,8 @@ class StaticPartitionsDefinition(
             raise DagsterInvalidDefinitionError("'...' is an invalid substring in a partition key")
 
         self._partitions = [Partition(key) for key in partition_keys]
+        self.partition_column = partition_column
+        self.partition_key_conversion = partition_key_conversion
 
     def get_partitions(
         self, current_time: Optional[datetime] = None  # pylint: disable=unused-argument

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -55,6 +55,8 @@ class TimeWindowPartitionsDefinition(
             ("fmt", PublicAttr[str]),
             ("end_offset", PublicAttr[int]),
             ("cron_schedule", PublicAttr[str]),
+            ("partition_column", PublicAttr[Optional[str]]),
+            ("partition_key_conversion", PublicAttr[Optional[Callable]]),
         ],
     ),
 ):
@@ -97,6 +99,8 @@ class TimeWindowPartitionsDefinition(
         hour_offset: Optional[int] = None,
         day_offset: Optional[int] = None,
         cron_schedule: Optional[str] = None,
+        partition_column: Optional[str] = None,
+        partition_key_conversion: Optional[Callable] = None,
     ):
         if isinstance(start, datetime):
             start_dt = start
@@ -121,7 +125,14 @@ class TimeWindowPartitionsDefinition(
             )
 
         return super(TimeWindowPartitionsDefinition, cls).__new__(
-            cls, start_dt, timezone or "UTC", fmt, end_offset, cron_schedule
+            cls,
+            start_dt,
+            timezone or "UTC",
+            fmt,
+            end_offset,
+            cron_schedule,
+            partition_column,
+            partition_key_conversion,
         )
 
     def get_partitions(
@@ -465,6 +476,8 @@ class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
         timezone: Optional[str] = None,
         fmt: Optional[str] = None,
         end_offset: int = 0,
+        partition_column: Optional[str] = None,
+        partition_key_conversion: Optional[Callable] = None,
     ):
         """A set of daily partitions.
 
@@ -506,6 +519,8 @@ class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
             timezone=timezone,
             fmt=_fmt,
             end_offset=end_offset,
+            partition_column=partition_column,
+            partition_key_conversion=partition_key_conversion,
         )
 
 

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -153,8 +153,9 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
 
 def _time_window_where_clause(table_partition: TablePartition) -> str:
     start_dt, end_dt = table_partition.time_window
-    start_dt_str = start_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
-    end_dt_str = end_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
+
+    start = table_partition.partition_key_conversion(start_dt)
+    end = table_partition.partition_key_conversion(end_dt)
     # Snowflake BETWEEN is inclusive; start <= partition expr <= end. We don't want to remove the next partition so we instead
     # write this as start <= partition expr < end.
-    return f"""WHERE {table_partition.partition_expr} >= '{start_dt_str}' AND {table_partition.partition_expr} < '{end_dt_str}'"""
+    return f"""WHERE {table_partition.partition_expr} >= {start} AND {table_partition.partition_expr} < {end}"""


### PR DESCRIPTION
### Summary & Motivation
I'm working on improving the Snowflake IO manager and one of the main areas for improvement is partitions support. I have a couple changes I'd like to explore making to the PartitionsDefinitions to support these improvements, but i'm not super knowledgeable on the nitty gritty details of partitions, so i'd like your feedback on if these seem like reasonable changes.

### 1
One of the ideas I'm playing with is moving the specification of which column in the db has the partition data (the timestamp) to the PartitionDefinition itself. Right now, you tell the IO manager where the partition data is like this:

```
@asset(
    io_manager_key="warehouse_io_manager",
    partitions_def=hourly_partitions,
    metadata={
        "partition_expr": "time",
    }
)
```

but we could also remove the need for this metadata entirely and do something like this:

```
hourly_partitions = HourlyPartitionsDefinition(
	start_date=datetime(2020, 12, 1), 
	partition_column="time",
)

@asset(
    io_manager_key="warehouse_io_manager",
    partitions_def=hourly_partitions,
)

```

There are definitely pros and cons to this. some that come to mind:
pro - having metadata be responsible for behavior feels a bit like what we do when we use tags as a catch all for different types of config. The user has to remember the correct key and remember that it goes in the metadata. Moving the column into the partition definition would let us document it better, get text editor hints, and add typing.
pro - this will make it much easier to support multi-partitions, since each sub-partition will maintain it's own `partition_column` value 
con - if you have multiple assets partitioned on the same time scale, but with different columns holding the partition data, you have to make multiple partition definition objects, which is a bit of a pain
con - it sort of muddies the distinction between the partition definition and the data format of the asset. by putting the column in it sort makes the PartitionDefinition "know" it's partitioning table data.


### 2
The second partition-related issue I'm trying to fix is the format of the partitioned data in the asset. Right now, unless the data in your `time` column is the exact format we expect (a datetime), the Snowflake IO manager chokes. So if you are storing posix time, you can't fetch any data. To fix this, I think we need to introduce a way for the user to provide a function that converts a partition key to the corresponding value you would find in the data. So for example, if the user is storing the date as a posix time, they could pass a function `lambda x: x.timestamp()`. The user could specify the partition conversion function like this

```
hourly_partitions = HourlyPartitionsDefinition(
	start_date=datetime(2020, 12, 1), 
	partition_column="time",
        partition_key_conversion=lambda x: x.timestamp()
)
```

--- 
This RFC isn't "feature complete", it just  adds these two new parameters to the base PartitionsDefinition classes and to `DailyPartitionsDefinition` to give a sense of what the changes would look like. I also updated the base `DBIOManager` to read these values in so that they can be used by the various type handlers.

I haven't thought too too much about the op/job version of this. that's what i'm looking at next

Interested to hear your thoughts on this approach, and if it sounds good, I'll go ahead and make a PR that converts all of the partition definitions to have the two new parameters. 

One thing I want to understand better is if serialization would become an issue with this. I'm not really sure what the consequences of having a function as a parameter to the PartitionsDefinition are

the alternative to this would be to keep the partition column as asset metadata. We'd change the name to `partition_column` to be more descriptive, and introduce new metadata for the conversion function 

### How I Tested These Changes
