### PR TITLE
[docs ] - fix image dimensions in hello-dagster materialize

### DIFF
--- a/docs/content/getting-started/hello-dagster.mdx
+++ b/docs/content/getting-started/hello-dagster.mdx
@@ -103,8 +103,8 @@ That's it! You now have two materialized Dagster assets:
 <Image
 alt="HackerNews asset graph"
 src="/images/getting-started/hello-dagster/hello-dagster.png"
-width={1331}
-height={874}
+width={2402}
+height={1956}
 />
 
 But wait - there's more. Because the `hackernews_top_stories` asset specified `metadata`, you can view the metadata right in Dagit:


### PR DESCRIPTION
### Summary & Motivation
Image was squished,  believe this was caused by an update to the image source without re-running `mdx-format`. This PR has the same image, just re-ran the formatting to get correct height / width.

### How I Tested These Changes
eyes