### PR TITLE
Adopt pyright for typechecking

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -77,8 +77,7 @@ def build_repo_wide_ruff_steps() -> List[CommandStep]:
 def build_repo_wide_pyright_steps() -> List[CommandStep]:
     return [
         CommandStepBuilder(":pyright: pyright")
-        .run("pip install -e python_modules/dagster[pyright]")
-        .run("make pyright")
+        .run("pip install -e python_modules/dagster[pyright]", "make pyright")
         .on_test_image(AvailablePythonVersion.get_default())
         .with_skip(skip_if_no_python_changes())
         .build(),

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -28,6 +28,7 @@ def build_repo_wide_steps() -> List[BuildkiteStep]:
     return [
         *build_repo_wide_black_steps(),
         *build_repo_wide_check_manifest_steps(),
+        *build_repo_wide_pyright_steps(),
         *build_repo_wide_ruff_steps(),
     ]
 
@@ -67,6 +68,17 @@ def build_repo_wide_ruff_steps() -> List[CommandStep]:
     return [
         CommandStepBuilder(":zap: ruff")
         .run("pip install -e python_modules/dagster[ruff]", "make check_ruff")
+        .on_test_image(AvailablePythonVersion.get_default())
+        .with_skip(skip_if_no_python_changes())
+        .build(),
+    ]
+
+
+def build_repo_wide_pyright_steps() -> List[CommandStep]:
+    return [
+        CommandStepBuilder(":pyright: pyright")
+        .run("pip install -e python_modules/dagster[pyright]")
+        .run("make pyright")
         .on_test_image(AvailablePythonVersion.get_default())
         .with_skip(skip_if_no_python_changes())
         .build(),

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
@@ -50,8 +50,6 @@ def build_docs_steps() -> List[BuildkiteStep]:
         .build(),
         # Verify screenshot integrity.
         build_tox_step("docs", "audit-screenshots", skip_reason=skip_if_no_docs_changes()),
-        # mypy for build scripts
-        build_tox_step("docs", "mypy", command_type="mypy", skip_reason=skip_if_no_docs_changes()),
     ]
 
     steps += [

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/helm.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/helm.py
@@ -9,6 +9,7 @@ from ..utils import (
     BuildkiteStep,
     CommandStep,
     GroupStep,
+    is_command_step,
     skip_if_no_helm_changes,
 )
 
@@ -27,7 +28,11 @@ def build_helm_steps() -> List[BuildkiteStep]:
 
     steps: List[BuildkiteLeafStep] = []
     steps += _build_lint_steps(package_spec)
-    steps += package_spec.build_steps()[0]["steps"]
+    pkg_step = package_spec.build_steps()[0]
+    if is_command_step(pkg_step):
+        steps.append(pkg_step)
+    else:
+        steps += pkg_step["steps"]  # type: ignore  # (strict type guard)
 
     return [
         GroupStep(

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
@@ -6,7 +6,7 @@ from ..package_spec import PackageSpec
 from ..python_version import AvailablePythonVersion
 from ..utils import (
     BuildkiteStep,
-    GroupStep,
+    BuildkiteTopLevelStep,
     connect_sibling_docker_container,
     library_version_from_core_version,
     network_buildkite_container,
@@ -40,7 +40,7 @@ def build_integration_steps() -> List[BuildkiteStep]:
 # ########################
 
 
-def build_backcompat_suite_steps() -> List[GroupStep]:
+def build_backcompat_suite_steps() -> List[BuildkiteTopLevelStep]:
     tox_factors = [
         "dagit-latest-release",
         "dagit-earliest-release",
@@ -118,7 +118,7 @@ def _get_library_version(version: str) -> str:
 # ########################
 
 
-def build_celery_k8s_suite_steps() -> List[GroupStep]:
+def build_celery_k8s_suite_steps() -> List[BuildkiteTopLevelStep]:
     pytest_tox_factors = [
         "-default",
         "-markusercodedeploymentsubchart",
@@ -182,7 +182,7 @@ def build_integration_suite_steps(
     pytest_tox_factors: Optional[List[str]],
     pytest_extra_cmds: Optional[Callable] = None,
     queue=None,
-) -> List[GroupStep]:
+) -> List[BuildkiteTopLevelStep]:
     pytest_extra_cmds = pytest_extra_cmds or default_integration_suite_pytest_extra_cmds
     return PackageSpec(
         directory,

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -306,7 +306,6 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     PackageSpec(
         "examples/docs_snippets",
         pytest_extra_cmds=docs_snippets_extra_cmds,
-        run_mypy=False,
         unsupported_python_versions=[
             # dependency on 3.9-incompatible extension libs
             AvailablePythonVersion.V3_9,
@@ -476,5 +475,4 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         ".buildkite/dagster-buildkite",
         run_pytest=False,
     ),
-    PackageSpec("scripts", run_pytest=False),
 ]

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/tox.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/tox.py
@@ -9,7 +9,6 @@ from dagster_buildkite.utils import CommandStep, make_buildkite_section_header
 
 _COMMAND_TYPE_TO_EMOJI_MAP = {
     "pytest": ":pytest:",
-    "mypy": ":mypy:",
     "miscellaneous": ":sparkle",
 }
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Union
 
 import packaging.version
 import yaml
-from typing_extensions import Literal, TypeAlias, TypedDict
+from typing_extensions import Literal, TypeAlias, TypedDict, TypeGuard
 
 from dagster_buildkite.git import ChangedFiles, get_commit_message
 
@@ -65,6 +65,12 @@ WaitStep: TypeAlias = Literal["wait"]
 
 BuildkiteStep: TypeAlias = Union[CommandStep, GroupStep, TriggerStep, WaitStep]
 BuildkiteLeafStep = Union[CommandStep, TriggerStep, WaitStep]
+BuildkiteTopLevelStep = Union[CommandStep, GroupStep]
+
+
+def is_command_step(step: BuildkiteStep) -> TypeGuard[CommandStep]:
+    return isinstance(step, dict) and "commands" in step
+
 
 # ########################
 # ##### FUNCTIONS

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: pyright
+
 # Makefile oddities:
 # - Commands must start with literal tab characters (\t), not spaces.
 # - Multi-command rules (like `black` below) by default terminate as soon as a command has a non-0
@@ -24,6 +26,9 @@ check_black:
     examples integration_tests helm python_modules .buildkite
 	black --check --fast \
     examples/docs_snippets
+
+pyright:
+	python scripts/run-pyright.py --all
 
 ruff:
 	ruff --fix .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,42 +22,73 @@ required-version = "22.12.0"
 target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
 
 # ########################
-# ##### MYPY
+# ##### PYRIGHT
 # ########################
 
 # [Docs root]
-#   https://mypy.readthedocs.io/en/stable/index.html
+#   https://github.com/microsoft/pyright/tree/main/docs
 # [Config option reference]
-#   https://mypy.readthedocs.io/en/stable/config_file.html#the-mypy-configuration-file
+#   https://github.com/microsoft/pyright/blob/main/docs/configuration.md
 
-[tool.mypy]
+# Pyright does not have a docs site, but the documentation (a collection of
+# markdown files in the GH repo, linked above) is pretty thorough.
 
-# Allow variables to be redefined with arbitrary types even if they already are typed.
-allow_redefinition = true
+[tool.pyright]
 
-# Allow for use of type annotations in local variables inside function bodies even when the
-# signature is not annotated.
-disable_error_code = ['annotation-unchecked']
+include = [
+  ".buildkite/dagster-buildkite",
+  "python_modules",
+  "examples",
+  "integration_tests",
+  "scripts",
+]
 
-# Ignore cases where mypy cannot resolve *the types* for a given import. Note that this is different
-# than not being able to resolve the import at runtime. A module can be installed, but mypy will
-# consider it unresolveable if it does not either (a) have a `py.typed` marker file; (b) have
-# a corresponding stub package (i.e. named `types-XXX`) available to mypy. Because Dagster uses
-# has several dependencies that do not satisfy either criterion, mypy will by default emit errors
-# when it encounters imports of those dependencies. Since there's no way to fix these, we silence
-# them.
-ignore_missing_imports = true
+# Unfortunately pyright does not offer a way to extend the default exclusions, so we have to
+# reiterate them here if we want to add anything else.
+exclude = [
+  "**/node_modules",
+  "**/__pycache__",
+  "**/__generated__",
+  "**/vendor",
+  "**/.tox",
+  ".git",
+  "**/.venv*",
+]
 
-# If a type stub package is missing from the environment but available on typeshed, automatically
-# install it. Note that without `--non-interactive` this will prompt the user.
-install_types = true
+# These two settings point pyright to a python environment to resolve imports against. This virtual
+# environment is defined in the `pyright` tox environment in the tox section below-- that
+# environment must be built before pyright can run correctly.
+venv = ".venv"
+venvPath = "pyright/envs/master"
 
-# Allow PEP-420-style namespace packages. Without this enabled, different parts of a namespace
-# package will trigger "Duplicate module" errors.
-namespace_packages = true
+# Set to false to help us during the transition from mypy to pyright. Mypy does
+# not analyze unannotated functions by default, and so as of 2023-02 the codebase contains a large
+# number of type errors in unannotated functions. Eventually we can turn off this setting.
+analyzeUnannotatedFunctions = false
 
-# Print codes (e.g. "[arg-type]") for each error in output.
-show_error_codes = true
+# Minimum version of Python on which code must run. This determines the standard library stubs used by
+# pyright.
+pythonVersion = "3.7"
+
+# Use "basic" ruleset. This differs from strict in several ways, but most
+# importantly it does not flag untyped code as an error.
+typeCheckingMode = "basic"
+
+# Disable reading type annotations from libraries that are not explicitly marked as typed (i.e. that
+# include a py.typed file). All imports from these libraries are given the `Unknown` type (i.e.
+# `Any`). This setting does not affect `py.typed` libraries.
+useLibraryCodeForTypes = false
+
+# We use ruff for this.
+reportInvalidStringEscapeSequence = false
+
+# As of 2023-02-02, there are still many `py.typed` libs that are not compliant with the standards
+# for defining a public API.
+reportPrivateImportUsage = false
+
+# ########################
+# ##### PYTEST
+# ########################
 
 [tool.pytest.ini_options]
 

--- a/pyright/alt-1/include.txt
+++ b/pyright/alt-1/include.txt
@@ -1,0 +1,3 @@
+examples/assets_pandas_type_metadata
+examples/experimental/project_fully_featured_v2_resources
+examples/project_fully_featured

--- a/pyright/alt-1/requirements.txt
+++ b/pyright/alt-1/requirements.txt
@@ -1,0 +1,43 @@
+### Requirements: alt-1
+#
+# This file defines the dependencies for an alternative pyright environment. The packages listed in
+# this file will not be present in the environment that pyright/pylance will use by default when
+# running as a language server.
+#
+# NOTE: It is important that dagster-* dependencies of any package listed here are also listed.
+# e.g. if examples/foo depends on python_modules/libraries/dagster-foo, then dagster-foo must be
+# listed if examples/foo is listed.
+#
+# NOTE: Paths are relative to repo root.
+
+### examples/assets_smoke_test
+# -e examples/assets_smoke_test
+#   -e python_modules/dagster[pyright,test]
+#   -e python_modules/dagit
+#   -e python_modules/dagster-graphql
+#   -e python_modules/libraries/dagster-pandas/
+#   -e python_modules/libraries/dagster-dbt/
+#   -e python_modules/libraries/dagster-snowflake/
+#   -e python_modules/libraries/dagster-snowflake-pandas/
+
+### examples/assets_pandas_type_metadata
+-e examples/assets_pandas_type_metadata
+  -e python_modules/dagster[pyright,test]
+  -e python_modules/dagit
+  -e python_modules/dagster-graphql
+  -e python_modules/libraries/dagster-pandera/
+
+### examples/project_fully_featured (and experimental version)
+-e examples/project_fully_featured
+-e examples/experimental/project_fully_featured_v2_resources
+  -e python_modules/dagster[pyright,test]
+  -e python_modules/dagit
+  -e python_modules/dagster-graphql
+  -e python_modules/libraries/dagster-aws/
+  -e python_modules/libraries/dagster-dbt/
+  -e python_modules/libraries/dagster-duckdb-pandas/
+    -e python_modules/libraries/dagster-duckdb/
+  -e python_modules/libraries/dagster-postgres/
+  -e python_modules/libraries/dagster-pyspark/
+  -e python_modules/libraries/dagster-slack/
+  -e python_modules/libraries/dagster-spark/

--- a/pyright/master/exclude.txt
+++ b/pyright/master/exclude.txt
@@ -1,0 +1,10 @@
+### CHECKED SEPARATELY
+
+examples/assets_pandas_type_metadata
+examples/project_fully_featured
+examples/experimental/project_fully_featured_v2_resources
+
+### NOT TYPE CHECKED
+
+examples/assets_smoke_test
+examples/tutorial_dbt_dagster/tutorial_template

--- a/pyright/master/include.txt
+++ b/pyright/master/include.txt
@@ -1,0 +1,5 @@
+.buildkite/dagster-buildkite
+python_modules
+examples
+integration_tests
+scripts

--- a/pyright/master/requirements.txt
+++ b/pyright/master/requirements.txt
@@ -1,0 +1,104 @@
+### Requirements: master
+#
+# This file defines the dependencies for the master pyright environment for the internal repo. This
+# is the environment that # pyright/pylance will use by default when running as a language server.
+#
+# Ideally, this would be the only pyright environment we need to define. This is not possible
+# because of dependency conflicts in between Dagster packages/examples. For ease of maintenance,
+# this file should maintain a complete list of Dagster packages, with packages excluded from the
+# enviroment commented out.
+#
+# NOTE: It is important that dagster-* dependencies of any package listed here are also listed.
+# e.g. if examples/foo depends on python_modules/libraries/dagster-foo, then dagster-foo must be
+# listed if examples/foo is listed.
+#
+# NOTE: Paths are relative to repo root.
+
+### EXAMPLES
+
+-e examples/assets_dbt_python
+-e examples/assets_modern_data_stack
+-e examples/assets_pandas_pyspark
+# -e examples/assets_pandas_type_metadata
+# -e examples/assets_smoke_test
+-r examples/deploy_docker/requirements.txt
+# -r examples/deploy_ecs/requirements.txt  # (no reqs)
+# -r examples/deploy_k8s/requirements.txt  # (no reqs)
+-e examples/development_to_production
+-e examples/docs_snippets
+# -e examples/experimental/project_fully_featured_v2_resources
+-e examples/feature_graph_backed_assets
+# -e examples/project_fully_featured
+# -e examples/quickstart_aws  # (analyzed but not installed)
+# -e examples/quickstart_etl  # (analyzed but not installed)
+# -e examples/quickstart_gcp  # (analyzed but not installed)
+# -e examples/quickstart_snowflake  # (analyzed but not installed)
+-e examples/tutorial_dbt_dagster
+-e examples/tutorial_notebook_assets
+-e examples/with_airflow
+-e examples/with_great_expectations
+-e examples/with_pyspark
+
+### HELM
+-e helm/dagster/schema
+
+### INTEGRATION TESTS
+-e integration_tests/python_modules/dagster-k8s-test-infra
+# -r integration_tests/test_suites/backcompat-test-suite/requirements.txt  # (no reqs)
+# -r integration_tests/test_suites/celery-k8s-test-suite/requirements.txt  # (no reqs)
+# -r integration_tests/test_suites/daemon-test-suite/requirements.txt  # (no reqs)
+# -r integration_tests/test_suites/k8s-test-suite/requirements.txt  # (no reqs)
+
+### LIBRARIES
+
+-e python_modules/automation
+-e python_modules/dagster[pyright,test]
+-e python_modules/dagit
+-e python_modules/dagster-graphql
+-e python_modules/dagster-test
+-e python_modules/libraries/dagster-airbyte/
+-e python_modules/libraries/dagster-airflow[test_airflow_2]
+-e python_modules/libraries/dagster-aws[test]
+-e python_modules/libraries/dagster-azure/
+-e python_modules/libraries/dagster-celery/
+-e python_modules/libraries/dagster-celery-docker/
+-e python_modules/libraries/dagster-celery-k8s/
+-e python_modules/libraries/dagster-census/
+-e python_modules/libraries/dagster-dask[yarn,pbs,kube,test]
+-e python_modules/libraries/dagster-databricks/
+-e python_modules/libraries/dagster-datadog/
+-e python_modules/libraries/dagster-datahub/
+-e python_modules/libraries/dagster-dbt/
+-e python_modules/libraries/dagster-docker/
+-e python_modules/libraries/dagster-duckdb/
+-e python_modules/libraries/dagster-duckdb-pandas/
+-e python_modules/libraries/dagster-duckdb-pyspark/
+-e python_modules/libraries/dagster-fivetran/
+-e python_modules/libraries/dagster-gcp/
+-e python_modules/libraries/dagster-ge/
+-e python_modules/libraries/dagster-github/
+-e python_modules/libraries/dagster-k8s/
+-e python_modules/libraries/dagster-managed-elements/
+-e python_modules/libraries/dagster-mlflow/
+-e python_modules/libraries/dagster-msteams/
+-e python_modules/libraries/dagster-mysql/
+-e python_modules/libraries/dagster-pagerduty/
+-e python_modules/libraries/dagster-pandas/
+-e python_modules/libraries/dagster-pandera/
+-e python_modules/libraries/dagster-papertrail/
+-e python_modules/libraries/dagster-postgres/
+-e python_modules/libraries/dagster-prometheus/
+-e python_modules/libraries/dagster-pyspark/
+-e python_modules/libraries/dagster-shell/
+-e python_modules/libraries/dagster-slack/
+-e python_modules/libraries/dagster-snowflake/
+-e python_modules/libraries/dagster-snowflake-pandas/
+-e python_modules/libraries/dagster-snowflake-pyspark/
+-e python_modules/libraries/dagster-spark/
+-e python_modules/libraries/dagster-ssh/
+-e python_modules/libraries/dagster-twilio/
+-e python_modules/libraries/dagstermill/
+
+### OTHER
+pandas_gbq  # (quickstart_gcp)
+wordcloud  # (quickstart-*)

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -125,6 +125,11 @@ setup(
         ],
         "mypy": [
             "mypy==0.991",
+        ],
+        "pyright": [
+            "pyright==1.1.292",
+            ### Stub packages
+            "pandas-stubs",  # version will be resolved against pandas
             "types-backports",  # version will be resolved against backports
             "types-certifi",  # version will be resolved against certifi
             "types-chardet",  # chardet is a 2+-order dependency of some Dagster libs
@@ -133,7 +138,6 @@ setup(
             "types-mock",  # version will be resolved against mock
             "types-paramiko",  # version will be resolved against paramiko
             "types-pkg-resources",  # version will be resolved against setuptools (contains pkg_resources)
-            "types-protobuf<=3.19.21",  # version will be resolved against protobuf (3.19.22 introduced breaking change)
             "types-pyOpenSSL",  # version will be resolved against pyOpenSSL
             "types-python-dateutil",  # version will be resolved against python-dateutil
             "types-PyYAML",  # version will be resolved against PyYAML
@@ -141,6 +145,7 @@ setup(
             "types-requests",  # version will be resolved against requests
             "types-simplejson",  # version will be resolved against simplejson
             "types-six",  # needed but not specified by grpcio
+            "types-sqlalchemy",  # version will be resolved against sqlalchemy
             "types-tabulate",  # version will be resolved against tabulate
             "types-tzlocal",  # version will be resolved against tzlocal
             "types-toml",  # version will be resolved against toml

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -41,7 +41,7 @@ def main(
 
     # Supported on all Python versions.
     install_targets += [
-        "-e python_modules/dagster[black,mypy,ruff,test]",
+        "-e python_modules/dagster[black,pyright,ruff,test]",
         "-e python_modules/dagster-graphql",
         "-e python_modules/dagster-test",
         "-e python_modules/dagit",
@@ -52,10 +52,11 @@ def main(
         "-e python_modules/libraries/dagster-aws[test]",
         "-e python_modules/libraries/dagster-celery",
         "-e python_modules/libraries/dagster-celery-docker",
-        '-e "python_modules/libraries/dagster-dask[yarn,pbs,kube]"',
+        "-e python_modules/libraries/dagster-dask[yarn,pbs,kube]",
         "-e python_modules/libraries/dagster-databricks",
         "-e python_modules/libraries/dagster-datadog",
         "-e python_modules/libraries/dagster-datahub",
+        "-e python_modules/libraries/dagster-dbt",
         "-e python_modules/libraries/dagster-docker",
         "-e python_modules/libraries/dagster-gcp",
         "-e python_modules/libraries/dagster-fivetran",
@@ -95,9 +96,7 @@ def main(
         ]
 
     if sys.version_info > (3, 6) and sys.version_info < (3, 10):
-        install_targets += [
-            "-e python_modules/libraries/dagster-dbt",
-        ]
+        install_targets += []
 
     if include_prebuilt_grpcio_wheel:
         install_targets += [

--- a/scripts/run-pyright.py
+++ b/scripts/run-pyright.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from contextlib import contextmanager
+from functools import reduce
+from itertools import groupby
+from typing import Dict, Iterator, List, Mapping, Optional, Sequence, cast
+
+import tomli
+from typing_extensions import Final, NotRequired, TypedDict
+
+parser = argparse.ArgumentParser(
+    prog="run-pyright",
+    description="Run pyright for every specified pyright environment and print the merged results.",
+)
+
+parser.add_argument(
+    "--all",
+    action="store_true",
+    default=False,
+    help=(
+        "Run pyright for all environments. Environments are discovered by looking for directories"
+        " at `pyright/envs/*`."
+    ),
+)
+
+parser.add_argument(
+    "--env",
+    "-e",
+    type=str,
+    action="append",
+    default=[],
+    help=(
+        "Names of pyright environment to run. Must be a directory in pyright/envs. Can be passed"
+        " multiple times."
+    ),
+)
+
+parser.add_argument(
+    "--rebuild",
+    "-r",
+    action="store_true",
+    default=False,
+    help="Force rebuild of virtual environment.",
+)
+
+parser.add_argument(
+    "paths",
+    type=str,
+    nargs="*",
+    help="Paths to run pyright on. If passed, must provide only a single environment.",
+)
+
+# ########################
+# ##### TYPES
+# ########################
+
+
+class Args(TypedDict):
+    envs: Sequence[str]
+    paths: Sequence[str]
+    rebuild: bool
+
+
+class Position(TypedDict):
+    line: int
+    character: int
+
+
+class Range(TypedDict):
+    start: Position
+    end: Position
+
+
+class Diagnostic(TypedDict):
+    file: str
+    message: str
+    severity: str
+    range: Range
+    rule: NotRequired[str]
+
+
+class Summary(TypedDict):
+    filesAnalyzed: int
+    errorCount: int
+    warningCount: int
+    informationCount: int
+    timeInSec: float
+
+
+class PyrightOutput(TypedDict):
+    version: str
+    time: str
+    generalDiagnostics: Sequence[Diagnostic]
+    summary: Summary
+
+
+class RunResult(TypedDict):
+    returncode: int
+    output: PyrightOutput
+
+
+class EnvPathSpec(TypedDict):
+    env: str
+    include: Sequence[str]
+    exclude: Sequence[str]
+
+
+# ########################
+# ##### LOGIC
+# ########################
+
+PYRIGHT_ENV_ROOT: Final = "pyright"
+
+
+def get_env_path(env: str, rel_path: Optional[str] = None) -> str:
+    env_root = os.path.join(PYRIGHT_ENV_ROOT, env)
+    return os.path.join(env_root, rel_path) if rel_path else env_root
+
+
+def load_path_file(path: str) -> Sequence[str]:
+    with open(path, "r", encoding="utf-8") as f:
+        return [line.strip() for line in f.readlines() if line.strip() and not line.startswith("#")]
+
+
+def normalize_args(args: argparse.Namespace) -> Args:
+    if args.all and (args.env or args.paths):
+        raise Exception("Cannot target specific environments or paths simultaneously with --all.")
+    elif len(args.paths) >= 1 and len(args.env) >= 1:
+        raise Exception("Cannot pass both paths and environments.")
+    use_all = args.all or not args.env and not args.paths
+    if args.env or use_all:
+        envs = os.listdir(PYRIGHT_ENV_ROOT) if use_all else args.env or ["master"]
+        for env in envs:
+            if not os.path.exists(get_env_path(env)):
+                raise Exception(f"Environment {env} not found in {PYRIGHT_ENV_ROOT}.")
+    else:
+        envs = []
+    return Args(envs=envs, paths=args.paths, rebuild=args.rebuild)
+
+
+def match_path(path: str, path_spec: EnvPathSpec) -> bool:
+    for include in path_spec["include"]:
+        if path.startswith(include):
+            if not any(path.startswith(exclude) for exclude in path_spec["exclude"]):
+                return True
+    return False
+
+
+def map_paths_to_envs(paths: Sequence[str]) -> Mapping[str, Sequence[str]]:
+    env_path_specs: List[EnvPathSpec] = []
+    for env in os.listdir(PYRIGHT_ENV_ROOT):
+        include_path = get_env_path(env, "include.txt")
+        exclude_path = get_env_path(env, "exclude.txt")
+        env_path_specs.append(
+            EnvPathSpec(
+                env=env,
+                include=load_path_file(include_path),
+                exclude=load_path_file(exclude_path) if os.path.exists(exclude_path) else [],
+            )
+        )
+    env_path_map: Dict[str, List[str]] = {}
+    for path in paths:
+        try:
+            env = next(
+                (
+                    env_path_spec["env"]
+                    for env_path_spec in env_path_specs
+                    if match_path(path, env_path_spec)
+                )
+            )
+        except StopIteration:
+            raise Exception(f"Could not find environment that matched path: {path}.")
+        env_path_map.setdefault(env, []).append(path)
+    return env_path_map
+
+
+def normalize_env(env: str, rebuild: bool) -> None:
+    venv_path = os.path.join(get_env_path(env), ".venv")
+    if rebuild and os.path.exists(venv_path):
+        print(f"Removing existing virtualenv for pyright environment {env}...")
+        subprocess.run(f"rm -rf {venv_path}", shell=True, check=True)
+    if not os.path.exists(venv_path):
+        print(f"Creating virtualenv for pyright environment {env}...")
+        requirements_path = f"requirements-{env}.txt"
+        cmd = " && ".join(
+            [
+                f"python -m venv {venv_path}",
+                f"{venv_path}/bin/pip install -U pip setuptools wheel",
+                f"{venv_path}/bin/pip install -r {requirements_path}",
+            ]
+        )
+        try:
+            shutil.copyfile(get_env_path(env, "requirements.txt"), requirements_path)
+            subprocess.run(cmd, shell=True, check=True)
+        finally:
+            os.remove(requirements_path)
+    return None
+
+
+def run_pyright(env: str, paths: Sequence[str], rebuild: bool) -> RunResult:
+    normalize_env(env, rebuild)
+    with temp_pyright_config_file(env) as config_path:
+        pyright_cmd = " ".join(
+            ["pyright", f"--project={config_path}", "--outputjson", "--level=warning", *paths]
+        )
+        shell_cmd = pyright_cmd
+        print(f"Running pyright for environment `{env}`...")
+        print(f"  {shell_cmd}")
+        result = subprocess.run(shell_cmd, capture_output=True, shell=True, text=True)
+    return {
+        "returncode": result.returncode,
+        "output": cast(PyrightOutput, json.loads(result.stdout)),
+    }
+
+
+@contextmanager
+def temp_pyright_config_file(env: str) -> Iterator[str]:
+    with open("pyproject.toml", "r", encoding="utf-8") as f:
+        toml = tomli.loads(f.read())
+    config = toml["tool"]["pyright"]
+    config["venvPath"] = f"{PYRIGHT_ENV_ROOT}/{env}"
+    include_path = get_env_path(env, "include.txt")
+    exclude_path = get_env_path(env, "exclude.txt")
+    config["include"] = load_path_file(include_path)
+    if os.path.exists(exclude_path):
+        config["exclude"] += load_path_file(exclude_path)
+    temp_config_path = f"pyrightconfig-{env}.json"
+    print("Creating temporary pyright config file at", temp_config_path)
+    try:
+        with open(temp_config_path, "w", encoding="utf-8") as f:
+            json.dump(config, f)
+        yield temp_config_path
+    finally:
+        os.remove(temp_config_path)
+
+
+def merge_pyright_results(result_1: RunResult, result_2: RunResult) -> RunResult:
+    returncode = 1 if 1 in (result_1["returncode"], result_2["returncode"]) else 0
+    output_1, output_2 = (result["output"] for result in (result_1, result_2))
+    summary = {}
+    for key in output_1["summary"].keys():
+        summary[key] = output_1["summary"][key] + output_2["summary"][key]  # type: ignore  # (all ints)
+    diagnostics = [*output_1["generalDiagnostics"], *output_2["generalDiagnostics"]]
+    return {
+        "returncode": returncode,
+        "output": {
+            "time": output_1["time"],
+            "version": output_1["version"],
+            "summary": cast(Summary, summary),
+            "generalDiagnostics": diagnostics,
+        },
+    }
+
+
+def print_report(result: RunResult) -> None:
+    output = result["output"]
+    diags = sorted(output["generalDiagnostics"], key=lambda diag: diag["file"])
+
+    print()  # blank line makes it more readable when run from `make`
+
+    # diagnostics
+    for file, file_diags in groupby(diags, key=lambda diag: diag["file"]):
+        print(f"{file}:")
+        for x in file_diags:
+            range_str = f"{x['range']['start']['line'] + 1}:{x['range']['start']['character']}"
+            head_str = f"  {range_str}: {x['message']}"
+            rule_str = f"({x['rule']})" if "rule" in x else None
+            full_str = " ".join(filter(None, (head_str, rule_str)))
+            print(full_str + "\n")  # extra blank line for readability
+
+    # summary
+    summary = output["summary"]
+    print(f"pyright {output['version']}")
+    print(f"Finished in {summary['timeInSec']} seconds")
+    print(f"Analyzed {summary['filesAnalyzed']} files")
+    print(f"Found {summary['errorCount']} errors")
+    print(f"Found {summary['warningCount']} warnings")
+
+
+if __name__ == "__main__":
+    assert os.path.exists(".git"), "Must be run from the root of the repository"
+    args = parser.parse_args()
+    norm_args = normalize_args(args)
+    if norm_args["paths"]:
+        env_path_map = map_paths_to_envs(norm_args["paths"])
+    else:
+        env_path_map = {env: [] for env in norm_args["envs"]}
+    run_results = [
+        run_pyright(env, paths=env_path_map[env], rebuild=norm_args["rebuild"])
+        for env in env_path_map
+    ]
+    merged_result = reduce(merge_pyright_results, run_results)
+    print_report(merged_result)
+    sys.exit(merged_result["returncode"])


### PR DESCRIPTION
### Summary & Motivation

- Drop mypy configuration and BK steps
- Add [Pyright](https://github.com/microsoft/pyright) configuration and a single BK step that checks the whole repo. BK step uses `make pyright`, which can also be run locally.

Benefits. Pyright:

- Is 4-5x faster than mypy (it runs on NodeJS and not Python)
- Is deeply integrated with Pylance, the state-of-the-art Python language server for VSCode. This allows rapid incremental type-checking during development, which makes it easy to achieve parity between editor diagnostics and CI.
- Is much better maintained than mypy. Bugs are fixed fast.
- Has a more powerful type-checking engine than mypy, allowing more expressive types to be used.
- Can be used to assess type-completeness of our public API in addition to type-correctness of annotated code.

Limitations:

- There are a few cases where third-party libraries use mypy-specific extensions to make non-standard APIs legible to mypy. Most of these do not yet offer similar "adapter" functionality for pyright. However, as Python's typing capabilities grow, the need for third-party extensions is diminishing.

### How I Tested These Changes

BK