### PR TITLE
[docs] - [definitions] Update Repository page for Definitions

### DIFF
--- a/docs/content/concepts/repositories-workspaces/repositories.mdx
+++ b/docs/content/concepts/repositories-workspaces/repositories.mdx
@@ -1,11 +1,29 @@
 ---
-title: Repositories | Dagster
+title: Repositories | Dagster Docs
 description: A repository is a collection of jobs, schedules, and sensor definitions that the Dagster CLI, Dagit and the Dagster Daemon can target to load them.
 ---
 
 # Repositories
 
-A repository is a collection of software-defined assets, jobs, schedules, and sensors. Repositories are loaded as a unit by the Dagster CLI, Dagit and the Dagster Daemon.
+<Note>
+  In 1.1.6, we introduced <PyObject object="Definitions" />, which replaces
+  repositories. While repositories will continue to work, we recommend migrating
+  to <code>Definitions</code>. Refer to the{" "}
+  <a href="/concepts/code-locations">Code locations documentation</a> for more
+  info.
+</Note>
+
+A repository is a collection of software-defined assets, jobs, schedules, and sensors. Repositories are loaded as a unit by the Dagster CLI, Dagit and the dagster-daemon.
+
+A convenient way to organize your job and other definitions, each repository:
+
+- Includes various definitions: [Software-defined assets](/concepts/assets/software-defined-assets), [Jobs](/concepts/ops-jobs-graphs/jobs), [Schedules](/concepts/partitions-schedules-sensors/schedules), and [Sensors](/concepts/partitions-schedules-sensors/sensors).
+- Is loaded in a different process than Dagster system processes like Dagit. Any communication between the Dagster system and repository code occurs over an RPC mechanism, ensuring that problems in repository code can't affect Dagster or other repositories.
+- Can be loaded in its own Python environment, so you can manage your dependencies (or even your own Python versions) separately.
+
+You can set up multiple repositories and load them all at once by creating a `workspace.yaml` file. This can be useful for grouping jobs and other artifacts by team for organizational purposes. Refer to the [Workspace documentation](/concepts/repositories-workspaces/workspaces) to learn more about setting up multiple repositories.
+
+---
 
 ## Relevant APIs
 
@@ -14,19 +32,9 @@ A repository is a collection of software-defined assets, jobs, schedules, and se
 | <PyObject object="repository" decorator /> | The decorator used to define repositories. The decorator returns a <PyObject object="RepositoryDefinition" />                                                                                                                |
 | <PyObject object="RepositoryDefinition" /> | Base class for repositories. You almost never want to use initialize this class directly. Instead, you should use the <PyObject object="repository" decorator /> which returns a <PyObject object="RepositoryDefinition"  /> |
 
-## Overview
-
-A repository is a convenient way to organize your job and other definitions. Each repository:
-
-- Includes various definitions: [Software-defined assets](/concepts/assets/software-defined-assets), [Jobs](/concepts/ops-jobs-graphs/jobs), [Schedules](/concepts/partitions-schedules-sensors/schedules), and [Sensors](/concepts/partitions-schedules-sensors/sensors).
-- Is loaded in a different process than Dagster system processes like Dagit. Any communication between the Dagster system and repository code occurs over an RPC mechanism, ensuring that problems in repository code can't affect Dagster or other repositories.
-- Can be loaded in its own Python environment, so you can manage your dependencies (or even your own Python versions) separately.
-
-You can set up multiple repositories and load them all at once by creating a `workspace.yaml` file. This can be useful for grouping jobs and other artifacts by team for organizational purposes. See [Workspace](/concepts/repositories-workspaces/workspaces) to learn more about setting up multiple repositories.
-
 ---
 
-## Defining a Repository
+## Defining a repository
 
 Repositories are typically declared using the <PyObject object="repository" decorator /> decorator. For example:
 
@@ -93,7 +101,9 @@ def my_repository():
 
 The repository specifies a list of items, each of which can be a <PyObject object="AssetsDefinition"/>, <PyObject object="JobDefinition"/>, <PyObject module="dagster" object="ScheduleDefinition" />, or <PyObject module="dagster" object="SensorDefinition" />. If you include a schedule or sensor, the job it targets will be automatically also included on the repository.
 
-## Using a Repository
+---
+
+## Using a repository
 
 If you save the code above as `repo.py`, you can then run the Dagster command line tools on it. Try running:
 


### PR DESCRIPTION
This PR updates the **Repository** concept page for the new `Definitions` world.

[Preview here](https://dagster-git-erin-repository-concept-definitions-elementl.vercel.app/concepts/repositories-workspaces/repositories).

**Note**: This page will be removed from the sidenav in #10843 