### PR TITLE
fix(dbt-cloud): parse command string to find materialization commands

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -107,7 +107,8 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
         # towards the single command constraint.
         self._job_commands = job["execute_steps"]
         materialization_command_filter = [
-            command.lower().startswith(("dbt run", "dbt build")) for command in self._job_commands
+            dbt_parse_args(shlex.split(command)[1:]).which in ["run", "build"]
+            for command in self._job_commands
         ]
         if sum(materialization_command_filter) != 1:
             raise DagsterDbtCloudJobInvariantViolationError(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
@@ -119,7 +119,10 @@ def _add_dbt_cloud_job_responses(
 @responses.activate
 @pytest.mark.parametrize("before_dbt_materialization_command", [[], ["dbt test"]])
 @pytest.mark.parametrize("dbt_materialization_command", ["dbt run", "dbt build"])
-@pytest.mark.parametrize("after_dbt_materialization_command", [[], ["dbt test"]])
+@pytest.mark.parametrize(
+    "after_dbt_materialization_command",
+    [[], ["dbt run-operation upload_dbt_artifacts --args '{filenames: [manifest, run_results]}'"]],
+)
 @pytest.mark.parametrize(
     ["dbt_materialization_command_options", "expected_dbt_materialization_command_options"],
     [


### PR DESCRIPTION
### Summary & Motivation
A user encountered an error like this:

```
dagster_dbt.errors.DagsterDbtCloudJobInvariantViolationError: The dbt Cloud job 'Dagster - Daily' (****) must have a single `dbt run` or `dbt build` in its commands. Received commands: ['dbt build --exclude tag:dbt_artifacts+', "dbt run-operation upload_dbt_artifacts --args '{filenames: [manifest, run_results]}'"].
```

This is because of our naive command search for the dbt materialization command - we attempted to match by string prefix. And the prefix `dbt run` matches both `dbt run` and `dbt run-operation`.

Instead, split the command string by its tokens and parse the command. Then explicitly query for the subcommand and check for equality to `run` or `build`.

### How I Tested These Changes
pytest
