### PR TITLE
Pin graphene to <3.2

### DIFF
--- a/python_modules/dagster-graphql/setup.py
+++ b/python_modules/dagster-graphql/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=find_packages(exclude=["dagster_graphql_tests*"]),
     install_requires=[
         f"dagster{pin}",
-        "graphene>=3",
+        "graphene>=3,<3.2",
         "gql[requests]",
         "requests",
         "starlette",  # used for run_in_threadpool utility fn


### PR DESCRIPTION
Summary & Motivation: It started breaking a ton of our tests. Doing this to unbork trunk

Test Plan: BK
