### PR TITLE
[dagster-airflow] provide interface for passing connection models directly to dagster

### DIFF
--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
@@ -8,6 +8,7 @@ def make_dagster_job_from_airflow_dag(
     unique_id=None,
     mock_xcom=False,
     use_ephemeral_airflow_db=False,
+    connections=None,
 ):
     """Construct a Dagster job corresponding to a given Airflow DAG.
 
@@ -55,6 +56,8 @@ def make_dagster_job_from_airflow_dag(
             depend on xcom may not work as expected. (default: False)
         use_ephemeral_airflow_db (bool): If True, dagster will create an ephemeral sqlite airflow
             database for each run. (default: False)
+        connections (List[Connection]): List of Airflow Connections to be created in the Ephemeral
+            Airflow DB, if use_emphemeral_airflow_db is False this will be ignored.
 
     Returns:
         JobDefinition: The generated Dagster job
@@ -67,6 +70,7 @@ def make_dagster_job_from_airflow_dag(
         unique_id=unique_id,
         mock_xcom=mock_xcom,
         use_ephemeral_airflow_db=use_ephemeral_airflow_db,
+        connections=connections,
     )
     # pass in tags manually because pipeline_def.graph doesn't have it threaded
     return pipeline_def.graph.to_job(

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -118,7 +118,7 @@ def make_dagster_repo_from_airflow_dag_bag(
     use_airflow_template_context=False,
     mock_xcom=False,
     use_ephemeral_airflow_db=False,
-    connections=[],
+    connections=None,
 ):
     """Construct a Dagster repository corresponding to Airflow DAGs in DagBag.
 
@@ -147,6 +147,8 @@ def make_dagster_repo_from_airflow_dag_bag(
             depend on xcom may not work as expected. (default: False)
         use_ephemeral_airflow_db (bool): If True, dagster will create an ephemeral sqlite airflow
             database for each run. (default: False)
+        connections (List[Connection]): List of Airflow Connections to be created in the Ephemeral
+            Airflow DB, if use_emphemeral_airflow_db is False this will be ignored.
 
     Returns:
         RepositoryDefinition
@@ -315,7 +317,7 @@ def make_dagster_repo_from_airflow_dags_path(
     use_airflow_template_context=False,
     mock_xcom=False,
     use_ephemeral_airflow_db=True,
-    connections=[],
+    connections=None,
 ):
     """Construct a Dagster repository corresponding to Airflow DAGs in dag_path.
 
@@ -352,7 +354,8 @@ def make_dagster_repo_from_airflow_dags_path(
             depend on xcom may not work as expected. (default: False)
         use_ephemeral_airflow_db (bool): If True, dagster will create an ephemeral sqlite airflow
             database for each run. (default: False)
-        connections (List[Connection]): List of Airflow connections to add to the Airflow DB.
+        connections (List[Connection]): List of Airflow Connections to be created in the Ephemeral
+            Airflow DB, if use_emphemeral_airflow_db is False this will be ignored.
 
     Returns:
         RepositoryDefinition
@@ -395,7 +398,7 @@ def make_dagster_pipeline_from_airflow_dag(
     unique_id=None,
     mock_xcom=False,
     use_ephemeral_airflow_db=False,
-    connections=[],
+    connections=None,
 ):
     """Construct a Dagster pipeline corresponding to a given Airflow DAG.
 
@@ -450,6 +453,8 @@ def make_dagster_pipeline_from_airflow_dag(
             depend on xcom may not work as expected.
         use_ephemeral_airflow_db (bool): If True, dagster will create an ephemeral sqlite airflow
             database for each run
+        connections (List[Connection]): List of Airflow Connections to be created in the Ephemeral
+            Airflow DB, if use_emphemeral_airflow_db is False this will be ignored.
 
     Returns:
         pipeline_def (PipelineDefinition): The generated Dagster pipeline

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -94,7 +94,9 @@ def create_airflow_connections(connections):
     with create_session() as session:
         for connection in connections:
             if session.query(Connection).filter(Connection.conn_id == connection.conn_id).first():
-                logging.info(f"Could not import connection {connection.conn_id}: connection already exists.")
+                logging.info(
+                    f"Could not import connection {connection.conn_id}: connection already exists."
+                )
                 continue
 
             session.add(connection)
@@ -539,7 +541,9 @@ def make_dagster_pipeline_from_airflow_dag(
                 importlib.reload(airflow)
             if not airflow_initialized:
                 db.initdb()
-                create_airflow_connections([Connection(**c) for c in context.resource_config["connections"]])
+                create_airflow_connections(
+                    [Connection(**c) for c in context.resource_config["connections"]]
+                )
 
             dag_bag = airflow.models.dagbag.DagBag(
                 dag_folder=context.resource_config["dag_location"], include_examples=False

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -14,6 +14,7 @@ import pendulum
 from airflow import __version__ as airflow_version
 from airflow.models import TaskInstance
 from airflow.models.baseoperator import BaseOperator
+from airflow.models.connection import Connection
 from airflow.models.dag import DAG
 from airflow.models.dagbag import DagBag
 from airflow.settings import LOG_FORMAT
@@ -21,6 +22,7 @@ from airflow.utils import db
 from dagster_airflow.patch_airflow_example_dag import patch_airflow_example_dag
 
 from dagster import (
+    Array,
     DagsterInvariantViolationError,
     DependencyDefinition,
     Field,
@@ -87,6 +89,11 @@ class Locker:
         self.fp.close()
 
 
+def create_airflow_connections(connections):
+    for connection in connections:
+        os.environ[f"AIRFLOW_CONN_{connection.conn_id}"] = connection.get_uri()
+
+
 def contains_duplicate_task_names(dag_bag, refresh_from_airflow_db):
     check.inst_param(dag_bag, "dag_bag", DagBag)
     check.bool_param(refresh_from_airflow_db, "refresh_from_airflow_db")
@@ -111,6 +118,7 @@ def make_dagster_repo_from_airflow_dag_bag(
     use_airflow_template_context=False,
     mock_xcom=False,
     use_ephemeral_airflow_db=False,
+    connections=[],
 ):
     """Construct a Dagster repository corresponding to Airflow DAGs in DagBag.
 
@@ -151,6 +159,7 @@ def make_dagster_repo_from_airflow_dag_bag(
     use_ephemeral_airflow_db = check.opt_bool_param(
         use_ephemeral_airflow_db, "use_ephemeral_airflow_db"
     )
+    connections = check.opt_list_param(connections, "connections", of_type=Connection)
 
     use_unique_id = contains_duplicate_task_names(dag_bag, refresh_from_airflow_db)
 
@@ -170,6 +179,7 @@ def make_dagster_repo_from_airflow_dag_bag(
                 use_airflow_template_context=use_airflow_template_context,
                 mock_xcom=mock_xcom,
                 use_ephemeral_airflow_db=use_ephemeral_airflow_db,
+                connections=connections,
             )
         else:
             pipeline_def = make_dagster_pipeline_from_airflow_dag(
@@ -179,6 +189,7 @@ def make_dagster_repo_from_airflow_dag_bag(
                 unique_id=count,
                 mock_xcom=mock_xcom,
                 use_ephemeral_airflow_db=use_ephemeral_airflow_db,
+                connections=connections,
             )
             count += 1
         # pass in tags manually because pipeline_def.graph doesn't have it threaded
@@ -304,6 +315,7 @@ def make_dagster_repo_from_airflow_dags_path(
     use_airflow_template_context=False,
     mock_xcom=False,
     use_ephemeral_airflow_db=True,
+    connections=[],
 ):
     """Construct a Dagster repository corresponding to Airflow DAGs in dag_path.
 
@@ -340,6 +352,7 @@ def make_dagster_repo_from_airflow_dags_path(
             depend on xcom may not work as expected. (default: False)
         use_ephemeral_airflow_db (bool): If True, dagster will create an ephemeral sqlite airflow
             database for each run. (default: False)
+        connections (List[Connection]): List of Airflow connections to add to the Airflow DB.
 
     Returns:
         RepositoryDefinition
@@ -353,6 +366,9 @@ def make_dagster_repo_from_airflow_dags_path(
     use_ephemeral_airflow_db = check.opt_bool_param(
         use_ephemeral_airflow_db, "use_ephemeral_airflow_db"
     )
+    connections = check.opt_list_param(connections, "connections", of_type=Connection)
+    # add connections as environment variables so that dag evaluation works
+    create_airflow_connections(connections)
     try:
         dag_bag = DagBag(
             dag_folder=dag_path,
@@ -368,6 +384,7 @@ def make_dagster_repo_from_airflow_dags_path(
         use_airflow_template_context=use_airflow_template_context,
         mock_xcom=mock_xcom,
         use_ephemeral_airflow_db=use_ephemeral_airflow_db,
+        connections=connections,
     )
 
 
@@ -378,6 +395,7 @@ def make_dagster_pipeline_from_airflow_dag(
     unique_id=None,
     mock_xcom=False,
     use_ephemeral_airflow_db=False,
+    connections=[],
 ):
     """Construct a Dagster pipeline corresponding to a given Airflow DAG.
 
@@ -445,6 +463,7 @@ def make_dagster_pipeline_from_airflow_dag(
     use_ephemeral_airflow_db = check.opt_bool_param(
         use_ephemeral_airflow_db, "use_ephemeral_airflow_db"
     )
+    connections = check.opt_list_param(connections, "connections", of_type=Connection)
 
     if IS_AIRFLOW_INGEST_PIPELINE_STR not in tags:
         tags[IS_AIRFLOW_INGEST_PIPELINE_STR] = "true"
@@ -463,6 +482,24 @@ def make_dagster_pipeline_from_airflow_dag(
         config_schema={
             "dag_location": Field(str, default_value=dag.fileloc),
             "dag_id": Field(str, default_value=dag.dag_id),
+            "connections": Field(
+                Array(inner_type=dict),
+                default_value=[
+                    {
+                        "conn_id": c.conn_id,
+                        "conn_type": c.conn_type,
+                        "description": c.description,
+                        "host": c.host,
+                        "login": c.login,
+                        "password": c.password,
+                        "schema": c.schema,
+                        "port": c.port,
+                        "extra": c.extra if c.extra else "{}",
+                    }
+                    for c in connections
+                ],
+                is_required=False,
+            ),
         }
     )
     def airflow_db(context):
@@ -481,9 +518,11 @@ def make_dagster_pipeline_from_airflow_dag(
 
             if not airflow_initialized:
                 db.initdb()
+                for c in context.resource_config["connections"]:
+                    db.merge_conn(Connection(**c))
 
             dag_bag = airflow.models.dagbag.DagBag(
-                dag_folder=context.resource_config["dag_location"], include_examples=True
+                dag_folder=context.resource_config["dag_location"], include_examples=False
             )
             dag = dag_bag.get_dag(context.resource_config["dag_id"])
             execution_date_str = context.dagster_run.tags.get(AIRFLOW_EXECUTION_DATE_STR)

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -18,6 +18,7 @@ from airflow.models.connection import Connection
 from airflow.models.dag import DAG
 from airflow.models.dagbag import DagBag
 from airflow.settings import LOG_FORMAT
+from airflow.utils import db
 from dagster_airflow.patch_airflow_example_dag import patch_airflow_example_dag
 
 from dagster import (

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_load_connections.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_load_connections.py
@@ -67,3 +67,66 @@ class TestConnections(unittest.TestCase):
                 assert event.event_type_value != "STEP_FAILURE"
             launch_run.assert_called_once()
             wait_for_run.assert_called_once()
+
+
+LOAD_CONNECTION_DAG_AIRFLOW_1_FILE_CONTENTS = """
+import pendulum
+from airflow import DAG
+from dagster_airflow import DagsterCloudOperator
+from airflow.utils.dates import days_ago
+
+with DAG(
+    "example_connections",
+    schedule_interval="@once",
+    start_date=days_ago(1),
+    catchup=False,
+) as dag:
+    ## never succeeds outside of mocks
+    connection_test = DagsterCloudOperator(
+        task_id="connection_test",
+        job_name="connection_test",
+        repository_name="test-repo",
+        repostitory_location_name="test-location",
+        user_token="test-token",
+        organization_id="test-org",
+        run_config={"foo": "bar"},
+        dagster_conn_id="dagster_connection_test",
+    )
+"""
+
+
+@pytest.mark.skipif(airflow_version >= "2.0.0", reason="requires airflow 1")
+@requires_airflow_db
+class TestConnections(unittest.TestCase):
+    @mock.patch("dagster_airflow.hooks.dagster_hook.DagsterHook.launch_run", return_value="run_id")
+    @mock.patch("dagster_airflow.hooks.dagster_hook.DagsterHook.wait_for_run")
+    def test_ingest_airflow_dags_with_connections(self, launch_run, wait_for_run):
+        repo_name = "my_repo_name"
+        connections = [
+            Connection(
+                conn_id="dagster_connection_test",
+                conn_type="dagster",
+                host="prod",
+                password="test_token",
+                port="test-port",
+                schema="test-port",
+                extra=json.dumps({"foo": "bar"}),
+            )
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir_path:
+            with open(os.path.join(tmpdir_path, "test_connection_dag.py"), "wb") as f:
+                f.write(bytes(LOAD_CONNECTION_DAG_AIRFLOW_1_FILE_CONTENTS.encode("utf-8")))
+
+            repo = make_dagster_repo_from_airflow_dags_path(
+                tmpdir_path, repo_name, connections=connections
+            )
+            assert repo.name == repo_name
+            assert repo.has_job("airflow_example_connections")
+
+            job = repo.get_job("airflow_example_connections")
+            result = job.execute_in_process()
+            assert result.success
+            for event in result.all_events:
+                assert event.event_type_value != "STEP_FAILURE"
+            launch_run.assert_called_once()
+            wait_for_run.assert_called_once()

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_load_connections.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_load_connections.py
@@ -33,7 +33,7 @@ with DAG(
 
 @pytest.mark.skipif(airflow_version < "2.0.0", reason="requires airflow 2")
 @requires_airflow_db
-class TestConnections(unittest.TestCase):
+class TestConnectionsAirflow2(unittest.TestCase):
     @mock.patch("dagster_airflow.hooks.dagster_hook.DagsterHook.launch_run", return_value="run_id")
     @mock.patch("dagster_airflow.hooks.dagster_hook.DagsterHook.wait_for_run")
     def test_ingest_airflow_dags_with_connections(self, launch_run, wait_for_run):
@@ -97,7 +97,7 @@ with DAG(
 
 @pytest.mark.skipif(airflow_version >= "2.0.0", reason="requires airflow 1")
 @requires_airflow_db
-class TestConnections(unittest.TestCase):
+class TestConnectionsAirflow1(unittest.TestCase):
     @mock.patch("dagster_airflow.hooks.dagster_hook.DagsterHook.launch_run", return_value="run_id")
     @mock.patch("dagster_airflow.hooks.dagster_hook.DagsterHook.wait_for_run")
     def test_ingest_airflow_dags_with_connections(self, launch_run, wait_for_run):

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_load_connections.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_load_connections.py
@@ -28,6 +28,21 @@ with DAG(
         run_config={"foo": "bar"},
         dagster_conn_id="dagster_connection_test",
     )
+
+with DAG(
+    "example_connections_duplicate",
+    schedule="@once",
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+    catchup=False,
+) as dag:
+    ## never succeeds outside of mocks
+    connection_test = DagsterCloudOperator(
+        task_id="connection_test_duplicate",
+        job_name="connection_test",
+        run_config={"foo": "bar"},
+        dagster_conn_id="dagster_connection_test",
+    )
+
 """
 
 


### PR DESCRIPTION
### Summary & Motivation

Currently users need to set connections with [environment variables](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html#storing-connections-in-environment-variables) outside of dagster. There are a few drawbacks to this approach mainly not all connection attributes can be serialized as a URI. letting users declare connections through the dagster conversion api also lets them avoid any env_var/connection_id collisions across pipelines in the situation where they've migrated multiple airflow instances into a single dagit.

### How I Tested These Changes
