### PR TITLE
Temporarily disable some Azure test suites

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,12 +13,12 @@ parameters:
     type: object
     default:
       - api_tests
-      - cli_tests
+      # - cli_tests
       - core_tests
-      - general_tests
+      # - general_tests
       - daemon_tests
-      - daemon_sensor_tests
-      - scheduler_tests
+      # - daemon_sensor_tests
+      # - scheduler_tests
 jobs:
   - job: "dagster"
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,11 +13,13 @@ parameters:
     type: object
     default:
       - api_tests
-      # - cli_tests
+      - cli_tests
       - core_tests
-      # - general_tests
+      - general_tests
       - daemon_tests
+      # All but 1 test in this suite are currently failing or erroring
       # - daemon_sensor_tests
+      # All but 10 tests in this suite are currently failing or erroring
       # - scheduler_tests
 jobs:
   - job: "dagster"

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
@@ -6,6 +6,7 @@ from dagster._cli.job import execute_launch_command, job_launch_command
 from dagster._core.errors import DagsterRunAlreadyExists
 from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import new_cwd
+from dagster._seven import IS_WINDOWS
 from dagster._utils import file_relative_path
 
 from .test_cli_commands import (
@@ -42,6 +43,7 @@ def run_job_launch_cli(execution_args, instance, expected_count=None):
         assert instance.get_runs_count() == expected_count
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="flaky in windows")
 @pytest.mark.parametrize("gen_pipeline_args", launch_command_contexts())
 def test_launch_pipeline(gen_pipeline_args):
     with gen_pipeline_args as (cli_args, instance):
@@ -56,6 +58,7 @@ def test_launch_non_existant_file():
             run_launch(kwargs, instance)
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="flaky in windows")
 @pytest.mark.parametrize("job_cli_args", valid_external_job_target_cli_args())
 def test_launch_job_cli(job_cli_args):
     with default_cli_test_instance() as instance:
@@ -196,6 +199,7 @@ def test_job_launch_queued(gen_pipeline_args):
             assert run.status == DagsterRunStatus.QUEUED
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="flaky in windows")
 def test_default_working_directory():
     runner = CliRunner()
     import os

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_print_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_print_command.py
@@ -3,6 +3,7 @@ from click.testing import CliRunner
 
 from dagster._cli.job import execute_print_command, job_print_command
 from dagster._core.test_utils import instance_for_test
+from dagster._seven import IS_WINDOWS
 from dagster._utils import file_relative_path
 
 from .test_cli_commands import launch_command_contexts, valid_external_job_target_cli_args
@@ -12,6 +13,7 @@ def no_print(_):
     return None
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="flaky in windows")
 @pytest.mark.parametrize("gen_pipeline_args", launch_command_contexts())
 def test_print_command_verbose(gen_pipeline_args):
     with gen_pipeline_args as (cli_args, instance):
@@ -23,6 +25,7 @@ def test_print_command_verbose(gen_pipeline_args):
         )
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="flaky in windows")
 @pytest.mark.parametrize("gen_pipeline_args", launch_command_contexts())
 def test_print_command(gen_pipeline_args):
     with gen_pipeline_args as (cli_args, instance):
@@ -34,6 +37,7 @@ def test_print_command(gen_pipeline_args):
         )
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="flaky in windows")
 @pytest.mark.parametrize("job_cli_args", valid_external_job_target_cli_args())
 def test_job_print_command_cli(job_cli_args):
     with instance_for_test():

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -337,6 +337,7 @@ def test_load_with_non_existant_file(capfd):
         assert "No such file or directory" in err
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="flaky in windows")
 def test_load_with_empty_working_directory(capfd):
     port = find_free_port()
     # File that will fail if working directory isn't set to default


### PR DESCRIPTION
Something that landed between now and Wednesday broke a lot of Windows tests. Temporarily disabling so broken builds are less noisy but we'll need to look into fixing these before the next release:

https://dev.azure.com/elementl/dagster/_build/results?buildId=17542&view=logs&j=a542e6c6-b199-516e-0d52-86faaec15bd8&t=c277973c-ae99-5b1f-d347-23af2b7d8f82&l=655

### Summary & Motivation

### How I Tested These Changes
