### PR TITLE
[dagster-airflow] reorg dagster airflow api docs

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-airflow.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-airflow.rst
@@ -1,13 +1,14 @@
 Airflow (dagster-airflow)
 -------------------------
 
+This library provides a Dagster integration with `Airflow <https://github.com/apache/airflow>`_.
+
+For more information on getting started, see the `Airflow integration guide </integrations/airflow>`_.
+
 .. currentmodule:: dagster_airflow
 
-.. autofunction:: make_airflow_dag
-
-.. autofunction:: make_airflow_dag_for_operator
-
-.. autofunction:: make_airflow_dag_containerized
+Run Airflow on Dagster
+======================
 
 .. autofunction:: make_dagster_job_from_airflow_dag
 
@@ -18,3 +19,21 @@ Airflow (dagster-airflow)
 .. autofunction:: make_dagster_repo_from_airflow_example_dags
 
 .. autofunction:: airflow_operator_to_op
+
+
+Run Dagster on Airflow
+======================
+
+.. autofunction:: make_airflow_dag
+
+.. autofunction:: make_airflow_dag_for_operator
+
+.. autofunction:: make_airflow_dag_containerized
+
+
+Orchestrate Dagster from Airflow
+================================
+
+.. autoclass:: DagsterCloudOperator
+
+.. autoclass:: DagsterOperator


### PR DESCRIPTION
Adds the new operator class docs and breaks them into sections related to usage pattern
