### PR TITLE
[graphql] fix for graphene 3.2

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/subscription.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/subscription.py
@@ -50,7 +50,7 @@ class GrapheneDagitSubscription(graphene.ObjectType):
         return gen_events_for_run(graphene_info, runId, cursor)
 
     def subscribe_computeLogs(self, graphene_info, runId, stepKey, ioType, cursor=None):
-        return gen_compute_logs(graphene_info, runId, stepKey, ComputeIOType(ioType), cursor)
+        return gen_compute_logs(graphene_info, runId, stepKey, ComputeIOType(ioType.value), cursor)
 
     def subscribe_capturedLogs(self, graphene_info, logKey, cursor=None):
         return gen_captured_log_data(graphene_info, logKey, cursor)

--- a/python_modules/dagster-graphql/setup.py
+++ b/python_modules/dagster-graphql/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=find_packages(exclude=["dagster_graphql_tests*"]),
     install_requires=[
         f"dagster{pin}",
-        "graphene>=3,<3.2",
+        "graphene>=3",
         "gql[requests]",
         "requests",
         "starlette",  # used for run_in_threadpool utility fn


### PR DESCRIPTION
discerned from errors in failing builds 
`'message': "<EnumMeta.STDERR: 'stderr'> is not a valid ComputeIOType"`
https://buildkite.com/dagster/dagster/builds/41570#0184f740-f01b-4428-b479-e297e3130a04/362-953

### How I Tested These Changes

bk