### PR TITLE
Pin tox on windows to < 4

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ jobs:
       - script: choco install vcpython27 --yes
         condition: eq(variables['python.version'], '2.7')
         displayName: "Install vcpython27"
-      - script: pip install tox
+      - script: pip install "tox<4.0.0"
         displayName: "Install tox"
       - script: cd python_modules\dagster && tox -e %TOXENV% && cd ..\..
         displayName: "Run tests"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,10 +17,8 @@ parameters:
       - core_tests
       - general_tests
       - daemon_tests
-      # All but 1 test in this suite are currently failing or erroring
-      # - daemon_sensor_tests
-      # All but 10 tests in this suite are currently failing or erroring
-      # - scheduler_tests
+      - daemon_sensor_tests
+      - scheduler_tests
 jobs:
   - job: "dagster"
     pool:

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
@@ -6,7 +6,6 @@ from dagster._cli.job import execute_launch_command, job_launch_command
 from dagster._core.errors import DagsterRunAlreadyExists
 from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import new_cwd
-from dagster._seven import IS_WINDOWS
 from dagster._utils import file_relative_path
 
 from .test_cli_commands import (
@@ -43,7 +42,6 @@ def run_job_launch_cli(execution_args, instance, expected_count=None):
         assert instance.get_runs_count() == expected_count
 
 
-@pytest.mark.skipif(IS_WINDOWS, reason="flaky in windows")
 @pytest.mark.parametrize("gen_pipeline_args", launch_command_contexts())
 def test_launch_pipeline(gen_pipeline_args):
     with gen_pipeline_args as (cli_args, instance):
@@ -58,7 +56,6 @@ def test_launch_non_existant_file():
             run_launch(kwargs, instance)
 
 
-@pytest.mark.skipif(IS_WINDOWS, reason="flaky in windows")
 @pytest.mark.parametrize("job_cli_args", valid_external_job_target_cli_args())
 def test_launch_job_cli(job_cli_args):
     with default_cli_test_instance() as instance:
@@ -199,7 +196,6 @@ def test_job_launch_queued(gen_pipeline_args):
             assert run.status == DagsterRunStatus.QUEUED
 
 
-@pytest.mark.skipif(IS_WINDOWS, reason="flaky in windows")
 def test_default_working_directory():
     runner = CliRunner()
     import os

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_print_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_print_command.py
@@ -3,7 +3,6 @@ from click.testing import CliRunner
 
 from dagster._cli.job import execute_print_command, job_print_command
 from dagster._core.test_utils import instance_for_test
-from dagster._seven import IS_WINDOWS
 from dagster._utils import file_relative_path
 
 from .test_cli_commands import launch_command_contexts, valid_external_job_target_cli_args
@@ -13,7 +12,6 @@ def no_print(_):
     return None
 
 
-@pytest.mark.skipif(IS_WINDOWS, reason="flaky in windows")
 @pytest.mark.parametrize("gen_pipeline_args", launch_command_contexts())
 def test_print_command_verbose(gen_pipeline_args):
     with gen_pipeline_args as (cli_args, instance):
@@ -25,7 +23,6 @@ def test_print_command_verbose(gen_pipeline_args):
         )
 
 
-@pytest.mark.skipif(IS_WINDOWS, reason="flaky in windows")
 @pytest.mark.parametrize("gen_pipeline_args", launch_command_contexts())
 def test_print_command(gen_pipeline_args):
     with gen_pipeline_args as (cli_args, instance):
@@ -37,7 +34,6 @@ def test_print_command(gen_pipeline_args):
         )
 
 
-@pytest.mark.skipif(IS_WINDOWS, reason="flaky in windows")
 @pytest.mark.parametrize("job_cli_args", valid_external_job_target_cli_args())
 def test_job_print_command_cli(job_cli_args):
     with instance_for_test():

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -337,7 +337,6 @@ def test_load_with_non_existant_file(capfd):
         assert "No such file or directory" in err
 
 
-@pytest.mark.skipif(_seven.IS_WINDOWS, reason="flaky in windows")
 def test_load_with_empty_working_directory(capfd):
     port = find_free_port()
     # File that will fail if working directory isn't set to default


### PR DESCRIPTION
@alangenfeld has a hunch that the recent tox upgrade might be to blame for the regressions we're skipping in https://github.com/dagster-io/dagster/pull/11007

### Summary & Motivation

### How I Tested These Changes
