### PR TITLE
[definitions-accessors] Add get_job_def to `Definitions`.

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -105,7 +105,7 @@ class Definitions:
         check.str_param(name, "name")
         return self.get_resolved_repo().get_job(name)
 
-    def get_resolved_repo(self):
+    def get_resolved_repo(self) -> RepositoryDefinition:
         if isinstance(self._created_repo, PendingRepositoryDefinition):
             self._created_repo = self._created_repo.compute_repository_definition()
         return self._created_repo

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -101,6 +101,8 @@ class Definitions:
         """Get a job definition by name. If you passed in a an UnresolvedAssetJobDefinition
         (return value of define_asset_job) it will be resolved to a JobDefinition when returned
         from this function."""
+
+        check.str_param(name, "name")
         return self.get_resolved_repo().get_job(name)
 
     def get_resolved_repo(self):

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Iterable, Mapping, Optional, Union
 
 import dagster._check as check
-from dagster._annotations import experimental
+from dagster._annotations import experimental, public
 from dagster._core.execution.with_resources import with_resources
 
 from .assets import AssetsDefinition, SourceAsset
@@ -95,6 +95,18 @@ class Definitions:
             ]
 
         self._created_repo = created_repo
+
+    @public
+    def get_job_def(self, name: str) -> JobDefinition:
+        """Get a job definition by name. If you passed in a an UnresolvedAssetJobDefinition
+        (return value of define_asset_job) it will be resolved to a JobDefinition when returned
+        from this function."""
+        return self.get_resolved_repo().get_job(name)
+
+    def get_resolved_repo(self):
+        if isinstance(self._created_repo, PendingRepositoryDefinition):
+            self._created_repo = self._created_repo.compute_repository_definition()
+        return self._created_repo
 
     def get_inner_repository(self) -> Union[RepositoryDefinition, PendingRepositoryDefinition]:
         return self._created_repo

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -754,7 +754,7 @@ def repository_def_from_target_def(
 
     if isinstance(target, Definitions):
         # reassign to handle both repository and pending repo case
-        target = target.get_inner_repository()
+        target = target.get_inner_repository_for_loading_process()
 
     # special case - we can wrap a single pipeline in a repository
     if isinstance(target, (PipelineDefinition, GraphDefinition)):

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions_class.py
@@ -1,3 +1,5 @@
+from dagster_tests.api_tests.api_tests_repo import define_other_foo_pipeline
+
 from dagster import (
     AssetKey,
     AssetsDefinition,
@@ -15,6 +17,8 @@ from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
     CacheableAssetsDefinition,
 )
+from dagster._core.definitions.decorators.job_decorator import job
+from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.repository_definition import (
     PendingRepositoryDefinition,
     RepositoryDefinition,
@@ -50,14 +54,27 @@ def test_basic_asset():
     assert all_assets[0].key.to_user_string() == "an_asset"
 
 
-def test_basic_job_definition():
+def test_basic_asset_job_definition():
     @asset
     def an_asset():
         pass
 
     defs = Definitions(assets=[an_asset], jobs=[define_asset_job(name="an_asset_job")])
 
-    assert resolve_pending_repo_if_required(defs).get_job("an_asset_job")
+    assert isinstance(defs.get_job_def("an_asset_job"), JobDefinition)
+
+
+def test_vanilla_job_definition():
+    @op
+    def an_op():
+        pass
+
+    @job
+    def a_job():
+        pass
+
+    defs = Definitions(jobs=[a_job])
+    assert isinstance(defs.get_job_def("a_job"), JobDefinition)
 
 
 def test_basic_schedule_definition():
@@ -181,3 +198,5 @@ def test_pending_repo():
     all_assets = get_all_assets_from_defs(defs)
     assert len(all_assets) == 1
     assert all_assets[0].key.to_user_string() == "foobar"
+
+    assert isinstance(defs.get_job_def("__ASSET_JOB"), JobDefinition)

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions_class.py
@@ -1,5 +1,3 @@
-from dagster_tests.api_tests.api_tests_repo import define_other_foo_pipeline
-
 from dagster import (
     AssetKey,
     AssetsDefinition,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions_class.py
@@ -30,7 +30,7 @@ def get_all_assets_from_defs(defs: Definitions):
 
 
 def resolve_pending_repo_if_required(definitions: Definitions) -> RepositoryDefinition:
-    repo_or_caching_repo = definitions.get_inner_repository()
+    repo_or_caching_repo = definitions.get_inner_repository_for_loading_process()
     return (
         repo_or_caching_repo.compute_repository_definition()
         if isinstance(repo_or_caching_repo, PendingRepositoryDefinition)


### PR DESCRIPTION
Summary & Motivation: We need to add accessors for testing/etc. This is an opportunity to clean up our interfaces as well.

This also renames get_inner_repository to get_inner_repository_for_loading_process to indicate that that method is supposed
to get used at a particular time.

Test Plan: BK
