### PR TITLE
[dagit] Disable Re-execute menu item in run action menu for perms

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.test.tsx
@@ -1,0 +1,97 @@
+import {act, render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+
+import {TestProvider} from '../testing/TestProvider';
+import {RunStatus} from '../types/globalTypes';
+
+import {RunActionsMenu} from './RunActionsMenu';
+import {RunTableRunFragment} from './types/RunTableRunFragment';
+
+describe('RunActionsMenu', () => {
+  const Test: React.FC<{permissionOverrides?: any; run: RunTableRunFragment}> = ({
+    permissionOverrides,
+    run,
+  }) => {
+    return (
+      <TestProvider permissionOverrides={permissionOverrides}>
+        <RunActionsMenu run={run} />
+      </TestProvider>
+    );
+  };
+
+  const runFragment: RunTableRunFragment = {
+    __typename: 'Run',
+    id: 'run-foo-bar',
+    runId: 'abcdef12',
+    status: RunStatus.SUCCESS,
+    stepKeysToExecute: null,
+    canTerminate: true,
+    mode: 'default',
+    rootRunId: 'abcdef12',
+    parentRunId: null,
+    pipelineSnapshotId: 'snapshotID',
+    parentPipelineSnapshotId: 'snapshotID',
+    pipelineName: 'job-bar',
+    repositoryOrigin: {
+      __typename: 'RepositoryOrigin',
+      id: 'repo',
+      repositoryName: 'my-repo',
+      repositoryLocationName: 'my-origin',
+    },
+    solidSelection: null,
+    assetSelection: null,
+    tags: [],
+    startTime: 123,
+    endTime: 456,
+    updateTime: 789,
+  };
+
+  describe('Permissions', () => {
+    it('renders menu when open', async () => {
+      await act(async () => {
+        render(<Test run={runFragment} />);
+      });
+
+      const button = screen.queryByRole('button') as HTMLButtonElement;
+      expect(button).toBeVisible();
+
+      await act(async () => {
+        userEvent.click(button);
+      });
+
+      expect(screen.queryByRole('button', {name: /view configuration/i})).toBeVisible();
+      expect(screen.queryByRole('link', {name: /open in launchpad/i})).toBeVisible();
+      expect(screen.queryByRole('button', {name: /re-execute/i})).toBeVisible();
+      expect(screen.queryByRole('link', {name: /download debug file/i})).toBeVisible();
+      expect(screen.queryByRole('button', {name: /delete/i})).toBeVisible();
+    });
+
+    it('disables re-execution if no permission', async () => {
+      await act(async () => {
+        render(
+          <Test
+            run={runFragment}
+            permissionOverrides={{
+              launch_pipeline_reexecution: {enabled: false, disabledReason: 'lol nope'},
+            }}
+          />,
+        );
+      });
+
+      const button = screen.queryByRole('button') as HTMLButtonElement;
+      expect(button).toBeVisible();
+
+      await act(async () => {
+        userEvent.click(button);
+      });
+
+      const reExecutionButton = screen.queryByRole('button', {
+        name: /re-execute/i,
+      }) as HTMLButtonElement;
+
+      // Blueprint doesn't actually set `disabled` on the button element.
+      expect(reExecutionButton.classList.contains('bp3-disabled')).toBe(true);
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
@@ -55,7 +55,11 @@ export const RunActionsMenu: React.FC<{
   >('none');
 
   const {rootServerURI} = React.useContext(AppContext);
-  const {canTerminatePipelineExecution, canDeletePipelineRun} = usePermissions();
+  const {
+    canTerminatePipelineExecution,
+    canDeletePipelineRun,
+    canLaunchPipelineReexecution,
+  } = usePermissions();
   const history = useHistory();
 
   const copyConfig = useCopyToClipboard();
@@ -97,7 +101,8 @@ export const RunActionsMenu: React.FC<{
         content={
           <Menu>
             <MenuItem
-              text={loading ? 'Loading Configuration...' : 'View Configuration...'}
+              tagName="button"
+              text={loading ? 'Loading configuration...' : 'View configuration...'}
               disabled={!runConfigYaml}
               icon="open_in_new"
               onClick={() => setVisibleDialog('config')}
@@ -124,14 +129,19 @@ export const RunActionsMenu: React.FC<{
                 />
               </Tooltip>
               <Tooltip
-                content="Re-execute is unavailable because the pipeline is not present in the current workspace."
+                content={
+                  !canLaunchPipelineReexecution.enabled
+                    ? canLaunchPipelineReexecution.disabledReason
+                    : 'Re-execute is unavailable because the pipeline is not present in the current workspace.'
+                }
                 position="bottom"
-                disabled={infoReady && !!repoMatch}
+                disabled={infoReady && !!repoMatch && canLaunchPipelineReexecution.enabled}
                 targetTagName="div"
               >
                 <MenuItem
+                  tagName="button"
                   text="Re-execute"
-                  disabled={!infoReady || !repoMatch}
+                  disabled={!infoReady || !repoMatch || !canLaunchPipelineReexecution.enabled}
                   icon="refresh"
                   onClick={async () => {
                     if (repoMatch && runConfigYaml) {
@@ -157,6 +167,7 @@ export const RunActionsMenu: React.FC<{
               </Tooltip>
               {isFinished || !canTerminatePipelineExecution.enabled ? null : (
                 <MenuItem
+                  tagName="button"
                   icon="cancel"
                   text="Terminate"
                   onClick={() => setVisibleDialog('terminate')}
@@ -165,13 +176,14 @@ export const RunActionsMenu: React.FC<{
               <MenuDivider />
             </>
             <MenuExternalLink
-              text="Download Debug File"
+              text="Download debug file"
               icon="download_for_offline"
               download
               href={`${rootServerURI}/download_debug/${run.runId}`}
             />
             {canDeletePipelineRun.enabled ? (
               <MenuItem
+                tagName="button"
                 icon="delete"
                 text="Delete"
                 intent="danger"

--- a/js_modules/dagit/packages/ui/src/components/Menu.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Menu.tsx
@@ -121,6 +121,7 @@ const StyledMenuItem = styled(BlueprintMenuItem)<StyledMenuItemProps>`
   padding: 6px 8px 6px 12px;
   transition: background-color 50ms, box-shadow 150ms;
   align-items: flex-start;
+  font-size: 14px;
 
   /**
    * Use margin instead of align-items: center because the contents of the menu item may wrap 


### PR DESCRIPTION
### Summary & Motivation

Relaunching a run errors out when the user doesn't have perms. Disable it instead.

### How I Tested These Changes

Force `canLaunchPipelineReexecution` permission to be disabled. Verify that the menu item is correctly disabled on the Runs page.

With the permission enabled, verify that the menu item is correctly enabled.
