### PR TITLE
Allow setting base_dir as a StringSource in sqlite storage

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/ref.py
+++ b/python_modules/dagster/dagster/_core/instance/ref.py
@@ -56,7 +56,13 @@ def configurable_secrets_loader_data(
 
 def configurable_storage_data(
     config_field: Mapping[str, Any], defaults: Mapping[str, Optional[ConfigurableClassData]]
-) -> Sequence[ConfigurableClassData]:
+) -> Sequence[Optional[ConfigurableClassData]]:
+
+    storage_data: ConfigurableClassData
+    run_storage_data: Optional[ConfigurableClassData]
+    event_storage_data: Optional[ConfigurableClassData]
+    schedule_storage_data: Optional[ConfigurableClassData]
+
     if not config_field:
         storage_data = check.not_none(defaults.get("storage"))
         run_storage_data = check.not_none(defaults.get("run_storage"))
@@ -111,28 +117,37 @@ def configurable_storage_data(
         )
 
     elif "sqlite" in config_field:
-        base_dir = check.str_elem(config_field["sqlite"], "base_dir")
+        base_dir = config_field["sqlite"]["base_dir"]
         storage_data = ConfigurableClassData(
             "dagster._core.storage.sqlite_storage",
             "DagsterSqliteStorage",
             yaml.dump({"base_dir": base_dir}, default_flow_style=False),
         )
-        run_storage_data = ConfigurableClassData(
-            "dagster._core.storage.runs",
-            "SqliteRunStorage",
-            yaml.dump({"base_dir": _runs_directory(base_dir)}, default_flow_style=False),
-        )
-        event_storage_data = ConfigurableClassData(
-            "dagster._core.storage.event_log",
-            "SqliteEventLogStorage",
-            yaml.dump({"base_dir": _event_logs_directory(base_dir)}, default_flow_style=False),
-        )
-        schedule_storage_data = ConfigurableClassData(
-            "dagster._core.storage.schedules",
-            "SqliteScheduleStorage",
-            yaml.dump({"base_dir": _schedule_directory(base_dir)}, default_flow_style=False),
-        )
 
+        # Back-compat fo the legacy storage field only works if the base_dir is a string
+        # (env var doesn't work since each storage has a different value for the base_dir field)
+        if isinstance(base_dir, str):
+            run_storage_data = ConfigurableClassData(
+                "dagster._core.storage.runs",
+                "SqliteRunStorage",
+                yaml.dump({"base_dir": _runs_directory(base_dir)}, default_flow_style=False),
+            )
+
+            event_storage_data = ConfigurableClassData(
+                "dagster._core.storage.event_log",
+                "SqliteEventLogStorage",
+                yaml.dump({"base_dir": _event_logs_directory(base_dir)}, default_flow_style=False),
+            )
+
+            schedule_storage_data = ConfigurableClassData(
+                "dagster._core.storage.schedules",
+                "SqliteScheduleStorage",
+                yaml.dump({"base_dir": _schedule_directory(base_dir)}, default_flow_style=False),
+            )
+        else:
+            run_storage_data = None
+            event_storage_data = None
+            schedule_storage_data = None
     else:
         storage_data = configurable_class_data(config_field["custom"])
         storage_config_yaml = yaml.dump(
@@ -170,9 +185,9 @@ class InstanceRef(
             # Required for backwards compatibility, but going forward will be unused by new versions
             # of DagsterInstance, which instead will instead grab the constituent storages from the
             # unified `storage_data`, if it is populated.
-            ("run_storage_data", ConfigurableClassData),
-            ("event_storage_data", ConfigurableClassData),
-            ("schedule_storage_data", ConfigurableClassData),
+            ("run_storage_data", Optional[ConfigurableClassData]),
+            ("event_storage_data", Optional[ConfigurableClassData]),
+            ("schedule_storage_data", Optional[ConfigurableClassData]),
             ("custom_instance_class_data", Optional[ConfigurableClassData]),
             # unified storage field
             ("storage_data", Optional[ConfigurableClassData]),
@@ -193,9 +208,9 @@ class InstanceRef(
         run_coordinator_data: Optional[ConfigurableClassData],
         run_launcher_data: Optional[ConfigurableClassData],
         settings: Mapping[str, object],
-        run_storage_data: ConfigurableClassData,
-        event_storage_data: ConfigurableClassData,
-        schedule_storage_data: ConfigurableClassData,
+        run_storage_data: Optional[ConfigurableClassData],
+        event_storage_data: Optional[ConfigurableClassData],
+        schedule_storage_data: Optional[ConfigurableClassData],
         custom_instance_class_data: Optional[ConfigurableClassData] = None,
         storage_data: Optional[ConfigurableClassData] = None,
         secrets_loader_data: Optional[ConfigurableClassData] = None,
@@ -218,13 +233,13 @@ class InstanceRef(
                 run_launcher_data, "run_launcher_data", ConfigurableClassData
             ),
             settings=check.opt_mapping_param(settings, "settings", key_type=str),
-            run_storage_data=check.inst_param(
+            run_storage_data=check.opt_inst_param(
                 run_storage_data, "run_storage_data", ConfigurableClassData
             ),
-            event_storage_data=check.inst_param(
+            event_storage_data=check.opt_inst_param(
                 event_storage_data, "event_storage_data", ConfigurableClassData
             ),
-            schedule_storage_data=check.inst_param(
+            schedule_storage_data=check.opt_inst_param(
                 schedule_storage_data, "schedule_storage_data", ConfigurableClassData
             ),
             custom_instance_class_data=check.opt_inst_param(
@@ -444,11 +459,11 @@ class InstanceRef(
 
     @property
     def run_storage(self):
-        return self.run_storage_data.rehydrate()
+        return self.run_storage_data.rehydrate() if self.run_storage_data else None
 
     @property
     def event_storage(self):
-        return self.event_storage_data.rehydrate()
+        return self.event_storage_data.rehydrate() if self.event_storage_data else None
 
     @property
     def schedule_storage(self):


### PR DESCRIPTION
Summary:
We say you can do this in the docs but it doesn't work - this makes it work.

There's a gotcha though, we can't set the legacy storage fields if we do this since they derive their values from the base_dir. I think it's OK for back-compat to not work in this scenario (it seems worse than parsing the env var and putting its value in plaintext) but open to other possibilities.

### Summary & Motivation

### How I Tested These Changes
