### PR TITLE
Replace usages of `nslookup` with `nc` for user deployments

### DIFF
--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -58,7 +58,7 @@ spec:
         {{- range $deployment := $userDeployments.deployments }}
         - name: "init-user-deployment-{{- $deployment.name -}}"
           image: {{ include "dagster.externalImage.name" $.Values.busybox.image | quote }}
-          command: ['sh', '-c', "until nslookup {{ $deployment.name -}}; do echo waiting for user service; sleep 2; done"]
+          command: ['sh', '-c', "until nc -zv {{ $deployment.name -}} {{ $deployment.port -}} -w1; do echo waiting for user service; sleep 2; done"]
         {{- end }}
         {{- end }}
       containers:

--- a/helm/dagster/templates/helpers/_deployment-dagit.tpl
+++ b/helm/dagster/templates/helpers/_deployment-dagit.tpl
@@ -55,7 +55,7 @@ spec:
         {{- range $deployment := $userDeployments.deployments }}
         - name: "init-user-deployment-{{- $deployment.name -}}"
           image: {{ include "dagster.externalImage.name" $.Values.busybox.image | quote }}
-          command: ['sh', '-c', "until nslookup {{ $deployment.name -}}; do echo waiting for user service; sleep 2; done"]
+          command: ['sh', '-c', "until nc -zv {{ $deployment.name -}} {{ $deployment.port -}} -w1; do echo waiting for user service; sleep 2; done"]
           securityContext:
             {{- toYaml $.Values.dagit.securityContext | nindent 12 }}
         {{- end }}


### PR DESCRIPTION
### Summary & Motivation
The effect of the two commands is basically the same, confirming the user deployments are functioning.  `nc` is slightly more robust as `nslookup` will fail if it fails on any of it's queries it takes, and apparently there are some cases where kubedns will be quirky and makes it spaz out.

### How I Tested These Changes
I wouldn't mind help running the helm unit tests