### PR TITLE
Pathspec typing fix

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/python_packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/python_packages.py
@@ -117,7 +117,7 @@ class PythonPackages:
             ignored = git_ignore.read_text().splitlines()
             git_ignore_spec = pathspec.PathSpec.from_lines("gitwildmatch", ignored)
         else:
-            git_ignore_spec = pathspec.PathSpec().from_lines([])
+            git_ignore_spec = pathspec.PathSpec([])
 
         # Consider any setup.py file to be a package
         packages = set(


### PR DESCRIPTION
### Summary & Motivation

New version of [pathspec](https://pypi.org/project/pathspec/) was released that added a `py.typed` file and was causing mypy on `dagster-buildkite` to fail. This fixes the type error.
