### PR TITLE
move ecs task tagging to run_task call

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -329,7 +329,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         }
         run_task_kwargs["tags"] = [
             *run_task_kwargs.get("tags", []),
-            *self.build_ecs_tags_for_run_task(),
+            *self.build_ecs_tags_for_run_task(run),
         ]
 
         # Run a task using the same network configuration as this processes's

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -252,13 +252,6 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
     def from_config_value(inst_data, config_value):
         return EcsRunLauncher(inst_data=inst_data, **config_value)
 
-    def _set_ecs_tags(self, run_id, task_arn):
-        try:
-            tags = [{"key": "dagster/run_id", "value": run_id}]
-            self.ecs.tag_resource(resourceArn=task_arn, tags=tags)
-        except ClientError:
-            pass
-
     def _set_run_tags(self, run_id: str, cluster: str, task_arn: str):
         tags = {
             "ecs/task_arn": task_arn,
@@ -358,7 +351,6 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         arn = tasks[0]["taskArn"]
         cluster_arn = tasks[0]["clusterArn"]
         self._set_run_tags(run.run_id, cluster=cluster_arn, task_arn=arn)
-        self._set_ecs_tags(run.run_id, task_arn=arn)
         self.report_launch_events(run, arn, cluster_arn)
 
     def report_launch_events(

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -252,6 +252,13 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
     def from_config_value(inst_data, config_value):
         return EcsRunLauncher(inst_data=inst_data, **config_value)
 
+    def _set_ecs_tags(self, run_id, task_arn):
+        try:
+            tags = [{"key": "dagster/run_id", "value": run_id}]
+            self.ecs.tag_resource(resourceArn=task_arn, tags=tags)
+        except ClientError:
+            pass
+
     def _set_run_tags(self, run_id: str, cluster: str, task_arn: str):
         tags = {
             "ecs/task_arn": task_arn,
@@ -351,6 +358,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         arn = tasks[0]["taskArn"]
         cluster_arn = tasks[0]["clusterArn"]
         self._set_run_tags(run.run_id, cluster=cluster_arn, task_arn=arn)
+        self._set_ecs_tags(run.run_id, task_arn=arn)
         self.report_launch_events(run, arn, cluster_arn)
 
     def report_launch_events(

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
@@ -359,8 +359,12 @@ class StubbedEcs:
             cluster = self._cluster(kwargs.get("cluster"))
             count = kwargs.get("count", 1)
             tasks = []
+            tags = kwargs.get("tags")
             for _ in range(count):
                 arn = self._task_arn(cluster)
+                if tags and self._long_arn_enabled():
+                    self.tags[arn] = tags
+
                 task = {
                     "attachments": [],
                     "clusterArn": self._cluster_arn(cluster),


### PR DESCRIPTION
### Summary & Motivation

ECS run tasks are not getting tagged with the appropriate tags.  Instead of calling `ecs.tag_resource` on the newly created run task (which relies on the task to be up and running, which is almost surely not going to be true), this instead constructs the set of desired tags and passes it into the `ecs.run_task` call.

### How I Tested These Changes
Manually tested against set of serverless run launches.  Also changed the ECS stubs so that tags passed in the `run_task` calls were tracked in the unit tests.
