### PR TITLE
eliminate SensorExecutionContext, ScheduleExecutionContext

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/__init__.py
@@ -105,13 +105,11 @@ from .schedule_definition import (
     DefaultScheduleStatus as DefaultScheduleStatus,
     ScheduleDefinition as ScheduleDefinition,
     ScheduleEvaluationContext as ScheduleEvaluationContext,
-    ScheduleExecutionContext as ScheduleExecutionContext,
 )
 from .sensor_definition import (
     DefaultSensorStatus as DefaultSensorStatus,
     SensorDefinition as SensorDefinition,
     SensorEvaluationContext as SensorEvaluationContext,
-    SensorExecutionContext as SensorExecutionContext,
 )
 from .solid_container import create_execution_structure as create_execution_structure
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
@@ -10,7 +10,7 @@ from .sensor_definition import (
     DefaultSensorStatus,
     RawSensorEvaluationFunctionReturn,
     SensorDefinition,
-    SensorExecutionContext,
+    SensorEvaluationContext,
 )
 from .target import ExecutableDefinition
 from .utils import check_valid_name
@@ -50,7 +50,7 @@ class AssetSensorDefinition(SensorDefinition):
         asset_key: AssetKey,
         job_name: Optional[str],
         asset_materialization_fn: Callable[
-            [SensorExecutionContext, "EventLogEntry"],
+            [SensorEvaluationContext, "EventLogEntry"],
             RawSensorEvaluationFunctionReturn,
         ],
         minimum_interval_seconds: Optional[int] = None,

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -650,7 +650,3 @@ class ScheduleDefinition:
     @property
     def default_status(self) -> DefaultScheduleStatus:
         return self._default_status
-
-
-# Preserve ScheduleExecutionContext for backcompat so type annotations don't break.
-ScheduleExecutionContext = ScheduleEvaluationContext

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -215,9 +215,6 @@ class SensorEvaluationContext:
         return self._log_key
 
 
-# Preserve SensorExecutionContext for backcompat so type annotations don't break.
-SensorExecutionContext = SensorEvaluationContext
-
 RawSensorEvaluationFunctionReturn = Union[
     Iterator[Union[SkipReason, RunRequest]],
     Sequence[RunRequest],

--- a/python_modules/dagster/dagster/_legacy/__init__.py
+++ b/python_modules/dagster/dagster/_legacy/__init__.py
@@ -10,8 +10,6 @@ from dagster._core.definitions import (
     PartitionSetDefinition as PartitionSetDefinition,
     PipelineDefinition as PipelineDefinition,
     PresetDefinition as PresetDefinition,
-    ScheduleExecutionContext as ScheduleExecutionContext,
-    SensorExecutionContext as SensorExecutionContext,
     build_assets_job as build_assets_job,
     daily_schedule as daily_schedule,
     default_executors as default_executors,

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
@@ -7,18 +7,9 @@ from dagster import (
     build_schedule_context,
     schedule,
 )
-from dagster._core.definitions.schedule_definition import (
-    ScheduleEvaluationContext,
-    ScheduleExecutionContext,
-)
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.test_utils import instance_for_test
 from dagster._legacy import daily_schedule
-
-
-def test_schedule_context_backcompat():
-    # ScheduleExecutionContext is a literal alias of ScheduleEvaluationContext
-    assert isinstance(ScheduleEvaluationContext(None, None), ScheduleExecutionContext)
 
 
 def cron_test_schedule_factory_context():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -20,7 +20,6 @@ from dagster import (
     PartitionMapping,
     PartitionsDefinition,
     RunRequest,
-    SensorEvaluationContext,
     SkipReason,
     StaticPartitionsDefinition,
     asset,
@@ -43,13 +42,6 @@ from dagster import (
 from dagster._check import CheckError
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import SensorExecutionContext
-
-
-def test_sensor_context_backcompat():
-    # If an instance of SensorEvaluationContext is a SensorExecutionContext, then annotating as
-    # SensorExecutionContext and passing in a SensorEvaluationContext should pass mypy
-    assert isinstance(SensorEvaluationContext(None, None, None, None, None), SensorExecutionContext)
 
 
 def test_sensor_invocation_args():


### PR DESCRIPTION
### Summary & Motivation

Both `SensorExecutionContext` and `ScheduleExecutionContext` were left in the codebase as aliases of their newer counterparts `SensorEvaulationContext` and `ScheduleEvaluationContext`. This PR just updates all references to the newer names.

### How I Tested These Changes

BK.
