### PR TITLE
[dagit] Persist AssetPartitions state to URL, open Materialize panel with same selection

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
@@ -45,14 +45,14 @@ export const AssetPartitions: React.FC<Props> = ({
   liveData,
 }) => {
   const [assetHealth] = usePartitionHealthData([assetKey], assetLastMaterializedAt);
-  const [ranges, setRanges] = usePartitionDimensionRanges(
+  const [ranges, setRanges] = usePartitionDimensionRanges({
+    knownDimensionNames: assetPartitionDimensions,
+    modifyQueryString: true,
     assetHealth,
-    assetPartitionDimensions,
-    true,
-  );
+  });
 
   const [stateFilters, setStateFilters] = useQueryPersistedState<PartitionState[]>({
-    defaults: {states: DISPLAYED_STATES.sort().join(',')},
+    defaults: {states: [...DISPLAYED_STATES].sort().join(',')},
     encode: (val) => ({states: [...val].sort().join(',')}),
     decode: (qs) =>
       (qs.states || '').split(',').filter((s: PartitionState) => DISPLAYED_STATES.includes(s)),

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -221,7 +221,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
           ) : selectedTab === 'partitions' ? (
             <AssetPartitions
               assetKey={assetKey}
-              assetPartitionNames={definition?.partitionKeysByDimension.map((k) => k.name)}
+              assetPartitionDimensions={definition?.partitionKeysByDimension.map((k) => k.name)}
               assetLastMaterializedAt={lastMaterializedAt}
               params={params}
               paramsTimeWindowOnly={!!params.asOf}

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -32,11 +32,11 @@ import {
   ConfigPartitionSelectionQuery,
   ConfigPartitionSelectionQueryVariables,
 } from '../launchpad/types/ConfigPartitionSelectionQuery';
-import {assembleIntoSpans, stringForSpan} from '../partitions/PartitionRangeInput';
 import {PartitionRangeWizard} from '../partitions/PartitionRangeWizard';
 import {PartitionStateCheckboxes} from '../partitions/PartitionStateCheckboxes';
 import {PartitionState} from '../partitions/PartitionStatus';
 import {showBackfillErrorToast, showBackfillSuccessToast} from '../partitions/PartitionsBackfill';
+import {assembleIntoSpans, stringForSpan} from '../partitions/SpanRepresentation';
 import {RepoAddress} from '../workspace/types';
 
 import {executionParamsForAssetJob} from './LaunchAssetExecutionButton';
@@ -111,6 +111,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
   const [ranges, setRanges] = usePartitionDimensionRanges(
     mergedHealth,
     partitionedAssets[0].partitionKeysByDimension.map((d) => d.name),
+    false,
   );
 
   const [stateFilters, setStateFilters] = React.useState<PartitionState[]>([

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -108,11 +108,11 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
   const assetHealth = usePartitionHealthData(partitionedAssets.map((a) => a.assetKey));
   const mergedHealth = React.useMemo(() => mergedAssetHealth(assetHealth), [assetHealth]);
 
-  const [ranges, setRanges] = usePartitionDimensionRanges(
-    mergedHealth,
-    partitionedAssets[0].partitionKeysByDimension.map((d) => d.name),
-    false,
-  );
+  const [ranges, setRanges] = usePartitionDimensionRanges({
+    knownDimensionNames: partitionedAssets[0].partitionKeysByDimension.map((d) => d.name),
+    modifyQueryString: false,
+    assetHealth: mergedHealth,
+  });
 
   const [stateFilters, setStateFilters] = React.useState<PartitionState[]>([
     PartitionState.MISSING,

--- a/js_modules/dagit/packages/core/src/assets/usePartitionDimensionRanges.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionDimensionRanges.tsx
@@ -1,26 +1,84 @@
 import React from 'react';
 
+import {QueryPersistedStateConfig, useQueryPersistedState} from '../hooks/useQueryPersistedState';
+import {
+  allPartitionsSpan,
+  partitionsToText,
+  textToPartitions,
+} from '../partitions/SpanRepresentation';
+
 import {placeholderDimensionRange} from './MultipartitioningSupport';
 import {PartitionHealthData, PartitionHealthDimensionRange} from './usePartitionHealthData';
 
+type DimensionQueryState = {
+  name: string;
+  rangeText: string | undefined;
+};
+
+const serializer: QueryPersistedStateConfig<DimensionQueryState[]> = {
+  defaults: {},
+  encode: (state) => Object.fromEntries(state.map((s) => [`${s.name}_range`, s.rangeText])),
+  decode: (qs) =>
+    Object.entries(qs)
+      .filter(([key]) => key.endsWith('_range'))
+      .map(([key, rangeText]) => ({name: key.replace(/_range$/, ''), rangeText})),
+};
+
+/**
+ * This hook behaves like useState and manages the user's selected partition key
+ * ranges on each partition dimension.
+ *
+ * Internally, this hook reads initial state from the query string and (optionally)
+ * writes changes back to the query string using the compacted "spans" format.
+ */
 export const usePartitionDimensionRanges = (
   assetHealth: Pick<PartitionHealthData, 'dimensions'>,
-  knownPartitionNames: string[] = [],
+  knownDimensionNames: string[] = [], // improves loading state if available
+  modifyQueryString = true,
 ) => {
-  const [ranges, setRanges] = React.useState<PartitionHealthDimensionRange[]>(
-    knownPartitionNames.map(placeholderDimensionRange),
+  const [query, setQuery] = useQueryPersistedState<DimensionQueryState[]>(serializer);
+  const [local, setLocal] = React.useState<DimensionQueryState[]>([]);
+
+  const knownDimensionNamesJSON = JSON.stringify(knownDimensionNames);
+  const inflated = React.useMemo((): PartitionHealthDimensionRange[] => {
+    if (!assetHealth) {
+      return JSON.parse(knownDimensionNamesJSON).map(placeholderDimensionRange);
+    }
+    return assetHealth.dimensions.map((dimension) => {
+      const saved =
+        local.find((s) => s.name === dimension.name) ||
+        query.find((s) => s.name === dimension.name);
+
+      // Note: It's valid for the user to clear the range to "", so it's
+      // important that we persist "" and specifically check for `undefined`
+      // when filling in the default value (all keys)
+      return {
+        dimension,
+        selected:
+          saved?.rangeText !== undefined
+            ? textToPartitions(saved.rangeText, dimension.partitionKeys)
+            : dimension.partitionKeys,
+      };
+    });
+  }, [query, local, assetHealth, knownDimensionNamesJSON]);
+
+  const setInflated = React.useCallback(
+    (ranges: PartitionHealthDimensionRange[]) => {
+      const next = ranges.map((r) => {
+        const rangeText = partitionsToText(r.selected, r.dimension.partitionKeys);
+        return {
+          name: r.dimension.name,
+          rangeText: rangeText !== allPartitionsSpan(r.dimension) ? rangeText : undefined,
+        };
+      });
+      if (modifyQueryString) {
+        setQuery(next);
+      } else {
+        setLocal(next);
+      }
+    },
+    [setQuery, modifyQueryString],
   );
 
-  React.useEffect(() => {
-    if (assetHealth) {
-      setRanges(
-        assetHealth.dimensions.map((dimension) => ({
-          dimension,
-          selected: dimension.partitionKeys,
-        })),
-      );
-    }
-  }, [assetHealth]);
-
-  return [ranges, setRanges] as const;
+  return [inflated, setInflated] as const;
 };

--- a/js_modules/dagit/packages/core/src/assets/usePartitionDimensionRanges.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionDimensionRanges.tsx
@@ -31,11 +31,12 @@ const serializer: QueryPersistedStateConfig<DimensionQueryState[]> = {
  * Internally, this hook reads initial state from the query string and (optionally)
  * writes changes back to the query string using the compacted "spans" format.
  */
-export const usePartitionDimensionRanges = (
-  assetHealth: Pick<PartitionHealthData, 'dimensions'>,
-  knownDimensionNames: string[] = [], // improves loading state if available
-  modifyQueryString = true,
-) => {
+export const usePartitionDimensionRanges = (opts: {
+  assetHealth: Pick<PartitionHealthData, 'dimensions'>;
+  modifyQueryString: boolean;
+  knownDimensionNames?: string[]; // improves loading state if available
+}) => {
+  const {assetHealth, knownDimensionNames = [], modifyQueryString} = opts;
   const [query, setQuery] = useQueryPersistedState<DimensionQueryState[]>(serializer);
   const [local, setLocal] = React.useState<DimensionQueryState[]>([]);
 

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRangeInput.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRangeInput.tsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {ClearButton} from '../ui/ClearButton';
 
+import {partitionsToText, textToPartitions} from './SpanRepresentation';
+
 export const PartitionRangeInput: React.FC<{
   value: string[];
   onChange: (partitionNames: string[]) => void;
@@ -56,30 +58,7 @@ export const PartitionRangeInput: React.FC<{
     />
   );
 };
-
-export function assembleIntoSpans<T>(keys: string[], keyTestFn: (key: string, idx: number) => T) {
-  const spans: {startIdx: number; endIdx: number; status: T}[] = [];
-
-  for (let ii = 0; ii < keys.length; ii++) {
-    const status = keyTestFn(keys[ii], ii);
-    if (!spans.length || spans[spans.length - 1].status !== status) {
-      spans.push({startIdx: ii, endIdx: ii, status});
-    } else {
-      spans[spans.length - 1].endIdx = ii;
-    }
-  }
-
-  return spans;
-}
-
-export function stringForSpan(
-  {startIdx, endIdx}: {startIdx: number; endIdx: number},
-  all: string[],
-) {
-  return startIdx === endIdx ? all[startIdx] : `[${all[startIdx]}...${all[endIdx]}]`;
-}
-
-function placeholderForPartitions(names: string[], isTimeseries: boolean) {
+export function placeholderForPartitions(names: string[], isTimeseries: boolean) {
   if (names.length === 0) {
     return '';
   }
@@ -87,41 +66,4 @@ function placeholderForPartitions(names: string[], isTimeseries: boolean) {
     return `ex: ${names[0]}, ${names[1]}`;
   }
   return `ex: ${names[0]}, ${names[1]}, [${names[2]}...${names[names.length - 1]}]`;
-}
-
-function textToPartitions(selected: string, all: string[]) {
-  const terms = selected.split(',').map((s) => s.trim());
-  const result = [];
-  for (const term of terms) {
-    if (term.length === 0) {
-      continue;
-    }
-    const rangeMatch = /^\[(.*)\.\.\.(.*)\]$/g.exec(term);
-    if (rangeMatch) {
-      const [, start, end] = rangeMatch;
-      const allStartIdx = all.indexOf(start);
-      const allEndIdx = all.indexOf(end);
-      if (allStartIdx === -1 || allEndIdx === -1) {
-        throw new Error(`Could not find partitions for provided range: ${start}...${end}`);
-      }
-      result.push(...all.slice(allStartIdx, allEndIdx + 1));
-    } else if (term.includes('*')) {
-      const [prefix, suffix] = term.split('*');
-      result.push(...all.filter((p) => p.startsWith(prefix) && p.endsWith(suffix)));
-    } else {
-      const idx = all.indexOf(term);
-      if (idx === -1) {
-        throw new Error(`Could not find partition: ${term}`);
-      }
-      result.push(term);
-    }
-  }
-  return result.sort((a, b) => all.indexOf(a) - all.indexOf(b));
-}
-
-function partitionsToText(selected: string[], all: string[]) {
-  return assembleIntoSpans(all, (key) => selected.includes(key))
-    .filter((s) => s.status)
-    .map((s) => stringForSpan(s, all))
-    .join(', ');
 }

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/macro';
 import {useViewport} from '../gantt/useViewport';
 import {RunStatus} from '../types/globalTypes';
 
-import {assembleIntoSpans} from './PartitionRangeInput';
+import {assembleIntoSpans} from './SpanRepresentation';
 
 type SelectionRange = {
   start: string;

--- a/js_modules/dagit/packages/core/src/partitions/SpanRepresentation.test.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/SpanRepresentation.test.tsx
@@ -1,0 +1,115 @@
+import {
+  allPartitionsSpan,
+  assembleIntoSpans,
+  partitionsToText,
+  stringForSpan,
+  textToPartitions,
+} from './SpanRepresentation';
+
+const MOCK_PARTITION_STATES = {
+  '2022-01-01': 0,
+  '2022-01-02': 0,
+  '2022-01-03': 0,
+  '2022-01-04': 0,
+  '2022-01-05': 0,
+  '2022-01-06': 0,
+  '2022-01-07': 1,
+  '2022-01-08': 1,
+  '2022-01-09': 1,
+  '2022-01-10': 0,
+};
+
+const MOCK_PARTITIONS = Object.keys(MOCK_PARTITION_STATES).sort();
+
+describe('SpanRepresentation', () => {
+  describe('assembleIntoSpans', () => {
+    it('returns spans of each returned value', async () => {
+      const result = assembleIntoSpans(MOCK_PARTITIONS, (key) => MOCK_PARTITION_STATES[key] === 1);
+      const expected = [
+        {startIdx: 0, endIdx: 5, status: false},
+        {startIdx: 6, endIdx: 8, status: true},
+        {startIdx: 9, endIdx: 9, status: false},
+      ];
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('stringForSpan', () => {
+    it('returns a single value for a span of length 1', () => {
+      expect(stringForSpan({startIdx: 4, endIdx: 4}, MOCK_PARTITIONS)).toEqual('2022-01-05');
+    });
+
+    it('returns the [...] range syntax for spans of length > 1', () => {
+      expect(stringForSpan({startIdx: 4, endIdx: 8}, MOCK_PARTITIONS)).toEqual(
+        '[2022-01-05...2022-01-09]',
+      );
+    });
+  });
+
+  describe('allPartitionsSpan', () => {
+    it('should return the full range span', () => {
+      expect(allPartitionsSpan({partitionKeys: MOCK_PARTITIONS})).toEqual(
+        '[2022-01-01...2022-01-10]',
+      );
+    });
+  });
+
+  describe('textToPartitions', () => {
+    it('should parse a single value', () => {
+      expect(textToPartitions('2022-01-01', MOCK_PARTITIONS)).toEqual(['2022-01-01']);
+    });
+    it('should parse comma-separated values', () => {
+      expect(textToPartitions('2022-01-01, 2022-01-02,2022-01-03', MOCK_PARTITIONS)).toEqual([
+        '2022-01-01',
+        '2022-01-02',
+        '2022-01-03',
+      ]);
+    });
+    it('should parse spans using the [...] syntax', () => {
+      expect(textToPartitions('[2022-01-01...2022-01-03]', MOCK_PARTITIONS)).toEqual([
+        '2022-01-01',
+        '2022-01-02',
+        '2022-01-03',
+      ]);
+    });
+    it('should parse a multi-span string', () => {
+      expect(
+        textToPartitions(
+          '[2022-01-01...2022-01-03],2022-01-05,[2022-01-06...2022-01-07]',
+          MOCK_PARTITIONS,
+        ),
+      ).toEqual([
+        '2022-01-01',
+        '2022-01-02',
+        '2022-01-03',
+        '2022-01-05',
+        '2022-01-06',
+        '2022-01-07',
+      ]);
+    });
+    it('should throw an exception if the string is invalid', () => {
+      expect(() => textToPartitions('[1980-01-01]', MOCK_PARTITIONS)).toThrow();
+    });
+  });
+
+  describe('partitionsToText', () => {
+    it('should correctly build single partition lists', () => {
+      expect(partitionsToText(['2022-01-01', '2022-01-07'], MOCK_PARTITIONS)).toEqual(
+        '2022-01-01, 2022-01-07',
+      );
+    });
+
+    it('should correctly build spans', () => {
+      expect(
+        partitionsToText(
+          ['2022-01-01', '2022-01-02', '2022-01-03', '2022-01-05', '2022-01-06', '2022-01-07'],
+          MOCK_PARTITIONS,
+        ),
+      ).toEqual('[2022-01-01...2022-01-03], [2022-01-05...2022-01-07]');
+    });
+
+    it('should ignore unknown partition keys, so the result string is always a valid selection', () => {
+      expect(partitionsToText(['XXX', '2022-01-02'], MOCK_PARTITIONS)).toEqual('2022-01-02');
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/partitions/SpanRepresentation.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/SpanRepresentation.tsx
@@ -1,0 +1,62 @@
+export function assembleIntoSpans<T>(keys: string[], keyTestFn: (key: string, idx: number) => T) {
+  const spans: {startIdx: number; endIdx: number; status: T}[] = [];
+
+  for (let ii = 0; ii < keys.length; ii++) {
+    const status = keyTestFn(keys[ii], ii);
+    if (!spans.length || spans[spans.length - 1].status !== status) {
+      spans.push({startIdx: ii, endIdx: ii, status});
+    } else {
+      spans[spans.length - 1].endIdx = ii;
+    }
+  }
+
+  return spans;
+}
+
+export function stringForSpan(
+  {startIdx, endIdx}: {startIdx: number; endIdx: number},
+  all: string[],
+) {
+  return startIdx === endIdx ? all[startIdx] : `[${all[startIdx]}...${all[endIdx]}]`;
+}
+
+export function allPartitionsSpan({partitionKeys}: {partitionKeys: string[]}) {
+  return stringForSpan({startIdx: 0, endIdx: partitionKeys.length - 1}, partitionKeys);
+}
+
+export function textToPartitions(selected: string, all: string[]) {
+  const terms = selected.split(',').map((s) => s.trim());
+  const result = [];
+  for (const term of terms) {
+    if (term.length === 0) {
+      continue;
+    }
+    const rangeMatch = /^\[(.*)\.\.\.(.*)\]$/g.exec(term);
+    if (rangeMatch) {
+      const [, start, end] = rangeMatch;
+      const allStartIdx = all.indexOf(start);
+      const allEndIdx = all.indexOf(end);
+      if (allStartIdx === -1 || allEndIdx === -1) {
+        throw new Error(`Could not find partitions for provided range: ${start}...${end}`);
+      }
+      result.push(...all.slice(allStartIdx, allEndIdx + 1));
+    } else if (term.includes('*')) {
+      const [prefix, suffix] = term.split('*');
+      result.push(...all.filter((p) => p.startsWith(prefix) && p.endsWith(suffix)));
+    } else {
+      const idx = all.indexOf(term);
+      if (idx === -1) {
+        throw new Error(`Could not find partition: ${term}`);
+      }
+      result.push(term);
+    }
+  }
+  return result.sort((a, b) => all.indexOf(a) - all.indexOf(b));
+}
+
+export function partitionsToText(selected: string[], all: string[]) {
+  return assembleIntoSpans(all, (key) => selected.includes(key))
+    .filter((s) => s.status)
+    .map((s) => stringForSpan(s, all))
+    .join(', ');
+}


### PR DESCRIPTION
### Summary & Motivation

This PR moves the "Completed, Missing" checkbox state and the selected partition range to the URL. A new option on the hook allows you to choose whether the URL should be kept in sync or just used for initial state.

This means 1) you can share links to the partitions page with selections made, and 2) when you open the backfill modal, it's prefilled with the selection you already made on the partitions page.

### How I Tested These Changes

I tested this by viewing the partitions page with all four styles of assets (multidimensional static, multidimensional time partitioned, static, and unpartitioned), reloading the page with various selections, and opening / editing in the "Materialize..." modal.