### PR TITLE
[dagit] Render assets with self-dependencies in Dagit

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -447,7 +447,7 @@ export const AssetGraphExplorerWithData: React.FC<
           <RightInfoPanel>
             <RightInfoPanelContent>
               <SidebarAssetInfo
-                assetKey={selectedGraphNodes[0].assetKey}
+                assetNode={selectedGraphNodes[0]}
                 liveData={liveDataByNode[selectedGraphNodes[0].id]}
               />
             </RightInfoPanelContent>

--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -12,6 +12,7 @@ import {
   metadataForAssetNode,
 } from '../assets/AssetMetadata';
 import {AssetSidebarActivitySummary} from '../assets/AssetSidebarActivitySummary';
+import {DependsOnSelfBanner} from '../assets/DependsOnSelfBanner';
 import {PartitionHealthSummary} from '../assets/PartitionHealthSummary';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {AssetKey} from '../assets/types';
@@ -25,13 +26,14 @@ import {pluginForMetadata} from '../plugins';
 import {Version} from '../versions/Version';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
-import {LiveDataForNode, displayNameForAssetKey} from './Utils';
+import {LiveDataForNode, displayNameForAssetKey, GraphNode, nodeDependsOnSelf} from './Utils';
 import {SidebarAssetQuery, SidebarAssetQueryVariables} from './types/SidebarAssetQuery';
 
 export const SidebarAssetInfo: React.FC<{
-  assetKey: AssetKey;
+  assetNode: GraphNode;
   liveData: LiveDataForNode;
-}> = ({assetKey, liveData}) => {
+}> = ({assetNode, liveData}) => {
+  const assetKey = assetNode.assetKey;
   const partitionHealthData = usePartitionHealthData([assetKey]);
   const {data} = useQuery<SidebarAssetQuery, SidebarAssetQueryVariables>(SIDEBAR_ASSET_QUERY, {
     variables: {assetKey: {path: assetKey.path}},
@@ -76,6 +78,8 @@ export const SidebarAssetInfo: React.FC<{
       />
 
       <div style={{borderBottom: `2px solid ${Colors.Gray300}`}} />
+
+      {nodeDependsOnSelf(assetNode) && <DependsOnSelfBanner />}
 
       {(asset.description || OpMetadataPlugin?.SidebarComponent || !hasAssetMetadata) && (
         <SidebarSection title="Description">

--- a/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
@@ -152,24 +152,24 @@ export const calculateGraphDistances = (items: GraphQueryItem[], assetKey: Asset
     return {upstream: 0, downstream: 0};
   }
 
-  const bfsUpstream = (ins: GraphQueryItem['inputs'], depth: number): number => {
-    const next = ins
+  const dfsUpstream = (name: string, depth: number): number => {
+    const next = map[name].inputs
       .flatMap((i) => i.dependsOn.map((d) => d.solid.name))
-      .map((name) => map[name].inputs);
+      .filter((dname) => dname !== name);
 
-    return Math.max(depth, ...next.map((nextIns) => bfsUpstream(nextIns, depth + 1)));
+    return Math.max(depth, ...next.map((dname) => dfsUpstream(dname, depth + 1)));
   };
-  const bfsDownstream = (outs: GraphQueryItem['outputs'], depth: number): number => {
-    const next = outs
+  const dfsDownstream = (name: string, depth: number): number => {
+    const next = map[name].outputs
       .flatMap((i) => i.dependedBy.map((d) => d.solid.name))
-      .map((name) => map[name].outputs);
+      .filter((dname) => dname !== name);
 
-    return Math.max(depth, ...next.map((nextOuts) => bfsDownstream(nextOuts, depth + 1)));
+    return Math.max(depth, ...next.map((dname) => dfsDownstream(dname, depth + 1)));
   };
 
   return {
-    upstream: bfsUpstream(start.inputs, 0),
-    downstream: bfsDownstream(start.outputs, 0),
+    upstream: dfsUpstream(start.name, 0),
+    downstream: dfsDownstream(start.name, 0),
   };
 };
 

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -28,6 +28,7 @@ import {
 } from './AssetMetadata';
 import {AssetNodeList} from './AssetNodeList';
 import {CurrentMinutesLateTag, freshnessPolicyDescription} from './CurrentMinutesLateTag';
+import {DependsOnSelfBanner} from './DependsOnSelfBanner';
 import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinitionFragment';
 
 export const AssetNodeDefinition: React.FC<{
@@ -35,7 +36,8 @@ export const AssetNodeDefinition: React.FC<{
   upstream: AssetGraphQuery_assetNodes[] | null;
   downstream: AssetGraphQuery_assetNodes[] | null;
   liveDataByNode: LiveData;
-}> = ({assetNode, upstream, downstream, liveDataByNode}) => {
+  dependsOnSelf: boolean;
+}> = ({assetNode, upstream, downstream, liveDataByNode, dependsOnSelf}) => {
   const {assetMetadata, assetType} = metadataForAssetNode(assetNode);
   const liveDataForNode = liveDataByNode[toGraphId(assetNode.assetKey)];
 
@@ -117,6 +119,7 @@ export const AssetNodeDefinition: React.FC<{
               </Box>
             </Link>
           </Box>
+          {dependsOnSelf && <DependsOnSelfBanner />}
           <AssetNodeList items={upstream} liveDataByNode={liveDataByNode} />
           <Box
             padding={{vertical: 16, horizontal: 24}}

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -20,7 +20,13 @@ import {
   useQueryRefreshAtInterval,
 } from '../app/QueryRefresh';
 import {Timestamp} from '../app/time/Timestamp';
-import {GraphData, LiveDataForNode, toGraphId, tokenForAssetKey} from '../asset-graph/Utils';
+import {
+  GraphData,
+  LiveDataForNode,
+  nodeDependsOnSelf,
+  toGraphId,
+  tokenForAssetKey,
+} from '../asset-graph/Utils';
 import {useAssetGraphData} from '../asset-graph/useAssetGraphData';
 import {useLiveDataForAssetKeys} from '../asset-graph/useLiveDataForAssetKeys';
 import {StaleTag} from '../assets/StaleTag';
@@ -79,6 +85,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
   });
 
   const {upstream, downstream} = useNeighborsFromGraph(visibleAssetGraph.assetGraphData, assetKey);
+  const node = visibleAssetGraph.assetGraphData?.nodes[toGraphId(assetKey)];
 
   // Observe the live state of the visible assets. Note: We use the "last materialization"
   // provided by this hook to trigger resets of the datasets inside the Activity / Plots tabs
@@ -108,6 +115,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
         assetNode={definition}
         upstream={upstream}
         downstream={downstream}
+        dependsOnSelf={node ? nodeDependsOnSelf(node) : false}
         liveDataByNode={liveDataByNode}
       />
     );

--- a/js_modules/dagit/packages/core/src/assets/DependsOnSelfBanner.tsx
+++ b/js_modules/dagit/packages/core/src/assets/DependsOnSelfBanner.tsx
@@ -1,0 +1,19 @@
+import {Alert, Box, Colors, Icon} from '@dagster-io/ui';
+import React from 'react';
+
+export const DependsOnSelfBanner: React.FC = () => {
+  return (
+    <Box
+      padding={{vertical: 16, left: 24, right: 12}}
+      border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+    >
+      <Alert
+        intent="warning"
+        icon={<Icon name="history_toggle_off" size={16} color={Colors.Yellow700} />}
+        title={
+          <div style={{fontWeight: 400}}>This asset depends on earlier partitions of itself. </div>
+        }
+      />
+    </Box>
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/DependsOnSelfBanner.tsx
+++ b/js_modules/dagit/packages/core/src/assets/DependsOnSelfBanner.tsx
@@ -8,8 +8,10 @@ export const DependsOnSelfBanner: React.FC = () => {
       border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
     >
       <Alert
-        intent="warning"
-        icon={<Icon name="history_toggle_off" size={16} color={Colors.Yellow700} />}
+        intent="info"
+        icon={
+          <Icon name="history_toggle_off" size={16} color={Colors.Blue700} style={{marginTop: 1}} />
+        }
         title={
           <div style={{fontWeight: 400}}>This asset depends on earlier partitions of itself. </div>
         }


### PR DESCRIPTION
### Summary & Motivation

This PR makes a few small changes to Dagit to support assets that rely on earlier partitions of themselves (pending backend changes):

- When an asset lists itself in it’s dependencyKeys, we ignore that edge and render the graph without it.

- When an asset lists itself in it’s dependencyKeys, we show a small banner in the sidebar and within the “Upstream Assets” section of the definition tab.

- The lineage graph also ignores self-dependencies when computing the “depth” of the graph. (I also renamed this function because it was doing depth-first search and not breadth-first search)

Note: This doesn't handle asset cycles, just assets with immediate self-dependencies. If you create a scenario where A relies on B, and B relies on yesterday's A, this notice is not displayed and Dagit will bail out of rendering the graph when it detects the cycle. I'm not sure if this scenario exists.

<img width="1104" alt="image" src="https://user-images.githubusercontent.com/1037212/207089616-f428b796-c390-4020-b240-d4734fd7f497.png">
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/1037212/207089657-fb0f9d6d-7cda-4eea-9eb1-24f4ecb541d8.png">

### How I Tested These Changes

I setup the repro case described here: https://elementl-workspace.slack.com/archives/C03CA4TVCAW/p1670541710139359, and then visited all the asset views to confirm they no longer crash or end up in infinite recursion.