### PR TITLE
[dagit] Add empty value string for invalid tag input in Runs filter

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
@@ -93,7 +93,7 @@ export function runsFilterForSearchTokens(search: TokenizingFieldValue[]) {
     } else if (item.token === 'snapshotId') {
       obj.snapshotId = item.value;
     } else if (item.token === 'tag') {
-      const [key, value] = item.value.split('=');
+      const [key, value = ''] = item.value.split('=');
       if (obj.tags) {
         obj.tags.push({key, value});
       } else {


### PR DESCRIPTION
### Summary & Motivation

Now that we don't show the full list of available tags to search Runs on, tags must be either entered with free text manually or via some other more structured means (e.g. clicking on the hover menu on a tag in the Runs list). The result is that it's possible to type an invalid tag pretty easily, which leads to a GraphQL error if the `value` field in the query variable is missing.

To resolve this, just tack on an empty string for the `value`. The query result will correctly come up empty (because no tags will match) and avoids the GraphQL error.

<img width="886" alt="Screenshot 2022-12-12 at 10 22 57 AM" src="https://user-images.githubusercontent.com/2823852/207098999-d2881c4c-d6f5-4e15-8403-909a6bd25406.png">


### How I Tested These Changes

View Runs list. Type `tag:job_name`, verify that the GraphQL query is performed without any errors. Repeat search with a valid tag query by clicking a tag in the Run list, verify that it filters successfully.
