### PR TITLE
[docs] - remove repository from hello dagster as its not needed

### DIFF
--- a/docs/content/getting-started/hello-dagster.mdx
+++ b/docs/content/getting-started/hello-dagster.mdx
@@ -56,11 +56,6 @@ def hackernews_top_stories(hackernews_top_story_ids):
     }
 
     return Output(value=df, metadata=metadata)
-
-
-@repository
-def hello_dagster():
-    return [hackernews_top_story_ids, hackernews_top_stories]
 ```
 
 ---

--- a/examples/docs_snippets/docs_snippets/getting-started/hello-dagster/hello-dagster.py
+++ b/examples/docs_snippets/docs_snippets/getting-started/hello-dagster/hello-dagster.py
@@ -36,8 +36,3 @@ def hackernews_top_stories(hackernews_top_story_ids):
     }
 
     return Output(value=df, metadata=metadata)
-
-
-@repository
-def hello_dagster():
-    return [hackernews_top_story_ids, hackernews_top_stories]


### PR DESCRIPTION
### Summary & Motivation

Instead of refactoring hello dagster with Definitions in place of repository,  both can be omitted because this simple example runs either way

The plan is to instead introduce Definitions in the quickstart_etl project guide (cc @yuhan  is this still planned?) which hello dagster will point towards

### How I Tested These Changes
- [x] code runs with repository removed 
- [x] renders look good
