### PR TITLE
[dagster-fivetran] Add missing docstring entry for build_fivetran_assets

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -119,6 +119,8 @@ def build_fivetran_assets(
         io_manager_key (Optional[str]): The io_manager to be used to handle each of these assets.
         asset_key_prefix (Optional[List[str]]): A prefix for the asset keys inside this asset.
             If left blank, assets will have a key of `AssetKey([schema_name, table_name])`.
+        metadata_by_table_name (Optional[Mapping[str, MetadataUserInput]]): A mapping from destination
+            table name to user-supplied metadata that should be associated with the asset for that table.
 
     Examples:
 


### PR DESCRIPTION
## Summary

Adds a brief docstring describing the `metadata_by_table_name` input to `build_fivetran_assets`.

Resolves #10582
