### PR TITLE
[dagit] Highlight Assets in top nav for global asset graph

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
@@ -71,7 +71,15 @@ export const AppTopNav: React.FC<Props> = ({
             shortcutLabel="⌥3"
             shortcutFilter={(e) => e.altKey && e.code === 'Digit3'}
           >
-            <TopNavLink to="/assets" data-cy="AppTopNav_AssetsLink" exact={false}>
+            <TopNavLink
+              to="/assets"
+              data-cy="AppTopNav_AssetsLink"
+              isActive={(_, location) => {
+                const {pathname} = location;
+                return pathname.startsWith('/assets') || pathname.startsWith('/asset-groups');
+              }}
+              exact={false}
+            >
               Assets
             </TopNavLink>
           </ShortcutHandler>


### PR DESCRIPTION
### Summary & Motivation

Set "Assets" item in top nav to active if we're viewing the global asset graph at `/asset-groups`.

### How I Tested These Changes

Navigate to global asset graph, verify top nav link highlighting.

View other assets at `/assets/foo`, verify that nav link highlighting remains correct.
