### PR TITLE
[ui] Show toast for GraphQL timeouts in Dagit

### DIFF
--- a/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, ExternalAnchorButton, NonIdealState, Spinner} from '@dagster-io/ui';
+import {Box, Colors, Spinner} from '@dagster-io/ui';
 import * as React from 'react';
 import {Redirect, Route, Switch} from 'react-router-dom';
 
@@ -79,26 +79,7 @@ const FinalRedirectOrLoadingRoot = () => {
     return <Redirect to="/overview" />;
   }
 
-  const repoWithNoJob = allRepos[0];
-
-  return (
-    <Box padding={{vertical: 64}}>
-      <NonIdealState
-        icon="no-results"
-        title={repoWithNoJob ? 'No jobs' : 'No definitions'}
-        description={
-          repoWithNoJob
-            ? 'Your definitions are loaded, but no jobs were found.'
-            : 'Add a job to get started.'
-        }
-        action={
-          <ExternalAnchorButton href="https://docs.dagster.io/getting-started">
-            View documentation
-          </ExternalAnchorButton>
-        }
-      />
-    </Box>
-  );
+  return <Redirect to="/locations" />;
 };
 
 // Imported via React.lazy, which requires a default export.

--- a/js_modules/dagit/packages/core/src/app/HTTPErrorCodes.tsx
+++ b/js_modules/dagit/packages/core/src/app/HTTPErrorCodes.tsx
@@ -1,0 +1,12 @@
+export const ERROR_CODES_TO_SURFACE = new Set([
+  504, // Gateway timeout
+]);
+
+export const errorCodeToMessage = (statusCode: number) => {
+  switch (statusCode) {
+    case 504:
+      return 'Request timed out. See console for details.';
+    default:
+      return 'A network error occurred. See console for details.';
+  }
+};

--- a/js_modules/dagit/packages/core/src/ui/Loading.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Loading.tsx
@@ -2,6 +2,8 @@ import {ApolloError, QueryResult} from '@apollo/client';
 import {Box, NonIdealState, Spinner} from '@dagster-io/ui';
 import * as React from 'react';
 
+import {ERROR_CODES_TO_SURFACE, errorCodeToMessage} from '../app/HTTPErrorCodes';
+
 interface ILoadingProps<TData> {
   queryResult: QueryResult<TData, any>;
   children: (data: TData) => React.ReactNode;
@@ -41,10 +43,25 @@ export const Loading = <TData extends Record<string, any>>(props: ILoadingProps<
     if (renderError) {
       return <>{renderError(error)}</>;
     }
-    if (!error.networkError) {
+
+    const {networkError} = error;
+    if (!networkError) {
       return (
         <Box padding={64} flex={{justifyContent: 'center'}}>
           <NonIdealState icon="error" title="GraphQL Error - see console for details" />
+        </Box>
+      );
+    }
+
+    if ('statusCode' in networkError && ERROR_CODES_TO_SURFACE.has(networkError.statusCode)) {
+      const statusCode = networkError.statusCode;
+      return (
+        <Box padding={64} flex={{justifyContent: 'center'}}>
+          <NonIdealState
+            icon="error"
+            title="Network error"
+            description={errorCodeToMessage(statusCode)}
+          />
         </Box>
       );
     }

--- a/js_modules/dagit/packages/ui/src/components/Toaster.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Toaster.tsx
@@ -10,7 +10,7 @@ import {createToaster} from './createToaster';
 export const GlobalToasterStyle = createGlobalStyle`
   .dagster-toaster {
     .bp4-toast {
-      padding: 6px;
+      padding: 8px 12px;
       border-radius: 8px;
       font-size: 14px;
       line-height: 22px;
@@ -40,14 +40,17 @@ export const GlobalToasterStyle = createGlobalStyle`
     }
 
     .bp4-toast.bp4-intent-warning,
-    .bp4-toast.bp4-intent-warning .bp4-button,
+    .bp4-toast.bp4-intent-warning .bp4-button {
+      background-color: ${Colors.Gray700} !important;
+
+      .bp4-icon-cross {
+        color: ${Colors.Gray300} !important;
+      }
+    }
+
     .bp4-toast.bp4-intent-danger,
     .bp4-toast.bp4-intent-danger .bp4-button {
       background-color: ${Colors.Red500} !important;
-    }
-
-    .bp4-toast .bp4-icon-cross {
-      color: ${Colors.Gray100};
     }
   }
 `;


### PR DESCRIPTION
### Summary & Motivation

When the `RootWorkspaceQuery` GraphQL query times out with a 504 gateway timeout, we currently do nothing to surface this to the user, so it looks like Dagit is just empty. I'm not sure there's a great way to surface these errors strictly for this operation, but we could surface a toast for any 504s to give the user a little bit of context about what's going on.

To accomplish this, I added a toast for 504/408 errors in the Apollo error link. I'm not sure this is really the correct thing to do in all cases, though. It might get pretty noisy in some circumstances.

This change also includes:

- Making the "warning" toast gray instead of red. It's weird that both "error" and "warning" toasts are currently red.
- Add a little more padding to the toast.
- Redirect to `/locations` in the fallthrough route if there are no code locations. This is a much better place to dump the user than the weird mystery empty state we currently show.

### How I Tested These Changes

Return a 504 error for `RootWorkspaceQuery` with a special case in Python.

Load Dagit, verify that the gray toast appears to indicate the 504. Verify also that I am redirected to `/locations` from the `/` fallthrough when no code locations have successfully loaded.
