### PR TITLE
convert-examples 1.1/ assets_dbt_python defs + pyproject

### DIFF
--- a/examples/assets_dbt_python/assets_dbt_python/__init__.py
+++ b/examples/assets_dbt_python/assets_dbt_python/__init__.py
@@ -1,1 +1,1 @@
-from .repository import assets_dbt_python
+from .repository import defs

--- a/examples/assets_dbt_python/assets_dbt_python/repository.py
+++ b/examples/assets_dbt_python/assets_dbt_python/repository.py
@@ -5,11 +5,11 @@ from dagster_dbt import dbt_cli_resource, load_assets_from_dbt_project
 from dagster_duckdb_pandas import duckdb_pandas_io_manager
 
 from dagster import (
+    Definitions,
     ScheduleDefinition,
     define_asset_job,
     fs_io_manager,
     load_assets_from_package_module,
-    Definitions,
 )
 from dagster._utils import file_relative_path
 

--- a/examples/assets_dbt_python/assets_dbt_python/repository.py
+++ b/examples/assets_dbt_python/assets_dbt_python/repository.py
@@ -9,8 +9,7 @@ from dagster import (
     define_asset_job,
     fs_io_manager,
     load_assets_from_package_module,
-    repository,
-    with_resources,
+    Definitions,
 )
 from dagster._utils import file_relative_path
 
@@ -44,25 +43,24 @@ forecasting_assets = load_assets_from_package_module(
 everything_job = define_asset_job("everything_everywhere_job", selection="*")
 forecast_job = define_asset_job("refresh_forecast_model_job", selection="*order_forecast_model")
 
+resources = {
+    # this io_manager allows us to load dbt models as pandas dataframes
+    "io_manager": duckdb_pandas_io_manager.configured(
+        {"database": os.path.join(DBT_PROJECT_DIR, "example.duckdb")}
+    ),
+    # this io_manager is responsible for storing/loading our pickled machine learning model
+    "model_io_manager": fs_io_manager,
+    # this resource is used to execute dbt cli commands
+    "dbt": dbt_cli_resource.configured(
+        {"project_dir": DBT_PROJECT_DIR, "profiles_dir": DBT_PROFILES_DIR}
+    ),
+}
 
-@repository
-def assets_dbt_python():
-    return with_resources(
-        dbt_assets + raw_data_assets + forecasting_assets,
-        resource_defs={
-            # this io_manager allows us to load dbt models as pandas dataframes
-            "io_manager": duckdb_pandas_io_manager.configured(
-                {"database": os.path.join(DBT_PROJECT_DIR, "example.duckdb")}
-            ),
-            # this io_manager is responsible for storing/loading our pickled machine learning model
-            "model_io_manager": fs_io_manager,
-            # this resource is used to execute dbt cli commands
-            "dbt": dbt_cli_resource.configured(
-                {"project_dir": DBT_PROJECT_DIR, "profiles_dir": DBT_PROFILES_DIR}
-            ),
-        },
-    ) + [
-        # run everything once a week, but update the forecast model daily
+defs = Definitions(
+    assets=dbt_assets + raw_data_assets + forecasting_assets,
+    resources=resources,
+    schedules=[
         ScheduleDefinition(job=everything_job, cron_schedule="@weekly"),
         ScheduleDefinition(job=forecast_job, cron_schedule="@daily"),
-    ]
+    ],
+)

--- a/examples/assets_dbt_python/assets_dbt_python/repository.py
+++ b/examples/assets_dbt_python/assets_dbt_python/repository.py
@@ -57,7 +57,7 @@ resources = {
 }
 
 defs = Definitions(
-    assets=dbt_assets + raw_data_assets + forecasting_assets,
+    assets=[*dbt_assets, *raw_data_assets, *forecasting_assets],
     resources=resources,
     schedules=[
         ScheduleDefinition(job=everything_job, cron_schedule="@weekly"),

--- a/examples/assets_dbt_python/assets_dbt_python_tests/test_repo_loads.py
+++ b/examples/assets_dbt_python/assets_dbt_python_tests/test_repo_loads.py
@@ -1,6 +1,6 @@
-from assets_dbt_python import assets_dbt_python
+from assets_dbt_python import defs
 
 
-def test_repo_can_load():
-    assert assets_dbt_python.get_job("everything_everywhere_job")
-    assert assets_dbt_python.get_job("refresh_forecast_model_job")
+def test_def_can_load():
+    assert defs.get_job_def("everything_everywhere_job")
+    assert defs.get_job_def("refresh_forecast_model_job")

--- a/examples/assets_dbt_python/pyproject.toml
+++ b/examples/assets_dbt_python/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.dagster]
+python_package = "assets_dbt_python"

--- a/examples/assets_dbt_python/workspace.yaml
+++ b/examples/assets_dbt_python/workspace.yaml
@@ -1,2 +1,0 @@
-load_from:
-  - python_package: assets_dbt_python


### PR DESCRIPTION
### Summary & Motivation
- `@repository` -> `Definitions`
- `workspace.yaml` -> `pyproject.toml`

file renames in 1.2/

### How I Tested These Changes
- unit test: can load
- `dagit` loads the code location
