### PR TITLE
convert-examples 2.1/ assets_modern_data_stack repo -> defs, pyproject

### DIFF
--- a/examples/assets_modern_data_stack/assets_modern_data_stack/__init__.py
+++ b/examples/assets_modern_data_stack/assets_modern_data_stack/__init__.py
@@ -1,1 +1,1 @@
-from .repository import assets_modern_data_stack
+from .repository import defs

--- a/examples/assets_modern_data_stack/assets_modern_data_stack/repository.py
+++ b/examples/assets_modern_data_stack/assets_modern_data_stack/repository.py
@@ -5,8 +5,7 @@ from dagster import (
     ScheduleDefinition,
     define_asset_job,
     load_assets_from_package_module,
-    repository,
-    with_resources,
+    Definitions,
 )
 
 from . import assets
@@ -14,19 +13,17 @@ from .db_io_manager import db_io_manager
 from .utils.constants import AIRBYTE_CONFIG, DBT_CONFIG, POSTGRES_CONFIG
 
 
-@repository
-def assets_modern_data_stack():
-    return [
-        with_resources(
-            load_assets_from_package_module(assets),
-            resource_defs={
-                "airbyte": airbyte_resource.configured(AIRBYTE_CONFIG),
-                "dbt": dbt_cli_resource.configured(DBT_CONFIG),
-                "db_io_manager": db_io_manager.configured(POSTGRES_CONFIG),
-            },
-        ),
+defs = Definitions(
+    assets=load_assets_from_package_module(assets),
+    resources={
+        "airbyte": airbyte_resource.configured(AIRBYTE_CONFIG),
+        "dbt": dbt_cli_resource.configured(DBT_CONFIG),
+        "db_io_manager": db_io_manager.configured(POSTGRES_CONFIG),
+    },
+    schedules=[
         # update all assets once a day
         ScheduleDefinition(
             job=define_asset_job("all_assets", selection="*"), cron_schedule="@daily"
         ),
-    ]
+    ],
+)

--- a/examples/assets_modern_data_stack/assets_modern_data_stack/repository.py
+++ b/examples/assets_modern_data_stack/assets_modern_data_stack/repository.py
@@ -2,16 +2,15 @@ from dagster_airbyte import airbyte_resource
 from dagster_dbt import dbt_cli_resource
 
 from dagster import (
+    Definitions,
     ScheduleDefinition,
     define_asset_job,
     load_assets_from_package_module,
-    Definitions,
 )
 
 from . import assets
 from .db_io_manager import db_io_manager
 from .utils.constants import AIRBYTE_CONFIG, DBT_CONFIG, POSTGRES_CONFIG
-
 
 defs = Definitions(
     assets=load_assets_from_package_module(assets),

--- a/examples/assets_modern_data_stack/assets_modern_data_stack_tests/test_repo_loads.py
+++ b/examples/assets_modern_data_stack/assets_modern_data_stack_tests/test_repo_loads.py
@@ -1,11 +1,7 @@
-from assets_modern_data_stack import assets_modern_data_stack
+from assets_modern_data_stack import defs
 
 
-def test_repo_can_load():
-    assets_modern_data_stack.load_all_definitions()
-
+def test_defs_can_load():
     # Repo should have only one "default" asset group, which is represented a "__ASSET_JOB" job
-    assert [job.name for job in assets_modern_data_stack.get_all_jobs()] == [
-        "__ASSET_JOB",
-        "all_assets",
-    ]
+    assert defs.get_job_def("__ASSET_JOB")
+    assert defs.get_job_def("all_assets")

--- a/examples/assets_modern_data_stack/pyproject.toml
+++ b/examples/assets_modern_data_stack/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.dagster]
+python_package = "assets_modern_data_stack"

--- a/examples/assets_modern_data_stack/workspace.yaml
+++ b/examples/assets_modern_data_stack/workspace.yaml
@@ -1,2 +1,0 @@
-load_from:
-  - python_package: assets_modern_data_stack


### PR DESCRIPTION
### Summary & Motivation
- `@repository` -> `Definitions`
- `workspace.yaml` -> `pyproject.toml`

file renames in 2.2/

### How I Tested These Changes
- `dagit` loads
- unit test
