### PR TITLE
Allow assets to depend on earlier partitions of themselves

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -270,7 +270,7 @@ class AssetGraph(NamedTuple):
         """Determines if an asset has any parents which are not source assets"""
         if asset_key in self.source_asset_keys:
             return False
-        return bool(self.get_parents(asset_key) - self.source_asset_keys)
+        return bool(self.get_parents(asset_key) - self.source_asset_keys - {asset_key})
 
     def get_non_source_roots(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
         """Returns all assets upstream of the given asset which do not consume any other
@@ -312,6 +312,9 @@ class AssetGraph(NamedTuple):
         return [
             {key for key in level} for level in toposort.toposort(self.asset_dep_graph["upstream"])
         ]
+
+    def has_self_dependency(self, asset_key: AssetKey) -> bool:
+        return asset_key in self.get_parents(asset_key)
 
     def __hash__(self):
         return id(self)

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -388,6 +388,11 @@ def build_node_deps(
             upstream_asset_key = resolved_asset_deps.get_resolved_asset_key_for_input(
                 assets_def, input_name
             )
+
+            # ignore self-deps
+            if upstream_asset_key in assets_def.keys:
+                continue
+
             if upstream_asset_key in node_alias_and_output_by_asset_key:
                 upstream_node_alias, upstream_output_name = node_alias_and_output_by_asset_key[
                     upstream_asset_key

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -235,7 +235,8 @@ def fetch_sinks(graph: DependencyGraph, within_selection: AbstractSet[T]) -> Abs
     traverser = Traverser(graph)
     sinks: Set[T] = set()
     for item in within_selection:
-        if len(traverser.fetch_downstream(item, depth=MAX_NUM) & within_selection) == 0:
+        downstream = traverser.fetch_downstream(item, depth=MAX_NUM) & within_selection
+        if len(downstream) == 0 or downstream == {item}:
             sinks.add(item)
     return sinks
 
@@ -248,7 +249,8 @@ def fetch_sources(graph: DependencyGraph, within_selection: AbstractSet[T]) -> A
     traverser = Traverser(graph)
     sources = set()
     for item in within_selection:
-        if len(traverser.fetch_upstream(item, depth=MAX_NUM) & within_selection) == 0:
+        upstream = traverser.fetch_upstream(item, depth=MAX_NUM) & within_selection
+        if len(upstream) == 0 or upstream == {item}:
             sources.add(item)
     return sources
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -700,3 +700,35 @@ def test_multi_asset_retry_policy():
         ...
 
     assert my_asset.op.retry_policy == retry_policy
+
+
+def test_invalid_self_dep():
+    from dagster import DailyPartitionsDefinition, TimeWindowPartitionMapping
+
+    with pytest.raises(DagsterInvalidDefinitionError):
+
+        @asset
+        def a(a):
+            del a
+
+    with pytest.raises(DagsterInvalidDefinitionError):
+
+        @asset(
+            partitions_def=DailyPartitionsDefinition(start_date="2020-01-01"),
+            ins={"b": AssetIn(partition_mapping=TimeWindowPartitionMapping())},
+        )
+        def b(b):
+            del b
+
+    with pytest.raises(DagsterInvalidDefinitionError):
+
+        @asset(
+            partitions_def=DailyPartitionsDefinition(start_date="2020-01-01"),
+            ins={
+                "c": AssetIn(
+                    partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=0)
+                )
+            },
+        )
+        def c(c):
+            del c

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_upath_io_manager.py
@@ -205,7 +205,7 @@ def test_upath_io_manager_multiple_static_partitions(dummy_io_manager: DummyIOMa
     )
     result = my_job.execute_in_process(partition_key="A")
     downstream_asset_data = result.output_for_node("downstream_asset", "result")
-    assert list(downstream_asset_data.keys()) == ["A", "B"]
+    assert set(downstream_asset_data.keys()) == {"A", "B"}
 
 
 def test_partitioned_io_manager_preserves_single_partition_dependency(


### PR DESCRIPTION
### Summary & Motivation

Support this:
```python
        @asset(
            partitions_def=DailyPartitionsDefinition(start_date="2020-01-01"),
            ins={
                "a": AssetIn(
                    partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
                )
            },
        )
        def a(a: Optional[int]) -> int:
            return 1 if a is None else a + 1
```

### How I Tested These Changes
