### PR TITLE
convert-examples 3.1/ assets_pandas_pyspark definitons, pyproject

### DIFF
--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark/__init__.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark/__init__.py
@@ -1,1 +1,1 @@
-from .repository import assets_pandas_pyspark
+from .repository import defs

--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark/repository.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark/repository.py
@@ -1,8 +1,5 @@
 from assets_pandas_pyspark.assets.spark_weather_assets import spark_weather_assets
 
-from dagster import repository
+from dagster import Definitions
 
-
-@repository
-def assets_pandas_pyspark():
-    return [spark_weather_assets]
+defs = Definitions(assets=spark_weather_assets)

--- a/examples/assets_pandas_pyspark/pyproject.toml
+++ b/examples/assets_pandas_pyspark/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.dagster]
+python_package = "assets_pandas_pyspark"

--- a/examples/assets_pandas_pyspark/workspace.yaml
+++ b/examples/assets_pandas_pyspark/workspace.yaml
@@ -1,2 +1,0 @@
-load_from:
-  - python_package: assets_pandas_pyspark


### PR DESCRIPTION
### Summary & Motivation
- `@repository` -> `Definitions`
- `workspace.yaml` -> `pyproject.toml`

file renames in 3.2/ - spotted outdated usage so 3.2 will be relatively heavy to review compared to other convert-examples

### How I Tested These Changes
- `dagit` loads
- unit test
