### PR TITLE
convert-examples 3.2/ asset_pandas_pyspark re-arrange files + [docs]

### DIFF
--- a/docs/content/guides/dagster/software-defined-assets.mdx
+++ b/docs/content/guides/dagster/software-defined-assets.mdx
@@ -65,7 +65,7 @@ The framework infers asset dependencies by looking at the names of the arguments
 
 Having defined some assets, we can combine them with resources, such as I/O managers, to determine how they're stored, and connect them to external services.
 
-We use <PyObject object="Definitions" /> to load definitions such as assets and resources. Let's take a closer look at how definitions are loaded:
+To load definitions such as assets and resources, we use <PyObject object="Definitions" />. Let's take a closer look at how definitions are loaded:
 
 - We add the assets that we want Dagster to load in the `assets` argument to the <PyObject object="Definitions" /> object. It's common to use a utility like <PyObject object="load_assets_from_modules" /> or <PyObject object="load_assets_from_package_name" /> to pick up all the assets within a module or package, so you don't need to list them individually. The order that we supply the assets doesn't matter, since the dependencies are determined by each asset definition.
 
@@ -170,13 +170,13 @@ Here's an extended version of `weather_assets` that contains the new asset:
 Because the same assets will be written and read into different Python types in different situations, we need to define an <PyObject object="IOManager" /> that can handle both of those types. Here's an extended version of the <PyObject object="IOManager" /> we defined before:
 
 ```python file=../../assets_pandas_pyspark/assets_pandas_pyspark/local_spark_filesystem_io_manager.py
-# local_filesystem_io_manager.py
+# local_spark_filesystem_io_manager.py
 
 # Data is stored in Parquet files using the "Hadoop-style" layout in which each table corresponds to a
 # directory, and each file within the directory contains some of the rows.
 
 # The processing options are Pandas and Spark. A table can be created from a Pandas DataFrame
-# and then consumed in a downstream computation as a Spark DataFrame. And vice versa.
+# and then consumed in a downstream computation as a Spark DataFrame, and vice versa.
 
 import glob
 import os
@@ -195,7 +195,7 @@ class LocalFileSystemIOManager(IOManager):
         return os.path.abspath(os.path.join(*asset_key.path))
 
     def handle_output(self, context, obj: Union[PandasDF, SparkDF]):
-        """This saves the dataframe as a CSV using the layout written and expected by Spark/Hadoop.
+        """This saves the DataFrame as a CSV using the layout written and expected by Spark/Hadoop.
 
         E.g. if the given storage maps the asset's path to the filesystem path "/a/b/c", a directory
         will be created with two files inside it:
@@ -218,7 +218,7 @@ class LocalFileSystemIOManager(IOManager):
             raise ValueError("Unexpected input type")
 
     def load_input(self, context) -> Union[PandasDF, SparkDF]:
-        """This reads a dataframe from a CSV using the layout written and expected by Spark/Hadoop.
+        """This reads a DataFrame from a CSV using the layout written and expected by Spark/Hadoop.
 
         E.g. if the given storage maps the asset's path to the filesystem path "/a/b/c", and that
         directory contains:

--- a/docs/content/guides/dagster/software-defined-assets.mdx
+++ b/docs/content/guides/dagster/software-defined-assets.mdx
@@ -63,7 +63,7 @@ The framework infers asset dependencies by looking at the names of the arguments
 
 ### Connecting assets to external services
 
-Having defined some assets, we can combine them with resources, such as IO managers, to determine how they're stored, and connect them to external services.
+Having defined some assets, we can combine them with resources, such as I/O managers, to determine how they're stored, and connect them to external services.
 
 We use <PyObject object="Definitions" /> to load definitions such as assets and resources. Let's take a closer look at how definitions are loaded:
 
@@ -73,15 +73,14 @@ We use <PyObject object="Definitions" /> to load definitions such as assets and 
 
 ```python file=../../assets_pandas_pyspark/assets_pandas_pyspark/__init__.py startafter=gather_assets_start endbefore=gather_assets_end
 # __init__.py
-
-    # imports the module called "assets" from the package containing the current module
-    # the "assets" module contains the asset definitions
     from dagster import Definitions, load_assets_from_modules
 
     from .assets import table_assets
     from .local_filesystem_io_manager import local_filesystem_io_manager
 
     defs = Definitions(
+        # imports the module called "assets" from the package containing the current module
+        # the "assets" module contains the asset definitions
         assets=load_assets_from_modules([table_assets]),
         resources={
             "io_manager": local_filesystem_io_manager,
@@ -166,7 +165,7 @@ Here's an extended version of `weather_assets` that contains the new asset:
     )
 ```
 
-### Defining a multi-type IO Manager
+### Defining a multi-type I/O Manager
 
 Because the same assets will be written and read into different Python types in different situations, we need to define an <PyObject object="IOManager" /> that can handle both of those types. Here's an extended version of the <PyObject object="IOManager" /> we defined before:
 

--- a/docs/content/guides/dagster/software-defined-assets.mdx
+++ b/docs/content/guides/dagster/software-defined-assets.mdx
@@ -63,29 +63,45 @@ The framework infers asset dependencies by looking at the names of the arguments
 
 ### Connecting assets to external services
 
-Having defined some assets, we can combine them with resources and IO managers to determine how they're stored, and connect them to external services. We use <PyObject object="with_resources" /> to provide resources to assets and source assets.
+Having defined some assets, we can combine them with resources, such as IO managers, to determine how they're stored, and connect them to external services.
 
-It's common to use a utility like <PyObject object="load_assets_from_modules" /> or <PyObject object="load_assets_from_package_name" /> to pick up all the assets within a module or package, so you don't need to list them individually.
+We use <PyObject object="Definitions" /> to load definitions such as assets and resources. Let's take a closer look at how definitions are loaded:
 
-```python file=../../assets_pandas_pyspark/assets_pandas_pyspark/assets/weather_assets.py startafter=gather_assets_start endbefore=gather_assets_end
-# imports the module called "assets" from the package containing the current module
-# the "assets" module contains the asset definitions
-from . import table_assets
-from dagster import load_assets_from_modules, with_resources
+- We add the assets that we want Dagster to load in the `assets` argument to the <PyObject object="Definitions" /> object. It's common to use a utility like <PyObject object="load_assets_from_modules" /> or <PyObject object="load_assets_from_package_name" /> to pick up all the assets within a module or package, so you don't need to list them individually. The order that we supply the assets doesn't matter, since the dependencies are determined by each asset definition.
 
-weather_assets = with_resources(
-    load_assets_from_modules(modules=[table_assets]),
-    resource_defs={
-        "io_manager": IOManagerDefinition.hardcoded_io_manager(LocalFileSystemIOManager())
-    },
-)
+- We supply resources mapped to the assets using the `resources` argument to the <PyObject object="Definitions" /> object.
+
+```python file=../../assets_pandas_pyspark/assets_pandas_pyspark/__init__.py startafter=gather_assets_start endbefore=gather_assets_end
+# __init__.py
+
+    # imports the module called "assets" from the package containing the current module
+    # the "assets" module contains the asset definitions
+    from dagster import Definitions, load_assets_from_modules
+
+    from .assets import table_assets
+    from .local_filesystem_io_manager import local_filesystem_io_manager
+
+    defs = Definitions(
+        assets=load_assets_from_modules([table_assets]),
+        resources={
+            "io_manager": local_filesystem_io_manager,
+        },
+    )
 ```
-
-The order that we supply the assets doesn't matter, since the dependencies are determined by each asset definition.
 
 The functions we used to define our assets describe how to compute their contents, but not how to read and write them to persistent storage. For reading and writing, we define an <PyObject object="IOManager" />. In this case, our `LocalFileSystemIOManager` stores DataFrames as CSVs on the local filesystem:
 
-```python file=../../assets_pandas_pyspark/assets_pandas_pyspark/assets/weather_assets.py startafter=io_manager_start endbefore=io_manager_end
+```python file=../../assets_pandas_pyspark/assets_pandas_pyspark/local_filesystem_io_manager.py
+# local_filesystem_io_manager.py
+
+import os
+
+import pandas as pd
+from pandas import DataFrame
+
+from dagster import AssetKey, IOManager, io_manager
+
+
 class LocalFileSystemIOManager(IOManager):
     """Translates between Pandas DataFrames and CSVs on the local filesystem."""
 
@@ -102,6 +118,11 @@ class LocalFileSystemIOManager(IOManager):
         """This reads a dataframe from a CSV."""
         fpath = self._get_fs_path(context.asset_key)
         return pd.read_csv(fpath)
+
+
+@io_manager
+def local_filesystem_io_manager():
+    return LocalFileSystemIOManager()
 ```
 
 ## Adding in Spark assets
@@ -131,23 +152,45 @@ def daily_temperature_high_diffs(daily_temperature_highs: SparkDF) -> SparkDF:
 
 Here's an extended version of `weather_assets` that contains the new asset:
 
-```python file=../../assets_pandas_pyspark/assets_pandas_pyspark/assets/spark_weather_assets.py startafter=gather_assets_start endbefore=gather_assets_end
-from . import table_assets, spark_asset
-from dagster import load_assets_from_modules, with_resources
+```python file=../../assets_pandas_pyspark/assets_pandas_pyspark/__init__.py  startafter=gather_spark_assets_start endbefore=gather_spark_assets_end
+# __init__.py
 
-spark_weather_assets = with_resources(
-    load_assets_from_modules(modules=[table_assets, spark_asset]),
-    resource_defs={
-        "io_manager": IOManagerDefinition.hardcoded_io_manager(LocalFileSystemIOManager())
-    },
-)
+    from dagster import Definitions, load_assets_from_modules
+
+    from .assets import spark_asset, table_assets
+    from .local_spark_filesystem_io_manager import local_filesystem_io_manager
+
+    defs = Definitions(
+        assets=load_assets_from_modules([table_assets, spark_asset]),
+        resources={"io_manager": local_filesystem_io_manager},
+    )
 ```
 
 ### Defining a multi-type IO Manager
 
 Because the same assets will be written and read into different Python types in different situations, we need to define an <PyObject object="IOManager" /> that can handle both of those types. Here's an extended version of the <PyObject object="IOManager" /> we defined before:
 
-```python file=../../assets_pandas_pyspark/assets_pandas_pyspark/assets/spark_weather_assets.py startafter=io_manager_start endbefore=io_manager_end
+```python file=../../assets_pandas_pyspark/assets_pandas_pyspark/local_spark_filesystem_io_manager.py
+# local_filesystem_io_manager.py
+
+# Data is stored in Parquet files using the "Hadoop-style" layout in which each table corresponds to a
+# directory, and each file within the directory contains some of the rows.
+
+# The processing options are Pandas and Spark. A table can be created from a Pandas DataFrame
+# and then consumed in a downstream computation as a Spark DataFrame. And vice versa.
+
+import glob
+import os
+from typing import Union
+
+import pandas as pd
+from pandas import DataFrame as PandasDF
+from pyspark.sql import DataFrame as SparkDF
+from pyspark.sql import SparkSession
+
+from dagster import AssetKey, IOManager, io_manager, _check as check
+
+
 class LocalFileSystemIOManager(IOManager):
     def _get_fs_path(self, asset_key: AssetKey) -> str:
         return os.path.abspath(os.path.join(*asset_key.path))
@@ -202,4 +245,9 @@ class LocalFileSystemIOManager(IOManager):
             )
         else:
             raise ValueError("Unexpected input type")
+
+
+@io_manager
+def local_filesystem_io_manager():
+    return LocalFileSystemIOManager()
 ```

--- a/docs/content/guides/dagster/software-defined-assets.mdx
+++ b/docs/content/guides/dagster/software-defined-assets.mdx
@@ -187,7 +187,9 @@ from pandas import DataFrame as PandasDF
 from pyspark.sql import DataFrame as SparkDF
 from pyspark.sql import SparkSession
 
-from dagster import AssetKey, IOManager, io_manager, _check as check
+from dagster import AssetKey, IOManager
+from dagster import _check as check
+from dagster import io_manager
 
 
 class LocalFileSystemIOManager(IOManager):

--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark/__init__.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark/__init__.py
@@ -2,15 +2,14 @@ def get_weather_defs():
     # gather_assets_start
 
     # __init__.py
-
-    # imports the module called "assets" from the package containing the current module
-    # the "assets" module contains the asset definitions
     from dagster import Definitions, load_assets_from_modules
 
     from .assets import table_assets
     from .local_filesystem_io_manager import local_filesystem_io_manager
 
     defs = Definitions(
+        # imports the module called "assets" from the package containing the current module
+        # the "assets" module contains the asset definitions
         assets=load_assets_from_modules([table_assets]),
         resources={
             "io_manager": local_filesystem_io_manager,

--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark/__init__.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark/__init__.py
@@ -1,1 +1,43 @@
-from .repository import defs
+def get_weather_defs():
+    # gather_assets_start
+
+    # __init__.py
+
+    # imports the module called "assets" from the package containing the current module
+    # the "assets" module contains the asset definitions
+    from dagster import Definitions, load_assets_from_modules
+
+    from .assets import table_assets
+    from .local_filesystem_io_manager import local_filesystem_io_manager
+
+    defs = Definitions(
+        assets=load_assets_from_modules([table_assets]),
+        resources={
+            "io_manager": local_filesystem_io_manager,
+        },
+    )
+    # gather_assets_end
+
+    return defs
+
+
+def get_spark_weather_defs():
+    # gather_spark_assets_start
+
+    # __init__.py
+
+    from dagster import Definitions, load_assets_from_modules
+
+    from .assets import spark_asset, table_assets
+    from .local_spark_filesystem_io_manager import local_filesystem_io_manager
+
+    defs = Definitions(
+        assets=load_assets_from_modules([table_assets, spark_asset]),
+        resources={"io_manager": local_filesystem_io_manager},
+    )
+    # gather_spark_assets_end
+
+    return defs
+
+
+defs = get_spark_weather_defs()

--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark/local_filesystem_io_manager.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark/local_filesystem_io_manager.py
@@ -1,17 +1,13 @@
-"""isort:skip_file
+# local_filesystem_io_manager.py
 
-Defines a group of weather assets.
-
-Data is locally stored in csv files on the local filesystem.
-"""
 import os
 
 import pandas as pd
 from pandas import DataFrame
 
-from dagster import AssetKey, IOManager, IOManagerDefinition
+from dagster import AssetKey, IOManager, io_manager
 
-# io_manager_start
+
 class LocalFileSystemIOManager(IOManager):
     """Translates between Pandas DataFrames and CSVs on the local filesystem."""
 
@@ -30,19 +26,6 @@ class LocalFileSystemIOManager(IOManager):
         return pd.read_csv(fpath)
 
 
-# io_manager_end
-
-# gather_assets_start
-# imports the module called "assets" from the package containing the current module
-# the "assets" module contains the asset definitions
-from . import table_assets
-from dagster import load_assets_from_modules, with_resources
-
-weather_assets = with_resources(
-    load_assets_from_modules(modules=[table_assets]),
-    resource_defs={
-        "io_manager": IOManagerDefinition.hardcoded_io_manager(LocalFileSystemIOManager())
-    },
-)
-
-# gather_assets_end
+@io_manager
+def local_filesystem_io_manager():
+    return LocalFileSystemIOManager()

--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark/local_spark_filesystem_io_manager.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark/local_spark_filesystem_io_manager.py
@@ -15,7 +15,9 @@ from pandas import DataFrame as PandasDF
 from pyspark.sql import DataFrame as SparkDF
 from pyspark.sql import SparkSession
 
-from dagster import AssetKey, IOManager, io_manager, _check as check
+from dagster import AssetKey, IOManager
+from dagster import _check as check
+from dagster import io_manager
 
 
 class LocalFileSystemIOManager(IOManager):

--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark/local_spark_filesystem_io_manager.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark/local_spark_filesystem_io_manager.py
@@ -1,10 +1,10 @@
-# local_filesystem_io_manager.py
+# local_spark_filesystem_io_manager.py
 
 # Data is stored in Parquet files using the "Hadoop-style" layout in which each table corresponds to a
 # directory, and each file within the directory contains some of the rows.
 
 # The processing options are Pandas and Spark. A table can be created from a Pandas DataFrame
-# and then consumed in a downstream computation as a Spark DataFrame. And vice versa.
+# and then consumed in a downstream computation as a Spark DataFrame, and vice versa.
 
 import glob
 import os
@@ -23,7 +23,7 @@ class LocalFileSystemIOManager(IOManager):
         return os.path.abspath(os.path.join(*asset_key.path))
 
     def handle_output(self, context, obj: Union[PandasDF, SparkDF]):
-        """This saves the dataframe as a CSV using the layout written and expected by Spark/Hadoop.
+        """This saves the DataFrame as a CSV using the layout written and expected by Spark/Hadoop.
 
         E.g. if the given storage maps the asset's path to the filesystem path "/a/b/c", a directory
         will be created with two files inside it:
@@ -46,7 +46,7 @@ class LocalFileSystemIOManager(IOManager):
             raise ValueError("Unexpected input type")
 
     def load_input(self, context) -> Union[PandasDF, SparkDF]:
-        """This reads a dataframe from a CSV using the layout written and expected by Spark/Hadoop.
+        """This reads a DataFrame from a CSV using the layout written and expected by Spark/Hadoop.
 
         E.g. if the given storage maps the asset's path to the filesystem path "/a/b/c", and that
         directory contains:

--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark/local_spark_filesystem_io_manager.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark/local_spark_filesystem_io_manager.py
@@ -1,13 +1,11 @@
-"""isort:skip_file
+# local_filesystem_io_manager.py
 
-Defines a group of the weather assets.
+# Data is stored in Parquet files using the "Hadoop-style" layout in which each table corresponds to a
+# directory, and each file within the directory contains some of the rows.
 
-Data is stored in Parquet files using the "Hadoop-style" layout in which each table corresponds to a
-directory, and each file within the directory contains some of the rows.
+# The processing options are Pandas and Spark. A table can be created from a Pandas DataFrame
+# and then consumed in a downstream computation as a Spark DataFrame. And vice versa.
 
-The processing options are Pandas and Spark.  A table can be created from a Pandas DataFrame
-and then consumed in a downstream computation as a Spark DataFrame.  And vice versa.
-"""
 import glob
 import os
 from typing import Union
@@ -17,9 +15,9 @@ from pandas import DataFrame as PandasDF
 from pyspark.sql import DataFrame as SparkDF
 from pyspark.sql import SparkSession
 
-from dagster import AssetKey, IOManager, IOManagerDefinition, _check as check
+from dagster import AssetKey, IOManager, io_manager, _check as check
 
-# io_manager_start
+
 class LocalFileSystemIOManager(IOManager):
     def _get_fs_path(self, asset_key: AssetKey) -> str:
         return os.path.abspath(os.path.join(*asset_key.path))
@@ -76,16 +74,6 @@ class LocalFileSystemIOManager(IOManager):
             raise ValueError("Unexpected input type")
 
 
-# io_manager_end
-
-# gather_assets_start
-from . import table_assets, spark_asset
-from dagster import load_assets_from_modules, with_resources
-
-spark_weather_assets = with_resources(
-    load_assets_from_modules(modules=[table_assets, spark_asset]),
-    resource_defs={
-        "io_manager": IOManagerDefinition.hardcoded_io_manager(LocalFileSystemIOManager())
-    },
-)
-# gather_assets_end
+@io_manager
+def local_filesystem_io_manager():
+    return LocalFileSystemIOManager()

--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark/repository.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark/repository.py
@@ -1,5 +1,0 @@
-from assets_pandas_pyspark.assets.spark_weather_assets import spark_weather_assets
-
-from dagster import Definitions
-
-defs = Definitions(assets=spark_weather_assets)

--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark_tests/test_assets.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark_tests/test_assets.py
@@ -7,21 +7,20 @@ from dagster._core.test_utils import instance_for_test
 def test_weather_assets():
     from assets_pandas_pyspark.local_filesystem_io_manager import local_filesystem_io_manager
 
-    weather_assets = with_resources(
-        load_assets_from_modules([table_assets]),
-        resource_defs={"io_manager": local_filesystem_io_manager},
-    )
     with instance_for_test() as instance:
-        assert materialize(weather_assets, instance=instance).success
+        assert materialize(
+            load_assets_from_modules([table_assets]),
+            instance=instance,
+            resources={"io_manager": local_filesystem_io_manager},
+        ).success
 
 
 def test_spark_weather_assets():
     from assets_pandas_pyspark.local_spark_filesystem_io_manager import local_filesystem_io_manager
 
-    spark_weather_assets = with_resources(
-        load_assets_from_modules([table_assets, spark_asset]),
-        resource_defs={"io_manager": local_filesystem_io_manager},
-    )
-
     with instance_for_test() as instance:
-        assert materialize(spark_weather_assets, instance=instance).success
+        assert materialize(
+            load_assets_from_modules([table_assets, spark_asset]),
+            instance=instance,
+            resources={"io_manager": local_filesystem_io_manager},
+        ).success

--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark_tests/test_assets.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark_tests/test_assets.py
@@ -1,14 +1,27 @@
-from assets_pandas_pyspark.assets.spark_weather_assets import spark_weather_assets
-from assets_pandas_pyspark.assets.weather_assets import weather_assets
+from assets_pandas_pyspark.assets import spark_asset, table_assets
 
-from dagster import instance_for_test, materialize
+from dagster import load_assets_from_modules, materialize, with_resources
+from dagster._core.test_utils import instance_for_test
 
 
 def test_weather_assets():
+    from assets_pandas_pyspark.local_filesystem_io_manager import local_filesystem_io_manager
+
+    weather_assets = with_resources(
+        load_assets_from_modules([table_assets]),
+        resource_defs={"io_manager": local_filesystem_io_manager},
+    )
     with instance_for_test() as instance:
         assert materialize(weather_assets, instance=instance).success
 
 
 def test_spark_weather_assets():
+    from assets_pandas_pyspark.local_spark_filesystem_io_manager import local_filesystem_io_manager
+
+    spark_weather_assets = with_resources(
+        load_assets_from_modules([table_assets, spark_asset]),
+        resource_defs={"io_manager": local_filesystem_io_manager},
+    )
+
     with instance_for_test() as instance:
         assert materialize(spark_weather_assets, instance=instance).success

--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark_tests/test_assets.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark_tests/test_assets.py
@@ -1,6 +1,6 @@
 from assets_pandas_pyspark.assets import spark_asset, table_assets
 
-from dagster import load_assets_from_modules, materialize, with_resources
+from dagster import load_assets_from_modules, materialize
 from dagster._core.test_utils import instance_for_test
 
 

--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark_tests/test_defs.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark_tests/test_defs.py
@@ -1,0 +1,9 @@
+from assets_pandas_pyspark import get_weather_defs, get_spark_weather_defs
+
+
+def test_weather_defs_can_load():
+    assert get_weather_defs()
+
+
+def test_spark_weather_defs_can_load():
+    assert get_spark_weather_defs()

--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark_tests/test_defs.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark_tests/test_defs.py
@@ -1,4 +1,4 @@
-from assets_pandas_pyspark import get_weather_defs, get_spark_weather_defs
+from assets_pandas_pyspark import get_spark_weather_defs, get_weather_defs
 
 
 def test_weather_defs_can_load():


### PR DESCRIPTION
### Summary & Motivation
depends on https://github.com/dagster-io/dagster/pull/11067
- `repository.py` -> `__init__.py` together with other changes:
  * add `get_weather_defs` and `get_spark_weather_defs` to fit the guide's script
  * use `resources` to `Definitions` instead of `with_resources`

- move io managers from `assets/` to their own `x_io_manager.py` also:
  * switch from `IOManagerDefinition.hardcoded_io_manager` to `@io_manager` 

- updated docs based on file changes [Preview](https://dagster-git-yuhan-12-12-convert-examples32asset-87a1e6-elementl.vercel.app/guides/dagster/software-defined-assets)

### How I Tested These Changes
- unit + `dagit` loads locally
- no "repo" mentions in the example
