### PR TITLE
convert-examples 4.1/ assets_pandas_type_metadata definitions, pyproject

### DIFF
--- a/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/__init__.py
+++ b/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/__init__.py
@@ -1,2 +1,2 @@
 from . import lib
-from .repository import assets_pandas_type_metadata
+from .repository import defs

--- a/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/repository.py
+++ b/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/repository.py
@@ -1,13 +1,8 @@
 from assets_pandas_type_metadata import assets
 from assets_pandas_type_metadata.resources.csv_io_manager import local_csv_io_manager
 
-from dagster import load_assets_from_package_module, repository, with_resources
+from dagster import Definitions, load_assets_from_package_module
 
-
-@repository
-def assets_pandas_type_metadata():
-    return [
-        *with_resources(
-            load_assets_from_package_module(assets), {"io_manager": local_csv_io_manager}
-        )
-    ]
+defs = Definitions(
+    assets=load_assets_from_package_module(assets), resources={"io_manager": local_csv_io_manager}
+)

--- a/examples/assets_pandas_type_metadata/assets_pandas_type_metadata_tests/test_defs.py
+++ b/examples/assets_pandas_type_metadata/assets_pandas_type_metadata_tests/test_defs.py
@@ -1,0 +1,5 @@
+from assets_pandas_type_metadata import defs
+
+
+def test_defs_can_load():
+    defs.get_repository_def().load_all_definitions()

--- a/examples/assets_pandas_type_metadata/assets_pandas_type_metadata_tests/test_defs.py
+++ b/examples/assets_pandas_type_metadata/assets_pandas_type_metadata_tests/test_defs.py
@@ -2,4 +2,4 @@ from assets_pandas_type_metadata import defs
 
 
 def test_defs_can_load():
-    defs.get_repository_def().load_all_definitions()
+    assert defs.get_job_def("__ASSET_JOB")

--- a/examples/assets_pandas_type_metadata/pyproject.toml
+++ b/examples/assets_pandas_type_metadata/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.dagster]
+python_package = "assets_pandas_type_metadata"

--- a/examples/assets_pandas_type_metadata/pyproject.toml
+++ b/examples/assets_pandas_type_metadata/pyproject.toml
@@ -3,4 +3,4 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.dagster]
-python_package = "assets_pandas_type_metadata"
+module_name = "assets_pandas_type_metadata"

--- a/examples/assets_pandas_type_metadata/workspace.yaml
+++ b/examples/assets_pandas_type_metadata/workspace.yaml
@@ -1,2 +1,0 @@
-load_from:
-  - python_package: assets_pandas_type_metadata


### PR DESCRIPTION
### Summary & Motivation
- `@repository` -> `Definitions`
- `workspace.yaml` -> `pyproject.toml`

file renames in 4.2/

### How I Tested These Changes
- `dagit` loads
- unit test
