### PR TITLE
convert-examples 4.2/ assets_pandas_type_metadata repository.py -> __init__.py

### DIFF
--- a/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/__init__.py
+++ b/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/__init__.py
@@ -1,2 +1,8 @@
-from . import lib
-from .repository import defs
+from dagster import Definitions, load_assets_from_package_module
+
+from . import assets, lib
+from .resources.csv_io_manager import local_csv_io_manager
+
+defs = Definitions(
+    assets=load_assets_from_package_module(assets), resources={"io_manager": local_csv_io_manager}
+)

--- a/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/repository.py
+++ b/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/repository.py
@@ -1,8 +1,0 @@
-from assets_pandas_type_metadata import assets
-from assets_pandas_type_metadata.resources.csv_io_manager import local_csv_io_manager
-
-from dagster import Definitions, load_assets_from_package_module
-
-defs = Definitions(
-    assets=load_assets_from_package_module(assets), resources={"io_manager": local_csv_io_manager}
-)


### PR DESCRIPTION
### Summary & Motivation
separate out file renames so it's easier to review
- `repository.py` -> `__init__.py`

### How I Tested These Changes
- unit + `dagit` loads locally
- no "repo" mentions in the example
