### PR TITLE
convert-examples 6.1/ feature_graph_backed_assets pyproject, @repository -> Definitions

### DIFF
--- a/examples/feature_graph_backed_assets/feature_graph_backed_assets/__init__.py
+++ b/examples/feature_graph_backed_assets/feature_graph_backed_assets/__init__.py
@@ -1,1 +1,1 @@
-from .repository import feature_graph_backed_assets
+from .repository import defs

--- a/examples/feature_graph_backed_assets/feature_graph_backed_assets/repository.py
+++ b/examples/feature_graph_backed_assets/feature_graph_backed_assets/repository.py
@@ -4,12 +4,12 @@ from feature_graph_backed_assets import assets
 from dagster import (
     AssetSelection,
     AssetsDefinition,
+    Definitions,
     GraphOut,
     define_asset_job,
     graph,
     load_assets_from_package_module,
     op,
-    repository,
 )
 
 
@@ -55,11 +55,11 @@ def layover_breakdown_2022(us_flights):
 airline_job = define_asset_job("airline_job", AssetSelection.keys("passenger_flights").downstream())
 
 
-@repository
-def feature_graph_backed_assets():
-    return [
-        load_assets_from_package_module(assets),
-        define_asset_job("airline_job", AssetSelection.keys("passenger_flights").downstream()),
+defs = Definitions(
+    assets=[
+        *load_assets_from_package_module(assets),
         AssetsDefinition.from_graph(us_assets),
         AssetsDefinition.from_graph(layover_breakdown_2022),
-    ]
+    ],
+    jobs=[define_asset_job("airline_job", AssetSelection.keys("passenger_flights").downstream())],
+)

--- a/examples/feature_graph_backed_assets/feature_graph_backed_assets_tests/test_assets.py
+++ b/examples/feature_graph_backed_assets/feature_graph_backed_assets_tests/test_assets.py
@@ -1,12 +1,8 @@
-from feature_graph_backed_assets import feature_graph_backed_assets
+from feature_graph_backed_assets import defs
 
 from dagster._core.test_utils import instance_for_test
 
 
 def test_feature_graph_backed_assets():
     with instance_for_test() as instance:
-        assert (
-            feature_graph_backed_assets.get_job("airline_job")
-            .execute_in_process(instance=instance)
-            .success
-        )
+        assert defs.get_job_def("airline_job").execute_in_process(instance=instance).success

--- a/examples/feature_graph_backed_assets/pyproject.toml
+++ b/examples/feature_graph_backed_assets/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.dagster]
+python_package = "feature_graph_backed_assets"

--- a/examples/feature_graph_backed_assets/workspace.yaml
+++ b/examples/feature_graph_backed_assets/workspace.yaml
@@ -1,2 +1,0 @@
-load_from:
-  - python_package: feature_graph_backed_assets


### PR DESCRIPTION
### Summary & Motivation
- `@repository` -> `Definitions`
- `workspace.yaml` -> `pyproject.toml`

file renames in 6.2/

### How I Tested These Changes
- `dagit` loads
- unit test (the existing test depends on a loadable defs)
