### PR TITLE
convert-examples 6.2/ feature_graph_backed_assets file rename and reorder

### DIFF
--- a/examples/feature_graph_backed_assets/feature_graph_backed_assets/__init__.py
+++ b/examples/feature_graph_backed_assets/feature_graph_backed_assets/__init__.py
@@ -1,1 +1,22 @@
-from .repository import defs
+from dagster import (
+    AssetSelection,
+    AssetsDefinition,
+    Definitions,
+    define_asset_job,
+    load_assets_from_package_module,
+)
+
+from . import assets
+from .graphs_and_ops import layover_breakdown_2022, us_assets
+
+airline_job = define_asset_job("airline_job", AssetSelection.keys("passenger_flights").downstream())
+
+
+defs = Definitions(
+    assets=[
+        *load_assets_from_package_module(assets),
+        AssetsDefinition.from_graph(us_assets),
+        AssetsDefinition.from_graph(layover_breakdown_2022),
+    ],
+    jobs=[define_asset_job("airline_job", AssetSelection.keys("passenger_flights").downstream())],
+)

--- a/examples/feature_graph_backed_assets/feature_graph_backed_assets/graphs_and_ops.py
+++ b/examples/feature_graph_backed_assets/feature_graph_backed_assets/graphs_and_ops.py
@@ -1,5 +1,6 @@
-from dagster import GraphOut, graph, op
 import pandas as pd
+
+from dagster import GraphOut, graph, op
 
 
 @op

--- a/examples/feature_graph_backed_assets/feature_graph_backed_assets/graphs_and_ops.py
+++ b/examples/feature_graph_backed_assets/feature_graph_backed_assets/graphs_and_ops.py
@@ -1,16 +1,5 @@
+from dagster import GraphOut, graph, op
 import pandas as pd
-from feature_graph_backed_assets import assets
-
-from dagster import (
-    AssetSelection,
-    AssetsDefinition,
-    Definitions,
-    GraphOut,
-    define_asset_job,
-    graph,
-    load_assets_from_package_module,
-    op,
-)
 
 
 @op
@@ -50,16 +39,3 @@ def filter_for_2022(flights):
 @graph
 def layover_breakdown_2022(us_flights):
     return layover_percentage_breakdown(filter_for_2022(us_flights))
-
-
-airline_job = define_asset_job("airline_job", AssetSelection.keys("passenger_flights").downstream())
-
-
-defs = Definitions(
-    assets=[
-        *load_assets_from_package_module(assets),
-        AssetsDefinition.from_graph(us_assets),
-        AssetsDefinition.from_graph(layover_breakdown_2022),
-    ],
-    jobs=[define_asset_job("airline_job", AssetSelection.keys("passenger_flights").downstream())],
-)


### PR DESCRIPTION
### Summary & Motivation
- `repository.py` -> `__init__.py`
- separate out ops and graphs to `graphs_and_ops.py` so we don't include everything in the init file

### How I Tested These Changes
- unit
- `dagit` loads
