### PR TITLE
convert-examples ?? with_airflow

### DIFF
--- a/examples/with_airflow/pyproject.toml
+++ b/examples/with_airflow/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.dagster]
+python_package = "with_airflow"

--- a/examples/with_airflow/with_airflow/__init__.py
+++ b/examples/with_airflow/with_airflow/__init__.py
@@ -1,1 +1,1 @@
-from .repository import airflow_examples_dags_repo, task_flow_repo, with_airflow
+from .repository import defs

--- a/examples/with_airflow/with_airflow/repository.py
+++ b/examples/with_airflow/with_airflow/repository.py
@@ -10,17 +10,13 @@ from with_airflow.airflow_complex_dag import complex_dag
 from with_airflow.airflow_kubernetes_dag import kubernetes_dag
 from with_airflow.airflow_simple_dag import simple_dag
 
-from dagster import repository
+from dagster import Definitions
 
 airflow_simple_dag = make_dagster_job_from_airflow_dag(simple_dag)
 airflow_complex_dag = make_dagster_job_from_airflow_dag(complex_dag)
 airflow_kubernetes_dag = make_dagster_job_from_airflow_dag(kubernetes_dag, mock_xcom=True)
 
-
-@repository
-def with_airflow():
-    return [airflow_complex_dag, airflow_simple_dag, airflow_kubernetes_dag]
-
+defs = Definitions(jobs=[airflow_complex_dag, airflow_simple_dag, airflow_kubernetes_dag])
 
 # end_repo_marker_0
 

--- a/examples/with_airflow/workspace.yaml
+++ b/examples/with_airflow/workspace.yaml
@@ -1,2 +1,0 @@
-load_from:
-  - python_package: with_airflow


### PR DESCRIPTION
### Summary & Motivation
two things blocking:
- we still got `make_dagster_repo_...` in airflow apis so it doesn't make much sense to keep defs and repos co-exist
- this project contains multiple repos. what do we do with multiple repos in the new world?

### How I Tested These Changes
