### PR TITLE
convert-examples 8.1/ with_great_expectations workspace->pyproject, repo->defs

### DIFF
--- a/examples/with_great_expectations/pyproject.toml
+++ b/examples/with_great_expectations/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.dagster]
+python_package = "with_great_expectations"

--- a/examples/with_great_expectations/with_great_expectations/__init__.py
+++ b/examples/with_great_expectations/with_great_expectations/__init__.py
@@ -1,1 +1,1 @@
-from .repository import with_great_expectations
+from .repository import defs

--- a/examples/with_great_expectations/with_great_expectations/repository.py
+++ b/examples/with_great_expectations/with_great_expectations/repository.py
@@ -1,8 +1,5 @@
 from with_great_expectations.ge_demo import payroll_data
 
-from dagster import repository
+from dagster import Definitions
 
-
-@repository
-def with_great_expectations():
-    return [payroll_data]
+defs = Definitions(jobs=[payroll_data])

--- a/examples/with_great_expectations/with_great_expectations_tests/test_ge_example.py
+++ b/examples/with_great_expectations/with_great_expectations_tests/test_ge_example.py
@@ -1,5 +1,6 @@
 import pytest
 from with_great_expectations.ge_demo import payroll_data
+from with_great_expectations import defs
 
 from dagster._utils import file_relative_path
 
@@ -22,7 +23,7 @@ def test_pipeline_failure():
                         }
                     }
                 },
-                "solids": {
+                "ops": {
                     "read_in_datafile": {
                         "inputs": {
                             "csv_path": {
@@ -35,3 +36,7 @@ def test_pipeline_failure():
                 },
             }
         )
+
+
+def test_defs_can_load():
+    assert defs.get_job_def("payroll_data")

--- a/examples/with_great_expectations/with_great_expectations_tests/test_ge_example.py
+++ b/examples/with_great_expectations/with_great_expectations_tests/test_ge_example.py
@@ -1,6 +1,6 @@
 import pytest
-from with_great_expectations.ge_demo import payroll_data
 from with_great_expectations import defs
+from with_great_expectations.ge_demo import payroll_data
 
 from dagster._utils import file_relative_path
 

--- a/examples/with_great_expectations/workspace.yaml
+++ b/examples/with_great_expectations/workspace.yaml
@@ -1,2 +1,0 @@
-load_from:
-  - python_package: with_great_expectations


### PR DESCRIPTION
### Summary & Motivation
- `@repository` -> `Definitions`
- `workspace.yaml` -> `pyproject.toml`

file rename in 8.2/

### How I Tested These Changes
- unit
- `dagit` loads
