### PR TITLE
Fix bug with logical versions for assets with changed deps

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -500,7 +500,9 @@ class ProjectedLogicalVersionLoader:
     # Returns true if the current logical version of at least one input asset differs from the
     # recorded logical version for that asset in the provenance. This indicates that a new
     # materialization with up-to-date data would produce a different logical verson.
-    def _is_provenance_stale(self, node: ExternalAssetNode, provenance: LogicalVersionProvenance) -> bool:
+    def _is_provenance_stale(
+        self, node: ExternalAssetNode, provenance: LogicalVersionProvenance
+    ) -> bool:
         if self._has_updated_dependencies(node, provenance):
             return True
         else:
@@ -509,7 +511,9 @@ class ProjectedLogicalVersionLoader:
                     return True
             return False
 
-    def _has_updated_dependencies(self, node: ExternalAssetNode, provenance: LogicalVersionProvenance) -> bool:
+    def _has_updated_dependencies(
+        self, node: ExternalAssetNode, provenance: LogicalVersionProvenance
+    ) -> bool:
         curr_dep_keys = {dep.upstream_asset_key for dep in node.dependencies}
         old_dep_keys = set(provenance.input_logical_versions.keys())
         return curr_dep_keys != old_dep_keys

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -490,7 +490,7 @@ class ProjectedLogicalVersionLoader:
                 if (
                     logical_version is None  # old materialization event before logical versions
                     or provenance is None  # should never happen
-                    or self._is_provenance_stale(provenance)
+                    or self._is_provenance_stale(node, provenance)
                 ):
                     version = self._compute_projected_new_materialization_logical_version(node)
                 else:
@@ -500,11 +500,19 @@ class ProjectedLogicalVersionLoader:
     # Returns true if the current logical version of at least one input asset differs from the
     # recorded logical version for that asset in the provenance. This indicates that a new
     # materialization with up-to-date data would produce a different logical verson.
-    def _is_provenance_stale(self, provenance: LogicalVersionProvenance) -> bool:
-        for k, v in provenance.input_logical_versions.items():
-            if self._get_version(key=k) != v:
-                return True
-        return False
+    def _is_provenance_stale(self, node: ExternalAssetNode, provenance: LogicalVersionProvenance) -> bool:
+        if self._has_updated_dependencies(node, provenance):
+            return True
+        else:
+            for k, v in provenance.input_logical_versions.items():
+                if self._get_version(key=k) != v:
+                    return True
+            return False
+
+    def _has_updated_dependencies(self, node: ExternalAssetNode, provenance: LogicalVersionProvenance) -> bool:
+        curr_dep_keys = {dep.upstream_asset_key for dep in node.dependencies}
+        old_dep_keys = set(provenance.input_logical_versions.keys())
+        return curr_dep_keys != old_dep_keys
 
     def _compute_projected_new_materialization_logical_version(
         self, node: ExternalAssetNode

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -130,6 +130,17 @@ GET_ASSET_LATEST_RUN_STATS = """
     }
 """
 
+GET_ASSET_LOGICAL_VERSIONS = """
+    query AssetNodeQuery($pipelineSelector: PipelineSelector!, $assetKeys: [AssetKeyInput!]) {
+        assetNodes(pipeline: $pipelineSelector, assetKeys: $assetKeys) {
+            id
+            currentLogicalVersion
+            projectedLogicalVersion
+        }
+    }
+"""
+
+
 
 GET_ASSET_NODES_FROM_KEYS = """
     query AssetNodeQuery($pipelineSelector: PipelineSelector!, $assetKeys: [AssetKeyInput!]) {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -141,7 +141,6 @@ GET_ASSET_LOGICAL_VERSIONS = """
 """
 
 
-
 GET_ASSET_NODES_FROM_KEYS = """
     query AssetNodeQuery($pipelineSelector: PipelineSelector!, $assetKeys: [AssetKeyInput!]) {
         assetNodes(pipeline: $pipelineSelector, assetKeys: $assetKeys) {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_logical_version_dependencies_changed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_logical_version_dependencies_changed.py
@@ -1,24 +1,29 @@
+from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
+from dagster_graphql.test.utils import (
+    define_out_of_process_context,
+    execute_dagster_graphql,
+    infer_job_or_pipeline_selector,
+)
+from dagster_graphql_tests.graphql.test_assets import GET_ASSET_LOGICAL_VERSIONS
+
 from dagster import asset
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.decorators.repository_decorator import repository
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.test_utils import instance_for_test, wait_for_runs_to_finish
 from dagster._core.workspace.context import WorkspaceRequestContext
-from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
-from dagster_graphql.test.utils import define_out_of_process_context, execute_dagster_graphql, infer_job_or_pipeline_selector
-from dagster_graphql_tests.graphql.test_assets import GET_ASSET_LOGICAL_VERSIONS
+
 
 def get_repo_v1():
-
     @asset
     def foo():
         return True
 
     @asset
-    def bar(foo):
+    def bar(foo):  # pylint: disable=unused-argument
         return True
 
-    all_job = define_asset_job('all_job', AssetSelection.all())
+    all_job = define_asset_job("all_job", AssetSelection.all())
 
     @repository
     def repo():
@@ -26,13 +31,13 @@ def get_repo_v1():
 
     return repo
 
-def get_repo_v2():
 
+def get_repo_v2():
     @asset
     def bar():
         return True
 
-    all_job = define_asset_job('all_job', AssetSelection.all())
+    all_job = define_asset_job("all_job", AssetSelection.all())
 
     @repository
     def repo():
@@ -40,16 +45,13 @@ def get_repo_v2():
 
     return repo
 
+
 def test_dependencies_changed():
     with instance_for_test() as instance:
-        with define_out_of_process_context(
-            __file__, "get_repo_v1", instance
-        ) as context_v1:
+        with define_out_of_process_context(__file__, "get_repo_v1", instance) as context_v1:
             assert _materialize_assets(context_v1)
             wait_for_runs_to_finish(context_v1.instance)
-        with define_out_of_process_context(
-            __file__, "get_repo_v2", instance
-        ) as context_v2:
+        with define_out_of_process_context(__file__, "get_repo_v2", instance) as context_v2:
             assert _fetch_logical_versions(context_v2)
 
 
@@ -64,6 +66,7 @@ def _materialize_assets(context: WorkspaceRequestContext):
             }
         },
     )
+
 
 def _fetch_logical_versions(context: WorkspaceRequestContext):
     selector = infer_job_or_pipeline_selector(context, "all_job")

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_logical_version_dependencies_changed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_logical_version_dependencies_changed.py
@@ -1,0 +1,76 @@
+from dagster import asset
+from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.decorators.repository_decorator import repository
+from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
+from dagster._core.test_utils import instance_for_test, wait_for_runs_to_finish
+from dagster._core.workspace.context import WorkspaceRequestContext
+from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
+from dagster_graphql.test.utils import define_out_of_process_context, execute_dagster_graphql, infer_job_or_pipeline_selector
+from dagster_graphql_tests.graphql.test_assets import GET_ASSET_LOGICAL_VERSIONS
+
+def get_repo_v1():
+
+    @asset
+    def foo():
+        return True
+
+    @asset
+    def bar(foo):
+        return True
+
+    all_job = define_asset_job('all_job', AssetSelection.all())
+
+    @repository
+    def repo():
+        return [all_job, foo, bar]
+
+    return repo
+
+def get_repo_v2():
+
+    @asset
+    def bar():
+        return True
+
+    all_job = define_asset_job('all_job', AssetSelection.all())
+
+    @repository
+    def repo():
+        return [all_job, bar]
+
+    return repo
+
+def test_dependencies_changed():
+    with instance_for_test() as instance:
+        with define_out_of_process_context(
+            __file__, "get_repo_v1", instance
+        ) as context_v1:
+            assert _materialize_assets(context_v1)
+            wait_for_runs_to_finish(context_v1.instance)
+        with define_out_of_process_context(
+            __file__, "get_repo_v2", instance
+        ) as context_v2:
+            assert _fetch_logical_versions(context_v2)
+
+
+def _materialize_assets(context: WorkspaceRequestContext):
+    selector = infer_job_or_pipeline_selector(context, "all_job")
+    return execute_dagster_graphql(
+        context,
+        LAUNCH_PIPELINE_EXECUTION_MUTATION,
+        variables={
+            "executionParams": {
+                "selector": selector,
+            }
+        },
+    )
+
+def _fetch_logical_versions(context: WorkspaceRequestContext):
+    selector = infer_job_or_pipeline_selector(context, "all_job")
+    return execute_dagster_graphql(
+        context,
+        GET_ASSET_LOGICAL_VERSIONS,
+        variables={
+            "pipelineSelector": selector,
+        },
+    )


### PR DESCRIPTION
### Summary & Motivation

This fixes a bug with the resolution of the projected logical version for assets with changed deps. Prior to this fix, if a previous dependency of an asset (that it had been most recently materialized with) was deleted, dagit would spam GraphQL errors as the projected logical version resolver endlessly tried to look up the missing asset while calculating provenance staleness. This PR adds a check that the dependencies have not changed  before attempting to calculate provenance staleness.

### How I Tested These Changes

- Unit test of the "deleted asset" scenario
- Manual dagit repro (h/t @owenkephart) for the repro

- Start with a file `my_defs.py`:

```
from dagster import asset


@asset
def repro_test_start():
    return 1


@asset
def repro_test_a(repro_test_start):
    return 1
```

- In shell, `$ dagit -f my_deps.py` and Materialize All
- Now change `my_defs.py` to:

```
from dagster import asset


@asset
def repro_test_a():
    return 1
```

- Reload definitions in dagit-- prior to fix produced GQL error, after fix, no longer does.
