### PR TITLE
Add get_sensor_def and get_schedule_def to Definitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -106,6 +106,17 @@ class Definitions:
         check.str_param(name, "name")
         return self.get_repository_def().get_job(name)
 
+    @public
+    def get_sensor_def(self, name: str) -> SensorDefinition:
+        """Get a sensor definition name"""
+        check.str_param(name, "name")
+        return self.get_repository_def().get_sensor_def(name)
+
+    @public
+    def get_schedule_def(self, name: str) -> ScheduleDefinition:
+        check.str_param(name, "name")
+        return self.get_repository_def().get_schedule_def(name)
+
     @cached_method
     def get_repository_def(self) -> RepositoryDefinition:
         return (

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions_class.py
@@ -91,7 +91,7 @@ def test_basic_schedule_definition():
         ],
     )
 
-    assert resolve_pending_repo_if_required(defs).get_schedule_def("daily_an_asset_schedule")
+    assert defs.get_schedule_def("daily_an_asset_schedule")
 
 
 def test_basic_sensor_definition():
@@ -109,9 +109,8 @@ def test_basic_sensor_definition():
         assets=[an_asset],
         sensors=[a_sensor],
     )
-    repo = resolve_pending_repo_if_required(defs)
 
-    assert repo.get_sensor_def("an_asset_sensor")
+    assert defs.get_sensor_def("an_asset_sensor")
 
 
 def test_with_resource_binding():


### PR DESCRIPTION
Summary & Motivation: We need these accessors to support basic test cases and scripting

Test Plan: BK
