### PR TITLE
[CacheableAssets] Fix bug that would cause definitions to be recomputed when using a StepDelegatingExecutor

### DIFF
--- a/examples/deploy_docker/from_source/repo.py
+++ b/examples/deploy_docker/from_source/repo.py
@@ -1,65 +1,49 @@
+import time
+
 from dagster_docker import docker_executor
 
-from dagster._core.definitions.cacheable_assets import (
-    AssetsDefinitionCacheableData,
-    CacheableAssetsDefinition,
-)
-
-from dagster import (
-    fs_io_manager,
-    asset,
-    op,
-    AssetsDefinition,
-    AssetKey,
-    DagsterInstance,
-    with_resources,
-    repository,
-)
+from dagster import fs_io_manager, graph, job, op, repository, schedule
 
 
-class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
-    _cacheable_data = AssetsDefinitionCacheableData(keys_by_output_name={"result": AssetKey("bar")})
-
-    def compute_cacheable_data(self):
-        # used for tracking how many times this function gets called over an execution
-        # if this gets called within the step worker, there will be an error as DAGSTER_HOME is not
-        # set in those containers
-        print("!!!!HERE")
-        import time
-
-        time.sleep(15)
-        # a quirk of how we end up launching this run requires us to get the definition twice before
-        # the run starts
-        return [self._cacheable_data]
-
-    def build_definitions(self, data):
-        assert len(data) == 1
-        assert data == [self._cacheable_data]
-
-        @op
-        def _op(foo):
-            return foo + 1
-
-        return [
-            AssetsDefinition.from_op(_op, keys_by_output_name=cd.keys_by_output_name) for cd in data
-        ]
-
-
-@asset
-def foo():
+@op
+def hello():
     return 1
 
 
-@asset
-def baz(bar):
-    return bar + 1
+@op
+def goodbye(foo):
+    return foo * 2
 
 
-@repository(default_executor_def=docker_executor)
+@op
+def hanging_op():
+    while True:
+        time.sleep(5)
+
+
+@job
+def hanging_job():
+    hanging_op()
+
+
+@graph
+def my_graph():
+    goodbye(hello())
+
+
+my_job = my_graph.to_job(name="my_job")
+my_step_isolated_job = my_graph.to_job(
+    name="my_step_isolated_job",
+    executor_def=docker_executor,
+    resource_defs={"io_manager": fs_io_manager.configured({"base_dir": "/tmp/io_manager_storage"})},
+)
+
+
+@schedule(cron_schedule="* * * * *", job=my_job, execution_timezone="US/Central")
+def my_schedule(_context):
+    return {}
+
+
+@repository
 def deploy_docker_repository():
-    return with_resources(
-        [foo, MyCacheableAssetsDefinition("bar"), baz],
-        resource_defs={
-            "io_manager": fs_io_manager.configured({"base_dir": "/tmp/io_manager_storage"})
-        },
-    )
+    return [my_job, hanging_job, my_schedule, my_step_isolated_job]

--- a/examples/deploy_docker/from_source/repo.py
+++ b/examples/deploy_docker/from_source/repo.py
@@ -1,49 +1,65 @@
-import time
-
 from dagster_docker import docker_executor
 
-from dagster import fs_io_manager, graph, job, op, repository, schedule
+from dagster._core.definitions.cacheable_assets import (
+    AssetsDefinitionCacheableData,
+    CacheableAssetsDefinition,
+)
 
-
-@op
-def hello():
-    return 1
-
-
-@op
-def goodbye(foo):
-    return foo * 2
-
-
-@op
-def hanging_op():
-    while True:
-        time.sleep(5)
-
-
-@job
-def hanging_job():
-    hanging_op()
-
-
-@graph
-def my_graph():
-    goodbye(hello())
-
-
-my_job = my_graph.to_job(name="my_job")
-my_step_isolated_job = my_graph.to_job(
-    name="my_step_isolated_job",
-    executor_def=docker_executor,
-    resource_defs={"io_manager": fs_io_manager.configured({"base_dir": "/tmp/io_manager_storage"})},
+from dagster import (
+    fs_io_manager,
+    asset,
+    op,
+    AssetsDefinition,
+    AssetKey,
+    DagsterInstance,
+    with_resources,
+    repository,
 )
 
 
-@schedule(cron_schedule="* * * * *", job=my_job, execution_timezone="US/Central")
-def my_schedule(_context):
-    return {}
+class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
+    _cacheable_data = AssetsDefinitionCacheableData(keys_by_output_name={"result": AssetKey("bar")})
+
+    def compute_cacheable_data(self):
+        # used for tracking how many times this function gets called over an execution
+        # if this gets called within the step worker, there will be an error as DAGSTER_HOME is not
+        # set in those containers
+        print("!!!!HERE")
+        import time
+
+        time.sleep(15)
+        # a quirk of how we end up launching this run requires us to get the definition twice before
+        # the run starts
+        return [self._cacheable_data]
+
+    def build_definitions(self, data):
+        assert len(data) == 1
+        assert data == [self._cacheable_data]
+
+        @op
+        def _op(foo):
+            return foo + 1
+
+        return [
+            AssetsDefinition.from_op(_op, keys_by_output_name=cd.keys_by_output_name) for cd in data
+        ]
 
 
-@repository
+@asset
+def foo():
+    return 1
+
+
+@asset
+def baz(bar):
+    return bar + 1
+
+
+@repository(default_executor_def=docker_executor)
 def deploy_docker_repository():
-    return [my_job, hanging_job, my_schedule, my_step_isolated_job]
+    return with_resources(
+        [foo, MyCacheableAssetsDefinition("bar"), baz],
+        resource_defs={
+            "io_manager": fs_io_manager.configured({"base_dir": "/tmp/io_manager_storage"})
+        },
+    )

--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/pending_repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/pending_repo.py
@@ -27,7 +27,7 @@ class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
         num_called = int(instance.run_storage.kvs_get({kvs_key}).get(kvs_key, "0"))
         # a quirk of how we end up launching this run requires us to get the definition twice before
         # the run starts
-        assert num_called < 2
+        assert num_called < 0
         instance.run_storage.kvs_set({kvs_key: str(num_called + 1)})
         return [self._cacheable_data]
 

--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/pending_repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/pending_repo.py
@@ -1,4 +1,5 @@
 import os
+
 from dagster import (
     AssetKey,
     AssetsDefinition,

--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/pending_repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/pending_repo.py
@@ -23,10 +23,11 @@ class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
         # set in those containers
         instance = DagsterInstance.get()
         kvs_key = "compute_cacheable_data_called"
+        print("!!!!HERE")
         num_called = int(instance.run_storage.kvs_get({kvs_key}).get(kvs_key, "0"))
         # a quirk of how we end up launching this run requires us to get the definition twice before
         # the run starts
-        assert num_called < 3
+        assert num_called < 2
         instance.run_storage.kvs_set({kvs_key: str(num_called + 1)})
         return [self._cacheable_data]
 

--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/pending_repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/pending_repo.py
@@ -25,9 +25,8 @@ class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
         kvs_key = "compute_cacheable_data_called"
         print("!!!!HERE")
         num_called = int(instance.run_storage.kvs_get({kvs_key}).get(kvs_key, "0"))
-        # a quirk of how we end up launching this run requires us to get the definition twice before
-        # the run starts
-        assert num_called < 0
+        # should only call this method a single time throughout the test
+        assert num_called == 0
         instance.run_storage.kvs_set({kvs_key: str(num_called + 1)})
         return [self._cacheable_data]
 

--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/pending_repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/pending_repo.py
@@ -19,7 +19,7 @@ class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
 
     def compute_cacheable_data(self):
         # make sure this never gets called in the normal course of a run
-        assert os.getenv("IN_EXTERNAL_PROCESS") == True
+        assert os.getenv("IN_EXTERNAL_PROCESS") == "yes"
         return [self._cacheable_data]
 
     def build_definitions(self, data):

--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/pending_repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/pending_repo.py
@@ -23,10 +23,7 @@ class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
         # set in those containers
         instance = DagsterInstance.get()
         kvs_key = "compute_cacheable_data_called"
-        print("!!!!HERE")
         num_called = int(instance.run_storage.kvs_get({kvs_key}).get(kvs_key, "0"))
-        # should only call this method a single time throughout the test
-        assert num_called == 0
         instance.run_storage.kvs_set({kvs_key: str(num_called + 1)})
         return [self._cacheable_data]
 

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -422,7 +422,7 @@ def _execute_step_command_body(
             recon_pipeline_from_origin(
                 cast(PipelinePythonOrigin, pipeline_run.pipeline_code_origin)
             )
-            .with_repository_load_data(repository_load_dat)
+            .with_repository_load_data(repository_load_data)
             .subset_for_execution_from_existing_pipeline(
                 pipeline_run.solids_to_execute, pipeline_run.asset_selection
             )

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -418,10 +418,14 @@ def _execute_step_command_body(
         else:
             repository_load_data = None
 
-        recon_pipeline = recon_pipeline_from_origin(
-            cast(PipelinePythonOrigin, pipeline_run.pipeline_code_origin)
-        ).subset_for_execution_from_existing_pipeline(
-            pipeline_run.solids_to_execute, pipeline_run.asset_selection
+        recon_pipeline = (
+            recon_pipeline_from_origin(
+                cast(PipelinePythonOrigin, pipeline_run.pipeline_code_origin)
+            )
+            .with_repository_load_data(repository_load_data)
+            .subset_for_execution_from_existing_pipeline(
+                pipeline_run.solids_to_execute, pipeline_run.asset_selection
+            )
         )
 
         execution_plan = create_execution_plan(

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -422,7 +422,7 @@ def _execute_step_command_body(
             recon_pipeline_from_origin(
                 cast(PipelinePythonOrigin, pipeline_run.pipeline_code_origin)
             )
-            .with_repository_load_data(repository_load_data)
+            .with_repository_load_data(repository_load_dat)
             .subset_for_execution_from_existing_pipeline(
                 pipeline_run.solids_to_execute, pipeline_run.asset_selection
             )

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -418,14 +418,10 @@ def _execute_step_command_body(
         else:
             repository_load_data = None
 
-        recon_pipeline = (
-            recon_pipeline_from_origin(
-                cast(PipelinePythonOrigin, pipeline_run.pipeline_code_origin)
-            )
-            .with_repository_load_data(repository_load_data)
-            .subset_for_execution_from_existing_pipeline(
-                pipeline_run.solids_to_execute, pipeline_run.asset_selection
-            )
+        recon_pipeline = recon_pipeline_from_origin(
+            cast(PipelinePythonOrigin, pipeline_run.pipeline_code_origin)
+        ).subset_for_execution_from_existing_pipeline(
+            pipeline_run.solids_to_execute, pipeline_run.asset_selection
         )
 
         execution_plan = create_execution_plan(

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
@@ -23,7 +23,7 @@ from . import IS_BUILDKITE, docker_postgres_instance
 
 @pytest.mark.parametrize("from_pending_repository", [True, False])
 def test_image_on_pipeline(aws_env, from_pending_repository):
-    os.environ["IN_EXTERNAL_PROCESS"] = True
+    os.environ["IN_EXTERNAL_PROCESS"] = "yes"
     docker_image = get_test_project_docker_image()
 
     launcher_config = {

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
@@ -94,7 +94,9 @@ def test_image_on_pipeline(aws_env, from_pending_repository):
                 external_pipeline_origin=external_pipeline.get_external_origin(),
                 pipeline_code_origin=external_pipeline.get_python_origin(),
                 repository_load_data=repository_load_data,
-                asset_selection=frozenset({AssetKey("foo"), AssetKey("bar")}),
+                asset_selection=frozenset({AssetKey("foo"), AssetKey("bar")})
+                if from_pending_repository
+                else None,
             )
 
             instance.launch_run(run.run_id, workspace)

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
@@ -22,6 +22,7 @@ from . import IS_BUILDKITE, docker_postgres_instance
 
 @pytest.mark.parametrize("from_pending_repository", [True, False])
 def test_image_on_pipeline(aws_env, from_pending_repository):
+    print("A")
     docker_image = get_test_project_docker_image()
 
     launcher_config = {
@@ -45,6 +46,7 @@ def test_image_on_pipeline(aws_env, from_pending_repository):
         if not from_pending_repository
         else {}
     )
+    print("B")
 
     env_yamls = [os.path.join(get_test_project_environments_path(), "env_s3.yaml")]
     if not from_pending_repository:
@@ -63,12 +65,15 @@ def test_image_on_pipeline(aws_env, from_pending_repository):
             }
         }
     ) as instance:
+        print("C")
         filename = "pending_repo.py" if from_pending_repository else "repo.py"
         recon_pipeline = get_test_project_recon_pipeline(
             "demo_pipeline_docker", docker_image, filename=filename
         )
+        print("D")
         repository_load_data = recon_pipeline.repository.get_definition().repository_load_data
         recon_pipeline = recon_pipeline.with_repository_load_data(repository_load_data)
+        print("E")
 
         with get_test_project_workspace_and_external_pipeline(
             instance,
@@ -79,10 +84,12 @@ def test_image_on_pipeline(aws_env, from_pending_repository):
             workspace,
             orig_pipeline,
         ):
+            print("F")
             external_pipeline = ReOriginatedExternalPipelineForTest(
                 orig_pipeline, container_image=docker_image, filename=filename
             )
 
+            print("G")
             run = instance.create_run_for_pipeline(
                 pipeline_def=recon_pipeline.get_definition(),
                 run_config=run_config,
@@ -90,8 +97,10 @@ def test_image_on_pipeline(aws_env, from_pending_repository):
                 pipeline_code_origin=external_pipeline.get_python_origin(),
                 repository_load_data=repository_load_data,
             )
+            print("H")
 
             instance.launch_run(run.run_id, workspace)
+            print("I")
 
             poll_for_finished_run(instance, run.run_id, timeout=60)
 

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
@@ -38,6 +38,7 @@ def test_image_on_pipeline(aws_env, from_pending_repository):
         launcher_config["registry"] = get_buildkite_registry_config()
     else:
         find_local_test_image(docker_image)
+    print("A2")
 
     executor_config = (
         {

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
@@ -12,6 +12,7 @@ from dagster_test.test_project import (
     get_test_project_workspace_and_external_pipeline,
 )
 
+from dagster._core.definitions.events import AssetKey
 from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import poll_for_finished_run
 from dagster._utils.merger import merge_dicts

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
@@ -107,6 +107,7 @@ def test_image_on_pipeline(aws_env, from_pending_repository):
             for log in instance.all_logs(run.run_id):
                 print(log)  # pylint: disable=print-call
 
+            print("J")
             assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.SUCCESS
 
 


### PR DESCRIPTION
### Summary & Motivation

Observed that when using the step delegating executor, CacheableAssetsDefinitions would be loaded on step start, which is very undesirable.

Turns out that subset_for_execution requires getting the full JobDefinition (it doesn't just add properties to the ReconstructablePipeline NamedTuple). Fix was simple, as we already had the RepositoryLoadInfo object available to us (and pass it into subsequent steps), we just didn't apply it to the ReconstructablePipeline soon enough.

The test did not catch this issue because it only occurs when there's an AssetSelection set. The test has been updated to be a bit more explicit, and also add an AssetSelection (which just selects all the assets available), so that this code path will be hit.

Manually verified the before/after behavior using the deploy_docker example.

### How I Tested These Changes
