### PR TITLE
Support module_name in tool.dagster section of pyproject.toml

### DIFF
--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -29,6 +29,7 @@ from dagster._core.workspace.load_target import (
     PackageTarget,
     PythonFileTarget,
     WorkspaceFileTarget,
+    WorkspaceLoadTarget,
 )
 from dagster._grpc.utils import get_loadable_targets
 from dagster._utils.hosted_user_process import recon_repository_from_origin
@@ -79,23 +80,28 @@ WORKSPACE_CLI_ARGS = (
 )
 
 
-def get_target_from_toml(path) -> Optional[PackageTarget]:
+def get_target_from_toml(path) -> Optional[WorkspaceLoadTarget]:
     with open(path, "rb") as f:
         data = tomli.load(f)
         if not isinstance(data, dict):
             return None
 
         dagster_block = data.get("tool", {}).get("dagster", {})
-        return (
-            PackageTarget(
+        if "module_name" in dagster_block:
+            return ModuleTarget(
+                module_name=dagster_block["module_name"],
+                attribute=None,
+                working_directory=os.getcwd(),
+                location_name=None,
+            )
+        if "python_package" in dagster_block:
+            return PackageTarget(
                 package_name=dagster_block["python_package"],
                 attribute=None,
                 working_directory=os.getcwd(),
                 location_name=None,
             )
-            if "python_package" in dagster_block
-            else None
-        )
+        return None
 
 
 def get_workspace_load_target(kwargs: ClickArgMapping):

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/single_module.toml
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/single_module.toml
@@ -1,0 +1,3 @@
+[tool.dagster]
+
+module_name = "baaz"

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/test_toml_loading.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/test_toml_loading.py
@@ -1,5 +1,5 @@
 from dagster._cli.workspace.cli_target import get_target_from_toml
-from dagster._core.workspace.load_target import PackageTarget
+from dagster._core.workspace.load_target import ModuleTarget, PackageTarget
 from dagster._utils import file_relative_path
 
 
@@ -7,6 +7,12 @@ def test_load_python_package_from_toml():
     target = get_target_from_toml(file_relative_path(__file__, "single_package.toml"))
     assert isinstance(target, PackageTarget)
     assert target.package_name == "foobar"
+
+
+def test_load_python_module_from_toml():
+    target = get_target_from_toml(file_relative_path(__file__, "single_module.toml"))
+    assert isinstance(target, ModuleTarget)
+    assert target.module_name == "baaz"
 
 
 def test_load_empty_toml():


### PR DESCRIPTION
Summary & Motivation: Per our decision to de-emphasize package-based verbiage for loading and instead do module-based verbiage, have pyproject.toml files support module loading and prefer that in all documentation. Once we convert over our existing examples we can eliminate support entirely.

Test Plan: BK
