### PR TITLE
[dagit] Don't show View link on code location toast if already there

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
@@ -35,6 +35,10 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
 
   const {data, previousData} = queryData;
 
+  const onClickViewButton = React.useCallback(() => {
+    history.push('/locations');
+  }, [history]);
+
   // Reload the workspace, but don't toast about it.
   const reloadWorkspaceQuietly = React.useCallback(async () => {
     setShowSpinner(true);
@@ -54,15 +58,15 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
         (entry) => entry.locationOrLoadError?.__typename === 'PythonError',
       );
 
+    const showViewButton = !alreadyViewingCodeLocations();
+
     if (anyErrors) {
       SharedToaster.show({
         intent: 'warning',
         message: (
           <Box flex={{direction: 'row', justifyContent: 'space-between', gap: 24, grow: 1}}>
-            <div>Workspace loaded with errors</div>
-            <ViewButton onClick={() => history.push('/locations')} color={Colors.White}>
-              View
-            </ViewButton>
+            <div>Definitions loaded with errors</div>
+            {showViewButton ? <ViewCodeLocationsButton onClick={onClickViewButton} /> : null}
           </Box>
         ),
         icon: 'check_circle',
@@ -73,15 +77,13 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
         message: (
           <Box flex={{direction: 'row', justifyContent: 'space-between', gap: 24, grow: 1}}>
             <div>Definitions reloaded</div>
-            <ViewButton onClick={() => history.push('/locations')} color={Colors.White}>
-              View
-            </ViewButton>
+            {showViewButton ? <ViewCodeLocationsButton onClick={onClickViewButton} /> : null}
           </Box>
         ),
         icon: 'check_circle',
       });
     }
-  }, [history, refetch]);
+  }, [onClickViewButton, refetch]);
 
   // Given the previous and current code locations, determine whether to show a) a loading spinner
   // and/or b) a toast indicating that a code location is being reloaded.
@@ -135,6 +137,8 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
       return;
     }
 
+    const showViewButton = !alreadyViewingCodeLocations();
+
     // We have a new entry, and it has already finished loading. Wow! It's surprisingly fast for it
     // to have finished loading so quickly, but go ahead and indicate that the location has
     // been added, then reload the workspace.
@@ -163,9 +167,7 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
             ) : (
               <span>{addedEntries.length} code locations added</span>
             )}
-            <ViewButton onClick={() => history.push('/locations')} color={Colors.White}>
-              View
-            </ViewButton>
+            {showViewButton ? <ViewCodeLocationsButton onClick={onClickViewButton} /> : null}
           </Box>
         ),
         icon: 'add_circle',
@@ -195,9 +197,7 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
             ) : (
               <span>Updating {currentlyLoading.length} code locations</span>
             )}
-            <ViewButton onClick={() => history.push('/locations')} color={Colors.White}>
-              View
-            </ViewButton>
+            {showViewButton ? <ViewCodeLocationsButton onClick={onClickViewButton} /> : null}
           </Box>
         ),
         icon: 'refresh',
@@ -220,7 +220,7 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
     // It's unlikely that we've made it to this point, since being inside this effect should
     // indicate that `data` and `previousData` have differences that would have been handled by
     // the conditionals above.
-  }, [data, previousData, reloadWorkspaceQuietly, reloadWorkspaceLoudly, history]);
+  }, [data, previousData, reloadWorkspaceQuietly, reloadWorkspaceLoudly, onClickViewButton]);
 
   if (showSpinner) {
     return {
@@ -245,6 +245,16 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
   }
 
   return null;
+};
+
+const alreadyViewingCodeLocations = () => document.location.pathname.endsWith('/locations');
+
+const ViewCodeLocationsButton: React.FC<{onClick: () => void}> = ({onClick}) => {
+  return (
+    <ViewButton onClick={onClick} color={Colors.White}>
+      View
+    </ViewButton>
+  );
 };
 
 const ViewButton = styled(ButtonLink)`


### PR DESCRIPTION
### Summary & Motivation

When a code location updates, don't show the "View" link in the resulting toast if we're already viewing the Code Locations page.

### How I Tested These Changes

Load Dagit, view Code Locations page. Reload a code location, verify that the toast appears without a "View" link.

Repeat from an asset permalink. Verify that the "View" link does appear in the resulting toast. Click "View", verify successful navigation without triggering a new toast.
