### PR TITLE
Add a graphql field and API for location-scoped permissions

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/graphql.ts
+++ b/js_modules/dagit/packages/core/src/graphql/graphql.ts
@@ -3425,6 +3425,7 @@ export type WorkspaceLocationEntry = {
   loadStatus: RepositoryLocationLoadStatus;
   locationOrLoadError: Maybe<RepositoryLocationOrLoadError>;
   name: Scalars['String'];
+  permissions: Array<Permission>;
   updatedTimestamp: Scalars['Float'];
 };
 

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1326,6 +1326,7 @@ type WorkspaceLocationEntry {
   loadStatus: RepositoryLocationLoadStatus!
   displayMetadata: [RepositoryMetadata!]!
   updatedTimestamp: Float!
+  permissions: [Permission!]!
 }
 
 union RepositoryLocationOrLoadError = RepositoryLocation | PythonError
@@ -1333,6 +1334,12 @@ union RepositoryLocationOrLoadError = RepositoryLocation | PythonError
 enum RepositoryLocationLoadStatus {
   LOADING
   LOADED
+}
+
+type Permission {
+  permission: String!
+  value: Boolean!
+  disabledReason: String
 }
 
 """
@@ -3317,12 +3324,6 @@ union PartitionBackfillsOrError = PartitionBackfills | PythonError
 
 type PartitionBackfills {
   results: [PartitionBackfill!]!
-}
-
-type Permission {
-  permission: String!
-  value: Boolean!
-  disabledReason: String
 }
 
 type AssetLatestInfo {

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -5,10 +5,16 @@ from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.host_representation.selector import PipelineSelector
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.pipeline_run import DagsterRun, RunsFilter
+from dagster._core.workspace.permissions import Permissions
 from graphene import ResolveInfo
 
 from ..external import get_external_pipeline_or_raise
-from ..utils import ExecutionMetadata, ExecutionParams, capture_error
+from ..utils import (
+    ExecutionMetadata,
+    ExecutionParams,
+    assert_permission_for_location,
+    capture_error,
+)
 from .run_lifecycle import create_valid_pipeline_run
 
 if TYPE_CHECKING:
@@ -92,6 +98,12 @@ def launch_reexecution_from_parent_run(
         repository_name=origin.external_repository_origin.repository_name,
         pipeline_name=parent_run.pipeline_name,
         solid_selection=None,
+    )
+
+    assert_permission_for_location(
+        graphene_info,
+        Permissions.LAUNCH_PIPELINE_REEXECUTION,
+        selector.location_name,
     )
 
     repo_location = graphene_info.context.get_repository_location(selector.location_name)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -2,11 +2,17 @@ import dagster._check as check
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.host_representation import PipelineSelector, RepositorySelector, SensorSelector
 from dagster._core.scheduler.instigation import InstigatorState, SensorInstigatorData
+from dagster._core.workspace.permissions import Permissions
 from dagster._seven import get_current_datetime_in_utc, get_timestamp_from_utc_datetime
 from graphene import ResolveInfo
 
 from .loader import RepositoryScopedBatchLoader
-from .utils import UserFacingGraphQLError, capture_error
+from .utils import (
+    UserFacingGraphQLError,
+    assert_permission,
+    assert_permission_for_location,
+    capture_error,
+)
 
 
 @capture_error
@@ -92,10 +98,24 @@ def stop_sensor(graphene_info, instigator_origin_id, instigator_selector_id):
         for repository in repository_location.get_repositories().values()
         for sensor in repository.get_external_sensors()
     }
+
+    external_sensor = external_sensors.get(instigator_origin_id)
+    if external_sensor:
+        assert_permission_for_location(
+            graphene_info,
+            Permissions.EDIT_SENSOR,
+            external_sensor.selector.location_name,
+        )
+    else:
+        assert_permission(
+            graphene_info,
+            Permissions.EDIT_SENSOR,
+        )
+
     state = instance.stop_sensor(
         instigator_origin_id,
         instigator_selector_id,
-        external_sensors.get(instigator_origin_id),
+        external_sensor,
     )
     return GrapheneStopSensorMutationResult(state)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -30,6 +30,7 @@ from dagster_graphql.implementation.loader import (
 from .asset_graph import GrapheneAssetGroup, GrapheneAssetNode
 from .errors import GraphenePythonError, GrapheneRepositoryNotFoundError
 from .partition_sets import GraphenePartitionSet
+from .permissions import GraphenePermission
 from .pipelines.pipeline import GrapheneJob, GraphenePipeline
 from .repository_origin import GrapheneRepositoryMetadata, GrapheneRepositoryOrigin
 from .schedules import GrapheneSchedule
@@ -157,6 +158,8 @@ class GrapheneWorkspaceLocationEntry(graphene.ObjectType):
     displayMetadata = non_null_list(GrapheneRepositoryMetadata)
     updatedTimestamp = graphene.NonNull(graphene.Float)
 
+    permissions = graphene.Field(non_null_list(GraphenePermission))
+
     class Meta:
         name = "WorkspaceLocationEntry"
 
@@ -191,6 +194,10 @@ class GrapheneWorkspaceLocationEntry(graphene.ObjectType):
 
     def resolve_updatedTimestamp(self, _):
         return self._location_entry.update_timestamp
+
+    def resolve_permissions(self, graphene_info):
+        permissions = graphene_info.context.permissions_for_location(self.name)
+        return [GraphenePermission(permission, value) for permission, value in permissions.items()]
 
 
 class GrapheneRepository(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -25,9 +25,11 @@ from ...implementation.utils import (
     ExecutionMetadata,
     ExecutionParams,
     UserFacingGraphQLError,
+    assert_permission_for_location,
     capture_error,
     check_permission,
     pipeline_selector_from_graphql,
+    require_permission_check,
 )
 from ..asset_key import GrapheneAssetKey
 from ..backfill import (
@@ -174,7 +176,7 @@ class GrapheneDeleteRunMutation(graphene.Mutation):
         name = "DeleteRunMutation"
 
     @capture_error
-    @check_permission(Permissions.DELETE_PIPELINE_RUN)
+    @require_permission_check(Permissions.DELETE_PIPELINE_RUN)
     def mutate(self, graphene_info, **kwargs):
         run_id = kwargs["runId"]
         return delete_pipeline_run(graphene_info, run_id)
@@ -234,13 +236,18 @@ class GrapheneTerminateRunResult(graphene.Union):
         name = "TerminateRunResult"
 
 
-@capture_error
 def create_execution_params_and_launch_pipeline_exec(graphene_info, execution_params_dict):
     # refactored into a helper function here in order to wrap with @capture_error,
     # because create_execution_params may raise
+    execution_params = create_execution_params(graphene_info, execution_params_dict)
+    assert_permission_for_location(
+        graphene_info,
+        Permissions.LAUNCH_PIPELINE_EXECUTION,
+        execution_params.selector.location_name,
+    )
     return launch_pipeline_execution(
         graphene_info,
-        execution_params=create_execution_params(graphene_info, execution_params_dict),
+        execution_params,
     )
 
 
@@ -256,7 +263,7 @@ class GrapheneLaunchRunMutation(graphene.Mutation):
         name = "LaunchRunMutation"
 
     @capture_error
-    @check_permission(Permissions.LAUNCH_PIPELINE_EXECUTION)
+    @require_permission_check(Permissions.LAUNCH_PIPELINE_EXECUTION)
     def mutate(self, graphene_info, **kwargs):
         return create_execution_params_and_launch_pipeline_exec(
             graphene_info, kwargs["executionParams"]
@@ -275,7 +282,7 @@ class GrapheneLaunchBackfillMutation(graphene.Mutation):
         name = "LaunchBackfillMutation"
 
     @capture_error
-    @check_permission(Permissions.LAUNCH_PARTITION_BACKFILL)
+    @require_permission_check(Permissions.LAUNCH_PARTITION_BACKFILL)
     def mutate(self, graphene_info, **kwargs):
         return create_and_launch_partition_backfill(graphene_info, kwargs["backfillParams"])
 
@@ -292,7 +299,7 @@ class GrapheneCancelBackfillMutation(graphene.Mutation):
         name = "CancelBackfillMutation"
 
     @capture_error
-    @check_permission(Permissions.CANCEL_PARTITION_BACKFILL)
+    @require_permission_check(Permissions.CANCEL_PARTITION_BACKFILL)
     def mutate(self, graphene_info, **kwargs):
         return cancel_partition_backfill(graphene_info, kwargs["backfillId"])
 
@@ -309,7 +316,7 @@ class GrapheneResumeBackfillMutation(graphene.Mutation):
         name = "ResumeBackfillMutation"
 
     @capture_error
-    @check_permission(Permissions.LAUNCH_PARTITION_BACKFILL)
+    @require_permission_check(Permissions.LAUNCH_PARTITION_BACKFILL)
     def mutate(self, graphene_info, **kwargs):
         return resume_partition_backfill(graphene_info, kwargs["backfillId"])
 
@@ -318,10 +325,13 @@ class GrapheneResumeBackfillMutation(graphene.Mutation):
 def create_execution_params_and_launch_pipeline_reexec(graphene_info, execution_params_dict):
     # refactored into a helper function here in order to wrap with @capture_error,
     # because create_execution_params may raise
-    return launch_pipeline_reexecution(
+    execution_params = create_execution_params(graphene_info, execution_params_dict)
+    assert_permission_for_location(
         graphene_info,
-        execution_params=create_execution_params(graphene_info, execution_params_dict),
+        Permissions.LAUNCH_PIPELINE_REEXECUTION,
+        execution_params.selector.location_name,
     )
+    return launch_pipeline_reexecution(graphene_info, execution_params=execution_params)
 
 
 class GrapheneLaunchRunReexecutionMutation(graphene.Mutation):
@@ -337,7 +347,7 @@ class GrapheneLaunchRunReexecutionMutation(graphene.Mutation):
         name = "LaunchRunReexecutionMutation"
 
     @capture_error
-    @check_permission(Permissions.LAUNCH_PIPELINE_REEXECUTION)
+    @require_permission_check(Permissions.LAUNCH_PIPELINE_REEXECUTION)
     def mutate(self, graphene_info, **kwargs):
         execution_params = kwargs.get("executionParams")
         reexecution_params = kwargs.get("reexecutionParams")
@@ -387,10 +397,10 @@ class GrapheneTerminateRunMutation(graphene.Mutation):
         name = "TerminateRunMutation"
 
     @capture_error
-    @check_permission(Permissions.TERMINATE_PIPELINE_EXECUTION)
+    @require_permission_check(Permissions.TERMINATE_PIPELINE_EXECUTION)
     def mutate(self, graphene_info, **kwargs):
         return terminate_pipeline_execution(
-            graphene_info.context.instance,
+            graphene_info,
             kwargs["runId"],
             kwargs.get("terminatePolicy", GrapheneTerminateRunPolicy.SAFE_TERMINATE),
         )
@@ -444,9 +454,12 @@ class GrapheneReloadRepositoryLocationMutation(graphene.Mutation):
         name = "ReloadRepositoryLocationMutation"
 
     @capture_error
-    @check_permission(Permissions.RELOAD_REPOSITORY_LOCATION)
+    @require_permission_check(Permissions.RELOAD_REPOSITORY_LOCATION)
     def mutate(self, graphene_info, **kwargs):
         location_name = kwargs["repositoryLocationName"]
+        assert_permission_for_location(
+            graphene_info, Permissions.RELOAD_REPOSITORY_LOCATION, location_name
+        )
 
         if not graphene_info.context.has_repository_location_name(location_name):
             return GrapheneRepositoryLocationNotFound(location_name)
@@ -475,10 +488,12 @@ class GrapheneShutdownRepositoryLocationMutation(graphene.Mutation):
         name = "ShutdownRepositoryLocationMutation"
 
     @capture_error
-    @check_permission(Permissions.RELOAD_REPOSITORY_LOCATION)
+    @require_permission_check(Permissions.RELOAD_REPOSITORY_LOCATION)
     def mutate(self, graphene_info, **kwargs):
         location_name = kwargs["repositoryLocationName"]
-
+        assert_permission_for_location(
+            graphene_info, Permissions.RELOAD_REPOSITORY_LOCATION, location_name
+        )
         if not graphene_info.context.has_repository_location_name(location_name):
             return GrapheneRepositoryLocationNotFound(location_name)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/__init__.py
@@ -3,7 +3,11 @@ from dagster._core.host_representation import ScheduleSelector
 from dagster._core.workspace.permissions import Permissions
 
 from ...implementation.fetch_schedules import start_schedule, stop_schedule
-from ...implementation.utils import capture_error, check_permission
+from ...implementation.utils import (
+    assert_permission_for_location,
+    capture_error,
+    require_permission_check,
+)
 from ..errors import (
     GraphenePythonError,
     GrapheneSchedulerNotDefinedError,
@@ -67,9 +71,13 @@ class GrapheneStartScheduleMutation(graphene.Mutation):
         name = "StartScheduleMutation"
 
     @capture_error
-    @check_permission(Permissions.START_SCHEDULE)
+    @require_permission_check(Permissions.START_SCHEDULE)
     def mutate(self, graphene_info, schedule_selector):
-        return start_schedule(graphene_info, ScheduleSelector.from_graphql_input(schedule_selector))
+        selector = ScheduleSelector.from_graphql_input(schedule_selector)
+        assert_permission_for_location(
+            graphene_info, Permissions.START_SCHEDULE, selector.location_name
+        )
+        return start_schedule(graphene_info, selector)
 
 
 class GrapheneStopRunningScheduleMutation(graphene.Mutation):
@@ -85,7 +93,7 @@ class GrapheneStopRunningScheduleMutation(graphene.Mutation):
         name = "StopRunningScheduleMutation"
 
     @capture_error
-    @check_permission(Permissions.STOP_RUNNING_SCHEDULE)
+    @require_permission_check(Permissions.STOP_RUNNING_SCHEDULE)
     def mutate(self, graphene_info, schedule_origin_id, schedule_selector_id):
         return stop_schedule(graphene_info, schedule_origin_id, schedule_selector_id)
 

--- a/python_modules/dagster-graphql/dagster_graphql/test/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/test/utils.py
@@ -70,16 +70,16 @@ def execute_dagster_graphql_and_finish_runs(context, query, variables=None):
 
 
 @contextmanager
-def define_out_of_process_context(python_file, fn_name, instance):
+def define_out_of_process_context(python_file, fn_name, instance, read_only=False):
     check.inst_param(instance, "instance", DagsterInstance)
 
     with define_out_of_process_workspace(
-        python_file, fn_name, instance
+        python_file, fn_name, instance, read_only=read_only
     ) as workspace_process_context:
         yield workspace_process_context.create_request_context()
 
 
-def define_out_of_process_workspace(python_file, fn_name, instance):
+def define_out_of_process_workspace(python_file, fn_name, instance, read_only=False):
     return WorkspaceProcessContext(
         instance,
         PythonFileTarget(
@@ -89,6 +89,7 @@ def define_out_of_process_workspace(python_file, fn_name, instance):
             location_name=main_repo_location_name(),
         ),
         version="",
+        read_only=read_only,
     )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_permissions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_permissions.py
@@ -2,11 +2,18 @@ from unittest.mock import Mock
 
 import dagster._check as check
 import pytest
-from dagster._core.workspace.permissions import EDITOR_PERMISSIONS, VIEWER_PERMISSIONS, Permissions
+from dagster._core.workspace.permissions import (
+    EDITOR_PERMISSIONS,
+    VIEWER_PERMISSIONS,
+    Permissions,
+    get_location_scoped_user_permissions,
+)
 from dagster_graphql.implementation.utils import (
     UserFacingGraphQLError,
     assert_permission,
+    assert_permission_for_location,
     check_permission,
+    require_permission_check,
 )
 from dagster_graphql.test.utils import execute_dagster_graphql
 
@@ -18,6 +25,22 @@ PERMISSIONS_QUERY = """
         permission
         value
         disabledReason
+      }
+    }
+"""
+
+WORKSPACE_PERMISSIONS_QUERY = """
+    query WorkspacePermissionsQuery {
+      workspaceOrError {
+        ... on Workspace {
+          locationEntries {
+            permissions {
+              permission
+              value
+              disabledReason
+            }
+          }
+        }
       }
     }
 """
@@ -47,21 +70,43 @@ class FakeEnumPermissionMutation:
         pass
 
 
-class FakeOtherEnumPermisisonMutation:
+class FakeOtherEnumPermissionMutation:
     @check_permission(Permissions.LAUNCH_PIPELINE_REEXECUTION)
     def mutate(self, graphene_info, **_kwargs):
         pass
 
 
-class FakeMissingEnumPermisisonMutation:
+class FakeMissingEnumPermissionMutation:
     @check_permission(Permissions.LAUNCH_PARTITION_BACKFILL)
     def mutate(self, graphene_info, **_kwargs):
         pass
 
 
+class EndpointWithRequiredPermissionCheck:
+    @require_permission_check(Permissions.LAUNCH_PIPELINE_EXECUTION)
+    def mutate(self, graphene_info, **_kwargs):
+        assert_permission(graphene_info, Permissions.LAUNCH_PIPELINE_EXECUTION)
+
+
+class EndpointMissingRequiredPermissionCheck:
+    @require_permission_check(Permissions.LAUNCH_PARTITION_BACKFILL)
+    def mutate(self, graphene_info, **_kwargs):
+        pass
+
+
+class FakeEnumLocationPermissionMutation:
+    @require_permission_check(Permissions.LAUNCH_PIPELINE_EXECUTION)
+    def mutate(self, graphene_info, **kwargs):
+        location_name = kwargs["locationName"]
+        assert_permission_for_location(
+            graphene_info, Permissions.LAUNCH_PIPELINE_EXECUTION, location_name
+        )
+
+
 @pytest.fixture(name="fake_graphene_info")
 def fake_graphene_info_fixture():
     context = Mock()
+    _did_check = {}
 
     def fake_has_permission(permission):
         permission_map = {
@@ -71,14 +116,50 @@ def fake_graphene_info_fixture():
             Permissions.LAUNCH_PIPELINE_REEXECUTION: False,
         }
         check.invariant(permission in permission_map, "Permission does not exist in map")
+        _did_check[permission] = True
         return permission_map[permission]
 
     context.has_permission = Mock(side_effect=fake_has_permission)
 
+    def fake_has_permission_for_location(permission, location_name):
+        _did_check[permission] = True
+        return location_name == "has_location_permission"
+
+    def fake_was_permission_checked(_permission):
+        return _did_check.get(_permission) or False
+
+    context.has_permission_for_location = Mock(side_effect=fake_has_permission_for_location)
+
+    context.was_permission_checked = Mock(side_effect=fake_was_permission_checked)
+
     graphene_info = Mock()
     graphene_info.context = context
 
-    return graphene_info
+    yield graphene_info
+
+
+def test_check_location_mutation(fake_graphene_info):
+    # Fails per-location check
+    mutation = FakeEnumLocationPermissionMutation()
+    mutation.mutate(fake_graphene_info, locationName="has_location_permission")
+
+    with pytest.raises(UserFacingGraphQLError, match="GrapheneUnauthorizedError"):
+        mutation.mutate(fake_graphene_info, locationName="no_location_permission")
+
+
+def test_require_permission_check_succeeds(fake_graphene_info):
+    # Fails per-location check
+    mutation = EndpointWithRequiredPermissionCheck()
+    mutation.mutate(fake_graphene_info)
+
+
+def test_require_permission_check_missing(fake_graphene_info):
+    # Fails per-location check
+    mutation = EndpointMissingRequiredPermissionCheck()
+    with pytest.raises(
+        Exception, match="Permission launch_partition_backfill was never checked during the request"
+    ):
+        mutation.mutate(fake_graphene_info)
 
 
 @pytest.mark.parametrize("mutation", [FakeMutation(), FakeEnumPermissionMutation()])
@@ -87,7 +168,7 @@ def test_check_permission_has_permission(fake_graphene_info, mutation):
 
 
 @pytest.mark.parametrize(
-    "mutation", [FakeOtherPermissionMutation(), FakeOtherEnumPermisisonMutation()]
+    "mutation", [FakeOtherPermissionMutation(), FakeOtherEnumPermissionMutation()]
 )
 def test_check_permission_does_not_have_permission(fake_graphene_info, mutation):
     with pytest.raises(UserFacingGraphQLError, match="GrapheneUnauthorizedError"):
@@ -95,7 +176,7 @@ def test_check_permission_does_not_have_permission(fake_graphene_info, mutation)
 
 
 @pytest.mark.parametrize(
-    "mutation", [FakeMissingPermissionMutation(), FakeMissingEnumPermisisonMutation()]
+    "mutation", [FakeMissingPermissionMutation(), FakeMissingEnumPermissionMutation()]
 )
 def test_check_permission_permission_does_not_exist(fake_graphene_info, mutation):
     with pytest.raises(check.CheckError):
@@ -161,3 +242,25 @@ class TestPermissionsQuery(NonLaunchableGraphQLContextTestMatrix):
                 pass
 
         permission_result.enabled  # pylint: disable=pointless-statement
+
+
+class TestWorkspacePermissionsQuery(NonLaunchableGraphQLContextTestMatrix):
+    def test_workspace_permissions_query(self, graphql_context):
+        result = execute_dagster_graphql(graphql_context, WORKSPACE_PERMISSIONS_QUERY)
+        assert result.data
+
+        assert result.data["workspaceOrError"]["locationEntries"]
+
+        for location in result.data["workspaceOrError"]["locationEntries"]:
+            permissions_map = {
+                permission["permission"]: permission["value"]
+                for permission in location["permissions"]
+            }
+
+            expected_permissions_map = {
+                key: perm.enabled
+                for key, perm in get_location_scoped_user_permissions(
+                    graphql_context.read_only
+                ).items()
+            }
+            assert permissions_map == expected_permissions_map

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -163,6 +163,10 @@ class ExternalAssetGraph(AssetGraph):
             job_names_by_key=job_names_by_key,
         )
 
+    @property
+    def repository_handles_by_key(self) -> Mapping[AssetKey, RepositoryHandle]:
+        return self._repo_handles_by_key
+
     def get_repository_handle(self, asset_key: AssetKey) -> RepositoryHandle:
         return self._repo_handles_by_key[asset_key]
 

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -563,14 +563,16 @@ class ExternalSchedule:
         return self.get_external_origin().get_id()
 
     @property
-    def selector_id(self) -> str:
-        return create_snapshot_id(
-            InstigatorSelector(
-                self.handle.location_name,
-                self.handle.repository_name,
-                self._external_schedule_data.name,
-            )
+    def selector(self) -> InstigatorSelector:
+        return InstigatorSelector(
+            self.handle.location_name,
+            self.handle.repository_name,
+            self._external_schedule_data.name,
         )
+
+    @property
+    def selector_id(self) -> str:
+        return create_snapshot_id(self.selector)
 
     @property
     def default_status(self) -> DefaultScheduleStatus:
@@ -687,14 +689,16 @@ class ExternalSensor:
         return self.get_external_origin().get_id()
 
     @property
-    def selector_id(self) -> str:
-        return create_snapshot_id(
-            InstigatorSelector(
-                self.handle.location_name,
-                self.handle.repository_name,
-                self._external_sensor_data.name,
-            )
+    def selector(self) -> InstigatorSelector:
+        return InstigatorSelector(
+            self.handle.location_name,
+            self.handle.repository_name,
+            self._external_sensor_data.name,
         )
+
+    @property
+    def selector_id(self) -> str:
+        return create_snapshot_id(self.selector)
 
     def get_current_instigator_state(
         self, stored_state: Optional["InstigatorState"]

--- a/python_modules/dagster/dagster/_core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/host_representation/origin.py
@@ -529,11 +529,13 @@ class ExternalPartitionSetOrigin(
     def get_id(self) -> str:
         return create_snapshot_id(self)
 
-    def get_selector_id(self) -> str:
-        return create_snapshot_id(
-            PartitionSetSelector(
-                self.external_repository_origin.repository_location_origin.location_name,
-                self.external_repository_origin.repository_name,
-                self.partition_set_name,
-            )
+    @property
+    def selector(self) -> PartitionSetSelector:
+        return PartitionSetSelector(
+            self.external_repository_origin.repository_location_origin.location_name,
+            self.external_repository_origin.repository_name,
+            self.partition_set_name,
         )
+
+    def get_selector_id(self) -> str:
+        return create_snapshot_id(self.selector)

--- a/python_modules/dagster/dagster/_core/workspace/permissions.py
+++ b/python_modules/dagster/dagster/_core/workspace/permissions.py
@@ -51,6 +51,19 @@ EDITOR_PERMISSIONS: Dict[str, bool] = {
     Permissions.CANCEL_PARTITION_BACKFILL: True,
 }
 
+LOCATION_SCOPED_PERMISSIONS = {
+    Permissions.LAUNCH_PIPELINE_EXECUTION,
+    Permissions.LAUNCH_PIPELINE_REEXECUTION,
+    Permissions.START_SCHEDULE,
+    Permissions.STOP_RUNNING_SCHEDULE,
+    Permissions.EDIT_SENSOR,
+    Permissions.TERMINATE_PIPELINE_EXECUTION,
+    Permissions.DELETE_PIPELINE_RUN,
+    Permissions.RELOAD_REPOSITORY_LOCATION,
+    Permissions.LAUNCH_PARTITION_BACKFILL,
+    Permissions.CANCEL_PARTITION_BACKFILL,
+}
+
 
 class PermissionResult(
     NamedTuple("_PermissionResult", [("enabled", bool), ("disabled_reason", Optional[str])])
@@ -74,4 +87,13 @@ def get_user_permissions(read_only: bool) -> Mapping[str, PermissionResult]:
     return {
         perm: PermissionResult(enabled=enabled, disabled_reason=_get_disabled_reason(enabled))
         for perm, enabled in perm_map.items()
+    }
+
+
+def get_location_scoped_user_permissions(read_only: bool) -> Mapping[str, PermissionResult]:
+    all_permissions = get_user_permissions(read_only)
+    return {
+        perm: result
+        for perm, result in all_permissions.items()
+        if perm in LOCATION_SCOPED_PERMISSIONS
     }


### PR DESCRIPTION
Summary:
Adds a permissions field to GrapheneRepoLocation that can be used to scope permissions to particular code locations. The idea is that the frontend will, for these permissions, instead of sourcing them for a single static map, source them from a map for each code location.

A thing we will need to figure out is how to handle permissions checks during edge cases where the underlying location is no longer in the workspace (for example, terminating a run after its code location has been removed from the workspace). One possibility to handle that case would be to add canXXX fields on the relevant graphql object that is then mutated. Another is to fall back to the global permissions map to check if they are permissioned to do it for *all* locations (which is what the server currently does).

Added an example handler for launching and re-exeucting a run to demonstrate what the serverside checks would look like.

### Summary & Motivation

### How I Tested These Changes
